### PR TITLE
feat: implement Gmail attachment fetching and inbound content ingestion

### DIFF
--- a/apps/web/src/app/(protected)/app/datasets/page.tsx
+++ b/apps/web/src/app/(protected)/app/datasets/page.tsx
@@ -28,7 +28,7 @@ function DatasetsPageContent() {
 
   return (
     <MainPage>
-      <MainPageHeader action=<CreateDatasetButton />>
+      <MainPageHeader action={<CreateDatasetButton />}>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Datasets' href='/app/datasets' />
           <MainPageBreadcrumbItem title='Overview' last />

--- a/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
+++ b/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
@@ -451,11 +451,13 @@ function MailboxInner({
             ) : (
               // Desktop: Keep existing ResizablePanelGroup
               <ResizablePanelGroup
+                id='mail-layout'
                 direction='horizontal'
                 // Ensure the group fills the available height and prevents internal overflow issues
                 className='h-full  flex-1 grow overflow-hidden bg-secondary dark:bg-primary-100'>
                 {/* Left Panel: Contains Tabs (if applicable), Search, and ThreadList */}
                 <ResizablePanel
+                  id='mail-thread-list'
                   defaultSize={defaultLayout[0]}
                   // minSize={20} // Minimum width for the list panel
                   // maxSize={40} // Maximum width for the list panel
@@ -477,7 +479,11 @@ function MailboxInner({
                 <ResizableHandle withHandle />
 
                 {/* Right Panel: Displays the selected thread details */}
-                <ResizablePanel defaultSize={defaultLayout[1]} minSize={30} collapsible>
+                <ResizablePanel
+                  id='mail-thread-display'
+                  defaultSize={defaultLayout[1]}
+                  minSize={30}
+                  collapsible>
                   <ThreadDisplay />
                 </ResizablePanel>
               </ResizablePanelGroup>

--- a/apps/web/src/app/(protected)/app/settings/snippets/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/snippets/page.tsx
@@ -85,8 +85,9 @@ function SnippetsPageContent() {
         </Button>
       }>
       <div className='flex h-full w-full overflow-hidden'>
-        <ResizablePanelGroup direction='horizontal'>
+        <ResizablePanelGroup id='snippets-layout' direction='horizontal'>
           <ResizablePanel
+            id='snippets-folders'
             ref={folderPanelRef}
             defaultSize={folderPanelState.isCollapsed ? 0 : folderPanelState.defaultSize}
             minSize={folderPanelState.minSize}
@@ -100,7 +101,7 @@ function SnippetsPageContent() {
             />
           </ResizablePanel>
           <ResizableHandle />
-          <ResizablePanel defaultSize={75} minSize={0}>
+          <ResizablePanel id='snippets-table' defaultSize={75} minSize={0}>
             <SnippetTable
               // folderId={selectedFolderId}
               onEdit={handleEditSnippet}

--- a/apps/web/src/components/global/sidebar-secondary.tsx
+++ b/apps/web/src/components/global/sidebar-secondary.tsx
@@ -93,6 +93,7 @@ function createSidebarGroup(
         {items.map((item) => (
           <li className='group/menu-item relative' key={item.id}>
             <Link
+              prefetch={false}
               href={`${baseUrl}/${item.slug}`}
               data-active={item.slug == current}
               className={cn(

--- a/apps/web/src/components/mail/email-display.tsx
+++ b/apps/web/src/components/mail/email-display.tsx
@@ -369,7 +369,9 @@ const EmailDisplay = ({ messageId, messageActions, isOpen }: EmailDisplayProps) 
           ) : contentMode === 'html' && htmlError ? (
             <div className='p-4 text-sm text-destructive'>{htmlError}</div>
           ) : contentMode === 'html' && resolvedHtml ? (
-            <SandboxedEmailHtml html={resolvedHtml} className='p-4' />
+            <div className='p-4'>
+              <SandboxedEmailHtml html={resolvedHtml} />
+            </div>
           ) : (
             <div className='whitespace-pre-wrap p-4 text-sm'>
               {message.textPlain || message.snippet || ''}

--- a/apps/web/src/components/mail/email-editor/hooks/use-draft.ts
+++ b/apps/web/src/components/mail/email-editor/hooks/use-draft.ts
@@ -1,6 +1,8 @@
 // apps/web/src/components/mail/email-editor/hooks/use-draft.ts
 'use client'
 
+import { useEffect } from 'react'
+import { getThreadStoreState } from '~/components/threads/store/thread-store'
 import { api } from '~/trpc/react'
 import type { DraftMessage } from '../types'
 
@@ -38,8 +40,21 @@ export function useDraft({ draftId, enabled = true }: UseDraftOptions): UseDraft
       enabled: enabled && !!draftId,
       // Always fetch fresh data - drafts change frequently via autosave
       staleTime: 0,
+      retry: (failureCount, error) => {
+        // Don't retry NOT_FOUND errors (draft was deleted after send)
+        if (error.data?.code === 'NOT_FOUND') return false
+        return failureCount < 3
+      },
     }
   )
+
+  // Defense-in-depth: if query fails with NOT_FOUND, tombstone the draft
+  // so useReplyBox skips future fetch attempts
+  useEffect(() => {
+    if (query.isError && draftId && query.error?.data?.code === 'NOT_FOUND') {
+      getThreadStoreState().markDraftNotFound(draftId)
+    }
+  }, [query.isError, query.error?.data?.code, draftId])
 
   return {
     draft: query.data,

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -14,7 +14,10 @@ import { useDropzone } from 'react-dropzone'
 import { EditorToolbar } from '~/components/editor/editor-button'
 import { EditorProvider, useEditorContext } from '~/components/editor/editor-context'
 import { useFileSelect } from '~/components/file-select/hooks/use-file-select'
+import { useCountUpdates } from '~/components/mail/hooks'
 import { SignatureEditor } from '~/components/signatures/ui'
+import { getMessageListStoreState } from '~/components/threads/store/message-list-store'
+import { getThreadStoreState } from '~/components/threads/store/thread-store'
 import { useAnalytics } from '~/hooks/use-analytics'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useDebouncedCallback } from '~/hooks/use-debounced-value'
@@ -91,6 +94,7 @@ function ReplyComposeEditorComponent({
   const activeState = useEditorActiveStateContext()
   const [confirm, ConfirmDialog] = useConfirm()
   const posthog = useAnalytics()
+  const { onSendDraft } = useCountUpdates()
 
   // Query integrations when needed
   const { data: integrations } = api.integration.getIntegrations.useQuery(undefined, {
@@ -257,8 +261,49 @@ function ReplyComposeEditorComponent({
 
   const sendMessageMutation = api.thread.sendMessage.useMutation({
     onMutate: () => setIsSending(true),
-    onSuccess: () => {
+    onSuccess: (sentMessage) => {
       toastSuccess({ description: 'Message sent successfully' })
+
+      // Draft cleanup (if sending from a draft)
+      if (state.draftId) {
+        // Tombstone: mark draft as not-found so useReplyBox skips fetch
+        getThreadStoreState().markDraftNotFound(state.draftId)
+
+        // Remove draft:<id> from thread's draftIds
+        const threadId = thread?.id ?? state.threadId
+        if (threadId) {
+          const currentThread = getThreadStoreState().getThread(threadId)
+          if (currentThread) {
+            const recordId = `draft:${state.draftId}`
+            getThreadStoreState().updateThread(threadId, {
+              draftIds: currentThread.draftIds.filter((id) => id !== recordId),
+            })
+          }
+        }
+
+        // Clear tRPC cache for this draft
+        utils.draft.getById.setData({ draftId: state.draftId }, undefined)
+
+        // Decrement draft count
+        onSendDraft()
+      }
+
+      // Message list refresh — invalidate both Zustand and React Query caches
+      if (sentMessage.threadId) {
+        getMessageListStoreState().invalidate(sentMessage.threadId)
+        utils.message.listByThread.invalidate({ threadId: sentMessage.threadId })
+      }
+
+      // Thread metadata patch
+      if (sentMessage.threadId) {
+        const currentThread = getThreadStoreState().getThread(sentMessage.threadId)
+        if (currentThread) {
+          getThreadStoreState().updateThread(sentMessage.threadId, {
+            lastMessageAt: sentMessage.sentAt?.toISOString() ?? new Date().toISOString(),
+          })
+        }
+      }
+
       onSendSuccess()
       onClose()
     },

--- a/apps/web/src/components/mail/thread-details.tsx
+++ b/apps/web/src/components/mail/thread-details.tsx
@@ -79,9 +79,7 @@ export default function ThreadDetails() {
               thread={thread}
               draft={draft}
               onClose={() => handlers.closeReplyBox()}
-              onSendSuccess={() => {
-                console.log('onSendSuccess callback triggered')
-              }}
+              onSendSuccess={() => {}}
             />
           </div>
         )}

--- a/apps/web/src/components/mail/utils/resolve-inline-email-html.ts
+++ b/apps/web/src/components/mail/utils/resolve-inline-email-html.ts
@@ -42,13 +42,26 @@ export function resolveInlineEmailHtml(
   attachments: AttachmentMeta[]
 ): string {
   if (!html) return ''
-  if (!html.includes('cid:') || attachments.length === 0) return html
 
-  const inlineAttachmentsByContentId = new Map(
+  const hasCid = html.includes('cid:')
+
+  console.log('[resolve-inline-email-html]', {
+    hasCid,
+    attachmentCount: attachments.length,
+    attachmentsWithContentId: attachments
+      .filter((a) => a.contentId)
+      .map((a) => ({ id: a.id, contentId: a.contentId, inline: a.inline })),
+  })
+
+  if (!hasCid || attachments.length === 0) return html
+
+  const attachmentsByContentId = new Map(
     attachments
-      .filter((attachment) => attachment.inline && attachment.contentId)
+      .filter((attachment) => attachment.contentId)
       .map((attachment) => [normalizeContentId(attachment.contentId!), attachment])
   )
+
+  console.log('[resolve-inline-email-html] lookup map keys:', [...attachmentsByContentId.keys()])
 
   let resolved = html
 
@@ -56,7 +69,14 @@ export function resolveInlineEmailHtml(
   resolved = resolved.replace(
     CID_SRC_QUOTED_PATTERN,
     (match, quote: string, rawContentId: string) => {
-      const attachment = inlineAttachmentsByContentId.get(normalizeContentId(rawContentId))
+      const normalized = normalizeContentId(rawContentId)
+      const attachment = attachmentsByContentId.get(normalized)
+      console.log('[resolve-inline-email-html] quoted match', {
+        rawContentId,
+        normalized,
+        found: !!attachment,
+        replacedWith: attachment ? `/api/attachments/${attachment.id}/content` : null,
+      })
       if (!attachment) return match
       return `src=${quote}/api/attachments/${attachment.id}/content${quote}`
     }
@@ -64,7 +84,13 @@ export function resolveInlineEmailHtml(
 
   // Rewrite unquoted src=cid:...
   resolved = resolved.replace(CID_SRC_UNQUOTED_PATTERN, (match, rawContentId: string) => {
-    const attachment = inlineAttachmentsByContentId.get(normalizeContentId(rawContentId))
+    const normalized = normalizeContentId(rawContentId)
+    const attachment = attachmentsByContentId.get(normalized)
+    console.log('[resolve-inline-email-html] unquoted match', {
+      rawContentId,
+      normalized,
+      found: !!attachment,
+    })
     if (!attachment) return match
     return `src="/api/attachments/${attachment.id}/content"`
   })
@@ -73,7 +99,13 @@ export function resolveInlineEmailHtml(
   resolved = resolved.replace(
     CID_CSS_URL_PATTERN,
     (match, _quote: string, rawContentId: string) => {
-      const attachment = inlineAttachmentsByContentId.get(normalizeContentId(rawContentId))
+      const normalized = normalizeContentId(rawContentId)
+      const attachment = attachmentsByContentId.get(normalized)
+      console.log('[resolve-inline-email-html] css match', {
+        rawContentId,
+        normalized,
+        found: !!attachment,
+      })
       if (!attachment) return match
       return `url('/api/attachments/${attachment.id}/content')`
     }

--- a/apps/web/src/components/mail/utils/sandboxed-email-html.tsx
+++ b/apps/web/src/components/mail/utils/sandboxed-email-html.tsx
@@ -17,15 +17,13 @@ interface SandboxedEmailHtmlProps {
  */
 export function SandboxedEmailHtml({ html, className }: SandboxedEmailHtmlProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
-  const [height, setHeight] = useState(100)
+  const [height, setHeight] = useState(0)
 
   const updateHeight = useCallback(() => {
     const doc = iframeRef.current?.contentDocument
     if (doc?.body) {
-      const newHeight = doc.body.scrollHeight
-      if (newHeight > 0) {
-        setHeight(newHeight)
-      }
+      const contentHeight = Math.max(doc.documentElement.scrollHeight, doc.body.scrollHeight)
+      setHeight(contentHeight)
     }
   }, [])
 
@@ -40,6 +38,7 @@ export function SandboxedEmailHtml({ html, className }: SandboxedEmailHtmlProps)
       if (doc?.body) {
         const observer = new ResizeObserver(updateHeight)
         observer.observe(doc.body)
+        observer.observe(doc.documentElement)
         return () => observer.disconnect()
       }
     }
@@ -55,25 +54,45 @@ export function SandboxedEmailHtml({ html, className }: SandboxedEmailHtmlProps)
       ref={iframeRef}
       srcDoc={srcdoc}
       sandbox='allow-same-origin'
+      scrolling='no'
       title='Email content'
       className={cn('w-full border-0', className)}
-      style={{ height: `${height}px` }}
+      style={{ height: `${height}px`, overflow: 'hidden' }}
     />
   )
 }
 
+const CSP_TAG =
+  "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; img-src 'self' https: http: data: blob:; style-src 'unsafe-inline'; frame-src 'none'; script-src 'none'; form-action 'none';\">"
+
+const BASE_STYLES =
+  "<style>body, p, h1, h2, h3, h4, h5, h6, ul, ol, li, blockquote, pre, figure, figcaption, dl, dd { margin: 0; padding: 0; } body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-size: 14px; line-height: 1.5; color: inherit; word-wrap: break-word; overflow-wrap: break-word; overflow: hidden; } img { max-width: 100%; height: auto; }</style>"
+
 /**
  * Wraps HTML in a full document with a restrictive CSP meta tag.
+ * If the HTML is already a full document, injects CSP and base styles into the existing <head>.
  */
 function buildSrcdoc(html: string): string {
+  const isFullDocument = /<html[\s>]/i.test(html)
+
+  if (isFullDocument) {
+    let result = html
+
+    // Inject CSP + base styles into existing <head>
+    const headMatch = result.match(/<head[^>]*>/i)
+    if (headMatch) {
+      const insertPos = (headMatch.index ?? 0) + headMatch[0].length
+      result = result.slice(0, insertPos) + CSP_TAG + BASE_STYLES + result.slice(insertPos)
+    }
+
+    return result
+  }
+
   return `<!DOCTYPE html>
 <html>
 <head>
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src https: http: data: blob:; style-src 'unsafe-inline'; frame-src 'none'; script-src 'none'; form-action 'none';">
-<style>
-  body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-size: 14px; line-height: 1.5; color: inherit; word-wrap: break-word; overflow-wrap: break-word; }
-  img { max-width: 100%; height: auto; }
-</style>
+${CSP_TAG}
+${BASE_STYLES}
 </head>
 <body>${html}</body>
 </html>`

--- a/apps/web/src/components/threads/store/thread-store.ts
+++ b/apps/web/src/components/threads/store/thread-store.ts
@@ -182,6 +182,9 @@ interface ThreadStoreState {
   startDraftBatch: () => string[]
   completeDraftBatch: (drafts: StandaloneDraftMeta[], notFoundIds: string[]) => void
 
+  /** Mark a draft as not-found (tombstone) so useReplyBox skips fetch */
+  markDraftNotFound: (id: string) => void
+
   // Selectors (for use outside React)
   getThread: (id: string) => ThreadMeta | undefined
   getDraft: (id: string) => StandaloneDraftMeta | undefined
@@ -520,6 +523,14 @@ export const useThreadStore = create<ThreadStoreState>()(
             state.loadingDraftIds.delete(id)
             state.notFoundDraftIds.add(id)
           }
+        }),
+
+      markDraftNotFound: (id) =>
+        set((state) => {
+          state.notFoundDraftIds.add(id)
+          state.pendingDraftIds.delete(id)
+          state.loadingDraftIds.delete(id)
+          state.standaloneDrafts.delete(id)
         }),
 
       // ═══════════════════════════════════════════════════════════════

--- a/apps/web/src/server/api/routers/integration.ts
+++ b/apps/web/src/server/api/routers/integration.ts
@@ -553,6 +553,71 @@ export const integrationRouter = createTRPCRouter({
     }),
 
   /**
+   * Reset sync state for a stuck integration.
+   * Clears throttle, resets stage to IDLE, and optionally clears lastHistoryId for full re-sync.
+   */
+  resetSyncState: protectedProcedure
+    .input(
+      z.object({
+        integrationId: z.string(),
+        fullResync: z.boolean().default(false),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { userId } = ctx.session
+      const organizationId = getUserOrganizationId(ctx.session)
+      await requireAdminAccess(userId, organizationId)
+
+      // Verify integration belongs to this org
+      const [integration] = await ctx.db
+        .select({ id: schema.Integration.id, syncStage: schema.Integration.syncStage })
+        .from(schema.Integration)
+        .where(
+          and(
+            eq(schema.Integration.id, input.integrationId),
+            eq(schema.Integration.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+
+      if (!integration) {
+        throw new Error('Integration not found')
+      }
+
+      // Clear Redis import cache (both main and processing sets)
+      const { clearImportCache } = await import('@auxx/lib/email/polling-import-cache')
+      await clearImportCache(input.integrationId)
+
+      // Reset sync state
+      const updateData: Record<string, any> = {
+        syncStage: 'IDLE',
+        syncStatus: 'ACTIVE',
+        syncStageStartedAt: null,
+        throttleFailureCount: 0,
+        throttleRetryAfter: null,
+        updatedAt: new Date(),
+      }
+
+      if (input.fullResync) {
+        updateData.lastHistoryId = null
+      }
+
+      await ctx.db
+        .update(schema.Integration)
+        .set(updateData)
+        .where(eq(schema.Integration.id, input.integrationId))
+
+      logger.info('Admin reset sync state', {
+        integrationId: input.integrationId,
+        fullResync: input.fullResync,
+        previousStage: integration.syncStage,
+        userId,
+      })
+
+      return { success: true }
+    }),
+
+  /**
    * Test IMAP/SMTP/LDAP connection without saving.
    */
   testImapConnection: protectedProcedure

--- a/apps/worker/src/workers/utils/createWorker.ts
+++ b/apps/worker/src/workers/utils/createWorker.ts
@@ -4,7 +4,7 @@ import type { JobHandler, LegacyJobHandler } from '@auxx/lib/jobs'
 import type { Queues } from '@auxx/lib/jobs/queues'
 import { createScopedLogger } from '@auxx/logger'
 import { getConnectionOptions } from '@auxx/redis'
-import { Worker, type WorkerOptions } from 'bullmq'
+import { Job, Worker, type WorkerOptions } from 'bullmq'
 import { createJobHandler } from './createJobHandler'
 
 const logger = createScopedLogger('worker')
@@ -24,7 +24,7 @@ export interface EnhancedWorkerOptions extends Omit<WorkerOptions, 'connection'>
  * Creates a fully configured BullMQ worker with:
  * - Job handling and error handling
  * - Cancellation support via AbortSignal
- * - Lock renewal failure handling
+ * - Lock renewal failure handling with integration recovery
  *
  * @param queue The queue to process
  * @param jobMappings Object mapping job names to their handler functions
@@ -52,9 +52,53 @@ export function createWorker<T extends Record<string, JobHandler | LegacyJobHand
     logger.error(`Worker error on queue ${queue}:`, { error: error.message })
   })
 
-  // Lock renewal failure handling (cancel jobs that lost their lock)
-  worker.on('lockRenewalFailed', (jobId: string, error: Error) => {
-    logger.warn('Lock renewal failed, cancelling job', { jobId, queue, error: error.message })
+  // Lock renewal failure handling with integration recovery
+  worker.on('lockRenewalFailed', async (jobId: string, error: Error) => {
+    logger.warn('Lock renewal failed', { jobId, queue, error: error.message })
+
+    // Attempt to recover integration state for polling sync jobs
+    try {
+      const job = await Job.fromId(worker, jobId)
+
+      if (job?.data?.integrationId) {
+        const { integrationId } = job.data
+
+        // Dynamic imports to avoid circular dependencies
+        const { recoverProcessingBatch, getImportCacheSize } = await import(
+          '@auxx/lib/email/polling-import-cache'
+        )
+        const { database: db, schema } = await import('@auxx/database')
+        const { and, eq, inArray } = await import('drizzle-orm')
+
+        const recovered = await recoverProcessingBatch(integrationId)
+        const cacheSize = await getImportCacheSize(integrationId)
+
+        const resetStage = cacheSize > 0 ? 'MESSAGES_IMPORT_PENDING' : 'MESSAGE_LIST_FETCH_PENDING'
+
+        await db
+          .update(schema.Integration)
+          .set({ syncStage: resetStage, syncStageStartedAt: null, updatedAt: new Date() })
+          .where(
+            and(
+              eq(schema.Integration.id, integrationId),
+              inArray(schema.Integration.syncStage, ['MESSAGE_LIST_FETCH', 'MESSAGES_IMPORT'])
+            )
+          )
+
+        logger.info('Recovered integration after lock loss', {
+          integrationId,
+          recoveredFromProcessing: recovered,
+          cacheSize,
+          resetStage,
+        })
+      }
+    } catch (err) {
+      // Best-effort — stale check will catch it in 15 minutes
+      logger.error('Failed to recover integration after lock loss', {
+        jobId,
+        error: (err as Error).message,
+      })
+    }
   })
 
   // Progress logging

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -142,6 +142,12 @@
       "import": "./dist/email/index.mjs",
       "default": "./src/email/index.ts"
     },
+    "./email/polling-import-cache": {
+      "types": "./src/email/polling-import-cache.ts",
+      "source": "./src/email/polling-import-cache.ts",
+      "import": "./dist/email/polling-import-cache.mjs",
+      "default": "./src/email/polling-import-cache.ts"
+    },
     "./embeddings": {
       "types": "./src/embeddings/index.ts",
       "source": "./src/embeddings/index.ts",

--- a/packages/lib/src/email/email-storage.ts
+++ b/packages/lib/src/email/email-storage.ts
@@ -47,6 +47,21 @@ export interface ParticipantInputData {
   raw?: string | null // Original raw string if available
 }
 
+/**
+ * Provider-side attachment metadata for downstream ingest (not persisted in DB).
+ */
+export interface MessageAttachmentMeta {
+  filename: string
+  mimeType: string
+  size: number
+  inline: boolean
+  contentId: string | null
+  /** Gmail: body.attachmentId for large parts; null for embedded parts */
+  providerAttachmentId?: string | null
+  /** Gmail: base64url-encoded body.data for small embedded parts */
+  embeddedData?: string | null
+}
+
 // Structure for message data coming from provider conversion methods
 export interface MessageData {
   externalId: string
@@ -92,6 +107,9 @@ export interface MessageData {
   isAutoReply?: boolean | null
   isFirstInThread?: boolean | null // Provider might determine this
   isAIGenerated?: boolean | null
+
+  /** Provider-side attachment metadata for downstream ingest (not persisted in DB) */
+  providerAttachments?: MessageAttachmentMeta[]
 }
 
 /**
@@ -847,7 +865,9 @@ export class MessageStorageService {
             externalId: messageData.externalId,
             externalThreadId: messageData.externalThreadId,
             textPlain: existingByMsgId.textPlain ?? messageData.textPlain,
-            textHtml: existingByMsgId.textHtml ?? messageData.textHtml,
+            textHtml: messageData.htmlBodyStorageLocationId
+              ? null
+              : (existingByMsgId.textHtml ?? messageData.textHtml),
             snippet: messageData.snippet ?? null,
             htmlBodyStorageLocationId: messageData.htmlBodyStorageLocationId ?? undefined,
             hasAttachments: messageData.hasAttachments,
@@ -1102,7 +1122,7 @@ export class MessageStorageService {
             this.extractInternetMessageId(messageData) || messageData.internetMessageId,
           subject: messageData.subject ?? '',
           hasAttachments: messageData.hasAttachments,
-          textHtml: messageData.textHtml,
+          textHtml: messageData.htmlBodyStorageLocationId ? null : messageData.textHtml,
           textPlain: messageData.textPlain,
           snippet: messageData.snippet,
           htmlBodyStorageLocationId: messageData.htmlBodyStorageLocationId ?? null,
@@ -1123,7 +1143,7 @@ export class MessageStorageService {
             receivedAt: messageData.receivedAt,
             subject: messageData.subject || '',
             hasAttachments: messageData.hasAttachments,
-            textHtml: messageData.textHtml,
+            textHtml: messageData.htmlBodyStorageLocationId ? null : messageData.textHtml,
             textPlain: messageData.textPlain,
             snippet: messageData.snippet,
             htmlBodyStorageLocationId: messageData.htmlBodyStorageLocationId ?? null,

--- a/packages/lib/src/email/inbound/__tests__/attachment-ingest.service.test.ts
+++ b/packages/lib/src/email/inbound/__tests__/attachment-ingest.service.test.ts
@@ -318,4 +318,32 @@ describe('InboundAttachmentIngestService', () => {
     expect(results[0]!.attachmentId).toBe(deriveAttachmentId('ses-msg-456', 0, 'a.png'))
     expect(results[1]!.attachmentId).toBe(deriveAttachmentId('ses-msg-456', 1, 'b.pdf'))
   })
+
+  it('skips reconciliation when skipReconciliation: true is passed', async () => {
+    // Only 1 duplicate check (empty), NO reconciliation select expected
+    const mockDb = buildMockDb([[]])
+    const service = new InboundAttachmentIngestService(mockDb as never)
+
+    await service.ingestAll([makeAttachment()], baseContext, { skipReconciliation: true })
+
+    // Upload + createWithVersion + attachmentCreate should still be called
+    expect(mocks.uploadContent).toHaveBeenCalledOnce()
+    expect(mocks.createWithVersion).toHaveBeenCalledOnce()
+    expect(mocks.attachmentCreate).toHaveBeenCalledOnce()
+
+    // Only 1 select call (the duplicate check), no reconciliation select
+    expect(mockDb.select).toHaveBeenCalledTimes(1)
+    expect(mockDb.delete).not.toHaveBeenCalled()
+  })
+
+  it('runs reconciliation by default (skipReconciliation not set)', async () => {
+    // 1 duplicate check (empty) + 1 reconciliation select
+    const mockDb = buildMockDb([[], []])
+    const service = new InboundAttachmentIngestService(mockDb as never)
+
+    await service.ingestAll([makeAttachment()], baseContext)
+
+    // 2 select calls: duplicate check + reconciliation
+    expect(mockDb.select).toHaveBeenCalledTimes(2)
+  })
 })

--- a/packages/lib/src/email/inbound/__tests__/body-ingest.service.test.ts
+++ b/packages/lib/src/email/inbound/__tests__/body-ingest.service.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => {
   return {
     uploadContent: vi.fn(),
+    findByExternalId: vi.fn(),
   }
 })
 
@@ -12,6 +13,12 @@ vi.mock('../../../files/storage/storage-manager', () => ({
   createStorageManager: () => ({
     uploadContent: mocks.uploadContent,
   }),
+}))
+
+vi.mock('../../../files/storage/storage-location-service', () => ({
+  storageLocationService: {
+    findByExternalId: mocks.findByExternalId,
+  },
 }))
 
 import { InboundBodyIngestService } from '../body-ingest.service'
@@ -26,6 +33,8 @@ describe('InboundBodyIngestService', () => {
 
   beforeEach(() => {
     mocks.uploadContent.mockReset()
+    mocks.findByExternalId.mockReset()
+    mocks.findByExternalId.mockResolvedValue([])
     service = new InboundBodyIngestService()
   })
 
@@ -92,5 +101,47 @@ describe('InboundBodyIngestService', () => {
 
     const call = mocks.uploadContent.mock.calls[0]![0]
     expect(call.key).toBe('email/inbound/org_xyz/gmail-msg-999/body.html')
+  })
+
+  it('returns existing StorageLocation when body was already uploaded (idempotency)', async () => {
+    mocks.findByExternalId.mockResolvedValue([{ id: 'sl_existing_42' }])
+
+    const result = await service.ingestBody({ textHtml: '<p>Duplicate</p>' }, baseContext)
+
+    expect(result).toEqual({ htmlBodyStorageLocationId: 'sl_existing_42' })
+    expect(mocks.uploadContent).not.toHaveBeenCalled()
+    expect(mocks.findByExternalId).toHaveBeenCalledWith(
+      'S3',
+      'email/inbound/org_abc/ses-msg-123/body.html'
+    )
+  })
+
+  it('uploads when findByExternalId returns empty array', async () => {
+    mocks.findByExternalId.mockResolvedValue([])
+    mocks.uploadContent.mockResolvedValue({ id: 'sl_new_1' })
+
+    const result = await service.ingestBody({ textHtml: '<p>New</p>' }, baseContext)
+
+    expect(result).toEqual({ htmlBodyStorageLocationId: 'sl_new_1' })
+    expect(mocks.uploadContent).toHaveBeenCalledOnce()
+  })
+
+  it('falls through to upload when findByExternalId throws (fail-open)', async () => {
+    mocks.findByExternalId.mockRejectedValue(new Error('DB connection refused'))
+    mocks.uploadContent.mockResolvedValue({ id: 'sl_fallback_1' })
+
+    const result = await service.ingestBody({ textHtml: '<p>Fallback</p>' }, baseContext)
+
+    expect(result).toEqual({ htmlBodyStorageLocationId: 'sl_fallback_1' })
+    expect(mocks.uploadContent).toHaveBeenCalledOnce()
+  })
+
+  it('propagates upload error even when lookup fails (upload is not optional)', async () => {
+    mocks.findByExternalId.mockRejectedValue(new Error('DB error'))
+    mocks.uploadContent.mockRejectedValue(new Error('S3 unavailable'))
+
+    await expect(service.ingestBody({ textHtml: '<p>Fail</p>' }, baseContext)).rejects.toThrow(
+      'S3 unavailable'
+    )
   })
 })

--- a/packages/lib/src/email/inbound/attachment-ingest.service.ts
+++ b/packages/lib/src/email/inbound/attachment-ingest.service.ts
@@ -39,7 +39,8 @@ export class InboundAttachmentIngestService {
    */
   async ingestAll(
     attachments: AttachmentIngestInput[],
-    context: AttachmentIngestContext
+    context: AttachmentIngestContext,
+    options?: { skipReconciliation?: boolean }
   ): Promise<StoredAttachmentMeta[]> {
     if (attachments.length === 0) return []
 
@@ -51,7 +52,10 @@ export class InboundAttachmentIngestService {
     }
 
     // Reconcile: remove stale ingest-managed attachments for this message
-    await this.reconcileAttachments(context, results)
+    // Skip reconciliation when the input set is known to be partial (e.g. some fetches failed)
+    if (!options?.skipReconciliation) {
+      await this.reconcileAttachments(context, results)
+    }
 
     return results
   }

--- a/packages/lib/src/email/inbound/body-ingest.service.ts
+++ b/packages/lib/src/email/inbound/body-ingest.service.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/email/inbound/body-ingest.service.ts
 
 import { createScopedLogger } from '@auxx/logger'
+import { storageLocationService } from '../../files/storage/storage-location-service'
 import { createStorageManager } from '../../files/storage/storage-manager'
 import type { IngestedBodyMeta } from './ingest-types'
 import { buildInboundHtmlBodyKey } from './object-keys'
@@ -29,6 +30,9 @@ export class InboundBodyIngestService {
   /**
    * Ingests the HTML body of an inbound email into object storage.
    * Returns the storageLocationId for the uploaded body, or null if no HTML is present.
+   *
+   * The idempotency lookup is best-effort: if it throws, we fall through to upload.
+   * This ensures a transient DB issue cannot prevent the message from being stored.
    */
   async ingestBody(input: BodyIngestInput, context: BodyIngestContext): Promise<IngestedBodyMeta> {
     if (!input.textHtml) {
@@ -39,6 +43,30 @@ export class InboundBodyIngestService {
       organizationId: context.organizationId,
       contentScopeId: context.contentScopeId,
     })
+
+    // Check if body was already uploaded (idempotency for repeated syncs).
+    // Fail-open: lookup errors do not prevent upload.
+    try {
+      const existing = await storageLocationService.findByExternalId('S3', key)
+      if (existing.length > 0) {
+        logger.debug('Body already uploaded, returning existing StorageLocation', {
+          organizationId: context.organizationId,
+          contentScopeId: context.contentScopeId,
+          storageLocationId: existing[0]!.id,
+        })
+        return { htmlBodyStorageLocationId: existing[0]!.id }
+      }
+    } catch (error) {
+      const cause = error instanceof Error ? error : new Error(String(error))
+      logger.warn('Idempotency lookup failed, proceeding with upload', {
+        organizationId: context.organizationId,
+        contentScopeId: context.contentScopeId,
+        key,
+        error: cause.message,
+        cause: (cause as any).cause?.message,
+        code: (cause as any).code ?? (cause as any).cause?.code,
+      })
+    }
 
     const storageManager = createStorageManager(context.organizationId)
     const content = Buffer.from(input.textHtml, 'utf-8')

--- a/packages/lib/src/email/polling-import-cache.ts
+++ b/packages/lib/src/email/polling-import-cache.ts
@@ -6,10 +6,15 @@ import { getRedisClient } from '@auxx/redis'
 const logger = createScopedLogger('polling-import-cache')
 
 const CACHE_PREFIX = 'poll-import:'
-const CACHE_TTL = 3600 // 1 hour — safety expiry to prevent leaks
+const PROCESSING_PREFIX = 'poll-import-processing:'
+const CACHE_TTL = 7200 // 2 hours — increased to survive FAILED state recovery
 
 function cacheKey(integrationId: string): string {
   return `${CACHE_PREFIX}${integrationId}`
+}
+
+function processingKey(integrationId: string): string {
+  return `${PROCESSING_PREFIX}${integrationId}`
 }
 
 /** Add discovered message IDs to the import cache */
@@ -30,7 +35,65 @@ export async function addToImportCache(integrationId: string, messageIds: string
   })
 }
 
-/** Pop a batch of message IDs from the import cache (SPOP) */
+/**
+ * Move a batch of IDs from the main cache to a processing set.
+ * IDs stay in the processing set until explicitly acknowledged.
+ * If the job crashes, recoverProcessingBatch() moves them back.
+ */
+export async function claimImportBatch(integrationId: string, count: number): Promise<string[]> {
+  const redis = await getRedisClient()
+  if (!redis) return []
+
+  const key = cacheKey(integrationId)
+  const procKey = processingKey(integrationId)
+
+  const ids = await redis.spop(key, count)
+  if (!ids || (Array.isArray(ids) && ids.length === 0)) return []
+
+  const idArray = Array.isArray(ids) ? ids : [ids]
+
+  await redis.sadd(procKey, ...idArray)
+  await redis.expire(procKey, CACHE_TTL)
+
+  return idArray
+}
+
+/**
+ * Acknowledge successful import — remove from processing set.
+ */
+export async function acknowledgeImportBatch(
+  integrationId: string,
+  messageIds: string[]
+): Promise<void> {
+  if (messageIds.length === 0) return
+  const redis = await getRedisClient()
+  if (!redis) return
+
+  await redis.srem(processingKey(integrationId), ...messageIds)
+}
+
+/**
+ * Recover a crashed batch — move processing set back to main cache.
+ * Called during stale-check recovery and lock-loss recovery.
+ */
+export async function recoverProcessingBatch(integrationId: string): Promise<number> {
+  const redis = await getRedisClient()
+  if (!redis) return 0
+
+  const procKey = processingKey(integrationId)
+  const key = cacheKey(integrationId)
+
+  const ids = await redis.smembers(procKey)
+  if (ids.length === 0) return 0
+
+  await redis.sadd(key, ...ids)
+  await redis.del(procKey)
+  await redis.expire(key, CACHE_TTL)
+
+  return ids.length
+}
+
+/** Pop a batch of message IDs from the import cache (SPOP) — legacy, prefer claimImportBatch */
 export async function popFromImportCache(integrationId: string, count: number): Promise<string[]> {
   const redis = await getRedisClient()
   if (!redis) return []
@@ -42,20 +105,24 @@ export async function popFromImportCache(integrationId: string, count: number): 
   return Array.isArray(ids) ? ids : [ids]
 }
 
-/** Get remaining count in cache */
+/** Get remaining count in cache (includes both main and processing sets) */
 export async function getImportCacheSize(integrationId: string): Promise<number> {
   const redis = await getRedisClient()
   if (!redis) return 0
 
-  return redis.scard(cacheKey(integrationId))
+  const [cacheCount, processingCount] = await Promise.all([
+    redis.scard(cacheKey(integrationId)),
+    redis.scard(processingKey(integrationId)),
+  ])
+  return cacheCount + processingCount
 }
 
-/** Clear the cache (on full sync reset or cleanup) */
+/** Clear the cache (both main and processing sets) */
 export async function clearImportCache(integrationId: string): Promise<void> {
   const redis = await getRedisClient()
   if (!redis) return
 
-  await redis.del(cacheKey(integrationId))
+  await redis.del(cacheKey(integrationId), processingKey(integrationId))
 
   logger.debug('Cleared import cache', { integrationId })
 }

--- a/packages/lib/src/files/core/attachment-service.ts
+++ b/packages/lib/src/files/core/attachment-service.ts
@@ -106,7 +106,7 @@ export class AttachmentService extends BaseService<
   }
   protected async processCreateData(data: CreateAttachmentRequest): Promise<any> {
     const orgId = data.organizationId || this.requireOrganization()
-    const userId = data.createdById || this.requireUserId()
+    const userId = data.createdById ?? this.userId ?? null
     this.validateTarget(data)
     await this.ensureAuth(data.entityType, data.entityId)
     const sort = data.sort ?? (await this.nextSort(data.entityType, data.entityId))

--- a/packages/lib/src/jobs/polling/message-list-fetch-job.ts
+++ b/packages/lib/src/jobs/polling/message-list-fetch-job.ts
@@ -3,10 +3,14 @@
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
-import { eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { MessageStorageService } from '../../email/email-storage'
 import { FolderDiscoveryService } from '../../email/labels/folder-discovery-service'
-import { addToImportCache } from '../../email/polling-import-cache'
+import {
+  addToImportCache,
+  getImportCacheSize,
+  recoverProcessingBatch,
+} from '../../email/polling-import-cache'
 import type { ImapImportBatchJobData } from '../../providers/imap/types'
 import { ProviderRegistryService } from '../../providers/provider-registry-service'
 import { getQueue } from '../queues'
@@ -23,6 +27,7 @@ export interface MessageListFetchJobData {
   integrationId: string
   organizationId: string
   provider: string
+  isWindowedScanContinuation?: boolean
 }
 
 /**
@@ -36,6 +41,9 @@ export interface MessageListFetchJobData {
 export const messageListFetchJob = async (job: Job<MessageListFetchJobData>) => {
   const { integrationId, organizationId, provider } = job.data
   const now = new Date()
+
+  // Extract signal from JobContext (passed via createJobHandler)
+  const signal = (job as any).signal as AbortSignal | undefined
 
   logger.info('Starting message list fetch', { integrationId, organizationId, provider })
 
@@ -57,8 +65,8 @@ export const messageListFetchJob = async (job: Job<MessageListFetchJobData>) => 
 
     // Check if provider supports two-phase sync
     if (providerInstance.supportsTwoPhaseSync?.()) {
-      // --- Label sync ---
-      if (providerInstance.discoverLabels) {
+      // --- Label sync (skip on windowed scan continuations — folders already discovered) ---
+      if (!job.data.isWindowedScanContinuation && providerInstance.discoverLabels) {
         const discoveredLabels = await providerInstance.discoverLabels()
         const folderDiscovery = new FolderDiscoveryService()
         await folderDiscovery.discoverAndUpsert({
@@ -200,9 +208,45 @@ export const messageListFetchJob = async (job: Job<MessageListFetchJobData>) => 
           updatedAt: new Date(),
         })
         .where(eq(schema.Integration.id, integrationId))
+    } else {
+      // Non-final attempt: reset stale timer so BullMQ retries get a fresh window
+      await db
+        .update(schema.Integration)
+        .set({ syncStageStartedAt: new Date(), updatedAt: new Date() })
+        .where(eq(schema.Integration.id, integrationId))
     }
 
     throw error
+  } finally {
+    // Phase 2: Signal-based recovery for lock loss / cancellation
+    if (signal?.aborted) {
+      const recovered = await recoverProcessingBatch(integrationId)
+      if (recovered > 0) {
+        logger.warn('Recovered processing batch after cancellation', {
+          integrationId,
+          recoveredCount: recovered,
+        })
+      }
+
+      const cacheSize = await getImportCacheSize(integrationId)
+      const resetStage = cacheSize > 0 ? 'MESSAGES_IMPORT_PENDING' : 'MESSAGE_LIST_FETCH_PENDING'
+
+      await db
+        .update(schema.Integration)
+        .set({ syncStage: resetStage, syncStageStartedAt: null, updatedAt: new Date() })
+        .where(
+          and(
+            eq(schema.Integration.id, integrationId),
+            inArray(schema.Integration.syncStage, ['MESSAGE_LIST_FETCH', 'MESSAGES_IMPORT'])
+          )
+        )
+
+      logger.info('Reset integration after signal abort', {
+        integrationId,
+        resetStage,
+        cacheSize,
+      })
+    }
   }
 }
 
@@ -312,7 +356,7 @@ async function handleImapListFetch(
     // All windows were empty but there are more windows to scan — re-enqueue list fetch
     await pollingSyncQueue.add(
       'messageListFetchJob',
-      { integrationId, organizationId, provider: 'imap' },
+      { integrationId, organizationId, provider: 'imap', isWindowedScanContinuation: true },
       {
         jobId: `poll-list-fetch-${integrationId}-${Date.now()}`,
         delay: 1000,

--- a/packages/lib/src/jobs/polling/messages-import-job.ts
+++ b/packages/lib/src/jobs/polling/messages-import-job.ts
@@ -3,8 +3,13 @@
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
-import { and, eq } from 'drizzle-orm'
-import { getImportCacheSize, popFromImportCache } from '../../email/polling-import-cache'
+import { and, eq, inArray } from 'drizzle-orm'
+import {
+  acknowledgeImportBatch,
+  claimImportBatch,
+  getImportCacheSize,
+  recoverProcessingBatch,
+} from '../../email/polling-import-cache'
 import type { ImapFolderCheckpoint, ImapImportBatchJobData } from '../../providers/imap/types'
 import {
   DEFAULT_IMPORT_BATCH_SIZE,
@@ -30,7 +35,7 @@ export interface MessagesImportJobData {
 
 /**
  * Phase 2: Fetch message content by external IDs from Redis cache.
- * Pops a batch, imports via provider, and transitions stage.
+ * Claims a batch (two-phase), imports via provider, then acknowledges.
  */
 export const messagesImportJob = async (job: Job<MessagesImportJobData>) => {
   const { integrationId, organizationId, provider } = job.data
@@ -38,7 +43,12 @@ export const messagesImportJob = async (job: Job<MessagesImportJobData>) => {
     job.data.batchSize ?? PROVIDER_IMPORT_BATCH_SIZE[provider] ?? DEFAULT_IMPORT_BATCH_SIZE
   const now = new Date()
 
+  // Extract signal from JobContext (passed via createJobHandler)
+  const signal = (job as any).signal as AbortSignal | undefined
+
   logger.info('Starting messages import', { integrationId, organizationId, batchSize })
+
+  let claimedIds: string[] = []
 
   try {
     // Set stage to MESSAGES_IMPORT
@@ -51,10 +61,10 @@ export const messagesImportJob = async (job: Job<MessagesImportJobData>) => {
       })
       .where(eq(schema.Integration.id, integrationId))
 
-    // Pop batch from Redis cache
-    const externalIds = await popFromImportCache(integrationId, batchSize)
+    // Claim batch from Redis cache (two-phase: main → processing set)
+    claimedIds = await claimImportBatch(integrationId, batchSize)
 
-    if (externalIds.length === 0) {
+    if (claimedIds.length === 0) {
       // No IDs remaining — done
       await db
         .update(schema.Integration)
@@ -83,13 +93,16 @@ export const messagesImportJob = async (job: Job<MessagesImportJobData>) => {
       throw new Error(`Provider ${provider} does not support importMessages`)
     }
 
-    const result = await providerInstance.importMessages(externalIds)
+    const result = await providerInstance.importMessages(claimedIds)
+
+    // Acknowledge successful import — remove from processing set
+    await acknowledgeImportBatch(integrationId, claimedIds)
 
     logger.info('Import batch completed', {
       integrationId,
       imported: result.imported,
       failed: result.failed,
-      batchSize: externalIds.length,
+      batchSize: claimedIds.length,
     })
 
     // Check remaining cache size
@@ -162,9 +175,45 @@ export const messagesImportJob = async (job: Job<MessagesImportJobData>) => {
           updatedAt: new Date(),
         })
         .where(eq(schema.Integration.id, integrationId))
+    } else {
+      // Non-final attempt: reset stale timer so BullMQ retries get a fresh window
+      await db
+        .update(schema.Integration)
+        .set({ syncStageStartedAt: new Date(), updatedAt: new Date() })
+        .where(eq(schema.Integration.id, integrationId))
     }
 
     throw error
+  } finally {
+    // Phase 2: Signal-based recovery for lock loss / cancellation
+    if (signal?.aborted) {
+      const recovered = await recoverProcessingBatch(integrationId)
+      if (recovered > 0) {
+        logger.warn('Recovered processing batch after cancellation', {
+          integrationId,
+          recoveredCount: recovered,
+        })
+      }
+
+      const cacheSize = await getImportCacheSize(integrationId)
+      const resetStage = cacheSize > 0 ? 'MESSAGES_IMPORT_PENDING' : 'MESSAGE_LIST_FETCH_PENDING'
+
+      await db
+        .update(schema.Integration)
+        .set({ syncStage: resetStage, syncStageStartedAt: null, updatedAt: new Date() })
+        .where(
+          and(
+            eq(schema.Integration.id, integrationId),
+            inArray(schema.Integration.syncStage, ['MESSAGE_LIST_FETCH', 'MESSAGES_IMPORT'])
+          )
+        )
+
+      logger.info('Reset integration after signal abort', {
+        integrationId,
+        resetStage,
+        cacheSize,
+      })
+    }
   }
 }
 
@@ -340,6 +389,44 @@ export const imapImportBatchJob = async (job: Job<ImapImportBatchJobData>) => {
       runId,
       error: error.message,
     })
+
+    // Phase 5: Apply throttle on final attempt for IMAP batch jobs
+    const maxAttempts = job.opts.attempts ?? 1
+    const isFinalAttempt = job.attemptsMade + 1 >= maxAttempts
+
+    if (isFinalAttempt) {
+      const [integration] = await db
+        .select({ throttleFailureCount: schema.Integration.throttleFailureCount })
+        .from(schema.Integration)
+        .where(eq(schema.Integration.id, integrationId))
+        .limit(1)
+
+      const newCount = (integration?.throttleFailureCount ?? 0) + 1
+      const backoffMs = Math.min(
+        BASE_THROTTLE_BACKOFF_MS * 2 ** (newCount - 1),
+        MAX_THROTTLE_BACKOFF_MS
+      )
+
+      await db
+        .update(schema.Integration)
+        .set({
+          syncStage: 'FAILED',
+          syncStatus: 'FAILED',
+          syncStageStartedAt: null,
+          throttleFailureCount: newCount,
+          throttleRetryAfter: new Date(Date.now() + backoffMs),
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.Integration.id, integrationId))
+
+      logger.warn('IMAP batch final attempt failed, throttling integration', {
+        integrationId,
+        labelId,
+        newCount,
+        backoffMs,
+      })
+    }
+
     throw error
   }
 }
@@ -362,8 +449,7 @@ async function maybeTransitionImapToIdle(integrationId: string, now: Date): Prom
 
   if (!hasActiveCheckpoints) {
     // Check if there's still incremental work in the Redis cache
-    const { getImportCacheSize: getCacheSize } = await import('../../email/polling-import-cache')
-    const remaining = await getCacheSize(integrationId)
+    const remaining = await getImportCacheSize(integrationId)
 
     if (remaining > 0) {
       // Still have incremental imports — let messagesImportJob handle transition

--- a/packages/lib/src/jobs/polling/polling-relaunch-failed-job.ts
+++ b/packages/lib/src/jobs/polling/polling-relaunch-failed-job.ts
@@ -4,6 +4,7 @@ import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
 import { and, eq, inArray } from 'drizzle-orm'
+import { getImportCacheSize, recoverProcessingBatch } from '../../email/polling-import-cache'
 import { resolveEffectiveSyncMode } from '../../providers/sync-mode-resolver'
 
 const logger = createScopedLogger('job:polling-relaunch-failed')
@@ -58,11 +59,17 @@ export const pollingRelaunchFailedJob = async (job: Job<PollingRelaunchFailedJob
     // Skip integrations still in backoff
     if (integration.throttleRetryAfter && integration.throttleRetryAfter > now) continue
 
-    // Reset to MESSAGE_LIST_FETCH_PENDING
+    // Recover any in-flight processing batch and check cache
+    const recovered = await recoverProcessingBatch(integration.id)
+    const cacheSize = await getImportCacheSize(integration.id)
+
+    // If cache has IDs, resume from MESSAGES_IMPORT_PENDING (cursor already advanced)
+    const resetStage = cacheSize > 0 ? 'MESSAGES_IMPORT_PENDING' : 'MESSAGE_LIST_FETCH_PENDING'
+
     await db
       .update(schema.Integration)
       .set({
-        syncStage: 'MESSAGE_LIST_FETCH_PENDING',
+        syncStage: resetStage,
         syncStatus: 'NOT_SYNCED',
         syncStageStartedAt: null,
         updatedAt: now,
@@ -74,6 +81,9 @@ export const pollingRelaunchFailedJob = async (job: Job<PollingRelaunchFailedJob
     logger.info('Relaunched failed integration', {
       integrationId: integration.id,
       provider: integration.provider,
+      resetStage,
+      recoveredFromProcessing: recovered,
+      cacheSize,
     })
   }
 

--- a/packages/lib/src/jobs/polling/polling-stale-check-job.ts
+++ b/packages/lib/src/jobs/polling/polling-stale-check-job.ts
@@ -4,7 +4,7 @@ import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
 import { and, eq, inArray, isNotNull, lt } from 'drizzle-orm'
-import { clearImportCache } from '../../email/polling-import-cache'
+import { getImportCacheSize, recoverProcessingBatch } from '../../email/polling-import-cache'
 import type { ImapFolderCheckpoint } from '../../providers/imap/types'
 import { getQueue } from '../queues'
 import { Queues } from '../queues/types'
@@ -23,6 +23,9 @@ export interface PollingStaleCheckJobData {
  *
  * For IMAP integrations with checkpoints, resumes from checkpoint state
  * instead of clearing all work.
+ *
+ * For Gmail/Outlook: preserves the Redis import cache so recovered jobs
+ * can resume importing rather than re-listing with an already-advanced cursor.
  */
 export const pollingStaleCheckJob = async (job: Job<PollingStaleCheckJobData>) => {
   const { staleThresholdMs = DEFAULT_STALE_THRESHOLD_MS } = job.data
@@ -82,22 +85,36 @@ export const pollingStaleCheckJob = async (job: Job<PollingStaleCheckJobData>) =
       }
     }
 
-    // Non-IMAP or no checkpoints: standard reset
+    // Recover any in-flight processing batch back to main cache
+    const recovered = await recoverProcessingBatch(integration.id)
+    if (recovered > 0) {
+      logger.info('Recovered processing batch during stale check', {
+        integrationId: integration.id,
+        recoveredCount: recovered,
+      })
+    }
+
+    // Check cache size to decide reset target
+    const cacheSize = await getImportCacheSize(integration.id)
+
+    // If cache has IDs, reset to MESSAGES_IMPORT_PENDING so they get imported
+    // (cursor is already advanced, re-listing would miss these IDs)
+    // If cache is empty, reset to MESSAGE_LIST_FETCH_PENDING to re-enter pipeline
+    const resetStage = cacheSize > 0 ? 'MESSAGES_IMPORT_PENDING' : 'MESSAGE_LIST_FETCH_PENDING'
+
     logger.warn('Resetting stale integration', {
       integrationId: integration.id,
       syncStage: integration.syncStage,
       stuckDurationMs,
       stuckMinutes: Math.round(stuckDurationMs / 60000),
+      cacheSize,
+      resetStage,
     })
 
-    // Clear Redis import cache (may contain partial/stale data)
-    await clearImportCache(integration.id)
-
-    // Reset to MESSAGE_LIST_FETCH_PENDING (re-enter pipeline from the top)
     await db
       .update(schema.Integration)
       .set({
-        syncStage: 'MESSAGE_LIST_FETCH_PENDING',
+        syncStage: resetStage,
         syncStageStartedAt: null,
         updatedAt: now,
       })
@@ -180,6 +197,15 @@ async function resumeImapFromCheckpoints(
   }
 
   if (resumedAny) {
+    // Recover any in-flight processing batch
+    const recovered = await recoverProcessingBatch(integrationId)
+    if (recovered > 0) {
+      logger.info('Recovered processing batch during IMAP resume', {
+        integrationId,
+        recoveredCount: recovered,
+      })
+    }
+
     // Re-enqueue list fetch job to continue from checkpoints
     await pollingSyncQueue.add(
       'messageListFetchJob',

--- a/packages/lib/src/jobs/polling/polling-sync-scanner-job.ts
+++ b/packages/lib/src/jobs/polling/polling-sync-scanner-job.ts
@@ -3,7 +3,7 @@
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, isNull, lt, or } from 'drizzle-orm'
 import { resolveEffectiveSyncMode } from '../../providers/sync-mode-resolver'
 import { getQueue } from '../queues'
 import { Queues } from '../queues/types'
@@ -11,6 +11,9 @@ import { Queues } from '../queues/types'
 const logger = createScopedLogger('job:polling-sync-scanner')
 
 const UNRECOVERABLE_AUTH_STATUSES = ['INVALID_GRANT', 'REVOKED_ACCESS', 'INSUFFICIENT_SCOPE']
+
+/** Minimum interval between enqueue claims to prevent double-enqueue from overlapping scanners */
+const CLAIM_COOLDOWN_MS = 30_000
 
 export interface PollingSyncScannerJobData {
   dryRun?: boolean
@@ -103,7 +106,7 @@ export const pollingSyncScannerJob = async (job: Job<PollingSyncScannerJobData>)
           continue
         }
 
-        // IDLE: check if sync is due
+        // IDLE: check if sync is due and atomically transition
         if (integration.syncStage === 'IDLE') {
           const intervalMs = integration.pollingIntervalMs ?? 300000 // 5 min default
           const isDue =
@@ -112,23 +115,27 @@ export const pollingSyncScannerJob = async (job: Job<PollingSyncScannerJobData>)
 
           if (!isDue) continue
 
-          // Transition to MESSAGE_LIST_FETCH_PENDING
           if (!dryRun) {
-            await db
+            // Atomic conditional UPDATE — only transition if still IDLE
+            const [updated] = await db
               .update(schema.Integration)
               .set({
                 syncStage: 'MESSAGE_LIST_FETCH_PENDING',
+                syncStageStartedAt: now,
                 updatedAt: now,
               })
-              .where(eq(schema.Integration.id, integration.id))
-          }
-        }
+              .where(
+                and(
+                  eq(schema.Integration.id, integration.id),
+                  eq(schema.Integration.syncStage, 'IDLE')
+                )
+              )
+              .returning({ id: schema.Integration.id })
 
-        // MESSAGE_LIST_FETCH_PENDING: enqueue list-fetch job
-        if (
-          integration.syncStage === 'MESSAGE_LIST_FETCH_PENDING' ||
-          integration.syncStage === 'IDLE' // Just transitioned above
-        ) {
+            if (!updated) continue // Another scanner already transitioned it
+          }
+
+          // Enqueue list-fetch job with unique ID
           if (!dryRun) {
             await pollingSyncQueue.add(
               'messageListFetchJob',
@@ -138,7 +145,7 @@ export const pollingSyncScannerJob = async (job: Job<PollingSyncScannerJobData>)
                 provider: integration.provider,
               },
               {
-                jobId: `poll-list-fetch-${integration.id}`,
+                jobId: `poll-list-fetch-${integration.id}-${Date.now()}`,
                 attempts: 3,
                 backoff: { type: 'exponential', delay: 60000 },
                 removeOnComplete: { count: 50 },
@@ -147,11 +154,75 @@ export const pollingSyncScannerJob = async (job: Job<PollingSyncScannerJobData>)
             )
           }
           stats.listFetchEnqueued++
+          continue
         }
 
-        // MESSAGES_IMPORT_PENDING: enqueue import job
+        // MESSAGE_LIST_FETCH_PENDING: atomically claim and enqueue list-fetch job
+        if (integration.syncStage === 'MESSAGE_LIST_FETCH_PENDING') {
+          if (!dryRun) {
+            const [claimed] = await db
+              .update(schema.Integration)
+              .set({ syncStageStartedAt: now, updatedAt: now })
+              .where(
+                and(
+                  eq(schema.Integration.id, integration.id),
+                  eq(schema.Integration.syncStage, 'MESSAGE_LIST_FETCH_PENDING'),
+                  or(
+                    isNull(schema.Integration.syncStageStartedAt),
+                    lt(
+                      schema.Integration.syncStageStartedAt,
+                      new Date(Date.now() - CLAIM_COOLDOWN_MS)
+                    )
+                  )
+                )
+              )
+              .returning({ id: schema.Integration.id })
+
+            if (!claimed) continue
+
+            await pollingSyncQueue.add(
+              'messageListFetchJob',
+              {
+                integrationId: integration.id,
+                organizationId: integration.organizationId,
+                provider: integration.provider,
+              },
+              {
+                jobId: `poll-list-fetch-${integration.id}-${Date.now()}`,
+                attempts: 3,
+                backoff: { type: 'exponential', delay: 60000 },
+                removeOnComplete: { count: 50 },
+                removeOnFail: { count: 100 },
+              }
+            )
+          }
+          stats.listFetchEnqueued++
+          continue
+        }
+
+        // MESSAGES_IMPORT_PENDING: atomically claim and enqueue import job
         if (integration.syncStage === 'MESSAGES_IMPORT_PENDING') {
           if (!dryRun) {
+            const [claimed] = await db
+              .update(schema.Integration)
+              .set({ syncStageStartedAt: now, updatedAt: now })
+              .where(
+                and(
+                  eq(schema.Integration.id, integration.id),
+                  eq(schema.Integration.syncStage, 'MESSAGES_IMPORT_PENDING'),
+                  or(
+                    isNull(schema.Integration.syncStageStartedAt),
+                    lt(
+                      schema.Integration.syncStageStartedAt,
+                      new Date(Date.now() - CLAIM_COOLDOWN_MS)
+                    )
+                  )
+                )
+              )
+              .returning({ id: schema.Integration.id })
+
+            if (!claimed) continue
+
             await pollingSyncQueue.add(
               'messagesImportJob',
               {
@@ -160,7 +231,7 @@ export const pollingSyncScannerJob = async (job: Job<PollingSyncScannerJobData>)
                 provider: integration.provider,
               },
               {
-                jobId: `poll-import-${integration.id}`,
+                jobId: `poll-import-${integration.id}-${Date.now()}`,
                 attempts: 3,
                 backoff: { type: 'exponential', delay: 30000 },
                 removeOnComplete: { count: 50 },
@@ -172,10 +243,6 @@ export const pollingSyncScannerJob = async (job: Job<PollingSyncScannerJobData>)
         }
       } catch (error: any) {
         stats.errors++
-        // Handle "Job already exists" — not an error
-        if (error.message?.includes('Job already exists')) {
-          continue
-        }
         logger.error('Error processing integration in scanner', {
           integrationId: integration.id,
           error: error.message,

--- a/packages/lib/src/providers/google/google-oauth.ts
+++ b/packages/lib/src/providers/google/google-oauth.ts
@@ -337,7 +337,13 @@ export class GoogleOAuthService {
             organizationId: orgId,
             provider: 'google',
           },
-          { jobId: `poll-list-fetch-${integration!.id}` }
+          {
+            jobId: `poll-list-fetch-${integration!.id}-${Date.now()}`,
+            attempts: 3,
+            backoff: { type: 'exponential', delay: 60000 },
+            removeOnComplete: { count: 50 },
+            removeOnFail: { count: 100 },
+          }
         )
 
         logger.info('Kicked off polling pipeline for new Google integration', {

--- a/packages/lib/src/providers/google/google-provider.ts
+++ b/packages/lib/src/providers/google/google-provider.ts
@@ -35,6 +35,7 @@ import { addLabel, createLabel, deleteLabel, getLabels, removeLabel, updateLabel
 // Import modular functions
 import { getMessagesBatch } from './messages/batch-fetch'
 import { createEmailMessage } from './messages/create-message'
+import { GmailInboundContentIngestor } from './messages/gmail-inbound-content-ingestor'
 import { convertMessagesToMessageData } from './messages/parse-message'
 import { sendGmailMessage } from './messages/send-message'
 import { syncGmailMessages } from './messages/sync-messages'
@@ -869,7 +870,7 @@ export class GoogleProvider
         if (messages.length === 0) break
 
         for (const msg of messages) {
-          if (msg.id) messageIds.push(msg.id)
+          if (msg.id) addedMessageIds.push(msg.id)
         }
 
         // We need to get historyId from the first batch of actual messages
@@ -932,37 +933,54 @@ export class GoogleProvider
 
     const accessToken = await this.getAccessToken()
 
-    const messages = await getMessagesBatch({
+    const { parsed, raw, failedMessageIds } = await getMessagesBatch({
       messageIds: externalIds,
       integrationId: this.integrationId!,
       throttler: this.throttler!,
       accessToken,
     })
 
-    if (messages.length === 0) {
+    if (failedMessageIds.length > 0) {
+      logger.warn('Some message IDs failed to fetch during import', {
+        integrationId: this.integrationId,
+        failedFetchCount: failedMessageIds.length,
+        failedFetchIds: failedMessageIds.slice(0, 20),
+      })
+    }
+
+    if (parsed.length === 0) {
       return { imported: 0, failed: externalIds.length }
     }
 
     const messageDataArray = convertMessagesToMessageData(
-      messages,
+      parsed,
+      raw,
       this.integrationId!,
       this.inboxId!,
       this.organizationId,
       this.userEmails
     )
 
-    const storedCount = await this.storageService.batchStoreMessages(messageDataArray)
+    const ingestor = new GmailInboundContentIngestor(this.organizationId, this.storageService)
+    const result = await ingestor.storeBatchWithIngest(messageDataArray, {
+      accessToken,
+      integrationId: this.integrationId!,
+      throttler: this.throttler!,
+    })
 
     logger.info('importMessages completed', {
       integrationId: this.integrationId,
       requested: externalIds.length,
-      fetched: messages.length,
-      stored: storedCount,
+      fetched: parsed.length,
+      stored: result.storedCount,
+      failedIngest: result.failedCount,
+      retriableFailures: result.retriableFailures.length,
+      failedExternalIds: result.failedExternalIds.slice(0, 20),
     })
 
     return {
-      imported: storedCount,
-      failed: externalIds.length - storedCount,
+      imported: result.storedCount,
+      failed: externalIds.length - result.storedCount,
     }
   }
 

--- a/packages/lib/src/providers/google/messages/__tests__/gmail-attachment-fetcher.test.ts
+++ b/packages/lib/src/providers/google/messages/__tests__/gmail-attachment-fetcher.test.ts
@@ -1,0 +1,213 @@
+// packages/lib/src/providers/google/messages/__tests__/gmail-attachment-fetcher.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MessageAttachmentMeta } from '../../../../email/email-storage'
+
+const mocks = vi.hoisted(() => {
+  return {
+    executeWithThrottle: vi.fn(),
+  }
+})
+
+vi.mock('../../shared/utils', () => ({
+  executeWithThrottle: mocks.executeWithThrottle,
+}))
+
+vi.mock('../../../../utils/rate-limiter', () => ({
+  getGmailQuotaCost: () => 5,
+}))
+
+import {
+  fetchAllGmailAttachmentBytes,
+  fetchGmailAttachmentBytes,
+} from '../gmail-attachment-fetcher'
+
+const baseContext = {
+  accessToken: 'ya29.test-token',
+  integrationId: 'int_123',
+  throttler: {} as any,
+}
+
+function makeAttMeta(overrides: Partial<MessageAttachmentMeta> = {}): MessageAttachmentMeta {
+  return {
+    filename: 'file.bin',
+    mimeType: 'application/octet-stream',
+    size: 100,
+    inline: false,
+    contentId: null,
+    providerAttachmentId: null,
+    embeddedData: null,
+    ...overrides,
+  }
+}
+
+describe('fetchGmailAttachmentBytes', () => {
+  beforeEach(() => {
+    mocks.executeWithThrottle.mockReset()
+  })
+
+  it('fetches and decodes base64url data from Gmail API', async () => {
+    // "hello world" in base64url
+    const base64urlData = 'aGVsbG8gd29ybGQ'
+
+    mocks.executeWithThrottle.mockImplementation(async (_op: string, fn: () => Promise<any>) => {
+      // Simulate the fetch function
+      return {
+        ok: true,
+        json: async () => ({ data: base64urlData, size: 11 }),
+      }
+    })
+
+    const result = await fetchGmailAttachmentBytes('msg_abc', 'att_xyz', baseContext)
+
+    expect(result).toBeInstanceOf(Buffer)
+    expect(result.toString('utf-8')).toBe('hello world')
+    expect(mocks.executeWithThrottle).toHaveBeenCalledOnce()
+  })
+
+  it('throws on non-ok response', async () => {
+    mocks.executeWithThrottle.mockImplementation(async (_op: string, fn: () => Promise<any>) => {
+      return {
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+      }
+    })
+
+    await expect(fetchGmailAttachmentBytes('msg_abc', 'att_xyz', baseContext)).rejects.toThrow(
+      'Gmail attachment fetch failed: 429 Too Many Requests'
+    )
+  })
+})
+
+describe('fetchAllGmailAttachmentBytes', () => {
+  beforeEach(() => {
+    mocks.executeWithThrottle.mockReset()
+  })
+
+  it('decodes embedded data without API call', async () => {
+    // "embedded" in base64url
+    const base64urlData = 'ZW1iZWRkZWQ'
+
+    const attachments = [makeAttMeta({ embeddedData: base64urlData })]
+
+    const { resolved, failedCount } = await fetchAllGmailAttachmentBytes(
+      'msg_001',
+      attachments,
+      baseContext
+    )
+
+    expect(failedCount).toBe(0)
+    expect(resolved.size).toBe(1)
+    expect(resolved.get(0)!.toString('utf-8')).toBe('embedded')
+    // No API call for embedded data
+    expect(mocks.executeWithThrottle).not.toHaveBeenCalled()
+  })
+
+  it('fetches large attachment via API', async () => {
+    const apiData = 'YXBpLWZldGNoZWQ' // "api-fetched"
+
+    mocks.executeWithThrottle.mockImplementation(async () => ({
+      ok: true,
+      json: async () => ({ data: apiData, size: 11 }),
+    }))
+
+    const attachments = [makeAttMeta({ providerAttachmentId: 'att_large_1' })]
+
+    const { resolved, failedCount } = await fetchAllGmailAttachmentBytes(
+      'msg_002',
+      attachments,
+      baseContext
+    )
+
+    expect(failedCount).toBe(0)
+    expect(resolved.size).toBe(1)
+    expect(resolved.get(0)!.toString('utf-8')).toBe('api-fetched')
+    expect(mocks.executeWithThrottle).toHaveBeenCalledOnce()
+  })
+
+  it('increments failedCount on fetch failure without throwing', async () => {
+    mocks.executeWithThrottle.mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    }))
+
+    const attachments = [makeAttMeta({ providerAttachmentId: 'att_fail_1' })]
+
+    const { resolved, failedCount } = await fetchAllGmailAttachmentBytes(
+      'msg_003',
+      attachments,
+      baseContext
+    )
+
+    expect(failedCount).toBe(1)
+    expect(resolved.size).toBe(0)
+  })
+
+  it('increments failedCount when neither embeddedData nor providerAttachmentId', async () => {
+    const attachments = [makeAttMeta({ embeddedData: null, providerAttachmentId: null })]
+
+    const { resolved, failedCount } = await fetchAllGmailAttachmentBytes(
+      'msg_004',
+      attachments,
+      baseContext
+    )
+
+    expect(failedCount).toBe(1)
+    expect(resolved.size).toBe(0)
+  })
+
+  it('handles mixed embedded + API-fetched attachments', async () => {
+    const embeddedB64 = 'ZW1i' // "emb"
+    const apiB64 = 'YXBp' // "api"
+
+    mocks.executeWithThrottle.mockImplementation(async () => ({
+      ok: true,
+      json: async () => ({ data: apiB64, size: 3 }),
+    }))
+
+    const attachments = [
+      makeAttMeta({ embeddedData: embeddedB64 }),
+      makeAttMeta({ providerAttachmentId: 'att_api_1' }),
+    ]
+
+    const { resolved, failedCount } = await fetchAllGmailAttachmentBytes(
+      'msg_005',
+      attachments,
+      baseContext
+    )
+
+    expect(failedCount).toBe(0)
+    expect(resolved.size).toBe(2)
+    expect(resolved.get(0)!.toString('utf-8')).toBe('emb')
+    expect(resolved.get(1)!.toString('utf-8')).toBe('api')
+    // Only one API call (for the non-embedded attachment)
+    expect(mocks.executeWithThrottle).toHaveBeenCalledOnce()
+  })
+
+  it('continues processing after a single fetch failure', async () => {
+    const embeddedB64 = 'b2s' // "ok"
+
+    mocks.executeWithThrottle.mockImplementation(async () => ({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    }))
+
+    const attachments = [
+      makeAttMeta({ providerAttachmentId: 'att_will_fail' }),
+      makeAttMeta({ embeddedData: embeddedB64 }),
+    ]
+
+    const { resolved, failedCount } = await fetchAllGmailAttachmentBytes(
+      'msg_006',
+      attachments,
+      baseContext
+    )
+
+    expect(failedCount).toBe(1)
+    expect(resolved.size).toBe(1)
+    expect(resolved.get(1)!.toString('utf-8')).toBe('ok')
+  })
+})

--- a/packages/lib/src/providers/google/messages/__tests__/gmail-inbound-content-ingestor.test.ts
+++ b/packages/lib/src/providers/google/messages/__tests__/gmail-inbound-content-ingestor.test.ts
@@ -1,0 +1,406 @@
+// packages/lib/src/providers/google/messages/__tests__/gmail-inbound-content-ingestor.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  return {
+    ingestBody: vi.fn(),
+    ingestAll: vi.fn(),
+    fetchAllGmailAttachmentBytes: vi.fn(),
+    storeMessage: vi.fn(),
+  }
+})
+
+vi.mock('../../../../email/inbound/body-ingest.service', () => ({
+  InboundBodyIngestService: class {
+    ingestBody = mocks.ingestBody
+  },
+}))
+
+vi.mock('../../../../email/inbound/attachment-ingest.service', () => ({
+  InboundAttachmentIngestService: class {
+    ingestAll = mocks.ingestAll
+  },
+}))
+
+vi.mock('../gmail-attachment-fetcher', () => ({
+  fetchAllGmailAttachmentBytes: mocks.fetchAllGmailAttachmentBytes,
+}))
+
+import type { MessageData, MessageStorageService } from '../../../../email/email-storage'
+import { GmailInboundContentIngestor } from '../gmail-inbound-content-ingestor'
+
+function makeStorageService(): MessageStorageService {
+  return {
+    storeMessage: mocks.storeMessage,
+  } as any
+}
+
+const fetchContext = {
+  accessToken: 'ya29.test',
+  integrationId: 'int_1',
+  throttler: {} as any,
+}
+
+function makeMessageData(overrides: Partial<MessageData> = {}): MessageData {
+  return {
+    externalId: 'gmail_msg_abc',
+    externalThreadId: 'thread_1',
+    integrationId: 'int_1',
+    organizationId: 'org_1',
+    isInbound: true,
+    hasAttachments: false,
+    from: { identifier: 'sender@example.com' },
+    to: [{ identifier: 'user@example.com' }],
+    createdTime: new Date('2025-01-01'),
+    sentAt: new Date('2025-01-01'),
+    receivedAt: new Date('2025-01-01'),
+    textHtml: '<p>Hello</p>',
+    textPlain: 'Hello',
+    snippet: 'Hello',
+    ...overrides,
+  } as MessageData
+}
+
+describe('GmailInboundContentIngestor', () => {
+  beforeEach(() => {
+    mocks.ingestBody.mockReset()
+    mocks.ingestAll.mockReset()
+    mocks.fetchAllGmailAttachmentBytes.mockReset()
+    mocks.storeMessage.mockReset()
+
+    mocks.ingestBody.mockResolvedValue({ htmlBodyStorageLocationId: 'sl_body_1' })
+    mocks.storeMessage.mockResolvedValue('msg_stored_1')
+    mocks.ingestAll.mockResolvedValue([])
+    mocks.fetchAllGmailAttachmentBytes.mockResolvedValue({
+      resolved: new Map(),
+      failedCount: 0,
+    })
+  })
+
+  it('skips body and attachment ingest for outbound messages', async () => {
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+
+    const msg = makeMessageData({ isInbound: false })
+    const result = await ingestor.storeBatchWithIngest([msg], fetchContext)
+
+    expect(result.storedCount).toBe(1)
+    expect(result.failedCount).toBe(0)
+    expect(mocks.storeMessage).toHaveBeenCalledOnce()
+    expect(mocks.ingestBody).not.toHaveBeenCalled()
+    expect(mocks.fetchAllGmailAttachmentBytes).not.toHaveBeenCalled()
+    expect(mocks.ingestAll).not.toHaveBeenCalled()
+  })
+
+  it('calls body ingest with externalId as contentScopeId for inbound messages', async () => {
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+
+    await ingestor.storeBatchWithIngest(
+      [makeMessageData({ externalId: 'gmail_123' })],
+      fetchContext
+    )
+
+    expect(mocks.ingestBody).toHaveBeenCalledWith(
+      { textHtml: '<p>Hello</p>' },
+      { organizationId: 'org_1', contentScopeId: 'gmail_123' }
+    )
+  })
+
+  it('sets htmlBodyStorageLocationId on MessageData before storeMessage', async () => {
+    mocks.ingestBody.mockResolvedValue({ htmlBodyStorageLocationId: 'sl_body_99' })
+
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+    await ingestor.storeBatchWithIngest([makeMessageData()], fetchContext)
+
+    const storedMsg = mocks.storeMessage.mock.calls[0]![0] as MessageData
+    expect(storedMsg.htmlBodyStorageLocationId).toBe('sl_body_99')
+  })
+
+  it('skips body ingest when textHtml is empty', async () => {
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+
+    await ingestor.storeBatchWithIngest([makeMessageData({ textHtml: '' })], fetchContext)
+
+    expect(mocks.ingestBody).not.toHaveBeenCalled()
+  })
+
+  it('fetches attachment bytes for inbound message with providerAttachments', async () => {
+    const providerAttachments = [
+      {
+        filename: 'doc.pdf',
+        mimeType: 'application/pdf',
+        size: 5000,
+        inline: false,
+        contentId: null,
+        providerAttachmentId: 'att_gmail_1',
+        embeddedData: null,
+      },
+    ]
+
+    const bytesMap = new Map([[0, Buffer.from('pdf-bytes')]])
+    mocks.fetchAllGmailAttachmentBytes.mockResolvedValue({
+      resolved: bytesMap,
+      failedCount: 0,
+    })
+
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+    await ingestor.storeBatchWithIngest(
+      [makeMessageData({ providerAttachments, hasAttachments: true })],
+      fetchContext
+    )
+
+    expect(mocks.fetchAllGmailAttachmentBytes).toHaveBeenCalledWith(
+      'gmail_msg_abc',
+      providerAttachments,
+      fetchContext
+    )
+  })
+
+  it('passes fetched bytes to ingestAll with correct inputs', async () => {
+    const providerAttachments = [
+      {
+        filename: 'image.png',
+        mimeType: 'image/png',
+        size: 1000,
+        inline: true,
+        contentId: 'cid@mail',
+        providerAttachmentId: null,
+        embeddedData: 'aW1hZ2VkYXRh',
+      },
+    ]
+
+    const decodedBytes = Buffer.from('imagedata')
+    mocks.fetchAllGmailAttachmentBytes.mockResolvedValue({
+      resolved: new Map([[0, decodedBytes]]),
+      failedCount: 0,
+    })
+
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+    await ingestor.storeBatchWithIngest(
+      [makeMessageData({ providerAttachments, hasAttachments: true })],
+      fetchContext
+    )
+
+    expect(mocks.ingestAll).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          content: decodedBytes,
+          filename: 'image.png',
+          mimeType: 'image/png',
+          inline: true,
+          contentId: 'cid@mail',
+          attachmentOrder: 0,
+        }),
+      ],
+      expect.objectContaining({
+        organizationId: 'org_1',
+        messageId: 'msg_stored_1',
+        contentScopeId: 'gmail_msg_abc',
+      }),
+      { skipReconciliation: false }
+    )
+  })
+
+  it('skips attachment with failed fetch (no 0-byte asset)', async () => {
+    const providerAttachments = [
+      {
+        filename: 'ok.png',
+        mimeType: 'image/png',
+        size: 100,
+        inline: false,
+        contentId: null,
+        providerAttachmentId: 'att_ok',
+        embeddedData: null,
+      },
+      {
+        filename: 'fail.pdf',
+        mimeType: 'application/pdf',
+        size: 200,
+        inline: false,
+        contentId: null,
+        providerAttachmentId: 'att_fail',
+        embeddedData: null,
+      },
+    ]
+
+    // Only index 0 resolved; index 1 failed
+    mocks.fetchAllGmailAttachmentBytes.mockResolvedValue({
+      resolved: new Map([[0, Buffer.from('ok-bytes')]]),
+      failedCount: 1,
+    })
+
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+    await ingestor.storeBatchWithIngest(
+      [makeMessageData({ providerAttachments, hasAttachments: true })],
+      fetchContext
+    )
+
+    // Only 1 attachment passed to ingestAll (the successful one)
+    const ingestInputs = mocks.ingestAll.mock.calls[0]![0]
+    expect(ingestInputs).toHaveLength(1)
+    expect(ingestInputs[0].filename).toBe('ok.png')
+  })
+
+  it('passes skipReconciliation: true when any fetch failed', async () => {
+    const providerAttachments = [
+      {
+        filename: 'ok.png',
+        mimeType: 'image/png',
+        size: 100,
+        inline: false,
+        contentId: null,
+        providerAttachmentId: 'att_ok',
+        embeddedData: null,
+      },
+    ]
+
+    mocks.fetchAllGmailAttachmentBytes.mockResolvedValue({
+      resolved: new Map([[0, Buffer.from('bytes')]]),
+      failedCount: 1,
+    })
+
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+    await ingestor.storeBatchWithIngest(
+      [makeMessageData({ providerAttachments, hasAttachments: true })],
+      fetchContext
+    )
+
+    const options = mocks.ingestAll.mock.calls[0]![2]
+    expect(options).toEqual({ skipReconciliation: true })
+  })
+
+  it('passes skipReconciliation: false when all fetches succeed', async () => {
+    const providerAttachments = [
+      {
+        filename: 'doc.pdf',
+        mimeType: 'application/pdf',
+        size: 100,
+        inline: false,
+        contentId: null,
+        providerAttachmentId: 'att_1',
+        embeddedData: null,
+      },
+    ]
+
+    mocks.fetchAllGmailAttachmentBytes.mockResolvedValue({
+      resolved: new Map([[0, Buffer.from('data')]]),
+      failedCount: 0,
+    })
+
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+    await ingestor.storeBatchWithIngest(
+      [makeMessageData({ providerAttachments, hasAttachments: true })],
+      fetchContext
+    )
+
+    const options = mocks.ingestAll.mock.calls[0]![2]
+    expect(options).toEqual({ skipReconciliation: false })
+  })
+
+  it('preserves chronological sort in batch', async () => {
+    const storedOrder: string[] = []
+    mocks.storeMessage.mockImplementation(async (msg: MessageData) => {
+      storedOrder.push(msg.externalId)
+      return `stored_${msg.externalId}`
+    })
+
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+
+    const messages = [
+      makeMessageData({ externalId: 'msg_c', sentAt: new Date('2025-01-03'), isInbound: false }),
+      makeMessageData({ externalId: 'msg_a', sentAt: new Date('2025-01-01'), isInbound: false }),
+      makeMessageData({ externalId: 'msg_b', sentAt: new Date('2025-01-02'), isInbound: false }),
+    ]
+
+    await ingestor.storeBatchWithIngest(messages, fetchContext)
+
+    expect(storedOrder).toEqual(['msg_a', 'msg_b', 'msg_c'])
+  })
+
+  it('returns empty result for empty batch', async () => {
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+
+    const result = await ingestor.storeBatchWithIngest([], fetchContext)
+
+    expect(result.storedCount).toBe(0)
+    expect(result.failedCount).toBe(0)
+    expect(result.failedExternalIds).toEqual([])
+    expect(mocks.storeMessage).not.toHaveBeenCalled()
+  })
+
+  it('continues processing remaining messages when one fails and reports failures', async () => {
+    mocks.storeMessage.mockRejectedValueOnce(new Error('DB error')).mockResolvedValueOnce('msg_2')
+
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+
+    const messages = [
+      makeMessageData({ externalId: 'msg_fail', isInbound: false }),
+      makeMessageData({ externalId: 'msg_ok', isInbound: false }),
+    ]
+
+    const result = await ingestor.storeBatchWithIngest(messages, fetchContext)
+
+    expect(result.storedCount).toBe(1)
+    expect(result.failedCount).toBe(1)
+    expect(result.failedExternalIds).toContain('msg_fail')
+    expect(result.retriableFailures).toHaveLength(1)
+    expect(mocks.storeMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not call ingestAll when no providerAttachments', async () => {
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+
+    await ingestor.storeBatchWithIngest([makeMessageData()], fetchContext)
+
+    expect(mocks.fetchAllGmailAttachmentBytes).not.toHaveBeenCalled()
+    expect(mocks.ingestAll).not.toHaveBeenCalled()
+  })
+
+  it('stores message even when body ingest throws (degraded ingest, fail-open)', async () => {
+    mocks.ingestBody.mockRejectedValue(new Error('S3 lookup failed'))
+
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+
+    const result = await ingestor.storeBatchWithIngest(
+      [makeMessageData({ externalId: 'msg_degraded' })],
+      fetchContext
+    )
+
+    expect(result.storedCount).toBe(1)
+    expect(result.failedCount).toBe(0)
+    expect(mocks.storeMessage).toHaveBeenCalledOnce()
+    // htmlBodyStorageLocationId should not be set since ingest failed
+    const storedMsg = mocks.storeMessage.mock.calls[0]![0] as MessageData
+    expect(storedMsg.htmlBodyStorageLocationId).toBeUndefined()
+  })
+
+  it('classifies constraint violations as non-retriable failures', async () => {
+    mocks.storeMessage.mockRejectedValueOnce(new Error('unique constraint violation'))
+
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+
+    const result = await ingestor.storeBatchWithIngest(
+      [makeMessageData({ externalId: 'msg_dup', isInbound: false })],
+      fetchContext
+    )
+
+    expect(result.failedCount).toBe(1)
+    expect(result.nonRetriableFailures).toHaveLength(1)
+    expect(result.retriableFailures).toHaveLength(0)
+  })
+
+  it('classifies connection errors as retriable failures', async () => {
+    mocks.storeMessage.mockRejectedValueOnce(new Error('connection refused'))
+
+    const ingestor = new GmailInboundContentIngestor('org_1', makeStorageService())
+
+    const result = await ingestor.storeBatchWithIngest(
+      [makeMessageData({ externalId: 'msg_conn', isInbound: false })],
+      fetchContext
+    )
+
+    expect(result.failedCount).toBe(1)
+    expect(result.retriableFailures).toHaveLength(1)
+    expect(result.nonRetriableFailures).toHaveLength(0)
+  })
+})

--- a/packages/lib/src/providers/google/messages/__tests__/parse-message.test.ts
+++ b/packages/lib/src/providers/google/messages/__tests__/parse-message.test.ts
@@ -1,0 +1,364 @@
+// packages/lib/src/providers/google/messages/__tests__/parse-message.test.ts
+
+import type { gmail_v1 } from 'googleapis'
+import { describe, expect, it } from 'vitest'
+import { extractPayloadAttachments } from '../parse-message'
+
+function makeHeader(name: string, value: string): gmail_v1.Schema$MessagePartHeader {
+  return { name, value }
+}
+
+function makePart(
+  overrides: Partial<gmail_v1.Schema$MessagePart> = {}
+): gmail_v1.Schema$MessagePart {
+  return {
+    mimeType: 'application/octet-stream',
+    filename: '',
+    headers: [],
+    body: { size: 0 },
+    ...overrides,
+  }
+}
+
+describe('extractPayloadAttachments', () => {
+  it('extracts small inline image with embedded body.data (no attachmentId)', () => {
+    const payload = makePart({
+      mimeType: 'multipart/mixed',
+      body: { size: 0 },
+      parts: [
+        makePart({
+          mimeType: 'text/html',
+          body: { size: 100, data: 'PGh0bWw-' },
+        }),
+        makePart({
+          mimeType: 'image/png',
+          filename: 'logo.png',
+          headers: [
+            makeHeader('Content-Disposition', 'inline; filename="logo.png"'),
+            makeHeader('Content-ID', '<img001@example.com>'),
+          ],
+          body: { size: 1024, data: 'iVBORw0KGgo' },
+        }),
+      ],
+    })
+
+    const result = extractPayloadAttachments(payload)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      filename: 'logo.png',
+      mimeType: 'image/png',
+      size: 1024,
+      inline: true,
+      contentId: 'img001@example.com',
+      gmailAttachmentId: null,
+      embeddedData: 'iVBORw0KGgo',
+    })
+  })
+
+  it('extracts large inline image with attachmentId (no embedded data)', () => {
+    const payload = makePart({
+      mimeType: 'multipart/related',
+      parts: [
+        makePart({
+          mimeType: 'text/html',
+          body: { size: 200 },
+        }),
+        makePart({
+          mimeType: 'image/jpeg',
+          filename: 'photo.jpg',
+          headers: [
+            makeHeader('Content-Disposition', 'inline; filename="photo.jpg"'),
+            makeHeader('Content-ID', '<photo001@example.com>'),
+          ],
+          body: { size: 500000, attachmentId: 'ANGjdJ8abc123' },
+        }),
+      ],
+    })
+
+    const result = extractPayloadAttachments(payload)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      filename: 'photo.jpg',
+      mimeType: 'image/jpeg',
+      size: 500000,
+      inline: true,
+      contentId: 'photo001@example.com',
+      gmailAttachmentId: 'ANGjdJ8abc123',
+      embeddedData: null,
+    })
+  })
+
+  it('extracts non-inline attachment with attachmentId', () => {
+    const payload = makePart({
+      mimeType: 'multipart/mixed',
+      parts: [
+        makePart({
+          mimeType: 'text/plain',
+          body: { size: 50 },
+        }),
+        makePart({
+          mimeType: 'application/pdf',
+          filename: 'invoice.pdf',
+          headers: [makeHeader('Content-Disposition', 'attachment; filename="invoice.pdf"')],
+          body: { size: 200000, attachmentId: 'ANGjdJ8xyz789' },
+        }),
+      ],
+    })
+
+    const result = extractPayloadAttachments(payload)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      filename: 'invoice.pdf',
+      mimeType: 'application/pdf',
+      size: 200000,
+      inline: false,
+      contentId: null,
+      gmailAttachmentId: 'ANGjdJ8xyz789',
+      embeddedData: null,
+    })
+  })
+
+  it('strips angle brackets from Content-ID header', () => {
+    const payload = makePart({
+      mimeType: 'multipart/related',
+      parts: [
+        makePart({
+          mimeType: 'image/gif',
+          filename: 'anim.gif',
+          headers: [
+            makeHeader('Content-ID', '<my-cid@host.com>'),
+            makeHeader('Content-Disposition', 'inline'),
+          ],
+          body: { size: 100, data: 'R0lGODlh' },
+        }),
+      ],
+    })
+
+    const result = extractPayloadAttachments(payload)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.contentId).toBe('my-cid@host.com')
+  })
+
+  it('does not include text/html or text/plain body parts as attachments', () => {
+    const payload = makePart({
+      mimeType: 'multipart/alternative',
+      parts: [
+        makePart({
+          mimeType: 'text/plain',
+          body: { size: 50, data: 'SGVsbG8' },
+        }),
+        makePart({
+          mimeType: 'text/html',
+          body: { size: 200, data: 'PGh0bWw-' },
+        }),
+      ],
+    })
+
+    const result = extractPayloadAttachments(payload)
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('treats text/html with Content-Disposition: attachment as a file part', () => {
+    const payload = makePart({
+      mimeType: 'multipart/mixed',
+      parts: [
+        makePart({
+          mimeType: 'text/html',
+          filename: 'report.html',
+          headers: [makeHeader('Content-Disposition', 'attachment; filename="report.html"')],
+          body: { size: 5000, attachmentId: 'ANGjdJ8html' },
+        }),
+      ],
+    })
+
+    const result = extractPayloadAttachments(payload)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.filename).toBe('report.html')
+    expect(result[0]!.inline).toBe(false)
+  })
+
+  it('handles mixed content: multiple inline + attachment parts in nested multipart', () => {
+    const payload = makePart({
+      mimeType: 'multipart/mixed',
+      parts: [
+        makePart({
+          mimeType: 'multipart/related',
+          parts: [
+            makePart({
+              mimeType: 'multipart/alternative',
+              parts: [
+                makePart({ mimeType: 'text/plain', body: { size: 50 } }),
+                makePart({ mimeType: 'text/html', body: { size: 200 } }),
+              ],
+            }),
+            makePart({
+              mimeType: 'image/png',
+              filename: 'inline1.png',
+              headers: [
+                makeHeader('Content-Disposition', 'inline'),
+                makeHeader('Content-ID', '<cid1@mail>'),
+              ],
+              body: { size: 500, data: 'aW1hZ2UxZGF0YQ' },
+            }),
+            makePart({
+              mimeType: 'image/jpeg',
+              filename: 'inline2.jpg',
+              headers: [
+                makeHeader('Content-Disposition', 'inline'),
+                makeHeader('Content-ID', '<cid2@mail>'),
+              ],
+              body: { size: 80000, attachmentId: 'att_inline2' },
+            }),
+          ],
+        }),
+        makePart({
+          mimeType: 'application/zip',
+          filename: 'files.zip',
+          headers: [makeHeader('Content-Disposition', 'attachment; filename="files.zip"')],
+          body: { size: 300000, attachmentId: 'att_zip' },
+        }),
+      ],
+    })
+
+    const result = extractPayloadAttachments(payload)
+
+    expect(result).toHaveLength(3)
+
+    // Inline 1 — small embedded
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        filename: 'inline1.png',
+        inline: true,
+        contentId: 'cid1@mail',
+        embeddedData: 'aW1hZ2UxZGF0YQ',
+        gmailAttachmentId: null,
+      })
+    )
+
+    // Inline 2 — large, needs API fetch
+    expect(result[1]).toEqual(
+      expect.objectContaining({
+        filename: 'inline2.jpg',
+        inline: true,
+        contentId: 'cid2@mail',
+        gmailAttachmentId: 'att_inline2',
+        embeddedData: null,
+      })
+    )
+
+    // Non-inline attachment
+    expect(result[2]).toEqual(
+      expect.objectContaining({
+        filename: 'files.zip',
+        inline: false,
+        contentId: null,
+        gmailAttachmentId: 'att_zip',
+      })
+    )
+  })
+
+  it('captures inline image with Content-ID but no Content-Disposition', () => {
+    const payload = makePart({
+      mimeType: 'multipart/related',
+      parts: [
+        makePart({ mimeType: 'text/html', body: { size: 100 } }),
+        makePart({
+          mimeType: 'image/png',
+          filename: 'no-disp.png',
+          headers: [makeHeader('Content-ID', '<nodispcid@example>')],
+          body: { size: 2048, data: 'c21hbGxkYXRh' },
+        }),
+      ],
+    })
+
+    const result = extractPayloadAttachments(payload)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.inline).toBe(true)
+    expect(result[0]!.contentId).toBe('nodispcid@example')
+    expect(result[0]!.embeddedData).toBe('c21hbGxkYXRh')
+  })
+
+  it('captures part with filename but no Content-Disposition and no attachmentId', () => {
+    const payload = makePart({
+      mimeType: 'multipart/mixed',
+      parts: [
+        makePart({
+          mimeType: 'application/octet-stream',
+          filename: 'mystery.bin',
+          headers: [],
+          body: { size: 512, data: 'ZmlsZWRhdGE' },
+        }),
+      ],
+    })
+
+    const result = extractPayloadAttachments(payload)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.filename).toBe('mystery.bin')
+    expect(result[0]!.embeddedData).toBe('ZmlsZWRhdGE')
+  })
+
+  it('marks attachment-disposition parts as not inline even if Content-ID is present', () => {
+    const payload = makePart({
+      mimeType: 'multipart/mixed',
+      parts: [
+        makePart({
+          mimeType: 'image/png',
+          filename: 'attached-img.png',
+          headers: [
+            makeHeader('Content-Disposition', 'attachment; filename="attached-img.png"'),
+            makeHeader('Content-ID', '<attached-cid@example>'),
+          ],
+          body: { size: 10000, attachmentId: 'att_attached_img' },
+        }),
+      ],
+    })
+
+    const result = extractPayloadAttachments(payload)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.inline).toBe(false)
+    expect(result[0]!.contentId).toBe('attached-cid@example')
+  })
+
+  it('returns empty array for payload with no attachment parts', () => {
+    const payload = makePart({
+      mimeType: 'multipart/alternative',
+      parts: [
+        makePart({ mimeType: 'text/plain', body: { size: 20 } }),
+        makePart({ mimeType: 'text/html', body: { size: 100 } }),
+      ],
+    })
+
+    const result = extractPayloadAttachments(payload)
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('defaults filename to "attachment" and mimeType to "application/octet-stream"', () => {
+    const payload = makePart({
+      mimeType: 'multipart/mixed',
+      parts: [
+        makePart({
+          mimeType: undefined as any,
+          filename: '',
+          headers: [makeHeader('Content-ID', '<fallback@example>')],
+          body: { size: 100, data: 'dGVzdA' },
+        }),
+      ],
+    })
+
+    const result = extractPayloadAttachments(payload)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.filename).toBe('attachment')
+    expect(result[0]!.mimeType).toBe('application/octet-stream')
+  })
+})

--- a/packages/lib/src/providers/google/messages/batch-fetch.ts
+++ b/packages/lib/src/providers/google/messages/batch-fetch.ts
@@ -10,8 +10,11 @@ import type { GmailMessageWithPayload, ParsedGmailMessage } from '../types'
 
 const logger = createScopedLogger('google-batch-fetch')
 
-const BATCH_LIMIT = 50 // Maximum messages per batch request
-const INTER_BATCH_DELAY_MS = 250 // Delay between batches to prevent rate limiting
+const BATCH_LIMIT = 20 // Max messages per batch request (reduced from 50 to avoid per-item 429s)
+const RETRY_BATCH_LIMIT = 5 // Smaller batch size for retry attempts
+const MAX_ITEM_RETRIES = 2 // Max retry rounds for item-level 429 failures
+const INTER_BATCH_DELAY_MS = 500 // Delay between batches
+const RETRY_BASE_DELAY_MS = 1000 // Base delay for retry backoff
 const BATCH_REQUEST_TIMEOUT_MS = 30000 // 30 second timeout for each batch request
 
 /**
@@ -26,10 +29,6 @@ export interface GetMessagesBatchInput {
 
 /**
  * Wrap a promise with a timeout
- * @param promise - Promise to wrap
- * @param timeoutMs - Timeout in milliseconds
- * @param operationName - Name of the operation for error messages
- * @returns Promise that rejects if timeout is exceeded
  */
 async function withTimeout<T>(
   promise: Promise<T>,
@@ -55,19 +54,28 @@ async function withTimeout<T>(
 }
 
 /**
- * Fetches multiple Gmail messages in batches using Gmail batch API
- * @param input - Batch fetch parameters
- * @returns Array of parsed Gmail messages
+ * Result of batch fetching Gmail messages.
+ * Contains both parsed messages (for headers, body) and raw messages (for attachment extraction).
+ * Also surfaces IDs that could not be fetched after retries.
  */
-export async function getMessagesBatch(
-  input: GetMessagesBatchInput
-): Promise<ParsedGmailMessage[]> {
+export interface BatchFetchResult {
+  parsed: ParsedGmailMessage[]
+  raw: GmailMessageWithPayload[]
+  failedMessageIds: string[]
+}
+
+/**
+ * Fetches multiple Gmail messages in batches using Gmail batch API.
+ * Item-level 429 errors are retried with exponential backoff and smaller batches.
+ */
+export async function getMessagesBatch(input: GetMessagesBatchInput): Promise<BatchFetchResult> {
   const { messageIds, integrationId, throttler, accessToken } = input
 
-  if (messageIds.length === 0) return []
+  if (messageIds.length === 0) return { parsed: [], raw: [], failedMessageIds: [] }
 
   logger.info('Starting batch fetch', {
     totalMessages: messageIds.length,
+    batchSize: BATCH_LIMIT,
     integrationId,
   })
 
@@ -81,9 +89,10 @@ export async function getMessagesBatch(
   }
 
   const allMessages: ParsedGmailMessage[] = []
+  const allRawMessages: GmailMessageWithPayload[] = []
+  const allFailedIds: string[] = []
   const totalBatches = Math.ceil(limitedMessageIds.length / BATCH_LIMIT)
 
-  // Process in chunks of BATCH_LIMIT with delays between batches
   for (let i = 0; i < limitedMessageIds.length; i += BATCH_LIMIT) {
     const batchIds = limitedMessageIds.slice(i, i + BATCH_LIMIT)
     const batchNumber = Math.floor(i / BATCH_LIMIT) + 1
@@ -96,71 +105,33 @@ export async function getMessagesBatch(
     })
 
     try {
-      // Wrap the entire batch request with a timeout
-      const batchResponses = await withTimeout(
-        executeBatchRequest(
-          batchIds,
-          '/gmail/v1/users/me/messages',
-          accessToken,
-          integrationId,
-          throttler
-        ),
-        BATCH_REQUEST_TIMEOUT_MS,
-        `Batch ${batchNumber}/${totalBatches}`
-      )
-
-      logger.info('Batch request completed', {
+      const { parsed, raw, failedIds } = await fetchBatchWithRetry({
+        ids: batchIds,
+        accessToken,
+        integrationId,
+        throttler,
         batchNumber,
         totalBatches,
-        responsesReceived: batchResponses.length,
-        integrationId,
       })
 
-      const messages = batchResponses
-        .map((response) => {
-          if (isBatchError(response)) {
-            logger.warn('Batch item error', {
-              error: response.error,
-              integrationId,
-            })
-            return undefined
-          }
-
-          if (
-            response &&
-            typeof response === 'object' &&
-            response.id &&
-            response.threadId &&
-            response.payload
-          ) {
-            return parseGmailMessage(response as GmailMessageWithPayload)
-          }
-
-          return undefined
-        })
-        .filter((msg): msg is ParsedGmailMessage => msg !== undefined)
-
-      allMessages.push(...messages)
+      allMessages.push(...parsed)
+      allRawMessages.push(...raw)
+      allFailedIds.push(...failedIds)
 
       logger.info('Batch parsed', {
         batchNumber,
         totalBatches,
-        messagesParsed: messages.length,
+        messagesParsed: parsed.length,
+        failedInBatch: failedIds.length,
         totalSoFar: allMessages.length,
         integrationId,
       })
 
       // Add delay between batches (except for the last batch)
       if (batchNumber < totalBatches) {
-        logger.debug('Waiting between batches', {
-          delayMs: INTER_BATCH_DELAY_MS,
-          nextBatch: batchNumber + 1,
-          integrationId,
-        })
         await new Promise((resolve) => setTimeout(resolve, INTER_BATCH_DELAY_MS))
       }
     } catch (error: any) {
-      // Check if it's a timeout error
       const isTimeout = error?.message?.includes('timed out')
       if (isTimeout) {
         logger.error('Batch fetch timed out', {
@@ -170,25 +141,25 @@ export async function getMessagesBatch(
           messagesProcessed: allMessages.length,
           integrationId,
         })
-        // Continue with next batch on timeout
+        allFailedIds.push(...batchIds)
         continue
       }
 
-      // Check if it's a rate limit error
       const isRateLimit =
         error?.message?.includes('429') ||
         error?.message?.includes('rateLimitExceeded') ||
         error?.message?.includes('Too many concurrent requests')
 
       if (isRateLimit) {
-        logger.error('Rate limit hit during batch fetch, stopping', {
+        logger.error('Rate limit hit during batch fetch, stopping remaining batches', {
           error: error.message,
           batchNumber,
           totalBatches,
           messagesProcessed: allMessages.length,
           integrationId,
         })
-        // Stop processing more batches if we hit rate limit
+        // Mark all remaining IDs as failed
+        allFailedIds.push(...limitedMessageIds.slice(i))
         break
       }
 
@@ -198,17 +169,115 @@ export async function getMessagesBatch(
         totalBatches,
         integrationId,
       })
-      // Continue with next batch for other errors
+      allFailedIds.push(...batchIds)
     }
   }
 
   logger.info('Batch fetch completed', {
     totalRequested: limitedMessageIds.length,
     totalFetched: allMessages.length,
+    totalFailed: allFailedIds.length,
     integrationId,
   })
 
-  return allMessages
+  return { parsed: allMessages, raw: allRawMessages, failedMessageIds: allFailedIds }
+}
+
+/**
+ * Fetch a single batch of IDs, retrying item-level 429s with smaller sub-batches.
+ */
+async function fetchBatchWithRetry(opts: {
+  ids: string[]
+  accessToken: string
+  integrationId: string
+  throttler: UniversalThrottler
+  batchNumber: number
+  totalBatches: number
+}): Promise<{ parsed: ParsedGmailMessage[]; raw: GmailMessageWithPayload[]; failedIds: string[] }> {
+  const { accessToken, integrationId, throttler, batchNumber, totalBatches } = opts
+
+  let pendingIds = [...opts.ids]
+  const parsed: ParsedGmailMessage[] = []
+  const raw: GmailMessageWithPayload[] = []
+  let currentBatchSize = Math.min(pendingIds.length, BATCH_LIMIT)
+
+  for (let attempt = 0; attempt <= MAX_ITEM_RETRIES && pendingIds.length > 0; attempt++) {
+    const batchLabel = `Batch ${batchNumber}/${totalBatches}${attempt > 0 ? ` retry-${attempt}` : ''}`
+
+    const batchResponses = await withTimeout(
+      executeBatchRequest(
+        pendingIds.slice(0, currentBatchSize),
+        '/gmail/v1/users/me/messages',
+        accessToken,
+        integrationId,
+        throttler
+      ),
+      BATCH_REQUEST_TIMEOUT_MS,
+      batchLabel
+    )
+
+    const rateLimitedIds: string[] = []
+    const requestedIds = pendingIds.slice(0, currentBatchSize)
+
+    for (let i = 0; i < batchResponses.length; i++) {
+      const response = batchResponses[i]
+      const messageId = requestedIds[i]
+
+      if (isBatchItemRateLimited(response)) {
+        if (messageId) rateLimitedIds.push(messageId)
+        logger.warn('Batch item rate-limited', {
+          messageId,
+          batchNumber,
+          attempt,
+          reason: response?.error?.message,
+          integrationId,
+        })
+        continue
+      }
+
+      if (isBatchError(response)) {
+        logger.warn('Batch item error (non-retriable)', {
+          messageId,
+          error: response.error,
+          integrationId,
+        })
+        continue
+      }
+
+      if (
+        response &&
+        typeof response === 'object' &&
+        response.id &&
+        response.threadId &&
+        response.payload
+      ) {
+        const rawMsg = response as GmailMessageWithPayload
+        raw.push(rawMsg)
+        parsed.push(parseGmailMessage(rawMsg))
+      }
+    }
+
+    // Remove successfully fetched IDs from pending
+    const fetchedIdSet = new Set(parsed.map((m) => m.id))
+    pendingIds = pendingIds.filter((id) => !fetchedIdSet.has(id))
+
+    if (rateLimitedIds.length === 0 || attempt === MAX_ITEM_RETRIES) break
+
+    // Retry rate-limited IDs with smaller batch + backoff
+    pendingIds = rateLimitedIds
+    currentBatchSize = RETRY_BATCH_LIMIT
+    const delay = RETRY_BASE_DELAY_MS * 2 ** attempt
+    logger.info('Retrying rate-limited message IDs', {
+      count: rateLimitedIds.length,
+      attempt: attempt + 1,
+      delayMs: delay,
+      batchSize: currentBatchSize,
+      integrationId,
+    })
+    await new Promise((resolve) => setTimeout(resolve, delay))
+  }
+
+  return { parsed, raw, failedIds: pendingIds }
 }
 
 /**
@@ -353,11 +422,23 @@ function parseBatchResponse(batchResponseText: string, contentTypeHeader: string
 
 /**
  * Check if batch response item contains an error
- * @param response - Batch response item
- * @returns True if response is an error object
  */
 function isBatchError(response: any): boolean {
   return response && typeof response === 'object' && 'error' in response
+}
+
+/**
+ * Check if a batch item error is a rate-limit (429 / RESOURCE_EXHAUSTED).
+ */
+function isBatchItemRateLimited(response: any): boolean {
+  if (!isBatchError(response)) return false
+  const code = response.error?.code
+  if (code === 429) return true
+  const reason = response.error?.errors?.[0]?.reason
+  if (reason === 'rateLimitExceeded' || reason === 'RESOURCE_EXHAUSTED') return true
+  const message = response.error?.message ?? ''
+  if (message.includes('Too many concurrent requests')) return true
+  return false
 }
 
 /**

--- a/packages/lib/src/providers/google/messages/gmail-attachment-fetcher.ts
+++ b/packages/lib/src/providers/google/messages/gmail-attachment-fetcher.ts
@@ -1,0 +1,105 @@
+// packages/lib/src/providers/google/messages/gmail-attachment-fetcher.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import type { MessageAttachmentMeta } from '../../../email/email-storage'
+import { getGmailQuotaCost, type UniversalThrottler } from '../../../utils/rate-limiter'
+import { executeWithThrottle } from '../shared/utils'
+
+const logger = createScopedLogger('gmail-attachment-fetcher')
+
+/**
+ * Decodes a base64url-encoded string to a Buffer.
+ */
+function decodeBase64Url(data: string): Buffer {
+  // base64url → base64: replace URL-safe chars and add padding
+  const base64 = data.replace(/-/g, '+').replace(/_/g, '/')
+  return Buffer.from(base64, 'base64')
+}
+
+/**
+ * Fetches a single attachment's bytes from the Gmail API.
+ */
+export async function fetchGmailAttachmentBytes(
+  gmailMessageId: string,
+  gmailAttachmentId: string,
+  context: { accessToken: string; integrationId: string; throttler: UniversalThrottler }
+): Promise<Buffer> {
+  const url = `https://gmail.googleapis.com/gmail/v1/users/me/messages/${gmailMessageId}/attachments/${gmailAttachmentId}`
+
+  const response = await executeWithThrottle(
+    'gmail.messages.attachments.get',
+    async () =>
+      fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${context.accessToken}`,
+          'User-Agent': 'AuxxGoogleProvider/1.0',
+        },
+      }),
+    {
+      userId: context.integrationId,
+      throttler: context.throttler,
+      cost: getGmailQuotaCost('messages.get'),
+      queue: true,
+      priority: 5,
+    }
+  )
+
+  if (!response.ok) {
+    throw new Error(`Gmail attachment fetch failed: ${response.status} ${response.statusText}`)
+  }
+
+  const json = (await response.json()) as { data: string; size: number }
+  return decodeBase64Url(json.data)
+}
+
+/**
+ * Fetches all attachment bytes for a message, handling both embedded data and API fetches.
+ * Returns a map from attachment index to Buffer, plus a count of failures.
+ */
+export async function fetchAllGmailAttachmentBytes(
+  gmailMessageId: string,
+  attachments: MessageAttachmentMeta[],
+  context: { accessToken: string; integrationId: string; throttler: UniversalThrottler }
+): Promise<{ resolved: Map<number, Buffer>; failedCount: number }> {
+  const resolved = new Map<number, Buffer>()
+  let failedCount = 0
+
+  for (let i = 0; i < attachments.length; i++) {
+    const att = attachments[i]!
+
+    try {
+      if (att.embeddedData) {
+        // Small embedded part — decode directly, no API call needed
+        resolved.set(i, decodeBase64Url(att.embeddedData))
+      } else if (att.providerAttachmentId) {
+        // Large part — fetch from Gmail API
+        const bytes = await fetchGmailAttachmentBytes(
+          gmailMessageId,
+          att.providerAttachmentId,
+          context
+        )
+        resolved.set(i, bytes)
+      } else {
+        // Neither embedded data nor attachmentId — unexpected
+        logger.warn('Attachment has neither embeddedData nor providerAttachmentId', {
+          gmailMessageId,
+          filename: att.filename,
+          index: i,
+        })
+        failedCount++
+      }
+    } catch (error) {
+      logger.warn('Failed to fetch attachment bytes', {
+        gmailMessageId,
+        filename: att.filename,
+        providerAttachmentId: att.providerAttachmentId,
+        index: i,
+        error: error instanceof Error ? error.message : error,
+      })
+      failedCount++
+    }
+  }
+
+  return { resolved, failedCount }
+}

--- a/packages/lib/src/providers/google/messages/gmail-inbound-content-ingestor.ts
+++ b/packages/lib/src/providers/google/messages/gmail-inbound-content-ingestor.ts
@@ -1,0 +1,292 @@
+// packages/lib/src/providers/google/messages/gmail-inbound-content-ingestor.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import type { MessageData, MessageStorageService } from '../../../email/email-storage'
+import { InboundAttachmentIngestService } from '../../../email/inbound/attachment-ingest.service'
+import { InboundBodyIngestService } from '../../../email/inbound/body-ingest.service'
+import type { AttachmentIngestInput } from '../../../email/inbound/ingest-types'
+import type { GmailFetchContext } from '../types'
+import { fetchAllGmailAttachmentBytes } from './gmail-attachment-fetcher'
+
+const logger = createScopedLogger('gmail-inbound-content-ingestor')
+
+/**
+ * Per-message failure detail returned by storeBatchWithIngest.
+ */
+export interface IngestFailure {
+  externalId: string
+  error: string
+  retriable: boolean
+}
+
+/**
+ * Structured result from storeBatchWithIngest.
+ */
+export interface BatchIngestResult {
+  storedCount: number
+  failedCount: number
+  failedExternalIds: string[]
+  retriableFailures: IngestFailure[]
+  nonRetriableFailures: IngestFailure[]
+}
+
+/**
+ * Orchestrates body ingest + message storage + attachment ingest for Gmail.
+ * Replaces direct batchStoreMessages calls to add inbound content processing.
+ */
+export class GmailInboundContentIngestor {
+  private bodyIngestService = new InboundBodyIngestService()
+  private attachmentIngestService = new InboundAttachmentIngestService()
+
+  constructor(
+    private organizationId: string,
+    private storageService: MessageStorageService
+  ) {}
+
+  /**
+   * Store a batch of Gmail messages with inbound content ingest.
+   * Preserves chronological sort and initial-sync bookkeeping from batchStoreMessages.
+   *
+   * Returns a structured result so the caller can decide whether to advance
+   * the sync cursor or schedule retries.
+   */
+  async storeBatchWithIngest(
+    messages: MessageData[],
+    fetchContext: GmailFetchContext,
+    options?: { batchId?: string; isInitialSync?: boolean }
+  ): Promise<BatchIngestResult> {
+    if (messages.length === 0) {
+      return {
+        storedCount: 0,
+        failedCount: 0,
+        failedExternalIds: [],
+        retriableFailures: [],
+        nonRetriableFailures: [],
+      }
+    }
+
+    // Sort messages chronologically (same as batchStoreMessages)
+    const sortedMessages = [...messages].sort(
+      (a, b) => (a.sentAt?.getTime() || 0) - (b.sentAt?.getTime() || 0)
+    )
+
+    logger.info(
+      `Starting batch store with ingest for ${messages.length} messages (sorted chronologically)`,
+      {
+        organizationId: this.organizationId,
+        isInitialSync: options?.isInitialSync,
+      }
+    )
+
+    let storedCount = 0
+    const retriableFailures: IngestFailure[] = []
+    const nonRetriableFailures: IngestFailure[] = []
+
+    for (const messageData of sortedMessages) {
+      try {
+        await this.storeOneWithIngest(messageData, fetchContext)
+        storedCount++
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        const retriable = isRetriableIngestError(error)
+
+        logger.error('Error storing message with ingest in batch', {
+          error: message,
+          externalId: messageData.externalId,
+          retriable,
+        })
+
+        const failure: IngestFailure = {
+          externalId: messageData.externalId,
+          error: message,
+          retriable,
+        }
+        if (retriable) {
+          retriableFailures.push(failure)
+        } else {
+          nonRetriableFailures.push(failure)
+        }
+      }
+    }
+
+    const failedCount = retriableFailures.length + nonRetriableFailures.length
+    const failedExternalIds = [
+      ...retriableFailures.map((f) => f.externalId),
+      ...nonRetriableFailures.map((f) => f.externalId),
+    ]
+
+    logger.info(
+      `Batch store with ingest completed: ${storedCount} stored, ${failedCount} failed (${retriableFailures.length} retriable).`,
+      {
+        organizationId: this.organizationId,
+        storedCount,
+        failedCount,
+        retriableFailures: retriableFailures.length,
+        nonRetriableFailures: nonRetriableFailures.length,
+        failedExternalIds,
+      }
+    )
+
+    return {
+      storedCount,
+      failedCount,
+      failedExternalIds,
+      retriableFailures,
+      nonRetriableFailures,
+    }
+  }
+
+  /**
+   * Store a single Gmail message with inbound content ingest.
+   * For outbound/draft messages, delegates directly to storeMessage().
+   *
+   * Body ingest failures are degraded (logged) but do not prevent message storage.
+   */
+  private async storeOneWithIngest(
+    messageData: MessageData,
+    fetchContext: GmailFetchContext
+  ): Promise<string> {
+    // Skip ingest for outbound/draft messages — they go straight through
+    if (!messageData.isInbound) {
+      return this.storageService.storeMessage(messageData)
+    }
+
+    const contentScopeId = messageData.externalId
+
+    // 1. Body ingest (before storeMessage) — fail-open: errors are degraded, not fatal
+    if (messageData.textHtml) {
+      try {
+        const bodyMeta = await this.bodyIngestService.ingestBody(
+          { textHtml: messageData.textHtml },
+          { organizationId: this.organizationId, contentScopeId }
+        )
+        messageData.htmlBodyStorageLocationId = bodyMeta.htmlBodyStorageLocationId
+      } catch (error) {
+        logger.warn('Body ingest failed, storing message with inline HTML (degraded ingest)', {
+          externalId: messageData.externalId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        // Leave htmlBodyStorageLocationId unset — message stores with textHtml inline
+      }
+      // textHtml nulling happens inside storeMessage (Fix 2)
+    }
+
+    // 2. Store message
+    const messageId = await this.storageService.storeMessage(messageData)
+
+    // 3. Attachment ingest (after storeMessage, only for inbound with attachments)
+    const providerAttachments = messageData.providerAttachments ?? []
+
+    logger.info('Attachment ingest check', {
+      messageId,
+      externalId: messageData.externalId,
+      providerAttachmentCount: providerAttachments.length,
+      attachments: providerAttachments.map((a) => ({
+        filename: a.filename,
+        mimeType: a.mimeType,
+        inline: a.inline,
+        contentId: a.contentId,
+        hasEmbeddedData: !!a.embeddedData,
+        hasProviderAttachmentId: !!a.providerAttachmentId,
+      })),
+    })
+
+    if (providerAttachments.length === 0) return messageId
+
+    // Fetch bytes (embedded + API)
+    const { resolved, failedCount } = await fetchAllGmailAttachmentBytes(
+      messageData.externalId,
+      providerAttachments,
+      fetchContext
+    )
+
+    logger.info('Attachment bytes fetch result', {
+      messageId,
+      resolvedCount: resolved.size,
+      failedCount,
+      resolvedIndices: [...resolved.keys()],
+    })
+
+    // Build inputs — only include successfully resolved attachments (Fix 3)
+    const inputs: AttachmentIngestInput[] = []
+    for (let i = 0; i < providerAttachments.length; i++) {
+      const bytes = resolved.get(i)
+      if (!bytes || bytes.length === 0) {
+        logger.warn('Skipping attachment with missing bytes', {
+          gmailMessageId: messageData.externalId,
+          filename: providerAttachments[i]!.filename,
+          providerAttachmentId: providerAttachments[i]!.providerAttachmentId,
+        })
+        continue
+      }
+      const att = providerAttachments[i]!
+      inputs.push({
+        content: bytes,
+        filename: att.filename,
+        mimeType: att.mimeType,
+        inline: att.inline,
+        contentId: att.contentId,
+        attachmentOrder: i,
+      })
+    }
+
+    if (inputs.length > 0) {
+      logger.info('Starting attachment ingest', {
+        messageId,
+        inputCount: inputs.length,
+        inputs: inputs.map((i) => ({
+          filename: i.filename,
+          mimeType: i.mimeType,
+          inline: i.inline,
+          contentId: i.contentId,
+          size: i.content.length,
+        })),
+      })
+
+      try {
+        // Fix 4: skip reconciliation if any fetch failed (partial set)
+        await this.attachmentIngestService.ingestAll(
+          inputs,
+          {
+            organizationId: this.organizationId,
+            messageId,
+            contentScopeId,
+          },
+          {
+            skipReconciliation: failedCount > 0,
+          }
+        )
+        logger.info('Attachment ingest completed successfully', { messageId })
+      } catch (error) {
+        logger.error('Attachment ingest FAILED', {
+          messageId,
+          error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        })
+        // Re-throw so the caller can track the failure
+        throw error
+      }
+    }
+
+    return messageId
+  }
+}
+
+/**
+ * Classify whether an ingest error is likely retriable.
+ * DB connection errors, timeouts, and rate limits are retriable.
+ * Validation errors and constraint violations are not.
+ */
+function isRetriableIngestError(error: unknown): boolean {
+  if (!(error instanceof Error)) return true
+  const msg = error.message.toLowerCase()
+  if (msg.includes('connection') || msg.includes('timeout') || msg.includes('econnrefused')) {
+    return true
+  }
+  if (msg.includes('rate limit') || msg.includes('too many')) return true
+  if (msg.includes('constraint') || msg.includes('unique') || msg.includes('validation')) {
+    return false
+  }
+  // Default to retriable for unknown errors
+  return true
+}

--- a/packages/lib/src/providers/google/messages/parse-message.ts
+++ b/packages/lib/src/providers/google/messages/parse-message.ts
@@ -3,7 +3,12 @@
 import { createScopedLogger } from '@auxx/logger'
 import { extractEmailAddress, isUserEmail } from '@auxx/utils'
 import parse from 'gmail-api-parse-message'
-import { EmailLabel, type MessageData } from '../../../email/email-storage'
+import type { gmail_v1 } from 'googleapis'
+import {
+  EmailLabel,
+  type MessageAttachmentMeta,
+  type MessageData,
+} from '../../../email/email-storage'
 import { isDefined, parseMultipleParticipants, parseParticipantString } from '../../provider-utils'
 import type { GmailMessageWithPayload, ParsedGmailMessage } from '../types'
 
@@ -38,15 +43,108 @@ export function parseGmailMessage(message: GmailMessageWithPayload): ParsedGmail
 }
 
 /**
- * Convert parsed Gmail messages to MessageData format
+ * Attachment metadata extracted directly from the raw Gmail API payload.
+ * Bypasses the gmail-api-parse-message library which discards body.data for inline parts.
+ */
+export interface GmailPayloadAttachment {
+  filename: string
+  mimeType: string
+  size: number
+  inline: boolean
+  contentId: string | null
+  /** Gmail attachmentId for large parts (requires separate API fetch) */
+  gmailAttachmentId: string | null
+  /** base64url-encoded body.data for small embedded parts */
+  embeddedData: string | null
+}
+
+/**
+ * Index MIME part headers into a lowercase key map for easy lookup.
+ */
+function indexPartHeaders(
+  headers: gmail_v1.Schema$MessagePartHeader[] | undefined
+): Record<string, string> {
+  const result: Record<string, string> = {}
+  if (!headers) return result
+  for (const h of headers) {
+    if (h.name && h.value) {
+      result[h.name.toLowerCase()] = h.value
+    }
+  }
+  return result
+}
+
+/**
+ * Recursively walks the raw Gmail API payload to extract all attachment/inline parts.
+ * This replaces the library's attachments[] and inline[] with a single unified list
+ * that preserves embedded body.data for small parts and Content-ID for inline images.
+ */
+export function extractPayloadAttachments(
+  payload: gmail_v1.Schema$MessagePart
+): GmailPayloadAttachment[] {
+  const results: GmailPayloadAttachment[] = []
+
+  function walk(part: gmail_v1.Schema$MessagePart) {
+    if (part.parts) {
+      for (const child of part.parts) walk(child)
+    }
+
+    if (!part.body) return
+
+    const headers = indexPartHeaders(part.headers)
+    const isText = part.mimeType?.startsWith('text/html') || part.mimeType?.startsWith('text/plain')
+    const hasAttachmentId = !!part.body.attachmentId
+    const disposition = headers['content-disposition']?.toLowerCase() ?? ''
+    const isInline = disposition.includes('inline')
+    const isAttachmentDisposition = disposition.includes('attachment')
+
+    // Skip text body parts (handled separately as textHtml/textPlain)
+    if (isText && !hasAttachmentId && !isAttachmentDisposition) return
+
+    // Detect Content-ID presence (identifies inline images even without Content-Disposition)
+    const contentIdRaw = headers['content-id']
+    const hasContentId = !!contentIdRaw
+    const contentId = contentIdRaw ? contentIdRaw.replace(/^<|>$/g, '') : null
+
+    // This is a file part if it has any attachment/inline indicator.
+    // Content-ID alone (without Content-Disposition) qualifies as inline —
+    // many MIME inline images omit Content-Disposition entirely.
+    // A filename also qualifies, as it indicates a file part.
+    if (hasAttachmentId || isAttachmentDisposition || isInline || hasContentId || part.filename) {
+      results.push({
+        filename: part.filename || 'attachment',
+        mimeType: part.mimeType || 'application/octet-stream',
+        size: part.body.size || 0,
+        inline:
+          (isInline || (hasContentId && !isAttachmentDisposition)) && !isAttachmentDisposition,
+        contentId,
+        gmailAttachmentId: part.body.attachmentId || null,
+        embeddedData: part.body.data || null,
+      })
+    }
+  }
+
+  walk(payload)
+  return results
+}
+
+/**
+ * Convert parsed Gmail messages to MessageData format.
+ * Requires both parsed messages (for headers, body text) and raw messages (for attachment extraction).
  */
 export function convertMessagesToMessageData(
   messages: ParsedGmailMessage[],
+  rawMessages: GmailMessageWithPayload[],
   integrationId: string,
   inboxId: string | undefined,
   organizationId: string,
   userEmails: string[]
 ): MessageData[] {
+  // Index raw messages by ID for lookup
+  const rawMessageMap = new Map<string, GmailMessageWithPayload>()
+  for (const raw of rawMessages) {
+    rawMessageMap.set(raw.id, raw)
+  }
   return messages
     .map((message): MessageData | null => {
       try {
@@ -102,12 +200,29 @@ export function convertMessagesToMessageData(
         // Determine email label
         const emailLabel = determineEmailLabel(message.labelIds || [])
 
-        // Process attachments
-        const attachments = (message.attachments || []).map((att: any) => ({
-          filename: att.filename || 'attachment',
-          mimeType: att.mimeType || 'application/octet-stream',
-          size: att.size || 0,
-          inline: !!att.inline,
+        // Extract attachments from raw payload (bypasses library limitations)
+        const rawMessage = rawMessageMap.get(message.id)
+        const payloadAttachments = rawMessage?.payload
+          ? extractPayloadAttachments(rawMessage.payload)
+          : []
+
+        // Map to MessageAttachmentMeta for downstream ingest
+        const providerAttachments: MessageAttachmentMeta[] = payloadAttachments.map((att) => ({
+          filename: att.filename,
+          mimeType: att.mimeType,
+          size: att.size,
+          inline: att.inline,
+          contentId: att.contentId,
+          providerAttachmentId: att.gmailAttachmentId,
+          embeddedData: att.embeddedData,
+        }))
+
+        // Legacy attachments array (for hasAttachments and backward compat)
+        const attachments = payloadAttachments.map((att) => ({
+          filename: att.filename,
+          mimeType: att.mimeType,
+          size: att.size,
+          inline: att.inline,
           contentId: att.contentId,
         }))
 
@@ -128,6 +243,7 @@ export function convertMessagesToMessageData(
           replyTo: replyToInputs,
           hasAttachments: attachments.length > 0,
           attachments,
+          providerAttachments,
           textHtml: message.textHtml || '',
           textPlain: message.textPlain || '',
           snippet: message.snippet || '',

--- a/packages/lib/src/providers/google/messages/sync-messages.ts
+++ b/packages/lib/src/providers/google/messages/sync-messages.ts
@@ -10,6 +10,7 @@ import { isDefined } from '../../provider-utils'
 import { handleGmailError } from '../shared/error-handler'
 import { executeWithThrottle } from '../shared/utils'
 import { getMessagesBatch } from './batch-fetch'
+import { GmailInboundContentIngestor } from './gmail-inbound-content-ingestor'
 import { convertMessagesToMessageData } from './parse-message'
 
 const logger = createScopedLogger('google-sync-messages')
@@ -182,8 +183,10 @@ async function syncViaHistory(
 ): Promise<{ messagesProcessed: number; messagesDeleted: number; newHistoryId: string }> {
   let nextPageToken: string | undefined | null
   let highestHistoryId = BigInt(startHistoryId)
+  let safeHistoryId = BigInt(startHistoryId) // Only advances when no retriable failures
   let totalProcessed = 0
   let totalDeleted = 0
+  let hasRetriableFailures = false
 
   logger.info('Starting history-based sync', {
     integrationId,
@@ -281,39 +284,79 @@ async function syncViaHistory(
         integrationId,
       })
 
-      const messages = await getMessagesBatch({
+      const {
+        parsed,
+        raw,
+        failedMessageIds: failedFetchIds,
+      } = await getMessagesBatch({
         messageIds: finalAddedIds,
         integrationId,
         throttler,
         accessToken,
       })
 
-      if (messages.length > 0) {
+      if (failedFetchIds.length > 0) {
+        logger.warn('Some message IDs failed to fetch', {
+          failedFetchCount: failedFetchIds.length,
+          failedFetchIds: failedFetchIds.slice(0, 20),
+          integrationId,
+        })
+      }
+
+      if (parsed.length > 0) {
         const messageDataArray = convertMessagesToMessageData(
-          messages,
+          parsed,
+          raw,
           integrationId,
           inboxId,
           organizationId,
           userEmails
         )
 
-        const storedCount = await storageService.batchStoreMessages(messageDataArray)
-        totalProcessed += storedCount
+        const ingestor = new GmailInboundContentIngestor(organizationId, storageService)
+        const result = await ingestor.storeBatchWithIngest(messageDataArray, {
+          accessToken,
+          integrationId,
+          throttler,
+        })
+        totalProcessed += result.storedCount
+
+        // If there are retriable failures, do not advance historyId past this page
+        if (result.retriableFailures.length > 0 || failedFetchIds.length > 0) {
+          hasRetriableFailures = true
+          logger.warn('Retriable failures detected — historyId will not advance past this page', {
+            retriableIngestFailures: result.retriableFailures.length,
+            failedFetchIds: failedFetchIds.length,
+            integrationId,
+          })
+        }
 
         logger.info('Processed history batch', {
-          fetched: messages.length,
-          stored: storedCount,
+          fetched: parsed.length,
+          stored: result.storedCount,
+          failedIngest: result.failedCount,
+          failedFetch: failedFetchIds.length,
           integrationId,
         })
       }
     }
 
+    // Only advance safeHistoryId if this page had no retriable failures
+    if (!hasRetriableFailures) {
+      safeHistoryId = highestHistoryId
+    }
+
     nextPageToken = historyResponse.data.nextPageToken
   } while (nextPageToken)
+
+  // Use safeHistoryId so we re-process pages that had retriable failures next cycle
+  const effectiveHistoryId = hasRetriableFailures ? safeHistoryId : highestHistoryId
 
   logger.info('Gmail history sync cycle completed', {
     integrationId,
     highestHistoryId: highestHistoryId.toString(),
+    effectiveHistoryId: effectiveHistoryId.toString(),
+    hasRetriableFailures,
     messagesProcessed: totalProcessed,
     messagesDeleted: totalDeleted,
   })
@@ -321,7 +364,7 @@ async function syncViaHistory(
   return {
     messagesProcessed: totalProcessed,
     messagesDeleted: totalDeleted,
-    newHistoryId: highestHistoryId.toString(),
+    newHistoryId: effectiveHistoryId.toString(),
   }
 }
 
@@ -352,7 +395,9 @@ async function syncViaMessageList(
   const query = since ? `after:${Math.floor(since.getTime() / 1000)}` : 'in:inbox'
   let nextPageToken: string | undefined | null
   let highestHistoryId = BigInt(0)
+  let safeHistoryId = BigInt(0)
   let totalProcessed = 0
+  let hasRetriableFailures = false
 
   logger.warn(`No startHistoryId found. Syncing via message list with query: "${query}"`, {
     integrationId,
@@ -393,24 +438,42 @@ async function syncViaMessageList(
       integrationId,
     })
 
-    const fetchedMessages = await getMessagesBatch({
+    const {
+      parsed: fetchedMessages,
+      raw: rawMessages,
+      failedMessageIds: failedFetchIds,
+    } = await getMessagesBatch({
       messageIds,
       integrationId,
       throttler,
       accessToken,
     })
 
+    if (failedFetchIds.length > 0) {
+      logger.warn('Some message IDs failed to fetch during list sync', {
+        failedFetchCount: failedFetchIds.length,
+        failedFetchIds: failedFetchIds.slice(0, 20),
+        integrationId,
+      })
+    }
+
     if (fetchedMessages.length > 0) {
       const messageDataArray = convertMessagesToMessageData(
         fetchedMessages,
+        rawMessages,
         integrationId,
         inboxId,
         organizationId,
         userEmails
       )
 
-      const storedCount = await storageService.batchStoreMessages(messageDataArray)
-      totalProcessed += storedCount
+      const ingestor = new GmailInboundContentIngestor(organizationId, storageService)
+      const result = await ingestor.storeBatchWithIngest(messageDataArray, {
+        accessToken,
+        integrationId,
+        throttler,
+      })
+      totalProcessed += result.storedCount
 
       // Track highest history ID
       for (const msg of fetchedMessages) {
@@ -420,9 +483,22 @@ async function syncViaMessageList(
         }
       }
 
+      if (result.retriableFailures.length > 0 || failedFetchIds.length > 0) {
+        hasRetriableFailures = true
+        logger.warn('Retriable failures in list batch — historyId may not advance fully', {
+          retriableIngestFailures: result.retriableFailures.length,
+          failedFetchIds: failedFetchIds.length,
+          integrationId,
+        })
+      } else {
+        safeHistoryId = highestHistoryId
+      }
+
       logger.info('Processed list batch', {
         fetched: fetchedMessages.length,
-        stored: storedCount,
+        stored: result.storedCount,
+        failedIngest: result.failedCount,
+        failedFetch: failedFetchIds.length,
         highestHistoryId: highestHistoryId.toString(),
         integrationId,
       })
@@ -431,14 +507,18 @@ async function syncViaMessageList(
     nextPageToken = listResponse.data.nextPageToken
   } while (nextPageToken)
 
+  const effectiveHistoryId = hasRetriableFailures ? safeHistoryId : highestHistoryId
+
   logger.info('Gmail list-based sync completed', {
     integrationId,
     messagesProcessed: totalProcessed,
     highestHistoryId: highestHistoryId.toString(),
+    effectiveHistoryId: effectiveHistoryId.toString(),
+    hasRetriableFailures,
   })
 
   return {
     messagesProcessed: totalProcessed,
-    newHistoryId: highestHistoryId.toString(),
+    newHistoryId: effectiveHistoryId.toString(),
   }
 }

--- a/packages/lib/src/providers/google/types.ts
+++ b/packages/lib/src/providers/google/types.ts
@@ -69,3 +69,12 @@ export interface GmailMessageWithPayload extends gmail_v1.Schema$Message {
  * Throttler context for Gmail operations
  */
 export type GoogleThrottleContext = 'sync' | 'history' | 'batch' | 'send' | 'webhook' | 'labels'
+
+/**
+ * Context required for fetching Gmail attachment bytes.
+ */
+export interface GmailFetchContext {
+  accessToken: string
+  integrationId: string
+  throttler: UniversalThrottler
+}

--- a/packages/lib/src/providers/imap/imap-get-message-list.ts
+++ b/packages/lib/src/providers/imap/imap-get-message-list.ts
@@ -8,7 +8,12 @@ import type { MessageListResult } from '../integration-provider.interface'
 import { ImapClientProvider } from './imap-client-provider'
 import { ImapSyncService } from './imap-sync-service'
 import type { ImapCredentialData, ImapFolderCheckpoint } from './types'
-import { IMAP_IMPORT_BATCH_SIZE, UID_SCAN_WINDOW } from './types'
+import {
+  IMAP_IMPORT_BATCH_SIZE,
+  MAX_CONSECUTIVE_EMPTY_WINDOWS,
+  MAX_TOTAL_EMPTY_WINDOWS,
+  UID_SCAN_WINDOW,
+} from './types'
 import { createSyncCursor } from './utils/create-sync-cursor'
 import { extractMailboxState } from './utils/extract-mailbox-state'
 
@@ -215,21 +220,65 @@ export class ImapGetMessageListService {
             continue
           }
 
-          // Scan one UID window
-          const windowStart = checkpoint.nextUidStart
-          const windowEnd = Math.min(
-            windowStart + UID_SCAN_WINDOW - 1,
-            checkpoint.snapshotHighestUid
-          )
+          // Safety valve: if this folder has exhausted its empty-window budget across
+          // all jobs in this run, mark it done instead of scanning further.
+          if ((checkpoint.totalEmptyWindowsScanned ?? 0) >= MAX_TOTAL_EMPTY_WINDOWS) {
+            logger.warn('Folder exceeded max total empty windows, marking done', {
+              folderPath,
+              integrationId,
+              totalEmptyWindowsScanned: checkpoint.totalEmptyWindowsScanned,
+              snapshotHighestUid: checkpoint.snapshotHighestUid,
+              nextUidStart: checkpoint.nextUidStart,
+            })
 
-          const scanResult = await this.syncService.scanUidWindow(
-            client,
-            mailbox,
-            windowStart,
-            windowEnd
-          )
+            checkpoint.phase = 'done'
+            results.push({
+              labelId: label.id,
+              folderPath,
+              batches: [],
+              checkpoint,
+              folderScanComplete: true,
+            })
+            continue
+          }
 
-          const externalIds = scanResult.uids.map((uid) => `${folderPath}:${uid}`)
+          // Scan multiple UID windows until we find messages or exhaust budget
+          let windowStart = checkpoint.nextUidStart
+          let totalWindowsScanned = 0
+          let foundUids: number[] = []
+          let finalWindowEnd = windowStart
+
+          while (windowStart <= checkpoint.snapshotHighestUid) {
+            const windowEnd = Math.min(
+              windowStart + UID_SCAN_WINDOW - 1,
+              checkpoint.snapshotHighestUid
+            )
+
+            const scanResult = await this.syncService.scanUidWindow(
+              client,
+              mailbox,
+              windowStart,
+              windowEnd
+            )
+
+            totalWindowsScanned++
+            finalWindowEnd = windowEnd
+
+            if (scanResult.uids.length > 0) {
+              foundUids = scanResult.uids
+              break
+            }
+
+            // Empty window — advance
+            windowStart = windowEnd + 1
+
+            // Budget exhausted — yield to job queue
+            if (totalWindowsScanned >= MAX_CONSECUTIVE_EMPTY_WINDOWS) {
+              break
+            }
+          }
+
+          const externalIds = foundUids.map((uid) => `${folderPath}:${uid}`)
 
           // Split into bounded import batches
           const batches: string[][] = []
@@ -237,21 +286,24 @@ export class ImapGetMessageListService {
             batches.push(externalIds.slice(i, i + IMAP_IMPORT_BATCH_SIZE))
           }
 
-          const folderScanComplete = windowEnd >= checkpoint.snapshotHighestUid
+          const folderScanComplete = finalWindowEnd >= checkpoint.snapshotHighestUid
 
           // Update checkpoint
           checkpoint.phase = batches.length > 0 ? 'importing' : 'listing'
-          checkpoint.discoveredMessageCount += scanResult.uids.length
+          checkpoint.discoveredMessageCount += foundUids.length
+          checkpoint.totalEmptyWindowsScanned =
+            (checkpoint.totalEmptyWindowsScanned ?? 0) +
+            (totalWindowsScanned - (foundUids.length > 0 ? 1 : 0))
 
           if (batches.length > 0) {
             checkpoint.activeWindowStart = windowStart
-            checkpoint.activeWindowEnd = windowEnd
+            checkpoint.activeWindowEnd = finalWindowEnd
             checkpoint.activeWindowBatchCount = batches.length
             checkpoint.activeWindowCompletedBatches = 0
             checkpoint.activeWindowFailedBatches = 0
           } else {
-            // Empty window — advance nextUidStart immediately
-            checkpoint.nextUidStart = windowEnd + 1
+            // All windows were empty — advance nextUidStart past everything scanned
+            checkpoint.nextUidStart = finalWindowEnd + 1
           }
 
           // If scan is complete and no batches to import, mark done
@@ -259,21 +311,23 @@ export class ImapGetMessageListService {
             checkpoint.phase = 'done'
           }
 
+          logger.info('Scanned UID window(s) for folder', {
+            folderPath,
+            integrationId,
+            scanStart: checkpoint.nextUidStart - totalWindowsScanned * UID_SCAN_WINDOW,
+            scanEnd: finalWindowEnd,
+            windowsScanned: totalWindowsScanned,
+            totalEmptyWindowsScanned: checkpoint.totalEmptyWindowsScanned,
+            uidsFound: foundUids.length,
+            batchCount: batches.length,
+            folderScanComplete,
+          })
+
           results.push({
             labelId: label.id,
             folderPath,
             batches,
             checkpoint,
-            folderScanComplete,
-          })
-
-          logger.info('Scanned UID window for folder', {
-            folderPath,
-            integrationId,
-            windowStart,
-            windowEnd,
-            uidsFound: scanResult.uids.length,
-            batchCount: batches.length,
             folderScanComplete,
           })
         } catch (error) {

--- a/packages/lib/src/providers/imap/types.ts
+++ b/packages/lib/src/providers/imap/types.ts
@@ -84,6 +84,15 @@ export const UID_SCAN_WINDOW = 1000
 /** Import batch size for IMAP full sync */
 export const IMAP_IMPORT_BATCH_SIZE = 50
 
+/** Max consecutive empty UID windows to scan per job before yielding */
+export const MAX_CONSECUTIVE_EMPTY_WINDOWS = 100
+
+/**
+ * Max total empty windows to scan across the entire full-sync lifecycle per folder.
+ * At 1K UIDs per window, 5000 windows = 5M UIDs — well beyond any realistic mailbox.
+ */
+export const MAX_TOTAL_EMPTY_WINDOWS = 5000
+
 /** Per-folder checkpoint for resumable IMAP full sync, stored in Label.syncCheckpoint */
 export interface ImapFolderCheckpoint {
   runId: string
@@ -102,6 +111,8 @@ export interface ImapFolderCheckpoint {
   /** Format: `${uidValidity}:${highestUid}` — encodes both validity and position */
   candidateCursor: string
   lastError?: string
+  /** Cumulative empty windows scanned across all jobs in this run */
+  totalEmptyWindowsScanned?: number
 }
 
 /** Job payload for a single IMAP import batch (self-contained, retryable) */

--- a/packages/lib/src/providers/outlook/outlook-oauth.ts
+++ b/packages/lib/src/providers/outlook/outlook-oauth.ts
@@ -321,7 +321,13 @@ export class OutlookOAuthService {
               organizationId: orgId as string,
               provider: 'outlook',
             },
-            { jobId: `poll-list-fetch-${integration.id}` }
+            {
+              jobId: `poll-list-fetch-${integration.id}-${Date.now()}`,
+              attempts: 3,
+              backoff: { type: 'exponential', delay: 60000 },
+              removeOnComplete: { count: 50 },
+              removeOnFail: { count: 100 },
+            }
           )
 
           logger.info('Kicked off polling pipeline for new Outlook integration', {

--- a/packages/redis/src/providers/ioredis-provider.ts
+++ b/packages/redis/src/providers/ioredis-provider.ts
@@ -185,9 +185,18 @@ export function createIORedisClient(provider: 'aws' | 'hosted'): RedisClient {
     zscore: async (key: string, member: string) =>
       (await client.zscore(key, member)) as string | null,
 
+    // Atomic counter operations
+    incr: async (key: string) => (await client.incr(key)) as number,
+    decr: async (key: string) => (await client.decr(key)) as number,
+
     // TTL operations (fully supported by IORedis)
     ttl: async (key: string) => (await client.ttl(key)) as number,
     pttl: async (key: string) => (await client.pttl(key)) as number,
+    pexpire: async (key: string, milliseconds: number) =>
+      (await client.pexpire(key, milliseconds)) as number,
+
+    // Pipeline support
+    pipeline: () => client.pipeline() as any,
   }
 
   logger.info(`Enhanced ${provider} Redis client created successfully`)

--- a/packages/redis/src/providers/upstash-provider.ts
+++ b/packages/redis/src/providers/upstash-provider.ts
@@ -386,6 +386,40 @@ export function createUpstashClient(): RedisClient {
       }
     },
 
+    pexpire: async (key: string, milliseconds: number) => {
+      try {
+        return (await upstashClient.pexpire(key, milliseconds)) as number
+      } catch (error) {
+        logger.error('Error setting PEXPIRE in Upstash', {
+          key,
+          error: (error as Error).message,
+        })
+        throw error
+      }
+    },
+
+    // Atomic counter operations
+    incr: async (key: string) => {
+      try {
+        return await upstashClient.incr(key)
+      } catch (error) {
+        logger.error('Error incrementing in Upstash', { key, error: (error as Error).message })
+        throw error
+      }
+    },
+
+    decr: async (key: string) => {
+      try {
+        return await upstashClient.decr(key)
+      } catch (error) {
+        logger.error('Error decrementing in Upstash', { key, error: (error as Error).message })
+        throw error
+      }
+    },
+
+    // Pipeline support (Upstash supports pipelines via REST)
+    pipeline: () => upstashClient.pipeline() as any,
+
     // Pub/Sub operations (not supported by Upstash, will throw errors)
     subscribe: async () => {
       throw new Error(

--- a/packages/redis/src/types.ts
+++ b/packages/redis/src/types.ts
@@ -4,6 +4,26 @@ import { createScopedLogger } from '@auxx/logger'
 export const logger = createScopedLogger('redis-client')
 
 /**
+ * Pipeline interface for batching Redis commands
+ */
+export interface RedisPipeline {
+  get(key: string): RedisPipeline
+  set(key: string, value: any, ...args: any[]): RedisPipeline
+  del(key: string): RedisPipeline
+  expire(key: string, seconds: number): RedisPipeline
+  incr(key: string): RedisPipeline
+  decr(key: string): RedisPipeline
+  sadd(key: string, ...members: string[]): RedisPipeline
+  srem(key: string, ...members: string[]): RedisPipeline
+  lpush(key: string, ...values: string[]): RedisPipeline
+  rpush(key: string, ...values: string[]): RedisPipeline
+  ltrim(key: string, start: number, stop: number): RedisPipeline
+  zadd(key: string, ...args: any[]): RedisPipeline
+  exec(): Promise<any[]>
+  [key: string]: any
+}
+
+/**
  * Enhanced Redis client interface with optional pub/sub methods
  * Not all providers support all operations
  */
@@ -63,9 +83,17 @@ export interface RedisClient {
   zrevrank(key: string, member: string): Promise<number | null>
   zscore(key: string, member: string): Promise<string | null>
 
+  // Atomic counter operations
+  incr(key: string): Promise<number>
+  decr(key: string): Promise<number>
+
   // TTL operations
   ttl(key: string): Promise<number>
   pttl(key: string): Promise<number>
+  pexpire(key: string, milliseconds: number): Promise<number>
+
+  // Pipeline support (batch operations)
+  pipeline(): RedisPipeline
 
   // Lua script support (IORedis/AWS)
   eval?(script: string, numKeys: number, ...args: any[]): Promise<any>


### PR DESCRIPTION
feat(gmail): implement Gmail attachment fetching and inbound content ingestion

- Added `gmail-attachment-fetcher.ts` for fetching Gmail attachments using the Gmail API.
- Introduced `gmail-inbound-content-ingestor.ts` to orchestrate body and attachment ingestion for Gmail messages.
- Enhanced `parse-message.ts` to extract attachment metadata directly from the Gmail API payload.
- Updated `sync-messages.ts` to utilize the new ingestion service for processing Gmail messages.
- Improved error handling and logging for message ingestion failures.
- Added new types for Gmail fetch context and attachment metadata.
- Refactored IMAP message listing to improve efficiency and handle empty UID windows.
- Enhanced Redis client with atomic counter operations and pipeline support.