### PR TITLE
feat: enhance output variable handling and introduce VarEditor compon…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,12 +101,12 @@ S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
 
 # Public bucket (avatars, logos, thumbnails)
-S3_PUBLIC_BUCKET=auxx-public-local
+S3_PUBLIC_BUCKET=auxx-dev-public
 # Private bucket (attachments, temp files)
-S3_PRIVATE_BUCKET=auxx-private-local
+S3_PRIVATE_BUCKET=auxx-dev-private
 
 # Public CDN/base URL for asset delivery
-CDN_URL=https://auxx-public-local.s3.us-west-1.amazonaws.com
+CDN_URL=https://auxx-dev-public.s3.us-west-1.amazonaws.com
 
 # ------------------------------------
 # AI Providers

--- a/apps/web/src/lib/extensions/component-registry.tsx
+++ b/apps/web/src/lib/extensions/component-registry.tsx
@@ -35,7 +35,11 @@ import {
   WorkflowNodeText,
   WorkflowPanel,
 } from './components/workflow'
-import { BooleanInput, NumberInput, SelectInput, StringInput } from './components/workflow/inputs'
+import { WorkflowVarField } from './components/workflow/fields/var-field'
+import { WorkflowVarFieldGroup } from './components/workflow/fields/var-field-group'
+// Note: Old input components (StringInput, NumberInput, etc.) are still available from
+// './components/workflow/inputs' for settings panels where VarEditor isn't needed.
+import { VarInputInternal } from './components/workflow/inputs/var-input'
 import {
   InputGroup,
   Section,
@@ -263,10 +267,16 @@ export const componentRegistry = {
   WorkflowNodeText: WorkflowNodeText,
   WorkflowNodeHandle: WorkflowNodeHandle,
   WorkflowPanel: WorkflowPanel,
-  StringInputInternal: StringInput,
-  NumberInputInternal: NumberInput,
-  BooleanInputInternal: BooleanInput,
-  SelectInputInternal: SelectInput,
+  // VarEditor-backed input components (v2 — all point to VarInputInternal)
+  VarInputInternal: VarInputInternal,
+  StringInputInternal: VarInputInternal,
+  NumberInputInternal: VarInputInternal,
+  BooleanInputInternal: VarInputInternal,
+  OptionsInputInternal: VarInputInternal,
+  SelectInputInternal: VarInputInternal, // Backward compat alias
+  // VarField wrappers
+  WorkflowVarField: WorkflowVarField,
+  WorkflowVarFieldGroup: WorkflowVarFieldGroup,
   WorkflowSection: Section,
   WorkflowInputGroup: InputGroup,
   WorkflowSeparator: WorkflowSeparatorComponent,

--- a/apps/web/src/lib/extensions/components/workflow/fields/var-field-group.tsx
+++ b/apps/web/src/lib/extensions/components/workflow/fields/var-field-group.tsx
@@ -1,0 +1,37 @@
+// apps/web/src/lib/extensions/components/workflow/fields/var-field-group.tsx
+
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import type React from 'react'
+import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
+
+/**
+ * WorkflowVarFieldGroup — container component that maps to VarEditorField.
+ *
+ * Provides the rounded border, background, and orientation context for grouped fields.
+ * Each VarField child inside this group gets a consistent visual treatment.
+ */
+export const WorkflowVarFieldGroup = ({
+  orientation,
+  validationError,
+  validationType,
+  className,
+  children,
+}: {
+  orientation?: 'horizontal' | 'vertical'
+  validationError?: string
+  validationType?: 'error' | 'warning'
+  className?: string
+  children: React.ReactNode
+}) => {
+  return (
+    <VarEditorField
+      orientation={orientation}
+      validationError={validationError}
+      validationType={validationType}
+      className={cn('p-0', className)}>
+      {children}
+    </VarEditorField>
+  )
+}

--- a/apps/web/src/lib/extensions/components/workflow/fields/var-field.tsx
+++ b/apps/web/src/lib/extensions/components/workflow/fields/var-field.tsx
@@ -1,0 +1,87 @@
+// apps/web/src/lib/extensions/components/workflow/fields/var-field.tsx
+
+'use client'
+
+import React from 'react'
+import { VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
+import { useAppWorkflowFieldContext } from '~/lib/workflow/components/app-workflow-field-context'
+import { mapFieldType } from '~/lib/workflow/utils/field-to-var-editor'
+
+/**
+ * Helper to get a nested value from an object using dot notation.
+ */
+function getNestedValue(obj: any, path: string): any {
+  const keys = path.split('.')
+  let result = obj
+  for (const key of keys) {
+    result = result?.[key]
+  }
+  return result
+}
+
+/**
+ * Extract the `name` prop from the first child element.
+ * Returns undefined if child doesn't have a name prop.
+ */
+function extractChildName(children: React.ReactNode): string | undefined {
+  const child = React.Children.toArray(children)[0]
+  if (React.isValidElement(child) && typeof (child.props as any)?.name === 'string') {
+    return (child.props as any).name
+  }
+  return undefined
+}
+
+/**
+ * WorkflowVarField — host component that wraps VarEditorFieldRow.
+ *
+ * Provides the label, description, type icon, required badge, and clear button chrome
+ * around child input components.
+ *
+ * Resolution order: explicit prop > schema metadata > fallback default
+ */
+export const WorkflowVarField = ({
+  name,
+  title,
+  description,
+  required,
+  type,
+  showIcon,
+  children,
+}: {
+  name?: string
+  title?: string
+  description?: string
+  required?: boolean
+  type?: string
+  showIcon?: boolean
+  children: React.ReactNode
+}) => {
+  const { nodeData, handleFieldChange, schema } = useAppWorkflowFieldContext()
+
+  // Resolve field name: explicit prop > child's name prop
+  const fieldName = name ?? extractChildName(children)
+  const fieldSchema = fieldName ? schema?.inputs?.[fieldName] : undefined
+
+  // Resolution order: explicit prop > schema metadata > fallback
+  const resolvedTitle = title ?? fieldSchema?.label ?? fieldName ?? ''
+  const resolvedDescription = description ?? fieldSchema?.description
+  const resolvedRequired = required ?? fieldSchema?.required
+  const resolvedType = type
+    ? mapFieldType(type)
+    : mapFieldType(fieldSchema?.type, fieldSchema?.format)
+
+  const value = fieldName ? getNestedValue(nodeData, fieldName) : undefined
+  const hasValue = value !== undefined && value !== '' && value !== null
+
+  return (
+    <VarEditorFieldRow
+      title={resolvedTitle}
+      description={resolvedDescription}
+      type={resolvedType}
+      isRequired={resolvedRequired}
+      showIcon={showIcon}
+      onClear={hasValue && fieldName ? () => handleFieldChange(fieldName, '', true) : undefined}>
+      {children}
+    </VarEditorFieldRow>
+  )
+}

--- a/apps/web/src/lib/extensions/components/workflow/inputs/var-input.tsx
+++ b/apps/web/src/lib/extensions/components/workflow/inputs/var-input.tsx
@@ -1,0 +1,86 @@
+// apps/web/src/lib/extensions/components/workflow/inputs/var-input.tsx
+
+'use client'
+
+import { VarEditor } from '~/components/workflow/ui/input-editor/var-editor'
+import { useAppWorkflowFieldContext } from '~/lib/workflow/components/app-workflow-field-context'
+import { mapFieldToVarEditorProps } from '~/lib/workflow/utils/field-to-var-editor'
+
+/**
+ * Helper to get a nested value from an object using dot notation.
+ */
+function getNestedValue(obj: any, path: string): any {
+  const keys = path.split('.')
+  let result = obj
+  for (const key of keys) {
+    result = result?.[key]
+  }
+  return result
+}
+
+/**
+ * VarInputInternal — the single host-side component for all app workflow input types.
+ *
+ * Renders a VarEditor configured for the appropriate BaseType/VarMode.
+ * Reads/writes through AppWorkflowFieldContext (no iframe round-trip).
+ *
+ * This component is used directly by the component registry for:
+ * - VarInputInternal (base component)
+ * - StringInputInternal, NumberInputInternal, BooleanInputInternal, OptionsInputInternal (aliases)
+ */
+export const VarInputInternal = ({
+  name,
+  type,
+  placeholder,
+  acceptsVariables,
+  variableTypes,
+  format,
+  options,
+  multiline,
+}: {
+  name: string
+  type: string
+  placeholder?: string
+  acceptsVariables?: boolean
+  variableTypes?: string[]
+  format?: string
+  options?: readonly (string | { label: string; value: string })[]
+  multiline?: boolean
+}) => {
+  const { nodeId, nodeData, handleFieldChange, getFieldMode, schema } = useAppWorkflowFieldContext()
+
+  // Resolve options: explicit prop > schema metadata > empty
+  const resolvedOptions = options ?? schema?.inputs?.[name]?.options
+
+  const { varType, mode, allowConstant, allowedTypes, fieldOptions } = mapFieldToVarEditorProps({
+    type,
+    format,
+    options: resolvedOptions,
+    acceptsVariables,
+    variableTypes,
+  })
+
+  // Dot-path access for nested fields
+  const value = getNestedValue(nodeData, name) ?? ''
+  const isConstantMode = getFieldMode(name)
+
+  return (
+    <VarEditor
+      nodeId={nodeId}
+      value={typeof value === 'string' ? value : String(value)}
+      onChange={(v, isConstant) => handleFieldChange(name, v, isConstant)}
+      varType={varType}
+      mode={mode}
+      allowConstant={allowConstant}
+      allowedTypes={allowedTypes}
+      fieldOptions={fieldOptions}
+      placeholder={placeholder}
+      isConstantMode={isConstantMode}
+      onConstantModeChange={(isConstant) => {
+        // When toggling mode, update fieldModes without changing the value
+        handleFieldChange(name, value, isConstant)
+      }}
+      hideClearButton
+    />
+  )
+}

--- a/apps/web/src/lib/workflow/components/app-workflow-field-context.tsx
+++ b/apps/web/src/lib/workflow/components/app-workflow-field-context.tsx
@@ -1,0 +1,42 @@
+// apps/web/src/lib/workflow/components/app-workflow-field-context.tsx
+
+'use client'
+
+import { createContext, useContext } from 'react'
+import type { WorkflowBlock } from '../types'
+
+/**
+ * Context for app workflow field state.
+ * Provides field-level access to node data, field mode tracking, and schema metadata
+ * for VarEditor-backed input components in extension app workflow panels.
+ */
+export interface AppWorkflowFieldContextValue {
+  /** Current node ID */
+  nodeId: string
+  /** Current node data (flat key-value pairs) */
+  nodeData: Record<string, any>
+  /** Update a field value. isConstantMode tracks whether the field is in constant (true) or variable (false) mode. */
+  handleFieldChange: (fieldKey: string, value: any, isConstantMode: boolean) => void
+  /** Get field mode: true = constant, false = variable. Defaults to true if not set. */
+  getFieldMode: (fieldKey: string) => boolean
+  /** Block schema with input/output field definitions */
+  schema: WorkflowBlock['schema'] | null
+}
+
+const AppWorkflowFieldContext = createContext<AppWorkflowFieldContextValue | null>(null)
+
+/**
+ * Hook to consume the app workflow field context.
+ * Must be used within an AppWorkflowFieldContext.Provider.
+ */
+export function useAppWorkflowFieldContext(): AppWorkflowFieldContextValue {
+  const ctx = useContext(AppWorkflowFieldContext)
+  if (!ctx) {
+    throw new Error(
+      'useAppWorkflowFieldContext must be used within AppWorkflowFieldContext.Provider'
+    )
+  }
+  return ctx
+}
+
+export { AppWorkflowFieldContext }

--- a/apps/web/src/lib/workflow/components/app-workflow-panel.tsx
+++ b/apps/web/src/lib/workflow/components/app-workflow-panel.tsx
@@ -2,13 +2,15 @@
 
 'use client'
 
-import { memo, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNodeCrud } from '~/components/workflow/hooks'
 import { BasePanel } from '~/components/workflow/nodes/shared/base/base-panel'
 import { OutputVariablesDisplay } from '~/components/workflow/ui/output-variables'
 import { reconstructReactTree } from '~/lib/extensions/reconstruct-react-tree'
 import { useAppStore } from '~/lib/extensions/use-app-store'
 import type { WorkflowBlock } from '../types'
+import { convertOutputFieldsToVariables } from '../utils/type-mapping'
+import { AppWorkflowFieldContext } from './app-workflow-field-context'
 
 /**
  * Props for AppWorkflowPanel component
@@ -44,6 +46,55 @@ export const AppWorkflowPanel = memo<AppWorkflowPanelProps>(
     useEffect(() => {
       nodeDataRef.current = nodeData
     }, [nodeData])
+
+    /**
+     * Handle field value changes from VarEditor-backed input components.
+     * Writes the raw value and field mode directly to ReactFlow node data.
+     */
+    const handleFieldChange = useCallback(
+      (fieldKey: string, value: any, isConstantMode: boolean) => {
+        setInputs({
+          ...nodeDataRef.current,
+          [fieldKey]: value,
+          fieldModes: {
+            ...(nodeDataRef.current.fieldModes || {}),
+            [fieldKey]: isConstantMode,
+          },
+        })
+      },
+      [setInputs]
+    )
+
+    /**
+     * Get the current mode for a field.
+     * Returns true (constant) by default — safe for existing nodes without fieldModes.
+     */
+    const getFieldMode = useCallback(
+      (fieldKey: string): boolean => {
+        return nodeData.fieldModes?.[fieldKey] !== false
+      },
+      [nodeData.fieldModes]
+    )
+
+    /** Context value for AppWorkflowFieldContext */
+    // biome-ignore lint/correctness/useExhaustiveDependencies: nodeData changes drive re-computation
+    const fieldContextValue = useMemo(
+      () => ({
+        nodeId,
+        nodeData,
+        handleFieldChange,
+        getFieldMode,
+        schema: block.schema,
+      }),
+      [nodeId, nodeData, handleFieldChange, getFieldMode, block.schema]
+    )
+
+    /** Merged output variables (static + computed from SDK-side computeOutputs) */
+    const mergedOutputVariables = useMemo(() => {
+      const staticOutputs = block.schema.outputs || {}
+      const computedOutputs = nodeData._computedOutputs || {}
+      return convertOutputFieldsToVariables({ ...staticOutputs, ...computedOutputs }, nodeId)
+    }, [block.schema.outputs, nodeData._computedOutputs, nodeId])
 
     // Load panel component from iframe
     useEffect(() => {
@@ -155,7 +206,8 @@ export const AppWorkflowPanel = memo<AppWorkflowPanelProps>(
     // Listen for data updates from iframe
     // biome-ignore lint/correctness/useExhaustiveDependencies: setInputs is stable from useNodeCrud
     useEffect(() => {
-      let unsubscribe: (() => void) | undefined
+      let unsubscribeData: (() => void) | undefined
+      let unsubscribeOutputs: (() => void) | undefined
       let isMounted = true
 
       const setupListener = async () => {
@@ -175,14 +227,30 @@ export const AppWorkflowPanel = memo<AppWorkflowPanelProps>(
 
           if (!isMounted) return
 
-          unsubscribe = messageClient.listenForRequest('workflow-node-data-update', (data: any) => {
-            if (data.nodeId === nodeId) {
-              setInputs({
-                ...nodeDataRef.current,
-                ...data.data,
-              })
+          unsubscribeData = messageClient.listenForRequest(
+            'workflow-node-data-update',
+            (data: any) => {
+              if (data.nodeId === nodeId) {
+                setInputs({
+                  ...nodeDataRef.current,
+                  ...data.data,
+                })
+              }
             }
-          })
+          )
+
+          // Listen for dynamic output updates from SDK-side computeOutputs
+          unsubscribeOutputs = messageClient.listenForRequest(
+            'workflow-block-outputs-updated',
+            (data: any) => {
+              if (data.nodeId === nodeId) {
+                setInputs({
+                  ...nodeDataRef.current,
+                  _computedOutputs: data.outputs,
+                })
+              }
+            }
+          )
         } catch (error) {
           console.error('[AppWorkflowPanel] Setup error:', error)
           // Retry on error
@@ -194,7 +262,8 @@ export const AppWorkflowPanel = memo<AppWorkflowPanelProps>(
 
       return () => {
         isMounted = false
-        unsubscribe?.()
+        unsubscribeData?.()
+        unsubscribeOutputs?.()
       }
     }, [appId, installationId, nodeId, appStore])
 
@@ -259,34 +328,36 @@ export const AppWorkflowPanel = memo<AppWorkflowPanelProps>(
           </div>
         ) : panelComponent ? (
           <>
-            {reconstructReactTree(panelComponent, {
-              onCallHandler: async (instanceId: number, eventName: string, ...args: any[]) => {
-                const messageClient = appStore.getMessageClient({
-                  appId,
-                  appInstallationId: installationId,
-                })
+            <AppWorkflowFieldContext.Provider value={fieldContextValue}>
+              {reconstructReactTree(panelComponent, {
+                onCallHandler: async (instanceId: number, eventName: string, ...args: any[]) => {
+                  const messageClient = appStore.getMessageClient({
+                    appId,
+                    appInstallationId: installationId,
+                  })
 
-                if (!messageClient) {
-                  console.error('[AppWorkflowPanel] No message client for event call')
-                  throw new Error('Message client not available')
-                }
+                  if (!messageClient) {
+                    console.error('[AppWorkflowPanel] No message client for event call')
+                    throw new Error('Message client not available')
+                  }
 
-                const result = await messageClient.sendRequest('call-instance-method', {
-                  instanceId,
-                  eventName,
-                  args,
-                })
+                  const result = await messageClient.sendRequest('call-instance-method', {
+                    instanceId,
+                    eventName,
+                    args,
+                  })
 
-                if (result?.error) {
-                  console.error('[AppWorkflowPanel] Event handler error:', result.error)
-                  throw new Error(result.error.message)
-                }
+                  if (result?.error) {
+                    console.error('[AppWorkflowPanel] Event handler error:', result.error)
+                    throw new Error(result.error.message)
+                  }
 
-                return result
-              },
-            })}
+                  return result
+                },
+              })}
+            </AppWorkflowFieldContext.Provider>
             <OutputVariablesDisplay
-              outputs={block.schema.outputs}
+              outputVariables={mergedOutputVariables}
               nodeId={nodeId}
               initialOpen={false}
             />

--- a/apps/web/src/lib/workflow/types.ts
+++ b/apps/web/src/lib/workflow/types.ts
@@ -1,6 +1,18 @@
 // apps/web/src/lib/workflow/types.ts
 
 /**
+ * Layout section for auto-generated panels
+ */
+export interface WorkflowLayoutSection {
+  type: 'section'
+  title: string
+  description?: string
+  fields: string[]
+  collapsible?: boolean
+  initialOpen?: boolean
+}
+
+/**
  * Workflow block definition from an app
  */
 export interface WorkflowBlock {
@@ -19,6 +31,7 @@ export interface WorkflowBlock {
       sources?: Array<{ id: string; label?: string }>
       targets?: Array<{ id: string; label?: string }>
     }
+    layout?: WorkflowLayoutSection[]
     validation?: {
       custom?: (data: any) => {
         valid: boolean
@@ -29,6 +42,8 @@ export interface WorkflowBlock {
   config?: {
     canRunSingle?: boolean
   }
+  /** Whether this block has a custom panel component */
+  hasPanel?: boolean
   components?: {
     node?: any
     panel?: any

--- a/apps/web/src/lib/workflow/utils/field-to-var-editor.ts
+++ b/apps/web/src/lib/workflow/utils/field-to-var-editor.ts
@@ -1,0 +1,225 @@
+// apps/web/src/lib/workflow/utils/field-to-var-editor.ts
+
+import { BaseType, VAR_MODE, type VarMode } from '~/components/workflow/types'
+import type { FieldOptions } from '~/components/workflow/ui/input-editor/get-input-component'
+
+/**
+ * Result of mapping an SDK field type to VarEditor props.
+ */
+export interface VarEditorMappedProps {
+  /** BaseType for VarEditor varType */
+  varType: BaseType
+  /** VarEditor mode: 'rich' for Tiptap, 'picker' for single variable selection */
+  mode: VarMode
+  /** Whether constant mode toggle is allowed */
+  allowConstant: boolean
+  /** Allowed variable types for filtering */
+  allowedTypes: BaseType[]
+  /** Type-specific field options (enum values, currency config, etc.) */
+  fieldOptions?: FieldOptions
+}
+
+/**
+ * Normalize an option to { label, value } format.
+ */
+function normalizeOption(opt: string | { label: string; value: string }): {
+  label: string
+  value: string
+} {
+  if (typeof opt === 'string') return { label: opt, value: opt }
+  return opt
+}
+
+/**
+ * Map an SDK field type + format to VarEditor props.
+ *
+ * Designed as an extensible switch — adding future BaseTypes means adding cases here.
+ *
+ * @param params.type - SDK field type (string, number, boolean, select)
+ * @param params.format - Optional format hint (email, url, date, datetime, time)
+ * @param params.options - Enum options for select fields
+ * @param params.acceptsVariables - Whether the field accepts variable references
+ * @param params.variableTypes - Allowed variable types for filtering
+ */
+export function mapFieldToVarEditorProps(params: {
+  type: string
+  format?: string
+  options?: readonly (string | { label: string; value: string })[]
+  acceptsVariables?: boolean
+  variableTypes?: string[]
+}): VarEditorMappedProps {
+  const { type, format, options, acceptsVariables, variableTypes } = params
+
+  // Determine allowConstant from acceptsVariables
+  // When acceptsVariables is false/undefined, render in constant-only mode
+  const allowConstant = acceptsVariables !== false
+
+  // Map variableTypes to BaseType array
+  const allowedTypes: BaseType[] = (variableTypes || [])
+    .map((t) => mapStringToBaseType(t))
+    .filter((t): t is BaseType => t !== null)
+
+  // First check format overrides for string type
+  if (type === 'string' && format) {
+    switch (format) {
+      case 'email':
+        return {
+          varType: BaseType.EMAIL,
+          mode: VAR_MODE.RICH,
+          allowConstant,
+          allowedTypes,
+          fieldOptions: undefined,
+        }
+      case 'url':
+      case 'uri':
+        return {
+          varType: BaseType.URL,
+          mode: VAR_MODE.RICH,
+          allowConstant,
+          allowedTypes,
+          fieldOptions: undefined,
+        }
+      case 'date':
+        return {
+          varType: BaseType.DATE,
+          mode: VAR_MODE.PICKER,
+          allowConstant,
+          allowedTypes,
+          fieldOptions: undefined,
+        }
+      case 'datetime':
+        return {
+          varType: BaseType.DATETIME,
+          mode: VAR_MODE.PICKER,
+          allowConstant,
+          allowedTypes,
+          fieldOptions: undefined,
+        }
+      case 'time':
+        return {
+          varType: BaseType.TIME,
+          mode: VAR_MODE.PICKER,
+          allowConstant,
+          allowedTypes,
+          fieldOptions: undefined,
+        }
+    }
+  }
+
+  // Map by primary type
+  switch (type) {
+    case 'string':
+      return {
+        varType: BaseType.STRING,
+        mode: VAR_MODE.RICH,
+        allowConstant,
+        allowedTypes,
+        fieldOptions: undefined,
+      }
+
+    case 'number':
+      return {
+        varType: BaseType.NUMBER,
+        mode: VAR_MODE.PICKER,
+        allowConstant,
+        allowedTypes,
+        fieldOptions: undefined,
+      }
+
+    case 'boolean':
+      return {
+        varType: BaseType.BOOLEAN,
+        mode: VAR_MODE.PICKER,
+        allowConstant,
+        allowedTypes,
+        fieldOptions: { variant: 'switch' },
+      }
+
+    case 'select': {
+      const normalizedOptions = options ? (options as any[]).map(normalizeOption) : []
+      return {
+        varType: BaseType.ENUM,
+        mode: VAR_MODE.PICKER,
+        allowConstant,
+        allowedTypes,
+        fieldOptions: { enum: normalizedOptions },
+      }
+    }
+
+    default:
+      // Unsupported type — graceful fallback to STRING/RICH
+      return {
+        varType: BaseType.STRING,
+        mode: VAR_MODE.RICH,
+        allowConstant,
+        allowedTypes,
+        fieldOptions: undefined,
+      }
+  }
+}
+
+/**
+ * Map a field type string to a BaseType enum value.
+ * Used for both varType resolution and type icon display.
+ */
+export function mapFieldType(type?: string, format?: string): BaseType {
+  if (!type) return BaseType.STRING
+
+  // Check format first for string types
+  if (type === 'string' && format) {
+    switch (format) {
+      case 'email':
+        return BaseType.EMAIL
+      case 'url':
+      case 'uri':
+        return BaseType.URL
+      case 'date':
+        return BaseType.DATE
+      case 'datetime':
+        return BaseType.DATETIME
+      case 'time':
+        return BaseType.TIME
+    }
+  }
+
+  switch (type) {
+    case 'string':
+      return BaseType.STRING
+    case 'number':
+      return BaseType.NUMBER
+    case 'boolean':
+      return BaseType.BOOLEAN
+    case 'select':
+      return BaseType.ENUM
+    case 'array':
+      return BaseType.ARRAY
+    case 'object':
+    case 'struct':
+      return BaseType.OBJECT
+    default:
+      return BaseType.STRING
+  }
+}
+
+/**
+ * Map a string to BaseType for variableTypes filtering.
+ */
+function mapStringToBaseType(typeStr: string): BaseType | null {
+  const mapping: Record<string, BaseType> = {
+    string: BaseType.STRING,
+    number: BaseType.NUMBER,
+    boolean: BaseType.BOOLEAN,
+    object: BaseType.OBJECT,
+    array: BaseType.ARRAY,
+    date: BaseType.DATE,
+    datetime: BaseType.DATETIME,
+    time: BaseType.TIME,
+    email: BaseType.EMAIL,
+    url: BaseType.URL,
+    file: BaseType.FILE,
+    json: BaseType.JSON,
+    any: BaseType.ANY,
+    enum: BaseType.ENUM,
+  }
+  return mapping[typeStr] ?? null
+}

--- a/apps/web/src/lib/workflow/workflow-block-registry.tsx
+++ b/apps/web/src/lib/workflow/workflow-block-registry.tsx
@@ -123,8 +123,9 @@ export class WorkflowBlockRegistry {
       // Validation
       validator: (data: any) => this.validateBlockData(block, data),
 
-      // Output variables
-      outputVariables: (data: any, nodeId: string) => this.createOutputVariables(block, nodeId),
+      // Output variables — merges static schema.outputs + computed outputs from data._computedOutputs
+      outputVariables: (data: any, nodeId: string) =>
+        this.createOutputVariables(block, nodeId, data),
 
       // UI Components - wrapped to handle app communication
       panel: this.createPanelComponent(
@@ -209,10 +210,18 @@ export class WorkflowBlockRegistry {
   }
 
   /**
-   * Create output variables for a block
+   * Create output variables for a block.
+   * Merges static schema.outputs with computed outputs from data._computedOutputs.
    */
-  private createOutputVariables(block: WorkflowBlock, nodeId: string): UnifiedVariable[] {
-    return convertOutputFieldsToVariables(block.schema.outputs || {}, nodeId)
+  private createOutputVariables(
+    block: WorkflowBlock,
+    nodeId: string,
+    data?: any
+  ): UnifiedVariable[] {
+    const staticOutputs = block.schema.outputs || {}
+    const computedOutputs = data?._computedOutputs || {}
+    const merged = { ...staticOutputs, ...computedOutputs }
+    return convertOutputFieldsToVariables(merged, nodeId)
   }
 
   /**

--- a/infra/storage.ts
+++ b/infra/storage.ts
@@ -8,7 +8,7 @@ export const publicBucket = new sst.aws.Bucket('PublicAssets', {
   access: 'public', // SST handles public read policy automatically
   transform: {
     bucket: {
-      bucket: $app.stage === 'production' ? 'auxx-public' : appify('public'), // auxx-public (prod), auxx-public-dev, auxx-public-local
+      bucket: $app.stage === 'production' ? 'auxx-public' : appify('public'), // auxx-public (prod), auxx-dev-public, auxx-local-public
 
       // CORS for browser uploads (still use presigned POST for upload)
       corsRules: [
@@ -58,7 +58,7 @@ export const publicBucket = new sst.aws.Bucket('PublicAssets', {
 export const privateBucket = new sst.aws.Bucket('PrivateAssets', {
   transform: {
     bucket: {
-      bucket: $app.stage === 'production' ? 'auxx-private' : appify('private'), // auxx-private (prod), auxx-private-dev, auxx-private-local
+      bucket: $app.stage === 'production' ? 'auxx-private' : appify('private'), // auxx-private (prod), auxx-dev-private, auxx-local-private
 
       // Block ALL public access
       publicAccessBlockConfiguration: {

--- a/packages/lib/src/workflow-engine/nodes/app-workflow-block-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/app-workflow-block-processor.ts
@@ -137,25 +137,35 @@ export class AppWorkflowBlockProcessor extends BaseNodeProcessor {
       )
     }
 
-    // 2. Resolve variables in input fields
+    // 2. Resolve variables in input fields using mode-driven resolution
     const resolvedInputs: Record<string, any> = {}
+    const fieldModes: Record<string, boolean> = node.data.fieldModes || {}
 
     for (const [fieldName, fieldValue] of Object.entries(node.data)) {
       // Skip metadata fields (prefixed with _)
       if (fieldName.startsWith('_')) continue
-
+      // Skip fieldModes itself
+      if (fieldName === 'fieldModes') continue
       // Skip non-input fields
       if (!this.blockMetadata.schema.inputs[fieldName]) continue
 
-      // Resolve {{variable}} syntax to actual values
-      const resolved = await this.resolveVariableValue(fieldValue, contextManager)
-      resolvedInputs[fieldName] = resolved
+      // Mode-driven resolution: fieldModes[field] !== false means constant (pass through)
+      const isConstant = fieldModes[fieldName] !== false
+
+      if (isConstant) {
+        // Constant mode — pass raw value through, no resolution
+        resolvedInputs[fieldName] = fieldValue
+      } else {
+        // Variable mode — resolve based on value shape
+        resolvedInputs[fieldName] = await this.resolveAppFieldValue(fieldValue, contextManager)
+      }
 
       logger.debug('Resolved input field', {
         nodeId: node.nodeId,
         fieldName,
         original: fieldValue,
-        resolved,
+        resolved: resolvedInputs[fieldName],
+        mode: isConstant ? 'constant' : 'variable',
       })
     }
 
@@ -286,22 +296,57 @@ export class AppWorkflowBlockProcessor extends BaseNodeProcessor {
   }
 
   /**
-   * Extract variables from app block inputs
+   * Resolve a variable-mode field value.
+   * Handles both template strings ({{variable}}) and plain variable paths (PICKER mode).
+   * Only called for fields where fieldModes[field] === false (variable mode).
+   */
+  private async resolveAppFieldValue(
+    value: any,
+    contextManager: ExecutionContextManager
+  ): Promise<any> {
+    if (typeof value !== 'string') return value
+
+    // Template strings: "Hello {{name}}, your order {{order.id}} is ready"
+    if (value.includes('{{') && value.includes('}}')) {
+      return await this.resolveVariableValue(value, contextManager)
+    }
+
+    // Plain variable path (PICKER mode): "node_abc.userId"
+    // In variable mode, the entire string IS the variable path — resolve it directly
+    if (value.length > 0) {
+      const resolved = await contextManager.getVariable(value)
+      return resolved !== undefined ? resolved : value
+    }
+
+    return value
+  }
+
+  /**
+   * Extract variables from app block inputs using fieldModes.
+   * Only extracts variables from fields in variable mode (fieldModes[field] === false).
    */
   protected extractRequiredVariables(node: WorkflowNode): string[] {
     const config = node.data
+    const fieldModes: Record<string, boolean> = config.fieldModes || {}
     const variables = new Set<string>()
 
-    // Extract from all input fields that might contain {{variable}} syntax
-    if (config.inputs && typeof config.inputs === 'object') {
-      Object.values(config.inputs).forEach((value: any) => {
-        if (typeof value === 'string') {
-          this.extractVariableIds(value).forEach((v) => variables.add(v))
-        } else if (value && typeof value === 'object') {
-          // Handle nested objects recursively
-          this.extractVariablesFromValue(value, variables)
+    for (const [fieldName, fieldValue] of Object.entries(config)) {
+      if (fieldName.startsWith('_')) continue
+      if (fieldName === 'fieldModes') continue
+      if (!this.blockMetadata?.schema?.inputs?.[fieldName]) continue
+
+      // Only extract variables from fields in variable mode
+      const isConstant = fieldModes[fieldName] !== false
+      if (isConstant) continue
+
+      if (typeof fieldValue === 'string') {
+        // Extract {{variable}} references from templates
+        this.extractVariableIds(fieldValue).forEach((v) => variables.add(v))
+        // Also add the raw value as a potential variable path (PICKER mode)
+        if (!fieldValue.includes('{{') && fieldValue.length > 0) {
+          variables.add(fieldValue)
         }
-      })
+      }
     }
 
     return Array.from(variables)

--- a/packages/sdk/src/client/workflow/components/fields/index.ts
+++ b/packages/sdk/src/client/workflow/components/fields/index.ts
@@ -1,0 +1,5 @@
+// packages/sdk/src/client/workflow/components/fields/index.ts
+
+export { VarField, type VarFieldProps } from './var-field.js'
+export { VarFieldGroup, type VarFieldGroupProps } from './var-field-group.js'
+export { VarInput, type VarInputProps } from './var-input.js'

--- a/packages/sdk/src/client/workflow/components/fields/var-field-group.tsx
+++ b/packages/sdk/src/client/workflow/components/fields/var-field-group.tsx
@@ -1,0 +1,42 @@
+// packages/sdk/src/client/workflow/components/fields/var-field-group.tsx
+
+import type React from 'react'
+
+/**
+ * Props for VarFieldGroup component.
+ */
+export interface VarFieldGroupProps {
+  /** Layout orientation for label vs content within each row */
+  orientation?: 'horizontal' | 'vertical'
+  /** Validation error message */
+  validationError?: string
+  /** Validation error type */
+  validationType?: 'error' | 'warning'
+  /** Child VarField components */
+  children?: React.ReactNode
+}
+
+/**
+ * VarFieldGroup — container providing VarEditorField chrome (rounded border, background).
+ */
+export const VarFieldGroup: React.FC<VarFieldGroupProps> = ({
+  orientation,
+  validationError,
+  validationType,
+  children,
+}) => {
+  const React = (window as any).React
+  if (!React) {
+    throw new Error('[auxx/client] React not available in window')
+  }
+  return React.createElement(
+    'auxxworkflowvarfieldgroup',
+    {
+      component: 'WorkflowVarFieldGroup',
+      orientation,
+      validationError,
+      validationType,
+    },
+    children
+  )
+}

--- a/packages/sdk/src/client/workflow/components/fields/var-field.tsx
+++ b/packages/sdk/src/client/workflow/components/fields/var-field.tsx
@@ -1,0 +1,55 @@
+// packages/sdk/src/client/workflow/components/fields/var-field.tsx
+
+import type React from 'react'
+
+/**
+ * Props for VarField component.
+ * All metadata props are optional — resolved from child's name + schema lookup on the host.
+ */
+export interface VarFieldProps {
+  /** Override which field to look up (defaults to child's name prop) */
+  name?: string
+  /** Override label (defaults to schema._metadata.label ?? name) */
+  title?: string
+  /** Override description (defaults to schema._metadata.description) */
+  description?: string
+  /** Override required (defaults to schema._metadata.required) */
+  required?: boolean
+  /** Override BaseType for icon (defaults to schema field type) */
+  type?: string
+  /** Show/hide type icon (defaults to true) */
+  showIcon?: boolean
+  /** Child input component(s) */
+  children?: React.ReactNode
+}
+
+/**
+ * VarField — wrapper providing VarEditorFieldRow chrome (title, description, type icon, clear button).
+ */
+export const VarField: React.FC<VarFieldProps> = ({
+  name,
+  title,
+  description,
+  required,
+  type,
+  showIcon,
+  children,
+}) => {
+  const React = (window as any).React
+  if (!React) {
+    throw new Error('[auxx/client] React not available in window')
+  }
+  return React.createElement(
+    'auxxworkflowvarfield',
+    {
+      component: 'WorkflowVarField',
+      name,
+      title,
+      description,
+      required,
+      type,
+      showIcon,
+    },
+    children
+  )
+}

--- a/packages/sdk/src/client/workflow/components/fields/var-input.tsx
+++ b/packages/sdk/src/client/workflow/components/fields/var-input.tsx
@@ -1,0 +1,43 @@
+// packages/sdk/src/client/workflow/components/fields/var-input.tsx
+
+import type React from 'react'
+
+/**
+ * Props for VarInput component.
+ * The base component for all VarEditor-backed inputs.
+ */
+export interface VarInputProps {
+  /** Field name from schema */
+  name: string
+  /** Field type: 'string' | 'number' | 'boolean' | 'select' */
+  type: string
+  /** Placeholder text */
+  placeholder?: string
+  /** Whether this field accepts variable references */
+  acceptsVariables?: boolean
+  /** Allowed variable types for filtering */
+  variableTypes?: string[]
+  /** Format hint (email, url, date, datetime, time) */
+  format?: string
+  /** Options for select fields */
+  options?: readonly (string | { label: string; value: string })[]
+  /** Use multiline mode for string type */
+  multiline?: boolean
+}
+
+/**
+ * VarInput — the base component for all VarEditor-backed inputs in extension workflows.
+ *
+ * Creates a custom element that the reconciler serializes to the host,
+ * where VarInputInternal renders the appropriate VarEditor.
+ */
+export const VarInput: React.FC<VarInputProps> = (props) => {
+  const React = (window as any).React
+  if (!React) {
+    throw new Error('[auxx/client] React not available in window')
+  }
+  return React.createElement('auxxworkflowvarinput', {
+    ...props,
+    component: 'VarInputInternal',
+  })
+}

--- a/packages/sdk/src/client/workflow/hooks/use-workflow.ts
+++ b/packages/sdk/src/client/workflow/hooks/use-workflow.ts
@@ -2,13 +2,15 @@
 
 'use client'
 
-import { createElement, type ReactElement, useCallback, useEffect, useMemo, useRef } from 'react'
+import { createElement, type ReactElement, useCallback, useMemo } from 'react'
 import type { InferWorkflowInput, WorkflowSchema } from '../../../root/workflow/types.js'
-import { BooleanInput, type BooleanInputProps } from '../components/inputs/boolean-input.js'
-import { NumberInput, type NumberInputProps } from '../components/inputs/number-input.js'
-import { SelectInput, type SelectInputProps } from '../components/inputs/select-input.js'
-// Import JSX components (these create custom elements)
-import { StringInput, type StringInputProps } from '../components/inputs/string-input.js'
+import { VarField, type VarFieldProps } from '../components/fields/var-field.js'
+import { VarFieldGroup, type VarFieldGroupProps } from '../components/fields/var-field-group.js'
+import { VarInput, type VarInputProps } from '../components/fields/var-input.js'
+import type { BooleanInputProps } from '../components/inputs/boolean-input.js'
+import type { NumberInputProps } from '../components/inputs/number-input.js'
+import type { SelectInputProps } from '../components/inputs/select-input.js'
+import type { StringInputProps } from '../components/inputs/string-input.js'
 import { InputGroup, type InputGroupProps } from '../components/layout/input-group.js'
 import { Section, type SectionProps } from '../components/layout/section.js'
 import {
@@ -28,27 +30,6 @@ function get(obj: any, path: string): any {
     result = result?.[key]
   }
   return result
-}
-
-/**
- * Helper to set nested value in object using dot notation
- */
-function set(obj: any, path: string, value: any): any {
-  const keys = path.split('.')
-  const lastKey = keys.pop()!
-  let current = obj
-
-  // Navigate to the parent object
-  for (const key of keys) {
-    if (!(key in current)) {
-      current[key] = {}
-    }
-    current = current[key]
-  }
-
-  // Set the value
-  current[lastKey] = value
-  return { ...obj }
 }
 
 /**
@@ -92,6 +73,41 @@ export interface WorkflowSelectInputProps<TSchema extends WorkflowSchema>
 }
 
 /**
+ * Props for workflow options input component (VarEditor-backed select).
+ * Same type-safe name as SelectInput but renders through VarEditor.
+ */
+export interface WorkflowOptionsInputProps<TSchema extends WorkflowSchema> {
+  /** Type-safe path to select field in schema */
+  name: PathToField<TSchema['inputs'], 'select'>
+  /** Dynamic options override (overrides schema options) */
+  options?: readonly (string | { label: string; value: string })[]
+  /** Placeholder text */
+  placeholder?: string
+}
+
+/**
+ * Props for VarInput component exposed by useWorkflow.
+ */
+export interface WorkflowVarInputProps {
+  /** Field name */
+  name: string
+  /** Field type: 'string' | 'number' | 'boolean' | 'select' */
+  type: string
+  /** Placeholder text */
+  placeholder?: string
+  /** Whether field accepts variable references */
+  acceptsVariables?: boolean
+  /** Allowed variable types */
+  variableTypes?: string[]
+  /** Format hint */
+  format?: string
+  /** Options for select fields */
+  options?: readonly (string | { label: string; value: string })[]
+  /** Multiline mode for string type */
+  multiline?: boolean
+}
+
+/**
  * Props for conditional render component.
  * Omits data since it's provided automatically by useWorkflow.
  */
@@ -108,57 +124,37 @@ export interface WorkflowConditionalRenderProps<TSchema extends WorkflowSchema>
  * and apply schema metadata.
  */
 export interface UseWorkflowApi<TSchema extends WorkflowSchema> {
-  /**
-   * String input field with automatic data binding.
-   *
-   * Automatically gets/sets value from WorkflowContext and applies
-   * label, description, and placeholder from schema metadata.
-   */
+  /** Base VarEditor component — renders any type based on `type` prop. */
+  VarInput: (props: WorkflowVarInputProps) => ReactElement
+
+  /** String input — convenience wrapper for VarInput type="string". */
   StringInput: (props: WorkflowStringInputProps<TSchema>) => ReactElement
 
-  /**
-   * Number input field with automatic data binding.
-   *
-   * Automatically gets/sets value from WorkflowContext and applies
-   * label, description, placeholder, min, max, step from schema metadata.
-   */
+  /** Number input — convenience wrapper for VarInput type="number". */
   NumberInput: (props: WorkflowNumberInputProps<TSchema>) => ReactElement
 
-  /**
-   * Boolean input field (checkbox/switch) with automatic data binding.
-   *
-   * Automatically gets/sets value from WorkflowContext and applies
-   * label and description from schema metadata.
-   */
+  /** Boolean input — convenience wrapper for VarInput type="boolean". */
   BooleanInput: (props: WorkflowBooleanInputProps<TSchema>) => ReactElement
 
-  /**
-   * Select/dropdown input field with automatic data binding.
-   *
-   * Automatically gets/sets value from WorkflowContext and applies
-   * label, description, placeholder, and options from schema metadata.
-   */
+  /** Select input — convenience wrapper for VarInput type="select". */
   SelectInput: (props: WorkflowSelectInputProps<TSchema>) => ReactElement
 
-  /**
-   * Section container for grouping inputs visually.
-   *
-   * Renders a titled section with optional description.
-   */
+  /** Options input — VarEditor-backed select with dynamic options support. */
+  OptionsInput: (props: WorkflowOptionsInputProps<TSchema>) => ReactElement
+
+  /** VarField — VarEditorFieldRow wrapper (title, description, type icon, clear button). */
+  VarField: (props: VarFieldProps) => ReactElement
+
+  /** VarFieldGroup — VarEditorField container (rounded border, background). */
+  VarFieldGroup: (props: VarFieldGroupProps) => ReactElement
+
+  /** Section container for grouping inputs visually. */
   Section: (props: SectionProps) => ReactElement
 
-  /**
-   * Input group for horizontal layout of inputs.
-   *
-   * Automatically arranges inputs in a responsive grid.
-   */
+  /** Input group for horizontal layout of inputs. */
   InputGroup: (props: InputGroupProps) => ReactElement
 
-  /**
-   * Conditional rendering based on data values.
-   *
-   * Evaluates condition function and renders children only if true.
-   */
+  /** Conditional rendering based on data values. */
   ConditionalRender: (props: WorkflowConditionalRenderProps<TSchema>) => ReactElement
 }
 
@@ -197,8 +193,8 @@ export interface UseWorkflowApi<TSchema extends WorkflowSchema> {
 export function useWorkflow<TSchema extends WorkflowSchema>(
   schema: TSchema
 ): UseWorkflowApi<TSchema> {
-  // Get data and updateData from WorkflowContext (source of truth)
-  const { data, updateData } = useWorkflowContext<InferWorkflowInput<TSchema>>()
+  // Get data from WorkflowContext (source of truth)
+  const { data } = useWorkflowContext<InferWorkflowInput<TSchema>>()
 
   // Extract input schema for metadata lookups
   const inputSchema = schema.inputs
@@ -214,91 +210,122 @@ export function useWorkflow<TSchema extends WorkflowSchema>(
     return result
   }, [])
 
-  // ✓ Store updateData in ref to avoid recreating callbacks
-  const updateDataRef = useRef(updateData)
-  useEffect(() => {
-    updateDataRef.current = updateData
-  }, [updateData])
+  // VarInput: Base component for all VarEditor-backed inputs
+  const WorkflowVarInput = useCallback(
+    (props: WorkflowVarInputProps): ReactElement => {
+      const fieldJson = get(serializedInputSchema, props.name)
+      const metadata = fieldJson?._metadata || {}
 
-  // ✓ Create stable onChange factory
-  const createOnChange = useCallback((fieldName: string) => {
-    return (value: any) => {
-      updateDataRef.current(set({}, fieldName, value) as Partial<InferWorkflowInput<TSchema>>)
-    }
-  }, []) // ✓ No dependencies - stable reference
+      return createElement(VarInput, {
+        name: props.name,
+        type: props.type,
+        placeholder: props.placeholder ?? metadata.placeholder,
+        acceptsVariables: props.acceptsVariables ?? fieldJson?.acceptsVariables,
+        variableTypes: props.variableTypes ?? fieldJson?.variableTypes,
+        format: props.format ?? metadata.format,
+        options: props.options ?? metadata.options,
+        multiline: props.multiline,
+      })
+    },
+    [serializedInputSchema]
+  )
 
-  // StringInput: Workflow string input component
+  // StringInput: VarInput type="string" convenience wrapper
   const WorkflowStringInput = useCallback(
     (props: WorkflowStringInputProps<TSchema>): ReactElement => {
-      // Get field metadata from schema
-      const metadata = get(serializedInputSchema, props.name as string)?._metadata || {}
+      const fieldJson = get(serializedInputSchema, props.name as string)
+      const metadata = fieldJson?._metadata || {}
 
-      console.log('[useWorkflow] Creating StringInput:', {
-        name: props.name,
-        metadata,
-        currentValue: get(data, props.name as string),
-        allData: data,
-      })
-
-      // Create element using JSX component (which creates custom element)
-      return createElement(StringInput, {
-        ...metadata, // Schema defaults (label, description, placeholder)
-        ...props, // User overrides
+      return createElement(VarInput, {
         name: props.name as string,
-        value: get(data, props.name as string) || '',
-        onChange: createOnChange(props.name as string), // ✓ Stable reference
+        type: 'string',
+        placeholder: props.placeholder ?? metadata.placeholder,
+        acceptsVariables: fieldJson?.acceptsVariables,
+        variableTypes: fieldJson?.variableTypes,
+        format: metadata.format,
+        multiline: props.multiline,
       })
     },
-    [data, serializedInputSchema, createOnChange]
+    [serializedInputSchema]
   )
 
-  // NumberInput: Workflow number input component
+  // NumberInput: VarInput type="number" convenience wrapper
   const WorkflowNumberInput = useCallback(
     (props: WorkflowNumberInputProps<TSchema>): ReactElement => {
-      const metadata = get(serializedInputSchema, props.name as string)?._metadata || {}
+      const fieldJson = get(serializedInputSchema, props.name as string)
+      const metadata = fieldJson?._metadata || {}
 
-      return createElement(NumberInput, {
-        ...metadata, // Schema defaults (label, description, min, max, step)
-        ...props, // User overrides
+      return createElement(VarInput, {
         name: props.name as string,
-        value: get(data, props.name as string) ?? undefined,
-        onChange: createOnChange(props.name as string), // ✓ Stable reference
+        type: 'number',
+        placeholder: metadata.placeholder,
+        acceptsVariables: fieldJson?.acceptsVariables,
+        variableTypes: fieldJson?.variableTypes,
       })
     },
-    [data, serializedInputSchema, createOnChange]
+    [serializedInputSchema]
   )
 
-  // BooleanInput: Workflow boolean input component
+  // BooleanInput: VarInput type="boolean" convenience wrapper
   const WorkflowBooleanInput = useCallback(
     (props: WorkflowBooleanInputProps<TSchema>): ReactElement => {
-      const metadata = get(serializedInputSchema, props.name as string)?._metadata || {}
+      const fieldJson = get(serializedInputSchema, props.name as string)
 
-      return createElement(BooleanInput, {
-        ...metadata, // Schema defaults (label, description)
-        ...props, // User overrides
+      return createElement(VarInput, {
         name: props.name as string,
-        value: get(data, props.name as string) ?? false,
-        onChange: createOnChange(props.name as string), // ✓ Stable reference
+        type: 'boolean',
+        acceptsVariables: fieldJson?.acceptsVariables,
+        variableTypes: fieldJson?.variableTypes,
       })
     },
-    [data, serializedInputSchema, createOnChange]
+    [serializedInputSchema]
   )
 
-  // SelectInput: Workflow select input component
+  // SelectInput: VarInput type="select" convenience wrapper (legacy name)
   const WorkflowSelectInput = useCallback(
     (props: WorkflowSelectInputProps<TSchema>): ReactElement => {
-      const metadata = get(serializedInputSchema, props.name as string)?._metadata || {}
+      const fieldJson = get(serializedInputSchema, props.name as string)
+      const metadata = fieldJson?._metadata || {}
 
-      return createElement(SelectInput, {
-        ...metadata, // Schema defaults (label, description, options)
-        ...props, // User overrides
+      return createElement(VarInput, {
         name: props.name as string,
-        value: get(data, props.name as string) || '',
-        onChange: createOnChange(props.name as string), // ✓ Stable reference
+        type: 'select',
+        placeholder: metadata.placeholder,
+        acceptsVariables: fieldJson?.acceptsVariables,
+        variableTypes: fieldJson?.variableTypes,
+        options: props.options ?? metadata.options,
       })
     },
-    [data, serializedInputSchema, createOnChange]
+    [serializedInputSchema]
   )
+
+  // OptionsInput: VarInput type="select" with explicit dynamic options
+  const WorkflowOptionsInput = useCallback(
+    (props: WorkflowOptionsInputProps<TSchema>): ReactElement => {
+      const fieldJson = get(serializedInputSchema, props.name as string)
+      const metadata = fieldJson?._metadata || {}
+
+      return createElement(VarInput, {
+        name: props.name as string,
+        type: 'select',
+        placeholder: props.placeholder ?? metadata.placeholder,
+        acceptsVariables: fieldJson?.acceptsVariables,
+        variableTypes: fieldJson?.variableTypes,
+        options: props.options ?? metadata.options,
+      })
+    },
+    [serializedInputSchema]
+  )
+
+  // VarField: Wrapper component (no data binding)
+  const WorkflowVarField = useCallback((props: VarFieldProps): ReactElement => {
+    return createElement(VarField, props)
+  }, [])
+
+  // VarFieldGroup: Container component (no data binding)
+  const WorkflowVarFieldGroup = useCallback((props: VarFieldGroupProps): ReactElement => {
+    return createElement(VarFieldGroup, props)
+  }, [])
 
   // Section: Layout component (no data binding needed)
   const WorkflowSection = useCallback((props: SectionProps): ReactElement => {
@@ -323,10 +350,14 @@ export function useWorkflow<TSchema extends WorkflowSchema>(
   )
 
   return {
+    VarInput: WorkflowVarInput,
     StringInput: WorkflowStringInput,
     NumberInput: WorkflowNumberInput,
     BooleanInput: WorkflowBooleanInput,
     SelectInput: WorkflowSelectInput,
+    OptionsInput: WorkflowOptionsInput,
+    VarField: WorkflowVarField,
+    VarFieldGroup: WorkflowVarFieldGroup,
     Section: WorkflowSection,
     InputGroup: WorkflowInputGroup,
     ConditionalRender: WorkflowConditionalRender,

--- a/packages/sdk/src/root/workflow/types.ts
+++ b/packages/sdk/src/root/workflow/types.ts
@@ -169,6 +169,18 @@ export interface WorkflowExecutionContext {
 }
 
 /**
+ * Layout section for auto-generated panels
+ */
+export interface WorkflowLayoutSection {
+  type: 'section'
+  title: string
+  description?: string
+  fields: string[]
+  collapsible?: boolean
+  initialOpen?: boolean
+}
+
+/**
  * Workflow schema definition with input and output fields
  */
 export interface WorkflowSchema {
@@ -176,6 +188,14 @@ export interface WorkflowSchema {
   inputs: Record<string, any>
   /** Output field definitions */
   outputs: Record<string, any>
+  /** Optional layout for auto-generated panels */
+  layout?: WorkflowLayoutSection[]
+  /**
+   * Compute additional output fields based on current input values.
+   * Runs in the SDK iframe whenever panel data changes.
+   * Returned fields are merged on top of static schema.outputs.
+   */
+  computeOutputs?: (inputs: Record<string, any>) => Record<string, any>
 }
 
 /**

--- a/packages/sdk/src/runtime/reconciler/tags/index.ts
+++ b/packages/sdk/src/runtime/reconciler/tags/index.ts
@@ -28,6 +28,9 @@ import { WorkflowSectionTag } from './workflow-section-tag.js'
 import { WorkflowSelectInputTag } from './workflow-select-input-tag.js'
 import { WorkflowSeparatorTag } from './workflow-separator-tag.js'
 import { WorkflowStringInputTag } from './workflow-string-input-tag.js'
+import { WorkflowVarFieldGroupTag } from './workflow-var-field-group-tag.js'
+import { WorkflowVarFieldTag } from './workflow-var-field-tag.js'
+import { WorkflowVarInputTag } from './workflow-var-input-tag.js'
 import { WorkflowVariableInputTag } from './workflow-variable-input-tag.js'
 
 /**
@@ -64,6 +67,10 @@ export const TAG_REGISTRY: Record<string, new (props: Record<string, any>) => Ba
   auxxworkflowconditionalrender: WorkflowConditionalRenderTag,
   auxxworkflowvariableinput: WorkflowVariableInputTag,
   auxxworkflowinputeditor: WorkflowInputEditorTag,
+  // v2: VarEditor-backed components (no event handlers)
+  auxxworkflowvarinput: WorkflowVarInputTag,
+  auxxworkflowvarfield: WorkflowVarFieldTag,
+  auxxworkflowvarfieldgroup: WorkflowVarFieldGroupTag,
 }
 
 /**
@@ -113,4 +120,7 @@ export { WorkflowSectionTag } from './workflow-section-tag.js'
 export { WorkflowSelectInputTag } from './workflow-select-input-tag.js'
 export { WorkflowSeparatorTag } from './workflow-separator-tag.js'
 export { WorkflowStringInputTag } from './workflow-string-input-tag.js'
+export { WorkflowVarFieldGroupTag } from './workflow-var-field-group-tag.js'
+export { WorkflowVarFieldTag } from './workflow-var-field-tag.js'
+export { WorkflowVarInputTag } from './workflow-var-input-tag.js'
 export { WorkflowVariableInputTag } from './workflow-variable-input-tag.js'

--- a/packages/sdk/src/runtime/reconciler/tags/workflow-var-field-group-tag.ts
+++ b/packages/sdk/src/runtime/reconciler/tags/workflow-var-field-group-tag.ts
@@ -1,0 +1,27 @@
+// packages/sdk/src/runtime/reconciler/tags/workflow-var-field-group-tag.ts
+
+import { BaseTag } from './base-tag.js'
+
+/**
+ * Tag for VarFieldGroup component.
+ * Renders VarEditorField container — purely declarative, no event handlers.
+ */
+export class WorkflowVarFieldGroupTag extends BaseTag {
+  getTagName(): string {
+    return 'div'
+  }
+
+  getComponentName(): string {
+    return 'WorkflowVarFieldGroup'
+  }
+
+  getAttributes(props: Record<string, any>): Record<string, any> {
+    const { orientation, validationError, validationType } = props
+
+    return {
+      orientation,
+      validationError,
+      validationType,
+    }
+  }
+}

--- a/packages/sdk/src/runtime/reconciler/tags/workflow-var-field-tag.ts
+++ b/packages/sdk/src/runtime/reconciler/tags/workflow-var-field-tag.ts
@@ -1,0 +1,30 @@
+// packages/sdk/src/runtime/reconciler/tags/workflow-var-field-tag.ts
+
+import { BaseTag } from './base-tag.js'
+
+/**
+ * Tag for VarField component.
+ * Renders VarEditorFieldRow wrapper — purely declarative, no event handlers.
+ */
+export class WorkflowVarFieldTag extends BaseTag {
+  getTagName(): string {
+    return 'div'
+  }
+
+  getComponentName(): string {
+    return 'WorkflowVarField'
+  }
+
+  getAttributes(props: Record<string, any>): Record<string, any> {
+    const { name, title, description, required, type, showIcon } = props
+
+    return {
+      name,
+      title,
+      description,
+      required,
+      type,
+      showIcon,
+    }
+  }
+}

--- a/packages/sdk/src/runtime/reconciler/tags/workflow-var-input-tag.ts
+++ b/packages/sdk/src/runtime/reconciler/tags/workflow-var-input-tag.ts
@@ -1,0 +1,34 @@
+// packages/sdk/src/runtime/reconciler/tags/workflow-var-input-tag.ts
+
+import { BaseTag } from './base-tag.js'
+
+/**
+ * Tag for VarInput component.
+ * Renders VarEditor for any BaseType — purely declarative, no event handlers.
+ * The host reads/writes through AppWorkflowFieldContext.
+ */
+export class WorkflowVarInputTag extends BaseTag {
+  getTagName(): string {
+    return 'div'
+  }
+
+  getComponentName(): string {
+    return 'VarInputInternal'
+  }
+
+  getAttributes(props: Record<string, any>): Record<string, any> {
+    const { name, type, placeholder, acceptsVariables, variableTypes, format, options, multiline } =
+      props
+
+    return {
+      name,
+      type,
+      placeholder,
+      acceptsVariables,
+      variableTypes,
+      format,
+      options,
+      multiline,
+    }
+  }
+}

--- a/packages/sdk/src/runtime/workflow.ts
+++ b/packages/sdk/src/runtime/workflow.ts
@@ -85,6 +85,14 @@ function WorkflowPanelContainer({
     return unsubscribe
   }, [nodeId])
 
+  // Evaluate computeOutputs whenever data changes
+  useEffect(() => {
+    const block = getWorkflowBlock(blockId)
+    if (block) {
+      evaluateComputeOutputs(block, nodeId, data)
+    }
+  }, [blockId, nodeId, data])
+
   const updateData = useCallback(
     (updates: Partial<any>) => {
       setData((prev: any) => ({ ...prev, ...updates }))
@@ -441,9 +449,13 @@ export function getWorkflowBlocks(): WorkflowBlock[] {
           inputs: serializeFields(fullBlock.schema.inputs || {}, 'input'),
           outputs: serializeFields(fullBlock.schema.outputs || {}, 'output'),
           handles: fullBlock.schema.handles || { sources: [], targets: [] },
+          layout: fullBlock.schema.layout,
           // Exclude validation.custom function (if present)
         }
       }
+
+      // Flag whether this block has a custom panel
+      metadata.hasPanel = !!fullBlock.panel
 
       // DO NOT include: components.node, components.panel, execute function
       // These remain in SURFACES and are accessed via getWorkflowBlock() for rendering
@@ -555,8 +567,13 @@ async function renderWorkflowPanel(
 
   if (!PanelComponent) {
     // Generate default panel from schema
+    const defaultPanel = generateDefaultPanel(block, data)
+
+    // Evaluate computeOutputs for default panels too
+    evaluateComputeOutputs(block, nodeId, data)
+
     return {
-      component: generateDefaultPanel(block, data),
+      component: defaultPanel,
     }
   }
 
@@ -618,19 +635,75 @@ function createDefaultNodeComponent(block: WorkflowBlock, _data: any): any {
 }
 
 /**
- * Generate default panel from schema
+ * Generate default panel from schema using VarFieldGroup > VarField > VarInput components.
+ *
+ * When a block has no custom panel component, this creates a configuration panel
+ * automatically from the schema's input field definitions and optional layout.
  */
 function generateDefaultPanel(block: WorkflowBlock, _data: any): any {
-  // TODO: Implement automatic panel generation from schema
-  // This would create form fields based on block.schema.inputs
-  // For now, return a simple serialized structure
+  const serializedInputs = serializeFields(block.schema.inputs || {}, 'input')
+  const inputFields = Object.entries(serializedInputs)
+
+  if (inputFields.length === 0) {
+    return {
+      children: [{ instance_type: 'text', text: `Configure ${block.label}` }],
+    }
+  }
+
+  // Use layout if defined, otherwise create a single default section
+  const layout = block.schema.layout || [
+    {
+      type: 'section' as const,
+      title: 'Configuration',
+      fields: inputFields.map(([name]) => name),
+    },
+  ]
+
   return {
-    children: [
-      {
-        instance_type: 'text',
-        text: `Configure ${block.label}`,
+    children: layout.map((section: any) => ({
+      instance_type: 'instance',
+      component: 'WorkflowSection',
+      attributes: {
+        title: section.title,
+        description: section.description,
+        collapsible: section.collapsible,
+        defaultOpen: section.initialOpen ?? true,
       },
-    ],
+      children: [
+        {
+          instance_type: 'instance',
+          component: 'WorkflowVarFieldGroup',
+          attributes: {},
+          children: section.fields
+            .map((fieldName: string) => {
+              const field = serializedInputs[fieldName]
+              if (!field) return null
+
+              return {
+                instance_type: 'instance',
+                component: 'WorkflowVarField',
+                attributes: {},
+                children: [
+                  {
+                    instance_type: 'instance',
+                    component: 'VarInputInternal',
+                    attributes: {
+                      name: fieldName,
+                      type: field.type,
+                      placeholder: field.placeholder,
+                      acceptsVariables: field.acceptsVariables,
+                      variableTypes: field.variableTypes,
+                      format: field.format,
+                      options: field.options,
+                    },
+                  },
+                ],
+              }
+            })
+            .filter(Boolean),
+        },
+      ],
+    })),
   }
 }
 
@@ -648,6 +721,74 @@ function cleanupWorkflowPanelRender(nodeId: string): void {
  */
 function cleanupWorkflowNodeRender(nodeId: string): void {
   activeNodeRenders.delete(nodeId)
+}
+
+// ===== computeOutputs =====
+
+/** Debounce timers per node for computeOutputs evaluation */
+const computeOutputsTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+/**
+ * Evaluate a block's computeOutputs function and send the result to the host.
+ * Debounced to avoid excessive messages during rapid editing.
+ */
+function evaluateComputeOutputs(block: WorkflowBlock, nodeId: string, data: any): void {
+  if (!block.schema?.computeOutputs) return
+
+  // Clear existing timer
+  const existing = computeOutputsTimers.get(nodeId)
+  if (existing) clearTimeout(existing)
+
+  computeOutputsTimers.set(
+    nodeId,
+    setTimeout(() => {
+      computeOutputsTimers.delete(nodeId)
+      try {
+        const computed = block.schema.computeOutputs!(data)
+        if (computed && typeof computed === 'object') {
+          // Serialize the computed output fields
+          const serialized = serializeComputedOutputs(computed)
+          Host.sendMessage('workflow-block-outputs-updated', {
+            nodeId,
+            blockId: block.id,
+            outputs: serialized,
+          })
+        }
+      } catch (err) {
+        console.error('[Workflow] computeOutputs error:', err)
+        // Static outputs remain as fallback — no action needed
+      }
+    }, 300)
+  )
+}
+
+/**
+ * Serialize computed output fields to WorkflowBlockField format.
+ * computeOutputs returns field nodes (same shape as schema.outputs).
+ */
+function serializeComputedOutputs(outputs: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = {}
+
+  for (const [key, fieldNode] of Object.entries(outputs)) {
+    // If it has toJSON, it's a field node — serialize it
+    if (fieldNode && typeof fieldNode.toJSON === 'function') {
+      const json = fieldNode.toJSON()
+      const metadata = json._metadata || {}
+      result[key] = {
+        name: key,
+        label: metadata.label || key,
+        type: json.type || 'any',
+        description: metadata.description,
+        required: metadata.required,
+        _fieldKind: 'output' as const,
+      }
+    } else if (fieldNode && typeof fieldNode === 'object' && fieldNode.type) {
+      // Already serialized — pass through
+      result[key] = { name: key, ...fieldNode }
+    }
+  }
+
+  return result
 }
 
 // ===== Request Handlers =====


### PR DESCRIPTION
feat(workflow): enhance output variable handling and introduce VarEditor components

- Updated WorkflowBlockRegistry to merge static schema outputs with computed outputs from block data.
- Added VarField, VarFieldGroup, and VarInput components for improved input handling in workflows.
- Implemented automatic panel generation using VarFieldGroup and VarField components based on schema layout.
- Introduced computeOutputs functionality to dynamically compute and serialize output fields based on input changes.
- Enhanced useWorkflow hook to support new VarEditor components and streamline input handling.
- Added new tags for VarField, VarFieldGroup, and VarInput in the reconciler for rendering.