### PR TITLE
feat: implement HMAC signing for Lambda invocations and add callback …

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -12,6 +12,9 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=
 
+# Lambda signing (must match apps/lambda/.env)
+LAMBDA_INVOKE_SECRET=
+
 # Extra CORS origins (optional — preview deploys, staging, etc.)
 # EXTRA_ALLOWED_ORIGINS=https://preview.example.com,https://staging.example.com
 

--- a/apps/api/src/lib/callback-auth.ts
+++ b/apps/api/src/lib/callback-auth.ts
@@ -1,0 +1,55 @@
+// apps/api/src/lib/callback-auth.ts
+
+import { type CallbackScope, verifyCallbackToken } from '@auxx/credentials/lambda-auth'
+import type { Context } from 'hono'
+import { errorResponse } from './response'
+
+/**
+ * Verify a callback token from Lambda SDK requests.
+ *
+ * Extracts the installation ID from X-App-Installation-Id header
+ * and the callback token from the Authorization: Bearer header.
+ *
+ * Returns the verified installationId and organizationId on success,
+ * or sends a 401 response and returns null on failure.
+ */
+export function verifyCallbackAuth(
+  c: Context,
+  scope: CallbackScope
+): { installationId: string; organizationId: string } | null {
+  const installationId = c.req.header('X-App-Installation-Id')
+
+  if (!installationId) {
+    c.res = c.json(errorResponse('UNAUTHORIZED', 'App installation ID required'), 401) as any
+    return null
+  }
+
+  const secret = process.env.LAMBDA_INVOKE_SECRET
+  if (!secret) {
+    // No secret configured — fall back to installation ID only (dev mode)
+    return { installationId, organizationId: '' }
+  }
+
+  const authHeader = c.req.header('Authorization')
+  if (!authHeader?.startsWith('Bearer ')) {
+    c.res = c.json(errorResponse('UNAUTHORIZED', 'Missing callback auth token'), 401) as any
+    return null
+  }
+
+  const result = verifyCallbackToken({
+    token: authHeader.slice(7),
+    expectedInstallationId: installationId,
+    expectedScope: scope,
+    secret,
+  })
+
+  if (!result.valid) {
+    c.res = c.json(
+      errorResponse('UNAUTHORIZED', result.error ?? 'Invalid callback token'),
+      401
+    ) as any
+    return null
+  }
+
+  return { installationId, organizationId: result.organizationId ?? '' }
+}

--- a/apps/api/src/routes/organizations/execute-server-function.ts
+++ b/apps/api/src/routes/organizations/execute-server-function.ts
@@ -1,10 +1,9 @@
 // apps/api/src/routes/organizations/execute-server-function.ts
 
-import { SERVER_FUNCTION_EXECUTOR_URL } from '@auxx/config/server'
-import { LAMBDA_API_URL } from '@auxx/config/urls'
 import { resolveAppConnectionForRuntime } from '@auxx/services/app-connections'
 import { getInstallationBundle } from '@auxx/services/app-installations'
 import { logServerFunctionExecution } from '@auxx/services/apps'
+import { invokeLambdaExecutor, prepareLambdaContext } from '@auxx/services/lambda-execution'
 import { Hono } from 'hono'
 import { ERROR_STATUS_MAP, errorResponse } from '../../lib/response'
 import type { AppContext } from '../../types/context'
@@ -15,22 +14,6 @@ const executeServerFunction = new Hono<AppContext>()
  * POST /api/v1/organizations/:handle/apps/:appId/installations/:installationId/execute-server-function
  *
  * Execute a server function from an extension's server bundle.
- *
- * Request body:
- *   {
- *     function_identifier: string  // moduleHash (e.g., "actions/myAction.server")
- *     function_args: string         // JSON-stringified array of arguments
- *   }
- *
- * Response:
- *   {
- *     execution_result: any  // Result from server function
- *   }
- *
- * OR error:
- *   {
- *     error: { message: string, code: string }
- *   }
  */
 executeServerFunction.post(
   '/apps/:appId/installations/:installationId/execute-server-function',
@@ -83,55 +66,45 @@ executeServerFunction.post(
 
       const connections = connectionsResult.value
 
-      const lambdaResponse = await fetch(SERVER_FUNCTION_EXECUTOR_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
+      // 4. Build context and invoke Lambda
+      const context = prepareLambdaContext({
+        appId,
+        installationId,
+        organizationId: organization.id,
+        organizationHandle: organization.handle,
+        userId: user.id,
+        userEmail: user.email,
+        userName: user.name,
+        userConnection: connections.userConnection,
+        organizationConnection: connections.organizationConnection,
+      })
+
+      const lambdaResult = await invokeLambdaExecutor({
+        caller: 'api',
+        payload: {
           type: 'function',
           bundleKey: bundle.serverBundleS3Key,
           functionIdentifier: function_identifier,
           functionArgs: function_args,
-          context: {
-            organizationId: organization.id,
-            organizationHandle: organization.handle,
-            userId: user.id,
-            userEmail: user.email,
-            appId,
-            apiUrl: LAMBDA_API_URL,
-            appInstallationId: installationId,
-
-            // Pass connections
-            userConnection: connections.userConnection,
-            organizationConnection: connections.organizationConnection,
-          },
-        }),
+          context,
+        },
       })
 
-      if (!lambdaResponse.ok) {
-        let errorData
-        try {
-          errorData = await lambdaResponse.json()
-        } catch {
-          const errorText = await lambdaResponse.text()
-          errorData = { error: { message: errorText, code: 'UNKNOWN_ERROR' } }
-        }
+      if (lambdaResult.isErr()) {
+        const error = lambdaResult.error
 
         // Check for connection errors (not found or expired)
-        if (
-          errorData.error?.code === 'CONNECTION_NOT_FOUND' ||
-          errorData.error?.code === 'CONNECTION_EXPIRED'
-        ) {
+        if (error.code === 'CONNECTION_REQUIRED') {
           console.log('[ExecuteServerFunction] Connection error, returning prompt:', {
-            code: errorData.error.code,
-            scope: errorData.error.scope,
+            code: error.code,
+            scope: error.details?.scope,
           })
           return c.json(
             {
               error: {
                 code: 'CONNECTION_REQUIRED',
-                message: errorData.error.message,
-                scope: errorData.error.scope || 'user',
-                // Frontend uses this to show connection prompt
+                message: error.message,
+                scope: error.details?.scope || 'user',
               },
             },
             403
@@ -139,27 +112,26 @@ executeServerFunction.post(
         }
 
         console.error('[ExecuteServerFunction] Lambda invocation failed:', {
-          status: lambdaResponse.status,
-          error: errorData,
+          status: error.statusCode,
+          error,
         })
-        const statusCode = lambdaResponse.status as 400 | 500
-        // Return structured error to client
+        const statusCode = error.statusCode as 400 | 500
         return c.json(
           {
             error: {
-              message: errorData.error?.message || 'Server function execution failed',
-              code: errorData.error?.code || 'EXECUTION_ERROR',
-              details: errorData.error?.details,
+              message: error.message,
+              code: error.code,
+              details: error.details,
             },
           },
           statusCode
         )
       }
 
-      const result = await lambdaResponse.json()
+      const result = lambdaResult.value
 
       // 5. Store console logs in database using service
-      if (result.metadata?.console_logs && result.metadata.console_logs.length > 0) {
+      if (result.metadata?.consoleLogs && result.metadata.consoleLogs.length > 0) {
         const logResult = await logServerFunctionExecution({
           appId,
           organizationId: organization.id,
@@ -167,17 +139,16 @@ executeServerFunction.post(
           userId: user.id,
           functionIdentifier: function_identifier,
           installationId,
-          consoleLogs: result.metadata.console_logs,
+          consoleLogs: result.metadata.consoleLogs,
           durationMs: result.metadata?.duration,
         })
 
         if (logResult.isErr()) {
-          // Don't fail the request if logging fails, just log the error
           console.error('[ExecuteServerFunction] Failed to store console logs:', logResult.error)
         } else {
           console.log('[ExecuteServerFunction] Stored console logs:', {
             logged: logResult.value.logged,
-            logCount: result.metadata.console_logs.length,
+            logCount: result.metadata.consoleLogs.length,
           })
         }
       }

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -12,6 +12,7 @@ import { database } from '@auxx/database'
 import { getAppSettings, saveAppSettings, setAppSetting } from '@auxx/services/app-settings'
 import { Hono } from 'hono'
 import { z } from 'zod'
+import { verifyCallbackAuth } from '../lib/callback-auth'
 import { ERROR_STATUS_MAP, errorResponse } from '../lib/response'
 import type { AppContext } from '../types/context'
 
@@ -101,15 +102,12 @@ const setSettingSchema = z.object({
  */
 settings.get('/', async (c) => {
   try {
-    const appInstallationId = c.req.header('X-App-Installation-Id')
-
-    if (!appInstallationId) {
-      return c.json(errorResponse('UNAUTHORIZED', 'App installation ID required'), 401)
-    }
+    const auth = verifyCallbackAuth(c, 'settings')
+    if (!auth) return c.res
 
     // Load installation to get current version
     const installation = await database.query.AppInstallation.findFirst({
-      where: (inst, { eq }) => eq(inst.id, appInstallationId),
+      where: (inst, { eq }) => eq(inst.id, auth.installationId),
       columns: {
         id: true,
         currentVersionId: true,
@@ -136,7 +134,7 @@ settings.get('/', async (c) => {
 
     // Get settings with schema for default merging
     const result = await getAppSettings({
-      appInstallationId,
+      appInstallationId: auth.installationId,
       schema,
     })
 
@@ -208,15 +206,12 @@ settings.get('/', async (c) => {
 settings.get('/:key', async (c) => {
   try {
     const key = c.req.param('key')
-    const appInstallationId = c.req.header('X-App-Installation-Id')
-
-    if (!appInstallationId) {
-      return c.json(errorResponse('UNAUTHORIZED', 'App installation ID required'), 401)
-    }
+    const auth = verifyCallbackAuth(c, 'settings')
+    if (!auth) return c.res
 
     // Load installation to get current version
     const installation = await database.query.AppInstallation.findFirst({
-      where: (inst, { eq }) => eq(inst.id, appInstallationId),
+      where: (inst, { eq }) => eq(inst.id, auth.installationId),
       columns: {
         id: true,
         currentVersionId: true,
@@ -242,7 +237,7 @@ settings.get('/:key', async (c) => {
 
     // Get all settings with schema (so defaults work), then extract the key
     const result = await getAppSettings({
-      appInstallationId,
+      appInstallationId: auth.installationId,
       schema,
     })
 
@@ -327,18 +322,15 @@ settings.get('/:key', async (c) => {
  */
 settings.post('/', async (c) => {
   try {
-    const appInstallationId = c.req.header('X-App-Installation-Id')
-
-    if (!appInstallationId) {
-      return c.json(errorResponse('UNAUTHORIZED', 'App installation ID required'), 401)
-    }
+    const auth = verifyCallbackAuth(c, 'settings')
+    if (!auth) return c.res
 
     const body = await c.req.json()
     const { settings: settingsToSave } = saveSettingsSchema.parse(body)
 
     // Load installation to get current version
     const installation = await database.query.AppInstallation.findFirst({
-      where: (inst, { eq }) => eq(inst.id, appInstallationId),
+      where: (inst, { eq }) => eq(inst.id, auth.installationId),
       columns: {
         id: true,
         currentVersionId: true,
@@ -354,7 +346,7 @@ settings.post('/', async (c) => {
 
     // Save settings with version ID to track which version they were saved with
     const result = await saveAppSettings({
-      appInstallationId,
+      appInstallationId: auth.installationId,
       appVersionId: installation.currentVersionId ?? undefined,
       settings: settingsToSave,
     })
@@ -427,18 +419,15 @@ settings.post('/', async (c) => {
 settings.put('/:key', async (c) => {
   try {
     const key = c.req.param('key')
-    const appInstallationId = c.req.header('X-App-Installation-Id')
-
-    if (!appInstallationId) {
-      return c.json(errorResponse('UNAUTHORIZED', 'App installation ID required'), 401)
-    }
+    const auth = verifyCallbackAuth(c, 'settings')
+    if (!auth) return c.res
 
     const body = await c.req.json()
     const { value } = setSettingSchema.parse(body)
 
     // Load installation to get current version
     const installation = await database.query.AppInstallation.findFirst({
-      where: (inst, { eq }) => eq(inst.id, appInstallationId),
+      where: (inst, { eq }) => eq(inst.id, auth.installationId),
       columns: {
         id: true,
         currentVersionId: true,
@@ -451,7 +440,7 @@ settings.put('/:key', async (c) => {
 
     // Set setting with version ID
     const result = await setAppSetting({
-      appInstallationId,
+      appInstallationId: auth.installationId,
       appVersionId: installation.currentVersionId ?? undefined,
       key,
       value,

--- a/apps/api/src/routes/webhook-handlers.ts
+++ b/apps/api/src/routes/webhook-handlers.ts
@@ -17,6 +17,7 @@ import {
 } from '@auxx/services/app-webhook-handlers'
 import { Hono } from 'hono'
 import { z } from 'zod'
+import { verifyCallbackAuth } from '../lib/callback-auth'
 import { ERROR_STATUS_MAP, errorResponse } from '../lib/response'
 import type { AppContext } from '../types/context'
 
@@ -124,13 +125,10 @@ const updateWebhookHandlerSchema = z.object({
  */
 webhookHandlers.get('/', async (c) => {
   try {
-    const appInstallationId = c.req.header('X-App-Installation-Id')
+    const auth = verifyCallbackAuth(c, 'webhooks')
+    if (!auth) return c.res
 
-    if (!appInstallationId) {
-      return c.json(errorResponse('UNAUTHORIZED', 'App installation ID required'), 401)
-    }
-
-    const result = await listWebhookHandlers({ appInstallationId })
+    const result = await listWebhookHandlers({ appInstallationId: auth.installationId })
 
     if (result.isErr()) {
       const status = ERROR_STATUS_MAP[result.error.code] || 500
@@ -220,18 +218,14 @@ webhookHandlers.get('/', async (c) => {
  */
 webhookHandlers.post('/', async (c) => {
   try {
-    // Get app installation ID from header (set by Lambda runtime)
-    const appInstallationId = c.req.header('X-App-Installation-Id')
-
-    if (!appInstallationId) {
-      return c.json(errorResponse('UNAUTHORIZED', 'App installation ID required'), 401)
-    }
+    const auth = verifyCallbackAuth(c, 'webhooks')
+    if (!auth) return c.res
 
     const body = await c.req.json()
     const { fileName, metadata } = createWebhookHandlerSchema.parse(body)
 
     const result = await createWebhookHandler({
-      appInstallationId,
+      appInstallationId: auth.installationId,
       fileName,
       metadata,
     })
@@ -335,18 +329,15 @@ webhookHandlers.post('/', async (c) => {
 webhookHandlers.patch('/:handlerId', async (c) => {
   try {
     const handlerId = c.req.param('handlerId')
-    const appInstallationId = c.req.header('X-App-Installation-Id')
-
-    if (!appInstallationId) {
-      return c.json(errorResponse('UNAUTHORIZED', 'App installation ID required'), 401)
-    }
+    const auth = verifyCallbackAuth(c, 'webhooks')
+    if (!auth) return c.res
 
     const body = await c.req.json()
     const { externalWebhookId, metadata } = updateWebhookHandlerSchema.parse(body)
 
     const result = await updateWebhookHandler({
       handlerId,
-      appInstallationId,
+      appInstallationId: auth.installationId,
       externalWebhookId,
       metadata,
     })
@@ -438,13 +429,10 @@ webhookHandlers.patch('/:handlerId', async (c) => {
 webhookHandlers.delete('/:handlerId', async (c) => {
   try {
     const handlerId = c.req.param('handlerId')
-    const appInstallationId = c.req.header('X-App-Installation-Id')
+    const auth = verifyCallbackAuth(c, 'webhooks')
+    if (!auth) return c.res
 
-    if (!appInstallationId) {
-      return c.json(errorResponse('UNAUTHORIZED', 'App installation ID required'), 401)
-    }
-
-    const result = await deleteWebhookHandler({ handlerId, appInstallationId })
+    const result = await deleteWebhookHandler({ handlerId, appInstallationId: auth.installationId })
 
     if (result.isErr()) {
       const status = ERROR_STATUS_MAP[result.error.code] || 500

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -1,9 +1,9 @@
 // apps/api/src/routes/webhooks.ts
 
-import { LAMBDA_API_URL, SERVER_FUNCTION_EXECUTOR_URL } from '@auxx/config/urls'
 import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { getWebhookHandler } from '@auxx/services/app-webhook-handlers'
+import { invokeLambdaExecutor, prepareLambdaContext } from '@auxx/services/lambda-execution'
 import { eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { errorResponse } from '../lib/response'
@@ -77,44 +77,39 @@ async function handleWebhookRequest(c: any) {
       body,
     }
 
-    // 4. Get Lambda executor URL from environment
-    const executorUrl = SERVER_FUNCTION_EXECUTOR_URL
-    // const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'
+    log.info('Invoking Lambda for webhook execution', { handlerId })
 
-    log.info('Invoking Lambda for webhook execution', { executorUrl, handlerId })
+    // 4. Build context and invoke Lambda via shared helper
+    const context = prepareLambdaContext({
+      appId: installationResult.appId,
+      installationId,
+      organizationId: installationResult.organizationId,
+      organizationHandle: installationResult.organization.handle,
+      userId: 'system',
+      userEmail: 'system@webhook',
+      userName: null,
+    })
 
-    // 5. Invoke Lambda via HTTP (works in dev AND production)
-    const response = await fetch(executorUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+    const lambdaResult = await invokeLambdaExecutor({
+      caller: 'webhook-route',
+      payload: {
         type: 'webhook',
         bundleKey: versionBundle.serverBundleS3Key,
         handlerId,
         request: webRequest,
-        context: {
-          organizationId: installationResult.organizationId,
-          organizationHandle: installationResult.organization.handle,
-          appId: installationResult.appId,
-          appInstallationId: installationId,
-          apiUrl: LAMBDA_API_URL,
-          // Webhooks don't have user context - use system defaults
-          userId: 'system',
-          userEmail: 'system@webhook',
-          // Connection data will be fetched by Lambda if needed
-        },
-      }),
+        context,
+      },
     })
 
-    if (!response.ok) {
-      const errorData = await response.json()
-      log.error('Webhook execution failed', { error: errorData, installationId, handlerId })
+    if (lambdaResult.isErr()) {
+      const error = lambdaResult.error
+      log.error('Webhook execution failed', { error, installationId, handlerId })
       return c.json(errorResponse('EXECUTION_ERROR', 'Webhook execution failed'), 500)
     }
 
-    const result = await response.json()
+    const result = lambdaResult.value
 
-    // 6. Return handler's response to third-party service
+    // 5. Return handler's response to third-party service
     const handlerExecutionResult = result.execution_result
 
     log.info('Webhook execution completed', {

--- a/apps/api/src/routes/workflows/execute-workflow-block.ts
+++ b/apps/api/src/routes/workflows/execute-workflow-block.ts
@@ -139,6 +139,7 @@ executeWorkflowBlock.post('/:workflowId/runs/:runId/blocks/:blockId/execute', as
 
     // Invoke Lambda using helper
     const lambdaResult = await invokeLambdaExecutor({
+      caller: 'api',
       payload: {
         type: 'workflow-block',
         bundleKey: bundle.serverBundleS3Key,

--- a/apps/lambda/src/auth/__tests__/verify-inbound.test.ts
+++ b/apps/lambda/src/auth/__tests__/verify-inbound.test.ts
@@ -1,0 +1,142 @@
+// apps/lambda/src/auth/__tests__/verify-inbound.test.ts
+
+/**
+ * Unit tests for inbound request verification (Deno Web Crypto).
+ *
+ * These tests validate the Deno-side verification logic independently.
+ * The cross-runtime compatibility test (Node.js sign + Deno verify) is in
+ * packages/credentials/src/lambda-auth/__tests__/inbound-signing.test.ts.
+ */
+
+import { assertEquals } from 'jsr:@std/assert'
+import { verifyInboundRequest } from '../verify-inbound.ts'
+
+const TEST_SECRET = 'test-secret-key-for-hmac-signing-32chars'
+
+/** Helper: sign a request using Web Crypto (same algorithm as Node.js signer) */
+async function signWithWebCrypto(params: {
+  body: string
+  caller: string
+  secret: string
+  timestamp?: string
+  nonce?: string
+  keyId?: string
+}): Promise<Record<string, string>> {
+  const { body, caller, secret, keyId = 'v1' } = params
+  const timestamp = params.timestamp ?? String(Date.now())
+  const nonce = params.nonce ?? crypto.randomUUID()
+
+  const encoder = new TextEncoder()
+
+  // SHA-256 of body
+  const bodyHash = await crypto.subtle.digest('SHA-256', encoder.encode(body))
+  const bodySha256 = Array.from(new Uint8Array(bodyHash))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+
+  // Build canonical message
+  const canonical = ['v1', timestamp, nonce, caller, keyId, bodySha256].join('\n')
+  const message = `inbound:v1:${canonical}`
+
+  // HMAC-SHA256
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(message))
+  const mac = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+
+  return {
+    'x-auxx-signature': `sha256=${mac}`,
+    'x-auxx-timestamp': timestamp,
+    'x-auxx-nonce': nonce,
+    'x-auxx-caller': caller,
+    'x-auxx-key-id': keyId,
+  }
+}
+
+Deno.test('verifyInboundRequest - accepts valid signature', async () => {
+  const body = '{"type":"function"}'
+  const headers = await signWithWebCrypto({ body, caller: 'api', secret: TEST_SECRET })
+
+  const result = await verifyInboundRequest({ headers, body, secret: TEST_SECRET })
+
+  assertEquals(result.valid, true)
+  assertEquals(result.caller, 'api')
+  assertEquals(result.reason, undefined)
+})
+
+Deno.test('verifyInboundRequest - rejects invalid signature', async () => {
+  const body = '{"type":"function"}'
+  const headers = await signWithWebCrypto({ body, caller: 'api', secret: TEST_SECRET })
+
+  // Tamper with signature
+  headers['x-auxx-signature'] =
+    'sha256=0000000000000000000000000000000000000000000000000000000000000000'
+
+  const result = await verifyInboundRequest({ headers, body, secret: TEST_SECRET })
+
+  assertEquals(result.valid, false)
+  assertEquals(result.reason, 'Invalid signature')
+})
+
+Deno.test('verifyInboundRequest - rejects timestamp outside ±5 min', async () => {
+  const body = '{"type":"function"}'
+  const oldTimestamp = String(Date.now() - 6 * 60 * 1000) // 6 minutes ago
+  const headers = await signWithWebCrypto({
+    body,
+    caller: 'api',
+    secret: TEST_SECRET,
+    timestamp: oldTimestamp,
+  })
+
+  const result = await verifyInboundRequest({ headers, body, secret: TEST_SECRET })
+
+  assertEquals(result.valid, false)
+  assertEquals(result.reason, 'Timestamp out of range')
+})
+
+Deno.test('verifyInboundRequest - rejects missing headers', async () => {
+  const result = await verifyInboundRequest({
+    headers: {},
+    body: '{"type":"function"}',
+    secret: TEST_SECRET,
+  })
+
+  assertEquals(result.valid, false)
+  assertEquals(result.reason, 'Missing auth headers')
+})
+
+Deno.test('verifyInboundRequest - rejects tampered body', async () => {
+  const body = '{"type":"function"}'
+  const headers = await signWithWebCrypto({ body, caller: 'api', secret: TEST_SECRET })
+
+  // Verify with different body
+  const result = await verifyInboundRequest({
+    headers,
+    body: '{"type":"tampered"}',
+    secret: TEST_SECRET,
+  })
+
+  assertEquals(result.valid, false)
+  assertEquals(result.reason, 'Invalid signature')
+})
+
+Deno.test('verifyInboundRequest - rejects wrong secret', async () => {
+  const body = '{"type":"function"}'
+  const headers = await signWithWebCrypto({ body, caller: 'api', secret: TEST_SECRET })
+
+  const result = await verifyInboundRequest({
+    headers,
+    body,
+    secret: 'wrong-secret',
+  })
+
+  assertEquals(result.valid, false)
+  assertEquals(result.reason, 'Invalid signature')
+})

--- a/apps/lambda/src/auth/verify-inbound.ts
+++ b/apps/lambda/src/auth/verify-inbound.ts
@@ -1,0 +1,101 @@
+// apps/lambda/src/auth/verify-inbound.ts
+
+/**
+ * Inbound request verification for Lambda (Deno runtime).
+ *
+ * Uses Web Crypto API exclusively — no node:crypto.
+ * Mirrors the signing algorithm in @auxx/credentials/lambda-auth/inbound-signing.ts.
+ *
+ * crypto.subtle.verify() performs constant-time comparison by spec,
+ * so we don't need to reimplement timingSafeEqual.
+ */
+
+const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000
+
+interface VerifyResult {
+  valid: boolean
+  caller?: string
+  reason?: string
+}
+
+function hexToUint8Array(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16)
+  }
+  return bytes
+}
+
+function uint8ArrayToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+async function sha256Hex(data: string): Promise<string> {
+  const encoded = new TextEncoder().encode(data)
+  const hash = await crypto.subtle.digest('SHA-256', encoded)
+  return uint8ArrayToHex(new Uint8Array(hash))
+}
+
+/**
+ * HMAC-SHA256 verification using Web Crypto API.
+ */
+async function hmacVerify(secret: string, message: string, signatureHex: string): Promise<boolean> {
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['verify']
+  )
+  const sigBytes = hexToUint8Array(signatureHex)
+  const msgBytes = encoder.encode(message)
+  return crypto.subtle.verify('HMAC', key, sigBytes as ArrayBufferView<ArrayBuffer>, msgBytes)
+}
+
+/**
+ * Verify an inbound Lambda invocation request.
+ *
+ * Checks all required auth headers, timestamp freshness,
+ * and HMAC-SHA256 signature validity.
+ */
+export async function verifyInboundRequest(params: {
+  headers: Record<string, string | undefined>
+  body: string
+  secret: string
+}): Promise<VerifyResult> {
+  const { headers, body, secret } = params
+
+  const signature = headers['x-auxx-signature']
+  const timestamp = headers['x-auxx-timestamp']
+  const nonce = headers['x-auxx-nonce']
+  const caller = headers['x-auxx-caller']
+  const keyId = headers['x-auxx-key-id']
+
+  if (!signature || !timestamp || !nonce || !caller || !keyId) {
+    return { valid: false, reason: 'Missing auth headers' }
+  }
+
+  // Check timestamp freshness
+  const ts = Number(timestamp)
+  if (Number.isNaN(ts) || Math.abs(Date.now() - ts) > TIMESTAMP_TOLERANCE_MS) {
+    return { valid: false, reason: 'Timestamp out of range' }
+  }
+
+  // Strip "sha256=" prefix
+  const mac = signature.startsWith('sha256=') ? signature.slice(7) : signature
+
+  // Rebuild canonical message and verify
+  const bodySha256 = await sha256Hex(body)
+  const canonical = ['v1', timestamp, nonce, caller, keyId, bodySha256].join('\n')
+  const message = `inbound:v1:${canonical}`
+
+  const valid = await hmacVerify(secret, message, mac)
+  if (!valid) {
+    return { valid: false, reason: 'Invalid signature' }
+  }
+
+  return { valid: true, caller }
+}

--- a/apps/lambda/src/context-provider.ts
+++ b/apps/lambda/src/context-provider.ts
@@ -51,5 +51,8 @@ export function createRuntimeContext(execContext: ExecutionContext): RuntimeCont
     // Connection data
     userConnection: execContext.userConnection,
     organizationConnection: execContext.organizationConnection,
+
+    // Callback tokens for SDK → API authentication
+    callbackTokens: execContext.callbackTokens,
   }
 }

--- a/apps/lambda/src/dev-server.ts
+++ b/apps/lambda/src/dev-server.ts
@@ -35,7 +35,14 @@ async function handleRequest(req: Request): Promise<Response> {
   // Main execution endpoint
   if (url.pathname === '/' && req.method === 'POST') {
     try {
-      const event = (await req.json()) as unknown as LambdaEvent
+      const rawBody = await req.text()
+      const event = JSON.parse(rawBody) as unknown as LambdaEvent
+
+      // Extract request headers for auth verification
+      const headers: Record<string, string> = {}
+      for (const [k, v] of req.headers.entries()) {
+        headers[k.toLowerCase()] = v
+      }
 
       console.log('[DevServer] Received request:', {
         type: event.type,
@@ -43,8 +50,8 @@ async function handleRequest(req: Request): Promise<Response> {
         ...('bundleKey' in event && { bundleKey: event.bundleKey }),
       })
 
-      // Call the same handler as Lambda
-      const response = await handler(event)
+      // Call the same handler as Lambda, with auth metadata
+      const response = await handler(event, { headers, rawBody })
 
       return new Response(response.body, {
         status: response.statusCode,

--- a/apps/lambda/src/index.ts
+++ b/apps/lambda/src/index.ts
@@ -1,5 +1,6 @@
 // apps/lambda/src/index.ts
 
+import { verifyInboundRequest } from './auth/verify-inbound.ts'
 import { loadBundle } from './bundle-loader.ts'
 import { createRuntimeContext } from './context-provider.ts'
 import { executeCode } from './executors/code-executor.ts'
@@ -78,13 +79,83 @@ async function executeCodeEvent(validatedEvent: ValidatedLambdaEvent) {
   return await executeCode(validatedEvent)
 }
 
+/** Caller-type allowlist: which callers can invoke which event types */
+const CALLER_TYPE_ALLOWLIST: Record<string, string[]> = {
+  api: ['function', 'workflow-block'],
+  'webhook-route': ['webhook'],
+  'app-events': ['event'],
+  'workflow-engine': ['workflow-block', 'code'],
+  worker: ['workflow-block', 'code', 'event'],
+}
+
+/** Maximum payload size (5 MB) */
+const MAX_PAYLOAD_BYTES = 5 * 1024 * 1024
+
 /**
  * Lambda handler - entry point for all server function executions
  */
-export async function handler(event: LambdaEvent): Promise<LambdaResponse> {
+export async function handler(
+  event: LambdaEvent,
+  meta?: { headers: Record<string, string>; rawBody: string }
+): Promise<LambdaResponse> {
   const startTime = Date.now()
 
   try {
+    // 0a. Payload size check
+    if (meta?.rawBody && meta.rawBody.length > MAX_PAYLOAD_BYTES) {
+      return {
+        statusCode: 413,
+        body: JSON.stringify({
+          error: { message: 'Payload too large', code: 'PAYLOAD_TOO_LARGE' },
+        }),
+      }
+    }
+
+    // 0b. Auth gate — reject unsigned requests
+    const secret = Deno.env.get('LAMBDA_INVOKE_SECRET')
+    let authCaller: string | undefined
+
+    if (!secret) {
+      if (Deno.env.get('NODE_ENV') !== 'development') {
+        return {
+          statusCode: 500,
+          body: JSON.stringify({
+            error: { message: 'Auth not configured', code: 'AUTH_CONFIG_ERROR' },
+          }),
+        }
+      }
+    } else if (meta?.headers && meta?.rawBody) {
+      const authResult = await verifyInboundRequest({
+        headers: meta.headers,
+        body: meta.rawBody,
+        secret,
+      })
+
+      console.log('[Lambda:Auth]', {
+        decision: authResult.valid ? 'accept' : 'reject',
+        caller: authResult.caller,
+        reason: authResult.reason,
+        requestId: meta.headers['x-amzn-requestid'],
+      })
+
+      if (!authResult.valid) {
+        return {
+          statusCode: 401,
+          body: JSON.stringify({
+            error: { message: authResult.reason, code: 'AUTH_FAILED' },
+          }),
+        }
+      }
+      authCaller = authResult.caller
+    } else if (Deno.env.get('NODE_ENV') !== 'development') {
+      return {
+        statusCode: 401,
+        body: JSON.stringify({
+          error: { message: 'Missing auth headers', code: 'AUTH_REQUIRED' },
+        }),
+      }
+    }
+
     // 1. Validate input - returns Zod safeParse result
     const validationResult = validateLambdaEvent(event)
 
@@ -110,9 +181,25 @@ export async function handler(event: LambdaEvent): Promise<LambdaResponse> {
     }
 
     const validatedEvent = validationResult.data
+    const eventType = validatedEvent.type || 'function'
+
+    // 1b. Caller-type allowlist check
+    if (authCaller) {
+      const allowed = CALLER_TYPE_ALLOWLIST[authCaller]
+      if (!allowed || !allowed.includes(eventType)) {
+        return {
+          statusCode: 403,
+          body: JSON.stringify({
+            error: {
+              message: `Caller "${authCaller}" cannot invoke type "${eventType}"`,
+              code: 'CALLER_TYPE_DENIED',
+            },
+          }),
+        }
+      }
+    }
 
     // 2. Route to appropriate executor based on event type
-    const eventType = validatedEvent.type || 'function'
     const executionResult =
       eventType === 'code'
         ? await executeCodeEvent(validatedEvent)
@@ -123,6 +210,7 @@ export async function handler(event: LambdaEvent): Promise<LambdaResponse> {
 
     console.log('[Lambda] Execution successful:', {
       type: eventType,
+      caller: authCaller,
       duration,
       hasSettingsSchema: !!executionResult.metadata?.settingsSchema,
       logCount: executionResult.metadata?.consoleLogs?.length || 0,

--- a/apps/lambda/src/lambda-runtime.ts
+++ b/apps/lambda/src/lambda-runtime.ts
@@ -45,12 +45,31 @@ function isFunctionUrlEvent(event: unknown): event is {
 
 /**
  * Extract the internal payload from a Lambda event.
- * - Function URL envelope: parse body as JSON
+ * - Function URL envelope: parse body as JSON, extract headers
  * - Direct invocation: pass through as-is
  */
-function extractPayload(event: unknown): { payload: unknown; fromFunctionUrl: boolean } {
+function extractPayload(event: unknown): {
+  payload: unknown
+  headers: Record<string, string>
+  rawBody: string
+  fromFunctionUrl: boolean
+} {
   if (!isFunctionUrlEvent(event)) {
-    return { payload: event, fromFunctionUrl: false }
+    const rawBody = JSON.stringify(event)
+    return { payload: event, headers: {}, rawBody, fromFunctionUrl: false }
+  }
+
+  // Extract headers from Function URL envelope (lowercased by API Gateway v2)
+  const headers: Record<string, string> = {}
+  if (
+    (event as Record<string, unknown>).headers &&
+    typeof (event as Record<string, unknown>).headers === 'object'
+  ) {
+    for (const [k, v] of Object.entries(
+      (event as Record<string, unknown>).headers as Record<string, string>
+    )) {
+      headers[k.toLowerCase()] = v
+    }
   }
 
   let body = event.body ?? ''
@@ -60,19 +79,23 @@ function extractPayload(event: unknown): { payload: unknown; fromFunctionUrl: bo
     body = atob(body)
   }
 
+  const rawBody = typeof body === 'string' ? body : JSON.stringify(body)
+
   // Parse JSON body
   if (typeof body === 'string') {
     try {
-      return { payload: JSON.parse(body), fromFunctionUrl: true }
+      return { payload: JSON.parse(body), headers, rawBody, fromFunctionUrl: true }
     } catch {
       return {
         payload: { __parseError: true, message: 'Invalid JSON in request body' },
+        headers,
+        rawBody,
         fromFunctionUrl: true,
       }
     }
   }
 
-  return { payload: body, fromFunctionUrl: true }
+  return { payload: body, headers, rawBody, fromFunctionUrl: true }
 }
 
 /**
@@ -99,8 +122,8 @@ async function runtimeLoop(): Promise<never> {
     const rawEvent = await next.json()
 
     try {
-      // 2. Extract internal payload
-      const { payload, fromFunctionUrl } = extractPayload(rawEvent)
+      // 2. Extract internal payload and headers
+      const { payload, headers, rawBody, fromFunctionUrl } = extractPayload(rawEvent)
 
       // Handle JSON parse errors from Function URL
       if (
@@ -129,8 +152,8 @@ async function runtimeLoop(): Promise<never> {
         continue
       }
 
-      // 3. Call handler with normalized payload
-      const result = await handler(payload as any)
+      // 3. Call handler with normalized payload and auth metadata
+      const result = await handler(payload as any, { headers, rawBody })
 
       // 4. Post response back
       const responseBody = fromFunctionUrl

--- a/apps/lambda/src/runtime-helpers/server-sdk.ts
+++ b/apps/lambda/src/runtime-helpers/server-sdk.ts
@@ -263,6 +263,22 @@ export interface ServerSDKFetchResponse {
  * ```
  */
 export function createServerSDK(context: RuntimeContext): ServerSDK {
+  /**
+   * Build callback headers for SDK → API requests.
+   * Uses scoped callback tokens when available, falls back to installation ID only.
+   */
+  function getCallbackHeaders(scope: 'webhooks' | 'settings'): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'X-App-Installation-Id': context.app.installationId,
+    }
+    const token = context.callbackTokens?.[scope]
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`
+    }
+    return headers
+  }
+
   // Create SDK fetch function that will be shared by all SDK methods
   const sdkFetch = async (options: ServerSDKFetchOptions): Promise<ServerSDKFetchResponse> => {
     console.log('[ServerSDK] fetch:', options.method, options.url)
@@ -473,10 +489,7 @@ export function createServerSDK(context: RuntimeContext): ServerSDK {
         const response = await sdkFetch({
           method: 'POST',
           url: `${context.apiUrl}/api/v1/apps/webhooks`,
-          headers: {
-            'Content-Type': 'application/json',
-            'X-App-Installation-Id': context.app.installationId,
-          },
+          headers: getCallbackHeaders('webhooks'),
           body: {
             fileName: options.fileName,
             metadata: options.metadata,
@@ -516,10 +529,7 @@ export function createServerSDK(context: RuntimeContext): ServerSDK {
       const response = await sdkFetch({
         method: 'PATCH',
         url: `${context.apiUrl}/api/v1/apps/webhooks/${handlerId}`,
-        headers: {
-          'Content-Type': 'application/json',
-          'X-App-Installation-Id': context.app.installationId,
-        },
+        headers: getCallbackHeaders('webhooks'),
         body: updates,
       })
 
@@ -537,9 +547,7 @@ export function createServerSDK(context: RuntimeContext): ServerSDK {
       const response = await sdkFetch({
         method: 'DELETE',
         url: `${context.apiUrl}/api/v1/apps/webhooks/${handlerId}`,
-        headers: {
-          'X-App-Installation-Id': context.app.installationId,
-        },
+        headers: getCallbackHeaders('webhooks'),
       })
 
       if (response.status !== 200) {
@@ -557,9 +565,7 @@ export function createServerSDK(context: RuntimeContext): ServerSDK {
         const response = await sdkFetch({
           method: 'GET',
           url: `${context.apiUrl}/api/v1/apps/webhooks`,
-          headers: {
-            'X-App-Installation-Id': context.app.installationId,
-          },
+          headers: getCallbackHeaders('webhooks'),
         })
 
         if (response.status !== 200) {
@@ -592,9 +598,7 @@ export function createServerSDK(context: RuntimeContext): ServerSDK {
         const response = await sdkFetch({
           method: 'GET',
           url: `${context.apiUrl}/api/v1/apps/settings/${key}`,
-          headers: {
-            'X-App-Installation-Id': context.app.installationId,
-          },
+          headers: getCallbackHeaders('settings'),
         })
 
         if (response.status !== 200) {
@@ -623,9 +627,7 @@ export function createServerSDK(context: RuntimeContext): ServerSDK {
         const response = await sdkFetch({
           method: 'GET',
           url: `${context.apiUrl}/api/v1/apps/settings`,
-          headers: {
-            'X-App-Installation-Id': context.app.installationId,
-          },
+          headers: getCallbackHeaders('settings'),
         })
 
         if (response.status !== 200) {
@@ -654,10 +656,7 @@ export function createServerSDK(context: RuntimeContext): ServerSDK {
         const response = await sdkFetch({
           method: 'PUT',
           url: `${context.apiUrl}/api/v1/apps/settings/${key}`,
-          headers: {
-            'Content-Type': 'application/json',
-            'X-App-Installation-Id': context.app.installationId,
-          },
+          headers: getCallbackHeaders('settings'),
           body: { value },
         })
 
@@ -684,10 +683,7 @@ export function createServerSDK(context: RuntimeContext): ServerSDK {
         const response = await sdkFetch({
           method: 'POST',
           url: `${context.apiUrl}/api/v1/apps/settings`,
-          headers: {
-            'Content-Type': 'application/json',
-            'X-App-Installation-Id': context.app.installationId,
-          },
+          headers: getCallbackHeaders('settings'),
           body: { settings },
         })
 

--- a/apps/lambda/src/types.ts
+++ b/apps/lambda/src/types.ts
@@ -76,6 +76,12 @@ export interface RuntimeContext {
   // Connection data (decrypted and passed from API)
   userConnection?: ConnectionData
   organizationConnection?: ConnectionData
+
+  // Scoped callback tokens for SDK → API authentication
+  callbackTokens?: {
+    webhooks: string
+    settings: string
+  }
 }
 
 /**

--- a/apps/lambda/src/validator.ts
+++ b/apps/lambda/src/validator.ts
@@ -28,6 +28,12 @@ export const ExecutionContextSchema = z.object({
   appInstallationId: z.string().min(1),
   userConnection: ConnectionDataSchema.optional(),
   organizationConnection: ConnectionDataSchema.optional(),
+  callbackTokens: z
+    .object({
+      webhooks: z.string(),
+      settings: z.string(),
+    })
+    .optional(),
 })
 
 // ============================================================================

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -28,6 +28,10 @@ REDIS_PORT=6379
 # ─── Auth (env-only secrets) ──────────────────────────────
 API_KEY_SALT=
 
+# ─── Lambda ───────────────────────────────────────────────
+# Shared secret for HMAC-signed Lambda invocations (must match apps/lambda/.env)
+LAMBDA_INVOKE_SECRET=
+
 # ─── Infra ────────────────────────────────────────────────
 AWS_REGION=us-west-1
 HOSTED_ZONE=

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -87,6 +87,9 @@ GOOGLE_API_KEY=
 GROQ_API_KEY=
 
 
+# Lambda signing (must match apps/lambda/.env)
+LAMBDA_INVOKE_SECRET=
+
 SKIP_CHAT_SESSION_VERIFICATION=true
 
 # Analytics

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,407 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@*": "1.0.15",
+    "jsr:@std/internal@^1.0.12": "1.0.12"
+  },
+  "jsr": {
+    "@std/assert@1.0.15": {
+      "integrity": "d64018e951dbdfab9777335ecdb000c0b4e3df036984083be219ce5941e4703b",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    }
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@aws-sdk/client-cloudfront@^3.995.0",
+        "npm:@aws-sdk/client-ssm@3.995.0",
+        "npm:@aws-sdk/client-sts@^3.995.0",
+        "npm:@biomejs/biome@^2.3.15",
+        "npm:@commitlint/cli@^20.4.1",
+        "npm:@commitlint/config-conventional@^20.4.1",
+        "npm:dotenv-cli@8",
+        "npm:husky@^9.1.7",
+        "npm:lint-staged@^16.2.7",
+        "npm:sst@3.19.0",
+        "npm:turbo@2.5.2",
+        "npm:undici-types@^7.16.0"
+      ]
+    },
+    "members": {
+      "apps/api": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@hono/node-server@^1.14.3",
+            "npm:hono@^4.7.11",
+            "npm:neverthrow@^8.2.0",
+            "npm:tsx@^4.19.2"
+          ]
+        }
+      },
+      "apps/build": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@hookform/resolvers@^4.1.0",
+            "npm:@trpc/client@^11.0.0-rc.446",
+            "npm:@trpc/react-query@^11.0.0-rc.446",
+            "npm:next-themes@~0.4.4",
+            "npm:react-hook-form@^7.54.2",
+            "npm:sonner@^2.0.7",
+            "npm:superjson@^2.2.1"
+          ]
+        }
+      },
+      "apps/docs": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@opennextjs/aws@3.9.15",
+            "npm:@types/mdx@^2.0.13",
+            "npm:fumadocs-core@15.7.8",
+            "npm:fumadocs-mdx@11.8.3",
+            "npm:fumadocs-ui@15.7.8"
+          ]
+        }
+      },
+      "apps/homepage": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@number-flow/react@~0.5.10",
+            "npm:@opennextjs/aws@3.9.15",
+            "npm:@radix-ui/react-accordion@^1.2.12",
+            "npm:@radix-ui/react-avatar@^1.1.10",
+            "npm:@radix-ui/react-context-menu@^2.2.16",
+            "npm:@radix-ui/react-navigation-menu@^1.2.14",
+            "npm:@radix-ui/react-slot@^1.2.3",
+            "npm:@radix-ui/react-tooltip@^1.2.8",
+            "npm:@tailwindcss/postcss@4",
+            "npm:class-variance-authority@~0.7.1",
+            "npm:clsx@^2.1.1",
+            "npm:motion@^12.23.16",
+            "npm:next-themes@~0.4.4",
+            "npm:recharts@^2.15.4",
+            "npm:tailwind-merge@^3.3.1",
+            "npm:tailwindcss@4",
+            "npm:tw-animate-css@^1.4.0"
+          ]
+        }
+      },
+      "apps/lambda": {
+        "dependencies": [
+          "npm:@aws-sdk/client-s3@^3.893.0",
+          "npm:zod@^4.1.5"
+        ],
+        "packageJson": {
+          "dependencies": [
+            "npm:deno@^2.1.4"
+          ]
+        }
+      },
+      "apps/web": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@better-auth/passkey@^1.4.19",
+            "npm:@formkit/auto-animate@~0.8.2",
+            "npm:@hookform/resolvers@^4.1.0",
+            "npm:@monaco-editor/react@^4.7.0",
+            "npm:@next/bundle-analyzer@^15.3.1",
+            "npm:@noble/hashes@^2.0.1",
+            "npm:@number-flow/react@~0.5.10",
+            "npm:@opennextjs/aws@3.9.15",
+            "npm:@radix-ui/react-accordion@^1.2.12",
+            "npm:@radix-ui/react-avatar@^1.1.10",
+            "npm:@radix-ui/react-context-menu@^2.2.16",
+            "npm:@radix-ui/react-navigation-menu@^1.2.14",
+            "npm:@radix-ui/react-slot@^1.2.3",
+            "npm:@tailwindcss/container-queries@~0.1.1",
+            "npm:@tailwindcss/typography@~0.5.16",
+            "npm:@tanstack/react-query-devtools@^5.72.1",
+            "npm:@tanstack/react-table@^8.21.2",
+            "npm:@tanstack/react-virtual@^3.13.2",
+            "npm:@testing-library/jest-dom@^6.6.3",
+            "npm:@testing-library/react@^16.1.0",
+            "npm:@testing-library/user-event@^14.5.2",
+            "npm:@tiptap/core@2.11.9",
+            "npm:@tiptap/extension-color@2.11.9",
+            "npm:@tiptap/extension-font-family@2.11.9",
+            "npm:@tiptap/extension-highlight@2.11.9",
+            "npm:@tiptap/extension-horizontal-rule@2.11.9",
+            "npm:@tiptap/extension-image@2.11.9",
+            "npm:@tiptap/extension-link@2.11.9",
+            "npm:@tiptap/extension-mention@2.11.9",
+            "npm:@tiptap/extension-placeholder@2.11.9",
+            "npm:@tiptap/extension-text-align@2.11.9",
+            "npm:@tiptap/extension-text-style@2.11.9",
+            "npm:@tiptap/extension-text@2.11.9",
+            "npm:@tiptap/extension-underline@2.11.9",
+            "npm:@tiptap/pm@2.11.9",
+            "npm:@tiptap/react@2.11.9",
+            "npm:@tiptap/starter-kit@2.11.9",
+            "npm:@tiptap/suggestion@2.11.9",
+            "npm:@trpc/client@^11.0.0-rc.446",
+            "npm:@trpc/react-query@^11.0.0-rc.446",
+            "npm:@types/canvas-confetti@^1.9.0",
+            "npm:@types/dagre@~0.7.52",
+            "npm:@types/papaparse@^5.5.2",
+            "npm:@types/ua-parser-js@~0.7.39",
+            "npm:@uidotdev/usehooks@^2.4.1",
+            "npm:@vercel/functions@2",
+            "npm:@xyflow/react@^12.9.0",
+            "npm:axios@^1.7.9",
+            "npm:canvas-confetti@^1.9.3",
+            "npm:class-variance-authority@~0.7.1",
+            "npm:clsx@^2.1.1",
+            "npm:cmdk@1.1.1",
+            "npm:croner@^9.1.0",
+            "npm:dagre@~0.8.5",
+            "npm:date-fns-tz@^3.2.0",
+            "npm:dompurify@^3.2.4",
+            "npm:immer@^10.1.1",
+            "npm:import-in-the-middle@^1.14.2",
+            "npm:input-otp@^1.4.2",
+            "npm:jotai@^2.14.0",
+            "npm:jsonwebtoken@^9.0.2",
+            "npm:jwks-rsa@^3.2.0",
+            "npm:kbar@0.1.0-beta.48",
+            "npm:motion@^12.23.16",
+            "npm:next-themes@~0.4.4",
+            "npm:nuqs@^2.4.0",
+            "npm:papaparse@^5.5.3",
+            "npm:prosemirror-state@^1.4.3",
+            "npm:radix-ui@^1.4.2",
+            "npm:react-avatar@^5.0.3",
+            "npm:react-day-picker@^9.8.1",
+            "npm:react-dropzone@^14.3.8",
+            "npm:react-hook-form@^7.54.2",
+            "npm:react-intersection-observer@^9.15.1",
+            "npm:react-letter@0.4",
+            "npm:react-markdown@^10.1.0",
+            "npm:react-phone-input-2@^2.15.1",
+            "npm:react-phone-number-input@^3.4.14",
+            "npm:react-qr-code@^2.0.15",
+            "npm:react-resizable-panels@^2.1.7",
+            "npm:react-select@^5.10.0",
+            "npm:recharts@^2.15.4",
+            "npm:require-in-the-middle@^7.5.2",
+            "npm:sonner@^2.0.7",
+            "npm:superjson@^2.2.1",
+            "npm:tailwind-merge@^3.0.1",
+            "npm:tailwindcss-animate@^1.0.7",
+            "npm:tippy.js@^6.3.7",
+            "npm:tiptap-markdown@~0.8.10",
+            "npm:tw-animate-css@^1.3.6",
+            "npm:ua-parser-js@~0.7.39",
+            "npm:usehooks-ts@^3.1.1",
+            "npm:vaul@^1.1.2",
+            "npm:zustand@^5.0.5"
+          ]
+        }
+      },
+      "apps/worker": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@hono/node-server@^1.13.7",
+            "npm:hono@^4.9.7",
+            "npm:socket.io@^4.8.1",
+            "npm:sst@^3.19.0"
+          ]
+        }
+      },
+      "packages/config": {
+        "packageJson": {
+          "dependencies": [
+            "npm:sst@^3.19.0"
+          ]
+        }
+      },
+      "packages/credentials": {
+        "packageJson": {
+          "dependencies": [
+            "npm:neverthrow@^6.2.2"
+          ]
+        }
+      },
+      "packages/database": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@paralleldrive/cuid2@^3.3.0"
+          ]
+        }
+      },
+      "packages/email": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@react-email/components@~0.5.5",
+            "npm:@react-email/preview-server@4.2.12",
+            "npm:clsx@^2.1.1",
+            "npm:form-data@^4.0.2",
+            "npm:mailgun.js@^12.0.1",
+            "npm:react-email@4.2.12",
+            "npm:tailwind-merge@^3.3.1"
+          ]
+        }
+      },
+      "packages/lib": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@anthropic-ai/sdk@0.39",
+            "npm:@azure/msal-node@^3.4.1",
+            "npm:@google-cloud/pubsub@^4.10.0",
+            "npm:@google/generative-ai@0.24",
+            "npm:@langchain/openai@~0.5.1",
+            "npm:@microsoft/microsoft-graph-client@^3.0.7",
+            "npm:@types/addressparser@^1.0.3",
+            "npm:@types/email-reply-parser@^1.4.2",
+            "npm:@types/html-to-text@^9.0.4",
+            "npm:@types/jsdom@^21.1.7",
+            "npm:@types/pdf-parse@^1.1.5",
+            "npm:addressparser@^1.0.1",
+            "npm:cheerio@^1.1.2",
+            "npm:cohere-ai@^7.18.1",
+            "npm:commander@12",
+            "npm:csv-parser@^3.2.0",
+            "npm:date-fns-tz@^3.2.0",
+            "npm:email-reply-parser@^1.9.4",
+            "npm:file-type@19",
+            "npm:form-data@^4.0.2",
+            "npm:gmail-api-parse-message@^2.1.2",
+            "npm:google-auth-library@^9.15.1",
+            "npm:groq-sdk@0.19",
+            "npm:html-to-text@^9.0.5",
+            "npm:jsep@^1.4.0",
+            "npm:json-logic-js@^2.0.5",
+            "npm:langsmith@0.3",
+            "npm:lru-cache@11.1.0",
+            "npm:mailgun.js@^12.0.1",
+            "npm:mammoth@^1.10.0",
+            "npm:nanoid@^5.1.5",
+            "npm:neverthrow@^6.2.2",
+            "npm:p-limit@^6.2.0",
+            "npm:pdf-parse@^1.1.1",
+            "npm:xlsx@~0.18.5",
+            "npm:zod-to-json-schema@^3.24.0"
+          ]
+        }
+      },
+      "packages/sdk": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@babel/code-frame@^7.27.1",
+            "npm:@fal-works/esbuild-plugin-global-externals@^2.1.2",
+            "npm:@graphql-codegen/core@^4.0.2",
+            "npm:@graphql-codegen/typescript-operations@^4.6.1",
+            "npm:@hono/graphql-server@0.6.2",
+            "npm:@hono/node-server@1.14.4",
+            "npm:@inquirer/prompts@7.5.3",
+            "npm:@postman/node-keytar@^7.9.0",
+            "npm:@types/babel__code-frame@^7.0.6",
+            "npm:@types/node-notifier@^8.0.5",
+            "npm:@types/node@20",
+            "npm:@types/react-dom@19.1.0",
+            "npm:@types/react-reconciler@~0.32.2",
+            "npm:@types/react@19.1.0",
+            "npm:@typescript-eslint/eslint-plugin@^8.44.1",
+            "npm:@typescript-eslint/parser@8.44.1",
+            "npm:@typescript-eslint/scope-manager@8.44.1",
+            "npm:ably@^2.0.1",
+            "npm:boxen@^8.0.1",
+            "npm:chalk@^5.4.1",
+            "npm:chokidar@^3.6.0",
+            "npm:cli-table3@~0.6.5",
+            "npm:commander@13",
+            "npm:date-fns@^2.21.1",
+            "npm:dotenv@^16.5.0",
+            "npm:esbuild@~0.25.5",
+            "npm:eslint@9",
+            "npm:find-up-simple@1",
+            "npm:glob@^11.0.2",
+            "npm:graphql@16.9.0",
+            "npm:hono@4.6.18",
+            "npm:node-notifier@^10.0.1",
+            "npm:open@7",
+            "npm:react-dom@19.1.0",
+            "npm:react-reconciler@0.33",
+            "npm:react@19.1.0",
+            "npm:stdin-blocker@2",
+            "npm:tiny-cursor@2",
+            "npm:tmp-promise@^3.0.3",
+            "npm:ts-morph@24",
+            "npm:typescript@5.9.2",
+            "npm:vitest@^4.0.18",
+            "npm:zimmerframe@1.1.4",
+            "npm:zod@^3.25.64"
+          ]
+        }
+      },
+      "packages/seed": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@noble/hashes@^2.0.1",
+            "npm:@paralleldrive/cuid2@^3.3.0",
+            "npm:commander@^11.1.0",
+            "npm:ora@7",
+            "npm:postgres@^3.4.0"
+          ]
+        }
+      },
+      "packages/services": {
+        "packageJson": {
+          "dependencies": [
+            "npm:neverthrow@^6.2.2"
+          ]
+        }
+      },
+      "packages/ui": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@radix-ui/react-accordion@^1.2.12",
+            "npm:@radix-ui/react-avatar@^1.1.10",
+            "npm:@radix-ui/react-context-menu@^2.2.16",
+            "npm:@radix-ui/react-navigation-menu@^1.2.14",
+            "npm:@radix-ui/react-slot@^1.2.3",
+            "npm:@tanstack/react-table@^8.21.2",
+            "npm:@testing-library/jest-dom@^6.6.3",
+            "npm:@testing-library/react@^16.1.0",
+            "npm:class-variance-authority@~0.7.1",
+            "npm:clsx@^2.1.1",
+            "npm:cmdk@1.1.1",
+            "npm:date-fns-tz@^3.2.0",
+            "npm:input-otp@^1.4.2",
+            "npm:motion@^12.23.16",
+            "npm:next-themes@~0.4.4",
+            "npm:radix-ui@^1.4.2",
+            "npm:react-day-picker@^9.8.1",
+            "npm:react-hook-form@^7.54.2",
+            "npm:react-phone-number-input@^3.4.14",
+            "npm:react-resizable-panels@^2.1.7",
+            "npm:recharts@^2.15.4",
+            "npm:sonner@^2.0.7",
+            "npm:tailwind-merge@^3.0.1",
+            "npm:tailwindcss-animate@^1.0.7",
+            "npm:vaul@^1.1.2"
+          ]
+        }
+      },
+      "packages/utils": {
+        "packageJson": {
+          "dependencies": [
+            "npm:date-fns-tz@^3.2.0",
+            "npm:nanoid@^5.1.5"
+          ]
+        }
+      },
+      "packages/workflow-nodes": {
+        "packageJson": {
+          "dependencies": [
+            "npm:fs-extra@^11.2.0",
+            "npm:glob@^10.3.10"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/infra/lambda.ts
+++ b/infra/lambda.ts
@@ -2,6 +2,7 @@
 /// <reference path="../.sst/platform/config.d.ts" />
 
 import { vpc } from './router-vpc'
+import { secretsConfig } from './secrets'
 import { privateBucket } from './storage'
 
 /**
@@ -28,6 +29,7 @@ export const serverFunctionExecutor = $dev
       environment: {
         NODE_ENV: $dev ? 'development' : 'production',
         S3_PRIVATE_BUCKET: privateBucket.name, // Server bundles stored in private bucket
+        LAMBDA_INVOKE_SECRET: secretsConfig.LAMBDA_INVOKE_SECRET.secret.value,
       },
 
       // Link resources (NOT secrets - extensions should not access platform secrets)
@@ -44,13 +46,9 @@ export const serverFunctionExecutor = $dev
       ],
 
       // Enable function URL (simpler than API Gateway)
+      // No CORS — Lambda is only called server-to-server, never from browsers
       url: {
-        cors: {
-          allowOrigins: ['*'], // Will be restricted by auth in API layer
-          allowMethods: ['POST'],
-          allowHeaders: ['*'],
-        },
-        authorization: 'none', // Auth handled by API layer
+        authorization: 'none', // Auth handled at application level (HMAC-SHA256)
       },
 
       // Development - container runtime not supported in sst dev

--- a/infra/worker.ts
+++ b/infra/worker.ts
@@ -27,4 +27,10 @@ export const worker = $dev
         lambdaExecutorUrl: serverFunctionExecutorUrl,
       }),
       link: [...getSecretsForLinking('worker'), rds, redis, publicBucket, privateBucket],
+      permissions: [
+        {
+          actions: ['ses:SendEmail', 'ses:SendRawEmail'],
+          resources: ['*'],
+        },
+      ],
     })

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -48,6 +48,11 @@
       "types": "./src/config/client.ts",
       "import": "./dist/config/client.mjs",
       "default": "./src/config/client.ts"
+    },
+    "./lambda-auth": {
+      "types": "./src/lambda-auth/index.ts",
+      "import": "./dist/lambda-auth/index.mjs",
+      "default": "./src/lambda-auth/index.ts"
     }
   },
   "scripts": {

--- a/packages/credentials/src/lambda-auth/__tests__/callback-token.test.ts
+++ b/packages/credentials/src/lambda-auth/__tests__/callback-token.test.ts
@@ -1,0 +1,171 @@
+// packages/credentials/src/lambda-auth/__tests__/callback-token.test.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createCallbackToken, verifyCallbackToken } from '../callback-token'
+
+const TEST_SECRET = 'test-callback-secret-for-hmac-signing'
+
+describe('callback-token', () => {
+  describe('round-trip', () => {
+    it('create + verify succeeds with matching params', () => {
+      const token = createCallbackToken({
+        installationId: 'inst_123',
+        organizationId: 'org_456',
+        scope: 'webhooks',
+        secret: TEST_SECRET,
+      })
+
+      const result = verifyCallbackToken({
+        token,
+        expectedInstallationId: 'inst_123',
+        expectedScope: 'webhooks',
+        secret: TEST_SECRET,
+      })
+
+      expect(result.valid).toBe(true)
+      expect(result.organizationId).toBe('org_456')
+      expect(result.error).toBeUndefined()
+    })
+
+    it('works for settings scope', () => {
+      const token = createCallbackToken({
+        installationId: 'inst_789',
+        organizationId: 'org_abc',
+        scope: 'settings',
+        secret: TEST_SECRET,
+      })
+
+      const result = verifyCallbackToken({
+        token,
+        expectedInstallationId: 'inst_789',
+        expectedScope: 'settings',
+        secret: TEST_SECRET,
+      })
+
+      expect(result.valid).toBe(true)
+      expect(result.organizationId).toBe('org_abc')
+    })
+  })
+
+  describe('rejection cases', () => {
+    it('rejects expired token', () => {
+      const token = createCallbackToken({
+        installationId: 'inst_123',
+        organizationId: 'org_456',
+        scope: 'webhooks',
+        secret: TEST_SECRET,
+        ttlMs: -1, // Already expired
+      })
+
+      const result = verifyCallbackToken({
+        token,
+        expectedInstallationId: 'inst_123',
+        expectedScope: 'webhooks',
+        secret: TEST_SECRET,
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toBe('Token expired')
+    })
+
+    it('rejects wrong installation ID', () => {
+      const token = createCallbackToken({
+        installationId: 'inst_123',
+        organizationId: 'org_456',
+        scope: 'webhooks',
+        secret: TEST_SECRET,
+      })
+
+      const result = verifyCallbackToken({
+        token,
+        expectedInstallationId: 'inst_WRONG',
+        expectedScope: 'webhooks',
+        secret: TEST_SECRET,
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toBe('Installation ID mismatch')
+    })
+
+    it('rejects wrong scope', () => {
+      const token = createCallbackToken({
+        installationId: 'inst_123',
+        organizationId: 'org_456',
+        scope: 'webhooks',
+        secret: TEST_SECRET,
+      })
+
+      const result = verifyCallbackToken({
+        token,
+        expectedInstallationId: 'inst_123',
+        expectedScope: 'settings',
+        secret: TEST_SECRET,
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toContain('Scope mismatch')
+    })
+
+    it('rejects tampered token', () => {
+      const token = createCallbackToken({
+        installationId: 'inst_123',
+        organizationId: 'org_456',
+        scope: 'webhooks',
+        secret: TEST_SECRET,
+      })
+
+      // Tamper by changing a character
+      const tampered = `${token.slice(0, -2)}xx`
+
+      const result = verifyCallbackToken({
+        token: tampered,
+        expectedInstallationId: 'inst_123',
+        expectedScope: 'webhooks',
+        secret: TEST_SECRET,
+      })
+
+      expect(result.valid).toBe(false)
+    })
+
+    it('rejects wrong secret', () => {
+      const token = createCallbackToken({
+        installationId: 'inst_123',
+        organizationId: 'org_456',
+        scope: 'webhooks',
+        secret: TEST_SECRET,
+      })
+
+      const result = verifyCallbackToken({
+        token,
+        expectedInstallationId: 'inst_123',
+        expectedScope: 'webhooks',
+        secret: 'wrong-secret',
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toBe('Invalid token signature')
+    })
+
+    it('rejects malformed token (not base64)', () => {
+      const result = verifyCallbackToken({
+        token: 'not-a-valid-token!!!',
+        expectedInstallationId: 'inst_123',
+        expectedScope: 'webhooks',
+        secret: TEST_SECRET,
+      })
+
+      expect(result.valid).toBe(false)
+    })
+
+    it('rejects empty token', () => {
+      const result = verifyCallbackToken({
+        token: '',
+        expectedInstallationId: 'inst_123',
+        expectedScope: 'webhooks',
+        secret: TEST_SECRET,
+      })
+
+      expect(result.valid).toBe(false)
+    })
+  })
+})

--- a/packages/credentials/src/lambda-auth/__tests__/cross-runtime.test.ts
+++ b/packages/credentials/src/lambda-auth/__tests__/cross-runtime.test.ts
@@ -1,0 +1,158 @@
+// packages/credentials/src/lambda-auth/__tests__/cross-runtime.test.ts
+
+/**
+ * Cross-runtime compatibility test.
+ *
+ * Signs a request using the Node.js signing module (node:crypto),
+ * then verifies the signature by reimplementing the Deno Web Crypto
+ * verification algorithm using Node.js webcrypto.
+ *
+ * This proves that the two implementations (inbound-signing.ts and
+ * verify-inbound.ts) produce and accept identical signatures.
+ */
+
+import { createHash, webcrypto } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { signInboundRequest } from '../inbound-signing'
+
+const TEST_SECRET = 'cross-runtime-test-secret-key-32-chars'
+
+// Reimplementation of the Deno verification using Node.js webcrypto
+// This mirrors apps/lambda/src/auth/verify-inbound.ts exactly
+async function verifyWithWebCrypto(params: {
+  headers: Record<string, string>
+  body: string
+  secret: string
+}): Promise<{ valid: boolean; caller?: string }> {
+  const { headers, body, secret } = params
+
+  const signature = headers['X-Auxx-Signature']
+  const timestamp = headers['X-Auxx-Timestamp']
+  const nonce = headers['X-Auxx-Nonce']
+  const caller = headers['X-Auxx-Caller']
+  const keyId = headers['X-Auxx-Key-Id']
+
+  if (!signature || !timestamp || !nonce || !caller || !keyId) {
+    return { valid: false }
+  }
+
+  // Strip "sha256=" prefix
+  const mac = signature.startsWith('sha256=') ? signature.slice(7) : signature
+
+  // SHA-256 of body using webcrypto
+  const encoder = new TextEncoder()
+  const bodyHash = await webcrypto.subtle.digest('SHA-256', encoder.encode(body))
+  const bodySha256 = Array.from(new Uint8Array(bodyHash))
+    .map((b: number) => b.toString(16).padStart(2, '0'))
+    .join('')
+
+  // Build canonical message (same format as Deno verifier)
+  const canonical = ['v1', timestamp, nonce, caller, keyId, bodySha256].join('\n')
+  const message = `inbound:v1:${canonical}`
+
+  // HMAC-SHA256 verify using webcrypto
+  const key = await webcrypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['verify']
+  )
+
+  const sigBytes = new Uint8Array(mac.length / 2)
+  for (let i = 0; i < mac.length; i += 2) {
+    sigBytes[i / 2] = Number.parseInt(mac.slice(i, i + 2), 16)
+  }
+
+  const valid = await webcrypto.subtle.verify('HMAC', key, sigBytes, encoder.encode(message))
+  return { valid, caller: valid ? caller : undefined }
+}
+
+describe('cross-runtime compatibility', () => {
+  it('Node.js node:crypto signature is verified by webcrypto', async () => {
+    const body =
+      '{"type":"function","functionIdentifier":"actions/test.server","functionArgs":"[]"}'
+
+    // Sign with node:crypto (what @auxx/credentials uses)
+    const headers = signInboundRequest({
+      body,
+      caller: 'api',
+      secret: TEST_SECRET,
+    })
+
+    // Verify with webcrypto (mirrors what Deno Lambda does)
+    const result = await verifyWithWebCrypto({
+      headers,
+      body,
+      secret: TEST_SECRET,
+    })
+
+    expect(result.valid).toBe(true)
+    expect(result.caller).toBe('api')
+  })
+
+  it('body SHA-256 matches between node:crypto and webcrypto', async () => {
+    const body = '{"test":"data","nested":{"key":"value"}}'
+
+    // node:crypto hash
+    const nodeHash = createHash('sha256').update(body).digest('hex')
+
+    // webcrypto hash
+    const encoder = new TextEncoder()
+    const webHash = await webcrypto.subtle.digest('SHA-256', encoder.encode(body))
+    const webHashHex = Array.from(new Uint8Array(webHash))
+      .map((b: number) => b.toString(16).padStart(2, '0'))
+      .join('')
+
+    expect(nodeHash).toBe(webHashHex)
+  })
+
+  it('different callers produce different valid signatures', async () => {
+    const body = '{"type":"webhook"}'
+
+    const apiHeaders = signInboundRequest({ body, caller: 'api', secret: TEST_SECRET })
+    const workerHeaders = signInboundRequest({ body, caller: 'worker', secret: TEST_SECRET })
+
+    // Both should be valid
+    const apiResult = await verifyWithWebCrypto({ headers: apiHeaders, body, secret: TEST_SECRET })
+    const workerResult = await verifyWithWebCrypto({
+      headers: workerHeaders,
+      body,
+      secret: TEST_SECRET,
+    })
+
+    expect(apiResult.valid).toBe(true)
+    expect(apiResult.caller).toBe('api')
+    expect(workerResult.valid).toBe(true)
+    expect(workerResult.caller).toBe('worker')
+
+    // But signatures differ
+    expect(apiHeaders['X-Auxx-Signature']).not.toBe(workerHeaders['X-Auxx-Signature'])
+  })
+
+  it('tampered body fails webcrypto verification', async () => {
+    const body = '{"type":"function"}'
+    const headers = signInboundRequest({ body, caller: 'api', secret: TEST_SECRET })
+
+    const result = await verifyWithWebCrypto({
+      headers,
+      body: '{"type":"tampered"}',
+      secret: TEST_SECRET,
+    })
+
+    expect(result.valid).toBe(false)
+  })
+
+  it('wrong secret fails webcrypto verification', async () => {
+    const body = '{"type":"function"}'
+    const headers = signInboundRequest({ body, caller: 'api', secret: TEST_SECRET })
+
+    const result = await verifyWithWebCrypto({
+      headers,
+      body,
+      secret: 'wrong-secret',
+    })
+
+    expect(result.valid).toBe(false)
+  })
+})

--- a/packages/credentials/src/lambda-auth/__tests__/inbound-signing.test.ts
+++ b/packages/credentials/src/lambda-auth/__tests__/inbound-signing.test.ts
@@ -1,0 +1,88 @@
+// packages/credentials/src/lambda-auth/__tests__/inbound-signing.test.ts
+
+import { createHash, createHmac } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { signInboundRequest } from '../inbound-signing'
+
+const TEST_SECRET = 'test-secret-key-for-hmac-signing-32chars'
+
+describe('inbound-signing', () => {
+  it('produces all required auth headers', () => {
+    const headers = signInboundRequest({
+      body: '{"type":"function"}',
+      caller: 'api',
+      secret: TEST_SECRET,
+    })
+
+    expect(headers['X-Auxx-Signature']).toMatch(/^sha256=[a-f0-9]{64}$/)
+    expect(headers['X-Auxx-Timestamp']).toMatch(/^\d+$/)
+    expect(headers['X-Auxx-Nonce']).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    )
+    expect(headers['X-Auxx-Caller']).toBe('api')
+    expect(headers['X-Auxx-Key-Id']).toBe('v1')
+  })
+
+  it('signature changes when body changes', () => {
+    const headers1 = signInboundRequest({
+      body: '{"type":"function","data":"a"}',
+      caller: 'api',
+      secret: TEST_SECRET,
+    })
+    const headers2 = signInboundRequest({
+      body: '{"type":"function","data":"b"}',
+      caller: 'api',
+      secret: TEST_SECRET,
+    })
+
+    expect(headers1['X-Auxx-Signature']).not.toBe(headers2['X-Auxx-Signature'])
+  })
+
+  it('signature changes when caller changes', () => {
+    const body = '{"type":"function"}'
+    const headers1 = signInboundRequest({ body, caller: 'api', secret: TEST_SECRET })
+    const headers2 = signInboundRequest({ body, caller: 'worker', secret: TEST_SECRET })
+
+    expect(headers1['X-Auxx-Signature']).not.toBe(headers2['X-Auxx-Signature'])
+  })
+
+  it('generates different nonce per call', () => {
+    const body = '{"type":"function"}'
+    const headers1 = signInboundRequest({ body, caller: 'api', secret: TEST_SECRET })
+    const headers2 = signInboundRequest({ body, caller: 'api', secret: TEST_SECRET })
+
+    expect(headers1['X-Auxx-Nonce']).not.toBe(headers2['X-Auxx-Nonce'])
+  })
+
+  it('uses custom keyId when provided', () => {
+    const headers = signInboundRequest({
+      body: '{"type":"function"}',
+      caller: 'api',
+      secret: TEST_SECRET,
+      keyId: 'v2',
+    })
+
+    expect(headers['X-Auxx-Key-Id']).toBe('v2')
+  })
+
+  it('produces a verifiable signature', () => {
+    const body = '{"type":"function"}'
+    const headers = signInboundRequest({ body, caller: 'api', secret: TEST_SECRET })
+
+    // Manually verify the signature using the same algorithm
+    const bodySha256 = createHash('sha256').update(body).digest('hex')
+    const canonical = [
+      'v1',
+      headers['X-Auxx-Timestamp'],
+      headers['X-Auxx-Nonce'],
+      'api',
+      'v1',
+      bodySha256,
+    ].join('\n')
+    const expectedMac = createHmac('sha256', TEST_SECRET)
+      .update(`inbound:v1:${canonical}`)
+      .digest('hex')
+
+    expect(headers['X-Auxx-Signature']).toBe(`sha256=${expectedMac}`)
+  })
+})

--- a/packages/credentials/src/lambda-auth/callback-token.ts
+++ b/packages/credentials/src/lambda-auth/callback-token.ts
@@ -1,0 +1,81 @@
+// packages/credentials/src/lambda-auth/callback-token.ts
+
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto'
+import type { CallbackScope } from './types'
+
+const DEFAULT_TTL_MS = 60_000
+
+/**
+ * Create a scoped callback token for Lambda SDK → API authentication.
+ *
+ * Token format: base64url(<scope>:<installationId>:<organizationId>:<expMs>:<nonce>.<hmacHex>)
+ *
+ * Domain prefix "callback:v1:" prevents cross-purpose reuse with inbound signatures.
+ * Scope field prevents a token issued for /webhooks from being replayed on /settings.
+ */
+export function createCallbackToken(params: {
+  installationId: string
+  organizationId: string
+  scope: CallbackScope
+  secret: string
+  ttlMs?: number
+}): string {
+  const { installationId, organizationId, scope, secret, ttlMs = DEFAULT_TTL_MS } = params
+  const exp = Date.now() + ttlMs
+  const nonce = randomUUID()
+  const data = `${scope}:${installationId}:${organizationId}:${exp}:${nonce}`
+  const mac = createHmac('sha256', secret).update(`callback:v1:${data}`).digest('hex')
+  return Buffer.from(`${data}.${mac}`).toString('base64url')
+}
+
+/**
+ * Verify a scoped callback token.
+ *
+ * Checks signature (constant-time), scope, installation ID, and expiry.
+ */
+export function verifyCallbackToken(params: {
+  token: string
+  expectedInstallationId: string
+  expectedScope: CallbackScope
+  secret: string
+}): { valid: boolean; organizationId?: string; error?: string } {
+  try {
+    const decoded = Buffer.from(params.token, 'base64url').toString()
+    const lastDot = decoded.lastIndexOf('.')
+    if (lastDot === -1) return { valid: false, error: 'Malformed token' }
+
+    const data = decoded.slice(0, lastDot)
+    const mac = decoded.slice(lastDot + 1)
+
+    // Constant-time signature verification
+    const expected = createHmac('sha256', params.secret).update(`callback:v1:${data}`).digest('hex')
+    if (
+      mac.length !== expected.length ||
+      !timingSafeEqual(Buffer.from(mac), Buffer.from(expected))
+    ) {
+      return { valid: false, error: 'Invalid token signature' }
+    }
+
+    // Parse claims
+    const parts = data.split(':')
+    if (parts.length !== 5) return { valid: false, error: 'Malformed token payload' }
+    const [scope, installationId, organizationId, expStr] = parts
+
+    if (scope !== params.expectedScope) {
+      return {
+        valid: false,
+        error: `Scope mismatch: expected "${params.expectedScope}", got "${scope}"`,
+      }
+    }
+    if (installationId !== params.expectedInstallationId) {
+      return { valid: false, error: 'Installation ID mismatch' }
+    }
+    if (Number(expStr) < Date.now()) {
+      return { valid: false, error: 'Token expired' }
+    }
+
+    return { valid: true, organizationId }
+  } catch {
+    return { valid: false, error: 'Malformed token' }
+  }
+}

--- a/packages/credentials/src/lambda-auth/inbound-signing.ts
+++ b/packages/credentials/src/lambda-auth/inbound-signing.ts
@@ -1,0 +1,52 @@
+// packages/credentials/src/lambda-auth/inbound-signing.ts
+
+import { createHash, createHmac, randomUUID } from 'node:crypto'
+import type { InboundAuthHeaders } from './types'
+
+/**
+ * Build the canonical message for HMAC signing.
+ *
+ * Format: v1\n<timestamp>\n<nonce>\n<caller>\n<keyId>\n<bodySha256>
+ */
+function buildCanonical(parts: {
+  timestamp: string
+  nonce: string
+  caller: string
+  keyId: string
+  bodySha256: string
+}): string {
+  return ['v1', parts.timestamp, parts.nonce, parts.caller, parts.keyId, parts.bodySha256].join(
+    '\n'
+  )
+}
+
+/**
+ * Sign an outbound Lambda invocation request with HMAC-SHA256.
+ *
+ * Returns headers that must be included in the HTTP request.
+ * The Lambda function verifies these headers before executing.
+ *
+ * Domain prefix "inbound:v1:" prevents cross-purpose replay with callback tokens.
+ */
+export function signInboundRequest(params: {
+  body: string
+  caller: string
+  secret: string
+  keyId?: string
+}): InboundAuthHeaders {
+  const { body, caller, secret, keyId = 'v1' } = params
+  const timestamp = String(Date.now())
+  const nonce = randomUUID()
+  const bodySha256 = createHash('sha256').update(body).digest('hex')
+
+  const canonical = buildCanonical({ timestamp, nonce, caller, keyId, bodySha256 })
+  const mac = createHmac('sha256', secret).update(`inbound:v1:${canonical}`).digest('hex')
+
+  return {
+    'X-Auxx-Signature': `sha256=${mac}`,
+    'X-Auxx-Timestamp': timestamp,
+    'X-Auxx-Nonce': nonce,
+    'X-Auxx-Caller': caller,
+    'X-Auxx-Key-Id': keyId,
+  }
+}

--- a/packages/credentials/src/lambda-auth/index.ts
+++ b/packages/credentials/src/lambda-auth/index.ts
@@ -1,0 +1,5 @@
+// packages/credentials/src/lambda-auth/index.ts
+
+export { createCallbackToken, verifyCallbackToken } from './callback-token'
+export { signInboundRequest } from './inbound-signing'
+export type { CallbackScope, InboundAuthHeaders, VerifyResult } from './types'

--- a/packages/credentials/src/lambda-auth/types.ts
+++ b/packages/credentials/src/lambda-auth/types.ts
@@ -1,0 +1,28 @@
+// packages/credentials/src/lambda-auth/types.ts
+
+/**
+ * Headers added to signed Lambda invocation requests.
+ * These headers authenticate the caller to the Lambda function.
+ */
+export interface InboundAuthHeaders {
+  'X-Auxx-Signature': string
+  'X-Auxx-Timestamp': string
+  'X-Auxx-Nonce': string
+  'X-Auxx-Caller': string
+  'X-Auxx-Key-Id': string
+}
+
+/**
+ * Scopes available for callback tokens.
+ * Each scope restricts the token to specific API callback routes.
+ */
+export type CallbackScope = 'webhooks' | 'settings'
+
+/**
+ * Result of verifying an inbound request signature.
+ */
+export interface VerifyResult {
+  valid: boolean
+  caller?: string
+  reason?: string
+}

--- a/packages/credentials/tsdown.config.ts
+++ b/packages/credentials/tsdown.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     'src/login-token/index.ts',
     'src/config/index.ts',
     'src/config/client.ts',
+    'src/lambda-auth/index.ts',
   ],
   format: 'esm',
   target: 'es2022',

--- a/packages/email/src/transports/factory.ts
+++ b/packages/email/src/transports/factory.ts
@@ -45,12 +45,19 @@ export class TransportFactory {
       configService.get<string>('AWS_SES_SECRET_ACCESS_KEY') ||
       configService.get<string>('AWS_SECRET_ACCESS_KEY')
 
-    const sesv2 = new SESv2Client({
+    const useExplicitCredentials = !!(accessKeyId && secretAccessKey)
+
+    logger.info('Creating SESv2 transporter', {
       region,
-      credentials: accessKeyId && secretAccessKey ? { accessKeyId, secretAccessKey } : undefined,
+      credentialSource: useExplicitCredentials ? 'explicit' : 'default-chain (IAM role)',
+      hasAccessKeyId: !!accessKeyId,
+      hasSecretAccessKey: !!secretAccessKey,
     })
 
-    logger.info('Creating SESv2 transporter', { region })
+    const sesv2 = new SESv2Client({
+      region,
+      credentials: useExplicitCredentials ? { accessKeyId, secretAccessKey } : undefined,
+    })
 
     return nodemailer.createTransport({
       SES: { sesClient: sesv2, SendEmailCommand },

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/code.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/code.ts
@@ -127,6 +127,7 @@ export class CodeProcessor extends BaseNodeProcessor {
     const { invokeLambdaExecutor } = await import('@auxx/services/lambda-execution')
 
     const lambdaResult = await invokeLambdaExecutor({
+      caller: 'workflow-engine',
       payload: {
         type: 'code',
         code: config.code,

--- a/packages/lib/src/workflow-engine/nodes/app-workflow-block-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/app-workflow-block-processor.ts
@@ -539,6 +539,7 @@ export class AppWorkflowBlockProcessor extends BaseNodeProcessor {
 
       // 4. Invoke Lambda executor
       const lambdaResult = await invokeLambdaExecutor({
+        caller: 'workflow-engine',
         payload: {
           type: 'workflow-block',
           bundleKey: bundle.serverBundleS3Key,

--- a/packages/services/src/app-events/index.ts
+++ b/packages/services/src/app-events/index.ts
@@ -1,10 +1,10 @@
 // packages/services/src/app-events/index.ts
 
-import { LAMBDA_API_URL, SERVER_FUNCTION_EXECUTOR_URL } from '@auxx/config/urls'
 import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
-import { err, ok, type Result } from 'neverthrow'
+import { err, ok } from 'neverthrow'
+import { invokeLambdaExecutor, prepareLambdaContext } from '../lambda-execution'
 import type { DatabaseError } from '../shared/errors'
 import { fromDatabase } from '../shared/utils'
 
@@ -35,33 +35,6 @@ export type AppEventError =
 
 /**
  * Connection data for event payload
- *
- * @description
- * Represents a connection object that can be passed to app event handlers.
- * Used when triggering connection-related events (connection-added, connection-removed).
- *
- * @example
- * // OAuth2 connection
- * const oauthConnection: EventConnectionData = {
- *   id: 'conn_123',
- *   type: 'oauth2-code',
- *   value: 'oauth2_access_token_xyz',
- *   metadata: {
- *     scopes: ['read', 'write'],
- *     expiresAt: '2025-12-31T23:59:59Z'
- *   }
- * }
- *
- * @example
- * // Secret/API key connection
- * const secretConnection: EventConnectionData = {
- *   id: 'conn_456',
- *   type: 'secret',
- *   value: 'sk_live_abc123xyz',
- *   metadata: {
- *     environment: 'production'
- *   }
- * }
  */
 export interface EventConnectionData {
   /** Unique identifier for the connection */
@@ -77,84 +50,8 @@ export interface EventConnectionData {
 /**
  * Trigger an app event handler
  *
- * @description
- * Executes an app's server-side event handler by invoking the Lambda executor.
- * This function:
- * 1. Retrieves the app installation and organization details
- * 2. Fetches the app version bundle containing the server code
- * 3. Invokes the Lambda executor with the event payload and context
- * 4. Returns once the event handler completes
- *
- * @param params - Event trigger parameters
- * @param params.appInstallationId - The ID of the app installation to trigger the event for
- * @param params.eventType - The type of event to trigger ('connection-added' | 'connection-removed')
- * @param params.payload - The event payload containing connection data
- * @param params.payload.connection - Connection data to pass to the event handler
- *
- * @returns {Promise<Result<void, AppEventError>>} Result indicating success or failure
- *
- * @example
- * // Trigger connection-added event
- * const result = await triggerAppEvent({
- *   appInstallationId: 'app_inst_123',
- *   eventType: 'connection-added',
- *   payload: {
- *     connection: {
- *       id: 'conn_456',
- *       type: 'oauth2-code',
- *       value: 'oauth2_access_token_xyz',
- *       metadata: {
- *         scopes: ['read', 'write']
- *       }
- *     }
- *   }
- * })
- *
- * if (result.isErr()) {
- *   console.error('Failed to trigger event:', result.error.message)
- * }
- *
- * @example
- * // Trigger connection-removed event
- * const result = await triggerAppEvent({
- *   appInstallationId: 'app_inst_789',
- *   eventType: 'connection-removed',
- *   payload: {
- *     connection: {
- *       id: 'conn_101',
- *       type: 'secret',
- *       value: 'sk_live_removed'
- *     }
- *   }
- * })
- *
- * if (result.isOk()) {
- *   console.log('Event triggered successfully')
- * }
- *
- * @example
- * // Usage in a tRPC mutation
- * const addConnection = api.appConnection.create.useMutation({
- *   onSuccess: async (connection) => {
- *     // Trigger event after connection is created
- *     const result = await triggerAppEvent({
- *       appInstallationId: connection.appInstallationId,
- *       eventType: 'connection-added',
- *       payload: {
- *         connection: {
- *           id: connection.id,
- *           type: connection.type,
- *           value: connection.value,
- *           metadata: connection.metadata
- *         }
- *       }
- *     })
- *
- *     if (result.isErr()) {
- *       throw new Error(`Failed to trigger event: ${result.error.message}`)
- *     }
- *   }
- * })
+ * Executes an app's server-side event handler by invoking the Lambda executor
+ * through the shared `invokeLambdaExecutor()` helper with HMAC signing.
  */
 export async function triggerAppEvent(params: {
   appInstallationId: string
@@ -227,54 +124,40 @@ export async function triggerAppEvent(params: {
     return ok(undefined)
   }
 
-  // Get Lambda executor URL and API URL from environment
-  const executorUrl = SERVER_FUNCTION_EXECUTOR_URL
+  // Build context and invoke Lambda via shared helper
+  const context = prepareLambdaContext({
+    appId: installation.appId,
+    installationId: appInstallationId,
+    organizationId: installation.organizationId,
+    organizationHandle: installation.organization.handle,
+    userId: 'system',
+    userEmail: 'system@auxx.ai',
+    userName: null,
+  })
 
-  // Invoke Lambda via HTTP (works in dev AND production)
-  try {
-    const response = await fetch(executorUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        type: 'event',
-        bundleKey: versionBundle.serverBundleS3Key,
-        eventType,
-        eventPayload: payload,
-        context: {
-          organizationId: installation.organizationId,
-          organizationHandle: installation.organization.handle,
-          appId: installation.appId,
-          appInstallationId,
-          apiUrl: LAMBDA_API_URL,
-          // Events don't have user context - use system defaults
-          userId: 'system',
-          userEmail: 'system@auxx.ai',
-        },
-      }),
-    })
+  const lambdaResult = await invokeLambdaExecutor({
+    caller: 'app-events',
+    payload: {
+      type: 'event',
+      bundleKey: versionBundle.serverBundleS3Key,
+      eventType,
+      eventPayload: payload,
+      context,
+    },
+  })
 
-    if (!response.ok) {
-      const error = await response.json()
-      logger.error('Event execution failed', { error, appInstallationId, eventType })
-      return err({
-        code: 'EVENT_EXECUTION_FAILED' as const,
-        message: `Event execution failed: ${error.message || error.error?.message}`,
-        appInstallationId,
-        eventType,
-        cause: error,
-      })
-    }
-
-    logger.info('Event execution completed', { appInstallationId, eventType })
-    return ok(undefined)
-  } catch (error) {
-    logger.error('Event execution error', { error, appInstallationId, eventType })
+  if (lambdaResult.isErr()) {
+    const error = lambdaResult.error
+    logger.error('Event execution failed', { error, appInstallationId, eventType })
     return err({
       code: 'EVENT_EXECUTION_FAILED' as const,
-      message: `Event execution error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      message: `Event execution failed: ${error.message}`,
       appInstallationId,
       eventType,
       cause: error,
     })
   }
+
+  logger.info('Event execution completed', { appInstallationId, eventType })
+  return ok(undefined)
 }

--- a/packages/services/src/lambda-execution/invoke-lambda-executor.ts
+++ b/packages/services/src/lambda-execution/invoke-lambda-executor.ts
@@ -1,6 +1,7 @@
 // packages/services/src/lambda-execution/invoke-lambda-executor.ts
 
 import { SERVER_FUNCTION_EXECUTOR_URL } from '@auxx/config/server'
+import { signInboundRequest } from '@auxx/credentials/lambda-auth'
 import type { Result } from 'neverthrow'
 import { err, ok } from 'neverthrow'
 
@@ -39,23 +40,34 @@ export interface LambdaExecutionError {
 }
 
 /**
- * Standardized Lambda invocation with error handling
- * Handles both server function and workflow block executions
+ * Standardized Lambda invocation with HMAC signing and error handling.
+ * All Lambda invocations must go through this function.
  *
- * @param params - Object containing payload and optional Lambda URL
- * @returns Result with execution result or structured error
+ * @param params.payload - The event payload to send to Lambda
+ * @param params.caller - Identity of the calling service (used for caller-type allowlist)
+ * @param params.lambdaUrl - Optional URL override (defaults to SERVER_FUNCTION_EXECUTOR_URL)
  */
 export async function invokeLambdaExecutor(params: {
   payload: any
+  caller: string
   lambdaUrl?: string
 }): Promise<Result<LambdaExecutionResult, LambdaExecutionError>> {
-  const { payload, lambdaUrl = SERVER_FUNCTION_EXECUTOR_URL } = params
+  const { payload, caller, lambdaUrl = SERVER_FUNCTION_EXECUTOR_URL } = params
 
   try {
+    const body = JSON.stringify(payload)
+
+    // Sign the request with HMAC-SHA256
+    const secret = process.env.LAMBDA_INVOKE_SECRET
+    const authHeaders = secret ? signInboundRequest({ body, caller, secret }) : {}
+
     const lambdaResponse = await fetch(lambdaUrl, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeaders,
+      },
+      body,
     })
 
     if (!lambdaResponse.ok) {

--- a/packages/services/src/lambda-execution/prepare-lambda-context.ts
+++ b/packages/services/src/lambda-execution/prepare-lambda-context.ts
@@ -1,13 +1,14 @@
 // packages/services/src/lambda-execution/prepare-lambda-context.ts
 
 import { LAMBDA_API_URL } from '@auxx/config/urls'
+import { type CallbackScope, createCallbackToken } from '@auxx/credentials/lambda-auth'
 
 /**
- * Build standardized Lambda execution context from installation and user/org info
+ * Build standardized Lambda execution context from installation and user/org info.
  * This context is passed to all Lambda executions (server functions, workflow blocks, etc.)
  *
- * @param params - Object containing context information
- * @returns Lambda context object
+ * Generates scoped callback tokens for SDK → API authentication when
+ * LAMBDA_INVOKE_SECRET is available.
  */
 export function prepareLambdaContext(params: {
   appId: string
@@ -20,6 +21,23 @@ export function prepareLambdaContext(params: {
   userConnection?: any
   organizationConnection?: any
 }) {
+  // Generate scoped callback tokens for SDK → API authentication
+  const secret = process.env.LAMBDA_INVOKE_SECRET
+  let callbackTokens: Record<CallbackScope, string> | undefined
+
+  if (secret) {
+    const scopes: CallbackScope[] = ['webhooks', 'settings']
+    callbackTokens = {} as Record<CallbackScope, string>
+    for (const scope of scopes) {
+      callbackTokens[scope] = createCallbackToken({
+        installationId: params.installationId,
+        organizationId: params.organizationId,
+        scope,
+        secret,
+      })
+    }
+  }
+
   return {
     organizationId: params.organizationId,
     organizationHandle: params.organizationHandle,
@@ -31,5 +49,6 @@ export function prepareLambdaContext(params: {
     appInstallationId: params.installationId,
     userConnection: params.userConnection,
     organizationConnection: params.organizationConnection,
+    callbackTokens,
   }
 }


### PR DESCRIPTION
feat(lambda-auth): implement HMAC signing for Lambda invocations and add callback token functionality

- Added `createCallbackToken` and `verifyCallbackToken` functions for scoped callback token generation and verification.
- Introduced `signInboundRequest` for signing Lambda invocation requests with HMAC-SHA256.
- Updated `invokeLambdaExecutor` to include HMAC signing in requests to Lambda.
- Enhanced `prepareLambdaContext` to generate scoped callback tokens for SDK to API authentication.
- Added tests for callback token creation and verification, ensuring security and functionality.
- Updated Lambda function configurations to include necessary secrets and permissions.
- Refactored event triggering logic to utilize the new Lambda invocation method with HMAC signing.