### PR TITLE
refactor: remove unused panel imports from various node schemas

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,4 @@
+{
+  "recommendations": ["biomejs.biome"],
+  "unwantedRecommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+}

--- a/apps/api/public/app-runtime/index.html
+++ b/apps/api/public/app-runtime/index.html
@@ -73,7 +73,7 @@
 
     <!-- Platform Runtime Bundle (same for ALL extensions) -->
     <!-- Hash is replaced during build: platform.{HASH}.js -->
-    <script src="/api/v1/app-runtime/platform.a9154c6b.js"></script>
+    <script src="/api/v1/app-runtime/platform.2620c4a4.js"></script>
 
     <!-- Extension bundle will be loaded dynamically by platform runtime -->
   </body>

--- a/apps/web/src/components/conditions/components/condition-group.tsx
+++ b/apps/web/src/components/conditions/components/condition-group.tsx
@@ -134,7 +134,7 @@ const ConditionGroup = ({
           <div
             className={cn(
               'absolute left-4 text-[13px] font-semibold leading-4 text-muted-foreground',
-              !showSubtext || group?.metadata?.subtext == '' ? 'top-2.5' : 'top-1'
+              !showSubtext || group?.metadata?.subtext === '' ? 'top-2.5' : 'top-1'
             )}>
             {group.metadata?.name || config.defaultGroupName || 'Group'}
             {showSubtext && group.metadata?.subtext && (

--- a/apps/web/src/components/conditions/components/condition-item.tsx
+++ b/apps/web/src/components/conditions/components/condition-item.tsx
@@ -37,8 +37,15 @@ const ConditionItem = ({
     nodeId,
   } = useConditionContext()
 
-  console.log('ConditionItem render:', condition.fieldId)
-  const fieldDef = getFieldDefinition(condition.fieldId)
+  const display = config.display ?? 'stacked'
+  const isInline = display === 'inline'
+
+  /** Resolve fieldId to a plain string (handles branded and array formats) */
+  const resolvedFieldId = Array.isArray(condition.fieldId)
+    ? (condition.fieldId[0] ?? '')
+    : (condition.fieldId as string)
+
+  const fieldDef = getFieldDefinition(resolvedFieldId)
 
   const handleUpdate = useCallback(
     (updates: Partial<typeof condition>) => {
@@ -110,6 +117,28 @@ const ConditionItem = ({
     [handleUpdate]
   )
 
+  /** Value input block — placed inline or stacked depending on config.display */
+  const valueBlock =
+    fieldDef && operatorRequiresValue(condition.operator) ? (
+      <div
+        className={cn(
+          'px-1 py-0.5',
+          isInline ? 'border-l border-l-divider w-0 grow' : 'border-t border-t-divider',
+          isHovered && 'border-destructive/20',
+          compactMode && 'max-h-[60px] overflow-y-auto'
+        )}>
+        <ValueInput
+          condition={condition}
+          field={fieldDef}
+          value={condition.value}
+          onChange={handleValueChange}
+          disabled={readOnly}
+          nodeId={nodeId}
+          className='text-xs w-full pe-1'
+        />
+      </div>
+    ) : null
+
   return (
     <div className={cn('mb-1 flex last-of-type:mb-0', className)}>
       <div
@@ -117,11 +146,11 @@ const ConditionItem = ({
           'grow rounded-xl bg-primary-200/30 border',
           isHovered && 'bg-destructive/10 border-destructive/20'
         )}>
-        <div className='flex items-center p-1'>
+        <div className={cn('flex items-center', isInline ? 'ps-1' : 'p-1')}>
           <div className='w-0 grow'>
             {config.mode === 'variable' && nodeId ? (
               <VariableFieldSelector
-                value={condition.fieldId}
+                value={resolvedFieldId}
                 onChange={handleFieldChange}
                 disabled={readOnly}
                 placeholder='Select field'
@@ -130,7 +159,7 @@ const ConditionItem = ({
               />
             ) : (
               <ResourceFieldSelector
-                value={condition.fieldId}
+                value={resolvedFieldId}
                 onChange={handleFieldChange}
                 disabled={readOnly}
                 placeholder='Select field'
@@ -143,31 +172,16 @@ const ConditionItem = ({
           <div className='mx-1 h-3 w-[1px] bg-divider'></div>
 
           <ConditionOperator
-            fieldId={condition.fieldId}
+            fieldId={resolvedFieldId}
             value={condition.operator}
             onChange={handleOperatorChange}
-            disabled={!condition.fieldId || readOnly}
+            disabled={!resolvedFieldId || readOnly}
           />
+
+          {isInline && valueBlock}
         </div>
 
-        {fieldDef && operatorRequiresValue(condition.operator) && (
-          <div
-            className={cn(
-              'border-t border-t-divider px-1 py-0.5',
-              isHovered && 'border-destructive/20',
-              compactMode && 'max-h-[60px] overflow-y-auto'
-            )}>
-            <ValueInput
-              condition={condition}
-              field={fieldDef}
-              value={condition.value}
-              onChange={handleValueChange}
-              disabled={readOnly}
-              nodeId={nodeId}
-              className='text-xs'
-            />
-          </div>
-        )}
+        {!isInline && valueBlock}
       </div>
 
       {showRemoveButton && !readOnly && (

--- a/apps/web/src/components/conditions/inputs/value-input.tsx
+++ b/apps/web/src/components/conditions/inputs/value-input.tsx
@@ -33,7 +33,8 @@ const ValueInput = ({
         onChange={(val) => onChange(val, true)} // Resource is always constant mode
         disabled={disabled}
         placeholder={placeholder}
-        className={className}
+        inputClassName={className}
+        triggerProps={className ? { className } : undefined}
       />
     )
   }

--- a/apps/web/src/components/conditions/types.ts
+++ b/apps/web/src/components/conditions/types.ts
@@ -88,6 +88,8 @@ export interface ConditionSystemConfig {
   showLogicalOperators?: boolean
   showGrouping?: boolean
   compactMode?: boolean
+  /** How to display the value input: 'inline' next to operator, 'stacked' below (default) */
+  display?: 'inline' | 'stacked'
   readOnly?: boolean
   allowGroupNaming?: boolean
   allowGroupCollapse?: boolean

--- a/apps/web/src/components/global/notifications/notification-center.tsx
+++ b/apps/web/src/components/global/notifications/notification-center.tsx
@@ -15,6 +15,7 @@ import { Bell, Check, Mail as MailIcon, Play, Trash } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 // components/notifications/notification-center.tsx
 import { useEffect, useState } from 'react'
+import { EmptyState } from '~/components/global/empty-state'
 import { HumanConfirmationDialog } from '~/components/workflow/dialogs/human-confirmation-dialog'
 import { api } from '~/trpc/react'
 
@@ -80,21 +81,18 @@ const NotificationItem = ({
   }
   return (
     <div
-      className={`group/item flex relative cursor-pointer items-start gap-1 px-2 py-2 hover:bg-primary-150 ${isRead ? 'opacity-70' : 'bg-blue-50'} `}
+      className={`group/item flex cursor-pointer items-start gap-1 px-2 py-2 hover:bg-primary-150 ${isRead ? 'opacity-70' : 'bg-blue-50 dark:bg-blue-900'} `}
       onClick={handleClick}>
-      <EntityIcon
-        {...(NOTIFICATION_ICON_MAP[type as NotificationType] ?? DEFAULT_NOTIFICATION_ICON)}
-        size='sm'
-        className='mt-1 me-1'
-      />
+      <div className='flex flex-col items-center gap-1 mt-1 me-1'>
+        <EntityIcon
+          {...(NOTIFICATION_ICON_MAP[type as NotificationType] ?? DEFAULT_NOTIFICATION_ICON)}
+          size='sm'
+        />
+        {!isRead && <span className='size-2 rounded-full bg-blue-500' />}
+      </div>
 
       <div className='min-w-0 grow'>
-        <div className='flex items-start justify-between'>
-          <p className='truncate text-sm font-medium'>{message}</p>
-          <div className='ml-2 flex shrink-0 gap-1'>
-            {!isRead && <span className='bg-info size-2 rounded-full bg-blue-500 shrink-0' />}
-          </div>
-        </div>
+        <p className='text-sm font-medium'>{message}</p>
 
         <div className='mt-1 flex items-center'>
           {actor && (
@@ -118,7 +116,7 @@ const NotificationItem = ({
       <Button
         variant='ghost'
         size='icon-sm'
-        className='absolute right-1 top-1 opacity-0 group-hover/item:opacity-100 hover:bg-destructive/20 hover:text-destructive border border-transparent hover:border-destructive/50'
+        className='shrink-0 opacity-0 group-hover/item:opacity-100 hover:bg-destructive/20 hover:text-destructive border border-transparent hover:border-destructive/50'
         onClick={(e) => {
           e.stopPropagation()
           onDelete(id)
@@ -297,21 +295,26 @@ export const NotificationCenter = () => {
             </RadioTab>
           </div>
 
-          <div className='m-0 flex-1'>
-            <div className='max-h-96 overflow-y-auto'>
-              {isLoading ? (
-                <>
-                  <NotificationSkeleton />
-                  <NotificationSkeleton />
-                  <NotificationSkeleton />
-                </>
-              ) : mode === 'all' ? (
-                data?.notifications.length === 0 ? (
-                  <div className='p-4 flex justify-center items-center text-center text-gray-500 text-sm'>
-                    No notifications yet
-                  </div>
-                ) : (
-                  data?.notifications.map((notification) => (
+          <div className='flex flex-col m-0 flex-1'>
+            {isLoading ? (
+              <div className='max-h-96 overflow-y-auto'>
+                <NotificationSkeleton />
+                <NotificationSkeleton />
+                <NotificationSkeleton />
+              </div>
+            ) : mode === 'all' ? (
+              data?.notifications.length === 0 ? (
+                <div className='flex flex-1 items-center justify-center'>
+                  <EmptyState
+                    icon={Bell}
+                    title='No notifications yet'
+                    className='py-8'
+                    iconClassName='h-8 w-8'
+                  />
+                </div>
+              ) : (
+                <div className='max-h-96 overflow-y-auto'>
+                  {data?.notifications.map((notification) => (
                     <NotificationItem
                       key={notification.id!}
                       notification={notification}
@@ -319,15 +322,22 @@ export const NotificationCenter = () => {
                       onDelete={handleDelete}
                       onOpenApprovalDialog={openHumanConfirmationDialog}
                     />
-                  ))
-                )
-              ) : mode === 'unread' ? (
-                data?.notifications.length === 0 ? (
-                  <div className='p-4 flex justify-center items-center text-center text-gray-500 text-sm'>
-                    No unread notifications
-                  </div>
-                ) : (
-                  data?.notifications
+                  ))}
+                </div>
+              )
+            ) : mode === 'unread' ? (
+              data?.notifications.filter((n) => !n.isRead).length === 0 ? (
+                <div className='flex flex-1 items-center justify-center'>
+                  <EmptyState
+                    icon={Bell}
+                    title='No unread notifications'
+                    className='py-8'
+                    iconClassName='h-8 w-8'
+                  />
+                </div>
+              ) : (
+                <div className='max-h-96 overflow-y-auto'>
+                  {data?.notifications
                     .filter((notification) => !notification.isRead)
                     .map((notification) => (
                       <NotificationItem
@@ -337,10 +347,10 @@ export const NotificationCenter = () => {
                         onDelete={handleDelete}
                         onOpenApprovalDialog={openHumanConfirmationDialog}
                       />
-                    ))
-                )
-              ) : null}
-            </div>
+                    ))}
+                </div>
+              )
+            ) : null}
 
             {data?.totalCount && data.totalCount > 10 ? (
               <div className='p-2 text-center'>

--- a/apps/web/src/components/global/sidebar/views-group.tsx
+++ b/apps/web/src/components/global/sidebar/views-group.tsx
@@ -38,6 +38,7 @@ import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
 import { useMailCountsStore } from '~/components/mail/store'
 import { MailViewDialog } from '~/components/mail-views/mail-view-dialog'
 import { useConfirm } from '~/hooks/use-confirm'
+import { api } from '~/trpc/react'
 import { useSidebarStateContext } from './sidebar-state-context'
 
 // import { useDndState } from '~/context/dnd-state-context'; // <-- IMPORT NEW HOOK

--- a/apps/web/src/components/mail-views/mail-view-filter-builder.tsx
+++ b/apps/web/src/components/mail-views/mail-view-filter-builder.tsx
@@ -25,22 +25,7 @@ export function MailViewFilterBuilder() {
   // Watch the filter groups from form state
   const filterGroups = watch('filterGroups') as ConditionGroup[] | undefined
 
-  // Convert field definitions to the format expected by ConditionProvider
-  const fieldDefinitions = useMemo(
-    () =>
-      MAIL_VIEW_FIELD_DEFINITIONS.map((field) => ({
-        id: field.id,
-        label: field.label,
-        type: field.type,
-        fieldType: field.fieldType,
-        operators: field.operators,
-        options: field.options,
-        targetTable: field.targetTable,
-        placeholder: field.placeholder,
-        description: field.description,
-      })),
-    []
-  )
+  const fieldDefinitions = MAIL_VIEW_FIELD_DEFINITIONS
 
   // Condition system config for mail view filters
   const config: ConditionSystemConfig = useMemo(
@@ -64,6 +49,7 @@ export function MailViewFilterBuilder() {
       // No variable mode for mail views
       allowVarEditor: false,
       allowConstantToggle: false,
+      display: 'inline',
     }),
     [fieldDefinitions]
   )
@@ -157,8 +143,6 @@ export function MailViewFilterBuilder() {
           emptyStateText='No filters added yet. Add conditions to filter threads.'
           showAddButton
           showGrouping
-          addConditionText='Add Condition'
-          addGroupText='Add Group'
         />
       </ConditionProvider>
     </div>

--- a/apps/web/src/components/mail/thread-header.tsx
+++ b/apps/web/src/components/mail/thread-header.tsx
@@ -208,12 +208,7 @@ export function ThreadHeader() {
               onChange={handleInboxChange}
               selected={thread?.inboxId ? [thread.inboxId] : undefined}
               allowMultiple={false}>
-              <RecordBadge recordId={thread?.inboxId} size='sm' className='me-2' />
-              {/* <Badge
-                variant="blue"
-                className="cursor-pointer data-[state=open]:brightness-90 shrink-0 text-nowrap rounded-full">
-                {inbox?.name || 'Loading...'}
-              </Badge> */}
+              <RecordBadge recordId={thread?.inboxId} className='me-2' />
             </InboxPicker>
           </div>
           <div className=' flex items-center '>

--- a/apps/web/src/components/workflow/dialogs/variable-editor-dialog.tsx
+++ b/apps/web/src/components/workflow/dialogs/variable-editor-dialog.tsx
@@ -252,51 +252,6 @@ export function VariableEditorDialog({ open, onOpenChange }: VariableEditorDialo
     }
   }, [open])
 
-  // Handle keyboard shortcuts
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (!open || isEditing) return
-
-      // Check if user is typing in an input field
-      const target = event.target as HTMLElement
-      const isInputField =
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.contentEditable === 'true' ||
-        target.getAttribute('role') === 'textbox'
-
-      if (isInputField) return
-
-      if (event.key === 'Delete') {
-        event.preventDefault()
-        if (bulkSelectMode && selectedVariableIds.size > 0) {
-          handleBulkDelete()
-        } else if (selectedVariableId) {
-          handleDelete(selectedVariableId)
-        }
-      }
-
-      if (event.key === 'Escape' && bulkSelectMode) {
-        event.preventDefault()
-        setBulkSelectMode(false)
-        setSelectedVariableIds(new Set())
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [
-    open,
-    isEditing,
-    selectedVariableId,
-    bulkSelectMode,
-    selectedVariableIds,
-    // biome-ignore lint/correctness/useExhaustiveDependencies: handler functions are intentionally used as dependencies
-    handleBulkDelete,
-    // biome-ignore lint/correctness/useExhaustiveDependencies: handler function is intentionally used as dependency
-    handleDelete,
-  ])
-
   const handleEdit = (variable: EnvVar) => {
     setEditingVariable(variable)
 
@@ -474,6 +429,49 @@ export function VariableEditorDialog({ open, onOpenChange }: VariableEditorDialo
       }
     }
   }
+
+  // Handle keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!open || isEditing) return
+
+      // Check if user is typing in an input field
+      const target = event.target as HTMLElement
+      const isInputField =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.contentEditable === 'true' ||
+        target.getAttribute('role') === 'textbox'
+
+      if (isInputField) return
+
+      if (event.key === 'Delete') {
+        event.preventDefault()
+        if (bulkSelectMode && selectedVariableIds.size > 0) {
+          handleBulkDelete()
+        } else if (selectedVariableId) {
+          handleDelete(selectedVariableId)
+        }
+      }
+
+      if (event.key === 'Escape' && bulkSelectMode) {
+        event.preventDefault()
+        setBulkSelectMode(false)
+        setSelectedVariableIds(new Set())
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [
+    open,
+    isEditing,
+    selectedVariableId,
+    bulkSelectMode,
+    selectedVariableIds,
+    handleBulkDelete,
+    handleDelete,
+  ])
 
   const handleSelectAll = () => {
     if (selectedVariableIds.size === envVariables.length) {

--- a/apps/web/src/components/workflow/index.ts
+++ b/apps/web/src/components/workflow/index.ts
@@ -6,13 +6,6 @@ export { WorkflowToolbar } from './canvas/workflow-toolbar'
 // Main editor component
 export { WorkflowEditor } from './editor/workflow-editor'
 
-// export { NodePalette } from './canvas/node-palette'
-
-// Panel components
-// export { PropertyPanel } from './panels/property-panel'
-// export { VariablePanel } from './panels/variable-panel'
-// export { DebugPanel } from './panels/debug-panel'
-
 // Node system exports
 export * from './nodes'
 // Store exports

--- a/apps/web/src/components/workflow/nodes/core/ai/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/ai/schema.ts
@@ -12,7 +12,6 @@ import {
 import { NodeType } from '~/components/workflow/types/node-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { AiPanel } from './panel'
 import { AiModelMode, type AiNodeData, PromptRole } from './types'
 
 /**
@@ -332,7 +331,6 @@ export const aiDefinition: NodeDefinition<AiNodeData> = {
   schema: aiSchema,
   dataSchema: aiNodeDataSchema,
   // validate: validateAiConfig,
-  panel: AiPanel,
   validator: validateAiData,
   canRunSingle: true,
   extractVariables: (data: AiNodeData) => extractAIVariableIds(data),

--- a/apps/web/src/components/workflow/nodes/core/answer/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/answer/schema.ts
@@ -11,7 +11,6 @@ import { NodeType } from '~/components/workflow/types/node-types'
 import { BaseType } from '~/components/workflow/types/variable-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { AnswerPanel } from './panel'
 import type { AnswerNodeData } from './types'
 
 /**
@@ -215,7 +214,6 @@ export const answerDefinition: NodeDefinition<AnswerNodeData> = {
   color: '#10b981', // ACTION category color
   defaultData: answerDefaultData,
   schema: answerNodeDataSchema,
-  panel: AnswerPanel,
   validator: validateAnswerConfig,
   canRunSingle: true,
   extractVariables: extractAnswerVariables,

--- a/apps/web/src/components/workflow/nodes/core/chunker/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/chunker/schema.ts
@@ -11,7 +11,6 @@ import { NodeType } from '~/components/workflow/types/node-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { isNodeVariable, isVariableMode } from '~/components/workflow/utils/variable-utils'
 import { getChunkerOutputVariables } from './output-variables'
-import { ChunkerPanel } from './panel'
 import type { ChunkerNodeData } from './types'
 
 /**
@@ -182,7 +181,6 @@ export const chunkerDefinition: NodeDefinition<ChunkerNodeData> = {
   canRunSingle: true,
   defaultData: chunkerDefaultData,
   schema: chunkerNodeDataSchema,
-  panel: ChunkerPanel,
   validator: validateChunkerConfig,
   extractVariables: extractChunkerVariables,
   outputVariables: (data: ChunkerNodeData, nodeId: string) =>

--- a/apps/web/src/components/workflow/nodes/core/code/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/code/schema.ts
@@ -10,7 +10,6 @@ import {
   type ValidationResult,
 } from '~/components/workflow/types'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { CodePanel } from './panel'
 import type { CodeNodeData } from './types'
 
 /**
@@ -197,7 +196,6 @@ export const codeDefinition: NodeDefinition<CodeNodeData> = {
   color: '#8B5CF6', // TRANSFORM category color
   defaultData: codeDefaultData,
   schema: codeNodeDataSchema,
-  panel: CodePanel,
   validator: validateCodeConfig as any,
   canRunSingle: true,
   extractVariables: extractCodeVariables as any,

--- a/apps/web/src/components/workflow/nodes/core/crud/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/crud/schema.ts
@@ -5,7 +5,6 @@ import { NodeType } from '~/components/workflow/types/node-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { isNodeVariable } from '~/components/workflow/utils/variable-utils'
 import { getCrudNodeOutputVariables } from './output-variables'
-import { CrudPanel } from './panel'
 import { type CrudNodeData, createCrudNodeDefaultData, crudNodeDataSchema } from './types'
 import { validateCrudNodeConfig } from './validation'
 /**
@@ -59,7 +58,6 @@ export const crudDefinition: NodeDefinition<CrudNodeData> = {
   canRunSingle: true,
   defaultData: createCrudNodeDefaultData(),
   schema: crudNodeDataSchema,
-  panel: CrudPanel,
   validator: validateCrudNodeConfig,
   extractVariables: extractCrudVariables,
   outputVariables: (data: CrudNodeData, nodeId: string, resource, allResources) =>

--- a/apps/web/src/components/workflow/nodes/core/dataset/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/dataset/schema.ts
@@ -7,7 +7,6 @@ import { NodeType } from '~/components/workflow/types/node-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { isNodeVariable, isVariableMode } from '~/components/workflow/utils/variable-utils'
 import { getDatasetOutputVariables } from './output-variables'
-import { DatasetPanel } from './panel'
 import type { DatasetNodeData } from './types'
 
 /**
@@ -115,7 +114,6 @@ export const datasetDefinition: NodeDefinition<DatasetNodeData> = {
   canRunSingle: true,
   defaultData: datasetDefaultData,
   schema: datasetNodeDataSchema,
-  panel: DatasetPanel,
   extractVariables: extractDatasetVariables,
   outputVariables: (data: DatasetNodeData, nodeId: string) =>
     getDatasetOutputVariables(data, nodeId),

--- a/apps/web/src/components/workflow/nodes/core/date-time/index.ts
+++ b/apps/web/src/components/workflow/nodes/core/date-time/index.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/nodes/core/date-time/index.ts
 
 export { DateTimeNode } from './node'
+export { DateTimePanel } from './panel'
 export { dateTimeNodeDefinition } from './schema'
 export type { DateTimeNodeData } from './types'

--- a/apps/web/src/components/workflow/nodes/core/date-time/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/date-time/schema.ts
@@ -7,7 +7,6 @@ import { NodeCategory } from '~/components/workflow/types/registry'
 import { BaseType } from '~/components/workflow/types/variable-types'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
 import { DEFAULT_DURATION, DEFAULT_PARSE_FORMAT_TYPE } from './constants'
-import { DateTimePanel } from './panel'
 import {
   DateFormatType,
   type DateTimeNodeData,
@@ -252,7 +251,6 @@ export const dateTimeNodeDefinition: NodeDefinition<DateTimeNodeData> = {
   color: '#3B82F6', // UTILITY category color
   defaultData: createDateTimeNodeDefaultData(),
   schema: dateTimeNodeSchema,
-  panel: DateTimePanel,
   validator: validateDateTimeNodeData,
   canRunSingle: true,
   extractVariables: extractDateTimeNodeVariables,

--- a/apps/web/src/components/workflow/nodes/core/document-extractor/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/document-extractor/schema.ts
@@ -7,7 +7,6 @@ import { NodeType } from '~/components/workflow/types/node-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { isNodeVariable, isVariableMode } from '~/components/workflow/utils/variable-utils'
 import { getDocumentExtractorOutputVariables } from './output-variables'
-import { DocumentExtractorPanel } from './panel'
 import { type DocumentExtractorNodeData, DocumentSourceType } from './types'
 
 /**
@@ -116,7 +115,6 @@ export const documentExtractorDefinition: NodeDefinition<DocumentExtractorNodeDa
   canRunSingle: true,
   defaultData: documentExtractorDefaultData,
   schema: documentExtractorNodeDataSchema,
-  panel: DocumentExtractorPanel,
   extractVariables: extractDocumentExtractorVariables,
   outputVariables: (data: DocumentExtractorNodeData, nodeId: string) =>
     getDocumentExtractorOutputVariables(data, nodeId),

--- a/apps/web/src/components/workflow/nodes/core/end/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/end/schema.ts
@@ -6,7 +6,6 @@ import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/t
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
 import { BaseType, NodeCategory, type NodeDefinition, type ValidationResult } from '../../../types'
 import { NodeType } from '../../../types/node-types'
-import { EndPanel } from './panel'
 import type { EndNodeData } from './types'
 
 /**
@@ -93,7 +92,6 @@ export const endDefinition: NodeDefinition<EndNodeData> = {
   color: '#10b981', // ACTION category color
   defaultData: endDefaultData,
   schema: endNodeDataSchema,
-  panel: EndPanel,
   validator: validateEndConfig,
   canRunSingle: true,
   extractVariables: extractEndVariables,

--- a/apps/web/src/components/workflow/nodes/core/find/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/find/schema.ts
@@ -5,7 +5,6 @@ import { NodeCategory, type NodeDefinition } from '~/components/workflow/types'
 import { NodeType } from '~/components/workflow/types/node-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { getFindNodeOutputVariables } from './output-variables'
-import { FindPanel } from './panel'
 import { createFindNodeDefaultData, type FindNodeData, findNodeDataSchema } from './types'
 import { validateFindNodeConfig } from './validation'
 
@@ -69,7 +68,6 @@ export const findDefinition: NodeDefinition<FindNodeData> = {
   canRunSingle: true, // Can run as a single node
   defaultData: createFindNodeDefaultData(),
   schema: findNodeDataSchema,
-  panel: FindPanel,
   extractVariables: extractFindVariables,
   validator: validateFindNodeConfig,
   outputVariables: (data: FindNodeData, nodeId: string, resource, allResources) =>

--- a/apps/web/src/components/workflow/nodes/core/http/index.ts
+++ b/apps/web/src/components/workflow/nodes/core/http/index.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/nodes/core/http/index.ts
 
 export { HttpNode } from './node'
+export { HttpNodePanel } from './panel'
 export { httpNodeDefinition } from './schema'
 export type { HttpNodeConfig, HttpNodeData } from './types'

--- a/apps/web/src/components/workflow/nodes/core/http/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/http/schema.ts
@@ -9,7 +9,6 @@ import type { OutputVariable } from '~/components/workflow/types/variable-types'
 import { BaseType } from '~/components/workflow/types/variable-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { HttpNodePanel } from './panel'
 import { AuthType, BodyType, ErrorStrategy, type HttpNodeData, Method } from './types'
 
 // Zod schema for validation (config - deprecated)
@@ -400,7 +399,6 @@ export const httpNodeDefinition: NodeDefinition<HttpNodeData> = {
   color: '#3B82F6', // UTILITY category color
   defaultData: createHttpDefaultData(),
   schema: httpNodeDataSchema,
-  panel: HttpNodePanel,
   validator: validateHttpNodeData,
   canRunSingle: true,
   extractVariables: extractHttpVariableIds,

--- a/apps/web/src/components/workflow/nodes/core/human/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/human/schema.ts
@@ -10,7 +10,6 @@ import {
 import { baseNodeDataSchema } from '~/components/workflow/types/node-base'
 import { NodeType } from '~/components/workflow/types/node-types'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { HumanConfirmationNodePanel } from './panel'
 import type { HumanConfirmationNodeData } from './types'
 
 /**
@@ -209,7 +208,6 @@ export const humanConfirmationDefinition: NodeDefinition<HumanConfirmationNodeDa
   color: '#f59e0b', // CONDITION category color
   defaultData: humanConfirmationDefaultData,
   schema: humanConfirmationNodeDataSchema,
-  panel: HumanConfirmationNodePanel,
   validator: validateHumanConfirmationConfig,
   canRunSingle: false,
   extractVariables: () => [], // Human confirmation doesn't extract variables

--- a/apps/web/src/components/workflow/nodes/core/if-else/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/if-else/schema.ts
@@ -11,7 +11,6 @@ import {
 } from '~/components/workflow/types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { createUnifiedOutputVariable } from '../../../utils/variable-conversion'
-import { IfElsePanel } from './panel'
 import type { IfElseNodeData } from './types'
 
 /**
@@ -208,7 +207,6 @@ export const ifElseDefinition: NodeDefinition<IfElseNodeData> = {
   color: '#f59e0b', // CONDITION category color
   defaultData: ifElseDefaultData,
   schema: ifElseNodeDataSchema,
-  panel: IfElsePanel,
   validator: validateIfElseConfig as any,
   canRunSingle: true,
   extractVariables: extractIfElseVariableIds as any,

--- a/apps/web/src/components/workflow/nodes/core/index.ts
+++ b/apps/web/src/components/workflow/nodes/core/index.ts
@@ -2,47 +2,75 @@
 
 import type { NodeProps } from '@xyflow/react'
 import type { ComponentType } from 'react'
-import { AiNode } from '~/components/workflow/nodes/core/ai'
-import { AnswerNode } from '~/components/workflow/nodes/core/answer'
-import { CodeNode } from '~/components/workflow/nodes/core/code'
-import { DateTimeNode } from '~/components/workflow/nodes/core/date-time'
-import { EndNode } from '~/components/workflow/nodes/core/end'
-import { HttpNode } from '~/components/workflow/nodes/core/http'
-import { HumanConfirmationNode } from '~/components/workflow/nodes/core/human'
-// Import all node components directly
-import { IfElseNode } from '~/components/workflow/nodes/core/if-else'
-import { InformationExtractorNode } from '~/components/workflow/nodes/core/information-extractor'
-import { ListNode } from '~/components/workflow/nodes/core/list'
-import { LoopNode } from '~/components/workflow/nodes/core/loop'
-import { MessageReceivedNode } from '~/components/workflow/nodes/core/message-received'
-import { NoteNode } from '~/components/workflow/nodes/core/note'
-import { TextClassifierNode } from '~/components/workflow/nodes/core/text-classifier'
-import { VarAssignNode } from '~/components/workflow/nodes/core/var-assign'
-import { WaitNode } from '~/components/workflow/nodes/core/wait'
-import { WebhookNode } from '~/components/workflow/nodes/core/webhook'
+import { AiNode, AiPanel } from '~/components/workflow/nodes/core/ai'
+import { AnswerNode, AnswerPanel } from '~/components/workflow/nodes/core/answer'
+import { CodeNode, CodePanel } from '~/components/workflow/nodes/core/code'
+import { DateTimeNode, DateTimePanel } from '~/components/workflow/nodes/core/date-time'
+import { EndNode, EndPanel } from '~/components/workflow/nodes/core/end'
+import { HttpNode, HttpNodePanel } from '~/components/workflow/nodes/core/http'
+import {
+  HumanConfirmationNode,
+  HumanConfirmationNodePanel,
+} from '~/components/workflow/nodes/core/human'
+// Import all node components and panels directly
+import { IfElseNode, IfElsePanel } from '~/components/workflow/nodes/core/if-else'
+import {
+  InformationExtractorNode,
+  InformationExtractorPanel,
+} from '~/components/workflow/nodes/core/information-extractor'
+import { ListNode, ListPanel } from '~/components/workflow/nodes/core/list'
+import { LoopNode, LoopPanel } from '~/components/workflow/nodes/core/loop'
+import {
+  MessageReceivedNode,
+  MessageReceivedPanel,
+} from '~/components/workflow/nodes/core/message-received'
+import { NoteNode, NotePanel } from '~/components/workflow/nodes/core/note'
+import {
+  TextClassifierNode,
+  TextClassifierPanel,
+} from '~/components/workflow/nodes/core/text-classifier'
+import { VarAssignNode, VarAssignPanel } from '~/components/workflow/nodes/core/var-assign'
+import { WaitNode, WaitNodePanel } from '~/components/workflow/nodes/core/wait'
+import { WebhookNode, WebhookPanel } from '~/components/workflow/nodes/core/webhook'
 import { type NodeDefinition, NodeType } from '~/components/workflow/types'
 import { aiDefinition } from './ai'
 import { answerDefinition } from './answer'
-import { ChunkerNode, chunkerDefinition } from './chunker'
+import { ChunkerNode, ChunkerPanel, chunkerDefinition } from './chunker'
 import { codeDefinition } from './code'
-import { CrudNode, crudDefinition } from './crud'
-import { DatasetNode, datasetDefinition } from './dataset'
+import { CrudNode, CrudPanel, crudDefinition } from './crud'
+import { DatasetNode, DatasetPanel, datasetDefinition } from './dataset'
 import { dateTimeNodeDefinition } from './date-time'
-import { DocumentExtractorNode, documentExtractorDefinition } from './document-extractor'
+import {
+  DocumentExtractorNode,
+  DocumentExtractorPanel,
+  documentExtractorDefinition,
+} from './document-extractor'
 import { endDefinition } from './end'
-import { FindNode, findDefinition } from './find'
+import { FindNode, FindPanel, findDefinition } from './find'
 import { httpNodeDefinition } from './http'
 import { humanConfirmationDefinition } from './human'
 import { ifElseDefinition } from './if-else'
 import { informationExtractorDefinition } from './information-extractor'
-import { KnowledgeRetrievalNode, knowledgeRetrievalDefinition } from './knowledge-retrieval'
+import {
+  KnowledgeRetrievalNode,
+  KnowledgeRetrievalPanel,
+  knowledgeRetrievalDefinition,
+} from './knowledge-retrieval'
 import { listNodeDefinition } from './list'
 import { loopDefinition } from './loop'
-import { ManualNode, manualDefinition } from './manual'
+import { ManualNode, ManualPanel, manualDefinition } from './manual'
 import { messageReceivedDefinition } from './message-received'
 import { noteDefinition } from './note'
-import { ResourceTriggerNode, resourceTriggerDefinition } from './resource-trigger'
-import { ScheduledTriggerNode, scheduledTriggerDefinition } from './scheduled'
+import {
+  ResourceTriggerNode,
+  ResourceTriggerPanel,
+  resourceTriggerDefinition,
+} from './resource-trigger'
+import {
+  ScheduledTriggerNode,
+  ScheduledTriggerPanel,
+  scheduledTriggerDefinition,
+} from './scheduled'
 import { textClassifierDefinition } from './text-classifier'
 import { varAssignDefinition } from './var-assign'
 import { waitDefinition } from './wait'
@@ -68,32 +96,48 @@ import {
  */
 export const NODE_DEFINITIONS: NodeDefinition[] = [
   // Core workflow nodes
-  { ...answerDefinition, component: AnswerNode },
-  { ...codeDefinition, component: CodeNode },
-  { ...ifElseDefinition, component: IfElseNode },
-  { ...messageReceivedDefinition, component: MessageReceivedNode },
-  { ...webhookDefinition, component: WebhookNode },
-  { ...scheduledTriggerDefinition, component: ScheduledTriggerNode },
-  { ...manualDefinition, component: ManualNode },
-  { ...resourceTriggerDefinition, component: ResourceTriggerNode },
-  { ...aiDefinition, component: AiNode },
-  { ...endDefinition, component: EndNode },
-  { ...noteDefinition, component: NoteNode },
-  { ...textClassifierDefinition, component: TextClassifierNode },
-  { ...informationExtractorDefinition, component: InformationExtractorNode },
-  { ...varAssignDefinition, component: VarAssignNode },
-  { ...dateTimeNodeDefinition, component: DateTimeNode },
-  { ...httpNodeDefinition, component: HttpNode },
-  { ...waitDefinition, component: WaitNode },
-  { ...listNodeDefinition, component: ListNode },
-  { ...loopDefinition, component: LoopNode },
-  { ...humanConfirmationDefinition, component: HumanConfirmationNode },
-  { ...findDefinition, component: FindNode },
-  { ...crudDefinition, component: CrudNode },
-  { ...documentExtractorDefinition, component: DocumentExtractorNode },
-  { ...chunkerDefinition, component: ChunkerNode },
-  { ...datasetDefinition, component: DatasetNode },
-  { ...knowledgeRetrievalDefinition, component: KnowledgeRetrievalNode },
+  { ...answerDefinition, component: AnswerNode, panel: AnswerPanel },
+  { ...codeDefinition, component: CodeNode, panel: CodePanel },
+  { ...ifElseDefinition, component: IfElseNode, panel: IfElsePanel },
+  { ...messageReceivedDefinition, component: MessageReceivedNode, panel: MessageReceivedPanel },
+  { ...webhookDefinition, component: WebhookNode, panel: WebhookPanel },
+  { ...scheduledTriggerDefinition, component: ScheduledTriggerNode, panel: ScheduledTriggerPanel },
+  { ...manualDefinition, component: ManualNode, panel: ManualPanel },
+  { ...resourceTriggerDefinition, component: ResourceTriggerNode, panel: ResourceTriggerPanel },
+  { ...aiDefinition, component: AiNode, panel: AiPanel },
+  { ...endDefinition, component: EndNode, panel: EndPanel },
+  { ...noteDefinition, component: NoteNode, panel: NotePanel },
+  { ...textClassifierDefinition, component: TextClassifierNode, panel: TextClassifierPanel },
+  {
+    ...informationExtractorDefinition,
+    component: InformationExtractorNode,
+    panel: InformationExtractorPanel,
+  },
+  { ...varAssignDefinition, component: VarAssignNode, panel: VarAssignPanel },
+  { ...dateTimeNodeDefinition, component: DateTimeNode, panel: DateTimePanel },
+  { ...httpNodeDefinition, component: HttpNode, panel: HttpNodePanel },
+  { ...waitDefinition, component: WaitNode, panel: WaitNodePanel },
+  { ...listNodeDefinition, component: ListNode, panel: ListPanel as any },
+  { ...loopDefinition, component: LoopNode, panel: LoopPanel },
+  {
+    ...humanConfirmationDefinition,
+    component: HumanConfirmationNode,
+    panel: HumanConfirmationNodePanel,
+  },
+  { ...findDefinition, component: FindNode, panel: FindPanel },
+  { ...crudDefinition, component: CrudNode, panel: CrudPanel },
+  {
+    ...documentExtractorDefinition,
+    component: DocumentExtractorNode,
+    panel: DocumentExtractorPanel,
+  },
+  { ...chunkerDefinition, component: ChunkerNode, panel: ChunkerPanel },
+  { ...datasetDefinition, component: DatasetNode, panel: DatasetPanel },
+  {
+    ...knowledgeRetrievalDefinition,
+    component: KnowledgeRetrievalNode,
+    panel: KnowledgeRetrievalPanel,
+  },
   // AppPlaceholder removed - using StandardNode fallback for unregistered app nodes instead
   ...INPUT_NODE_DEFINITIONS,
   // App integration nodes

--- a/apps/web/src/components/workflow/nodes/core/information-extractor/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/information-extractor/schema.ts
@@ -11,7 +11,6 @@ import { NodeType } from '~/components/workflow/types/node-types'
 import { BaseType, type UnifiedVariable } from '~/components/workflow/types/variable-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { InformationExtractorPanel } from './panel'
 import type { InformationExtractorNodeData } from './types'
 
 /**
@@ -362,7 +361,6 @@ export const informationExtractorDefinition: NodeDefinition<InformationExtractor
   schema: informationExtractorSchema,
   defaultData: createInformationExtractorDefaultData(),
   canRunSingle: true,
-  panel: InformationExtractorPanel,
   validator: validateInformationExtractor,
   extractVariables: extractInformationExtractorVariables,
   outputVariables: getInformationExtractorOutputVariables as any,

--- a/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/schema.ts
@@ -7,7 +7,6 @@ import { NodeType } from '~/components/workflow/types/node-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { isNodeVariable, isVariableMode } from '~/components/workflow/utils/variable-utils'
 import { getKnowledgeRetrievalOutputVariables } from './output-variables'
-import { KnowledgeRetrievalPanel } from './panel'
 import type { KnowledgeRetrievalNodeData } from './types'
 
 /**
@@ -122,7 +121,6 @@ export const knowledgeRetrievalDefinition: NodeDefinition<KnowledgeRetrievalNode
   canRunSingle: true,
   defaultData: knowledgeRetrievalDefaultData,
   schema: knowledgeRetrievalNodeDataSchema,
-  panel: KnowledgeRetrievalPanel,
   extractVariables: extractKnowledgeRetrievalVariables,
   outputVariables: (data: KnowledgeRetrievalNodeData, nodeId: string) =>
     getKnowledgeRetrievalOutputVariables(data, nodeId),

--- a/apps/web/src/components/workflow/nodes/core/list/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/list/schema.ts
@@ -5,7 +5,6 @@ import { NodeCategory, type NodeDefinition, NodeType } from '~/components/workfl
 import type { ValidationResult } from '../../../types'
 import { extractListVariables } from './extract-variables'
 import { computeListOutputVariables } from './output-variables'
-import { ListPanel } from './panel'
 import type { ListNodeData, ListOperation } from './types'
 
 /**
@@ -185,7 +184,6 @@ export const listNodeDefinition: NodeDefinition<ListNodeData> = {
   color: '#3B82F6', // UTILITY category color
   schema: listNodeSchema,
   defaultData: createListDefaultData(),
-  panel: ListPanel as any, // Type assertion needed due to NodePanelProps mismatch
   canRunSingle: true,
 
   /**

--- a/apps/web/src/components/workflow/nodes/core/loop/index.ts
+++ b/apps/web/src/components/workflow/nodes/core/loop/index.ts
@@ -2,5 +2,6 @@
 
 export { LOOP_CONSTANTS, LOOP_HANDLES, LOOP_VARIABLES } from './constants'
 export { LoopNode } from './node'
+export { LoopPanel } from './panel'
 export { loopDefinition } from './schema'
 export type { LoopContext, LoopNodeConfig, LoopNodeData, LoopProgress } from './types'

--- a/apps/web/src/components/workflow/nodes/core/loop/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/loop/schema.ts
@@ -10,7 +10,6 @@ import { NodeType } from '~/components/workflow/types/node-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
 import { LOOP_CONSTANTS } from './constants'
-import { LoopPanel } from './panel'
 import type { LoopNodeData } from './types'
 
 /**
@@ -178,7 +177,6 @@ export const loopDefinition: NodeDefinition<LoopNodeData> = {
   schema: loopConfigSchema,
   defaultData: loopDefaultData,
   canRunSingle: false, // Loops need context, can't run in isolation
-  panel: LoopPanel,
   validator: validateLoop,
   extractVariables: extractLoopVariables,
   outputVariables: getLoopOutputVariables,

--- a/apps/web/src/components/workflow/nodes/core/manual/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/manual/schema.ts
@@ -11,7 +11,6 @@ import { baseNodeDataSchema } from '~/components/workflow/types/node-base'
 import { NodeType } from '~/components/workflow/types/node-types'
 import { BaseType, type UnifiedVariable } from '~/components/workflow/types/variable-types'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { ManualPanel } from './panel'
 import type { ManualNodeData } from './types'
 
 /**
@@ -112,7 +111,6 @@ export const manualDefinition: NodeDefinition<ManualNodeData> = {
   schema: manualNodeDataSchema,
   defaultData: manualDefaultData,
   canRunSingle: false, // Triggers cannot be run individually
-  panel: ManualPanel,
   triggerType: WorkflowTriggerType.MANUAL,
   validator: validateManualData,
   outputVariables: getManualOutputVariables as any,

--- a/apps/web/src/components/workflow/nodes/core/message-received/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/message-received/schema.ts
@@ -10,7 +10,6 @@ import {
 } from '~/components/workflow/types'
 import { BaseType, type UnifiedVariable } from '../../../types/variable-types'
 import { createNestedVariable } from '../../../utils/variable-conversion'
-import { MessageReceivedPanel } from './panel'
 import type { MessageReceivedNodeData } from './types'
 
 /**
@@ -124,7 +123,6 @@ export const messageReceivedDefinition: NodeDefinition<MessageReceivedNodeData> 
   color: '#10b981', // TRIGGER category color
   defaultData: messageReceivedDefaultData,
   schema: messageReceivedNodeDataSchema,
-  panel: MessageReceivedPanel,
   validator: validateMessageReceivedConfig as any,
   triggerType: WorkflowTriggerType.MESSAGE_RECEIVED,
   outputVariables: getMessageReceivedOutputVariables as any,

--- a/apps/web/src/components/workflow/nodes/core/note/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/note/schema.ts
@@ -5,7 +5,6 @@ import { baseNodeDataSchema } from '~/components/workflow/types/node-base'
 import { NodeCategory, type NodeDefinition, type ValidationResult } from '../../../types'
 import { NodeType } from '../../../types/node-types'
 import { DEFAULT_NOTE_HEIGHT, DEFAULT_NOTE_WIDTH } from './constants'
-import { NotePanel } from './panel'
 import type { NoteNodeData, NoteTheme } from './types'
 
 /**
@@ -56,7 +55,6 @@ export const noteDefinition: NodeDefinition<NoteNodeData> = {
   color: '#FBBF24',
   defaultData: noteDefaultData,
   schema: noteNodeDataSchema,
-  panel: NotePanel,
   validator: validateNoteConfig,
   canConnect: false, // Note nodes can be added to canvas but cannot connect to other blocks
   // Custom properties for note nodes

--- a/apps/web/src/components/workflow/nodes/core/resource-trigger/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/resource-trigger/schema.ts
@@ -3,7 +3,6 @@
 import { WorkflowTriggerType } from '@auxx/lib/workflow-engine/types'
 import { NodeCategory, type NodeDefinition } from '~/components/workflow/types'
 import { getResourceTriggerOutputVariables } from './output-variables'
-import { ResourceTriggerPanel } from './panel'
 import {
   type ResourceTriggerData,
   resourceTriggerNodeDataSchema,
@@ -110,7 +109,6 @@ export const resourceTriggerDefinition: NodeDefinition<ResourceTriggerData> = {
   color: '#10b981',
   defaultData: createResourceTriggerDefaultData('contact', 'created'),
   schema: resourceTriggerNodeDataSchema,
-  panel: ResourceTriggerPanel,
   validator: validateResourceTriggerConfig,
   triggerType: WorkflowTriggerType.RESOURCE_TRIGGER,
   // Pattern: Accepts resource context from var store for dynamic variable generation

--- a/apps/web/src/components/workflow/nodes/core/scheduled/index.ts
+++ b/apps/web/src/components/workflow/nodes/core/scheduled/index.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/nodes/core/scheduled-trigger/index.ts
 
 export { ScheduledTriggerNode } from './node'
+export { ScheduledTriggerPanel } from './panel'
 export { scheduledTriggerDefinition } from './schema'
 export type { ScheduledTriggerNodeData, ScheduledTriggerUIConfig } from './types'

--- a/apps/web/src/components/workflow/nodes/core/scheduled/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/scheduled/schema.ts
@@ -11,7 +11,6 @@ import { baseNodeDataSchema } from '~/components/workflow/types/node-base'
 import { NodeType } from '~/components/workflow/types/node-types'
 import { BaseType, type UnifiedVariable } from '~/components/workflow/types/variable-types'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { ScheduledTriggerPanel } from './panel'
 import type { ScheduledTriggerNodeData } from './types'
 
 /**
@@ -252,7 +251,6 @@ export const scheduledTriggerDefinition: NodeDefinition<ScheduledTriggerNodeData
   schema: scheduledTriggerNodeDataSchema,
   defaultData: scheduledTriggerDefaultData,
   canRunSingle: false,
-  panel: ScheduledTriggerPanel,
   triggerType: WorkflowTriggerType.SCHEDULED,
   validator: validateScheduledTriggerData,
   extractVariables: extractScheduledTriggerVariables,

--- a/apps/web/src/components/workflow/nodes/core/text-classifier/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/text-classifier/schema.ts
@@ -11,7 +11,6 @@ import {
 import { NodeType } from '~/components/workflow/types/node-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { TextClassifierPanel } from './panel'
 import { AiModelMode, type TextClassifierNodeData } from './types'
 
 /**
@@ -283,7 +282,6 @@ export const textClassifierDefinition: NodeDefinition<TextClassifierNodeData> = 
   color: '#f59e0b', // CONDITION category color
   defaultData: createTextClassifierDefaultData(),
   schema: textClassifierSchema,
-  panel: TextClassifierPanel,
   validator: validateTextClassifierData,
   canRunSingle: true,
   extractVariables: extractTextClassifierVariables,

--- a/apps/web/src/components/workflow/nodes/core/var-assign/index.ts
+++ b/apps/web/src/components/workflow/nodes/core/var-assign/index.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/nodes/core/var-assign/index.ts
 
 export { VarAssignNode } from './node'
+export { VarAssignPanel } from './panel'
 export { varAssignDefinition } from './schema'
 export type { VarAssignNodeConfig, VarAssignNodeData } from './types'

--- a/apps/web/src/components/workflow/nodes/core/var-assign/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/var-assign/schema.ts
@@ -12,7 +12,6 @@ import { BaseType } from '~/components/workflow/types/unified-types'
 import type { UnifiedVariable } from '~/components/workflow/types/variable-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { VarAssignPanel } from './panel'
 import type { VarAssignNodeData, VariableAssignment } from './types'
 
 /**
@@ -198,7 +197,6 @@ export const varAssignDefinition: NodeDefinition<VarAssignNodeData> = {
   schema: varAssignNodeDataSchema,
   defaultData: varAssignDefaultData,
   canRunSingle: true,
-  panel: VarAssignPanel,
   validator: validateVarAssign as any,
   extractVariables: extractVarAssignVariables as any,
   outputVariables: getVarAssignOutputVariables as any,

--- a/apps/web/src/components/workflow/nodes/core/wait/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/wait/schema.ts
@@ -11,7 +11,6 @@ import { baseNodeDataSchema } from '~/components/workflow/types/node-base'
 import { NodeType } from '~/components/workflow/types/node-types'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
 import { BaseType } from '../if-else'
-import { WaitNodePanel } from './panel'
 import { DurationUnit, type WaitNodeData, WaitType } from './types'
 
 /**
@@ -154,7 +153,6 @@ export const waitDefinition: NodeDefinition<WaitNodeData> = {
   color: '#3B82F6', // UTILITY category color
   defaultData: waitDefaultData,
   schema: waitNodeDataSchema,
-  panel: WaitNodePanel,
   validator: validateWaitConfig,
   canRunSingle: true,
   extractVariables: () => [], // Wait node doesn't use any variables

--- a/apps/web/src/components/workflow/nodes/core/webhook/index.ts
+++ b/apps/web/src/components/workflow/nodes/core/webhook/index.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/nodes/core/webhook/index.ts
 
 export { WebhookNode } from './node'
+export { WebhookPanel } from './panel'
 export { webhookDefinition } from './schema'
-export type { WebhookNodeConfig, WebhookNodeData } from './types'
+export type { WebhookNodeData } from './types'

--- a/apps/web/src/components/workflow/nodes/core/webhook/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/webhook/schema.ts
@@ -12,7 +12,6 @@ import { NodeType } from '~/components/workflow/types/node-types'
 import { BaseType, type UnifiedVariable } from '~/components/workflow/types/variable-types'
 import { schemaToUnifiedVariable } from '~/components/workflow/utils/schema-to-variable'
 import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
-import { WebhookPanel } from './panel'
 import type { WebhookNodeData } from './types'
 
 /**
@@ -138,7 +137,6 @@ export const webhookDefinition: NodeDefinition<WebhookNodeData> = {
   schema: webhookNodeDataSchema,
   defaultData: webhookDefaultData,
   canRunSingle: false, // Triggers cannot be run individually
-  panel: WebhookPanel,
   triggerType: WorkflowTriggerType.WEBHOOK,
   validator: validateWebhookData,
   outputVariables: getWebhookOutputVariables as any,

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsup",
     "start": "cd dist && node server.js",
-    "dev": "node --import tsx/esm --watch src/server.ts",
+    "dev": "node --env-file .env --import tsx/esm --watch src/server.ts",
     "tc": "tsc --noEmit",
     "clean": "rm -rf node_modules dist .turbo"
   },

--- a/apps/worker/src/workers/utils/createJobHandler.ts
+++ b/apps/worker/src/workers/utils/createJobHandler.ts
@@ -95,6 +95,7 @@ export function createJobHandler<T extends Record<string, JobHandler | LegacyJob
 
       logger.error(`Error processing job ${jobName}:`, {
         error: error instanceof Error ? error.message : error,
+        cause: error instanceof Error && error.cause ? String(error.cause) : undefined,
         jobId: job.id,
       })
       throw error

--- a/packages/lib/src/jobs/billing/apply-scheduled-subscription-changes-job.ts
+++ b/packages/lib/src/jobs/billing/apply-scheduled-subscription-changes-job.ts
@@ -2,10 +2,10 @@
 
 import { stripeClient } from '@auxx/billing'
 import { database as db, schema } from '@auxx/database'
-import type { Job } from 'bullmq'
 import { and, eq, inArray, isNotNull, lte } from 'drizzle-orm'
 import { z } from 'zod'
 import { createScopedLogger } from '../../logger'
+import type { JobContext } from '../types'
 
 const logger = createScopedLogger('apply-scheduled-subscription-changes-job')
 
@@ -261,9 +261,10 @@ async function applyScheduledChange(
  * Runs every hour as backup to Stripe webhooks.
  */
 export async function applyScheduledSubscriptionChangesJob(
-  job: Job<ApplyScheduledChangesJobData>
+  ctx: JobContext<ApplyScheduledChangesJobData>
 ): Promise<ApplyScheduledChangesResult> {
-  const input = payloadSchema.parse(job.data)
+  const { job, data } = ctx
+  const input = payloadSchema.parse(data)
 
   logger.info('Starting scheduled subscription changes job', {
     jobId: job.id,
@@ -322,7 +323,7 @@ export async function applyScheduledSubscriptionChangesJob(
         const progress = Math.round(
           ((result.successful + result.skipped + result.failed) / result.totalFound) * 100
         )
-        await job.updateProgress(progress)
+        await ctx.updateProgress(progress)
       } catch (error) {
         logger.error('Unexpected error processing subscription', {
           subscriptionId: subscription.id,
@@ -337,7 +338,7 @@ export async function applyScheduledSubscriptionChangesJob(
       }
     }
 
-    await job.updateProgress(100)
+    await ctx.updateProgress(100)
 
     logger.info('Scheduled subscription changes job completed', {
       jobId: job.id,
@@ -348,6 +349,7 @@ export async function applyScheduledSubscriptionChangesJob(
   } catch (error) {
     logger.error('Scheduled subscription changes job failed', {
       error: error instanceof Error ? error.message : String(error),
+      cause: error instanceof Error && error.cause ? String(error.cause) : undefined,
       jobId: job.id,
     })
     throw error

--- a/packages/lib/src/jobs/messages/monitor-message-sync-job.ts
+++ b/packages/lib/src/jobs/messages/monitor-message-sync-job.ts
@@ -2,11 +2,11 @@
 
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import type { Job } from 'bullmq'
 import { and, eq } from 'drizzle-orm'
 import { publisher } from '../../events/publisher'
 import type { MessageSyncCompleteEvent, MessageSyncFailedEvent } from '../../events/types'
 import { getQueue, Queues } from '../queues'
+import type { JobContext } from '../types'
 
 const logger = createScopedLogger('job:message-sync-monitor')
 
@@ -19,9 +19,10 @@ export type MonitorMessageSyncJobData = {
 
 export const MONITOR_RECHECK_DELAY_MS = 5000
 
-export const monitorMessageSyncJob = async (job: Job<MonitorMessageSyncJobData>) => {
-  const { syncRunId: syncJobId, organizationId, userId } = job.data
-  const jobAttempt = job.data.attempt || 1
+export const monitorMessageSyncJob = async (ctx: JobContext<MonitorMessageSyncJobData>) => {
+  const { job, data } = ctx
+  const { syncRunId: syncJobId, organizationId, userId } = data
+  const jobAttempt = data.attempt || 1
 
   logger.info(`Monitoring sync job ${syncJobId}, attempt ${jobAttempt}`, {
     bullmqJobId: job.id,
@@ -252,7 +253,7 @@ export const monitorMessageSyncJob = async (job: Job<MonitorMessageSyncJobData>)
       // Reschedule the monitor job using the same ID
       await messageSyncQueue.add(
         job.name,
-        { ...job.data, attempt: jobAttempt + 1 },
+        { ...data, attempt: jobAttempt + 1 },
         {
           delay: MONITOR_RECHECK_DELAY_MS,
           jobId: job.id,
@@ -265,6 +266,7 @@ export const monitorMessageSyncJob = async (job: Job<MonitorMessageSyncJobData>)
     logger.error(`Error in monitorMessageSyncJob for sync job ${syncJobId}`, {
       bullmqJobId: job.id,
       error,
+      cause: error instanceof Error && error.cause ? String(error.cause) : undefined,
     })
     throw error
   }


### PR DESCRIPTION
- Removed panel imports from answer, chunker, code, crud, dataset, date-time, document-extractor, end, find, human, if-else, and other node schemas.
- Updated NODE_DEFINITIONS to include panel references for nodes where applicable.
- Added missing panel exports for date-time, http, loop, manual, message-received, var-assign, and webhook nodes.
- Updated job handler to include error cause logging for better debugging.
- Refactored scheduled subscription changes job and message sync job to use JobContext for better type safety and clarity.