### PR TITLE
feat: add dynamic trigger input registration and unregistration

### DIFF
--- a/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/connection-variable-dialog.tsx
+++ b/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/connection-variable-dialog.tsx
@@ -1,0 +1,317 @@
+// apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/connection-variable-dialog.tsx
+'use client'
+
+import type { ConnectionVariable } from '@auxx/database'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@auxx/ui/components/empty'
+import { Field, FieldDescription, FieldLabel } from '@auxx/ui/components/field'
+import { Input } from '@auxx/ui/components/input'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Switch } from '@auxx/ui/components/switch'
+import { TooltipExplanation } from '@auxx/ui/components/tooltip'
+import { Edit2, Lock, Plus, Trash2, Variable, X } from 'lucide-react'
+import { useState } from 'react'
+import { toastError } from '~/components/global/toast'
+
+/** Variable definition item row */
+function VariableDefinitionItem({
+  variable,
+  onEdit,
+  onDelete,
+}: {
+  variable: ConnectionVariable
+  onEdit: () => void
+  onDelete: () => void
+}) {
+  return (
+    <div className='group flex items-center gap-3 rounded-xl border px-3 py-2 hover:bg-muted/50 transition-colors'>
+      <code className='text-sm font-mono text-muted-foreground'>{`{${variable.key}}`}</code>
+      <div className='flex-1 min-w-0'>
+        <div className='flex items-center gap-2'>
+          <span className='text-sm font-medium'>{variable.label}</span>
+          {variable.secret && <Lock className='size-3 text-muted-foreground' />}
+          {variable.required !== false && (
+            <span className='text-xs text-muted-foreground'>required</span>
+          )}
+        </div>
+        {variable.description && (
+          <p className='text-xs text-muted-foreground truncate'>{variable.description}</p>
+        )}
+      </div>
+      <div className='opacity-0 group-hover:opacity-100 transition-opacity flex gap-1'>
+        <Button variant='ghost' size='icon-sm' onClick={onEdit}>
+          <Edit2 />
+        </Button>
+        <Button
+          variant='ghost'
+          size='icon-sm'
+          className='text-destructive hover:text-destructive'
+          onClick={onDelete}>
+          <Trash2 />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/** Dialog for defining connection variables */
+export function ConnectionVariableDialog({
+  open,
+  onOpenChange,
+  variables,
+  onChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  variables: ConnectionVariable[]
+  onChange: (variables: ConnectionVariable[]) => void
+}) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [editingIndex, setEditingIndex] = useState<number | null>(null)
+  const [formData, setFormData] = useState<ConnectionVariable>({
+    key: '',
+    label: '',
+    description: '',
+    placeholder: '',
+    required: true,
+    secret: false,
+  })
+
+  const handleAdd = () => {
+    setEditingIndex(null)
+    setFormData({
+      key: '',
+      label: '',
+      description: '',
+      placeholder: '',
+      required: true,
+      secret: false,
+    })
+    setIsEditing(true)
+  }
+
+  const handleEdit = (index: number) => {
+    const v = variables[index]
+    setEditingIndex(index)
+    setFormData({ ...v })
+    setIsEditing(true)
+  }
+
+  const handleDelete = (index: number) => {
+    onChange(variables.filter((_, i) => i !== index))
+  }
+
+  const handleSave = () => {
+    const keyRegex = /^[a-z][a-z0-9_]*$/
+    if (!keyRegex.test(formData.key)) {
+      toastError({
+        title: 'Invalid key',
+        description:
+          'Key must start with a letter and contain only lowercase letters, numbers, and underscores.',
+      })
+      return
+    }
+    if (!formData.label.trim()) {
+      toastError({
+        title: 'Label required',
+        description: 'Please provide a label for this variable.',
+      })
+      return
+    }
+
+    const isDuplicate = variables.some((v, i) => v.key === formData.key && i !== editingIndex)
+    if (isDuplicate) {
+      toastError({
+        title: 'Duplicate key',
+        description: `A variable with key "${formData.key}" already exists.`,
+      })
+      return
+    }
+
+    const updated = [...variables]
+    const cleanedData: ConnectionVariable = {
+      key: formData.key,
+      label: formData.label.trim(),
+      ...(formData.description?.trim() && { description: formData.description.trim() }),
+      ...(formData.placeholder?.trim() && { placeholder: formData.placeholder.trim() }),
+      ...(formData.required === false && { required: false }),
+      ...(formData.secret && { secret: true }),
+    }
+
+    if (editingIndex !== null) {
+      updated[editingIndex] = cleanedData
+    } else {
+      updated.push(cleanedData)
+    }
+    onChange(updated)
+    setIsEditing(false)
+    setEditingIndex(null)
+  }
+
+  const handleCancel = () => {
+    setIsEditing(false)
+    setEditingIndex(null)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent position='tc' className='sm:max-w-lg'>
+        <DialogHeader>
+          <DialogTitle>Connection Variables</DialogTitle>
+          <DialogDescription>
+            Define variables that organizations must provide when setting up this connection.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className='space-y-3'>
+          <div className='flex items-center justify-between'>
+            <span className='text-sm font-medium'>Variables</span>
+            <Button type='button' variant='outline' size='sm' onClick={handleAdd}>
+              <Plus />
+              Add Variable
+            </Button>
+          </div>
+
+          {variables.length === 0 && !isEditing ? (
+            <div className=''>
+              <Empty className='border border-primary-300'>
+                <EmptyHeader className='gap-0'>
+                  <EmptyMedia variant='icon' className='bg-primary-100'>
+                    <Variable />
+                  </EmptyMedia>
+                  <EmptyTitle>No variables defined</EmptyTitle>
+                  <EmptyDescription>
+                    Add variables for dynamic values like shop subdomains or client credentials.
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
+            </div>
+          ) : (
+            <ScrollArea className='max-h-[240px]'>
+              <div className='space-y-2'>
+                {variables.map((v, i) => (
+                  <VariableDefinitionItem
+                    key={v.key}
+                    variable={v}
+                    onEdit={() => handleEdit(i)}
+                    onDelete={() => handleDelete(i)}
+                  />
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+
+          {isEditing && (
+            <div className='space-y-3 border rounded-lg p-3 bg-primary-100'>
+              <div className='flex items-center justify-between'>
+                <span className='text-sm font-medium'>
+                  {editingIndex !== null ? 'Edit Variable' : 'Add Variable'}
+                </span>
+                <Button variant='ghost' size='icon' onClick={handleCancel} className='h-6 w-6'>
+                  <X />
+                </Button>
+              </div>
+
+              <div className='grid grid-cols-2 gap-3'>
+                <Field>
+                  <FieldLabel htmlFor='cv-key'>
+                    Key <span className='text-red-500'>*</span>
+                  </FieldLabel>
+                  <Input
+                    id='cv-key'
+                    value={formData.key}
+                    onChange={(e) => setFormData({ ...formData, key: e.target.value })}
+                    placeholder='shop'
+                  />
+                  <FieldDescription>
+                    Used as {'{'}
+                    <em>key</em>
+                    {'}'} in URLs and fields
+                  </FieldDescription>
+                </Field>
+
+                <Field>
+                  <FieldLabel htmlFor='cv-label'>
+                    Label <span className='text-red-500'>*</span>
+                  </FieldLabel>
+                  <Input
+                    id='cv-label'
+                    value={formData.label}
+                    onChange={(e) => setFormData({ ...formData, label: e.target.value })}
+                    placeholder='Shop Subdomain'
+                  />
+                  <FieldDescription>Shown to the user in the connection form</FieldDescription>
+                </Field>
+              </div>
+
+              <Field>
+                <FieldLabel htmlFor='cv-description'>Description</FieldLabel>
+                <Input
+                  id='cv-description'
+                  value={formData.description ?? ''}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  placeholder='e.g. my-store from my-store.myshopify.com'
+                />
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor='cv-placeholder'>Placeholder</FieldLabel>
+                <Input
+                  id='cv-placeholder'
+                  value={formData.placeholder ?? ''}
+                  onChange={(e) => setFormData({ ...formData, placeholder: e.target.value })}
+                  placeholder='my-store'
+                />
+              </Field>
+
+              <div className='flex items-center gap-6'>
+                <div className='flex items-center gap-2'>
+                  <Switch
+                    id='cv-required'
+                    checked={formData.required !== false}
+                    onCheckedChange={(checked) => setFormData({ ...formData, required: checked })}
+                  />
+                  <FieldLabel htmlFor='cv-required'>Required</FieldLabel>
+                </div>
+                <div className='flex items-center gap-2'>
+                  <Switch
+                    id='cv-secret'
+                    checked={formData.secret ?? false}
+                    onCheckedChange={(checked) => setFormData({ ...formData, secret: checked })}
+                  />
+                  <FieldLabel htmlFor='cv-secret'>Secret</FieldLabel>
+                  <TooltipExplanation
+                    text='Secret variables are masked in the connection form. Use for values like client secrets that the org provides.'
+                    side='right'
+                  />
+                </div>
+              </div>
+
+              <div className='flex gap-2 justify-end'>
+                <Button variant='ghost' size='sm' onClick={handleCancel}>
+                  Cancel
+                </Button>
+                <Button variant='outline' size='sm' onClick={handleSave}>
+                  {editingIndex !== null ? 'Update' : 'Add'}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/page.tsx
+++ b/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/page.tsx
@@ -1,6 +1,8 @@
 // apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/page.tsx
 'use client'
 
+import type { ConnectionVariable } from '@auxx/database'
+import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import {
   Empty,
@@ -26,17 +28,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@auxx/ui/components/select'
+import { Separator } from '@auxx/ui/components/separator'
 import { Switch } from '@auxx/ui/components/switch'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { TooltipError, TooltipExplanation } from '@auxx/ui/components/tooltip'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-import { Loader2, X } from 'lucide-react'
+import { AlertTriangle, Loader2, Settings2, X } from 'lucide-react'
 import { useParams } from 'next/navigation'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { toastError } from '~/components/global/toast'
 import { api } from '~/trpc/react'
+import { ConnectionVariableDialog } from './connection-variable-dialog'
 
 /** Connection form validation schema */
 const connectionFormSchema = z
@@ -48,16 +52,26 @@ const connectionFormSchema = z
     // OAuth2 fields - conditionally validated
     oauth2AuthorizeUrl: z
       .string()
-      .refine((val) => !val || val === '' || z.string().url().safeParse(val).success, {
-        message: 'Must be a valid URL',
-      })
+      .refine(
+        (val) => {
+          if (!val || val === '') return true
+          if (/\{[^}]+\}/.test(val)) return true
+          return z.string().url().safeParse(val).success
+        },
+        { message: 'Must be a valid URL or contain {variable} placeholders' }
+      )
       .optional()
       .or(z.literal('')),
     oauth2AccessTokenUrl: z
       .string()
-      .refine((val) => !val || val === '' || z.string().url().safeParse(val).success, {
-        message: 'Must be a valid URL',
-      })
+      .refine(
+        (val) => {
+          if (!val || val === '') return true
+          if (/\{[^}]+\}/.test(val)) return true
+          return z.string().url().safeParse(val).success
+        },
+        { message: 'Must be a valid URL or contain {variable} placeholders' }
+      )
       .optional()
       .or(z.literal('')),
     oauth2ClientId: z.string().optional().or(z.literal('')),
@@ -227,6 +241,9 @@ export default function ConnectionsPage() {
   } = form
 
   const [showAdvanced, setShowAdvanced] = useState(false)
+  const [connectionVariables, setConnectionVariables] = useState<ConnectionVariable[]>([])
+  const [variableDialogOpen, setVariableDialogOpen] = useState(false)
+  const [variablesDirty, setVariablesDirty] = useState(false)
 
   // Watch form fields - using watch instead of useWatch to avoid timing issues with reset
   const connectionType = watch('connectionType') || 'none'
@@ -264,6 +281,9 @@ export default function ConnectionsPage() {
           (features.callbackMetadataParams as string[])?.join(', ') ?? '',
       })
 
+      // Load connection variables from features
+      setConnectionVariables((features.connectionVariables as ConnectionVariable[]) ?? [])
+
       // Auto-open advanced section if any advanced field has a value
       if (
         features.pkce ||
@@ -284,6 +304,7 @@ export default function ConnectionsPage() {
   const upsertConnection = api.connections.upsert.useMutation({
     onSuccess: () => {
       hasLoadedConnection.current = false
+      setVariablesDirty(false)
       utils.connections.get.invalidate({
         appId: app?.id ?? '',
         version: 1,
@@ -300,6 +321,25 @@ export default function ConnectionsPage() {
 
   // Computed value for conditional rendering
   const isOAuth2 = connectionType === 'oauth2-code'
+
+  // Watch URL fields for placeholder auto-detection
+  const authorizeUrl = watch('oauth2AuthorizeUrl') || ''
+  const tokenUrl = watch('oauth2AccessTokenUrl') || ''
+  const clientId = watch('oauth2ClientId') || ''
+  const clientSecret = watch('oauth2ClientSecret') || ''
+
+  const detectedPlaceholders = useMemo(() => {
+    const allFields = [authorizeUrl, tokenUrl, clientId, clientSecret].join(' ')
+    const matches = allFields.match(/\{([^}]+)\}/g)
+    if (!matches) return []
+    const keys = [...new Set(matches.map((m) => m.slice(1, -1)))]
+    return keys.filter((k) => !connectionVariables.some((v) => v.key === k))
+  }, [authorizeUrl, tokenUrl, clientId, clientSecret, connectionVariables])
+
+  const handleVariablesChange = (vars: ConnectionVariable[]) => {
+    setConnectionVariables(vars)
+    setVariablesDirty(true)
+  }
 
   // Form submission handler
   const onSubmit = async (data: ConnectionFormData) => {
@@ -330,6 +370,7 @@ export default function ConnectionsPage() {
         oauth2TokenRequestAuthMethod: data.oauth2TokenRequestAuthMethod,
         oauth2RefreshTokenIntervalSeconds: refreshSeconds,
         oauth2Features: {
+          ...(connectionVariables.length > 0 && { connectionVariables }),
           ...(data.oauth2Pkce && { pkce: true }),
           ...(data.oauth2CallbackBaseUrl && { callbackBaseUrl: data.oauth2CallbackBaseUrl }),
           ...(data.oauth2ScopeSeparator && { scopeSeparator: data.oauth2ScopeSeparator }),
@@ -442,6 +483,61 @@ export default function ConnectionsPage() {
 
               {isOAuth2 && (
                 <FieldGroup>
+                  <Field>
+                    <FieldLabel className='flex items-center gap-1'>
+                      Dynamic Variables
+                      <TooltipExplanation
+                        text='Define variables that organizations must provide when connecting. Use {variable_name} placeholders in the Authorize URL, Token URL, Client ID, or Client Secret fields below.'
+                        side='right'
+                      />
+                    </FieldLabel>
+                    <div className='flex items-center gap-2'>
+                      <Button
+                        type='button'
+                        variant='outline'
+                        size='sm'
+                        onClick={() => setVariableDialogOpen(true)}>
+                        <Settings2 />
+                        Define Variables
+                      </Button>
+                      {connectionVariables.length > 0 && (
+                        <>
+                          <Separator orientation='vertical' className='h-5' />
+                          <div className='flex flex-wrap items-center gap-1'>
+                            {connectionVariables.map((v) => (
+                              <Badge key={v.key} variant='zinc' size='sm'>
+                                {`{${v.key}}`}
+                              </Badge>
+                            ))}
+                          </div>
+                        </>
+                      )}
+                    </div>
+                    <FieldDescription>
+                      Use these as placeholders in the fields below (e.g.{' '}
+                      <code className='text-xs'>
+                        {'https://{shop}.myshopify.com/admin/oauth/authorize'}
+                      </code>
+                      )
+                    </FieldDescription>
+                  </Field>
+
+                  {detectedPlaceholders.length > 0 && (
+                    <div className='flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800'>
+                      <AlertTriangle className='size-4 shrink-0' />
+                      <span>
+                        Unmatched placeholders detected:{' '}
+                        {detectedPlaceholders.map((p, i) => (
+                          <span key={p}>
+                            {i > 0 && ', '}
+                            <code className='font-mono'>{`{${p}}`}</code>
+                          </span>
+                        ))}
+                        . Define these as variables above.
+                      </span>
+                    </div>
+                  )}
+
                   <Field>
                     <FieldLabel htmlFor='app-organization-authorize-url'>Authorize URL</FieldLabel>
                     <InputGroup>
@@ -705,12 +801,19 @@ export default function ConnectionsPage() {
                 size='sm'
                 loading={upsertConnection.isPending}
                 loadingText='Saving...'
-                disabled={!isDirty || upsertConnection.isPending}>
+                disabled={(!isDirty && !variablesDirty) || upsertConnection.isPending}>
                 Save Connection
               </Button>
             </Field>
           </FieldGroup>
         </form>
+
+        <ConnectionVariableDialog
+          open={variableDialogOpen}
+          onOpenChange={setVariableDialogOpen}
+          variables={connectionVariables}
+          onChange={handleVariablesChange}
+        />
       </div>
     </div>
   )

--- a/apps/build/src/components/build-nav-main.tsx
+++ b/apps/build/src/components/build-nav-main.tsx
@@ -42,27 +42,29 @@ export function BuildNavMain({ accountSlug }: Props) {
               <div className='px-2 py-1.5 text-xs text-muted-foreground'>No apps yet</div>
             </SidebarMenuItem>
           ) : (
-            apps.map((app) => (
-              <SidebarMenuItem key={app.id}>
-                <SidebarItem
-                  id={app.id}
-                  name={app.title}
-                  href={`/${accountSlug}/apps/${app.slug}`}
-                  icon={
-                    app.avatarUrl ? (
-                      <img
-                        src={app.avatarUrl}
-                        alt={app.title}
-                        className='size-4 rounded-sm object-cover'
-                      />
-                    ) : (
-                      <Package />
-                    )
-                  }
-                  isActive={isActive(app.slug)}
-                />
-              </SidebarMenuItem>
-            ))
+            apps
+              .toSorted((a, b) => a.title.localeCompare(b.title))
+              .map((app) => (
+                <SidebarMenuItem key={app.id}>
+                  <SidebarItem
+                    id={app.id}
+                    name={app.title}
+                    href={`/${accountSlug}/apps/${app.slug}`}
+                    icon={
+                      app.avatarUrl ? (
+                        <img
+                          src={app.avatarUrl}
+                          alt={app.title}
+                          className='size-4 rounded-sm object-cover'
+                        />
+                      ) : (
+                        <Package />
+                      )
+                    }
+                    isActive={isActive(app.slug)}
+                  />
+                </SidebarMenuItem>
+              ))
           )}
           {apps.length > 0 && (
             <SidebarMenuItem>

--- a/apps/build/src/server/api/routers/connections.ts
+++ b/apps/build/src/server/api/routers/connections.ts
@@ -80,8 +80,8 @@ export const connectionsRouter = createTRPCRouter({
         connectionType: z.enum(['oauth2-code', 'secret', 'none']),
         label: z.string(),
         description: z.string().optional(),
-        oauth2AuthorizeUrl: z.url().optional(),
-        oauth2AccessTokenUrl: z.url().optional(),
+        oauth2AuthorizeUrl: z.string().optional(),
+        oauth2AccessTokenUrl: z.string().optional(),
         oauth2ClientId: z.string().optional(),
         oauth2ClientSecret: z.string().optional(),
         oauth2Scopes: z
@@ -105,6 +105,18 @@ export const connectionsRouter = createTRPCRouter({
             additionalTokenParams: z.record(z.string(), z.string()).optional(),
             scopeSeparator: z.string().optional(),
             callbackMetadataParams: z.array(z.string()).optional(),
+            connectionVariables: z
+              .array(
+                z.object({
+                  key: z.string(),
+                  label: z.string(),
+                  description: z.string().optional(),
+                  placeholder: z.string().optional(),
+                  required: z.boolean().optional(),
+                  secret: z.boolean().optional(),
+                })
+              )
+              .optional(),
           })
           .optional(),
       })

--- a/apps/lambda/src/executors/polling-trigger-executor.ts
+++ b/apps/lambda/src/executors/polling-trigger-executor.ts
@@ -27,21 +27,18 @@ export async function executePollingTrigger(
 
   try {
     // Execute bundle to register workflow blocks
-    const codeWithReturn = bundleCode + '\nreturn { __AUXX_WORKFLOW_BLOCKS__ };'
+    // Return stdin_workflow_block_handlers_default which properly forwards all args,
+    // unlike __AUXX_WORKFLOW_BLOCKS__ which only forwards `input` in older bundles.
+    const codeWithReturn =
+      bundleCode + '\nreturn { __AUXX_WORKFLOW_BLOCKS__, stdin_workflow_block_handlers_default };'
     const fn = new Function(codeWithReturn)
     const result = fn()
+    const workflowBlockHandler = result.stdin_workflow_block_handlers_default
     const workflowBlocks = result.__AUXX_WORKFLOW_BLOCKS__
 
-    if (!workflowBlocks) {
-      throw new Error('Server bundle does not export workflow blocks')
-    }
-
-    const trigger = workflowBlocks[triggerId]
-    if (!trigger) {
+    // Verify trigger exists
+    if (!workflowBlocks?.[triggerId]) {
       throw new Error(`Polling trigger not found: ${triggerId}`)
-    }
-    if (typeof trigger.execute !== 'function') {
-      throw new Error(`Polling trigger ${triggerId} does not have an execute function`)
     }
 
     // Build polling context from the connection already resolved into the runtime context
@@ -54,8 +51,11 @@ export async function executePollingTrigger(
 
     const pollingContext = { state: pollingState, connection }
 
-    // Execute with timeout
-    const execPromise = trigger.execute(triggerInput, pollingContext)
+    // Execute with timeout — use stdin_workflow_block_handlers_default to properly
+    // forward all args (input + polling context) to the underlying execute function
+    const execPromise = workflowBlockHandler
+      ? workflowBlockHandler(triggerId, 'execute', [triggerInput, pollingContext])
+      : workflowBlocks[triggerId].execute(triggerInput, pollingContext)
     const timeoutPromise = new Promise<never>((_, reject) =>
       setTimeout(() => reject(new Error(`Poll function timed out after ${timeout}ms`)), timeout)
     )

--- a/apps/web/src/app/(protected)/app/workflows/_components/executions/execution-tracing-view.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/_components/executions/execution-tracing-view.tsx
@@ -121,7 +121,7 @@ export function ExecutionTracingView() {
           if (group.type === 'single') {
             // Single execution (not part of a grouped branch)
             const depth = (group.execution.executionMetadata as any)?.depth ?? 0
-            console.log(activeRun.status)
+
             // Check if this is a loop node
             if (group.execution.nodeType === 'loop') {
               const iterations = getLoopIterations(group.execution.nodeId)

--- a/apps/web/src/app/admin/_components/admin-nav-main.tsx
+++ b/apps/web/src/app/admin/_components/admin-nav-main.tsx
@@ -1,10 +1,16 @@
 // apps/web/src/app/admin/_components/admin-nav-main.tsx
 'use client'
 
-import { SidebarGroup, SidebarMenu, SidebarMenuItem } from '@auxx/ui/components/sidebar'
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuItem,
+} from '@auxx/ui/components/sidebar'
 import {
   Activity,
   Building2,
+  Code,
   CreditCard,
   LayoutDashboard,
   type LucideIcon,
@@ -27,56 +33,90 @@ interface NavItem {
 }
 
 /**
- * Admin navigation items
+ * Navigation group interface
  */
-const ADMIN_NAV_ITEMS: NavItem[] = [
+interface NavGroup {
+  label: string
+  items: NavItem[]
+}
+
+/**
+ * Admin navigation groups
+ */
+const ADMIN_NAV_GROUPS: NavGroup[] = [
   {
-    id: 'dashboard',
-    label: 'Dashboard',
-    slug: '',
-    icon: LayoutDashboard,
+    label: 'Overview',
+    items: [
+      {
+        id: 'dashboard',
+        label: 'Dashboard',
+        slug: '',
+        icon: LayoutDashboard,
+      },
+    ],
   },
   {
-    id: 'organizations',
-    label: 'Organizations',
-    slug: 'organizations',
-    icon: Building2,
+    label: 'People',
+    items: [
+      {
+        id: 'organizations',
+        label: 'Organizations',
+        slug: 'organizations',
+        icon: Building2,
+      },
+      {
+        id: 'users',
+        label: 'Users',
+        slug: 'users',
+        icon: Users,
+      },
+    ],
   },
   {
-    id: 'users',
-    label: 'Users',
-    slug: 'users',
-    icon: Users,
+    label: 'Platform',
+    items: [
+      {
+        id: 'apps',
+        label: 'Apps',
+        slug: 'apps',
+        icon: Package,
+      },
+      {
+        id: 'workflows',
+        label: 'Workflow Templates',
+        slug: 'workflows',
+        icon: Workflow,
+      },
+      {
+        id: 'developer-accounts',
+        label: 'Developer Accounts',
+        slug: 'developer-accounts',
+        icon: Code,
+      },
+    ],
   },
   {
-    id: 'apps',
-    label: 'Apps',
-    slug: 'apps',
-    icon: Package,
-  },
-  {
-    id: 'workflows',
-    label: 'Workflow Templates',
-    slug: 'workflows',
-    icon: Workflow,
-  },
-  {
-    id: 'plans',
-    label: 'Plans',
-    slug: 'plans',
-    icon: CreditCard,
-  },
-  {
-    id: 'config',
-    label: 'Config',
-    slug: 'config',
-    icon: Settings,
-  },
-  {
-    id: 'health',
-    label: 'Health',
-    slug: 'health',
-    icon: Activity,
+    label: 'System',
+    items: [
+      {
+        id: 'plans',
+        label: 'Plans',
+        slug: 'plans',
+        icon: CreditCard,
+      },
+      {
+        id: 'config',
+        label: 'Config',
+        slug: 'config',
+        icon: Settings,
+      },
+      {
+        id: 'health',
+        label: 'Health',
+        slug: 'health',
+        icon: Activity,
+      },
+    ],
   },
 ]
 
@@ -93,32 +133,35 @@ export function AdminNavMain() {
     const url = `/admin/${item.slug}`
 
     if (item.slug === '') {
-      // Dashboard - only active on exact match
       return pathname === '/admin' || pathname === '/admin/'
     }
 
-    // Other items - active if path starts with the URL
     return pathname.startsWith(url) || pathname === url
   }
 
   return (
-    <SidebarGroup>
-      <SidebarMenu>
-        {ADMIN_NAV_ITEMS.map((item) => {
-          const url = `/admin/${item.slug}`
-          return (
-            <SidebarMenuItem key={item.id}>
-              <SidebarItem
-                id={item.id}
-                name={item.label}
-                href={url}
-                icon={<item.icon />}
-                isActive={isActive(item)}
-              />
-            </SidebarMenuItem>
-          )
-        })}
-      </SidebarMenu>
-    </SidebarGroup>
+    <div className='space-y-4'>
+      {ADMIN_NAV_GROUPS.map((group) => (
+        <SidebarGroup key={group.label}>
+          <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+          <SidebarMenu>
+            {group.items.map((item) => {
+              const url = `/admin/${item.slug}`
+              return (
+                <SidebarMenuItem key={item.id}>
+                  <SidebarItem
+                    id={item.id}
+                    name={item.label}
+                    href={url}
+                    icon={<item.icon />}
+                    isActive={isActive(item)}
+                  />
+                </SidebarMenuItem>
+              )
+            })}
+          </SidebarMenu>
+        </SidebarGroup>
+      ))}
+    </div>
   )
 }

--- a/apps/web/src/app/admin/apps/[id]/page.tsx
+++ b/apps/web/src/app/admin/apps/[id]/page.tsx
@@ -354,243 +354,262 @@ export default function AppDetailPage({ params }: { params: Promise<{ id: string
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>
-          <div className='grid lg:grid-cols-3'>
-            <Card className='border-none rounded-none shadow-none'>
-              <CardHeader>
-                <CardTitle>App Information</CardTitle>
-                <CardDescription>Details about this app</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className='overflow-hidden rounded-md border bg-background'>
-                  <Table>
-                    <TableBody>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>
-                          Developer Account
-                        </TableCell>
-                        <TableCell className='py-2'>{app.developerAccount?.title || '-'}</TableCell>
-                      </TableRow>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>Slug</TableCell>
-                        <TableCell className='py-2 font-mono text-sm'>{app.slug}</TableCell>
-                      </TableRow>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>Category</TableCell>
-                        <TableCell className='py-2'>{app.category || '-'}</TableCell>
-                      </TableRow>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>
-                          Publication Status
-                        </TableCell>
-                        <TableCell className='py-2'>
-                          <Badge variant={getPublicationStatusVariant(app.publicationStatus)}>
-                            {app.publicationStatus}
-                          </Badge>
-                        </TableCell>
-                      </TableRow>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>Auto-Approve</TableCell>
-                        <TableCell className='py-2'>
-                          <div className='flex items-center gap-2'>
-                            <Switch
-                              checked={app.autoApprove || false}
-                              onCheckedChange={handleToggleAutoApprove}
-                              disabled={toggleAutoApprove.isPending}
-                            />
-                            <span className='text-sm text-muted-foreground'>
-                              {app.autoApprove ? 'Enabled' : 'Disabled'}
-                            </span>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>Website</TableCell>
-                        <TableCell className='py-2'>
-                          {app.websiteUrl ? (
-                            <Button variant='link' className='h-auto p-0' asChild>
-                              <a href={app.websiteUrl} target='_blank' rel='noopener noreferrer'>
-                                <ExternalLink />
-                                Link
-                              </a>
-                            </Button>
-                          ) : (
-                            '-'
-                          )}
-                        </TableCell>
-                      </TableRow>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>
-                          Documentation
-                        </TableCell>
-                        <TableCell className='py-2'>
-                          {app.documentationUrl ? (
-                            <Button variant='link' className='h-auto p-0' asChild>
-                              <a
-                                href={app.documentationUrl}
-                                target='_blank'
-                                rel='noopener noreferrer'>
-                                <ExternalLink />
-                                Link
-                              </a>
-                            </Button>
-                          ) : (
-                            '-'
-                          )}
-                        </TableCell>
-                      </TableRow>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>Support Site</TableCell>
-                        <TableCell className='py-2'>
-                          {app.supportSiteUrl ? (
-                            <Button variant='link' className='h-auto p-0' asChild>
-                              <a
-                                href={app.supportSiteUrl}
-                                target='_blank'
-                                rel='noopener noreferrer'>
-                                <ExternalLink />
-                                Link
-                              </a>
-                            </Button>
-                          ) : (
-                            '-'
-                          )}
-                        </TableCell>
-                      </TableRow>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>Has OAuth</TableCell>
-                        <TableCell className='py-2'>{app.hasOauth ? 'Yes' : 'No'}</TableCell>
-                      </TableRow>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>Has Bundle</TableCell>
-                        <TableCell className='py-2'>{app.hasBundle ? 'Yes' : 'No'}</TableCell>
-                      </TableRow>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>Scopes</TableCell>
-                        <TableCell className='py-2'>
-                          {app.scopes.length > 0 ? app.scopes.join(', ') : '-'}
-                        </TableCell>
-                      </TableRow>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>Created</TableCell>
-                        <TableCell className='py-2'>
-                          {formatDistanceToNow(new Date(app.createdAt), { addSuffix: true })}
-                        </TableCell>
-                      </TableRow>
-                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                        <TableCell className='bg-muted/50 py-2 font-medium'>Updated</TableCell>
-                        <TableCell className='py-2'>
-                          {formatDistanceToNow(new Date(app.updatedAt), { addSuffix: true })}
-                        </TableCell>
-                      </TableRow>
-                      {app.description && (
-                        <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                          <TableCell className='bg-muted/50 py-2 font-medium'>
-                            Description
-                          </TableCell>
-                          <TableCell className='py-2 text-sm'>{app.description}</TableCell>
-                        </TableRow>
-                      )}
-                    </TableBody>
-                  </Table>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card className='col-span-2 border-none rounded-none shadow-none'>
-              <CardHeader>
-                <CardTitle>Deployments</CardTitle>
-                <CardDescription>Manage app deployments</CardDescription>
-              </CardHeader>
-              <CardContent>
-                {app.deployments.length === 0 ? (
-                  <div className='flex h-40 items-center justify-center text-muted-foreground'>
-                    No deployments found
-                  </div>
-                ) : (
-                  <div className='rounded-md border'>
-                    <Table>
-                      <TableHeader>
-                        <TableRow>
-                          <TableHead>Deployment</TableHead>
-                          <TableHead>Status</TableHead>
-                          <TableHead>Actions</TableHead>
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {app.deployments.map((deployment) => (
-                          <TableRow key={deployment.id}>
-                            <TableCell>
-                              <div>
-                                <div className='font-medium font-mono'>
-                                  {deployment.version || 'Development'}
-                                </div>
-                                <div className='text-xs text-muted-foreground'>
-                                  <Badge variant='outline' className='mr-2'>
-                                    {deployment.deploymentType}
-                                  </Badge>
-                                  {formatDistanceToNow(new Date(deployment.createdAt), {
-                                    addSuffix: true,
-                                  })}
-                                </div>
-                              </div>
+          <div className='flex-1 overflow-hidden flex flex-col min-h-0 relative'>
+            <div className='overflow-auto flex-1 relative'>
+              <div className='grid lg:grid-cols-3'>
+                <Card className='border-none rounded-none shadow-none'>
+                  <CardHeader>
+                    <CardTitle>App Information</CardTitle>
+                    <CardDescription>Details about this app</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className='overflow-hidden rounded-md border bg-background'>
+                      <Table>
+                        <TableBody>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>
+                              Developer Account
                             </TableCell>
-                            <TableCell>
-                              <Badge variant={getDeploymentStatusVariant(deployment.status)}>
-                                {deployment.status}
+                            <TableCell className='py-2'>
+                              {app.developerAccount?.title || '-'}
+                            </TableCell>
+                          </TableRow>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>Slug</TableCell>
+                            <TableCell className='py-2 font-mono text-sm'>{app.slug}</TableCell>
+                          </TableRow>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>Category</TableCell>
+                            <TableCell className='py-2'>{app.category || '-'}</TableCell>
+                          </TableRow>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>
+                              Publication Status
+                            </TableCell>
+                            <TableCell className='py-2'>
+                              <Badge variant={getPublicationStatusVariant(app.publicationStatus)}>
+                                {app.publicationStatus}
                               </Badge>
                             </TableCell>
-                            <TableCell>
-                              <div className='flex gap-1 justify-between'>
-                                <div className='flex gap-0.5'>
-                                  {(deployment.status === 'pending-review' ||
-                                    deployment.status === 'in-review') && (
-                                    <>
-                                      <Button
-                                        size='sm'
-                                        variant='outline'
-                                        onClick={() => handleApproveDeployment(deployment.id)}
-                                        loading={approveDeployment.isPending}>
-                                        <CheckCircle />
-                                        Approve
-                                      </Button>
-                                      <Button
-                                        size='sm'
-                                        variant='outline'
-                                        onClick={() => handleRejectDeploymentClick(deployment.id)}
-                                        loading={rejectDeployment.isPending}>
-                                        <XCircle />
-                                        Reject
-                                      </Button>
-                                    </>
-                                  )}
-                                  {deployment.status === 'published' && (
-                                    <Button
-                                      size='sm'
-                                      variant='outline'
-                                      onClick={() => handleDeprecateDeployment(deployment.id)}
-                                      loading={deprecateDeployment.isPending}>
-                                      <Ban />
-                                      Deprecate
-                                    </Button>
-                                  )}
-                                </div>
-                                <Button
-                                  size='sm'
-                                  variant='destructive-hover'
-                                  onClick={() => handleDeleteDeployment(deployment.id)}
-                                  loading={deleteDeployment.isPending}>
-                                  <Trash2 />
-                                </Button>
+                          </TableRow>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>
+                              Auto-Approve
+                            </TableCell>
+                            <TableCell className='py-2'>
+                              <div className='flex items-center gap-2'>
+                                <Switch
+                                  checked={app.autoApprove || false}
+                                  onCheckedChange={handleToggleAutoApprove}
+                                  disabled={toggleAutoApprove.isPending}
+                                />
+                                <span className='text-sm text-muted-foreground'>
+                                  {app.autoApprove ? 'Enabled' : 'Disabled'}
+                                </span>
                               </div>
                             </TableCell>
                           </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>Website</TableCell>
+                            <TableCell className='py-2'>
+                              {app.websiteUrl ? (
+                                <Button variant='link' className='h-auto p-0' asChild>
+                                  <a
+                                    href={app.websiteUrl}
+                                    target='_blank'
+                                    rel='noopener noreferrer'>
+                                    <ExternalLink />
+                                    Link
+                                  </a>
+                                </Button>
+                              ) : (
+                                '-'
+                              )}
+                            </TableCell>
+                          </TableRow>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>
+                              Documentation
+                            </TableCell>
+                            <TableCell className='py-2'>
+                              {app.documentationUrl ? (
+                                <Button variant='link' className='h-auto p-0' asChild>
+                                  <a
+                                    href={app.documentationUrl}
+                                    target='_blank'
+                                    rel='noopener noreferrer'>
+                                    <ExternalLink />
+                                    Link
+                                  </a>
+                                </Button>
+                              ) : (
+                                '-'
+                              )}
+                            </TableCell>
+                          </TableRow>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>
+                              Support Site
+                            </TableCell>
+                            <TableCell className='py-2'>
+                              {app.supportSiteUrl ? (
+                                <Button variant='link' className='h-auto p-0' asChild>
+                                  <a
+                                    href={app.supportSiteUrl}
+                                    target='_blank'
+                                    rel='noopener noreferrer'>
+                                    <ExternalLink />
+                                    Link
+                                  </a>
+                                </Button>
+                              ) : (
+                                '-'
+                              )}
+                            </TableCell>
+                          </TableRow>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>
+                              Has OAuth
+                            </TableCell>
+                            <TableCell className='py-2'>{app.hasOauth ? 'Yes' : 'No'}</TableCell>
+                          </TableRow>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>
+                              Has Bundle
+                            </TableCell>
+                            <TableCell className='py-2'>{app.hasBundle ? 'Yes' : 'No'}</TableCell>
+                          </TableRow>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>Scopes</TableCell>
+                            <TableCell className='py-2'>
+                              {app.scopes.length > 0 ? app.scopes.join(', ') : '-'}
+                            </TableCell>
+                          </TableRow>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>Created</TableCell>
+                            <TableCell className='py-2'>
+                              {formatDistanceToNow(new Date(app.createdAt), { addSuffix: true })}
+                            </TableCell>
+                          </TableRow>
+                          <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                            <TableCell className='bg-muted/50 py-2 font-medium'>Updated</TableCell>
+                            <TableCell className='py-2'>
+                              {formatDistanceToNow(new Date(app.updatedAt), { addSuffix: true })}
+                            </TableCell>
+                          </TableRow>
+                          {app.description && (
+                            <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                              <TableCell className='bg-muted/50 py-2 font-medium'>
+                                Description
+                              </TableCell>
+                              <TableCell className='py-2 text-sm'>{app.description}</TableCell>
+                            </TableRow>
+                          )}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <Card className='col-span-2 border-none rounded-none shadow-none'>
+                  <CardHeader>
+                    <CardTitle>Deployments</CardTitle>
+                    <CardDescription>Manage app deployments</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    {app.deployments.length === 0 ? (
+                      <div className='flex h-40 items-center justify-center text-muted-foreground'>
+                        No deployments found
+                      </div>
+                    ) : (
+                      <div className='rounded-md border'>
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>Deployment</TableHead>
+                              <TableHead>Status</TableHead>
+                              <TableHead>Actions</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {app.deployments.map((deployment) => (
+                              <TableRow key={deployment.id}>
+                                <TableCell>
+                                  <div>
+                                    <div className='font-medium font-mono'>
+                                      {deployment.version || 'Development'}
+                                    </div>
+                                    <div className='text-xs text-muted-foreground'>
+                                      <Badge variant='outline' className='mr-2'>
+                                        {deployment.deploymentType}
+                                      </Badge>
+                                      {formatDistanceToNow(new Date(deployment.createdAt), {
+                                        addSuffix: true,
+                                      })}
+                                    </div>
+                                  </div>
+                                </TableCell>
+                                <TableCell>
+                                  <Badge variant={getDeploymentStatusVariant(deployment.status)}>
+                                    {deployment.status}
+                                  </Badge>
+                                </TableCell>
+                                <TableCell>
+                                  <div className='flex gap-1 justify-between'>
+                                    <div className='flex gap-0.5'>
+                                      {(deployment.status === 'pending-review' ||
+                                        deployment.status === 'in-review') && (
+                                        <>
+                                          <Button
+                                            size='sm'
+                                            variant='outline'
+                                            onClick={() => handleApproveDeployment(deployment.id)}
+                                            loading={approveDeployment.isPending}>
+                                            <CheckCircle />
+                                            Approve
+                                          </Button>
+                                          <Button
+                                            size='sm'
+                                            variant='outline'
+                                            onClick={() =>
+                                              handleRejectDeploymentClick(deployment.id)
+                                            }
+                                            loading={rejectDeployment.isPending}>
+                                            <XCircle />
+                                            Reject
+                                          </Button>
+                                        </>
+                                      )}
+                                      {deployment.status === 'published' && (
+                                        <Button
+                                          size='sm'
+                                          variant='outline'
+                                          onClick={() => handleDeprecateDeployment(deployment.id)}
+                                          loading={deprecateDeployment.isPending}>
+                                          <Ban />
+                                          Deprecate
+                                        </Button>
+                                      )}
+                                    </div>
+                                    <Button
+                                      size='sm'
+                                      variant='destructive-hover'
+                                      onClick={() => handleDeleteDeployment(deployment.id)}
+                                      loading={deleteDeployment.isPending}>
+                                      <Trash2 />
+                                    </Button>
+                                  </div>
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
           </div>
         </MainPageContent>
       </MainPage>

--- a/apps/web/src/app/admin/apps/page.tsx
+++ b/apps/web/src/app/admin/apps/page.tsx
@@ -147,55 +147,56 @@ export default function AppsPage() {
             </div>
           ) : (
             <>
-              <div className='flex-1'>
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>App Name</TableHead>
-                      <TableHead>Developer Account</TableHead>
-                      <TableHead>Version</TableHead>
-                      <TableHead>Status</TableHead>
-                      <TableHead>Created</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {apps.map((app) => (
-                      <TableRow
-                        key={app.id}
-                        className='cursor-pointer'
-                        onClick={() => handleRowClick(app.id)}>
-                        <TableCell>
-                          <div>
-                            <div className='font-medium'>{app.title}</div>
-                            <div className='text-sm text-muted-foreground'>@{app.slug}</div>
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          {app.developerAccount ? (
-                            <div>{app.developerAccount.title}</div>
-                          ) : (
-                            <span className='text-muted-foreground'>-</span>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          {app.latestDeployment?.version || (
-                            <span className='text-muted-foreground'>-</span>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant={getStatusVariant(app.publicationStatus)}>
-                            {app.publicationStatus}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className='text-muted-foreground'>
-                          {formatDistanceToNow(new Date(app.createdAt), { addSuffix: true })}
-                        </TableCell>
+              <div className='flex-1 overflow-hidden flex flex-col min-h-0 relative'>
+                <div className='overflow-auto flex-1 relative'>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>App Name</TableHead>
+                        <TableHead>Developer Account</TableHead>
+                        <TableHead>Version</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Created</TableHead>
                       </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
+                    </TableHeader>
+                    <TableBody>
+                      {apps.map((app) => (
+                        <TableRow
+                          key={app.id}
+                          className='cursor-pointer'
+                          onClick={() => handleRowClick(app.id)}>
+                          <TableCell>
+                            <div>
+                              <div className='font-medium'>{app.title}</div>
+                              <div className='text-sm text-muted-foreground'>@{app.slug}</div>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            {app.developerAccount ? (
+                              <div>{app.developerAccount.title}</div>
+                            ) : (
+                              <span className='text-muted-foreground'>-</span>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            {app.latestDeployment?.version || (
+                              <span className='text-muted-foreground'>-</span>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant={getStatusVariant(app.publicationStatus)}>
+                              {app.publicationStatus}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className='text-muted-foreground'>
+                            {formatDistanceToNow(new Date(app.createdAt), { addSuffix: true })}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
               </div>
-
               <div className='border-t py-1 px-2 flex items-center justify-between'>
                 <div className='text-sm text-muted-foreground'>
                   Showing {page * PAGE_SIZE + 1} to{' '}

--- a/apps/web/src/app/admin/developer-accounts/_components/developer-account-drawer.tsx
+++ b/apps/web/src/app/admin/developer-accounts/_components/developer-account-drawer.tsx
@@ -1,0 +1,308 @@
+// apps/web/src/app/admin/developer-accounts/_components/developer-account-drawer.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
+import { DrawerHeader } from '@auxx/ui/components/drawer'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Section } from '@auxx/ui/components/section'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { toastError } from '@auxx/ui/components/toast'
+import { formatDistanceToNow } from 'date-fns'
+import { Ban, Code, Download, MoreHorizontal, Trash2 } from 'lucide-react'
+import Link from 'next/link'
+import { DockToggleButton } from '~/components/global/dock-toggle-button'
+import { Tooltip } from '~/components/global/tooltip'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useDockStore } from '~/stores/dock-store'
+import { api } from '~/trpc/react'
+
+interface DeveloperAccount {
+  id: string
+  slug: string
+  title: string
+  logoUrl: string | null
+  appCount: number
+  memberCount: number
+  createdAt: Date
+}
+
+interface DeveloperAccountDrawerProps {
+  account: DeveloperAccount | undefined
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Get badge variant for publication status
+ */
+function getStatusVariant(status: string): 'outline' | 'secondary' | 'default' | 'destructive' {
+  switch (status) {
+    case 'private':
+      return 'outline'
+    case 'review':
+      return 'secondary'
+    case 'published':
+      return 'default'
+    case 'rejected':
+      return 'destructive'
+    default:
+      return 'outline'
+  }
+}
+
+/**
+ * Right-side drawer showing developer account details and their apps.
+ */
+export function DeveloperAccountDrawer({
+  account,
+  open,
+  onOpenChange,
+}: DeveloperAccountDrawerProps) {
+  const isDocked = useEffectiveDockState()
+  const dockedWidth = useDockStore((state) => state.dockedWidth)
+  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
+  const [confirm, ConfirmDialog] = useConfirm()
+  const utils = api.useUtils()
+
+  const { data: apps, isLoading: appsLoading } = api.admin.apps.getApps.useQuery(
+    { developerAccountId: account?.id!, limit: 100, offset: 0 },
+    { enabled: !!account?.id && open }
+  )
+
+  const { refetch: fetchExport, isFetching: isExporting } =
+    api.admin.apps.exportByDeveloperAccount.useQuery(
+      { developerAccountId: account?.id ?? '' },
+      { enabled: false }
+    )
+
+  const deleteApp = api.admin.apps.deleteApp.useMutation({
+    onSuccess: () => {
+      utils.admin.apps.getApps.invalidate()
+      utils.admin.getDeveloperAccounts.invalidate()
+    },
+    onError: (error) => {
+      toastError({ title: 'Failed to delete app', description: error.message })
+    },
+  })
+
+  const unpublishApp = api.admin.apps.unpublishApp.useMutation({
+    onSuccess: () => {
+      utils.admin.apps.getApps.invalidate()
+    },
+    onError: (error) => {
+      toastError({ title: 'Failed to unpublish app', description: error.message })
+    },
+  })
+
+  /** Handle delete app with confirmation */
+  const handleDeleteApp = async (appId: string, appTitle: string) => {
+    const confirmed = await confirm({
+      title: `Delete ${appTitle}?`,
+      description:
+        'This will permanently delete the app and all its deployments. This action cannot be undone.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) {
+      await deleteApp.mutateAsync({ id: appId })
+    }
+  }
+
+  /** Handle unpublish app with confirmation */
+  const handleUnpublishApp = async (appId: string, appTitle: string) => {
+    const confirmed = await confirm({
+      title: `Unpublish ${appTitle}?`,
+      description:
+        'This will remove the app from the marketplace. Existing installations will continue to work.',
+      confirmText: 'Unpublish',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) {
+      await unpublishApp.mutateAsync({ appId })
+    }
+  }
+
+  const handleExport = async () => {
+    const { data } = await fetchExport()
+    if (!data) return
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `auxx-apps-export-${account!.slug}-${new Date().toISOString().slice(0, 10)}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  if (!open || !account) return null
+
+  return (
+    <>
+      <ConfirmDialog />
+      <DockableDrawer
+        open={open}
+        onOpenChange={onOpenChange}
+        isDocked={isDocked}
+        width={dockedWidth}
+        onWidthChange={setDockedWidth}
+        minWidth={400}
+        maxWidth={600}
+        title='Developer Account'>
+        <DrawerHeader
+          icon={<Code className='h-4 w-4' />}
+          title='Developer Account'
+          actions={
+            <>
+              <Tooltip content='Export apps as JSON'>
+                <Button
+                  variant='ghost'
+                  size='icon-sm'
+                  className='rounded-full'
+                  loading={isExporting}
+                  onClick={handleExport}
+                  tabIndex={-1}>
+                  <Download />
+                </Button>
+              </Tooltip>
+              <DockToggleButton />
+            </>
+          }
+          onClose={() => onOpenChange(false)}
+        />
+
+        {/* Account header */}
+        <div className='flex gap-3 py-2 px-3 flex-row items-center justify-start border-b'>
+          <EntityIcon iconId='code' color='gray' className='size-10' />
+          <div className='flex flex-col align-start w-full'>
+            <div className='text-lg font-medium text-neutral-900 dark:text-neutral-400'>
+              {account.title}
+            </div>
+            <div className='text-xs text-neutral-500'>@{account.slug}</div>
+          </div>
+        </div>
+
+        <ScrollArea className='flex-1'>
+          <div>
+            <Section title='Details'>
+              <div className='grid grid-cols-2 gap-4 text-sm'>
+                <div>
+                  <div className='text-muted-foreground'>Members</div>
+                  <div className='font-medium'>{account.memberCount}</div>
+                </div>
+                <div>
+                  <div className='text-muted-foreground'>Apps</div>
+                  <div className='font-medium'>{account.appCount}</div>
+                </div>
+                <div>
+                  <div className='text-muted-foreground'>Created</div>
+                  <div className='font-medium'>
+                    {formatDistanceToNow(new Date(account.createdAt), { addSuffix: true })}
+                  </div>
+                </div>
+              </div>
+            </Section>
+
+            <Section title='Apps' description='Apps published by this developer account'>
+              {appsLoading ? (
+                <div className='space-y-2'>
+                  {[...Array(3)].map((_, i) => (
+                    <Skeleton key={i} className='h-10 w-full' />
+                  ))}
+                </div>
+              ) : !apps || apps.length === 0 ? (
+                <div className='text-sm text-muted-foreground py-4 text-center'>No apps found</div>
+              ) : (
+                <div className='rounded-md border'>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Name</TableHead>
+                        <TableHead>Version</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Created</TableHead>
+                        <TableHead className='w-10' />
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {apps.map((app) => (
+                        <TableRow key={app.id}>
+                          <TableCell>
+                            <div>
+                              <Link
+                                href={`/admin/apps/${app.id}`}
+                                className='font-medium text-sm hover:underline'>
+                                {app.title}
+                              </Link>
+                              <div className='text-xs text-muted-foreground'>@{app.slug}</div>
+                            </div>
+                          </TableCell>
+                          <TableCell className='text-sm'>
+                            {app.latestDeployment?.version || (
+                              <span className='text-muted-foreground'>-</span>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant={getStatusVariant(app.publicationStatus)}>
+                              {app.publicationStatus}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className='text-sm text-muted-foreground'>
+                            {formatDistanceToNow(new Date(app.createdAt), { addSuffix: true })}
+                          </TableCell>
+                          <TableCell>
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button variant='ghost' size='icon-sm'>
+                                  <MoreHorizontal />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align='end'>
+                                {app.publicationStatus === 'published' && (
+                                  <DropdownMenuItem
+                                    onClick={() => handleUnpublishApp(app.id, app.title)}>
+                                    <Ban />
+                                    Unpublish
+                                  </DropdownMenuItem>
+                                )}
+                                <DropdownMenuItem
+                                  variant='destructive'
+                                  onClick={() => handleDeleteApp(app.id, app.title)}>
+                                  <Trash2 />
+                                  Delete App
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </Section>
+          </div>
+        </ScrollArea>
+      </DockableDrawer>
+    </>
+  )
+}

--- a/apps/web/src/app/admin/developer-accounts/page.tsx
+++ b/apps/web/src/app/admin/developer-accounts/page.tsx
@@ -1,0 +1,199 @@
+// apps/web/src/app/admin/developer-accounts/page.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Input } from '@auxx/ui/components/input'
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageContent,
+  MainPageHeader,
+  MainPageSubheader,
+} from '@auxx/ui/components/main-page'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { formatDistanceToNow } from 'date-fns'
+import { ChevronLeft, ChevronRight, Search } from 'lucide-react'
+import { useState } from 'react'
+import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useDockStore } from '~/stores/dock-store'
+import { api } from '~/trpc/react'
+import { DeveloperAccountDrawer } from './_components/developer-account-drawer'
+
+const PAGE_SIZE = 100
+
+/**
+ * Developer Accounts list page for admin
+ */
+export default function DeveloperAccountsPage() {
+  const [search, setSearch] = useState('')
+  const [page, setPage] = useState(0)
+  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null)
+
+  const isDocked = useEffectiveDockState()
+  const dockedWidth = useDockStore((state) => state.dockedWidth)
+  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
+  const minWidth = useDockStore((state) => state.minWidth)
+  const maxWidth = useDockStore((state) => state.maxWidth)
+
+  const { data: accounts, isLoading } = api.admin.getDeveloperAccounts.useQuery({
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+    search: search || undefined,
+  })
+
+  const selectedAccount = accounts?.find((a) => a.id === selectedAccountId)
+  const isDrawerOpen = !!selectedAccountId
+
+  /** Handle search input change */
+  const handleSearch = (value: string) => {
+    setSearch(value)
+    setPage(0)
+  }
+
+  /** Handle row click - open drawer */
+  const handleRowClick = (accountId: string) => {
+    setSelectedAccountId(accountId)
+  }
+
+  /** Handle drawer open change */
+  const handleDrawerOpenChange = (open: boolean) => {
+    if (!open) setSelectedAccountId(null)
+  }
+
+  /** Docked panel content */
+  const dockedPanel =
+    isDocked && isDrawerOpen ? (
+      <DeveloperAccountDrawer
+        account={selectedAccount}
+        open={isDrawerOpen}
+        onOpenChange={handleDrawerOpenChange}
+      />
+    ) : undefined
+
+  return (
+    <>
+      <MainPage>
+        <MainPageHeader>
+          <MainPageBreadcrumb>
+            <MainPageBreadcrumbItem title='Admin' href='/admin' />
+            <MainPageBreadcrumbItem
+              title='Developer Accounts'
+              href='/admin/developer-accounts'
+              last
+            />
+          </MainPageBreadcrumb>
+        </MainPageHeader>
+        <MainPageContent
+          dockedPanel={dockedPanel}
+          dockedPanelWidth={dockedWidth}
+          onDockedPanelWidthChange={setDockedWidth}
+          dockedPanelMinWidth={minWidth}
+          dockedPanelMaxWidth={maxWidth}>
+          <MainPageSubheader>
+            <div className='relative flex-1'>
+              <Search className='absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground' />
+              <Input
+                placeholder='Search by name or slug...'
+                value={search}
+                size='sm'
+                onChange={(e) => handleSearch(e.target.value)}
+                className='pl-9'
+              />
+            </div>
+          </MainPageSubheader>
+
+          {isLoading ? (
+            <div className='space-y-3'>
+              {[...Array(5)].map((_, i) => (
+                <Skeleton key={i} className='h-12 w-full' />
+              ))}
+            </div>
+          ) : !accounts || accounts.length === 0 ? (
+            <div className='flex h-40 items-center justify-center text-muted-foreground'>
+              No developer accounts found
+            </div>
+          ) : (
+            <>
+              <div className='flex-1 overflow-hidden flex flex-col min-h-0 relative'>
+                <div className='overflow-auto flex-1 relative'>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Account Name</TableHead>
+                        <TableHead className='text-right'>Members</TableHead>
+                        <TableHead className='text-right'>Apps</TableHead>
+                        <TableHead>Created</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {accounts.map((account) => (
+                        <TableRow
+                          key={account.id}
+                          className='cursor-pointer'
+                          onClick={() => handleRowClick(account.id)}>
+                          <TableCell>
+                            <div>
+                              <div className='font-medium'>{account.title}</div>
+                              <div className='text-sm text-muted-foreground'>@{account.slug}</div>
+                            </div>
+                          </TableCell>
+                          <TableCell className='text-right'>{account.memberCount}</TableCell>
+                          <TableCell className='text-right'>{account.appCount}</TableCell>
+                          <TableCell className='text-muted-foreground'>
+                            {formatDistanceToNow(new Date(account.createdAt), { addSuffix: true })}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </div>
+              <div className='border-t py-1 px-2 flex items-center justify-between'>
+                <div className='text-sm text-muted-foreground'>
+                  Showing {page * PAGE_SIZE + 1} to{' '}
+                  {Math.min((page + 1) * PAGE_SIZE, page * PAGE_SIZE + accounts.length)} results
+                </div>
+                <div className='flex gap-2'>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={() => setPage((p) => Math.max(0, p - 1))}
+                    disabled={page === 0}>
+                    <ChevronLeft />
+                    Previous
+                  </Button>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={() => setPage((p) => p + 1)}
+                    disabled={!accounts || accounts.length < PAGE_SIZE}>
+                    Next
+                    <ChevronRight />
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </MainPageContent>
+      </MainPage>
+
+      {/* Drawer - overlay mode only (docked mode handled by dockedPanel above) */}
+      {!isDocked && (
+        <DeveloperAccountDrawer
+          account={selectedAccount}
+          open={isDrawerOpen}
+          onOpenChange={handleDrawerOpenChange}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
@@ -1,9 +1,11 @@
 // apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
 
 import { WEBAPP_URL } from '@auxx/config/urls'
+import type { OAuth2Features } from '@auxx/database'
 import { database as db } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
+import { interpolateConnectionFields } from '@auxx/services/app-connections'
 import crypto from 'crypto'
 
 const OAUTH_REDIRECT_BASE = process.env.NGROK_URL || WEBAPP_URL
@@ -111,12 +113,29 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const state = crypto.randomBytes(32).toString('hex')
 
     // PKCE support (RFC 7636)
-    const features = connDef.oauth2Features ?? {}
+    const features = (connDef.oauth2Features ?? {}) as OAuth2Features
     let codeVerifier: string | undefined
 
     if (features.pkce) {
       codeVerifier = crypto.randomBytes(96).toString('base64url')
     }
+
+    // Extract connection variables from query params (allowlisted by definitions)
+    const connectionVariables: Record<string, string> = {}
+    const connectionVarDefs = features.connectionVariables ?? []
+    for (const varDef of connectionVarDefs) {
+      const value = searchParams.get(`var_${varDef.key}`)
+      if (!value && varDef.required !== false) {
+        return NextResponse.json(
+          { error: `Missing required variable: ${varDef.label}` },
+          { status: 400 }
+        )
+      }
+      if (value) connectionVariables[varDef.key] = value
+    }
+
+    // Interpolate all connection fields with variables
+    const resolved = interpolateConnectionFields(connDef, connectionVariables)
 
     // Store state in Redis with metadata (expires in 10 minutes)
     const redis = await getRedisClient()
@@ -134,6 +153,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         ...(connectionId && { connectionId }),
         ...(codeVerifier && { codeVerifier }),
         ...(validReturnTo && { returnTo: validReturnTo }),
+        ...(Object.keys(connectionVariables).length > 0 && { connectionVariables }),
       })
     )
 
@@ -141,11 +161,11 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const callbackBase = features.callbackBaseUrl || OAUTH_REDIRECT_BASE
 
     const scopes = connDef.oauth2Scopes || []
-    const googleParams = getGoogleOfflineParams(connDef.oauth2AuthorizeUrl!)
+    const googleParams = getGoogleOfflineParams(resolved.authorizeUrl)
 
     // Build OAuth authorization URL
-    const authUrl = new URL(connDef.oauth2AuthorizeUrl!)
-    authUrl.searchParams.set('client_id', connDef.oauth2ClientId!)
+    const authUrl = new URL(resolved.authorizeUrl)
+    authUrl.searchParams.set('client_id', resolved.clientId)
     authUrl.searchParams.set('redirect_uri', `${callbackBase}/api/apps/${slug}/oauth2/callback`)
     const scopeSeparator = features.scopeSeparator || ' '
     authUrl.searchParams.set('scope', scopes.join(scopeSeparator))

--- a/apps/web/src/app/api/apps/[slug]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/callback/route.ts
@@ -4,10 +4,10 @@ import { WEBAPP_URL } from '@auxx/config/urls'
 import { database as db } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
+import { interpolateConnectionFields, saveAppConnection } from '@auxx/services/app-connections'
 
 const OAUTH_REDIRECT_BASE = process.env.NGROK_URL || WEBAPP_URL
 
-import { saveAppConnection } from '@auxx/services/app-connections'
 import { type NextRequest, NextResponse } from 'next/server'
 
 const logger = createScopedLogger('oauth-callback')
@@ -122,11 +122,15 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const features = (connDef.oauth2Features as Record<string, any>) ?? {}
     const callbackBase = features.callbackBaseUrl || OAUTH_REDIRECT_BASE
 
+    // Interpolate connection fields with stored variables
+    const connectionVariables: Record<string, string> = metadata.connectionVariables ?? {}
+    const resolved = interpolateConnectionFields(connDef, connectionVariables)
+
     // Exchange authorization code for access token
     const tokenRequestBody: Record<string, string> = {
       code,
-      client_id: connDef.oauth2ClientId!,
-      client_secret: connDef.oauth2ClientSecret!,
+      client_id: resolved.clientId,
+      client_secret: resolved.clientSecret,
       redirect_uri: `${callbackBase}/api/apps/${slug}/oauth2/callback`,
       grant_type: 'authorization_code',
     }
@@ -151,9 +155,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     if (connDef.oauth2TokenRequestAuthMethod === 'basic-auth') {
-      const basicAuth = Buffer.from(
-        `${connDef.oauth2ClientId}:${connDef.oauth2ClientSecret}`
-      ).toString('base64')
+      const basicAuth = Buffer.from(`${resolved.clientId}:${resolved.clientSecret}`).toString(
+        'base64'
+      )
       tokenRequestHeaders['Authorization'] = `Basic ${basicAuth}`
       // Don't include client_id and client_secret in body for basic auth
       delete tokenRequestBody.client_id
@@ -167,7 +171,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       tokenUrl: connDef.oauth2AccessTokenUrl,
     })
 
-    const tokenResponse = await fetch(connDef.oauth2AccessTokenUrl!, {
+    const tokenResponse = await fetch(resolved.accessTokenUrl, {
       method: 'POST',
       headers: tokenRequestHeaders,
       body: new URLSearchParams(tokenRequestBody).toString(),
@@ -245,6 +249,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
           scope: tokens.scope,
           tokenType: tokens.token_type,
           ...callbackMetadata,
+          ...(Object.keys(connectionVariables).length > 0 && { connectionVariables }),
         },
       },
       metadata.connectionId ? { connectionId: metadata.connectionId } : undefined

--- a/apps/web/src/components/apps/app-connections.tsx
+++ b/apps/web/src/components/apps/app-connections.tsx
@@ -2,15 +2,24 @@
 
 'use client'
 
+import type { ConnectionVariable, OAuth2Features } from '@auxx/database'
 import { Button } from '@auxx/ui/components/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@auxx/ui/components/card'
-import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
+import { Field, FieldDescription, FieldLabel } from '@auxx/ui/components/field'
+import { Input } from '@auxx/ui/components/input'
 import {
   InputGroup,
   InputGroupAddon,
@@ -51,6 +60,9 @@ function AppConnections({ app }: Props) {
   const [secretDialogOpen, setSecretDialogOpen] = useState(false)
   const [secret, setSecret] = useState('')
   const [showSecret, setShowSecret] = useState(false)
+  const [variableDialogOpen, setVariableDialogOpen] = useState(false)
+  const [variableValues, setVariableValues] = useState<Record<string, string>>({})
+  const [reconnectConnectionId, setReconnectConnectionId] = useState<string | null>(null)
 
   const { data: installedResult } = api.apps.listInstalled.useQuery({})
   const { data: connectionsResult, refetch: refetchConnections } =
@@ -133,6 +145,52 @@ function AppConnections({ app }: Props) {
 
   const connectionType = connectionDefinition.global ? 'organization' : 'user'
   const isOAuth = connectionDefinition.connectionType === 'oauth2-code'
+  const connectionVarDefs: ConnectionVariable[] =
+    (connectionDefinition.oauth2Features as OAuth2Features | null)?.connectionVariables ?? []
+
+  const handleAddConnection = () => {
+    if (connectionVarDefs.length > 0) {
+      setReconnectConnectionId(null)
+      setVariableValues({})
+      setVariableDialogOpen(true)
+    } else if (addConnectionUrl) {
+      window.location.href = addConnectionUrl
+    }
+  }
+
+  const handleReconnect = (connectionId: string) => {
+    if (connectionVarDefs.length > 0) {
+      setReconnectConnectionId(connectionId)
+      setVariableValues({})
+      setVariableDialogOpen(true)
+    } else {
+      window.location.href = `/api/apps/${app.app.slug}/oauth2/authorize?installation=${installation.installationId}&type=${connectionType}&connectionId=${connectionId}`
+    }
+  }
+
+  const handleVariableSubmit = () => {
+    // Validate required variables
+    for (const varDef of connectionVarDefs) {
+      if (varDef.required !== false && !variableValues[varDef.key]?.trim()) {
+        toastError({
+          title: 'Missing required field',
+          description: `Please provide a value for "${varDef.label}".`,
+        })
+        return
+      }
+    }
+
+    const params = new URLSearchParams()
+    params.set('installation', installation.installationId)
+    params.set('type', connectionType)
+    if (reconnectConnectionId) {
+      params.set('connectionId', reconnectConnectionId)
+    }
+    for (const [key, value] of Object.entries(variableValues)) {
+      if (value) params.set(`var_${key}`, value)
+    }
+    window.location.href = `/api/apps/${app.app.slug}/oauth2/authorize?${params}`
+  }
 
   const handleDisconnect = async (credentialId: string, label: string | null) => {
     const confirmed = await confirm({
@@ -196,11 +254,9 @@ function AppConnections({ app }: Props) {
             </CardDescription>
           </div>
           {addConnectionUrl ? (
-            <Button variant='outline' size='sm' asChild>
-              <Link href={addConnectionUrl}>
-                <Plus />
-                Add Connection
-              </Link>
+            <Button variant='outline' size='sm' onClick={handleAddConnection}>
+              <Plus />
+              Add Connection
             </Button>
           ) : (
             connectionDefinition.connectionType === 'secret' && (
@@ -288,11 +344,8 @@ function AppConnections({ app }: Props) {
                       {(conn.connectionStatus === 'expired' ||
                         conn.connectionStatus === 'connected') &&
                         isOAuth && (
-                          <DropdownMenuItem asChild>
-                            <Link
-                              href={`/api/apps/${app.app.slug}/oauth2/authorize?installation=${installation.installationId}&type=${connectionType}&connectionId=${conn.id}`}>
-                              Reconnect
-                            </Link>
+                          <DropdownMenuItem onClick={() => handleReconnect(conn.id)}>
+                            Reconnect
                           </DropdownMenuItem>
                         )}
                       <DropdownMenuItem
@@ -322,6 +375,41 @@ function AppConnections({ app }: Props) {
             handleSaveSecret={handleSaveSecret}
             onClose={() => setSecretDialogOpen(false)}
           />
+        </DialogContent>
+      </Dialog>
+      <Dialog open={variableDialogOpen} onOpenChange={setVariableDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Connection Details</DialogTitle>
+            <DialogDescription>
+              Provide the following details to connect {app.app.title}.
+            </DialogDescription>
+          </DialogHeader>
+          <div className='space-y-4'>
+            {connectionVarDefs.map((varDef) => (
+              <Field key={varDef.key}>
+                <FieldLabel>
+                  {varDef.label}
+                  {varDef.required !== false && <span className='text-destructive ml-1'>*</span>}
+                </FieldLabel>
+                <Input
+                  type={varDef.secret ? 'password' : 'text'}
+                  placeholder={varDef.placeholder}
+                  value={variableValues[varDef.key] ?? ''}
+                  onChange={(e) =>
+                    setVariableValues((prev) => ({ ...prev, [varDef.key]: e.target.value }))
+                  }
+                />
+                {varDef.description && <FieldDescription>{varDef.description}</FieldDescription>}
+              </Field>
+            ))}
+            <div className='flex justify-end gap-2 pt-2'>
+              <Button variant='ghost' onClick={() => setVariableDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleVariableSubmit}>Connect</Button>
+            </div>
+          </div>
         </DialogContent>
       </Dialog>
       <ConfirmDialog />

--- a/apps/web/src/components/workflow/nodes/core/app-trigger/app-trigger-test-section.tsx
+++ b/apps/web/src/components/workflow/nodes/core/app-trigger/app-trigger-test-section.tsx
@@ -3,25 +3,16 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
-import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
 import { Play, Radio } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { useAppTriggerTestListener } from '~/components/workflow/hooks/use-app-trigger-test-listener'
 import Section from '~/components/workflow/ui/section'
+import CodeEditor from '~/components/workflow/ui/structured-output-generator/code-editor'
 import type { WorkflowBlockOutput } from '~/lib/workflow/types'
 import { AppTriggerTestEvents } from './app-trigger-test-events'
 
-interface AppTriggerTestSectionProps {
-  installationId: string
-  triggerId: string
-  schema?: { outputs?: Record<string, WorkflowBlockOutput> }
-}
-
-/**
- * Builds a sample JSON object from schema output fields for the test editor.
- */
 function buildSampleData(outputs?: Record<string, WorkflowBlockOutput>): Record<string, unknown> {
   if (!outputs) return {}
   const sample: Record<string, unknown> = {}
@@ -47,6 +38,12 @@ function buildSampleData(outputs?: Record<string, WorkflowBlockOutput>): Record<
     }
   }
   return sample
+}
+
+interface AppTriggerTestSectionProps {
+  installationId: string
+  triggerId: string
+  schema?: { outputs?: Record<string, WorkflowBlockOutput> }
 }
 
 export function AppTriggerTestSection({
@@ -98,7 +95,7 @@ export function AppTriggerTestSection({
         <div className='flex items-center gap-2'>
           <div
             className={cn(
-              'h-2 w-2 rounded-full',
+              'size-2 rounded-full',
               connectionStatus === 'connected'
                 ? 'bg-green-500'
                 : connectionStatus === 'connecting'
@@ -141,12 +138,10 @@ export function AppTriggerTestSection({
 
         {showTestEditor && (
           <div className='space-y-2'>
-            <Textarea
+            <CodeEditor
               value={testData}
-              onChange={(e) => setTestData(e.target.value)}
-              placeholder='{"key": "value"}'
-              className='font-mono text-xs min-h-24'
-              rows={6}
+              onUpdate={setTestData}
+              className='h-40 rounded-lg border'
             />
             <Button
               variant='default'

--- a/apps/web/src/components/workflow/nodes/shared/app-trigger-input.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/app-trigger-input.tsx
@@ -1,0 +1,46 @@
+// apps/web/src/components/workflow/nodes/shared/app-trigger-input.tsx
+
+'use client'
+
+import { useCallback } from 'react'
+import { CodeEditor } from '~/components/workflow/ui/code-editor'
+import { CodeLanguage } from '~/components/workflow/ui/code-editor/types'
+import Field from '~/components/workflow/ui/field'
+import Section from '~/components/workflow/ui/section'
+import type { TriggerInputProps } from '../trigger-registry'
+
+/**
+ * App trigger input component for the Run panel's Input tab.
+ * Renders a JSON editor pre-filled with sample data from the trigger's schema outputs.
+ */
+export function AppTriggerInput({ inputs, errors, onChange }: TriggerInputProps) {
+  const handleChange = useCallback(
+    (value: string) => {
+      onChange('triggerData', value)
+    },
+    [onChange]
+  )
+
+  const value =
+    typeof inputs.triggerData === 'string'
+      ? inputs.triggerData
+      : JSON.stringify(inputs.triggerData ?? {}, null, 2)
+
+  return (
+    <Section title='Trigger Data' initialOpen>
+      <Field
+        title='Test Payload'
+        description='JSON data to simulate the trigger event. This will be passed to your workflow as trigger data.'>
+        <CodeEditor
+          value={value}
+          onChange={handleChange}
+          language={CodeLanguage.json}
+          readOnly={false}
+          minHeight={150}
+          height={200}
+        />
+        {errors.triggerData && <p className='text-sm text-destructive'>{errors.triggerData}</p>}
+      </Field>
+    </Section>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/trigger-registry.ts
+++ b/apps/web/src/components/workflow/nodes/trigger-registry.ts
@@ -64,6 +64,13 @@ export function registerDynamicTriggerInput(nodeType: string, config: TriggerInp
 }
 
 /**
+ * Unregister a dynamic trigger input configuration
+ */
+export function unregisterDynamicTriggerInput(nodeType: string): void {
+  delete dynamicTriggerRegistry[nodeType]
+}
+
+/**
  * Get trigger input configuration
  */
 export function getTriggerInputConfig(

--- a/apps/web/src/components/workflow/panels/run/components/node-execution-card.tsx
+++ b/apps/web/src/components/workflow/panels/run/components/node-execution-card.tsx
@@ -8,13 +8,16 @@ import type {
 import { Alert, AlertDescription } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
+import { useCopy } from '@auxx/ui/hooks/use-copy'
 import { cn } from '@auxx/ui/lib/utils'
 import {
   AlertCircle,
+  Check,
   CheckCircle,
   ChevronRight,
   Clock,
   Coins,
+  Copy,
   FileInput,
   FileOutput,
   FileText,
@@ -115,6 +118,8 @@ export function NodeExecutionCard({ execution, workflowStatus, children }: NodeE
   const [activeTab, setActiveTab] = useState<'outputs' | 'inputs' | 'process' | 'metadata'>(
     'outputs'
   )
+  const outputsCopy = useCopy({ toastMessage: 'Outputs copied to clipboard' })
+  const inputsCopy = useCopy({ toastMessage: 'Inputs copied to clipboard' })
 
   // Get node icon from registry
   const nodeIcon = unifiedNodeRegistry.getNodeIcon(execution.nodeType, 'h-4 w-4')
@@ -227,9 +232,23 @@ export function NodeExecutionCard({ execution, workflowStatus, children }: NodeE
           {activeTab === 'outputs' && (
             <div className='mt-3'>
               {execution.outputs && (
-                <pre className='p-3 bg-muted rounded-md text-xs overflow-auto max-h-[300px] font-mono'>
-                  {JSON.stringify(execution.outputs, null, 2)}
-                </pre>
+                <div className='relative group'>
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    className='absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground size-7'
+                    onClick={() => outputsCopy.copy(JSON.stringify(execution.outputs, null, 2))}
+                    aria-label='Copy outputs'>
+                    {outputsCopy.copied ? (
+                      <Check className='h-3.5 w-3.5' />
+                    ) : (
+                      <Copy className='h-3.5 w-3.5' />
+                    )}
+                  </Button>
+                  <pre className='p-3 bg-muted rounded-md text-xs overflow-auto max-h-[300px] font-mono'>
+                    {JSON.stringify(execution.outputs, null, 2)}
+                  </pre>
+                </div>
               )}
             </div>
           )}
@@ -237,9 +256,23 @@ export function NodeExecutionCard({ execution, workflowStatus, children }: NodeE
           {activeTab === 'inputs' && (
             <div className='mt-3'>
               {execution.inputs ? (
-                <pre className='p-3 bg-muted rounded-md text-xs overflow-auto max-h-[300px] font-mono'>
-                  {JSON.stringify(execution.inputs, null, 2)}
-                </pre>
+                <div className='relative group'>
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    className='absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground size-7'
+                    onClick={() => inputsCopy.copy(JSON.stringify(execution.inputs, null, 2))}
+                    aria-label='Copy inputs'>
+                    {inputsCopy.copied ? (
+                      <Check className='h-3.5 w-3.5' />
+                    ) : (
+                      <Copy className='h-3.5 w-3.5' />
+                    )}
+                  </Button>
+                  <pre className='p-3 bg-muted rounded-md text-xs overflow-auto max-h-[300px] font-mono'>
+                    {JSON.stringify(execution.inputs, null, 2)}
+                  </pre>
+                </div>
               ) : (
                 <p className='text-sm text-muted-foreground py-8 text-center'>No inputs provided</p>
               )}

--- a/apps/web/src/components/workflow/panels/run/tabs/input-tab.tsx
+++ b/apps/web/src/components/workflow/panels/run/tabs/input-tab.tsx
@@ -240,6 +240,16 @@ export function InputTab({ workflowId, workflowAppId }: InputTabProps) {
         finalInputs = formatManualTriggerInputs(inputs)
       }
 
+      // Transform inputs for app triggers — parse JSON triggerData and spread as top-level inputs
+      if (
+        triggerType === WorkflowTriggerType.APP_TRIGGER ||
+        triggerType === WorkflowTriggerType.APP_POLLING_TRIGGER
+      ) {
+        const raw = inputs.triggerData
+        const parsed = typeof raw === 'string' ? JSON.parse(raw) : (raw ?? {})
+        finalInputs = { ...parsed }
+      }
+
       // Transform inputs for RESOURCE_TRIGGER to match expected format
       if (triggerType === WorkflowTriggerType.RESOURCE_TRIGGER) {
         // Get resource type from the trigger node - read from ReactFlow's live store

--- a/apps/web/src/components/workflow/ui/code-editor/code-editor-content.tsx
+++ b/apps/web/src/components/workflow/ui/code-editor/code-editor-content.tsx
@@ -27,6 +27,32 @@ const Editor = dynamic(() => import('@monaco-editor/react').then((m) => m.defaul
   ),
 })
 
+interface WorkflowContext {
+  getNodes: () => any[]
+  getNodeVariables: (targetNodeId: string) => any[]
+}
+
+/**
+ * Bridge component that safely calls ReactFlow/VarStore hooks
+ * Only rendered when nodeId is provided, avoiding conditional hook calls
+ */
+const WorkflowCompletionsBridge: React.FC<{
+  contextRef: React.MutableRefObject<WorkflowContext | null>
+}> = ({ contextRef }) => {
+  const reactFlowInstance = useReactFlow()
+  const varStore = useVarStore()
+
+  contextRef.current = {
+    getNodes: () => reactFlowInstance.getNodes(),
+    getNodeVariables: (targetNodeId: string) => {
+      const nodeCache = varStore.nodeOutputCache.get(targetNodeId)
+      return nodeCache?.variables || []
+    },
+  }
+
+  return null
+}
+
 /**
  * CodeEditor Content Component
  * Integrates Monaco Editor with resize functionality
@@ -59,10 +85,7 @@ const CodeEditorContent: React.FC = () => {
   const [isMounted, setIsMounted] = useState(false)
   const completionProviderRef = useRef<IDisposable | null>(null)
   const overflowContainerRef = useRef<HTMLElement | null>(null)
-
-  // Only use ReactFlow hooks if we're in a workflow context
-  const reactFlowInstance = nodeId ? useReactFlow() : null
-  const varStore = nodeId ? useVarStore() : null
+  const workflowContextRef = useRef<WorkflowContext | null>(null)
 
   // Calculate editor height
   // const editorHeight = isExpanded ? editorExpandHeight : contentHeight
@@ -119,15 +142,12 @@ const CodeEditorContent: React.FC = () => {
         nodeId &&
         enableWorkflowCompletions &&
         language === CodeLanguage.javascript &&
-        reactFlowInstance &&
-        varStore
+        workflowContextRef.current
       ) {
+        const wfContext = workflowContextRef.current
         const context = {
-          getNodes: () => reactFlowInstance.getNodes(),
-          getNodeVariables: (targetNodeId: string) => {
-            const nodeCache = varStore.nodeOutputCache.get(targetNodeId)
-            return nodeCache?.variables || []
-          },
+          getNodes: () => wfContext.getNodes(),
+          getNodeVariables: (targetNodeId: string) => wfContext.getNodeVariables(targetNodeId),
           getCurrentNodeId: () => nodeId,
         }
 
@@ -149,8 +169,6 @@ const CodeEditorContent: React.FC = () => {
       nodeId,
       enableWorkflowCompletions,
       language,
-      reactFlowInstance,
-      varStore,
       onMount,
     ]
   )
@@ -177,10 +195,15 @@ const CodeEditorContent: React.FC = () => {
     ...(overflowContainer && { overflowWidgetsDomNode: overflowContainer }),
   }
 
+  const bridgeElement = nodeId ? (
+    <WorkflowCompletionsBridge contextRef={workflowContextRef} />
+  ) : null
+
   // When expanded, use full height layout without resize wrapper
   if (isExpanded) {
     return (
       <>
+        {bridgeElement}
         {tip && <div className='px-1 py-0.5'>{tip}</div>}
         <div className='h-full pb-4 px-2 flex-1 min-h-0 flex'>
           <div className='relative h-full flex-1 pt-1'>
@@ -207,6 +230,7 @@ const CodeEditorContent: React.FC = () => {
   // Inline view with resize wrapper
   return (
     <>
+      {bridgeElement}
       {/* Tip section */}
       {tip && <div className='px-1 py-0.5'>{tip}</div>}
 

--- a/apps/web/src/components/workflow/ui/structured-output-generator/code-editor.tsx
+++ b/apps/web/src/components/workflow/ui/structured-output-generator/code-editor.tsx
@@ -1,8 +1,9 @@
 // apps/web/src/components/workflow/ui/structured-output-generator/code-editor.tsx
 
 import { Spinner } from '@auxx/ui/components/spinner'
+import { useCopy } from '@auxx/ui/hooks/use-copy'
 import { cn } from '@auxx/ui/lib/utils'
-import { Clipboard, IndentIncrease } from 'lucide-react'
+import { Check, Clipboard, IndentIncrease } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import { useTheme } from 'next-themes'
 import React, { type FC, useCallback, useEffect, useRef } from 'react'
@@ -41,6 +42,7 @@ const CodeEditor: FC<CodeEditorProps> = ({
   const [isMounted, setIsMounted] = React.useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const { theme } = useTheme()
+  const { copy, copied } = useCopy({ toastMessage: 'Copied to clipboard' })
 
   const handleEditorDidMount = useCallback(
     (editor: any, monaco: any) => {
@@ -130,18 +132,18 @@ const CodeEditor: FC<CodeEditorProps> = ({
                 </button>
               </Tooltip>
             )}
-            <Tooltip content='Copy'>
+            <Tooltip content={copied ? 'Copied' : 'Copy'}>
               <button
                 type='button'
                 className='flex h-6 w-6 items-center justify-center'
-                onClick={() => navigator.clipboard.writeText(value)}>
-                <Clipboard className='h-4 w-4' />
+                onClick={() => copy(value)}>
+                {copied ? <Check className='h-4 w-4' /> : <Clipboard className='h-4 w-4' />}
               </button>
             </Tooltip>
           </div>
         </div>
       )}
-      <div className={cn('relative overflow-hidden', editorWrapperClassName)}>
+      <div className={cn('relative overflow-hidden flex-1', editorWrapperClassName)}>
         <Editor
           defaultLanguage='json'
           theme={
@@ -159,7 +161,7 @@ const CodeEditor: FC<CodeEditorProps> = ({
           options={{
             readOnly,
             stickyScroll: { enabled: false },
-            domReadOnly: true,
+            domReadOnly: readOnly,
             minimap: { enabled: false },
             tabSize: 2,
             scrollBeyondLastLine: false,

--- a/apps/web/src/lib/workflow/components/app-polling-section.tsx
+++ b/apps/web/src/lib/workflow/components/app-polling-section.tsx
@@ -1,9 +1,7 @@
-// apps/web/src/lib/workflow/components/polling-interval-selector.tsx
+// apps/web/src/lib/workflow/components/app-polling-section.tsx
 
 'use client'
 
-import { Label } from '@auxx/ui/components/label'
-import { Section } from '@auxx/ui/components/section'
 import {
   Select,
   SelectContent,
@@ -12,6 +10,7 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { useNodeDataUpdate } from '~/components/workflow/hooks/use-node-data-update'
+import Section from '~/components/workflow/ui/section'
 
 const INTERVAL_OPTIONS = [
   { value: '1', label: 'Every 1 minute' },
@@ -23,19 +22,19 @@ const INTERVAL_OPTIONS = [
   { value: '60', label: 'Every hour' },
 ]
 
-interface PollingIntervalSelectorProps {
+interface AppPollingSectionProps {
   nodeId: string
   data: any
   defaultInterval?: number
   minInterval?: number
 }
 
-export function PollingIntervalSelector({
+export function AppPollingSection({
   nodeId,
   data,
   defaultInterval = 5,
   minInterval = 1,
-}: PollingIntervalSelectorProps) {
+}: AppPollingSectionProps) {
   const { handleNodeDataUpdateWithSync } = useNodeDataUpdate()
 
   const currentInterval = data?.config?.polling?.intervalMinutes ?? defaultInterval
@@ -58,11 +57,13 @@ export function PollingIntervalSelector({
   }
 
   return (
-    <Section title='Polling'>
-      <div className='space-y-1.5'>
-        <Label>Check interval</Label>
+    <Section
+      title='Polling'
+      collapsible={false}
+      className='**:data-[slot=section]:pb-0'
+      actions={
         <Select value={String(currentInterval)} onValueChange={handleChange}>
-          <SelectTrigger>
+          <SelectTrigger variant='ghost' size='sm' className='w-auto'>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -73,7 +74,7 @@ export function PollingIntervalSelector({
             ))}
           </SelectContent>
         </Select>
-      </div>
-    </Section>
+      }
+    />
   )
 }

--- a/apps/web/src/lib/workflow/components/app-workflow-panel.tsx
+++ b/apps/web/src/lib/workflow/components/app-workflow-panel.tsx
@@ -14,8 +14,8 @@ import type { WorkflowBlock } from '../types'
 import { computeOutputSignature, resolveAppBlockOutputFields } from '../utils/resolve-app-outputs'
 import { convertOutputFieldsToVariables } from '../utils/type-mapping'
 import { AppConnectionPicker } from './app-connection-picker'
+import { AppPollingSection } from './app-polling-section'
 import { AppWorkflowFieldContext } from './app-workflow-field-context'
-import { PollingIntervalSelector } from './polling-interval-selector'
 
 /**
  * Props for AppWorkflowPanel component
@@ -335,14 +335,14 @@ export const AppWorkflowPanel = memo<AppWorkflowPanelProps>(
           />
         )}
         {isTrigger && block.config?.polling && (
-          <PollingIntervalSelector
+          <AppPollingSection
             nodeId={nodeId}
             data={nodeData}
             defaultInterval={block.config.polling.intervalMinutes}
             minInterval={block.config.polling.minIntervalMinutes}
           />
         )}
-        {isTrigger && (
+        {isTrigger && !block.config?.polling && (
           <AppTriggerTestSection
             installationId={resolvedInstallationId}
             triggerId={block.id}

--- a/apps/web/src/lib/workflow/workflow-block-registry.tsx
+++ b/apps/web/src/lib/workflow/workflow-block-registry.tsx
@@ -3,6 +3,11 @@
 import { WorkflowTriggerType } from '@auxx/lib/workflow-engine/client'
 import type { ComponentType } from 'react'
 import { useMemo } from 'react'
+import { AppTriggerInput } from '~/components/workflow/nodes/shared/app-trigger-input'
+import {
+  registerDynamicTriggerInput,
+  unregisterDynamicTriggerInput,
+} from '~/components/workflow/nodes/trigger-registry'
 import type {
   NodeDefinition,
   NodePanelProps,
@@ -15,10 +20,40 @@ import { convertOutputFieldsToVariables } from '~/lib/workflow/utils/type-mappin
 import { useExtensionsContext } from '~/providers/extensions/extensions-context'
 // import { AppWorkflowNode } from './components/app-workflow-node'
 import { AppWorkflowPanel } from './components/app-workflow-panel'
-import type { WorkflowBlock } from './types'
+import type { WorkflowBlock, WorkflowBlockOutput } from './types'
 
 // In-memory cache for loaded blocks
 const schemaCache = new Map<string, WorkflowBlock[]>()
+
+/**
+ * Builds a sample JSON object from schema output fields.
+ */
+function buildSampleData(outputs?: Record<string, WorkflowBlockOutput>): Record<string, unknown> {
+  if (!outputs) return {}
+  const sample: Record<string, unknown> = {}
+  for (const [key, field] of Object.entries(outputs)) {
+    switch (field.type) {
+      case 'string':
+        sample[key] = ''
+        break
+      case 'number':
+        sample[key] = 0
+        break
+      case 'boolean':
+        sample[key] = false
+        break
+      case 'array':
+        sample[key] = []
+        break
+      case 'object':
+        sample[key] = field.properties ? buildSampleData(field.properties) : {}
+        break
+      default:
+        sample[key] = null
+    }
+  }
+  return sample
+}
 
 /**
  * Converts app workflow blocks to ReactFlow node definitions
@@ -122,6 +157,30 @@ export class WorkflowBlockRegistry {
 
       this.nodeDefinitions.set(triggerKey, definition)
       nodeDefinitions.push(definition)
+
+      // Register dynamic trigger input so the Run panel's Input tab
+      // shows a JSON editor pre-filled with sample data from schema.outputs
+      const sampleData = buildSampleData(trigger.schema?.outputs)
+      registerDynamicTriggerInput(triggerKey, {
+        component: AppTriggerInput,
+        description: trigger.description || `Trigger data for ${trigger.label}`,
+        validate: (inputs: Record<string, any>) => {
+          if (typeof inputs.triggerData === 'string') {
+            try {
+              JSON.parse(inputs.triggerData)
+            } catch {
+              return {
+                isValid: false,
+                errors: [{ field: 'triggerData', message: 'Trigger data must be valid JSON' }],
+              }
+            }
+          }
+          return { isValid: true, errors: [] }
+        },
+        getDefaultInputs: () => ({
+          triggerData: JSON.stringify(sampleData, null, 2),
+        }),
+      })
     }
 
     return nodeDefinitions
@@ -136,6 +195,7 @@ export class WorkflowBlockRegistry {
       if (key.startsWith(`${appId}:`)) {
         this.blocks.delete(key)
         this.nodeDefinitions.delete(key)
+        unregisterDynamicTriggerInput(key)
       }
     }
   }
@@ -353,7 +413,7 @@ export class WorkflowBlockRegistry {
 
   /**
    * Create trigger panel component — renders AppWorkflowPanel with isTrigger flag.
-   * PollingIntervalSelector and AppTriggerTestSection are rendered inside AppWorkflowPanel.
+   * AppPollingSection and AppTriggerTestSection are rendered inside AppWorkflowPanel.
    */
   private createTriggerPanelComponent(
     appId: string,

--- a/apps/web/src/server/api/routers/admin-apps.ts
+++ b/apps/web/src/server/api/routers/admin-apps.ts
@@ -1,6 +1,6 @@
 // apps/web/src/server/api/routers/admin-apps.ts
 
-import { database } from '@auxx/database'
+import { database, schema } from '@auxx/database'
 import { AdminService } from '@auxx/lib/admin'
 import {
   adminApproveDeployment,
@@ -8,6 +8,7 @@ import {
   adminDeprecateDeployment,
   adminRejectDeployment,
 } from '@auxx/services/app-versions'
+import { eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { createTRPCRouter, superAdminProcedure } from '~/server/api/trpc'
 import { invalidateBuildCacheForDeveloperAccount } from '~/server/lib/invalidate-build-cache'
@@ -26,6 +27,7 @@ export const adminAppsRouter = createTRPCRouter({
         offset: z.number().min(0).default(0),
         search: z.string().optional(),
         publicationStatus: z.enum(['unpublished', 'published']).optional(),
+        developerAccountId: z.string().optional(),
       })
     )
     .query(async ({ ctx, input }) => {
@@ -185,6 +187,20 @@ export const adminAppsRouter = createTRPCRouter({
     }),
 
   /**
+   * Export all apps for a developer account as portable JSON
+   */
+  exportByDeveloperAccount: superAdminProcedure
+    .input(
+      z.object({
+        developerAccountId: z.string(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const adminService = new AdminService(ctx.db)
+      return adminService.exportByDeveloperAccount(input.developerAccountId)
+    }),
+
+  /**
    * Toggle auto-approve for an app
    */
   toggleAutoApprove: superAdminProcedure
@@ -197,6 +213,24 @@ export const adminAppsRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const adminService = new AdminService(ctx.db)
       await adminService.toggleAutoApprove(input.appId, input.autoApprove)
+
+      return { success: true }
+    }),
+
+  /**
+   * Unpublish an app (set publication status to 'unpublished')
+   */
+  unpublishApp: superAdminProcedure
+    .input(
+      z.object({
+        appId: z.string(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      await ctx.db
+        .update(schema.App)
+        .set({ publicationStatus: 'unpublished', updatedAt: new Date() })
+        .where(eq(schema.App.id, input.appId))
 
       return { success: true }
     }),

--- a/apps/web/src/server/api/routers/admin.ts
+++ b/apps/web/src/server/api/routers/admin.ts
@@ -2,7 +2,9 @@
 
 import { AdminBillingService, PlanAdminService, PlanService } from '@auxx/billing'
 import { WEBAPP_URL } from '@auxx/config/server'
+import { schema } from '@auxx/database'
 import { AdminService } from '@auxx/lib/admin'
+import { eq, ilike, or, sql } from 'drizzle-orm'
 import { z } from 'zod'
 import { createTRPCRouter, superAdminProcedure } from '~/server/api/trpc'
 import { adminAppsRouter } from './admin-apps'
@@ -529,6 +531,52 @@ export const adminRouter = createTRPCRouter({
         }
       }),
   }),
+
+  /**
+   * Get developer accounts with app/member counts
+   */
+  getDeveloperAccounts: superAdminProcedure
+    .input(
+      z.object({
+        limit: z.number().min(1).max(100).optional(),
+        offset: z.number().min(0).optional(),
+        search: z.string().optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { limit = 100, offset = 0, search } = input
+
+      const conditions = search
+        ? or(
+            ilike(schema.DeveloperAccount.title, `%${search}%`),
+            ilike(schema.DeveloperAccount.slug, `%${search}%`)
+          )
+        : undefined
+
+      const accounts = await ctx.db
+        .select({
+          id: schema.DeveloperAccount.id,
+          slug: schema.DeveloperAccount.slug,
+          title: schema.DeveloperAccount.title,
+          logoUrl: schema.DeveloperAccount.logoUrl,
+          createdAt: schema.DeveloperAccount.createdAt,
+          appCount: sql<number>`cast(count(distinct ${schema.App.id}) as int)`,
+          memberCount: sql<number>`cast(count(distinct ${schema.DeveloperAccountMember.id}) as int)`,
+        })
+        .from(schema.DeveloperAccount)
+        .leftJoin(schema.App, eq(schema.App.developerAccountId, schema.DeveloperAccount.id))
+        .leftJoin(
+          schema.DeveloperAccountMember,
+          eq(schema.DeveloperAccountMember.developerAccountId, schema.DeveloperAccount.id)
+        )
+        .where(conditions)
+        .groupBy(schema.DeveloperAccount.id)
+        .orderBy(schema.DeveloperAccount.createdAt)
+        .limit(limit)
+        .offset(offset)
+
+      return accounts
+    }),
 
   /**
    * Apps management router

--- a/packages/database/src/db/schema/connection-definition.ts
+++ b/packages/database/src/db/schema/connection-definition.ts
@@ -15,6 +15,22 @@ import {
 import { App } from './app'
 import { DeveloperAccount } from './developer-account'
 
+/** A dynamic variable that organizations must provide when connecting */
+export type ConnectionVariable = {
+  /** Variable key matching {placeholder} in fields (e.g., "shop", "client_id") */
+  key: string
+  /** Human-readable label shown in the form (e.g., "Shop Subdomain") */
+  label: string
+  /** Help text (e.g., "Only the subdomain, e.g. my-store from my-store.myshopify.com") */
+  description?: string
+  /** Placeholder text for the input field */
+  placeholder?: string
+  /** Whether this variable is required (default: true) */
+  required?: boolean
+  /** Whether the input should be masked (for secrets like client_secret) */
+  secret?: boolean
+}
+
 /** OAuth2 feature flags and provider-specific configuration */
 export type OAuth2Features = {
   /** Enable PKCE with S256 (RFC 7636) */
@@ -29,6 +45,8 @@ export type OAuth2Features = {
   scopeSeparator?: string
   /** Callback query param names to capture and store as connection metadata */
   callbackMetadataParams?: string[]
+  /** Dynamic variables the org must provide before OAuth redirect */
+  connectionVariables?: ConnectionVariable[]
 }
 
 /** Drizzle table for ConnectionDefinition */

--- a/packages/lib/src/admin/admin-service.ts
+++ b/packages/lib/src/admin/admin-service.ts
@@ -777,8 +777,9 @@ export class AdminService {
     offset?: number
     search?: string
     publicationStatus?: 'unpublished' | 'published'
+    developerAccountId?: string
   }): Promise<AppWithMetrics[]> {
-    const { limit = 100, offset = 0, search, publicationStatus } = params
+    const { limit = 100, offset = 0, search, publicationStatus, developerAccountId } = params
 
     logger.debug(
       `Fetching apps with limit=${limit}, offset=${offset}, search=${search}, publicationStatus=${publicationStatus}`
@@ -789,6 +790,10 @@ export class AdminService {
 
     if (publicationStatus) {
       conditions.push(eq(schema.App.publicationStatus, publicationStatus))
+    }
+
+    if (developerAccountId) {
+      conditions.push(eq(schema.App.developerAccountId, developerAccountId))
     }
 
     if (search) {
@@ -961,5 +966,101 @@ export class AdminService {
 
     logger.info(`Successfully toggled auto-approve for app ${appId}`)
     return app
+  }
+
+  /**
+   * Export all apps for a developer account as a portable JSON structure.
+   * Excludes secrets, S3 assets, and internal IDs.
+   */
+  async exportByDeveloperAccount(developerAccountId: string) {
+    logger.info(`Exporting apps for developer account ${developerAccountId}`)
+
+    const devAccount = await this.db.query.DeveloperAccount.findFirst({
+      where: (da, { eq }) => eq(da.id, developerAccountId),
+    })
+
+    if (!devAccount) {
+      throw new Error('Developer account not found')
+    }
+
+    const apps = await this.db.query.App.findMany({
+      where: (a, { eq }) => eq(a.developerAccountId, developerAccountId),
+      with: {
+        oauthApplication: true,
+        connectionDefinitions: true,
+        deployments: {
+          orderBy: (d, { desc }) => [desc(d.createdAt)],
+        },
+      },
+    })
+
+    return {
+      exportVersion: '1.0',
+      exportedAt: new Date().toISOString(),
+      developerAccount: {
+        slug: devAccount.slug,
+        title: devAccount.title,
+        featureFlags: devAccount.featureFlags,
+      },
+      apps: apps.map((app) => {
+        // Find latest production deployment
+        const latestProdDeployment = app.deployments.find((d) => d.deploymentType === 'production')
+
+        return {
+          slug: app.slug,
+          title: app.title,
+          description: app.description,
+          category: app.category,
+          scopes: app.scopes,
+          hasOauth: app.hasOauth,
+          hasBundle: app.hasBundle,
+          publicationStatus: app.publicationStatus,
+          reviewStatus: app.reviewStatus,
+          autoApprove: app.autoApprove,
+          overview: app.overview,
+          contentOverview: app.contentOverview,
+          contentHowItWorks: app.contentHowItWorks,
+          contentConfigure: app.contentConfigure,
+          websiteUrl: app.websiteUrl,
+          documentationUrl: app.documentationUrl,
+          contactUrl: app.contactUrl,
+          supportSiteUrl: app.supportSiteUrl,
+          termsOfServiceUrl: app.termsOfServiceUrl,
+          oauthExternalEntrypointUrl: app.oauthExternalEntrypointUrl,
+          oauthApplication: app.oauthApplication
+            ? {
+                clientId: app.oauthApplication.clientId,
+                name: app.oauthApplication.name,
+                redirectURLs: app.oauthApplication.redirectURLs,
+                type: app.oauthApplication.type,
+              }
+            : null,
+          connectionDefinitions: app.connectionDefinitions.map((cd) => ({
+            connectionType: cd.connectionType,
+            label: cd.label,
+            description: cd.description,
+            global: cd.global,
+            major: cd.major,
+            oauth2AuthorizeUrl: cd.oauth2AuthorizeUrl,
+            oauth2AccessTokenUrl: cd.oauth2AccessTokenUrl,
+            oauth2ClientId: cd.oauth2ClientId,
+            // oauth2ClientSecret intentionally excluded
+            oauth2Scopes: cd.oauth2Scopes,
+            oauth2TokenRequestAuthMethod: cd.oauth2TokenRequestAuthMethod,
+            oauth2RefreshTokenIntervalSeconds: cd.oauth2RefreshTokenIntervalSeconds,
+            oauth2Features: cd.oauth2Features,
+          })),
+          latestDeployment: latestProdDeployment
+            ? {
+                version: latestProdDeployment.version,
+                settingsSchema: latestProdDeployment.settingsSchema,
+                status: latestProdDeployment.status,
+                releaseNotes: latestProdDeployment.releaseNotes,
+                metadata: latestProdDeployment.metadata,
+              }
+            : null,
+        }
+      }),
+    }
   }
 }

--- a/packages/lib/src/workflow-engine/execution/trigger-app-workflow.ts
+++ b/packages/lib/src/workflow-engine/execution/trigger-app-workflow.ts
@@ -75,15 +75,17 @@ export async function executeAppTriggeredWorkflow(params: {
     const workflowRun = await executionService.createRun({
       workflowId: publishedWorkflow.id,
       inputs: {
-        trigger_type: 'app-trigger',
-        app_id: appId,
-        trigger_id: triggerId,
-        installation_id: installationId,
-        event_id: eventId,
-        triggered_at: new Date().toISOString(),
-        // The trigger data is passed as the triggerData input
-        // The AppWorkflowTriggerProcessor reads from context.triggerData
+        // App's trigger data becomes node output variables
         ...triggerData,
+        // Platform metadata nested under _meta to avoid polluting node outputs
+        _meta: {
+          trigger_type: 'app-trigger',
+          app_id: appId,
+          trigger_id: triggerId,
+          installation_id: installationId,
+          event_id: eventId,
+          triggered_at: new Date().toISOString(),
+        },
       },
       mode: 'production',
       userId: null,

--- a/packages/lib/src/workflow-engine/nodes/trigger-nodes/app-polling-trigger-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/trigger-nodes/app-polling-trigger-processor.ts
@@ -4,6 +4,7 @@ import type { ExecutionContextManager } from '../../core/execution-context'
 import type { NodeExecutionResult, ValidationResult, WorkflowNode } from '../../core/types'
 import { NodeRunningStatus, WorkflowNodeType } from '../../core/types'
 import { BaseNodeProcessor } from '../base-node'
+import { extractUserInputs } from './extract-user-inputs'
 
 /**
  * Processor for extension app polling trigger nodes.
@@ -71,18 +72,32 @@ export class AppPollingTriggerProcessor extends BaseNodeProcessor {
       }
     }
 
-    // Map each trigger data field to a node variable for downstream access
+    // Expose configured trigger inputs (e.g., calendarId, triggerOn) as node variables
+    const configuredInputs = extractUserInputs(node.data)
+    for (const [key, value] of Object.entries(configuredInputs)) {
+      contextManager.setNodeVariable(node.nodeId, key, value)
+    }
+
+    // Map each trigger event data field to a node variable
+    // Event data takes precedence over configured inputs for same-named fields
     if (typeof triggerData === 'object' && triggerData !== null) {
       for (const [key, value] of Object.entries(triggerData)) {
+        if (key.startsWith('_')) continue
         contextManager.setNodeVariable(node.nodeId, key, value)
       }
     }
 
-    contextManager.setNodeVariable(node.nodeId, 'output', triggerData)
+    // Build clean output: configured inputs + event data
+    const eventOutput =
+      typeof triggerData === 'object' && triggerData !== null
+        ? Object.fromEntries(Object.entries(triggerData).filter(([k]) => !k.startsWith('_')))
+        : triggerData
+    const output = { ...configuredInputs, ...eventOutput }
+    contextManager.setNodeVariable(node.nodeId, 'output', output)
 
     return {
       status: NodeRunningStatus.Succeeded,
-      output: triggerData,
+      output,
       outputHandle: 'source',
     }
   }

--- a/packages/lib/src/workflow-engine/nodes/trigger-nodes/app-workflow-trigger-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/trigger-nodes/app-workflow-trigger-processor.ts
@@ -4,6 +4,7 @@ import type { ExecutionContextManager } from '../../core/execution-context'
 import type { NodeExecutionResult, ValidationResult, WorkflowNode } from '../../core/types'
 import { NodeRunningStatus, WorkflowNodeType } from '../../core/types'
 import { BaseNodeProcessor } from '../base-node'
+import { extractUserInputs } from './extract-user-inputs'
 
 /**
  * Processor for extension app trigger nodes.
@@ -75,20 +76,34 @@ export class AppWorkflowTriggerProcessor extends BaseNodeProcessor {
       }
     }
 
-    // Map each trigger data field to a node variable for downstream access
+    // Expose configured trigger inputs (e.g., calendarId, triggerOn) as node variables
+    // so downstream nodes can reference them via {{triggerNodeId.calendarId}}
+    const configuredInputs = extractUserInputs(node.data)
+    for (const [key, value] of Object.entries(configuredInputs)) {
+      contextManager.setNodeVariable(node.nodeId, key, value)
+    }
+
+    // Map each trigger event data field to a node variable for downstream access
     // e.g., {{triggerNodeId.orderId}}, {{triggerNodeId.customerEmail}}
+    // Event data takes precedence over configured inputs for same-named fields
     if (typeof triggerData === 'object' && triggerData !== null) {
       for (const [key, value] of Object.entries(triggerData)) {
+        if (key.startsWith('_')) continue
         contextManager.setNodeVariable(node.nodeId, key, value)
       }
     }
 
-    // Also set the full output for convenience
-    contextManager.setNodeVariable(node.nodeId, 'output', triggerData)
+    // Build clean output: configured inputs + event data (without platform metadata)
+    const eventOutput =
+      typeof triggerData === 'object' && triggerData !== null
+        ? Object.fromEntries(Object.entries(triggerData).filter(([k]) => !k.startsWith('_')))
+        : triggerData
+    const output = { ...configuredInputs, ...eventOutput }
+    contextManager.setNodeVariable(node.nodeId, 'output', output)
 
     return {
       status: NodeRunningStatus.Succeeded,
-      output: triggerData,
+      output,
       outputHandle: 'source',
     }
   }

--- a/packages/lib/src/workflow-engine/nodes/trigger-nodes/extract-user-inputs.ts
+++ b/packages/lib/src/workflow-engine/nodes/trigger-nodes/extract-user-inputs.ts
@@ -1,0 +1,40 @@
+// packages/lib/src/workflow-engine/nodes/trigger-nodes/extract-user-inputs.ts
+
+const METADATA_FIELDS = new Set([
+  'id',
+  'type',
+  'appId',
+  'appSlug',
+  'blockId',
+  'triggerId',
+  'installationId',
+  'connectionId',
+  'config',
+  'title',
+  'name',
+  'desc',
+  'description',
+  'color',
+  'icon',
+  'isEnabled',
+  'disabled',
+  'isValid',
+  'isInLoop',
+  'errors',
+  'fieldModes',
+  'triggerFilters',
+  'metadata',
+])
+
+/**
+ * Extract user-configured input fields from trigger node data,
+ * stripping platform metadata so only app-specific inputs remain.
+ */
+export function extractUserInputs(data: Record<string, unknown>): Record<string, unknown> {
+  const inputs: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(data)) {
+    if (METADATA_FIELDS.has(key) || key.startsWith('_')) continue
+    inputs[key] = value
+  }
+  return inputs
+}

--- a/packages/lib/src/workflows/oauth2-workflow.service.ts
+++ b/packages/lib/src/workflows/oauth2-workflow.service.ts
@@ -4,6 +4,7 @@ import { WEBAPP_URL } from '@auxx/config/server'
 import { CredentialService, CredentialTypeRegistry, configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { interpolateConnectionFields } from '@auxx/services/app-connections'
 import { URLTemplateService } from '@auxx/workflow-nodes/server'
 import type {
   OAuth2CallbackResult,
@@ -556,6 +557,7 @@ export class OAuth2WorkflowService {
           ),
           columns: {
             id: true,
+            oauth2AuthorizeUrl: true,
             oauth2AccessTokenUrl: true,
             oauth2ClientId: true,
             oauth2ClientSecret: true,
@@ -567,11 +569,15 @@ export class OAuth2WorkflowService {
           return { success: false, error: 'ConnectionDefinition not found' }
         }
 
+        // Interpolate connection fields with stored variables
+        const variables = (oauth2Data.metadata?.connectionVariables as Record<string, string>) ?? {}
+        const resolved = interpolateConnectionFields(connDef, variables)
+
         // Make refresh request to provider
         tokenData = await this.makeTokenRefreshRequest(
-          connDef.oauth2AccessTokenUrl,
-          connDef.oauth2ClientId!,
-          connDef.oauth2ClientSecret!,
+          resolved.accessTokenUrl,
+          resolved.clientId,
+          resolved.clientSecret,
           oauth2Data.refreshToken,
           connDef.oauth2TokenRequestAuthMethod || 'request-body'
         )

--- a/packages/lib/src/workflows/polling-trigger-service.ts
+++ b/packages/lib/src/workflows/polling-trigger-service.ts
@@ -3,6 +3,7 @@
 import { getQueue, Queues } from '../jobs/queues'
 import { createScopedLogger } from '../logger'
 import { WorkflowTriggerType } from '../workflow-engine/core/types'
+import { extractUserInputs } from '../workflow-engine/nodes/trigger-nodes/extract-user-inputs'
 import type { WorkflowApp } from './types'
 
 const logger = createScopedLogger('polling-trigger-service')
@@ -69,7 +70,7 @@ export class PollingTriggerService {
             triggerId: workflowApp.publishedWorkflow.triggerTriggerId,
             installationId: workflowApp.publishedWorkflow.triggerInstallationId,
             connectionId: workflowApp.publishedWorkflow.triggerConnectionId,
-            triggerConfig: triggerNode.data.config,
+            triggerConfig: extractUserInputs(triggerNode.data),
           },
           opts: {
             attempts: 3,

--- a/packages/sdk/src/build/server/generate-server-entry.ts
+++ b/packages/sdk/src/build/server/generate-server-entry.ts
@@ -264,7 +264,7 @@ export async function generateServerEntry({
 
         for (const [blockId, handlers] of workflowModules.entries()) {
             __AUXX_WORKFLOW_BLOCKS__[blockId] = {
-                execute: async (input) => {
+                execute: async (...args) => {
                     const executeHandler = handlers.execute;
                     if (!executeHandler) {
                         throw new Error(\`No execute handler for block \${blockId}\`);
@@ -277,7 +277,7 @@ export async function generateServerEntry({
                     if (typeof func !== "function") {
                         throw new Error(\`Execute export in block \${blockId} is not a function\`);
                     }
-                    return await func(input);
+                    return await func(...args);
                 }
             };
         }

--- a/packages/services/src/app-connections/get-app-connection-definition.ts
+++ b/packages/services/src/app-connections/get-app-connection-definition.ts
@@ -23,6 +23,7 @@ export async function getAppConnectionDefinition(appId: string, global: boolean)
         label: true,
         global: true,
         connectionType: true,
+        oauth2Features: true,
       },
     }),
     'get-connection-definition'

--- a/packages/services/src/app-connections/index.ts
+++ b/packages/services/src/app-connections/index.ts
@@ -5,6 +5,8 @@ export { getAppConnection } from './get-app-connection'
 
 // Export service functions
 export { getAppConnectionDefinition } from './get-app-connection-definition'
+// Export interpolation utilities
+export { extractPlaceholders, interpolateConnectionFields } from './interpolate-connection'
 export { listAppConnections } from './list-app-connections'
 export { renameAppConnection } from './rename-app-connection'
 export { resolveAppConnectionForRuntime } from './resolve-app-connection-for-runtime'

--- a/packages/services/src/app-connections/interpolate-connection.ts
+++ b/packages/services/src/app-connections/interpolate-connection.ts
@@ -1,0 +1,51 @@
+// packages/services/src/app-connections/interpolate-connection.ts
+
+/**
+ * Resolve {key} placeholders across all OAuth connection fields.
+ * URL values are URI-encoded; credential values are used as-is.
+ */
+export function interpolateConnectionFields(
+  connDef: {
+    oauth2AuthorizeUrl: string | null
+    oauth2AccessTokenUrl: string | null
+    oauth2ClientId: string | null
+    oauth2ClientSecret: string | null
+  },
+  variables: Record<string, string>
+): {
+  authorizeUrl: string
+  accessTokenUrl: string
+  clientId: string
+  clientSecret: string
+} {
+  return {
+    authorizeUrl: interpolateUrl(connDef.oauth2AuthorizeUrl ?? '', variables),
+    accessTokenUrl: interpolateUrl(connDef.oauth2AccessTokenUrl ?? '', variables),
+    clientId: interpolateValue(connDef.oauth2ClientId ?? '', variables),
+    clientSecret: interpolateValue(connDef.oauth2ClientSecret ?? '', variables),
+  }
+}
+
+/** Replace {key} in a URL — values are URI-encoded for path safety. */
+function interpolateUrl(template: string, variables: Record<string, string>): string {
+  let result = template
+  for (const [key, value] of Object.entries(variables)) {
+    result = result.replaceAll(`{${key}}`, encodeURIComponent(value))
+  }
+  return result
+}
+
+/** Replace {key} in a non-URL value — values used as-is (no encoding). */
+function interpolateValue(template: string, variables: Record<string, string>): string {
+  let result = template
+  for (const [key, value] of Object.entries(variables)) {
+    result = result.replaceAll(`{${key}}`, value)
+  }
+  return result
+}
+
+/** Extract {key} placeholder names from a template string. */
+export function extractPlaceholders(template: string): string[] {
+  const matches = template.match(/\{([^}]+)\}/g)
+  return matches ? matches.map((m) => m.slice(1, -1)) : []
+}


### PR DESCRIPTION
feat: add dynamic trigger input registration and unregistration

- Implemented `unregisterDynamicTriggerInput` function to allow dynamic trigger input configurations to be removed.
- Enhanced `NodeExecutionCard` to include copy functionality for outputs and inputs using `useCopy` hook.
- Updated `InputTab` to transform inputs for app triggers by parsing JSON triggerData.
- Introduced `WorkflowCompletionsBridge` to safely call ReactFlow/VarStore hooks in the code editor.
- Added `AppPollingSection` component for configuring polling intervals in app workflows.
- Registered dynamic trigger inputs in `WorkflowBlockRegistry` to pre-fill sample data in the Run panel's Input tab.
- Enhanced admin API to export apps by developer account and unpublish apps.
- Added interpolation utilities for OAuth connection fields to resolve placeholders.
- Refactored trigger processors to extract user inputs and build clean outputs for node variables.