### PR TITLE
feat: implement storage cleanup job for async S3 object deletion and Redis cache clearing

### DIFF
--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -15,7 +15,7 @@ import {
 } from '@auxx/lib/providers'
 import { widgetSchema as chatWidgetInputSchema } from '@auxx/lib/widgets/types'
 import { createScopedLogger } from '@auxx/logger'
-import { and, asc, eq } from 'drizzle-orm'
+import { and, asc, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '../trpc'
 
@@ -47,7 +47,12 @@ export const channelRouter = createTRPCRouter({
         enabled: schema.Integration.enabled,
       })
       .from(schema.Integration)
-      .where(eq(schema.Integration.organizationId, organizationId))
+      .where(
+        and(
+          eq(schema.Integration.organizationId, organizationId),
+          isNull(schema.Integration.deletedAt)
+        )
+      )
       .orderBy(asc(schema.Integration.name))
     return integrations
   }),
@@ -525,7 +530,8 @@ export const channelRouter = createTRPCRouter({
         .where(
           and(
             eq(schema.Integration.id, input.integrationId),
-            eq(schema.Integration.organizationId, organizationId)
+            eq(schema.Integration.organizationId, organizationId),
+            isNull(schema.Integration.deletedAt)
           )
         )
         .limit(1)

--- a/apps/web/src/server/api/routers/integration-reauth.ts
+++ b/apps/web/src/server/api/routers/integration-reauth.ts
@@ -8,7 +8,7 @@ import {
   OutlookOAuthService,
 } from '@auxx/lib/providers'
 import { TRPCError } from '@trpc/server'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
 
@@ -37,7 +37,8 @@ export const integrationReauthRouter = createTRPCRouter({
         .where(
           and(
             eq(schema.Integration.id, input.integrationId),
-            eq(schema.Integration.organizationId, organizationId)
+            eq(schema.Integration.organizationId, organizationId),
+            isNull(schema.Integration.deletedAt)
           )
         )
         .limit(1)
@@ -134,7 +135,8 @@ export const integrationReauthRouter = createTRPCRouter({
         .where(
           and(
             eq(schema.Integration.id, input.integrationId),
-            eq(schema.Integration.organizationId, organizationId)
+            eq(schema.Integration.organizationId, organizationId),
+            isNull(schema.Integration.deletedAt)
           )
         )
         .limit(1)
@@ -192,7 +194,8 @@ export const integrationReauthRouter = createTRPCRouter({
         .where(
           and(
             eq(schema.Integration.id, input.integrationId),
-            eq(schema.Integration.organizationId, organizationId)
+            eq(schema.Integration.organizationId, organizationId),
+            isNull(schema.Integration.deletedAt)
           )
         )
         .limit(1)
@@ -255,6 +258,7 @@ export const integrationReauthRouter = createTRPCRouter({
         .where(
           and(
             eq(schema.Integration.organizationId, organizationId),
+            isNull(schema.Integration.deletedAt),
             ...(input.integrationIds ? [inArray(schema.Integration.id, input.integrationIds)] : [])
           )
         )

--- a/apps/web/src/server/api/routers/label.ts
+++ b/apps/web/src/server/api/routers/label.ts
@@ -10,7 +10,7 @@ import {
 import { ProviderRegistryService } from '@auxx/lib/providers'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { adminProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
 
@@ -353,7 +353,8 @@ export const labelRouter = createTRPCRouter({
         .where(
           and(
             eq(schema.Integration.id, input.integrationId),
-            eq(schema.Integration.organizationId, organizationId)
+            eq(schema.Integration.organizationId, organizationId),
+            isNull(schema.Integration.deletedAt)
           )
         )
         .limit(1)

--- a/apps/web/src/server/api/routers/user.ts
+++ b/apps/web/src/server/api/routers/user.ts
@@ -5,7 +5,7 @@ import { FeaturePermissionService } from '@auxx/lib/permissions'
 import { SettingsService, UserSettingsService } from '@auxx/lib/settings'
 import { autoSyncShopify } from '@auxx/lib/shopify'
 import { TRPCError } from '@trpc/server'
-import { count, eq } from 'drizzle-orm'
+import { and, count, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
 
@@ -108,7 +108,12 @@ export const userRouter = createTRPCRouter({
     const [{ integrationCount }] = await db
       .select({ integrationCount: count() })
       .from(schema.Integration)
-      .where(eq(schema.Integration.organizationId, organizationId))
+      .where(
+        and(
+          eq(schema.Integration.organizationId, organizationId),
+          isNull(schema.Integration.deletedAt)
+        )
+      )
     const hasIntegrations = integrationCount > 0
 
     // Fetch avatar URL if user has an avatar asset

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
@@ -17,6 +17,7 @@ import {
   sendGettingStartedEmailsJob,
   sendMidTrialEmailsJob,
   sendTrialConversionEmailsJob,
+  storageCleanupJob,
   stripeSubscriptionSyncJob,
   thumbnailCleanupJob,
 } from '@auxx/lib/jobs'
@@ -72,6 +73,9 @@ const jobMappings = {
 
   // Quota management jobs
   quotaResetJob,
+
+  // Storage cleanup (on-demand, enqueued by disconnect/delete flows)
+  storageCleanupJob,
 }
 
 export function startMaintenanceWorker() {

--- a/packages/database/drizzle/0097_add-soft-delete-integration-storage-location.sql
+++ b/packages/database/drizzle/0097_add-soft-delete-integration-storage-location.sql
@@ -1,0 +1,8 @@
+DROP INDEX "Integration_organizationId_email_key";--> statement-breakpoint
+ALTER TABLE "Integration" ADD COLUMN "deletedAt" timestamp (3);--> statement-breakpoint
+ALTER TABLE "StorageLocation" ADD COLUMN "organizationId" text;--> statement-breakpoint
+ALTER TABLE "StorageLocation" ADD COLUMN "deletedAt" timestamp (3);--> statement-breakpoint
+ALTER TABLE "StorageLocation" ADD CONSTRAINT "StorageLocation_organizationId_Organization_id_fk" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+CREATE INDEX "StorageLocation_organizationId_idx" ON "StorageLocation" USING btree ("organizationId");--> statement-breakpoint
+CREATE INDEX "StorageLocation_deletedAt_idx" ON "StorageLocation" USING btree ("deletedAt") WHERE "StorageLocation"."deletedAt" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "Integration_organizationId_email_key" ON "Integration" USING btree ("organizationId","email") WHERE "Integration"."deletedAt" IS NULL;

--- a/packages/database/drizzle/meta/0097_snapshot.json
+++ b/packages/database/drizzle/meta/0097_snapshot.json
@@ -1,0 +1,27630 @@
+{
+  "id": "aaf2909c-ffc5-48bd-a9c4-1be14a6419d8",
+  "prevId": "6eb3d20e-d306-48b6-b5c0-e1cf73b3f718",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHistoryId": {
+          "name": "lastHistoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_providerId_accountId_key": {
+          "name": "account_providerId_accountId_key",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_User_id_fk": {
+          "name": "account_userId_User_id_fk",
+          "tableFrom": "account",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Address": {
+      "name": "Address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address1": {
+          "name": "address1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address2": {
+          "name": "address2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "countryCode": {
+          "name": "countryCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provinceCode": {
+          "name": "provinceCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orderType": {
+          "name": "orderType",
+          "type": "ORDER_ADDRESS_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Address_customerId_idx": {
+          "name": "Address_customerId_idx",
+          "columns": [
+            {
+              "expression": "customerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Address_orderId_idx": {
+          "name": "Address_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Address_customerId_shopify_customers_id_fk": {
+          "name": "Address_customerId_shopify_customers_id_fk",
+          "tableFrom": "Address",
+          "tableTo": "shopify_customers",
+          "columnsFrom": ["customerId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Address_organizationId_Organization_id_fk": {
+          "name": "Address_organizationId_Organization_id_fk",
+          "tableFrom": "Address",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Address_integrationId_ShopifyIntegration_id_fk": {
+          "name": "Address_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "Address",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AdminActionLog": {
+      "name": "AdminActionLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "adminUserId": {
+          "name": "adminUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionType": {
+          "name": "actionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetType": {
+          "name": "targetType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousState": {
+          "name": "previousState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newState": {
+          "name": "newState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AdminActionLog_organizationId_idx": {
+          "name": "AdminActionLog_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminActionLog_adminUserId_idx": {
+          "name": "AdminActionLog_adminUserId_idx",
+          "columns": [
+            {
+              "expression": "adminUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminActionLog_createdAt_idx": {
+          "name": "AdminActionLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminActionLog_actionType_idx": {
+          "name": "AdminActionLog_actionType_idx",
+          "columns": [
+            {
+              "expression": "actionType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AdminActionLog_adminUserId_User_id_fk": {
+          "name": "AdminActionLog_adminUserId_User_id_fk",
+          "tableFrom": "AdminActionLog",
+          "tableTo": "User",
+          "columnsFrom": ["adminUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "AdminActionLog_organizationId_Organization_id_fk": {
+          "name": "AdminActionLog_organizationId_Organization_id_fk",
+          "tableFrom": "AdminActionLog",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiIntegration": {
+      "name": "AiIntegration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiKey": {
+          "name": "apiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "AiIntegrationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryptedCredentials": {
+          "name": "encryptedCredentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loadBalancingEnabled": {
+          "name": "loadBalancingEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm'"
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "quotaLimit": {
+          "name": "quotaLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-1'"
+        },
+        "quotaType": {
+          "name": "quotaType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaUsed": {
+          "name": "quotaUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "AiIntegration_organizationId_idx": {
+          "name": "AiIntegration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_organizationId_isDefault_idx": {
+          "name": "AiIntegration_organizationId_isDefault_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isDefault",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_organizationId_modelType_idx": {
+          "name": "AiIntegration_organizationId_modelType_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_organizationId_providerType_idx": {
+          "name": "AiIntegration_organizationId_providerType_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_provider_organizationId_key": {
+          "name": "AiIntegration_provider_organizationId_key",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiIntegration_organizationId_Organization_id_fk": {
+          "name": "AiIntegration_organizationId_Organization_id_fk",
+          "tableFrom": "AiIntegration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiIntegration_userId_User_id_fk": {
+          "name": "AiIntegration_userId_User_id_fk",
+          "tableFrom": "AiIntegration",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiUsage": {
+      "name": "AiUsage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputTokens": {
+          "name": "inputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm'"
+        },
+        "outputTokens": {
+          "name": "outputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creditsUsed": {
+          "name": "creditsUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "ProviderType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialSource": {
+          "name": "credentialSource",
+          "type": "CredentialSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "AiUsage_createdAt_idx": {
+          "name": "AiUsage_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiUsage_organizationId_createdAt_idx": {
+          "name": "AiUsage_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiUsage_provider_model_idx": {
+          "name": "AiUsage_provider_model_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiUsage_source_idx": {
+          "name": "AiUsage_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiUsage_organizationId_Organization_id_fk": {
+          "name": "AiUsage_organizationId_Organization_id_fk",
+          "tableFrom": "AiUsage",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiUsage_userId_User_id_fk": {
+          "name": "AiUsage_userId_User_id_fk",
+          "tableFrom": "AiUsage",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApiKey": {
+      "name": "ApiKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashedKey": {
+          "name": "hashedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app'"
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ApiKey_hashedKey_key": {
+          "name": "ApiKey_hashedKey_key",
+          "columns": [
+            {
+              "expression": "hashedKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApiKey_userId_isActive_idx": {
+          "name": "ApiKey_userId_isActive_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApiKey_type_referenceId_idx": {
+          "name": "ApiKey_type_referenceId_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referenceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApiKey_userId_User_id_fk": {
+          "name": "ApiKey_userId_User_id_fk",
+          "tableFrom": "ApiKey",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ApiKey_organizationId_Organization_id_fk": {
+          "name": "ApiKey_organizationId_Organization_id_fk",
+          "tableFrom": "ApiKey",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppBundle": {
+      "name": "AppBundle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundleType": {
+          "name": "bundleType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploadedAt": {
+          "name": "uploadedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppBundle_content_idx": {
+          "name": "AppBundle_content_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundleType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppBundle_appId_idx": {
+          "name": "AppBundle_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppBundle_appId_App_id_fk": {
+          "name": "AppBundle_appId_App_id_fk",
+          "tableFrom": "AppBundle",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppDeployment": {
+      "name": "AppDeployment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deploymentType": {
+          "name": "deploymentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientBundleId": {
+          "name": "clientBundleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverBundleId": {
+          "name": "serverBundleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settingsSchema": {
+          "name": "settingsSchema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetOrganizationId": {
+          "name": "targetOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environmentVariables": {
+          "name": "environmentVariables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "reviewedAt": {
+          "name": "reviewedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewedBy": {
+          "name": "reviewedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectionReason": {
+          "name": "rejectionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "releaseNotes": {
+          "name": "releaseNotes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppDeployment_appId_idx": {
+          "name": "AppDeployment_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppDeployment_type_idx": {
+          "name": "AppDeployment_type_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deploymentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppDeployment_targetOrganizationId_idx": {
+          "name": "AppDeployment_targetOrganizationId_idx",
+          "columns": [
+            {
+              "expression": "targetOrganizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppDeployment_appId_App_id_fk": {
+          "name": "AppDeployment_appId_App_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppDeployment_clientBundleId_AppBundle_id_fk": {
+          "name": "AppDeployment_clientBundleId_AppBundle_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "AppBundle",
+          "columnsFrom": ["clientBundleId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "AppDeployment_serverBundleId_AppBundle_id_fk": {
+          "name": "AppDeployment_serverBundleId_AppBundle_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "AppBundle",
+          "columnsFrom": ["serverBundleId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "AppDeployment_targetOrganizationId_Organization_id_fk": {
+          "name": "AppDeployment_targetOrganizationId_Organization_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "Organization",
+          "columnsFrom": ["targetOrganizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppEventLog": {
+      "name": "AppEventLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appDeploymentId": {
+          "name": "appDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventData": {
+          "name": "eventData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestMethod": {
+          "name": "requestMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestPath": {
+          "name": "requestPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseStatus": {
+          "name": "responseStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppEventLog_appId_idx": {
+          "name": "AppEventLog_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppEventLog_organizationId_idx": {
+          "name": "AppEventLog_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppEventLog_appDeploymentId_idx": {
+          "name": "AppEventLog_appDeploymentId_idx",
+          "columns": [
+            {
+              "expression": "appDeploymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppEventLog_timestamp_idx": {
+          "name": "AppEventLog_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppEventLog_appId_App_id_fk": {
+          "name": "AppEventLog_appId_App_id_fk",
+          "tableFrom": "AppEventLog",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppEventLog_organizationId_Organization_id_fk": {
+          "name": "AppEventLog_organizationId_Organization_id_fk",
+          "tableFrom": "AppEventLog",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppEventLog_appDeploymentId_AppDeployment_id_fk": {
+          "name": "AppEventLog_appDeploymentId_AppDeployment_id_fk",
+          "tableFrom": "AppEventLog",
+          "tableTo": "AppDeployment",
+          "columnsFrom": ["appDeploymentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppInstallation": {
+      "name": "AppInstallation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installationType": {
+          "name": "installationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentDeploymentId": {
+          "name": "currentDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installedAt": {
+          "name": "installedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "uninstalledAt": {
+          "name": "uninstalledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppInstallation_unique_idx": {
+          "name": "AppInstallation_unique_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppInstallation_appId_idx": {
+          "name": "AppInstallation_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppInstallation_organizationId_idx": {
+          "name": "AppInstallation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppInstallation_appId_App_id_fk": {
+          "name": "AppInstallation_appId_App_id_fk",
+          "tableFrom": "AppInstallation",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppInstallation_organizationId_Organization_id_fk": {
+          "name": "AppInstallation_organizationId_Organization_id_fk",
+          "tableFrom": "AppInstallation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppInstallation_currentDeploymentId_AppDeployment_id_fk": {
+          "name": "AppInstallation_currentDeploymentId_AppDeployment_id_fk",
+          "tableFrom": "AppInstallation",
+          "tableTo": "AppDeployment",
+          "columnsFrom": ["currentDeploymentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppMarketplaceImage": {
+      "name": "AppMarketplaceImage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileExtension": {
+          "name": "fileExtension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "savedSortOrder": {
+          "name": "savedSortOrder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploadCompletedAt": {
+          "name": "uploadCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSavedAt": {
+          "name": "lastSavedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppMarketplaceImage_appId_idx": {
+          "name": "AppMarketplaceImage_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppMarketplaceImage_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "AppMarketplaceImage_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "AppMarketplaceImage",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppMarketplaceImage_appId_App_id_fk": {
+          "name": "AppMarketplaceImage_appId_App_id_fk",
+          "tableFrom": "AppMarketplaceImage",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppSetting": {
+      "name": "AppSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appDeploymentId": {
+          "name": "appDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppSetting_appInstallationId_key_key": {
+          "name": "AppSetting_appInstallationId_key_key",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppSetting_appInstallationId_idx": {
+          "name": "AppSetting_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppSetting_appDeploymentId_idx": {
+          "name": "AppSetting_appDeploymentId_idx",
+          "columns": [
+            {
+              "expression": "appDeploymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppSetting_appInstallationId_AppInstallation_id_fk": {
+          "name": "AppSetting_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "AppSetting",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppSetting_appDeploymentId_AppDeployment_id_fk": {
+          "name": "AppSetting_appDeploymentId_AppDeployment_id_fk",
+          "tableFrom": "AppSetting",
+          "tableTo": "AppDeployment",
+          "columnsFrom": ["appDeploymentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppWebhookHandler": {
+      "name": "AppWebhookHandler",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handlerId": {
+          "name": "handlerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalWebhookId": {
+          "name": "externalWebhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerId": {
+          "name": "triggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppWebhookHandler_unique_idx": {
+          "name": "AppWebhookHandler_unique_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handlerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppWebhookHandler_appInstallationId_idx": {
+          "name": "AppWebhookHandler_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppWebhookHandler_appInstallationId_AppInstallation_id_fk": {
+          "name": "AppWebhookHandler_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "AppWebhookHandler",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "AppWebhookHandler_connectionId_WorkflowCredentials_id_fk": {
+          "name": "AppWebhookHandler_connectionId_WorkflowCredentials_id_fk",
+          "tableFrom": "AppWebhookHandler",
+          "tableTo": "WorkflowCredentials",
+          "columnsFrom": ["connectionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.App": {
+      "name": "App",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarId": {
+          "name": "avatarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "websiteUrl": {
+          "name": "websiteUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentationUrl": {
+          "name": "documentationUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contactUrl": {
+          "name": "contactUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supportSiteUrl": {
+          "name": "supportSiteUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termsOfServiceUrl": {
+          "name": "termsOfServiceUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentOverview": {
+          "name": "contentOverview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentHowItWorks": {
+          "name": "contentHowItWorks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentConfigure": {
+          "name": "contentConfigure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "hasOauth": {
+          "name": "hasOauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "oauthApplicationId": {
+          "name": "oauthApplicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauthExternalEntrypointUrl": {
+          "name": "oauthExternalEntrypointUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasBundle": {
+          "name": "hasBundle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "publicationStatus": {
+          "name": "publicationStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpublished'"
+        },
+        "reviewStatus": {
+          "name": "reviewStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autoApprove": {
+          "name": "autoApprove",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "App_slug_idx": {
+          "name": "App_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "App_developerAccountId_idx": {
+          "name": "App_developerAccountId_idx",
+          "columns": [
+            {
+              "expression": "developerAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "App_reviewStatus_idx": {
+          "name": "App_reviewStatus_idx",
+          "columns": [
+            {
+              "expression": "reviewStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "App_autoApprove_idx": {
+          "name": "App_autoApprove_idx",
+          "columns": [
+            {
+              "expression": "autoApprove",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "App_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "App_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "App",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "App_oauthApplicationId_oauthApplication_id_fk": {
+          "name": "App_oauthApplicationId_oauthApplication_id_fk",
+          "tableFrom": "App",
+          "tableTo": "oauthApplication",
+          "columnsFrom": ["oauthApplicationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "App_slug_unique": {
+          "name": "App_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApprovalRequest": {
+      "name": "ApprovalRequest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowRunId": {
+          "name": "workflowRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeName": {
+          "name": "nodeName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ApprovalStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeUsers": {
+          "name": "assigneeUsers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeGroups": {
+          "name": "assigneeGroups",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflowName": {
+          "name": "workflowName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ApprovalRequest_createdById_idx": {
+          "name": "ApprovalRequest_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_organizationId_assigneeGroups_idx": {
+          "name": "ApprovalRequest_organizationId_assigneeGroups_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigneeGroups",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_organizationId_assigneeUsers_idx": {
+          "name": "ApprovalRequest_organizationId_assigneeUsers_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigneeUsers",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_organizationId_idx": {
+          "name": "ApprovalRequest_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_status_expiresAt_idx": {
+          "name": "ApprovalRequest_status_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_workflowRunId_idx": {
+          "name": "ApprovalRequest_workflowRunId_idx",
+          "columns": [
+            {
+              "expression": "workflowRunId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApprovalRequest_organizationId_Organization_id_fk": {
+          "name": "ApprovalRequest_organizationId_Organization_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ApprovalRequest_workflowId_Workflow_id_fk": {
+          "name": "ApprovalRequest_workflowId_Workflow_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ApprovalRequest_workflowRunId_WorkflowRun_id_fk": {
+          "name": "ApprovalRequest_workflowRunId_WorkflowRun_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "WorkflowRun",
+          "columnsFrom": ["workflowRunId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ApprovalRequest_createdById_User_id_fk": {
+          "name": "ApprovalRequest_createdById_User_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApprovalResponse": {
+      "name": "ApprovalResponse",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "approvalRequestId": {
+          "name": "approvalRequestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "ApprovalAction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responseMethod": {
+          "name": "responseMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ApprovalResponse_approvalRequestId_userId_key": {
+          "name": "ApprovalResponse_approvalRequestId_userId_key",
+          "columns": [
+            {
+              "expression": "approvalRequestId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalResponse_userId_idx": {
+          "name": "ApprovalResponse_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApprovalResponse_approvalRequestId_ApprovalRequest_id_fk": {
+          "name": "ApprovalResponse_approvalRequestId_ApprovalRequest_id_fk",
+          "tableFrom": "ApprovalResponse",
+          "tableTo": "ApprovalRequest",
+          "columnsFrom": ["approvalRequestId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ApprovalResponse_userId_User_id_fk": {
+          "name": "ApprovalResponse_userId_User_id_fk",
+          "tableFrom": "ApprovalResponse",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ArticleRevision": {
+      "name": "ArticleRevision",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editorId": {
+          "name": "editorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousContent": {
+          "name": "previousContent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "previousContentJson": {
+          "name": "previousContentJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wasCategory": {
+          "name": "wasCategory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ArticleRevision_articleId_Article_id_fk": {
+          "name": "ArticleRevision_articleId_Article_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "Article",
+          "columnsFrom": ["articleId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ArticleRevision_editorId_User_id_fk": {
+          "name": "ArticleRevision_editorId_User_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "User",
+          "columnsFrom": ["editorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ArticleRevision_organizationId_Organization_id_fk": {
+          "name": "ArticleRevision_organizationId_Organization_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ArticleTag": {
+      "name": "ArticleTag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ArticleTag_name_organizationId_key": {
+          "name": "ArticleTag_name_organizationId_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ArticleTag_organizationId_Organization_id_fk": {
+          "name": "ArticleTag_organizationId_Organization_id_fk",
+          "tableFrom": "ArticleTag",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Article": {
+      "name": "Article",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentJson": {
+          "name": "contentJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isCategory": {
+          "name": "isCategory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ArticleStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastReviewedAt": {
+          "name": "lastReviewedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewsCount": {
+          "name": "viewsCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "knowledgeBaseId": {
+          "name": "knowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isPublished": {
+          "name": "isPublished",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isHomePage": {
+          "name": "isHomePage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Article_isCategory_idx": {
+          "name": "Article_isCategory_idx",
+          "columns": [
+            {
+              "expression": "isCategory",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_knowledgeBaseId_idx": {
+          "name": "Article_knowledgeBaseId_idx",
+          "columns": [
+            {
+              "expression": "knowledgeBaseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_knowledgeBaseId_slug_key": {
+          "name": "Article_knowledgeBaseId_slug_key",
+          "columns": [
+            {
+              "expression": "knowledgeBaseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_parentId_idx": {
+          "name": "Article_parentId_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Article_authorId_User_id_fk": {
+          "name": "Article_authorId_User_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "User",
+          "columnsFrom": ["authorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Article_knowledgeBaseId_KnowledgeBase_id_fk": {
+          "name": "Article_knowledgeBaseId_KnowledgeBase_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "KnowledgeBase",
+          "columnsFrom": ["knowledgeBaseId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Article_organizationId_Organization_id_fk": {
+          "name": "Article_organizationId_Organization_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Article_parentId_Article_id_fk": {
+          "name": "Article_parentId_Article_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "Article",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Attachment": {
+      "name": "Attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ATTACHMENT'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort": {
+          "name": "sort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileVersionId": {
+          "name": "fileVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assetVersionId": {
+          "name": "assetVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentId": {
+          "name": "contentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Attachment_assetId_idx": {
+          "name": "Attachment_assetId_idx",
+          "columns": [
+            {
+              "expression": "assetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_createdAt_idx": {
+          "name": "Attachment_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_entityType_entityId_idx": {
+          "name": "Attachment_entityType_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_fileId_idx": {
+          "name": "Attachment_fileId_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_id_organizationId_key": {
+          "name": "Attachment_id_organizationId_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_organizationId_entityType_entityId_idx": {
+          "name": "Attachment_organizationId_entityType_entityId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Attachment_organizationId_Organization_id_fk": {
+          "name": "Attachment_organizationId_Organization_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Attachment_fileId_FolderFile_id_fk": {
+          "name": "Attachment_fileId_FolderFile_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "FolderFile",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Attachment_fileVersionId_FileVersion_id_fk": {
+          "name": "Attachment_fileVersionId_FileVersion_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "FileVersion",
+          "columnsFrom": ["fileVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Attachment_assetId_MediaAsset_id_fk": {
+          "name": "Attachment_assetId_MediaAsset_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["assetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Attachment_assetVersionId_MediaAssetVersion_id_fk": {
+          "name": "Attachment_assetVersionId_MediaAssetVersion_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "MediaAssetVersion",
+          "columnsFrom": ["assetVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Attachment_createdById_User_id_fk": {
+          "name": "Attachment_createdById_User_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatAttachment": {
+      "name": "ChatAttachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ChatAttachment_messageId_idx": {
+          "name": "ChatAttachment_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatAttachment_sessionId_idx": {
+          "name": "ChatAttachment_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatAttachment_sessionId_ChatSession_id_fk": {
+          "name": "ChatAttachment_sessionId_ChatSession_id_fk",
+          "tableFrom": "ChatAttachment",
+          "tableTo": "ChatSession",
+          "columnsFrom": ["sessionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatAttachment_messageId_ChatMessage_id_fk": {
+          "name": "ChatAttachment_messageId_ChatMessage_id_fk",
+          "tableFrom": "ChatAttachment",
+          "tableTo": "ChatMessage",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatMessage": {
+      "name": "ChatMessage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SENT'"
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ChatMessage_agentId_idx": {
+          "name": "ChatMessage_agentId_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatMessage_createdAt_idx": {
+          "name": "ChatMessage_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatMessage_sessionId_idx": {
+          "name": "ChatMessage_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatMessage_threadId_idx": {
+          "name": "ChatMessage_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatMessage_sessionId_ChatSession_id_fk": {
+          "name": "ChatMessage_sessionId_ChatSession_id_fk",
+          "tableFrom": "ChatMessage",
+          "tableTo": "ChatSession",
+          "columnsFrom": ["sessionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatMessage_agentId_User_id_fk": {
+          "name": "ChatMessage_agentId_User_id_fk",
+          "tableFrom": "ChatMessage",
+          "tableTo": "User",
+          "columnsFrom": ["agentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ChatMessage_threadId_Thread_id_fk": {
+          "name": "ChatMessage_threadId_Thread_id_fk",
+          "tableFrom": "ChatMessage",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatSession": {
+      "name": "ChatSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "widgetId": {
+          "name": "widgetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "lastActivityAt": {
+          "name": "lastActivityAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closedById": {
+          "name": "closedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorId": {
+          "name": "visitorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitorName": {
+          "name": "visitorName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorEmail": {
+          "name": "visitorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ChatSession_lastActivityAt_idx": {
+          "name": "ChatSession_lastActivityAt_idx",
+          "columns": [
+            {
+              "expression": "lastActivityAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatSession_organizationId_idx": {
+          "name": "ChatSession_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatSession_status_idx": {
+          "name": "ChatSession_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatSession_visitorId_idx": {
+          "name": "ChatSession_visitorId_idx",
+          "columns": [
+            {
+              "expression": "visitorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatSession_widgetId_idx": {
+          "name": "ChatSession_widgetId_idx",
+          "columns": [
+            {
+              "expression": "widgetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatSession_widgetId_ChatWidget_id_fk": {
+          "name": "ChatSession_widgetId_ChatWidget_id_fk",
+          "tableFrom": "ChatSession",
+          "tableTo": "ChatWidget",
+          "columnsFrom": ["widgetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatSession_organizationId_Organization_id_fk": {
+          "name": "ChatSession_organizationId_Organization_id_fk",
+          "tableFrom": "ChatSession",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatSession_threadId_Thread_id_fk": {
+          "name": "ChatSession_threadId_Thread_id_fk",
+          "tableFrom": "ChatSession",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatSession_closedById_User_id_fk": {
+          "name": "ChatSession_closedById_User_id_fk",
+          "tableFrom": "ChatSession",
+          "tableTo": "User",
+          "columnsFrom": ["closedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatWidget": {
+      "name": "ChatWidget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Chat Support'"
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryColor": {
+          "name": "primaryColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#4F46E5'"
+        },
+        "logoUrl": {
+          "name": "logoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BOTTOM_RIGHT'"
+        },
+        "welcomeMessage": {
+          "name": "welcomeMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autoOpen": {
+          "name": "autoOpen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mobileFullScreen": {
+          "name": "mobileFullScreen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collectUserInfo": {
+          "name": "collectUserInfo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "offlineMessage": {
+          "name": "offlineMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'We''re currently offline. Please leave a message and we''ll get back to you as soon as possible.'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowedDomains": {
+          "name": "allowedDomains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "useAi": {
+          "name": "useAi",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiInstructions": {
+          "name": "aiInstructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ChatWidget_integrationId_key": {
+          "name": "ChatWidget_integrationId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatWidget_organizationId_idx": {
+          "name": "ChatWidget_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatWidget_organizationId_name_key": {
+          "name": "ChatWidget_organizationId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatWidget_integrationId_Integration_id_fk": {
+          "name": "ChatWidget_integrationId_Integration_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatWidget_organizationId_Organization_id_fk": {
+          "name": "ChatWidget_organizationId_Organization_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CommentMention": {
+      "name": "CommentMention",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "CommentMention_commentId_idx": {
+          "name": "CommentMention_commentId_idx",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentMention_commentId_userId_key": {
+          "name": "CommentMention_commentId_userId_key",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentMention_userId_idx": {
+          "name": "CommentMention_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CommentMention_commentId_Comment_id_fk": {
+          "name": "CommentMention_commentId_Comment_id_fk",
+          "tableFrom": "CommentMention",
+          "tableTo": "Comment",
+          "columnsFrom": ["commentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CommentMention_userId_User_id_fk": {
+          "name": "CommentMention_userId_User_id_fk",
+          "tableFrom": "CommentMention",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CommentReaction": {
+      "name": "CommentReaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "CommentReaction_commentId_idx": {
+          "name": "CommentReaction_commentId_idx",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReaction_commentId_userId_type_emoji_key": {
+          "name": "CommentReaction_commentId_userId_type_emoji_key",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReaction_type_idx": {
+          "name": "CommentReaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReaction_userId_idx": {
+          "name": "CommentReaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CommentReaction_commentId_Comment_id_fk": {
+          "name": "CommentReaction_commentId_Comment_id_fk",
+          "tableFrom": "CommentReaction",
+          "tableTo": "Comment",
+          "columnsFrom": ["commentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CommentReaction_userId_User_id_fk": {
+          "name": "CommentReaction_userId_User_id_fk",
+          "tableFrom": "CommentReaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Comment": {
+      "name": "Comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinnedAt": {
+          "name": "pinnedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinnedById": {
+          "name": "pinnedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Comment_createdById_idx": {
+          "name": "Comment_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_deletedAt_idx": {
+          "name": "Comment_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_entityId_entityDefinitionId_idx": {
+          "name": "Comment_entityId_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_isPinned_idx": {
+          "name": "Comment_isPinned_idx",
+          "columns": [
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_organizationId_idx": {
+          "name": "Comment_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_parentId_idx": {
+          "name": "Comment_parentId_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Comment_createdById_User_id_fk": {
+          "name": "Comment_createdById_User_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Comment_organizationId_Organization_id_fk": {
+          "name": "Comment_organizationId_Organization_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Comment_parentId_Comment_id_fk": {
+          "name": "Comment_parentId_Comment_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "Comment",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Comment_pinnedById_User_id_fk": {
+          "name": "Comment_pinnedById_User_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "User",
+          "columnsFrom": ["pinnedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ConnectionDefinition": {
+      "name": "ConnectionDefinition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major": {
+          "name": "major",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionType": {
+          "name": "connectionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global": {
+          "name": "global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "oauth2AuthorizeUrl": {
+          "name": "oauth2AuthorizeUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2AccessTokenUrl": {
+          "name": "oauth2AccessTokenUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2Scopes": {
+          "name": "oauth2Scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "oauth2ClientId": {
+          "name": "oauth2ClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2ClientSecret": {
+          "name": "oauth2ClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2TokenRequestAuthMethod": {
+          "name": "oauth2TokenRequestAuthMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'request-body'"
+        },
+        "oauth2RefreshTokenIntervalSeconds": {
+          "name": "oauth2RefreshTokenIntervalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2Features": {
+          "name": "oauth2Features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ConnectionDefinition_app_version_idx": {
+          "name": "ConnectionDefinition_app_version_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "major",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ConnectionDefinition_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "ConnectionDefinition_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "ConnectionDefinition",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ConnectionDefinition_appId_App_id_fk": {
+          "name": "ConnectionDefinition_appId_App_id_fk",
+          "tableFrom": "ConnectionDefinition",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CustomField": {
+      "name": "CustomField",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "ContactFieldType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a0'"
+        },
+        "displayOptions": {
+          "name": "displayOptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "defaultValue": {
+          "name": "defaultValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contact'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isCustom": {
+          "name": "isCustom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "systemAttribute": {
+          "name": "systemAttribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isUnique": {
+          "name": "isUnique",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isCreatable": {
+          "name": "isCreatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isUpdatable": {
+          "name": "isUpdatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isComputed": {
+          "name": "isComputed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isSortable": {
+          "name": "isSortable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isFilterable": {
+          "name": "isFilterable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "CustomField_modelType_idx": {
+          "name": "CustomField_modelType_idx",
+          "columns": [
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_name_org_model_entity_key": {
+          "name": "CustomField_name_org_model_entity_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_organizationId_idx": {
+          "name": "CustomField_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_entityDefinitionId_idx": {
+          "name": "CustomField_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_organizationId_entityDefinitionId_sortOrder_idx": {
+          "name": "CustomField_organizationId_entityDefinitionId_sortOrder_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortOrder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CustomField_organizationId_Organization_id_fk": {
+          "name": "CustomField_organizationId_Organization_id_fk",
+          "tableFrom": "CustomField",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CustomField_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "CustomField_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "CustomField",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DatasetMetadata": {
+      "name": "DatasetMetadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "DatasetMetadata_datasetId_idx": {
+          "name": "DatasetMetadata_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetMetadata_datasetId_name_key": {
+          "name": "DatasetMetadata_datasetId_name_key",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetMetadata_type_idx": {
+          "name": "DatasetMetadata_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DatasetMetadata_datasetId_Dataset_id_fk": {
+          "name": "DatasetMetadata_datasetId_Dataset_id_fk",
+          "tableFrom": "DatasetMetadata",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DatasetSearchQuery": {
+      "name": "DatasetSearchQuery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queryType": {
+          "name": "queryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hybrid'"
+        },
+        "resultsCount": {
+          "name": "resultsCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vectorSimilarityThreshold": {
+          "name": "vectorSimilarityThreshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.7
+        },
+        "maxResults": {
+          "name": "maxResults",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "DatasetSearchQuery_createdAt_idx": {
+          "name": "DatasetSearchQuery_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchQuery_datasetId_idx": {
+          "name": "DatasetSearchQuery_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchQuery_organizationId_idx": {
+          "name": "DatasetSearchQuery_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchQuery_userId_idx": {
+          "name": "DatasetSearchQuery_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DatasetSearchQuery_datasetId_Dataset_id_fk": {
+          "name": "DatasetSearchQuery_datasetId_Dataset_id_fk",
+          "tableFrom": "DatasetSearchQuery",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DatasetSearchQuery_organizationId_Organization_id_fk": {
+          "name": "DatasetSearchQuery_organizationId_Organization_id_fk",
+          "tableFrom": "DatasetSearchQuery",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DatasetSearchQuery_userId_User_id_fk": {
+          "name": "DatasetSearchQuery_userId_User_id_fk",
+          "tableFrom": "DatasetSearchQuery",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DatasetSearchResult": {
+      "name": "DatasetSearchResult",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queryId": {
+          "name": "queryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segmentId": {
+          "name": "segmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "DatasetSearchResult_queryId_idx": {
+          "name": "DatasetSearchResult_queryId_idx",
+          "columns": [
+            {
+              "expression": "queryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_queryId_segmentId_key": {
+          "name": "DatasetSearchResult_queryId_segmentId_key",
+          "columns": [
+            {
+              "expression": "queryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_rank_idx": {
+          "name": "DatasetSearchResult_rank_idx",
+          "columns": [
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_score_idx": {
+          "name": "DatasetSearchResult_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_segmentId_idx": {
+          "name": "DatasetSearchResult_segmentId_idx",
+          "columns": [
+            {
+              "expression": "segmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DatasetSearchResult_queryId_DatasetSearchQuery_id_fk": {
+          "name": "DatasetSearchResult_queryId_DatasetSearchQuery_id_fk",
+          "tableFrom": "DatasetSearchResult",
+          "tableTo": "DatasetSearchQuery",
+          "columnsFrom": ["queryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DatasetSearchResult_segmentId_DocumentSegment_id_fk": {
+          "name": "DatasetSearchResult_segmentId_DocumentSegment_id_fk",
+          "tableFrom": "DatasetSearchResult",
+          "tableTo": "DocumentSegment",
+          "columnsFrom": ["segmentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Dataset": {
+      "name": "Dataset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "DatasetStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "documentCount": {
+          "name": "documentCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalSize": {
+          "name": "totalSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastIndexedAt": {
+          "name": "lastIndexedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunkSettings": {
+          "name": "chunkSettings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"strategy\":\"FIXED_SIZE\",\"size\":1024,\"overlap\":50,\"delimiter\":\"\\n\\n\",\"preprocessing\":{\"normalizeWhitespace\":true,\"removeUrlsAndEmails\":false}}'::jsonb"
+        },
+        "vectorDbConfig": {
+          "name": "vectorDbConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingModel": {
+          "name": "embeddingModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vectorDimension": {
+          "name": "vectorDimension",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vectorDbType": {
+          "name": "vectorDbType",
+          "type": "VectorDbType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POSTGRESQL'"
+        },
+        "searchConfig": {
+          "name": "searchConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"searchType\":\"hybrid\"}'::jsonb"
+        }
+      },
+      "indexes": {
+        "Dataset_createdById_idx": {
+          "name": "Dataset_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Dataset_organizationId_idx": {
+          "name": "Dataset_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Dataset_organizationId_name_key": {
+          "name": "Dataset_organizationId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Dataset_status_idx": {
+          "name": "Dataset_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dataset_org_status": {
+          "name": "idx_dataset_org_status",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Dataset_organizationId_Organization_id_fk": {
+          "name": "Dataset_organizationId_Organization_id_fk",
+          "tableFrom": "Dataset",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Dataset_createdById_User_id_fk": {
+          "name": "Dataset_createdById_User_id_fk",
+          "tableFrom": "Dataset",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeveloperAccountInvite": {
+      "name": "DeveloperAccountInvite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailAddress": {
+          "name": "emailAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessLevel": {
+          "name": "accessLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "failedToSend": {
+          "name": "failedToSend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeveloperAccountInvite_account_idx": {
+          "name": "DeveloperAccountInvite_account_idx",
+          "columns": [
+            {
+              "expression": "developerAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeveloperAccountInvite_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "DeveloperAccountInvite_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "DeveloperAccountInvite",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeveloperAccountMember": {
+      "name": "DeveloperAccountMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailAddress": {
+          "name": "emailAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessLevel": {
+          "name": "accessLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeveloperAccountMember_unique_idx": {
+          "name": "DeveloperAccountMember_unique_idx",
+          "columns": [
+            {
+              "expression": "developerAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DeveloperAccountMember_userId_idx": {
+          "name": "DeveloperAccountMember_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeveloperAccountMember_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "DeveloperAccountMember_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "DeveloperAccountMember",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DeveloperAccountMember_userId_User_id_fk": {
+          "name": "DeveloperAccountMember_userId_User_id_fk",
+          "tableFrom": "DeveloperAccountMember",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeveloperAccount": {
+      "name": "DeveloperAccount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logoId": {
+          "name": "logoId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoUrl": {
+          "name": "logoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featureFlags": {
+          "name": "featureFlags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"legacy-collection-scopes\":false,\"search-records-api\":false,\"find-create-meetings-api\":false,\"get-list-meetings-api\":true,\"write-call-recordings-api\":false,\"read-call-recordings-api\":true}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeveloperAccount_slug_idx": {
+          "name": "DeveloperAccount_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "DeveloperAccount_slug_unique": {
+          "name": "DeveloperAccount_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DocumentSegment": {
+      "name": "DocumentSegment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startOffset": {
+          "name": "startOffset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endOffset": {
+          "name": "endOffset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenCount": {
+          "name": "tokenCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_512": {
+          "name": "embedding_512",
+          "type": "vector(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_768": {
+          "name": "embedding_768",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_1024": {
+          "name": "embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_1536": {
+          "name": "embedding_1536",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_3072": {
+          "name": "embedding_3072",
+          "type": "vector(3072)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingModel": {
+          "name": "embeddingModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingDimension": {
+          "name": "embeddingDimension",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "indexStatus": {
+          "name": "indexStatus",
+          "type": "IndexStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "searchMetadata": {
+          "name": "searchMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchVector": {
+          "name": "searchVector",
+          "type": "tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "DocumentSegment_documentId_idx": {
+          "name": "DocumentSegment_documentId_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DocumentSegment_organizationId_idx": {
+          "name": "DocumentSegment_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DocumentSegment_position_idx": {
+          "name": "DocumentSegment_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_embedding_512_hnsw": {
+          "name": "idx_embedding_512_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_512",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_512 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_embedding_768_hnsw": {
+          "name": "idx_embedding_768_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_768",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_768 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_embedding_1024_hnsw": {
+          "name": "idx_embedding_1024_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_1024",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_1024 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_embedding_1536_hnsw": {
+          "name": "idx_embedding_1536_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_1536",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_1536 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_document_segment_search_vector": {
+          "name": "idx_document_segment_search_vector",
+          "columns": [
+            {
+              "expression": "searchVector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_document_segment_dataset_filter": {
+          "name": "idx_document_segment_dataset_filter",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((enabled = true) AND (\"indexStatus\" = 'INDEXED'::\"IndexStatus\"))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DocumentSegment_documentId_Document_id_fk": {
+          "name": "DocumentSegment_documentId_Document_id_fk",
+          "tableFrom": "DocumentSegment",
+          "tableTo": "Document",
+          "columnsFrom": ["documentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DocumentSegment_organizationId_Organization_id_fk": {
+          "name": "DocumentSegment_organizationId_Organization_id_fk",
+          "tableFrom": "DocumentSegment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalPath": {
+          "name": "originalPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "DocumentType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "DocumentStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UPLOADED'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingTime": {
+          "name": "processingTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalChunks": {
+          "name": "totalChunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploadedById": {
+          "name": "uploadedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunkSettings": {
+          "name": "chunkSettings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mediaAssetId": {
+          "name": "mediaAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Document_checksum_idx": {
+          "name": "Document_checksum_idx",
+          "columns": [
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_datasetId_checksum_key": {
+          "name": "Document_datasetId_checksum_key",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_datasetId_idx": {
+          "name": "Document_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_enabled_idx": {
+          "name": "Document_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_mediaAssetId_idx": {
+          "name": "Document_mediaAssetId_idx",
+          "columns": [
+            {
+              "expression": "mediaAssetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_organizationId_idx": {
+          "name": "Document_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_status_idx": {
+          "name": "Document_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_type_idx": {
+          "name": "Document_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_uploadedById_idx": {
+          "name": "Document_uploadedById_idx",
+          "columns": [
+            {
+              "expression": "uploadedById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_document_dataset_enabled": {
+          "name": "idx_document_dataset_enabled",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Document_datasetId_Dataset_id_fk": {
+          "name": "Document_datasetId_Dataset_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Document_organizationId_Organization_id_fk": {
+          "name": "Document_organizationId_Organization_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Document_uploadedById_User_id_fk": {
+          "name": "Document_uploadedById_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["uploadedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Document_mediaAssetId_MediaAsset_id_fk": {
+          "name": "Document_mediaAssetId_MediaAsset_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["mediaAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Draft": {
+      "name": "Draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inReplyToMessageId": {
+          "name": "inReplyToMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerThreadId": {
+          "name": "providerThreadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Draft_organizationId_idx": {
+          "name": "Draft_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_createdById_idx": {
+          "name": "Draft_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_threadId_idx": {
+          "name": "Draft_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_integrationId_idx": {
+          "name": "Draft_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_threadId_createdById_key": {
+          "name": "Draft_threadId_createdById_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"threadId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_organizationId_providerId_key": {
+          "name": "Draft_organizationId_providerId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"providerId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_organizationId_createdById_idx": {
+          "name": "Draft_organizationId_createdById_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Draft_organizationId_Organization_id_fk": {
+          "name": "Draft_organizationId_Organization_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Draft_createdById_User_id_fk": {
+          "name": "Draft_createdById_User_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Draft_threadId_Thread_id_fk": {
+          "name": "Draft_threadId_Thread_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Draft_inReplyToMessageId_Message_id_fk": {
+          "name": "Draft_inReplyToMessageId_Message_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Message",
+          "columnsFrom": ["inReplyToMessageId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Draft_integrationId_Integration_id_fk": {
+          "name": "Draft_integrationId_Integration_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailAddress": {
+      "name": "EmailAddress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationType": {
+          "name": "integrationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "EmailAddress_integrationId_address_key": {
+          "name": "EmailAddress_integrationId_address_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailEmbedding": {
+      "name": "EmailEmbedding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text-embedding-3-small'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EmailEmbedding_messageId_idx": {
+          "name": "EmailEmbedding_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EmailEmbedding_messageId_Message_id_fk": {
+          "name": "EmailEmbedding_messageId_Message_id_fk",
+          "tableFrom": "EmailEmbedding",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailTemplate": {
+      "name": "EmailTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "EmailTemplateType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bodyHtml": {
+          "name": "bodyHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bodyPlain": {
+          "name": "bodyPlain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "EmailTemplate_organizationId_type_idx": {
+          "name": "EmailTemplate_organizationId_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EmailTemplate_organizationId_type_isDefault_key": {
+          "name": "EmailTemplate_organizationId_type_isDefault_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isDefault",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EmailTemplate_organizationId_Organization_id_fk": {
+          "name": "EmailTemplate_organizationId_Organization_id_fk",
+          "tableFrom": "EmailTemplate",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.embedding_jobs": {
+      "name": "embedding_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documents": {
+          "name": "documents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunkingOptions": {
+          "name": "chunkingOptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentCount": {
+          "name": "documentCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processedCount": {
+          "name": "processedCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errorCount": {
+          "name": "errorCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "embedding_jobs_collection_idx": {
+          "name": "embedding_jobs_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_jobs_status_idx": {
+          "name": "embedding_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "embedding_jobs_organizationId_Organization_id_fk": {
+          "name": "embedding_jobs_organizationId_Organization_id_fk",
+          "tableFrom": "embedding_jobs",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.embeddings": {
+      "name": "embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "jobId": {
+          "name": "jobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "embeddings_collection_idx": {
+          "name": "embeddings_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embeddings_documentId_idx": {
+          "name": "embeddings_documentId_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embeddings_jobId_idx": {
+          "name": "embeddings_jobId_idx",
+          "columns": [
+            {
+              "expression": "jobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "embeddings_jobId_embedding_jobs_id_fk": {
+          "name": "embeddings_jobId_embedding_jobs_id_fk",
+          "tableFrom": "embeddings",
+          "tableTo": "embedding_jobs",
+          "columnsFrom": ["jobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EndUser": {
+      "name": "EndUser",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "totalRuns": {
+          "name": "totalRuns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EndUser_workflowAppId_idx": {
+          "name": "EndUser_workflowAppId_idx",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_sessionId_idx": {
+          "name": "EndUser_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_userId_idx": {
+          "name": "EndUser_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_workflowAppId_sessionId_idx": {
+          "name": "EndUser_workflowAppId_sessionId_idx",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_workflowAppId_userId_idx": {
+          "name": "EndUser_workflowAppId_userId_idx",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EndUser_workflowAppId_WorkflowApp_id_fk": {
+          "name": "EndUser_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "EndUser",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EndUser_userId_User_id_fk": {
+          "name": "EndUser_userId_User_id_fk",
+          "tableFrom": "EndUser",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EntityDefinition": {
+      "name": "EntityDefinition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiSlug": {
+          "name": "apiSlug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Box'"
+        },
+        "singular": {
+          "name": "singular",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plural": {
+          "name": "plural",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standardType": {
+          "name": "standardType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryDisplayFieldId": {
+          "name": "primaryDisplayFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondaryDisplayFieldId": {
+          "name": "secondaryDisplayFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarFieldId": {
+          "name": "avatarFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isVisible": {
+          "name": "isVisible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "EntityDefinition_apiSlug_organizationId_key": {
+          "name": "EntityDefinition_apiSlug_organizationId_key",
+          "columns": [
+            {
+              "expression": "apiSlug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_organizationId_idx": {
+          "name": "EntityDefinition_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_entityType_idx": {
+          "name": "EntityDefinition_entityType_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_archivedAt_idx": {
+          "name": "EntityDefinition_archivedAt_idx",
+          "columns": [
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EntityDefinition_organizationId_Organization_id_fk": {
+          "name": "EntityDefinition_organizationId_Organization_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_primaryDisplayFieldId_CustomField_id_fk": {
+          "name": "EntityDefinition_primaryDisplayFieldId_CustomField_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "CustomField",
+          "columnsFrom": ["primaryDisplayFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_secondaryDisplayFieldId_CustomField_id_fk": {
+          "name": "EntityDefinition_secondaryDisplayFieldId_CustomField_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "CustomField",
+          "columnsFrom": ["secondaryDisplayFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_avatarFieldId_CustomField_id_fk": {
+          "name": "EntityDefinition_avatarFieldId_CustomField_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "CustomField",
+          "columnsFrom": ["avatarFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EntityGroupMember": {
+      "name": "EntityGroupMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "groupInstanceId": {
+          "name": "groupInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memberType": {
+          "name": "memberType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memberRefId": {
+          "name": "memberRefId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedById": {
+          "name": "addedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortKey": {
+          "name": "sortKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a0'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EntityGroupMember_group_member_key": {
+          "name": "EntityGroupMember_group_member_key",
+          "columns": [
+            {
+              "expression": "groupInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memberType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memberRefId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityGroupMember_group_idx": {
+          "name": "EntityGroupMember_group_idx",
+          "columns": [
+            {
+              "expression": "groupInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityGroupMember_member_idx": {
+          "name": "EntityGroupMember_member_idx",
+          "columns": [
+            {
+              "expression": "memberType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memberRefId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EntityGroupMember_groupInstanceId_EntityInstance_id_fk": {
+          "name": "EntityGroupMember_groupInstanceId_EntityInstance_id_fk",
+          "tableFrom": "EntityGroupMember",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["groupInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityGroupMember_addedById_User_id_fk": {
+          "name": "EntityGroupMember_addedById_User_id_fk",
+          "tableFrom": "EntityGroupMember",
+          "tableTo": "User",
+          "columnsFrom": ["addedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EntityInstance": {
+      "name": "EntityInstance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondaryDisplayValue": {
+          "name": "secondaryDisplayValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchText": {
+          "name": "searchText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "EntityInstance_entityDefinitionId_idx": {
+          "name": "EntityInstance_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_organizationId_idx": {
+          "name": "EntityInstance_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_archivedAt_idx": {
+          "name": "EntityInstance_archivedAt_idx",
+          "columns": [
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_orgId_defId_idx": {
+          "name": "EntityInstance_orgId_defId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_displayName_idx": {
+          "name": "EntityInstance_displayName_idx",
+          "columns": [
+            {
+              "expression": "displayName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EntityInstance_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "EntityInstance_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "EntityInstance",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityInstance_organizationId_Organization_id_fk": {
+          "name": "EntityInstance_organizationId_Organization_id_fk",
+          "tableFrom": "EntityInstance",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityInstance_createdById_User_id_fk": {
+          "name": "EntityInstance_createdById_User_id_fk",
+          "tableFrom": "EntityInstance",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Event": {
+      "name": "Event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "Event_organizationId_idx": {
+          "name": "Event_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Event_type_idx": {
+          "name": "Event_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Event_organizationId_Organization_id_fk": {
+          "name": "Event_organizationId_Organization_id_fk",
+          "tableFrom": "Event",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ExternalKnowledgeSource": {
+      "name": "ExternalKnowledgeSource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "syncEnabled": {
+          "name": "syncEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "syncInterval": {
+          "name": "syncInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextSyncAt": {
+          "name": "nextSyncAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ExternalKnowledgeSource_datasetId_idx": {
+          "name": "ExternalKnowledgeSource_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_datasetId_name_key": {
+          "name": "ExternalKnowledgeSource_datasetId_name_key",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_nextSyncAt_idx": {
+          "name": "ExternalKnowledgeSource_nextSyncAt_idx",
+          "columns": [
+            {
+              "expression": "nextSyncAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_organizationId_idx": {
+          "name": "ExternalKnowledgeSource_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_status_idx": {
+          "name": "ExternalKnowledgeSource_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ExternalKnowledgeSource_datasetId_Dataset_id_fk": {
+          "name": "ExternalKnowledgeSource_datasetId_Dataset_id_fk",
+          "tableFrom": "ExternalKnowledgeSource",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ExternalKnowledgeSource_organizationId_Organization_id_fk": {
+          "name": "ExternalKnowledgeSource_organizationId_Organization_id_fk",
+          "tableFrom": "ExternalKnowledgeSource",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ExternalKnowledgeSource_createdById_User_id_fk": {
+          "name": "ExternalKnowledgeSource_createdById_User_id_fk",
+          "tableFrom": "ExternalKnowledgeSource",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FieldValue": {
+      "name": "FieldValue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fieldId": {
+          "name": "fieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valueText": {
+          "name": "valueText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueNumber": {
+          "name": "valueNumber",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueBoolean": {
+          "name": "valueBoolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueDate": {
+          "name": "valueDate",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueJson": {
+          "name": "valueJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optionId": {
+          "name": "optionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedEntityId": {
+          "name": "relatedEntityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedEntityDefinitionId": {
+          "name": "relatedEntityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortKey": {
+          "name": "sortKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a'"
+        }
+      },
+      "indexes": {
+        "FieldValue_organizationId_idx": {
+          "name": "FieldValue_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityId_idx": {
+          "name": "FieldValue_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityDefinitionId_idx": {
+          "name": "FieldValue_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_fieldId_idx": {
+          "name": "FieldValue_fieldId_idx",
+          "columns": [
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityId_fieldId_idx": {
+          "name": "FieldValue_entityId_fieldId_idx",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityDefinitionId_entityId_idx": {
+          "name": "FieldValue_entityDefinitionId_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_optionId_idx": {
+          "name": "FieldValue_optionId_idx",
+          "columns": [
+            {
+              "expression": "optionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_relatedEntityId_idx": {
+          "name": "FieldValue_relatedEntityId_idx",
+          "columns": [
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_relatedEntityDefinitionId_idx": {
+          "name": "FieldValue_relatedEntityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "relatedEntityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_actorId_idx": {
+          "name": "FieldValue_actorId_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entity_field_sortKey_key": {
+          "name": "FieldValue_entity_field_sortKey_key",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FieldValue_organizationId_Organization_id_fk": {
+          "name": "FieldValue_organizationId_Organization_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FieldValue_fieldId_CustomField_id_fk": {
+          "name": "FieldValue_fieldId_CustomField_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "CustomField",
+          "columnsFrom": ["fieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FieldValue_actorId_User_id_fk": {
+          "name": "FieldValue_actorId_User_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "User",
+          "columnsFrom": ["actorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FileAttachment": {
+      "name": "FileAttachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachableId": {
+          "name": "attachableId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachableType": {
+          "name": "attachableType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FileAttachment_attachableId_attachableType_idx": {
+          "name": "FileAttachment_attachableId_attachableType_idx",
+          "columns": [
+            {
+              "expression": "attachableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachableType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FileAttachment_fileId_attachableId_attachableType_key": {
+          "name": "FileAttachment_fileId_attachableId_attachableType_key",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachableType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FileAttachment_fileId_File_id_fk": {
+          "name": "FileAttachment_fileId_File_id_fk",
+          "tableFrom": "FileAttachment",
+          "tableTo": "File",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FileVersion": {
+      "name": "FileVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageLocationId": {
+          "name": "storageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "FileVersion_fileId_createdAt_idx": {
+          "name": "FileVersion_fileId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FileVersion_fileId_versionNumber_key": {
+          "name": "FileVersion_fileId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FileVersion_fileId_FolderFile_id_fk": {
+          "name": "FileVersion_fileId_FolderFile_id_fk",
+          "tableFrom": "FileVersion",
+          "tableTo": "FolderFile",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FileVersion_storageLocationId_StorageLocation_id_fk": {
+          "name": "FileVersion_storageLocationId_StorageLocation_id_fk",
+          "tableFrom": "FileVersion",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["storageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.File": {
+      "name": "File",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashedKey": {
+          "name": "hashedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedById": {
+          "name": "deletedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "knowledgeBaseId": {
+          "name": "knowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmedAt": {
+          "name": "confirmedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "downloadCount": {
+          "name": "downloadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "FileStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "FileVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        }
+      },
+      "indexes": {
+        "File_checksum_organizationId_idx": {
+          "name": "File_checksum_organizationId_idx",
+          "columns": [
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_hashedKey_key": {
+          "name": "File_hashedKey_key",
+          "columns": [
+            {
+              "expression": "hashedKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_organizationId_status_idx": {
+          "name": "File_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_status_expiresAt_idx": {
+          "name": "File_status_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_visibility_hashedKey_idx": {
+          "name": "File_visibility_hashedKey_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hashedKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "File_createdById_User_id_fk": {
+          "name": "File_createdById_User_id_fk",
+          "tableFrom": "File",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "File_organizationId_Organization_id_fk": {
+          "name": "File_organizationId_Organization_id_fk",
+          "tableFrom": "File",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "File_deletedById_User_id_fk": {
+          "name": "File_deletedById_User_id_fk",
+          "tableFrom": "File",
+          "tableTo": "User",
+          "columnsFrom": ["deletedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "File_articleId_Article_id_fk": {
+          "name": "File_articleId_Article_id_fk",
+          "tableFrom": "File",
+          "tableTo": "Article",
+          "columnsFrom": ["articleId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "File_knowledgeBaseId_KnowledgeBase_id_fk": {
+          "name": "File_knowledgeBaseId_KnowledgeBase_id_fk",
+          "tableFrom": "File",
+          "tableTo": "KnowledgeBase",
+          "columnsFrom": ["knowledgeBaseId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FolderFile": {
+      "name": "FolderFile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentVersionId": {
+          "name": "currentVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "StorageProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FolderFile_currentVersionId_key": {
+          "name": "FolderFile_currentVersionId_key",
+          "columns": [
+            {
+              "expression": "currentVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_checksum_idx": {
+          "name": "FolderFile_organizationId_checksum_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_deletedAt_isArchived_idx": {
+          "name": "FolderFile_organizationId_deletedAt_isArchived_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_ext_createdAt_idx": {
+          "name": "FolderFile_organizationId_ext_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ext",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_folderId_idx": {
+          "name": "FolderFile_organizationId_folderId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_folderId_path_idx": {
+          "name": "FolderFile_organizationId_folderId_path_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_mimeType_updatedAt_idx": {
+          "name": "FolderFile_organizationId_mimeType_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mimeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_name_idx": {
+          "name": "FolderFile_organizationId_name_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_path_idx": {
+          "name": "FolderFile_organizationId_path_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_updatedAt_idx": {
+          "name": "FolderFile_organizationId_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_path_name_idx": {
+          "name": "FolderFile_path_name_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FolderFile_organizationId_Organization_id_fk": {
+          "name": "FolderFile_organizationId_Organization_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FolderFile_folderId_Folder_id_fk": {
+          "name": "FolderFile_folderId_Folder_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "Folder",
+          "columnsFrom": ["folderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "FolderFile_currentVersionId_FileVersion_id_fk": {
+          "name": "FolderFile_currentVersionId_FileVersion_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "FileVersion",
+          "columnsFrom": ["currentVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "FolderFile_createdById_User_id_fk": {
+          "name": "FolderFile_createdById_User_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Folder": {
+      "name": "Folder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Folder_organizationId_deletedAt_isArchived_idx": {
+          "name": "Folder_organizationId_deletedAt_isArchived_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_organizationId_depth_path_idx": {
+          "name": "Folder_organizationId_depth_path_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_organizationId_parentId_idx": {
+          "name": "Folder_organizationId_parentId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_organizationId_parentId_name_key": {
+          "name": "Folder_organizationId_parentId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_parentId_name_idx": {
+          "name": "Folder_parentId_name_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Folder_organizationId_Organization_id_fk": {
+          "name": "Folder_organizationId_Organization_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Folder_parentId_Folder_id_fk": {
+          "name": "Folder_parentId_Folder_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "Folder",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Folder_createdById_User_id_fk": {
+          "name": "Folder_createdById_User_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FulfillmentTracking": {
+      "name": "FulfillmentTracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillmentId": {
+          "name": "fulfillmentId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "FulfillmentTracking_fulfillmentId_idx": {
+          "name": "FulfillmentTracking_fulfillmentId_idx",
+          "columns": [
+            {
+              "expression": "fulfillmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FulfillmentTracking_number_idx": {
+          "name": "FulfillmentTracking_number_idx",
+          "columns": [
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FulfillmentTracking_number_key": {
+          "name": "FulfillmentTracking_number_key",
+          "columns": [
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FulfillmentTracking_orderId_idx": {
+          "name": "FulfillmentTracking_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FulfillmentTracking_orderId_Order_id_fk": {
+          "name": "FulfillmentTracking_orderId_Order_id_fk",
+          "tableFrom": "FulfillmentTracking",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FulfillmentTracking_fulfillmentId_OrderFulfillment_id_fk": {
+          "name": "FulfillmentTracking_fulfillmentId_OrderFulfillment_id_fk",
+          "tableFrom": "FulfillmentTracking",
+          "tableTo": "OrderFulfillment",
+          "columnsFrom": ["fulfillmentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJobMappableProperty": {
+      "name": "ImportJobMappableProperty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnIndex": {
+          "name": "columnIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibleName": {
+          "name": "visibleName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ImportJobMappableProperty_importJobId_idx": {
+          "name": "ImportJobMappableProperty_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobMappableProperty_jobId_columnIndex_key": {
+          "name": "ImportJobMappableProperty_jobId_columnIndex_key",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "columnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJobMappableProperty_importJobId_ImportJob_id_fk": {
+          "name": "ImportJobMappableProperty_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportJobMappableProperty",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJobProperty": {
+      "name": "ImportJobProperty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importMappingPropertyId": {
+          "name": "importMappingPropertyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uniqueValueCount": {
+          "name": "uniqueValueCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolvedCount": {
+          "name": "resolvedCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errorCount": {
+          "name": "errorCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ImportJobProperty_importJobId_idx": {
+          "name": "ImportJobProperty_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobProperty_jobId_mappingPropertyId_key": {
+          "name": "ImportJobProperty_jobId_mappingPropertyId_key",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "importMappingPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJobProperty_importJobId_ImportJob_id_fk": {
+          "name": "ImportJobProperty_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportJobProperty",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportJobProperty_importMappingPropertyId_ImportMappingProperty_id_fk": {
+          "name": "ImportJobProperty_importMappingPropertyId_ImportMappingProperty_id_fk",
+          "tableFrom": "ImportJobProperty",
+          "tableTo": "ImportMappingProperty",
+          "columnsFrom": ["importMappingPropertyId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJobRawData": {
+      "name": "ImportJobRawData",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnIndex": {
+          "name": "columnIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "valueHash": {
+          "name": "valueHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ImportJobRawData_importJobId_idx": {
+          "name": "ImportJobRawData_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobRawData_importJobId_rowIndex_idx": {
+          "name": "ImportJobRawData_importJobId_rowIndex_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobRawData_importJobId_columnIndex_idx": {
+          "name": "ImportJobRawData_importJobId_columnIndex_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "columnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobRawData_valueHash_idx": {
+          "name": "ImportJobRawData_valueHash_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "columnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJobRawData_importJobId_ImportJob_id_fk": {
+          "name": "ImportJobRawData_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportJobRawData",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJob": {
+      "name": "ImportJob",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importMappingId": {
+          "name": "importMappingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceFileName": {
+          "name": "sourceFileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnCount": {
+          "name": "columnCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowCount": {
+          "name": "rowCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalChunks": {
+          "name": "totalChunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedChunks": {
+          "name": "receivedChunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportJobStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "ingestionFailureReason": {
+          "name": "ingestionFailureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowPlanGeneration": {
+          "name": "allowPlanGeneration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmedAt": {
+          "name": "confirmedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedExecutionAt": {
+          "name": "startedExecutionAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportJob_organizationId_idx": {
+          "name": "ImportJob_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJob_importMappingId_idx": {
+          "name": "ImportJob_importMappingId_idx",
+          "columns": [
+            {
+              "expression": "importMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJob_status_idx": {
+          "name": "ImportJob_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJob_createdById_idx": {
+          "name": "ImportJob_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJob_organizationId_Organization_id_fk": {
+          "name": "ImportJob_organizationId_Organization_id_fk",
+          "tableFrom": "ImportJob",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportJob_importMappingId_ImportMapping_id_fk": {
+          "name": "ImportJob_importMappingId_ImportMapping_id_fk",
+          "tableFrom": "ImportJob",
+          "tableTo": "ImportMapping",
+          "columnsFrom": ["importMappingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportJob_createdById_User_id_fk": {
+          "name": "ImportJob_createdById_User_id_fk",
+          "tableFrom": "ImportJob",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportMappingProperty": {
+      "name": "ImportMappingProperty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importMappingId": {
+          "name": "importMappingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceColumnIndex": {
+          "name": "sourceColumnIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceColumnName": {
+          "name": "sourceColumnName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetType": {
+          "name": "targetType",
+          "type": "ImportMappingTargetType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skip'"
+        },
+        "targetFieldKey": {
+          "name": "targetFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customFieldId": {
+          "name": "customFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolutionType": {
+          "name": "resolutionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text:value'"
+        },
+        "resolutionConfig": {
+          "name": "resolutionConfig",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportMappingProperty_importMappingId_idx": {
+          "name": "ImportMappingProperty_importMappingId_idx",
+          "columns": [
+            {
+              "expression": "importMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportMappingProperty_sourceColumnIndex_idx": {
+          "name": "ImportMappingProperty_sourceColumnIndex_idx",
+          "columns": [
+            {
+              "expression": "importMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceColumnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportMappingProperty_importMappingId_ImportMapping_id_fk": {
+          "name": "ImportMappingProperty_importMappingId_ImportMapping_id_fk",
+          "tableFrom": "ImportMappingProperty",
+          "tableTo": "ImportMapping",
+          "columnsFrom": ["importMappingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportMappingProperty_customFieldId_CustomField_id_fk": {
+          "name": "ImportMappingProperty_customFieldId_CustomField_id_fk",
+          "tableFrom": "ImportMappingProperty",
+          "tableTo": "CustomField",
+          "columnsFrom": ["customFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportMapping": {
+      "name": "ImportMapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv'"
+        },
+        "defaultStrategy": {
+          "name": "defaultStrategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'create'"
+        },
+        "identifierFieldKey": {
+          "name": "identifierFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportMapping_organizationId_idx": {
+          "name": "ImportMapping_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportMapping_entityDefinitionId_idx": {
+          "name": "ImportMapping_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportMapping_organizationId_Organization_id_fk": {
+          "name": "ImportMapping_organizationId_Organization_id_fk",
+          "tableFrom": "ImportMapping",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportMapping_createdById_User_id_fk": {
+          "name": "ImportMapping_createdById_User_id_fk",
+          "tableFrom": "ImportMapping",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportPlanRow": {
+      "name": "ImportPlanRow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importPlanStrategyId": {
+          "name": "importPlanStrategyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "existingRecordId": {
+          "name": "existingRecordId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportPlanRowStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "resultRecordId": {
+          "name": "resultRecordId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executedAt": {
+          "name": "executedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportPlanRow_importPlanStrategyId_idx": {
+          "name": "ImportPlanRow_importPlanStrategyId_idx",
+          "columns": [
+            {
+              "expression": "importPlanStrategyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlanRow_status_idx": {
+          "name": "ImportPlanRow_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlanRow_strategyId_rowIndex_key": {
+          "name": "ImportPlanRow_strategyId_rowIndex_key",
+          "columns": [
+            {
+              "expression": "importPlanStrategyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportPlanRow_importPlanStrategyId_ImportPlanStrategy_id_fk": {
+          "name": "ImportPlanRow_importPlanStrategyId_ImportPlanStrategy_id_fk",
+          "tableFrom": "ImportPlanRow",
+          "tableTo": "ImportPlanStrategy",
+          "columnsFrom": ["importPlanStrategyId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportPlanStrategy": {
+      "name": "ImportPlanStrategy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importPlanId": {
+          "name": "importPlanId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "ImportStrategyType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matchingFieldKey": {
+          "name": "matchingFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matchingCustomFieldId": {
+          "name": "matchingCustomFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportStrategyStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planning_queued'"
+        },
+        "planningProgress": {
+          "name": "planningProgress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planningStartedAt": {
+          "name": "planningStartedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planningCompletedAt": {
+          "name": "planningCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionStartedAt": {
+          "name": "executionStartedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionCompletedAt": {
+          "name": "executionCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportPlanStrategy_importPlanId_idx": {
+          "name": "ImportPlanStrategy_importPlanId_idx",
+          "columns": [
+            {
+              "expression": "importPlanId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlanStrategy_strategy_idx": {
+          "name": "ImportPlanStrategy_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportPlanStrategy_importPlanId_ImportPlan_id_fk": {
+          "name": "ImportPlanStrategy_importPlanId_ImportPlan_id_fk",
+          "tableFrom": "ImportPlanStrategy",
+          "tableTo": "ImportPlan",
+          "columnsFrom": ["importPlanId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportPlanStrategy_matchingCustomFieldId_CustomField_id_fk": {
+          "name": "ImportPlanStrategy_matchingCustomFieldId_CustomField_id_fk",
+          "tableFrom": "ImportPlanStrategy",
+          "tableTo": "CustomField",
+          "columnsFrom": ["matchingCustomFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportPlan": {
+      "name": "ImportPlan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportPlanStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planning'"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportPlan_importJobId_idx": {
+          "name": "ImportPlan_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlan_status_idx": {
+          "name": "ImportPlan_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportPlan_importJobId_ImportJob_id_fk": {
+          "name": "ImportPlan_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportPlan",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportValueResolution": {
+      "name": "ImportValueResolution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importJobPropertyId": {
+          "name": "importJobPropertyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashedValue": {
+          "name": "hashedValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rawValue": {
+          "name": "rawValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cellCount": {
+          "name": "cellCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "resolvedValues": {
+          "name": "resolvedValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportResolutionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "isValid": {
+          "name": "isValid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userOverride": {
+          "name": "userOverride",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overriddenAt": {
+          "name": "overriddenAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportValueResolution_importJobPropertyId_idx": {
+          "name": "ImportValueResolution_importJobPropertyId_idx",
+          "columns": [
+            {
+              "expression": "importJobPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportValueResolution_propertyId_hash_key": {
+          "name": "ImportValueResolution_propertyId_hash_key",
+          "columns": [
+            {
+              "expression": "importJobPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hashedValue",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportValueResolution_status_idx": {
+          "name": "ImportValueResolution_status_idx",
+          "columns": [
+            {
+              "expression": "importJobPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportValueResolution_importJobPropertyId_ImportJobProperty_id_fk": {
+          "name": "ImportValueResolution_importJobPropertyId_ImportJobProperty_id_fk",
+          "tableFrom": "ImportValueResolution",
+          "tableTo": "ImportJobProperty",
+          "columnsFrom": ["importJobPropertyId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.InboxIntegration": {
+      "name": "InboxIntegration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "inboxId": {
+          "name": "inboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "InboxIntegration_inboxId_idx": {
+          "name": "InboxIntegration_inboxId_idx",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "InboxIntegration_inboxId_integrationId_key": {
+          "name": "InboxIntegration_inboxId_integrationId_key",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "InboxIntegration_integrationId_key": {
+          "name": "InboxIntegration_integrationId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "InboxIntegration_inboxId_EntityInstance_id_fk": {
+          "name": "InboxIntegration_inboxId_EntityInstance_id_fk",
+          "tableFrom": "InboxIntegration",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["inboxId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "InboxIntegration_integrationId_Integration_id_fk": {
+          "name": "InboxIntegration_integrationId_Integration_id_fk",
+          "tableFrom": "InboxIntegration",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Integration": {
+      "name": "Integration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "IntegrationProviderType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSuccessfulSync": {
+          "name": "lastSuccessfulSync",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHistoryId": {
+          "name": "lastHistoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authStatus": {
+          "name": "authStatus",
+          "type": "IntegrationAuthStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AUTHENTICATED'"
+        },
+        "requiresReauth": {
+          "name": "requiresReauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastAuthError": {
+          "name": "lastAuthError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAuthErrorAt": {
+          "name": "lastAuthErrorAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncStatus": {
+          "name": "syncStatus",
+          "type": "IntegrationSyncStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOT_SYNCED'"
+        },
+        "syncStage": {
+          "name": "syncStage",
+          "type": "IntegrationSyncStage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDLE'"
+        },
+        "syncStageStartedAt": {
+          "name": "syncStageStartedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "throttleFailureCount": {
+          "name": "throttleFailureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "throttleRetryAfter": {
+          "name": "throttleRetryAfter",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncMode": {
+          "name": "syncMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "pollingIntervalMs": {
+          "name": "pollingIntervalMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 300000
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Integration_organizationId_email_key": {
+          "name": "Integration_organizationId_email_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"Integration\".\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_organizationId_idx": {
+          "name": "Integration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_provider_organizationId_idx": {
+          "name": "Integration_provider_organizationId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_credentialId_idx": {
+          "name": "Integration_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credentialId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_syncStatus_idx": {
+          "name": "Integration_syncStatus_idx",
+          "columns": [
+            {
+              "expression": "syncStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Integration_organizationId_Organization_id_fk": {
+          "name": "Integration_organizationId_Organization_id_fk",
+          "tableFrom": "Integration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Integration_credentialId_WorkflowCredentials_id_fk": {
+          "name": "Integration_credentialId_WorkflowCredentials_id_fk",
+          "tableFrom": "Integration",
+          "tableTo": "WorkflowCredentials",
+          "columnsFrom": ["credentialId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.IntegrationTagLabel": {
+      "name": "IntegrationTagLabel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IntegrationTagLabel_integrationId_idx": {
+          "name": "IntegrationTagLabel_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IntegrationTagLabel_integrationId_labelId_key": {
+          "name": "IntegrationTagLabel_integrationId_labelId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "labelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IntegrationTagLabel_integrationId_tagId_key": {
+          "name": "IntegrationTagLabel_integrationId_tagId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IntegrationTagLabel_organizationId_idx": {
+          "name": "IntegrationTagLabel_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "IntegrationTagLabel_tagId_Tag_id_fk": {
+          "name": "IntegrationTagLabel_tagId_Tag_id_fk",
+          "tableFrom": "IntegrationTagLabel",
+          "tableTo": "Tag",
+          "columnsFrom": ["tagId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "IntegrationTagLabel_labelId_Label_id_fk": {
+          "name": "IntegrationTagLabel_labelId_Label_id_fk",
+          "tableFrom": "IntegrationTagLabel",
+          "tableTo": "Label",
+          "columnsFrom": ["labelId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "IntegrationTagLabel_organizationId_Organization_id_fk": {
+          "name": "IntegrationTagLabel_organizationId_Organization_id_fk",
+          "tableFrom": "IntegrationTagLabel",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Inventory": {
+      "name": "Inventory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partId": {
+          "name": "partId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reorderPoint": {
+          "name": "reorderPoint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reorderQty": {
+          "name": "reorderQty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Inventory_partId_key": {
+          "name": "Inventory_partId_key",
+          "columns": [
+            {
+              "expression": "partId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Inventory_organizationId_Organization_id_fk": {
+          "name": "Inventory_organizationId_Organization_id_fk",
+          "tableFrom": "Inventory",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Inventory_partId_Part_id_fk": {
+          "name": "Inventory_partId_Part_id_fk",
+          "tableFrom": "Inventory",
+          "tableTo": "Part",
+          "columnsFrom": ["partId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Invoice": {
+      "name": "Invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoiceNumber": {
+          "name": "invoiceNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "InvoiceStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "invoiceDate": {
+          "name": "invoiceDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paidDate": {
+          "name": "paidDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billingReason": {
+          "name": "billingReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeInvoiceId": {
+          "name": "stripeInvoiceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdfUrl": {
+          "name": "pdfUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Invoice_organizationId_idx": {
+          "name": "Invoice_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Invoice_stripeInvoiceId_key": {
+          "name": "Invoice_stripeInvoiceId_key",
+          "columns": [
+            {
+              "expression": "stripeInvoiceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Invoice_subscriptionId_idx": {
+          "name": "Invoice_subscriptionId_idx",
+          "columns": [
+            {
+              "expression": "subscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Invoice_organizationId_Organization_id_fk": {
+          "name": "Invoice_organizationId_Organization_id_fk",
+          "tableFrom": "Invoice",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Invoice_subscriptionId_PlanSubscription_id_fk": {
+          "name": "Invoice_subscriptionId_PlanSubscription_id_fk",
+          "tableFrom": "Invoice",
+          "tableTo": "PlanSubscription",
+          "columnsFrom": ["subscriptionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KeyValuePair": {
+      "name": "KeyValuePair",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEncrypted": {
+          "name": "isEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedById": {
+          "name": "updatedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "KeyValuePair_key_userId_organizationId_key": {
+          "name": "KeyValuePair_key_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_key_organizationId_null_userId_key": {
+          "name": "KeyValuePair_key_organizationId_null_userId_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"userId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_key_userId_null_organizationId_key": {
+          "name": "KeyValuePair_key_userId_null_organizationId_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organizationId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_key_system_unique": {
+          "name": "KeyValuePair_key_system_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"userId\" IS NULL AND \"organizationId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_type_idx": {
+          "name": "KeyValuePair_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_organizationId_idx": {
+          "name": "KeyValuePair_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_userId_idx": {
+          "name": "KeyValuePair_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "KeyValuePair_organizationId_Organization_id_fk": {
+          "name": "KeyValuePair_organizationId_Organization_id_fk",
+          "tableFrom": "KeyValuePair",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KeyValuePair_userId_User_id_fk": {
+          "name": "KeyValuePair_userId_User_id_fk",
+          "tableFrom": "KeyValuePair",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KeyValuePair_updatedById_User_id_fk": {
+          "name": "KeyValuePair_updatedById_User_id_fk",
+          "tableFrom": "KeyValuePair",
+          "tableTo": "User",
+          "columnsFrom": ["updatedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KnowledgeBase": {
+      "name": "KnowledgeBase",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customDomain": {
+          "name": "customDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoDark": {
+          "name": "logoDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoLight": {
+          "name": "logoLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'clean'"
+        },
+        "showMode": {
+          "name": "showMode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "defaultMode": {
+          "name": "defaultMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'light'"
+        },
+        "primaryColorLight": {
+          "name": "primaryColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryColorDark": {
+          "name": "primaryColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tintColorLight": {
+          "name": "tintColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tintColorDark": {
+          "name": "tintColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "infoColorLight": {
+          "name": "infoColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "infoColorDark": {
+          "name": "infoColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successColorLight": {
+          "name": "successColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successColorDark": {
+          "name": "successColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warningColorLight": {
+          "name": "warningColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warningColorDark": {
+          "name": "warningColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dangerColorLight": {
+          "name": "dangerColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dangerColorDark": {
+          "name": "dangerColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fontFamily": {
+          "name": "fontFamily",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iconsFamily": {
+          "name": "iconsFamily",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Regular'"
+        },
+        "cornerStyle": {
+          "name": "cornerStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Rounded'"
+        },
+        "sidebarListStyle": {
+          "name": "sidebarListStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Default'"
+        },
+        "searchbarPosition": {
+          "name": "searchbarPosition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'center'"
+        },
+        "headerNavigation": {
+          "name": "headerNavigation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "footerNavigation": {
+          "name": "footerNavigation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoDarkId": {
+          "name": "logoDarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoLightId": {
+          "name": "logoLightId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "KnowledgeBase_logoDarkId_key": {
+          "name": "KnowledgeBase_logoDarkId_key",
+          "columns": [
+            {
+              "expression": "logoDarkId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeBase_logoLightId_key": {
+          "name": "KnowledgeBase_logoLightId_key",
+          "columns": [
+            {
+              "expression": "logoLightId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeBase_organizationId_idx": {
+          "name": "KnowledgeBase_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeBase_organizationId_slug_key": {
+          "name": "KnowledgeBase_organizationId_slug_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "KnowledgeBase_organizationId_Organization_id_fk": {
+          "name": "KnowledgeBase_organizationId_Organization_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeBase_logoDarkId_MediaAsset_id_fk": {
+          "name": "KnowledgeBase_logoDarkId_MediaAsset_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["logoDarkId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeBase_logoLightId_MediaAsset_id_fk": {
+          "name": "KnowledgeBase_logoLightId_MediaAsset_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["logoLightId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Label": {
+      "name": "Label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationType": {
+          "name": "integrationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isVisible": {
+          "name": "isVisible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "backgroundColor": {
+          "name": "backgroundColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "textColor": {
+          "name": "textColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "LabelType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerCursor": {
+          "name": "providerCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pendingAction": {
+          "name": "pendingAction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isSentBox": {
+          "name": "isSentBox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parentLabelId": {
+          "name": "parentLabelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCheckpoint": {
+          "name": "syncCheckpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Label_labelId_organizationId_integrationId_key": {
+          "name": "Label_labelId_organizationId_integrationId_key",
+          "columns": [
+            {
+              "expression": "labelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Label_name_organizationId_integrationId_idx": {
+          "name": "Label_name_organizationId_integrationId_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Label_integrationId_idx": {
+          "name": "Label_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Label_organizationId_Organization_id_fk": {
+          "name": "Label_organizationId_Organization_id_fk",
+          "tableFrom": "Label",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Label_parentLabelId_Label_id_fk": {
+          "name": "Label_parentLabelId_Label_id_fk",
+          "tableFrom": "Label",
+          "tableTo": "Label",
+          "columnsFrom": ["parentLabelId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LabelsOnThread": {
+      "name": "LabelsOnThread",
+      "schema": "",
+      "columns": {
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "LabelsOnThread_threadId_Thread_id_fk": {
+          "name": "LabelsOnThread_threadId_Thread_id_fk",
+          "tableFrom": "LabelsOnThread",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "LabelsOnThread_labelId_Label_id_fk": {
+          "name": "LabelsOnThread_labelId_Label_id_fk",
+          "tableFrom": "LabelsOnThread",
+          "tableTo": "Label",
+          "columnsFrom": ["labelId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "LabelsOnThread_pkey": {
+          "name": "LabelsOnThread_pkey",
+          "columns": ["threadId", "labelId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LoadBalancingConfig": {
+      "name": "LoadBalancingConfig",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "LoadBalancingConfig_organizationId_provider_model_idx": {
+          "name": "LoadBalancingConfig_organizationId_provider_model_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LoadBalancingConfig_organizationId_provider_model_modelType_key": {
+          "name": "LoadBalancingConfig_organizationId_provider_model_modelType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LoadBalancingConfig_organizationId_Organization_id_fk": {
+          "name": "LoadBalancingConfig_organizationId_Organization_id_fk",
+          "tableFrom": "LoadBalancingConfig",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MailDomain": {
+      "name": "MailDomain",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "DomainType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CUSTOM'"
+        },
+        "routingPrefix": {
+          "name": "routingPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "isVerified": {
+          "name": "isVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verificationToken": {
+          "name": "verificationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookKey": {
+          "name": "webhookKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "MailDomain_organizationId_domain_key": {
+          "name": "MailDomain_organizationId_domain_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MailDomain_organizationId_Organization_id_fk": {
+          "name": "MailDomain_organizationId_Organization_id_fk",
+          "tableFrom": "MailDomain",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MailView": {
+      "name": "MailView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortField": {
+          "name": "sortField",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortDirection": {
+          "name": "sortDirection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'desc'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "MailView_isDefault_idx": {
+          "name": "MailView_isDefault_idx",
+          "columns": [
+            {
+              "expression": "isDefault",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MailView_name_userId_organizationId_key": {
+          "name": "MailView_name_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MailView_organizationId_idx": {
+          "name": "MailView_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MailView_userId_idx": {
+          "name": "MailView_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MailView_organizationId_Organization_id_fk": {
+          "name": "MailView_organizationId_Organization_id_fk",
+          "tableFrom": "MailView",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MailView_userId_User_id_fk": {
+          "name": "MailView_userId_User_id_fk",
+          "tableFrom": "MailView",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MediaAsset": {
+      "name": "MediaAsset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPrivate": {
+          "name": "isPrivate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentVersionId": {
+          "name": "currentVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ORIGINAL'"
+        }
+      },
+      "indexes": {
+        "MediaAsset_currentVersionId_key": {
+          "name": "MediaAsset_currentVersionId_key",
+          "columns": [
+            {
+              "expression": "currentVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_expiresAt_idx": {
+          "name": "MediaAsset_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_id_organizationId_key": {
+          "name": "MediaAsset_id_organizationId_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_kind_isPrivate_idx": {
+          "name": "MediaAsset_kind_isPrivate_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPrivate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_organizationId_expiresAt_idx": {
+          "name": "MediaAsset_organizationId_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_organizationId_kind_idx": {
+          "name": "MediaAsset_organizationId_kind_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_organizationId_purpose_kind_idx": {
+          "name": "MediaAsset_organizationId_purpose_kind_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thumbnail_assets": {
+          "name": "idx_thumbnail_assets",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((kind = 'THUMBNAIL'::text) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MediaAsset_organizationId_Organization_id_fk": {
+          "name": "MediaAsset_organizationId_Organization_id_fk",
+          "tableFrom": "MediaAsset",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MediaAsset_currentVersionId_MediaAssetVersion_id_fk": {
+          "name": "MediaAsset_currentVersionId_MediaAssetVersion_id_fk",
+          "tableFrom": "MediaAsset",
+          "tableTo": "MediaAssetVersion",
+          "columnsFrom": ["currentVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "MediaAsset_createdById_User_id_fk": {
+          "name": "MediaAsset_createdById_User_id_fk",
+          "tableFrom": "MediaAsset",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MediaAssetVersion": {
+      "name": "MediaAssetVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageLocationId": {
+          "name": "storageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivedFromVersionId": {
+          "name": "derivedFromVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preset": {
+          "name": "preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "AssetVersionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        }
+      },
+      "indexes": {
+        "MediaAssetVersion_assetId_createdAt_idx": {
+          "name": "MediaAssetVersion_assetId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "assetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_assetId_versionNumber_key": {
+          "name": "MediaAssetVersion_assetId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "assetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_derivedFromVersionId_preset_key": {
+          "name": "MediaAssetVersion_derivedFromVersionId_preset_key",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_derivedFromVersionId_preset_status_idx": {
+          "name": "MediaAssetVersion_derivedFromVersionId_preset_status_idx",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_status_idx": {
+          "name": "MediaAssetVersion_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thumbnail_cleanup": {
+          "name": "idx_thumbnail_cleanup",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((\"derivedFromVersionId\" IS NOT NULL) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thumbnail_lookup_covering": {
+          "name": "idx_thumbnail_lookup_covering",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((\"derivedFromVersionId\" IS NOT NULL) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_thumbnail": {
+          "name": "idx_unique_thumbnail",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((\"derivedFromVersionId\" IS NOT NULL) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MediaAssetVersion_assetId_MediaAsset_id_fk": {
+          "name": "MediaAssetVersion_assetId_MediaAsset_id_fk",
+          "tableFrom": "MediaAssetVersion",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["assetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MediaAssetVersion_storageLocationId_StorageLocation_id_fk": {
+          "name": "MediaAssetVersion_storageLocationId_StorageLocation_id_fk",
+          "tableFrom": "MediaAssetVersion",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["storageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MediaAssetVersion_derivedFromVersionId_MediaAssetVersion_id_fk": {
+          "name": "MediaAssetVersion_derivedFromVersionId_MediaAssetVersion_id_fk",
+          "tableFrom": "MediaAssetVersion",
+          "tableTo": "MediaAssetVersion",
+          "columnsFrom": ["derivedFromVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalThreadId": {
+          "name": "externalThreadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isInbound": {
+          "name": "isInbound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isFirstInThread": {
+          "name": "isFirstInThread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "textHtml": {
+          "name": "textHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "textPlain": {
+          "name": "textPlain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internetMessageId": {
+          "name": "internetMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromId": {
+          "name": "fromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replyToId": {
+          "name": "replyToId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isReply": {
+          "name": "isReply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "historyId": {
+          "name": "historyId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedAt": {
+          "name": "receivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureId": {
+          "name": "signatureId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "htmlBodyStorageLocationId": {
+          "name": "htmlBodyStorageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasAttachments": {
+          "name": "hasAttachments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerError": {
+          "name": "providerError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sendStatus": {
+          "name": "sendStatus",
+          "type": "SendStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'SENT'"
+        },
+        "sendToken": {
+          "name": "sendToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Message_createdById_idx": {
+          "name": "Message_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_fromId_idx": {
+          "name": "Message_fromId_idx",
+          "columns": [
+            {
+              "expression": "fromId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_integrationId_externalId_key": {
+          "name": "Message_integrationId_externalId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_integrationId_idx": {
+          "name": "Message_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_organizationId_idx": {
+          "name": "Message_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_organizationId_internetMessageId_key": {
+          "name": "Message_organizationId_internetMessageId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internetMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"internetMessageId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_replyToId_idx": {
+          "name": "Message_replyToId_idx",
+          "columns": [
+            {
+              "expression": "replyToId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_sendToken_key": {
+          "name": "Message_sendToken_key",
+          "columns": [
+            {
+              "expression": "sendToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"sendToken\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_sentAt_idx": {
+          "name": "Message_sentAt_idx",
+          "columns": [
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_threadId_createdById_idx": {
+          "name": "Message_threadId_createdById_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_threadId_idx": {
+          "name": "Message_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retry_queue_idx": {
+          "name": "retry_queue_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sendStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastAttemptAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_messages_idx": {
+          "name": "thread_messages_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Message_threadId_Thread_id_fk": {
+          "name": "Message_threadId_Thread_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Message_integrationId_Integration_id_fk": {
+          "name": "Message_integrationId_Integration_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Message_createdById_User_id_fk": {
+          "name": "Message_createdById_User_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Message_organizationId_Organization_id_fk": {
+          "name": "Message_organizationId_Organization_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Message_fromId_Participant_id_fk": {
+          "name": "Message_fromId_Participant_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Participant",
+          "columnsFrom": ["fromId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "Message_replyToId_Participant_id_fk": {
+          "name": "Message_replyToId_Participant_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Participant",
+          "columnsFrom": ["replyToId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Message_signatureId_EntityInstance_id_fk": {
+          "name": "Message_signatureId_EntityInstance_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["signatureId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Message_htmlBodyStorageLocationId_StorageLocation_id_fk": {
+          "name": "Message_htmlBodyStorageLocationId_StorageLocation_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["htmlBodyStorageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MessageParticipant": {
+      "name": "MessageParticipant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "ParticipantRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participantId": {
+          "name": "participantId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "MessageParticipant_messageId_idx": {
+          "name": "MessageParticipant_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageParticipant_messageId_participantId_role_key": {
+          "name": "MessageParticipant_messageId_participantId_role_key",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "participantId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageParticipant_participantId_idx": {
+          "name": "MessageParticipant_participantId_idx",
+          "columns": [
+            {
+              "expression": "participantId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageParticipant_role_idx": {
+          "name": "MessageParticipant_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_idx": {
+          "name": "contact_history_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "participant_lookup_idx": {
+          "name": "participant_lookup_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MessageParticipant_messageId_Message_id_fk": {
+          "name": "MessageParticipant_messageId_Message_id_fk",
+          "tableFrom": "MessageParticipant",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MessageParticipant_participantId_Participant_id_fk": {
+          "name": "MessageParticipant_participantId_Participant_id_fk",
+          "tableFrom": "MessageParticipant",
+          "tableTo": "Participant",
+          "columnsFrom": ["participantId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ModelConfiguration": {
+      "name": "ModelConfiguration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ModelConfiguration_organizationId_enabled_idx": {
+          "name": "ModelConfiguration_organizationId_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModelConfiguration_organizationId_provider_idx": {
+          "name": "ModelConfiguration_organizationId_provider_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModelConfiguration_organizationId_provider_model_modelType_key": {
+          "name": "ModelConfiguration_organizationId_provider_model_modelType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ModelConfiguration_organizationId_Organization_id_fk": {
+          "name": "ModelConfiguration_organizationId_Organization_id_fk",
+          "tableFrom": "ModelConfiguration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Notification": {
+      "name": "Notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryMethod": {
+          "name": "deliveryMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Notification_entityType_entityId_idx": {
+          "name": "Notification_entityType_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_organizationId_idx": {
+          "name": "Notification_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_userId_createdAt_idx": {
+          "name": "Notification_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_userId_isRead_idx": {
+          "name": "Notification_userId_isRead_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Notification_userId_User_id_fk": {
+          "name": "Notification_userId_User_id_fk",
+          "tableFrom": "Notification",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Notification_actorId_User_id_fk": {
+          "name": "Notification_actorId_User_id_fk",
+          "tableFrom": "Notification",
+          "tableTo": "User",
+          "columnsFrom": ["actorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Notification_organizationId_Organization_id_fk": {
+          "name": "Notification_organizationId_Organization_id_fk",
+          "tableFrom": "Notification",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauthAccessToken_userId_User_id_fk": {
+          "name": "oauthAccessToken_userId_User_id_fk",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthAccessToken_accessToken_unique": {
+          "name": "oauthAccessToken_accessToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["accessToken"]
+        },
+        "oauthAccessToken_refreshToken_unique": {
+          "name": "oauthAccessToken_refreshToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refreshToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthApplication": {
+      "name": "oauthApplication",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectURLs": {
+          "name": "redirectURLs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauthApplication_userId_User_id_fk": {
+          "name": "oauthApplication_userId_User_id_fk",
+          "tableFrom": "oauthApplication",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthApplication_clientId_unique": {
+          "name": "oauthApplication_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["clientId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthConsent": {
+      "name": "oauthConsent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentGiven": {
+          "name": "consentGiven",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauthConsent_userId_User_id_fk": {
+          "name": "oauthConsent_userId_User_id_fk",
+          "tableFrom": "oauthConsent",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OperatingHours": {
+      "name": "OperatingHours",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgetId": {
+          "name": "widgetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dayOfWeek": {
+          "name": "dayOfWeek",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startHour": {
+          "name": "startHour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startMinute": {
+          "name": "startMinute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endHour": {
+          "name": "endHour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endMinute": {
+          "name": "endMinute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        }
+      },
+      "indexes": {
+        "OperatingHours_widgetId_dayOfWeek_key": {
+          "name": "OperatingHours_widgetId_dayOfWeek_key",
+          "columns": [
+            {
+              "expression": "widgetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dayOfWeek",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OperatingHours_widgetId_idx": {
+          "name": "OperatingHours_widgetId_idx",
+          "columns": [
+            {
+              "expression": "widgetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OperatingHours_widgetId_ChatWidget_id_fk": {
+          "name": "OperatingHours_widgetId_ChatWidget_id_fk",
+          "tableFrom": "OperatingHours",
+          "tableTo": "ChatWidget",
+          "columnsFrom": ["widgetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Order": {
+      "name": "Order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelReason": {
+          "name": "cancelReason",
+          "type": "ORDER_CANCEL_REASON",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canNotifyCustomer": {
+          "name": "canNotifyCustomer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confirmationNumber": {
+          "name": "confirmationNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "discountCode": {
+          "name": "discountCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "financialStatus": {
+          "name": "financialStatus",
+          "type": "ORDER_FINANCIAL_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillmentStatus": {
+          "name": "fulfillmentStatus",
+          "type": "ORDER_FULFILLMENT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poNumber": {
+          "name": "poNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returnStatus": {
+          "name": "returnStatus",
+          "type": "ORDER_RETURN_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taxExempt": {
+          "name": "taxExempt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "subtotalPrice": {
+          "name": "subtotalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalDiscounts": {
+          "name": "totalDiscounts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalRefunded": {
+          "name": "totalRefunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalShippingPrice": {
+          "name": "totalShippingPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalTax": {
+          "name": "totalTax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shippingAddressId": {
+          "name": "shippingAddressId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billingAddressId": {
+          "name": "billingAddressId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Order_customerId_idx": {
+          "name": "Order_customerId_idx",
+          "columns": [
+            {
+              "expression": "customerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Order_name_idx": {
+          "name": "Order_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Order_shippingAddressId_Address_id_fk": {
+          "name": "Order_shippingAddressId_Address_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "Address",
+          "columnsFrom": ["shippingAddressId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Order_billingAddressId_Address_id_fk": {
+          "name": "Order_billingAddressId_Address_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "Address",
+          "columnsFrom": ["billingAddressId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Order_customerId_shopify_customers_id_fk": {
+          "name": "Order_customerId_shopify_customers_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "shopify_customers",
+          "columnsFrom": ["customerId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Order_organizationId_Organization_id_fk": {
+          "name": "Order_organizationId_Organization_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Order_integrationId_ShopifyIntegration_id_fk": {
+          "name": "Order_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrderFulfillment": {
+      "name": "OrderFulfillment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "FULFILLMENT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "requiresShipping": {
+          "name": "requiresShipping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrderFulfillment_orderId_idx": {
+          "name": "OrderFulfillment_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrderFulfillment_status_idx": {
+          "name": "OrderFulfillment_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrderFulfillment_orderId_Order_id_fk": {
+          "name": "OrderFulfillment_orderId_Order_id_fk",
+          "tableFrom": "OrderFulfillment",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrderLineItem": {
+      "name": "OrderLineItem",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productId": {
+          "name": "productId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variantId": {
+          "name": "variantId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalTotal": {
+          "name": "originalTotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "originalUnitPrice": {
+          "name": "originalUnitPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrderLineItem_orderId_idx": {
+          "name": "OrderLineItem_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrderLineItem_orderId_Order_id_fk": {
+          "name": "OrderLineItem_orderId_Order_id_fk",
+          "tableFrom": "OrderLineItem",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrderRefund": {
+      "name": "OrderRefund",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalRefundedAmount": {
+          "name": "totalRefundedAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrderRefund_orderId_idx": {
+          "name": "OrderRefund_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrderRefund_orderId_Order_id_fk": {
+          "name": "OrderRefund_orderId_Order_id_fk",
+          "tableFrom": "OrderRefund",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrderReturn": {
+      "name": "OrderReturn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "RETURN_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrderReturn_orderId_idx": {
+          "name": "OrderReturn_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrderReturn_orderId_Order_id_fk": {
+          "name": "OrderReturn_orderId_Order_id_fk",
+          "tableFrom": "OrderReturn",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_domain": {
+          "name": "email_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "OrganizationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'TEAM'"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "systemUserId": {
+          "name": "systemUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledReason": {
+          "name": "disabledReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledBy": {
+          "name": "disabledBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedOnboarding": {
+          "name": "completedOnboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Organization_handle_idx": {
+          "name": "Organization_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_handle_key": {
+          "name": "Organization_handle_key",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_systemUserId_key": {
+          "name": "Organization_systemUserId_key",
+          "columns": [
+            {
+              "expression": "systemUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Organization_createdById_User_id_fk": {
+          "name": "Organization_createdById_User_id_fk",
+          "tableFrom": "Organization",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "Organization_systemUserId_User_id_fk": {
+          "name": "Organization_systemUserId_User_id_fk",
+          "tableFrom": "Organization",
+          "tableTo": "User",
+          "columnsFrom": ["systemUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationInvitation": {
+      "name": "OrganizationInvitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "OrganizationRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "InvitationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitedById": {
+          "name": "invitedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptedById": {
+          "name": "acceptedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "OrganizationInvitation_email_idx": {
+          "name": "OrganizationInvitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationInvitation_organizationId_idx": {
+          "name": "OrganizationInvitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationInvitation_status_idx": {
+          "name": "OrganizationInvitation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationInvitation_token_key": {
+          "name": "OrganizationInvitation_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationInvitation_organizationId_Organization_id_fk": {
+          "name": "OrganizationInvitation_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationInvitation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationInvitation_invitedById_User_id_fk": {
+          "name": "OrganizationInvitation_invitedById_User_id_fk",
+          "tableFrom": "OrganizationInvitation",
+          "tableTo": "User",
+          "columnsFrom": ["invitedById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationInvitation_acceptedById_User_id_fk": {
+          "name": "OrganizationInvitation_acceptedById_User_id_fk",
+          "tableFrom": "OrganizationInvitation",
+          "tableTo": "User",
+          "columnsFrom": ["acceptedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationMember": {
+      "name": "OrganizationMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "OrganizationMemberStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "role": {
+          "name": "role",
+          "type": "OrganizationRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        }
+      },
+      "indexes": {
+        "OrganizationMember_organizationId_idx": {
+          "name": "OrganizationMember_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_userId_idx": {
+          "name": "OrganizationMember_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_userId_organizationId_key": {
+          "name": "OrganizationMember_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationMember_userId_User_id_fk": {
+          "name": "OrganizationMember_userId_User_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationMember_organizationId_Organization_id_fk": {
+          "name": "OrganizationMember_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationSetting": {
+      "name": "OrganizationSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowUserOverride": {
+          "name": "allowUserOverride",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "SettingScope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GENERAL'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrganizationSetting_key_idx": {
+          "name": "OrganizationSetting_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationSetting_organizationId_idx": {
+          "name": "OrganizationSetting_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationSetting_organizationId_key_key": {
+          "name": "OrganizationSetting_organizationId_key_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationSetting_scope_idx": {
+          "name": "OrganizationSetting_scope_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationSetting_organizationId_Organization_id_fk": {
+          "name": "OrganizationSetting_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationSetting",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Part": {
+      "name": "Part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hsCode": {
+          "name": "hsCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shopifyProductLinkId": {
+          "name": "shopifyProductLinkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Part_sku_key": {
+          "name": "Part_sku_key",
+          "columns": [
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Part_createdById_User_id_fk": {
+          "name": "Part_createdById_User_id_fk",
+          "tableFrom": "Part",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Part_organizationId_Organization_id_fk": {
+          "name": "Part_organizationId_Organization_id_fk",
+          "tableFrom": "Part",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Participant": {
+      "name": "Participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifierType": {
+          "name": "identifierType",
+          "type": "IdentifierType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isSpammer": {
+          "name": "isSpammer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstInteractionDate": {
+          "name": "firstInteractionDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstInteractionType": {
+          "name": "firstInteractionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasReceivedMessage": {
+          "name": "hasReceivedMessage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSentMessageAt": {
+          "name": "lastSentMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Participant_entityInstanceId_idx": {
+          "name": "Participant_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_identifierType_idx": {
+          "name": "Participant_identifierType_idx",
+          "columns": [
+            {
+              "expression": "identifierType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_identifier_idx": {
+          "name": "Participant_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_organizationId_identifier_identifierType_key": {
+          "name": "Participant_organizationId_identifier_identifierType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifierType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_organizationId_idx": {
+          "name": "Participant_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Participant_entityInstanceId_EntityInstance_id_fk": {
+          "name": "Participant_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "Participant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Participant_organizationId_Organization_id_fk": {
+          "name": "Participant_organizationId_Organization_id_fk",
+          "tableFrom": "Participant",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Passkey": {
+      "name": "Passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Passkey_userId_User_id_fk": {
+          "name": "Passkey_userId_User_id_fk",
+          "tableFrom": "Passkey",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PasswordResetToken": {
+      "name": "PasswordResetToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "PasswordResetToken_token_key": {
+          "name": "PasswordResetToken_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PasswordResetToken_userId_idx": {
+          "name": "PasswordResetToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PasswordResetToken_userId_User_id_fk": {
+          "name": "PasswordResetToken_userId_User_id_fk",
+          "tableFrom": "PasswordResetToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Plan": {
+      "name": "Plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "monthlyPrice": {
+          "name": "monthlyPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annualPrice": {
+          "name": "annualPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isCustomPricing": {
+          "name": "isCustomPricing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trialDays": {
+          "name": "trialDays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "hasTrial": {
+          "name": "hasTrial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "minSeats": {
+          "name": "minSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "maxSeats": {
+          "name": "maxSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "isLegacy": {
+          "name": "isLegacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selfServed": {
+          "name": "selfServed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isMostPopular": {
+          "name": "isMostPopular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isFree": {
+          "name": "isFree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featureLimits": {
+          "name": "featureLimits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "stripeProductId": {
+          "name": "stripeProductId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripePriceIdMonthly": {
+          "name": "stripePriceIdMonthly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripePriceIdAnnual": {
+          "name": "stripePriceIdAnnual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchyLevel": {
+          "name": "hierarchyLevel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PlanSubscription": {
+      "name": "PlanSubscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planId": {
+          "name": "planId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incomplete'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "billingCycle": {
+          "name": "billingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MONTHLY'"
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "creditsBalance": {
+          "name": "creditsBalance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "trialStart": {
+          "name": "trialStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trialEnd": {
+          "name": "trialEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasTrialEnded": {
+          "name": "hasTrialEnded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trialConversionStatus": {
+          "name": "trialConversionStatus",
+          "type": "TrialConversionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEligibleForTrial": {
+          "name": "isEligibleForTrial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trialEligibilityReason": {
+          "name": "trialEligibilityReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPlanId": {
+          "name": "scheduledPlanId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPlan": {
+          "name": "scheduledPlan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledBillingCycle": {
+          "name": "scheduledBillingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledSeats": {
+          "name": "scheduledSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledChangeAt": {
+          "name": "scheduledChangeAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeletionNotificationSent": {
+          "name": "lastDeletionNotificationSent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeletionNotificationDate": {
+          "name": "lastDeletionNotificationDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletionScheduledDate": {
+          "name": "deletionScheduledDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletionReason": {
+          "name": "deletionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customFeatureLimits": {
+          "name": "customFeatureLimits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customPricingMonthly": {
+          "name": "customPricingMonthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customPricingAnnual": {
+          "name": "customPricingAnnual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customPricingNotes": {
+          "name": "customPricingNotes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "PlanSubscription_organizationId_key": {
+          "name": "PlanSubscription_organizationId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PlanSubscription_organizationId_Organization_id_fk": {
+          "name": "PlanSubscription_organizationId_Organization_id_fk",
+          "tableFrom": "PlanSubscription",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PlanSubscription_planId_Plan_id_fk": {
+          "name": "PlanSubscription_planId_Plan_id_fk",
+          "tableFrom": "PlanSubscription",
+          "tableTo": "Plan",
+          "columnsFrom": ["planId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PlanSubscription_scheduledPlanId_Plan_id_fk": {
+          "name": "PlanSubscription_scheduledPlanId_Plan_id_fk",
+          "tableFrom": "PlanSubscription",
+          "tableTo": "Plan",
+          "columnsFrom": ["scheduledPlanId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PlanSubscriptionHistory": {
+      "name": "PlanSubscriptionHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changeType": {
+          "name": "changeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromPlan": {
+          "name": "fromPlan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toPlan": {
+          "name": "toPlan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromBillingCycle": {
+          "name": "fromBillingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toBillingCycle": {
+          "name": "toBillingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromSeats": {
+          "name": "fromSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toSeats": {
+          "name": "toSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immediate": {
+          "name": "immediate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledFor": {
+          "name": "scheduledFor",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appliedAt": {
+          "name": "appliedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prorationAmount": {
+          "name": "prorationAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PollingTriggerState": {
+      "name": "PollingTriggerState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerId": {
+          "name": "triggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "lastPollAt": {
+          "name": "lastPollAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPollStatus": {
+          "name": "lastPollStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPollError": {
+          "name": "lastPollError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutiveErrors": {
+          "name": "consecutiveErrors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "PollingTriggerState_workflowAppId_triggerId_key": {
+          "name": "PollingTriggerState_workflowAppId_triggerId_key",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PollingTriggerState_organizationId_idx": {
+          "name": "PollingTriggerState_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PollingTriggerState_organizationId_Organization_id_fk": {
+          "name": "PollingTriggerState_organizationId_Organization_id_fk",
+          "tableFrom": "PollingTriggerState",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PollingTriggerState_workflowAppId_WorkflowApp_id_fk": {
+          "name": "PollingTriggerState_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "PollingTriggerState",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Product": {
+      "name": "Product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descriptionHtml": {
+          "name": "descriptionHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasOnlyDefaultVariant": {
+          "name": "hasOnlyDefaultVariant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productType": {
+          "name": "productType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "PRODUDT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracksInventory": {
+          "name": "tracksInventory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalInventory": {
+          "name": "totalInventory",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Product_handle_key": {
+          "name": "Product_handle_key",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Product_integrationId_ShopifyIntegration_id_fk": {
+          "name": "Product_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "Product",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Product_organizationId_Organization_id_fk": {
+          "name": "Product_organizationId_Organization_id_fk",
+          "tableFrom": "Product",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProductMedia": {
+      "name": "ProductMedia",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mediaContentType": {
+          "name": "mediaContentType",
+          "type": "MEDIA_CONTENT_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IMAGE'"
+        },
+        "previewId": {
+          "name": "previewId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previewAlt": {
+          "name": "previewAlt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewHeight": {
+          "name": "previewHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewWidth": {
+          "name": "previewWidth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewUrl": {
+          "name": "previewUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variantIds": {
+          "name": "variantIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProductMedia_productId_idx": {
+          "name": "ProductMedia_productId_idx",
+          "columns": [
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProductMedia_productId_Product_id_fk": {
+          "name": "ProductMedia_productId_Product_id_fk",
+          "tableFrom": "ProductMedia",
+          "tableTo": "Product",
+          "columnsFrom": ["productId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProductOption": {
+      "name": "ProductOption",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "values": {
+          "name": "values",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProductOption_productId_idx": {
+          "name": "ProductOption_productId_idx",
+          "columns": [
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProductOption_productId_Product_id_fk": {
+          "name": "ProductOption_productId_Product_id_fk",
+          "tableFrom": "ProductOption",
+          "tableTo": "Product",
+          "columnsFrom": ["productId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProductVariant": {
+      "name": "ProductVariant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "availableForSale": {
+          "name": "availableForSale",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compareAtPrice": {
+          "name": "compareAtPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selectedOptions": {
+          "name": "selectedOptions",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageId": {
+          "name": "imageId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventoryItemId": {
+          "name": "inventoryItemId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventoryManagement": {
+          "name": "inventoryManagement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventoryPolicy": {
+          "name": "inventoryPolicy",
+          "type": "INVENTORY_POLICY",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONTINUE'"
+        },
+        "inventoryQuantity": {
+          "name": "inventoryQuantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weightUnit": {
+          "name": "weightUnit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProductVariant_productId_idx": {
+          "name": "ProductVariant_productId_idx",
+          "columns": [
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProductVariant_productId_Product_id_fk": {
+          "name": "ProductVariant_productId_Product_id_fk",
+          "tableFrom": "ProductVariant",
+          "tableTo": "Product",
+          "columnsFrom": ["productId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ProductVariant_organizationId_Organization_id_fk": {
+          "name": "ProductVariant_organizationId_Organization_id_fk",
+          "tableFrom": "ProductVariant",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ProductVariant_integrationId_ShopifyIntegration_id_fk": {
+          "name": "ProductVariant_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "ProductVariant",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PromptHistory": {
+      "name": "PromptHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "PromptHistory_userId_User_id_fk": {
+          "name": "PromptHistory_userId_User_id_fk",
+          "tableFrom": "PromptHistory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProviderConfiguration": {
+      "name": "ProviderConfiguration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "quotaType": {
+          "name": "quotaType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaLimit": {
+          "name": "quotaLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-1'"
+        },
+        "quotaPeriodEnd": {
+          "name": "quotaPeriodEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaPeriodStart": {
+          "name": "quotaPeriodStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaUsed": {
+          "name": "quotaUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ProviderConfiguration_organizationId_provider_idx": {
+          "name": "ProviderConfiguration_organizationId_provider_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ProviderConfiguration_organizationId_provider_key": {
+          "name": "ProviderConfiguration_organizationId_provider_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProviderConfiguration_organizationId_Organization_id_fk": {
+          "name": "ProviderConfiguration_organizationId_Organization_id_fk",
+          "tableFrom": "ProviderConfiguration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProviderPreference": {
+      "name": "ProviderPreference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferredType": {
+          "name": "preferredType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProviderPreference_organizationId_provider_idx": {
+          "name": "ProviderPreference_organizationId_provider_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ProviderPreference_organizationId_provider_key": {
+          "name": "ProviderPreference_organizationId_provider_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProviderPreference_organizationId_Organization_id_fk": {
+          "name": "ProviderPreference_organizationId_Organization_id_fk",
+          "tableFrom": "ProviderPreference",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ResourceAccess": {
+      "name": "ResourceAccess",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granteeType": {
+          "name": "granteeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granteeId": {
+          "name": "granteeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantedById": {
+          "name": "grantedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ResourceAccess_entity_grantee_key": {
+          "name": "ResourceAccess_entity_grantee_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granteeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granteeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_entityDef_idx": {
+          "name": "ResourceAccess_entityDef_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_instance_idx": {
+          "name": "ResourceAccess_instance_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_grantee_idx": {
+          "name": "ResourceAccess_grantee_idx",
+          "columns": [
+            {
+              "expression": "granteeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granteeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_org_idx": {
+          "name": "ResourceAccess_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ResourceAccess_organizationId_Organization_id_fk": {
+          "name": "ResourceAccess_organizationId_Organization_id_fk",
+          "tableFrom": "ResourceAccess",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ResourceAccess_grantedById_User_id_fk": {
+          "name": "ResourceAccess_grantedById_User_id_fk",
+          "tableFrom": "ResourceAccess",
+          "tableTo": "User",
+          "columnsFrom": ["grantedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SearchHistory": {
+      "name": "SearchHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "searchedAt": {
+          "name": "searchedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SearchHistory_userId_organizationId_searchedAt_idx": {
+          "name": "SearchHistory_userId_organizationId_searchedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "searchedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SearchHistory_userId_User_id_fk": {
+          "name": "SearchHistory_userId_User_id_fk",
+          "tableFrom": "SearchHistory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SearchHistory_organizationId_Organization_id_fk": {
+          "name": "SearchHistory_organizationId_Organization_id_fk",
+          "tableFrom": "SearchHistory",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonatedBy": {
+          "name": "impersonatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_User_id_fk": {
+          "name": "session_userId_User_id_fk",
+          "tableFrom": "session",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ShopifyAuthState": {
+      "name": "ShopifyAuthState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shopDomain": {
+          "name": "shopDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ShopifyAuthState_state_idx": {
+          "name": "ShopifyAuthState_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ShopifyAuthState_userId_idx": {
+          "name": "ShopifyAuthState_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ShopifyAuthState_userId_User_id_fk": {
+          "name": "ShopifyAuthState_userId_User_id_fk",
+          "tableFrom": "ShopifyAuthState",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ShopifyAuthState_organizationId_Organization_id_fk": {
+          "name": "ShopifyAuthState_organizationId_Organization_id_fk",
+          "tableFrom": "ShopifyAuthState",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopify_customers": {
+      "name": "shopify_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "numberOfOrders": {
+          "name": "numberOfOrders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amountSpent": {
+          "name": "amountSpent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifiedEmail": {
+          "name": "verifiedEmail",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multipassIdentifier": {
+          "name": "multipassIdentifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taxExempt": {
+          "name": "taxExempt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defaultAddressId": {
+          "name": "defaultAddressId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastOrderId": {
+          "name": "lastOrderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastOrderName": {
+          "name": "lastOrderName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shopify_customers_entityInstanceId_idx": {
+          "name": "shopify_customers_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopify_customers_defaultAddressId_key": {
+          "name": "shopify_customers_defaultAddressId_key",
+          "columns": [
+            {
+              "expression": "defaultAddressId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopify_customers_email_idx": {
+          "name": "shopify_customers_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopify_customers_lastOrderId_key": {
+          "name": "shopify_customers_lastOrderId_key",
+          "columns": [
+            {
+              "expression": "lastOrderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopify_customers_phone_idx": {
+          "name": "shopify_customers_phone_idx",
+          "columns": [
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopify_customers_defaultAddressId_Address_id_fk": {
+          "name": "shopify_customers_defaultAddressId_Address_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "Address",
+          "columnsFrom": ["defaultAddressId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "shopify_customers_lastOrderId_Order_id_fk": {
+          "name": "shopify_customers_lastOrderId_Order_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "Order",
+          "columnsFrom": ["lastOrderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "shopify_customers_organizationId_Organization_id_fk": {
+          "name": "shopify_customers_organizationId_Organization_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "shopify_customers_integrationId_ShopifyIntegration_id_fk": {
+          "name": "shopify_customers_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "shopify_customers_entityInstanceId_EntityInstance_id_fk": {
+          "name": "shopify_customers_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ShopifyIntegration": {
+      "name": "ShopifyIntegration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shopDomain": {
+          "name": "shopDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ShopifyIntegration_organizationId_idx": {
+          "name": "ShopifyIntegration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ShopifyIntegration_organizationId_shopDomain_key": {
+          "name": "ShopifyIntegration_organizationId_shopDomain_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shopDomain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ShopifyIntegration_shopDomain_idx": {
+          "name": "ShopifyIntegration_shopDomain_idx",
+          "columns": [
+            {
+              "expression": "shopDomain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ShopifyIntegration_organizationId_Organization_id_fk": {
+          "name": "ShopifyIntegration_organizationId_Organization_id_fk",
+          "tableFrom": "ShopifyIntegration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ShopifyIntegration_createdById_User_id_fk": {
+          "name": "ShopifyIntegration_createdById_User_id_fk",
+          "tableFrom": "ShopifyIntegration",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SignatureIntegrationShare": {
+      "name": "SignatureIntegrationShare",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SignatureIntegrationShare_integrationId_idx": {
+          "name": "SignatureIntegrationShare_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SignatureIntegrationShare_entityInstanceId_idx": {
+          "name": "SignatureIntegrationShare_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SignatureIntegrationShare_entityInstanceId_integrationId_key": {
+          "name": "SignatureIntegrationShare_entityInstanceId_integrationId_key",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SignatureIntegrationShare_entityInstanceId_EntityInstance_id_fk": {
+          "name": "SignatureIntegrationShare_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "SignatureIntegrationShare",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SignatureIntegrationShare_integrationId_Integration_id_fk": {
+          "name": "SignatureIntegrationShare_integrationId_Integration_id_fk",
+          "tableFrom": "SignatureIntegrationShare",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Snippet": {
+      "name": "Snippet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHtml": {
+          "name": "contentHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDeleted": {
+          "name": "isDeleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharingType": {
+          "name": "sharingType",
+          "type": "SnippetSharingType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "isFavorite": {
+          "name": "isFavorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usageCount": {
+          "name": "usageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "Snippet_createdById_idx": {
+          "name": "Snippet_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Snippet_folderId_idx": {
+          "name": "Snippet_folderId_idx",
+          "columns": [
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Snippet_organizationId_idx": {
+          "name": "Snippet_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Snippet_sharingType_idx": {
+          "name": "Snippet_sharingType_idx",
+          "columns": [
+            {
+              "expression": "sharingType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Snippet_folderId_SnippetFolder_id_fk": {
+          "name": "Snippet_folderId_SnippetFolder_id_fk",
+          "tableFrom": "Snippet",
+          "tableTo": "SnippetFolder",
+          "columnsFrom": ["folderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Snippet_organizationId_Organization_id_fk": {
+          "name": "Snippet_organizationId_Organization_id_fk",
+          "tableFrom": "Snippet",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Snippet_createdById_User_id_fk": {
+          "name": "Snippet_createdById_User_id_fk",
+          "tableFrom": "Snippet",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SnippetFolder": {
+      "name": "SnippetFolder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "SnippetFolder_createdById_idx": {
+          "name": "SnippetFolder_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SnippetFolder_organizationId_idx": {
+          "name": "SnippetFolder_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SnippetFolder_organizationId_parentId_name_key": {
+          "name": "SnippetFolder_organizationId_parentId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SnippetFolder_parentId_SnippetFolder_id_fk": {
+          "name": "SnippetFolder_parentId_SnippetFolder_id_fk",
+          "tableFrom": "SnippetFolder",
+          "tableTo": "SnippetFolder",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "SnippetFolder_organizationId_Organization_id_fk": {
+          "name": "SnippetFolder_organizationId_Organization_id_fk",
+          "tableFrom": "SnippetFolder",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SnippetFolder_createdById_User_id_fk": {
+          "name": "SnippetFolder_createdById_User_id_fk",
+          "tableFrom": "SnippetFolder",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.StorageLocation": {
+      "name": "StorageLocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "StorageProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalUrl": {
+          "name": "externalUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalRev": {
+          "name": "externalRev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "StorageLocation_credentialId_idx": {
+          "name": "StorageLocation_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credentialId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StorageLocation_provider_externalId_idx": {
+          "name": "StorageLocation_provider_externalId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StorageLocation_organizationId_idx": {
+          "name": "StorageLocation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StorageLocation_deletedAt_idx": {
+          "name": "StorageLocation_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"StorageLocation\".\"deletedAt\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "StorageLocation_organizationId_Organization_id_fk": {
+          "name": "StorageLocation_organizationId_Organization_id_fk",
+          "tableFrom": "StorageLocation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "StorageLocation_credentialId_WorkflowCredentials_id_fk": {
+          "name": "StorageLocation_credentialId_WorkflowCredentials_id_fk",
+          "tableFrom": "StorageLocation",
+          "tableTo": "WorkflowCredentials",
+          "columnsFrom": ["credentialId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Subpart": {
+      "name": "Subpart",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentPartId": {
+          "name": "parentPartId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "childPartId": {
+          "name": "childPartId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Subpart_parentPartId_childPartId_key": {
+          "name": "Subpart_parentPartId_childPartId_key",
+          "columns": [
+            {
+              "expression": "parentPartId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "childPartId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Subpart_organizationId_Organization_id_fk": {
+          "name": "Subpart_organizationId_Organization_id_fk",
+          "tableFrom": "Subpart",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Subpart_parentPartId_Part_id_fk": {
+          "name": "Subpart_parentPartId_Part_id_fk",
+          "tableFrom": "Subpart",
+          "tableTo": "Part",
+          "columnsFrom": ["parentPartId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Subpart_childPartId_Part_id_fk": {
+          "name": "Subpart_childPartId_Part_id_fk",
+          "tableFrom": "Subpart",
+          "tableTo": "Part",
+          "columnsFrom": ["childPartId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Subscription": {
+      "name": "Subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Subscription_provider_integrationId_topic_key": {
+          "name": "Subscription_provider_integrationId_topic_key",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Subscription_organizationId_Organization_id_fk": {
+          "name": "Subscription_organizationId_Organization_id_fk",
+          "tableFrom": "Subscription",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Subscription_integrationId_ShopifyIntegration_id_fk": {
+          "name": "Subscription_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "Subscription",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SyncJob": {
+      "name": "SyncJob",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "SYNC_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalRecords": {
+          "name": "totalRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processedRecords": {
+          "name": "processedRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failedRecords": {
+          "name": "failedRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "integrationCategory": {
+          "name": "integrationCategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'message'"
+        },
+        "integrationSyncJobIds": {
+          "name": "integrationSyncJobIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"RAY\"}'"
+        }
+      },
+      "indexes": {
+        "SyncJob_organizationId_integrationCategory_integrationId_idx": {
+          "name": "SyncJob_organizationId_integrationCategory_integrationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationCategory",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SyncJob_organizationId_integrationCategory_status_idx": {
+          "name": "SyncJob_organizationId_integrationCategory_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationCategory",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SyncJob_organizationId_type_status_idx": {
+          "name": "SyncJob_organizationId_type_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SyncJob_organizationId_Organization_id_fk": {
+          "name": "SyncJob_organizationId_Organization_id_fk",
+          "tableFrom": "SyncJob",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SystemModelDefault": {
+      "name": "SystemModelDefault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "SystemModelDefault_organizationId_modelType_key": {
+          "name": "SystemModelDefault_organizationId_modelType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SystemModelDefault_organizationId_idx": {
+          "name": "SystemModelDefault_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SystemModelDefault_organizationId_Organization_id_fk": {
+          "name": "SystemModelDefault_organizationId_Organization_id_fk",
+          "tableFrom": "SystemModelDefault",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TableView": {
+      "name": "TableView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tableId": {
+          "name": "tableId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextType": {
+          "name": "contextType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'table'"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TableView_tableId_organizationId_idx": {
+          "name": "TableView_tableId_organizationId_idx",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TableView_tableId_organizationId_contextType_isDefault_key": {
+          "name": "TableView_tableId_organizationId_contextType_isDefault_key",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"TableView\".\"isDefault\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TableView_tableId_userId_idx": {
+          "name": "TableView_tableId_userId_idx",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TableView_tableId_userId_name_contextType_key": {
+          "name": "TableView_tableId_userId_name_contextType_key",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TableView_userId_User_id_fk": {
+          "name": "TableView_userId_User_id_fk",
+          "tableFrom": "TableView",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TableView_organizationId_Organization_id_fk": {
+          "name": "TableView_organizationId_Organization_id_fk",
+          "tableFrom": "TableView",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Tag": {
+      "name": "Tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isSystemTag": {
+          "name": "isSystemTag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Tag_organizationId_idx": {
+          "name": "Tag_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Tag_parentId_idx": {
+          "name": "Tag_parentId_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Tag_title_organizationId_parentId_key": {
+          "name": "Tag_title_organizationId_parentId_key",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Tag_parentId_Tag_id_fk": {
+          "name": "Tag_parentId_Tag_id_fk",
+          "tableFrom": "Tag",
+          "tableTo": "Tag",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Tag_organizationId_Organization_id_fk": {
+          "name": "Tag_organizationId_Organization_id_fk",
+          "tableFrom": "Tag",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TagsOnArticle": {
+      "name": "TagsOnArticle",
+      "schema": "",
+      "columns": {
+        "articleId": {
+          "name": "articleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "TagsOnArticle_articleId_Article_id_fk": {
+          "name": "TagsOnArticle_articleId_Article_id_fk",
+          "tableFrom": "TagsOnArticle",
+          "tableTo": "Article",
+          "columnsFrom": ["articleId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TagsOnArticle_tagId_ArticleTag_id_fk": {
+          "name": "TagsOnArticle_tagId_ArticleTag_id_fk",
+          "tableFrom": "TagsOnArticle",
+          "tableTo": "ArticleTag",
+          "columnsFrom": ["tagId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "TagsOnArticle_pkey": {
+          "name": "TagsOnArticle_pkey",
+          "columns": ["articleId", "tagId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Task": {
+      "name": "Task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedById": {
+          "name": "completedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchText": {
+          "name": "searchText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedUserCount": {
+          "name": "assignedUserCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "referenceCount": {
+          "name": "referenceCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Task_organizationId_idx": {
+          "name": "Task_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_archivedAt_deadline_idx": {
+          "name": "Task_organizationId_archivedAt_deadline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_createdById_idx": {
+          "name": "Task_organizationId_createdById_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_deadline_idx": {
+          "name": "Task_organizationId_deadline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_createdAt_idx": {
+          "name": "Task_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_completedAt_idx": {
+          "name": "Task_organizationId_completedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Task_organizationId_Organization_id_fk": {
+          "name": "Task_organizationId_Organization_id_fk",
+          "tableFrom": "Task",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Task_createdById_User_id_fk": {
+          "name": "Task_createdById_User_id_fk",
+          "tableFrom": "Task",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Task_completedById_User_id_fk": {
+          "name": "Task_completedById_User_id_fk",
+          "tableFrom": "Task",
+          "tableTo": "User",
+          "columnsFrom": ["completedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TaskAssignment": {
+      "name": "TaskAssignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedToUserId": {
+          "name": "assignedToUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedAt": {
+          "name": "assignedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "assignedById": {
+          "name": "assignedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unassignedAt": {
+          "name": "unassignedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TaskAssignment_organizationId_idx": {
+          "name": "TaskAssignment_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_taskId_idx": {
+          "name": "TaskAssignment_taskId_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_assignedToUserId_idx": {
+          "name": "TaskAssignment_assignedToUserId_idx",
+          "columns": [
+            {
+              "expression": "assignedToUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_organizationId_assignedToUserId_unassignedAt_idx": {
+          "name": "TaskAssignment_organizationId_assignedToUserId_unassignedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedToUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "unassignedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_taskId_assignedAt_idx": {
+          "name": "TaskAssignment_taskId_assignedAt_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_unassignedAt_idx": {
+          "name": "TaskAssignment_unassignedAt_idx",
+          "columns": [
+            {
+              "expression": "unassignedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_taskId_assignedToUserId_key": {
+          "name": "TaskAssignment_taskId_assignedToUserId_key",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedToUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TaskAssignment_organizationId_Organization_id_fk": {
+          "name": "TaskAssignment_organizationId_Organization_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskAssignment_taskId_Task_id_fk": {
+          "name": "TaskAssignment_taskId_Task_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "Task",
+          "columnsFrom": ["taskId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskAssignment_assignedToUserId_User_id_fk": {
+          "name": "TaskAssignment_assignedToUserId_User_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "User",
+          "columnsFrom": ["assignedToUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskAssignment_assignedById_User_id_fk": {
+          "name": "TaskAssignment_assignedById_User_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "User",
+          "columnsFrom": ["assignedById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TaskReference": {
+      "name": "TaskReference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referencedEntityInstanceId": {
+          "name": "referencedEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referencedEntityDefinitionId": {
+          "name": "referencedEntityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TaskReference_organizationId_idx": {
+          "name": "TaskReference_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_taskId_idx": {
+          "name": "TaskReference_taskId_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_referencedEntityInstanceId_idx": {
+          "name": "TaskReference_referencedEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "referencedEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_referencedEntityDefinitionId_idx": {
+          "name": "TaskReference_referencedEntityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "referencedEntityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_organizationId_referencedEntityInstanceId_deletedAt_idx": {
+          "name": "TaskReference_organizationId_referencedEntityInstanceId_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referencedEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_deletedAt_idx": {
+          "name": "TaskReference_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_taskId_referencedEntityInstanceId_key": {
+          "name": "TaskReference_taskId_referencedEntityInstanceId_key",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referencedEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TaskReference_organizationId_Organization_id_fk": {
+          "name": "TaskReference_organizationId_Organization_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_taskId_Task_id_fk": {
+          "name": "TaskReference_taskId_Task_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "Task",
+          "columnsFrom": ["taskId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_referencedEntityInstanceId_EntityInstance_id_fk": {
+          "name": "TaskReference_referencedEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["referencedEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_referencedEntityDefinitionId_EntityDefinition_id_fk": {
+          "name": "TaskReference_referencedEntityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["referencedEntityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_createdById_User_id_fk": {
+          "name": "TaskReference_createdById_User_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Thread": {
+      "name": "Thread",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ThreadStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "messageCount": {
+          "name": "messageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participantCount": {
+          "name": "participantCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "firstMessageAt": {
+          "name": "firstMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latestMessageId": {
+          "name": "latestMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latestCommentId": {
+          "name": "latestCommentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inboxId": {
+          "name": "inboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repliedAt": {
+          "name": "repliedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitingSince": {
+          "name": "waitingSince",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Thread_integrationId_externalId_key": {
+          "name": "Thread_integrationId_externalId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_integrationId_idx": {
+          "name": "Thread_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_lastMessageAt_idx": {
+          "name": "Thread_lastMessageAt_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_assigneeId_status_idx": {
+          "name": "Thread_organizationId_assigneeId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigneeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_createdAt_idx": {
+          "name": "Thread_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_idx": {
+          "name": "Thread_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_status_idx": {
+          "name": "Thread_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_status_idx": {
+          "name": "Thread_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_pagination_idx": {
+          "name": "thread_pagination_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_inboxId_idx": {
+          "name": "Thread_inboxId_idx",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Thread_organizationId_Organization_id_fk": {
+          "name": "Thread_organizationId_Organization_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Thread_integrationId_Integration_id_fk": {
+          "name": "Thread_integrationId_Integration_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Thread_assigneeId_User_id_fk": {
+          "name": "Thread_assigneeId_User_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "User",
+          "columnsFrom": ["assigneeId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_latestMessageId_Message_id_fk": {
+          "name": "Thread_latestMessageId_Message_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Message",
+          "columnsFrom": ["latestMessageId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_latestCommentId_Comment_id_fk": {
+          "name": "Thread_latestCommentId_Comment_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Comment",
+          "columnsFrom": ["latestCommentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_inboxId_EntityInstance_id_fk": {
+          "name": "Thread_inboxId_EntityInstance_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["inboxId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ThreadParticipant": {
+      "name": "ThreadParticipant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isInternal": {
+          "name": "isInternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "messageCount": {
+          "name": "messageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "firstMessageAt": {
+          "name": "firstMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ThreadParticipant_threadId_email_key": {
+          "name": "ThreadParticipant_threadId_email_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ThreadParticipant_threadId_Thread_id_fk": {
+          "name": "ThreadParticipant_threadId_Thread_id_fk",
+          "tableFrom": "ThreadParticipant",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ThreadReadStatus": {
+      "name": "ThreadReadStatus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSeenMessageId": {
+          "name": "lastSeenMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ThreadReadStatus_isRead_idx": {
+          "name": "ThreadReadStatus_isRead_idx",
+          "columns": [
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_organizationId_idx": {
+          "name": "ThreadReadStatus_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_organizationId_userId_idx": {
+          "name": "ThreadReadStatus_organizationId_userId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_threadId_idx": {
+          "name": "ThreadReadStatus_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_threadId_userId_key": {
+          "name": "ThreadReadStatus_threadId_userId_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_userId_idx": {
+          "name": "ThreadReadStatus_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_userId_isRead_idx": {
+          "name": "ThreadReadStatus_userId_isRead_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ThreadReadStatus_threadId_Thread_id_fk": {
+          "name": "ThreadReadStatus_threadId_Thread_id_fk",
+          "tableFrom": "ThreadReadStatus",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadReadStatus_userId_User_id_fk": {
+          "name": "ThreadReadStatus_userId_User_id_fk",
+          "tableFrom": "ThreadReadStatus",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadReadStatus_organizationId_Organization_id_fk": {
+          "name": "ThreadReadStatus_organizationId_Organization_id_fk",
+          "tableFrom": "ThreadReadStatus",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TicketReply": {
+      "name": "TicketReply",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "senderEmail": {
+          "name": "senderEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isFromCustomer": {
+          "name": "isFromCustomer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ccEmails": {
+          "name": "ccEmails",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"RAY\"}'"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inReplyTo": {
+          "name": "inReplyTo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TicketReply_messageId_idx": {
+          "name": "TicketReply_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TicketReply_messageId_key": {
+          "name": "TicketReply_messageId_key",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TicketReply_entityInstanceId_idx": {
+          "name": "TicketReply_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TicketReply_organizationId_idx": {
+          "name": "TicketReply_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TicketReply_entityInstanceId_EntityInstance_id_fk": {
+          "name": "TicketReply_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "TicketReply",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TicketReply_organizationId_Organization_id_fk": {
+          "name": "TicketReply_organizationId_Organization_id_fk",
+          "tableFrom": "TicketReply",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TicketReply_createdById_User_id_fk": {
+          "name": "TicketReply_createdById_User_id_fk",
+          "tableFrom": "TicketReply",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TicketSequence": {
+      "name": "TicketSequence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentNumber": {
+          "name": "currentNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paddingLength": {
+          "name": "paddingLength",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4
+        },
+        "usePrefix": {
+          "name": "usePrefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "useDateInPrefix": {
+          "name": "useDateInPrefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dateFormat": {
+          "name": "dateFormat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'YYMM'"
+        },
+        "separator": {
+          "name": "separator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-'"
+        },
+        "suffix": {
+          "name": "suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "useSuffix": {
+          "name": "useSuffix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TicketSequence_organizationId_key": {
+          "name": "TicketSequence_organizationId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TicketSequence_organizationId_Organization_id_fk": {
+          "name": "TicketSequence_organizationId_Organization_id_fk",
+          "tableFrom": "TicketSequence",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TimelineEvent": {
+      "name": "TimelineEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relatedEntityType": {
+          "name": "relatedEntityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedEntityId": {
+          "name": "relatedEntityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorType": {
+          "name": "actorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventData": {
+          "name": "eventData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isGrouped": {
+          "name": "isGrouped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "groupedEventIds": {
+          "name": "groupedEventIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TimelineEvent_entity_idx": {
+          "name": "TimelineEvent_entity_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_actor_idx": {
+          "name": "TimelineEvent_actor_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actorType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_type_idx": {
+          "name": "TimelineEvent_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_related_entity_idx": {
+          "name": "TimelineEvent_related_entity_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_org_timeline_idx": {
+          "name": "TimelineEvent_org_timeline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TimelineEvent_organizationId_Organization_id_fk": {
+          "name": "TimelineEvent_organizationId_Organization_id_fk",
+          "tableFrom": "TimelineEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TwoFactor": {
+      "name": "TwoFactor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backupCodes": {
+          "name": "backupCodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TwoFactor_userId_key": {
+          "name": "TwoFactor_userId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TwoFactor_userId_User_id_fk": {
+          "name": "TwoFactor_userId_User_id_fk",
+          "tableFrom": "TwoFactor",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UploadSession": {
+      "name": "UploadSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "StorageProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S3'"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expectedSize": {
+          "name": "expectedSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UploadSession_organizationId_createdById_idx": {
+          "name": "UploadSession_organizationId_createdById_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UploadSession_provider_externalId_idx": {
+          "name": "UploadSession_provider_externalId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UploadSession_organizationId_Organization_id_fk": {
+          "name": "UploadSession_organizationId_Organization_id_fk",
+          "tableFrom": "UploadSession",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastLoginAt": {
+          "name": "lastLoginAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferredTimezone": {
+          "name": "preferredTimezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedOnboarding": {
+          "name": "completedOnboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "twoFactorEnabled": {
+          "name": "twoFactorEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "hashedPassword": {
+          "name": "hashedPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchEmailsExpirationDate": {
+          "name": "watchEmailsExpirationDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isSuperAdmin": {
+          "name": "isSuperAdmin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "defaultOrganizationId": {
+          "name": "defaultOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "webhookSecret": {
+          "name": "webhookSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "phoneNumber": {
+          "name": "phoneNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phoneNumberVerified": {
+          "name": "phoneNumberVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatarAssetId": {
+          "name": "avatarAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userType": {
+          "name": "userType",
+          "type": "UserType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bannedReason": {
+          "name": "bannedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannedAt": {
+          "name": "bannedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forcePasswordChange": {
+          "name": "forcePasswordChange",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "User_avatarAssetId_key": {
+          "name": "User_avatarAssetId_key",
+          "columns": [
+            {
+              "expression": "avatarAssetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_email_key": {
+          "name": "User_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "User_avatarAssetId_MediaAsset_id_fk": {
+          "name": "User_avatarAssetId_MediaAsset_id_fk",
+          "tableFrom": "User",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["avatarAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserInboxUnreadCount": {
+      "name": "UserInboxUnreadCount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inboxId": {
+          "name": "inboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastUpdatedAt": {
+          "name": "lastUpdatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UserInboxUnreadCount_inboxId_idx": {
+          "name": "UserInboxUnreadCount_inboxId_idx",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_organizationId_idx": {
+          "name": "UserInboxUnreadCount_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_organizationId_inboxId_userId_key": {
+          "name": "UserInboxUnreadCount_organizationId_inboxId_userId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_organizationId_userId_idx": {
+          "name": "UserInboxUnreadCount_organizationId_userId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_userId_idx": {
+          "name": "UserInboxUnreadCount_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserInboxUnreadCount_inboxId_EntityInstance_id_fk": {
+          "name": "UserInboxUnreadCount_inboxId_EntityInstance_id_fk",
+          "tableFrom": "UserInboxUnreadCount",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["inboxId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "UserInboxUnreadCount_userId_User_id_fk": {
+          "name": "UserInboxUnreadCount_userId_User_id_fk",
+          "tableFrom": "UserInboxUnreadCount",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "UserInboxUnreadCount_organizationId_Organization_id_fk": {
+          "name": "UserInboxUnreadCount_organizationId_Organization_id_fk",
+          "tableFrom": "UserInboxUnreadCount",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserSetting": {
+      "name": "UserSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationSettingId": {
+          "name": "organizationSettingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UserSetting_organizationSettingId_idx": {
+          "name": "UserSetting_organizationSettingId_idx",
+          "columns": [
+            {
+              "expression": "organizationSettingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSetting_userId_idx": {
+          "name": "UserSetting_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSetting_userId_organizationSettingId_key": {
+          "name": "UserSetting_userId_organizationSettingId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationSettingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserSetting_userId_User_id_fk": {
+          "name": "UserSetting_userId_User_id_fk",
+          "tableFrom": "UserSetting",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "UserSetting_organizationSettingId_OrganizationSetting_id_fk": {
+          "name": "UserSetting_organizationSettingId_OrganizationSetting_id_fk",
+          "tableFrom": "UserSetting",
+          "tableTo": "OrganizationSetting",
+          "columnsFrom": ["organizationSettingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.VendorPart": {
+      "name": "VendorPart",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partId": {
+          "name": "partId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vendorSku": {
+          "name": "vendorSku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unitPrice": {
+          "name": "unitPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leadTime": {
+          "name": "leadTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minOrderQty": {
+          "name": "minOrderQty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPreferred": {
+          "name": "isPreferred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "VendorPart_partId_entityInstanceId_key": {
+          "name": "VendorPart_partId_entityInstanceId_key",
+          "columns": [
+            {
+              "expression": "partId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "VendorPart_organizationId_Organization_id_fk": {
+          "name": "VendorPart_organizationId_Organization_id_fk",
+          "tableFrom": "VendorPart",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "VendorPart_partId_Part_id_fk": {
+          "name": "VendorPart_partId_Part_id_fk",
+          "tableFrom": "VendorPart",
+          "tableTo": "Part",
+          "columnsFrom": ["partId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "VendorPart_entityInstanceId_EntityInstance_id_fk": {
+          "name": "VendorPart_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "VendorPart",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.VerificationToken": {
+      "name": "VerificationToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "VerificationToken_token_key": {
+          "name": "VerificationToken_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "VerificationToken_userId_idx": {
+          "name": "VerificationToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "VerificationToken_userId_User_id_fk": {
+          "name": "VerificationToken_userId_User_id_fk",
+          "tableFrom": "VerificationToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Webhook": {
+      "name": "Webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "eventTypes": {
+          "name": "eventTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastTriggeredAt": {
+          "name": "lastTriggeredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Webhook_organizationId_idx": {
+          "name": "Webhook_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Webhook_organizationId_Organization_id_fk": {
+          "name": "Webhook_organizationId_Organization_id_fk",
+          "tableFrom": "Webhook",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WebhookDelivery": {
+      "name": "WebhookDelivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookId": {
+          "name": "webhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responseStatus": {
+          "name": "responseStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responseBody": {
+          "name": "responseBody",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attemptCount": {
+          "name": "attemptCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "nextRetryAt": {
+          "name": "nextRetryAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "WebhookDelivery_webhookId_idx": {
+          "name": "WebhookDelivery_webhookId_idx",
+          "columns": [
+            {
+              "expression": "webhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WebhookDelivery_webhookId_Webhook_id_fk": {
+          "name": "WebhookDelivery_webhookId_Webhook_id_fk",
+          "tableFrom": "WebhookDelivery",
+          "tableTo": "Webhook",
+          "columnsFrom": ["webhookId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WebhookEvent": {
+      "name": "WebhookEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retryCount": {
+          "name": "retryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "SYNC_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WebhookEvent_integrationId_idx": {
+          "name": "WebhookEvent_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WebhookEvent_organizationId_idx": {
+          "name": "WebhookEvent_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WebhookEvent_subscriptionId_Subscription_id_fk": {
+          "name": "WebhookEvent_subscriptionId_Subscription_id_fk",
+          "tableFrom": "WebhookEvent",
+          "tableTo": "Subscription",
+          "columnsFrom": ["subscriptionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WebhookEvent_integrationId_ShopifyIntegration_id_fk": {
+          "name": "WebhookEvent_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "WebhookEvent",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WebhookEvent_organizationId_Organization_id_fk": {
+          "name": "WebhookEvent_organizationId_Organization_id_fk",
+          "tableFrom": "WebhookEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Workflow": {
+      "name": "Workflow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAppId": {
+          "name": "triggerAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerTriggerId": {
+          "name": "triggerTriggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerInstallationId": {
+          "name": "triggerInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerConnectionId": {
+          "name": "triggerConnectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Workflow_organizationId_enabled_idx": {
+          "name": "Workflow_organizationId_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Workflow_orgId_triggerType_entityDefId_idx": {
+          "name": "Workflow_orgId_triggerType_entityDefId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Workflow_orgId_appTrigger_idx": {
+          "name": "Workflow_orgId_appTrigger_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerTriggerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Workflow_organizationId_Organization_id_fk": {
+          "name": "Workflow_organizationId_Organization_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Workflow_createdById_User_id_fk": {
+          "name": "Workflow_createdById_User_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Workflow_workflowAppId_WorkflowApp_id_fk": {
+          "name": "Workflow_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowApp": {
+      "name": "WorkflowApp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isUniversal": {
+          "name": "isUniversal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draftWorkflowId": {
+          "name": "draftWorkflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shareToken": {
+          "name": "shareToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webEnabled": {
+          "name": "webEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "apiEnabled": {
+          "name": "apiEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessMode": {
+          "name": "accessMode",
+          "type": "WorkflowShareAccessMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rateLimit": {
+          "name": "rateLimit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalRuns": {
+          "name": "totalRuns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowApp_draftWorkflowId_key": {
+          "name": "WorkflowApp_draftWorkflowId_key",
+          "columns": [
+            {
+              "expression": "draftWorkflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_organizationId_enabled_idx": {
+          "name": "WorkflowApp_organizationId_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_organizationId_isPublic_idx": {
+          "name": "WorkflowApp_organizationId_isPublic_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_workflowId_key": {
+          "name": "WorkflowApp_workflowId_key",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_shareToken_key": {
+          "name": "WorkflowApp_shareToken_key",
+          "columns": [
+            {
+              "expression": "shareToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_webEnabled_idx": {
+          "name": "WorkflowApp_webEnabled_idx",
+          "columns": [
+            {
+              "expression": "webEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_apiEnabled_idx": {
+          "name": "WorkflowApp_apiEnabled_idx",
+          "columns": [
+            {
+              "expression": "apiEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowApp_organizationId_Organization_id_fk": {
+          "name": "WorkflowApp_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowApp_createdById_User_id_fk": {
+          "name": "WorkflowApp_createdById_User_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "WorkflowApp_workflowId_Workflow_id_fk": {
+          "name": "WorkflowApp_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "WorkflowApp_draftWorkflowId_Workflow_id_fk": {
+          "name": "WorkflowApp_draftWorkflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "Workflow",
+          "columnsFrom": ["draftWorkflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "WorkflowApp_shareToken_unique": {
+          "name": "WorkflowApp_shareToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["shareToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowCredentials": {
+      "name": "WorkflowCredentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryptedData": {
+          "name": "encryptedData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastTokenRefreshAt": {
+          "name": "lastTokenRefreshAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRefreshFailureAt": {
+          "name": "lastRefreshFailureAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutiveRefreshFailures": {
+          "name": "consecutiveRefreshFailures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "WorkflowCredentials_createdById_idx": {
+          "name": "WorkflowCredentials_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_organizationId_idx": {
+          "name": "WorkflowCredentials_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_organizationId_type_idx": {
+          "name": "WorkflowCredentials_organizationId_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_appId_organizationId_idx": {
+          "name": "WorkflowCredentials_appId_organizationId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_userId_appId_idx": {
+          "name": "WorkflowCredentials_userId_appId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_appInstallationId_idx": {
+          "name": "WorkflowCredentials_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_expiresAt_idx": {
+          "name": "WorkflowCredentials_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_lastTokenRefreshAt_idx": {
+          "name": "WorkflowCredentials_lastTokenRefreshAt_idx",
+          "columns": [
+            {
+              "expression": "lastTokenRefreshAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowCredentials_organizationId_Organization_id_fk": {
+          "name": "WorkflowCredentials_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowCredentials_createdById_User_id_fk": {
+          "name": "WorkflowCredentials_createdById_User_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowCredentials_userId_User_id_fk": {
+          "name": "WorkflowCredentials_userId_User_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowCredentials_appId_App_id_fk": {
+          "name": "WorkflowCredentials_appId_App_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowCredentials_appInstallationId_AppInstallation_id_fk": {
+          "name": "WorkflowCredentials_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowFile": {
+      "name": "WorkflowFile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploadedAt": {
+          "name": "uploadedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "uploadSource": {
+          "name": "uploadSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "originalUrl": {
+          "name": "originalUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowFile_expiresAt_idx": {
+          "name": "WorkflowFile_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowFile_nodeId_idx": {
+          "name": "WorkflowFile_nodeId_idx",
+          "columns": [
+            {
+              "expression": "nodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowFile_workflowId_fileId_key": {
+          "name": "WorkflowFile_workflowId_fileId_key",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowFile_workflowId_idx": {
+          "name": "WorkflowFile_workflowId_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowFile_workflowId_Workflow_id_fk": {
+          "name": "WorkflowFile_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowFile",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowFile_fileId_File_id_fk": {
+          "name": "WorkflowFile_fileId_File_id_fk",
+          "tableFrom": "WorkflowFile",
+          "tableTo": "File",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowJoinState": {
+      "name": "WorkflowJoinState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joinNodeId": {
+          "name": "joinNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forkNodeId": {
+          "name": "forkNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expectedInputs": {
+          "name": "expectedInputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedInputs": {
+          "name": "completedInputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branchResults": {
+          "name": "branchResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "WorkflowJoinState_executionId_idx": {
+          "name": "WorkflowJoinState_executionId_idx",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowJoinState_executionId_joinNodeId_key": {
+          "name": "WorkflowJoinState_executionId_joinNodeId_key",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "joinNodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowJoinState_workflowId_idx": {
+          "name": "WorkflowJoinState_workflowId_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowJoinState_workflowId_Workflow_id_fk": {
+          "name": "WorkflowJoinState_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowJoinState",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowNodeExecution": {
+      "name": "WorkflowNodeExecution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggeredFrom": {
+          "name": "triggeredFrom",
+          "type": "NodeTriggerSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowRunId": {
+          "name": "workflowRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "predecessorNodeId": {
+          "name": "predecessorNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeType": {
+          "name": "nodeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processData": {
+          "name": "processData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "NodeExecutionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsedTime": {
+          "name": "elapsedTime",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionMetadata": {
+          "name": "executionMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowNodeExecution_nodeId_idx": {
+          "name": "WorkflowNodeExecution_nodeId_idx",
+          "columns": [
+            {
+              "expression": "nodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowNodeExecution_status_idx": {
+          "name": "WorkflowNodeExecution_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowNodeExecution_workflowRunId_idx": {
+          "name": "WorkflowNodeExecution_workflowRunId_idx",
+          "columns": [
+            {
+              "expression": "workflowRunId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowNodeExecution_organizationId_Organization_id_fk": {
+          "name": "WorkflowNodeExecution_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_workflowAppId_WorkflowApp_id_fk": {
+          "name": "WorkflowNodeExecution_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_workflowId_Workflow_id_fk": {
+          "name": "WorkflowNodeExecution_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_workflowRunId_WorkflowRun_id_fk": {
+          "name": "WorkflowNodeExecution_workflowRunId_WorkflowRun_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "WorkflowRun",
+          "columnsFrom": ["workflowRunId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_createdById_User_id_fk": {
+          "name": "WorkflowNodeExecution_createdById_User_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowRun": {
+      "name": "WorkflowRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequenceNumber": {
+          "name": "sequenceNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggeredFrom": {
+          "name": "triggeredFrom",
+          "type": "WorkflowTriggerSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsedTime": {
+          "name": "elapsedTime",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalSteps": {
+          "name": "totalSteps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pausedAt": {
+          "name": "pausedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pausedNodeId": {
+          "name": "pausedNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumeAt": {
+          "name": "resumeAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serializedState": {
+          "name": "serializedState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endUserId": {
+          "name": "endUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowRun_createdAt_idx": {
+          "name": "WorkflowRun_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_organizationId_workflowAppId_idx": {
+          "name": "WorkflowRun_organizationId_workflowAppId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_resumeAt_idx": {
+          "name": "WorkflowRun_resumeAt_idx",
+          "columns": [
+            {
+              "expression": "resumeAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_status_idx": {
+          "name": "WorkflowRun_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_workflowId_idx": {
+          "name": "WorkflowRun_workflowId_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowRun_organizationId_Organization_id_fk": {
+          "name": "WorkflowRun_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_workflowAppId_WorkflowApp_id_fk": {
+          "name": "WorkflowRun_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_workflowId_Workflow_id_fk": {
+          "name": "WorkflowRun_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_createdBy_User_id_fk": {
+          "name": "WorkflowRun_createdBy_User_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "User",
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_endUserId_EndUser_id_fk": {
+          "name": "WorkflowRun_endUserId_EndUser_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "EndUser",
+          "columnsFrom": ["endUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowTemplate": {
+      "name": "WorkflowTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "imgUrl": {
+          "name": "imgUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerConfig": {
+          "name": "triggerConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envVars": {
+          "name": "envVars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "WorkflowTemplate_status_idx": {
+          "name": "WorkflowTemplate_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowTemplate_popularity_idx": {
+          "name": "WorkflowTemplate_popularity_idx",
+          "columns": [
+            {
+              "expression": "popularity",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowTemplate_name_idx": {
+          "name": "WorkflowTemplate_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowTemplate_categories_idx": {
+          "name": "WorkflowTemplate_categories_idx",
+          "columns": [
+            {
+              "expression": "categories",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ActionType": {
+      "name": "ActionType",
+      "schema": "public",
+      "values": [
+        "ARCHIVE",
+        "LABEL",
+        "REPLY",
+        "FORWARD",
+        "MARK_SPAM",
+        "DRAFT_EMAIL",
+        "SEND_MESSAGE",
+        "APPLY_TAG",
+        "REMOVE_TAG",
+        "APPLY_LABEL",
+        "REMOVE_LABEL",
+        "MARK_TRASH",
+        "ASSIGN_THREAD",
+        "ARCHIVE_THREAD",
+        "UNARCHIVE_THREAD",
+        "MOVE_TO_TRASH",
+        "REACT_TO_MESSAGE",
+        "SHARE_MESSAGE",
+        "SEND_SMS",
+        "MAKE_CALL",
+        "ESCALATE",
+        "ASSIGN",
+        "NOTIFY",
+        "CREATE_TICKET",
+        "SHOPIFY_ORDER_LOOKUP",
+        "SHOPIFY_GENERATE_RESPONSE"
+      ]
+    },
+    "public.AiIntegrationStatus": {
+      "name": "AiIntegrationStatus",
+      "schema": "public",
+      "values": ["PENDING", "VALID", "INVALID"]
+    },
+    "public.ApprovalAction": {
+      "name": "ApprovalAction",
+      "schema": "public",
+      "values": ["approve", "deny"]
+    },
+    "public.ApprovalStatus": {
+      "name": "ApprovalStatus",
+      "schema": "public",
+      "values": ["pending", "approved", "denied", "timeout"]
+    },
+    "public.ArticleStatus": {
+      "name": "ArticleStatus",
+      "schema": "public",
+      "values": ["DRAFT", "PUBLISHED", "ARCHIVED"]
+    },
+    "public.AssetVersionStatus": {
+      "name": "AssetVersionStatus",
+      "schema": "public",
+      "values": ["PENDING", "PROCESSING", "READY", "FAILED"]
+    },
+    "public.BillingCycle": {
+      "name": "BillingCycle",
+      "schema": "public",
+      "values": ["MONTHLY", "ANNUAL"]
+    },
+    "public.ChunkingStrategy": {
+      "name": "ChunkingStrategy",
+      "schema": "public",
+      "values": ["FIXED_SIZE", "SEMANTIC", "SENTENCE", "PARAGRAPH", "DOCUMENT"]
+    },
+    "public.ContactFieldType": {
+      "name": "ContactFieldType",
+      "schema": "public",
+      "values": [
+        "PHONE",
+        "EMAIL",
+        "ADDRESS",
+        "URL",
+        "TAGS",
+        "DATE",
+        "DATETIME",
+        "TIME",
+        "CHECKBOX",
+        "TEXT",
+        "NUMBER",
+        "CURRENCY",
+        "MULTI_SELECT",
+        "SINGLE_SELECT",
+        "RICH_TEXT",
+        "PHONE_INTL",
+        "ADDRESS_STRUCT",
+        "FILE",
+        "NAME",
+        "RELATIONSHIP",
+        "CALC",
+        "ACTOR",
+        "JSON"
+      ]
+    },
+    "public.CredentialSource": {
+      "name": "CredentialSource",
+      "schema": "public",
+      "values": ["SYSTEM", "CUSTOM", "MODEL_SPECIFIC", "LOAD_BALANCED"]
+    },
+    "public.CustomerSourceType": {
+      "name": "CustomerSourceType",
+      "schema": "public",
+      "values": ["EMAIL", "TICKET_SYSTEM", "SHOPIFY", "MANUAL", "OTHER", "FACEBOOK_PSID"]
+    },
+    "public.CustomerStatus": {
+      "name": "CustomerStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE", "SPAM", "MERGED"]
+    },
+    "public.DatasetStatus": {
+      "name": "DatasetStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE", "PROCESSING", "ERROR"]
+    },
+    "public.DeliveryStatus": {
+      "name": "DeliveryStatus",
+      "schema": "public",
+      "values": ["DELIVERED", "BOUNCED", "DELAYED", "DEFERRED", "REJECTED"]
+    },
+    "public.DocumentStatus": {
+      "name": "DocumentStatus",
+      "schema": "public",
+      "values": ["UPLOADED", "PROCESSING", "INDEXED", "FAILED", "ARCHIVED", "WAITING"]
+    },
+    "public.DocumentType": {
+      "name": "DocumentType",
+      "schema": "public",
+      "values": ["PDF", "DOCX", "TXT", "HTML", "MARKDOWN", "CSV", "JSON", "XML"]
+    },
+    "public.DomainType": {
+      "name": "DomainType",
+      "schema": "public",
+      "values": ["CUSTOM", "PROVIDER"]
+    },
+    "public.EmailLabel": {
+      "name": "EmailLabel",
+      "schema": "public",
+      "values": ["inbox", "sent", "draft"]
+    },
+    "public.EmailProvider": {
+      "name": "EmailProvider",
+      "schema": "public",
+      "values": ["GMAIL", "OUTLOOK", "IMAP"]
+    },
+    "public.EmailTemplateType": {
+      "name": "EmailTemplateType",
+      "schema": "public",
+      "values": [
+        "TICKET_CREATED",
+        "TICKET_REPLIED",
+        "TICKET_CLOSED",
+        "TICKET_REOPENED",
+        "TICKET_ASSIGNED",
+        "TICKET_STATUS_CHANGED",
+        "CUSTOM"
+      ]
+    },
+    "public.ExtractionRuleType": {
+      "name": "ExtractionRuleType",
+      "schema": "public",
+      "values": ["REGEX", "MARKER", "POSITION", "AI_ASSISTED", "VISUAL_SELECTION"]
+    },
+    "public.FileStatus": {
+      "name": "FileStatus",
+      "schema": "public",
+      "values": ["PENDING", "CONFIRMED", "ARCHIVED", "DELETED", "FAILED"]
+    },
+    "public.FileVisibility": {
+      "name": "FileVisibility",
+      "schema": "public",
+      "values": ["PUBLIC", "PRIVATE", "INTERNAL"]
+    },
+    "public.FULFILLMENT_STATUS": {
+      "name": "FULFILLMENT_STATUS",
+      "schema": "public",
+      "values": ["CANCELLED", "ERROR", "FAILURE", "SUCCESS", "OPEN", "PENDING"]
+    },
+    "public.IdentifierType": {
+      "name": "IdentifierType",
+      "schema": "public",
+      "values": ["EMAIL", "PHONE", "FACEBOOK_PSID", "INSTAGRAM_IGSID"]
+    },
+    "public.ImportJobStatus": {
+      "name": "ImportJobStatus",
+      "schema": "public",
+      "values": [
+        "uploading",
+        "ingesting",
+        "waiting",
+        "planning",
+        "ready",
+        "executing",
+        "completed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.ImportMappingTargetType": {
+      "name": "ImportMappingTargetType",
+      "schema": "public",
+      "values": ["particle", "relation", "skip"]
+    },
+    "public.ImportPlanRowStatus": {
+      "name": "ImportPlanRowStatus",
+      "schema": "public",
+      "values": ["planned", "executing", "completed", "failed"]
+    },
+    "public.ImportPlanStatus": {
+      "name": "ImportPlanStatus",
+      "schema": "public",
+      "values": ["planning", "planned", "executing", "completed"]
+    },
+    "public.ImportResolutionStatus": {
+      "name": "ImportResolutionStatus",
+      "schema": "public",
+      "values": ["pending", "valid", "error", "warning", "create"]
+    },
+    "public.ImportStrategyStatus": {
+      "name": "ImportStrategyStatus",
+      "schema": "public",
+      "values": ["planning_queued", "planning", "planned", "executing", "completed"]
+    },
+    "public.ImportStrategyType": {
+      "name": "ImportStrategyType",
+      "schema": "public",
+      "values": ["create", "update", "skip"]
+    },
+    "public.InboxStatus": {
+      "name": "InboxStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "ARCHIVED", "PAUSED"]
+    },
+    "public.IndexStatus": {
+      "name": "IndexStatus",
+      "schema": "public",
+      "values": ["PENDING", "INDEXED", "ERROR"]
+    },
+    "public.IntegrationAuthStatus": {
+      "name": "IntegrationAuthStatus",
+      "schema": "public",
+      "values": [
+        "AUTHENTICATED",
+        "UNAUTHENTICATED",
+        "ERROR",
+        "INVALID_GRANT",
+        "EXPIRED_TOKEN",
+        "REVOKED_ACCESS",
+        "INSUFFICIENT_SCOPE",
+        "RATE_LIMITED",
+        "PROVIDER_ERROR",
+        "NETWORK_ERROR",
+        "UNKNOWN_ERROR"
+      ]
+    },
+    "public.IntegrationProviderType": {
+      "name": "IntegrationProviderType",
+      "schema": "public",
+      "values": [
+        "google",
+        "outlook",
+        "facebook",
+        "instagram",
+        "openphone",
+        "mailgun",
+        "sms",
+        "whatsapp",
+        "chat",
+        "email",
+        "shopify",
+        "imap"
+      ]
+    },
+    "public.IntegrationSyncStage": {
+      "name": "IntegrationSyncStage",
+      "schema": "public",
+      "values": [
+        "IDLE",
+        "MESSAGE_LIST_FETCH_PENDING",
+        "MESSAGE_LIST_FETCH",
+        "MESSAGES_IMPORT_PENDING",
+        "MESSAGES_IMPORT",
+        "FAILED"
+      ]
+    },
+    "public.IntegrationSyncStatus": {
+      "name": "IntegrationSyncStatus",
+      "schema": "public",
+      "values": ["NOT_SYNCED", "SYNCING", "ACTIVE", "FAILED"]
+    },
+    "public.INVENTORY_POLICY": {
+      "name": "INVENTORY_POLICY",
+      "schema": "public",
+      "values": ["CONTINUE", "DENY"]
+    },
+    "public.InvitationStatus": {
+      "name": "InvitationStatus",
+      "schema": "public",
+      "values": ["PENDING", "ACCEPTED", "EXPIRED", "CANCELLED"]
+    },
+    "public.InvoiceStatus": {
+      "name": "InvoiceStatus",
+      "schema": "public",
+      "values": ["PENDING", "PAID", "VOID", "UNCOLLECTIBLE", "DRAFT"]
+    },
+    "public.JobStatus": {
+      "name": "JobStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "PROCESSING",
+        "COMPLETED_SUCCESS",
+        "COMPLETED_PARTIAL",
+        "COMPLETED_FAILURE",
+        "FAILED",
+        "RETRYING"
+      ]
+    },
+    "public.LabelType": {
+      "name": "LabelType",
+      "schema": "public",
+      "values": ["system", "user"]
+    },
+    "public.MEDIA_CONTENT_TYPE": {
+      "name": "MEDIA_CONTENT_TYPE",
+      "schema": "public",
+      "values": ["EXTERNAL_VIDEO", "IMAGE", "MODEL_3D", "VIDEO"]
+    },
+    "public.MeetingMessageMethod": {
+      "name": "MeetingMessageMethod",
+      "schema": "public",
+      "values": ["request", "reply", "cancel", "counter", "other"]
+    },
+    "public.MessageType": {
+      "name": "MessageType",
+      "schema": "public",
+      "values": ["EMAIL", "FACEBOOK", "SMS", "WHATSAPP", "INSTAGRAM", "OPENPHONE", "CHAT"]
+    },
+    "public.ModelType": {
+      "name": "ModelType",
+      "schema": "public",
+      "values": ["LLM", "TEXT_EMBEDDING", "RERANK", "TTS", "SPEECH2TEXT", "MODERATION", "VISION"]
+    },
+    "public.NodeExecutionStatus": {
+      "name": "NodeExecutionStatus",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        "exception",
+        "skipped",
+        "stopped",
+        "waiting"
+      ]
+    },
+    "public.NodeTriggerSource": {
+      "name": "NodeTriggerSource",
+      "schema": "public",
+      "values": ["SINGLE_STEP", "WORKFLOW_RUN"]
+    },
+    "public.NotificationType": {
+      "name": "NotificationType",
+      "schema": "public",
+      "values": [
+        "COMMENT_MENTION",
+        "COMMENT_REPLY",
+        "COMMENT_REACTION",
+        "TICKET_ASSIGNED",
+        "TICKET_UPDATED",
+        "TICKET_MENTIONED",
+        "THREAD_ACTIVITY",
+        "SYSTEM_MESSAGE",
+        "WORKFLOW_APPROVAL_REQUIRED",
+        "WORKFLOW_APPROVAL_REMINDER",
+        "WORKFLOW_APPROVAL_COMPLETED"
+      ]
+    },
+    "public.ORDER_ADDRESS_TYPE": {
+      "name": "ORDER_ADDRESS_TYPE",
+      "schema": "public",
+      "values": ["SHIPPING", "BILLING"]
+    },
+    "public.ORDER_CANCEL_REASON": {
+      "name": "ORDER_CANCEL_REASON",
+      "schema": "public",
+      "values": ["CUSTOMER", "DECLINED", "FRAUD", "INVENTORY", "OTHER", "STAFF"]
+    },
+    "public.ORDER_FINANCIAL_STATUS": {
+      "name": "ORDER_FINANCIAL_STATUS",
+      "schema": "public",
+      "values": [
+        "AUTHORIZED",
+        "EXPIRED",
+        "PAID",
+        "PARTIALLY_PAID",
+        "PARTIALLY_REFUNDED",
+        "PENDING",
+        "REFUNDED",
+        "VOIDED"
+      ]
+    },
+    "public.ORDER_FULFILLMENT_STATUS": {
+      "name": "ORDER_FULFILLMENT_STATUS",
+      "schema": "public",
+      "values": [
+        "FULFILLED",
+        "IN_PROGRESS",
+        "ON_HOLD",
+        "OPEN",
+        "PARTIALLY_FULFILLED",
+        "PENDING_FULFILLMENT",
+        "REQUEST_DECLINED",
+        "RESTOCKED",
+        "SCHEDULED",
+        "UNFULFILLED"
+      ]
+    },
+    "public.ORDER_RETURN_STATUS": {
+      "name": "ORDER_RETURN_STATUS",
+      "schema": "public",
+      "values": [
+        "INSPECTION_COMPLETED",
+        "IN_PROGRESS",
+        "NO_RETURN",
+        "RETURNED",
+        "RETURN_FAILED",
+        "RETURN_REQUESTED"
+      ]
+    },
+    "public.OrganizationMemberStatus": {
+      "name": "OrganizationMemberStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE"]
+    },
+    "public.OrganizationRole": {
+      "name": "OrganizationRole",
+      "schema": "public",
+      "values": ["OWNER", "ADMIN", "USER"]
+    },
+    "public.OrganizationType": {
+      "name": "OrganizationType",
+      "schema": "public",
+      "values": ["INDIVIDUAL", "TEAM"]
+    },
+    "public.ParticipantRole": {
+      "name": "ParticipantRole",
+      "schema": "public",
+      "values": ["FROM", "TO", "CC", "BCC", "REPLY_TO"]
+    },
+    "public.PRODUDT_STATUS": {
+      "name": "PRODUDT_STATUS",
+      "schema": "public",
+      "values": ["ACTIVE", "ARCHIVED", "DRAFT"]
+    },
+    "public.ProposedActionStatus": {
+      "name": "ProposedActionStatus",
+      "schema": "public",
+      "values": ["PENDING", "APPROVED", "REJECTED", "EXECUTED", "FAILED"]
+    },
+    "public.ProviderQuotaType": {
+      "name": "ProviderQuotaType",
+      "schema": "public",
+      "values": ["PAID", "FREE", "TRIAL"]
+    },
+    "public.ProviderType": {
+      "name": "ProviderType",
+      "schema": "public",
+      "values": ["SYSTEM", "CUSTOM"]
+    },
+    "public.RecipientRole": {
+      "name": "RecipientRole",
+      "schema": "public",
+      "values": ["FROM", "TO", "CC", "BCC"]
+    },
+    "public.ResponseStatus": {
+      "name": "ResponseStatus",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "PENDING_APPROVAL",
+        "APPROVED",
+        "SCHEDULED",
+        "SENDING",
+        "SENT",
+        "FAILED",
+        "CANCELLED"
+      ]
+    },
+    "public.ResponseType": {
+      "name": "ResponseType",
+      "schema": "public",
+      "values": ["MANUAL", "TEMPLATE", "AI_GENERATED", "RULE_BASED", "HYBRID"]
+    },
+    "public.RETURN_STATUS": {
+      "name": "RETURN_STATUS",
+      "schema": "public",
+      "values": ["CANCELLED", "CLOSED", "DECLINED", "OPEN", "REQUESTED"]
+    },
+    "public.RuleGroupOperator": {
+      "name": "RuleGroupOperator",
+      "schema": "public",
+      "values": ["AND", "OR", "NOT", "XOR", "THRESHOLD"]
+    },
+    "public.RuleType": {
+      "name": "RuleType",
+      "schema": "public",
+      "values": ["STATIC", "CATEGORY", "AI", "SPAM_HANDLER", "RULE_GROUP", "SHOPIFY_AUTOMATION"]
+    },
+    "public.SendStatus": {
+      "name": "SendStatus",
+      "schema": "public",
+      "values": ["PENDING", "SENT", "FAILED"]
+    },
+    "public.SenderType": {
+      "name": "SenderType",
+      "schema": "public",
+      "values": [
+        "INTERNAL_STAFF",
+        "INTERNAL_SYSTEM",
+        "PARTNER",
+        "CUSTOMER",
+        "VENDOR",
+        "UNKNOWN_EXTERNAL"
+      ]
+    },
+    "public.Sensitivity": {
+      "name": "Sensitivity",
+      "schema": "public",
+      "values": ["normal", "private", "personal", "confidential"]
+    },
+    "public.SettingScope": {
+      "name": "SettingScope",
+      "schema": "public",
+      "values": [
+        "APPEARANCE",
+        "NOTIFICATION",
+        "DASHBOARD",
+        "COMMUNICATION",
+        "SECURITY",
+        "INTEGRATION",
+        "GENERAL",
+        "SIDEBAR"
+      ]
+    },
+    "public.SignatureSharingType": {
+      "name": "SignatureSharingType",
+      "schema": "public",
+      "values": ["PRIVATE", "ORGANIZATION_WIDE", "SPECIFIC_INTEGRATIONS"]
+    },
+    "public.SnippetPermission": {
+      "name": "SnippetPermission",
+      "schema": "public",
+      "values": ["VIEW", "EDIT"]
+    },
+    "public.SnippetSharingType": {
+      "name": "SnippetSharingType",
+      "schema": "public",
+      "values": ["PRIVATE", "ORGANIZATION", "GROUPS", "MEMBERS"]
+    },
+    "public.StaticRuleType": {
+      "name": "StaticRuleType",
+      "schema": "public",
+      "values": [
+        "SENDER_DOMAIN",
+        "SENDER_ADDRESS",
+        "RECIPIENT_PATTERN",
+        "SUBJECT_MATCH",
+        "BODY_KEYWORD",
+        "HEADER_CHECK",
+        "ATTACHMENT_TYPE",
+        "COMBINED",
+        "INTERNAL_EXTERNAL",
+        "THREAD_BASED"
+      ]
+    },
+    "public.StorageProvider": {
+      "name": "StorageProvider",
+      "schema": "public",
+      "values": ["S3", "GOOGLE_DRIVE", "DROPBOX", "ONEDRIVE", "BOX", "GENERIC_URL"]
+    },
+    "public.SYNC_STATUS": {
+      "name": "SYNC_STATUS",
+      "schema": "public",
+      "values": ["PENDING", "IN_PROGRESS", "COMPLETED", "FAILED"]
+    },
+    "public.ThreadStatus": {
+      "name": "ThreadStatus",
+      "schema": "public",
+      "values": ["OPEN", "ARCHIVED", "ACTIVE", "RESOLVED", "PENDING", "CLOSED", "SPAM", "TRASH"]
+    },
+    "public.ThreadType": {
+      "name": "ThreadType",
+      "schema": "public",
+      "values": ["EMAIL", "CHAT"]
+    },
+    "public.TicketPriority": {
+      "name": "TicketPriority",
+      "schema": "public",
+      "values": ["LOW", "MEDIUM", "HIGH", "URGENT"]
+    },
+    "public.TicketStatus": {
+      "name": "TicketStatus",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "IN_PROGRESS",
+        "WAITING_FOR_CUSTOMER",
+        "WAITING_FOR_THIRD_PARTY",
+        "RESOLVED",
+        "CLOSED",
+        "CANCELLED",
+        "MERGED"
+      ]
+    },
+    "public.TicketType": {
+      "name": "TicketType",
+      "schema": "public",
+      "values": [
+        "GENERAL",
+        "MISSING_ITEM",
+        "RETURN",
+        "REFUND",
+        "PRODUCT_ISSUE",
+        "SHIPPING_ISSUE",
+        "BILLING",
+        "TECHNICAL",
+        "OTHER"
+      ]
+    },
+    "public.TrialConversionStatus": {
+      "name": "TrialConversionStatus",
+      "schema": "public",
+      "values": [
+        "TRIAL_ACTIVE",
+        "CONVERTED_TO_PAID",
+        "EXPIRED_WITHOUT_CONVERSION",
+        "CANCELED_DURING_TRIAL",
+        "MANUAL_CONVERSION"
+      ]
+    },
+    "public.UserType": {
+      "name": "UserType",
+      "schema": "public",
+      "values": ["USER", "SYSTEM"]
+    },
+    "public.VectorDbType": {
+      "name": "VectorDbType",
+      "schema": "public",
+      "values": ["POSTGRESQL", "CHROMA", "QDRANT", "WEAVIATE", "PINECONE", "MILVUS"]
+    },
+    "public.WorkflowRunStatus": {
+      "name": "WorkflowRunStatus",
+      "schema": "public",
+      "values": ["RUNNING", "SUCCEEDED", "FAILED", "STOPPED", "WAITING"]
+    },
+    "public.WorkflowShareAccessMode": {
+      "name": "WorkflowShareAccessMode",
+      "schema": "public",
+      "values": ["public", "organization"]
+    },
+    "public.WorkflowTriggerSource": {
+      "name": "WorkflowTriggerSource",
+      "schema": "public",
+      "values": ["DEBUGGING", "APP_RUN", "SINGLE_STEP", "PUBLIC_SHARE", "API_KEY", "WEBHOOK"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -680,6 +680,13 @@
       "when": 1773297768370,
       "tag": "0096_unified_attachment_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 97,
+      "version": "7",
+      "when": 1773360405271,
+      "tag": "0097_add-soft-delete-integration-storage-location",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/db/schema/integration.ts
+++ b/packages/database/src/db/schema/integration.ts
@@ -13,6 +13,7 @@ import {
   integrationSyncStatus,
   jsonb,
   pgTable,
+  sql,
   text,
   timestamp,
   uniqueIndex,
@@ -60,13 +61,12 @@ export const Integration = pgTable(
     metadata: jsonb(),
     updatedAt: timestamp({ precision: 3 }).notNull(),
     createdAt: timestamp({ precision: 3 }).defaultNow().notNull(),
+    deletedAt: timestamp({ precision: 3 }),
   },
   (table) => [
-    uniqueIndex('Integration_organizationId_email_key').using(
-      'btree',
-      table.organizationId.asc().nullsLast(),
-      table.email.asc().nullsLast()
-    ),
+    uniqueIndex('Integration_organizationId_email_key')
+      .using('btree', table.organizationId.asc().nullsLast(), table.email.asc().nullsLast())
+      .where(sql`${table.deletedAt} IS NULL`),
     index('Integration_organizationId_idx').using('btree', table.organizationId.asc().nullsLast()),
     index('Integration_provider_organizationId_idx').using(
       'btree',

--- a/packages/database/src/db/schema/storage-location.ts
+++ b/packages/database/src/db/schema/storage-location.ts
@@ -8,11 +8,13 @@ import {
   index,
   jsonb,
   pgTable,
+  sql,
   storageProvider,
   text,
   timestamp,
 } from './_shared'
 
+import { Organization } from './organization'
 import { WorkflowCredentials } from './workflow-credentials'
 
 /** Drizzle table for storageLocation */
@@ -27,6 +29,10 @@ export const StorageLocation = pgTable(
     externalId: text().notNull(),
     externalUrl: text().notNull(),
     externalRev: text().notNull(),
+    organizationId: text().references((): AnyPgColumn => Organization.id, {
+      onUpdate: 'cascade',
+      onDelete: 'cascade',
+    }),
     credentialId: text().references((): AnyPgColumn => WorkflowCredentials.id, {
       onUpdate: 'cascade',
     }),
@@ -34,6 +40,7 @@ export const StorageLocation = pgTable(
     size: bigint({ mode: 'number' }).default(0),
     mimeType: text(),
     createdAt: timestamp({ precision: 3 }).defaultNow().notNull(),
+    deletedAt: timestamp({ precision: 3 }),
     metadata: jsonb().default({}).notNull(),
   },
   (table) => [
@@ -43,6 +50,13 @@ export const StorageLocation = pgTable(
       table.provider.asc().nullsLast(),
       table.externalId.asc().nullsLast()
     ),
+    index('StorageLocation_organizationId_idx').using(
+      'btree',
+      table.organizationId.asc().nullsLast()
+    ),
+    index('StorageLocation_deletedAt_idx')
+      .using('btree', table.deletedAt.asc().nullsLast())
+      .where(sql`${table.deletedAt} IS NOT NULL`),
   ]
 )
 

--- a/packages/lib/src/email/email-storage.ts
+++ b/packages/lib/src/email/email-storage.ts
@@ -16,7 +16,7 @@ import type {
   ThreadEntity as Thread,
 } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, inArray, sql } from 'drizzle-orm'
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm'
 import { v4 as uuidv4 } from 'uuid'
 import { SelectiveModeCache } from '../cache/selective-mode-cache'
 import { MessageReconcilerService } from '../messages/message-reconciler.service'
@@ -232,7 +232,7 @@ export class MessageStorageService {
     const [integration] = await db
       .select({ provider: schema.Integration.provider })
       .from(schema.Integration)
-      .where(eq(schema.Integration.id, integrationId))
+      .where(and(eq(schema.Integration.id, integrationId), isNull(schema.Integration.deletedAt)))
       .limit(1)
 
     const provider = integration?.provider
@@ -969,7 +969,12 @@ export class MessageStorageService {
         const [integration] = await db
           .select({ metadata: schema.Integration.metadata })
           .from(schema.Integration)
-          .where(eq(schema.Integration.id, messageData.integrationId))
+          .where(
+            and(
+              eq(schema.Integration.id, messageData.integrationId),
+              isNull(schema.Integration.deletedAt)
+            )
+          )
           .limit(1)
 
         this.integrationSettings = (integration?.metadata as any)?.settings as

--- a/packages/lib/src/email/inbound/integration-resolver.ts
+++ b/packages/lib/src/email/inbound/integration-resolver.ts
@@ -2,7 +2,7 @@
 
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { PermanentProcessingError } from './errors'
 import type { ForwardingIntegrationMetadata, ResolvedInboundIntegration } from './types'
 
@@ -59,7 +59,8 @@ export class InboundIntegrationResolver {
         and(
           eq(schema.Integration.provider, 'email'),
           eq(schema.Integration.enabled, true),
-          inArray(schema.Integration.email, normalizedRecipients)
+          inArray(schema.Integration.email, normalizedRecipients),
+          isNull(schema.Integration.deletedAt)
         )
       )
 

--- a/packages/lib/src/files/core/file-service.ts
+++ b/packages/lib/src/files/core/file-service.ts
@@ -780,7 +780,10 @@ export class FileService
           )
           .leftJoin(
             schema.StorageLocation,
-            eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id)
+            and(
+              eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id),
+              isNull(schema.StorageLocation.deletedAt)
+            )
           )
           .leftJoin(schema.User, eq(schema.FolderFile.createdById, schema.User.id))
           .where(where)
@@ -1464,7 +1467,10 @@ export class FileService
         .from(schema.FileVersion)
         .leftJoin(
           schema.StorageLocation,
-          eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id)
+          and(
+            eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id),
+            isNull(schema.StorageLocation.deletedAt)
+          )
         )
         .where(eq(schema.FileVersion.id, (entity as any).currentVersionId))
         .limit(1)
@@ -1493,7 +1499,10 @@ export class FileService
       .from(schema.FileVersion)
       .leftJoin(
         schema.StorageLocation,
-        eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id)
+        and(
+          eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id),
+          isNull(schema.StorageLocation.deletedAt)
+        )
       )
       .where(eq(schema.FileVersion.fileId, entityId))
       .orderBy(desc(schema.FileVersion.versionNumber))
@@ -1544,7 +1553,12 @@ export class FileService
       const [storageLocation] = await tx
         .select()
         .from(schema.StorageLocation)
-        .where(eq(schema.StorageLocation.id, storageLocationId))
+        .where(
+          and(
+            eq(schema.StorageLocation.id, storageLocationId),
+            isNull(schema.StorageLocation.deletedAt)
+          )
+        )
         .limit(1)
 
       if (!storageLocation) {
@@ -1623,7 +1637,10 @@ export class FileService
       .from(schema.FileVersion)
       .leftJoin(
         schema.StorageLocation,
-        eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id)
+        and(
+          eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id),
+          isNull(schema.StorageLocation.deletedAt)
+        )
       )
       .where(eq(schema.FileVersion.fileId, entityId))
       .orderBy(desc(schema.FileVersion.versionNumber))
@@ -1669,7 +1686,10 @@ export class FileService
       .from(schema.FileVersion)
       .leftJoin(
         schema.StorageLocation,
-        eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id)
+        and(
+          eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id),
+          isNull(schema.StorageLocation.deletedAt)
+        )
       )
       .where(
         and(
@@ -1772,7 +1792,10 @@ export class FileService
       .from(schema.FileVersion)
       .leftJoin(
         schema.StorageLocation,
-        eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id)
+        and(
+          eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id),
+          isNull(schema.StorageLocation.deletedAt)
+        )
       )
       .where(eq(schema.FileVersion.fileId, entityId))
       .orderBy(desc(schema.FileVersion.versionNumber))

--- a/packages/lib/src/files/core/media-asset-service.ts
+++ b/packages/lib/src/files/core/media-asset-service.ts
@@ -1137,7 +1137,10 @@ export class MediaAssetService
 
       // Get storage location details
       const storageLocation = await db.query.StorageLocation.findFirst({
-        where: eq(schema.StorageLocation.id, storageLocationId),
+        where: and(
+          eq(schema.StorageLocation.id, storageLocationId),
+          isNull(schema.StorageLocation.deletedAt)
+        ),
       })
 
       if (!storageLocation) {

--- a/packages/lib/src/files/lifecycle/orphaned-cleanup.ts
+++ b/packages/lib/src/files/lifecycle/orphaned-cleanup.ts
@@ -1,8 +1,10 @@
 // packages/lib/src/files/lifecycle/orphaned-cleanup.ts
 
-import { database as db } from '@auxx/database'
+import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
+import { and, eq, isNotNull, lt } from 'drizzle-orm'
+import { StorageManager } from '../storage/storage-manager'
 import { deleteExpiredFiles, deleteFilesByIds } from './cleanup-service'
 import type { OrphanedFileCleanupJobData, OrphanedFileCleanupResult } from './types'
 
@@ -138,10 +140,68 @@ export async function deletedFileCleanupJob(
       await job.updateProgress(100)
     }
 
+    // Phase 2: Sweep marked StorageLocations (safety net for storageCleanupJob)
+    // Only sweep records marked for deletion > 24h ago (storageCleanupJob handles immediate cleanup)
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    let storageLocationsSwept = 0
+
+    const markedLocations = await db
+      .select({
+        id: schema.StorageLocation.id,
+        provider: schema.StorageLocation.provider,
+        externalId: schema.StorageLocation.externalId,
+        organizationId: schema.StorageLocation.organizationId,
+      })
+      .from(schema.StorageLocation)
+      .where(
+        and(
+          isNotNull(schema.StorageLocation.deletedAt),
+          lt(schema.StorageLocation.deletedAt, oneDayAgo)
+        )
+      )
+      .limit(batchSize)
+
+    if (markedLocations.length > 0) {
+      logger.info(`Found ${markedLocations.length} stale marked StorageLocations to sweep`)
+
+      for (const loc of markedLocations) {
+        try {
+          if (!dryRun) {
+            // Delete from S3
+            const storageManager = new StorageManager(loc.organizationId || undefined)
+            try {
+              await storageManager.deleteByKey({
+                provider: loc.provider as any,
+                key: loc.externalId,
+              })
+            } catch (s3Error) {
+              logger.warn('Failed to delete S3 object during sweep, continuing', {
+                storageLocationId: loc.id,
+                error: s3Error instanceof Error ? s3Error.message : String(s3Error),
+              })
+            }
+
+            // Hard-delete the StorageLocation record
+            await db.delete(schema.StorageLocation).where(eq(schema.StorageLocation.id, loc.id))
+          }
+          storageLocationsSwept++
+        } catch (error) {
+          logger.error('Failed to sweep StorageLocation', {
+            storageLocationId: loc.id,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          result.errors++
+        }
+      }
+
+      logger.info(`Swept ${storageLocationsSwept} stale marked StorageLocations`, { dryRun })
+    }
+
     // Log summary
     logger.info('Soft-deleted file cleanup completed', {
       processed: result.processed,
       deleted: result.deleted,
+      storageLocationsSwept,
       errors: result.errors,
       dryRun,
     })

--- a/packages/lib/src/files/lifecycle/quota-cleanup.ts
+++ b/packages/lib/src/files/lifecycle/quota-cleanup.ts
@@ -155,7 +155,10 @@ export async function quotaEnforcementCleanupJob(
       .leftJoin(schema.FileVersion, eq(schema.FolderFile.currentVersionId, schema.FileVersion.id))
       .leftJoin(
         schema.StorageLocation,
-        eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id)
+        and(
+          eq(schema.FileVersion.storageLocationId, schema.StorageLocation.id),
+          isNull(schema.StorageLocation.deletedAt)
+        )
       )
       .leftJoin(schema.Attachment, eq(schema.FolderFile.id, schema.Attachment.folderFileId))
       .where(

--- a/packages/lib/src/files/storage/storage-location-service.ts
+++ b/packages/lib/src/files/storage/storage-location-service.ts
@@ -6,7 +6,7 @@ import type {
   StorageProvider,
 } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
-import { and, count, desc, eq, inArray, isNotNull, lt, sql, sum } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, isNotNull, isNull, lt, sql, sum } from 'drizzle-orm'
 
 // NOTE: StorageLocationService focuses only on database operations
 const logger = createScopedLogger('storage-location-service')
@@ -43,6 +43,8 @@ export interface CreateStorageLocationRequest {
   // Optional external URL (for URL providers or public files)
   externalUrl: string
   externalRev: string
+  // Organization scope (nullable for backfill compatibility, required going forward)
+  organizationId?: string
   // Authentication (all providers can have credentials)
   credentialId?: string
   // File metadata
@@ -271,6 +273,7 @@ export class StorageLocationService {
           provider: data.provider,
           externalId: data.externalId,
           externalUrl: data.externalUrl,
+          organizationId: data.organizationId || null,
           credentialId: data.credentialId,
           size: data.size || null,
           mimeType: data.mimeType || null,
@@ -293,7 +296,7 @@ export class StorageLocationService {
       const [location] = await db
         .select()
         .from(schema.StorageLocation)
-        .where(eq(schema.StorageLocation.id, id))
+        .where(and(eq(schema.StorageLocation.id, id), isNull(schema.StorageLocation.deletedAt)))
         .limit(1)
       return location || null
     } catch (error) {
@@ -330,7 +333,7 @@ export class StorageLocationService {
           schema.WorkflowCredentials,
           eq(schema.StorageLocation.credentialId, schema.WorkflowCredentials.id)
         )
-        .where(eq(schema.StorageLocation.id, id))
+        .where(and(eq(schema.StorageLocation.id, id), isNull(schema.StorageLocation.deletedAt)))
         .limit(1)
       if (!result) return null
       return {
@@ -422,7 +425,12 @@ export class StorageLocationService {
       return await db
         .select()
         .from(schema.StorageLocation)
-        .where(eq(schema.StorageLocation.provider, provider))
+        .where(
+          and(
+            eq(schema.StorageLocation.provider, provider),
+            isNull(schema.StorageLocation.deletedAt)
+          )
+        )
         .orderBy(desc(schema.StorageLocation.createdAt))
     } catch (error) {
       logger.error('Failed to get storage locations by provider', { provider, error })
@@ -437,7 +445,12 @@ export class StorageLocationService {
       return await db
         .select()
         .from(schema.StorageLocation)
-        .where(eq(schema.StorageLocation.credentialId, credentialId))
+        .where(
+          and(
+            eq(schema.StorageLocation.credentialId, credentialId),
+            isNull(schema.StorageLocation.deletedAt)
+          )
+        )
         .orderBy(desc(schema.StorageLocation.createdAt))
     } catch (error) {
       logger.error('Failed to get storage locations by credential', { credentialId, error })
@@ -458,7 +471,8 @@ export class StorageLocationService {
         .where(
           and(
             eq(schema.StorageLocation.provider, provider),
-            eq(schema.StorageLocation.externalId, externalId)
+            eq(schema.StorageLocation.externalId, externalId),
+            isNull(schema.StorageLocation.deletedAt)
           )
         )
         .orderBy(desc(schema.StorageLocation.createdAt))
@@ -479,7 +493,10 @@ export class StorageLocationService {
     metadataQuery: Record<string, any>
   ): Promise<StorageLocationEntity[]> {
     try {
-      const conditions = [eq(schema.StorageLocation.provider, provider)]
+      const conditions = [
+        eq(schema.StorageLocation.provider, provider),
+        isNull(schema.StorageLocation.deletedAt),
+      ]
       // Add metadata conditions for each key-value pair using PostgreSQL JSON operators
       for (const [key, value] of Object.entries(metadataQuery)) {
         conditions.push(sql`${schema.StorageLocation.metadata}->>${key} = ${value}`)
@@ -610,6 +627,7 @@ export class StorageLocationService {
                 externalId: location.externalId,
                 externalUrl: location.externalUrl,
                 externalRev: location.externalRev,
+                organizationId: location.organizationId || null,
                 credentialId: location.credentialId || null,
                 size: location.size || null,
                 mimeType: location.mimeType || null,
@@ -724,7 +742,10 @@ export class StorageLocationService {
   }> {
     try {
       // Get total count
-      const [{ totalCount }] = await db.select({ totalCount: count() }).from(schema.StorageLocation)
+      const [{ totalCount }] = await db
+        .select({ totalCount: count() })
+        .from(schema.StorageLocation)
+        .where(isNull(schema.StorageLocation.deletedAt))
       // Get count by provider
       const providerCounts = await db
         .select({
@@ -732,6 +753,7 @@ export class StorageLocationService {
           count: count(),
         })
         .from(schema.StorageLocation)
+        .where(isNull(schema.StorageLocation.deletedAt))
         .groupBy(schema.StorageLocation.provider)
       // Get size by provider
       const providerSizes = await db
@@ -740,7 +762,9 @@ export class StorageLocationService {
           totalSize: sum(schema.StorageLocation.size),
         })
         .from(schema.StorageLocation)
-        .where(isNotNull(schema.StorageLocation.size))
+        .where(
+          and(isNotNull(schema.StorageLocation.size), isNull(schema.StorageLocation.deletedAt))
+        )
         .groupBy(schema.StorageLocation.provider)
       // Transform results
       const locationsByProvider: Record<string, number> = {}
@@ -783,14 +807,24 @@ export class StorageLocationService {
           totalSize: sum(schema.StorageLocation.size),
         })
         .from(schema.StorageLocation)
-        .where(eq(schema.StorageLocation.credentialId, credentialId))
+        .where(
+          and(
+            eq(schema.StorageLocation.credentialId, credentialId),
+            isNull(schema.StorageLocation.deletedAt)
+          )
+        )
       // Get unique providers for this credential
       const providerResults = await db
         .selectDistinct({
           provider: schema.StorageLocation.provider,
         })
         .from(schema.StorageLocation)
-        .where(eq(schema.StorageLocation.credentialId, credentialId))
+        .where(
+          and(
+            eq(schema.StorageLocation.credentialId, credentialId),
+            isNull(schema.StorageLocation.deletedAt)
+          )
+        )
       const providers = providerResults.map((item) => item.provider)
       return {
         locationCount: stats.locationCount || 0,

--- a/packages/lib/src/files/storage/storage-manager.ts
+++ b/packages/lib/src/files/storage/storage-manager.ts
@@ -823,6 +823,7 @@ export class StorageManager {
           externalId: params.externalId,
           externalUrl: params.externalUrl || '',
           externalRev: params.externalRev || '',
+          organizationId: this.organizationId,
           credentialId: params.credentialId,
           size: params.size,
           mimeType: params.mimeType,
@@ -1765,6 +1766,7 @@ export class StorageManager {
           externalId: params.key,
           externalUrl: '', // No URL for multipart uploads initially
           externalRev: result.etag || '',
+          organizationId: this.organizationId,
           credentialId: params.credentialId,
           size: result.size ? BigInt(result.size) : undefined,
           mimeType: undefined, // Not provided in completion

--- a/packages/lib/src/files/upload/processors/entity-processors.ts
+++ b/packages/lib/src/files/upload/processors/entity-processors.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/files/upload/processors/entity-processors.ts
 import { database as db, schema } from '@auxx/database'
 import type { MediaAsset } from '@auxx/database/types'
-import { and, desc, eq } from 'drizzle-orm'
+import { and, desc, eq, isNull } from 'drizzle-orm'
 import { MemberService } from '../../../members/member-service'
 import { ensureThumbnailPresets } from '../../core/thumbnail-batch'
 import type { ThumbnailSource } from '../../core/thumbnail-types'
@@ -242,7 +242,10 @@ export class UserProfileProcessor extends BaseAssetProcessor {
       )
       .leftJoin(
         schema.StorageLocation,
-        eq(schema.MediaAssetVersion.storageLocationId, schema.StorageLocation.id)
+        and(
+          eq(schema.MediaAssetVersion.storageLocationId, schema.StorageLocation.id),
+          isNull(schema.StorageLocation.deletedAt)
+        )
       )
       .where(eq(schema.MediaAsset.id, assetId))
       .limit(1)
@@ -664,7 +667,10 @@ export class KnowledgeBaseProcessor extends BaseAttachmentProcessor {
         )
         .leftJoin(
           schema.StorageLocation,
-          eq(schema.MediaAssetVersion.storageLocationId, schema.StorageLocation.id)
+          and(
+            eq(schema.MediaAssetVersion.storageLocationId, schema.StorageLocation.id),
+            isNull(schema.StorageLocation.deletedAt)
+          )
         )
         .where(eq(schema.MediaAsset.id, assetId))
         .limit(1)

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -64,6 +64,11 @@ export {
 export { type MidTrialStats, sendMidTrialEmailsJob } from './maintenance/mid-trial-job'
 export { oauth2TokenRefreshScannerJob } from './maintenance/oauth2-token-refresh-scanner-job'
 export { type QuotaResetStats, quotaResetJob } from './maintenance/quota-reset-job'
+export {
+  enqueueStorageCleanupJob,
+  type StorageCleanupJobData,
+  storageCleanupJob,
+} from './maintenance/storage-cleanup-job'
 export { getThumbnailCleanupStats, thumbnailCleanupJob } from './maintenance/thumbnail-cleanup-job'
 export {
   sendTrialConversionEmailsJob,

--- a/packages/lib/src/jobs/maintenance/generate-thumbnail-job.ts
+++ b/packages/lib/src/jobs/maintenance/generate-thumbnail-job.ts
@@ -102,7 +102,10 @@ export const generateThumbnailJob = async (job: any): Promise<void> => {
       .leftJoin(schema.MediaAsset, eq(schema.MediaAssetVersion.assetId, schema.MediaAsset.id))
       .leftJoin(
         schema.StorageLocation,
-        eq(schema.MediaAssetVersion.storageLocationId, schema.StorageLocation.id)
+        and(
+          eq(schema.MediaAssetVersion.storageLocationId, schema.StorageLocation.id),
+          isNull(schema.StorageLocation.deletedAt)
+        )
       )
       .where(eq(schema.MediaAssetVersion.id, versionId))
       .limit(1)
@@ -326,7 +329,10 @@ async function updateKBLogoIfApplicable(params: {
     .from(schema.MediaAssetVersion)
     .leftJoin(
       schema.StorageLocation,
-      eq(schema.MediaAssetVersion.storageLocationId, schema.StorageLocation.id)
+      and(
+        eq(schema.MediaAssetVersion.storageLocationId, schema.StorageLocation.id),
+        isNull(schema.StorageLocation.deletedAt)
+      )
     )
     .where(eq(schema.MediaAssetVersion.id, derivedVersionId))
     .limit(1)

--- a/packages/lib/src/jobs/maintenance/index.ts
+++ b/packages/lib/src/jobs/maintenance/index.ts
@@ -19,5 +19,10 @@ export { cleanupExpiredMediaAssetsJob, getMediaAssetCleanupStats } from './media
 export { type MidTrialStats, sendMidTrialEmailsJob } from './mid-trial-job'
 export { oauth2TokenRefreshScannerJob } from './oauth2-token-refresh-scanner-job'
 export { type QuotaResetStats, quotaResetJob } from './quota-reset-job'
+export {
+  enqueueStorageCleanupJob,
+  type StorageCleanupJobData,
+  storageCleanupJob,
+} from './storage-cleanup-job'
 export { getThumbnailCleanupStats, thumbnailCleanupJob } from './thumbnail-cleanup-job'
 export { sendTrialConversionEmailsJob, type TrialConversionStats } from './trial-conversion-job'

--- a/packages/lib/src/jobs/maintenance/integration-token-refresh-job.ts
+++ b/packages/lib/src/jobs/maintenance/integration-token-refresh-job.ts
@@ -4,7 +4,7 @@ import { WEBAPP_URL } from '@auxx/config/server'
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
-import { eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { GoogleOAuthService } from '../../providers/google/google-oauth'
 import { OutlookOAuthService } from '../../providers/outlook/outlook-oauth'
 import { ProviderRegistryService } from '../../providers/provider-registry-service'
@@ -58,7 +58,7 @@ export const integrationTokenRefreshJob = async (
     const [integration] = await db
       .select()
       .from(schema.Integration)
-      .where(eq(schema.Integration.id, integrationId))
+      .where(and(eq(schema.Integration.id, integrationId), isNull(schema.Integration.deletedAt)))
       .limit(1)
 
     if (!integration) {

--- a/packages/lib/src/jobs/maintenance/integration-token-refresh-scanner-job.ts
+++ b/packages/lib/src/jobs/maintenance/integration-token-refresh-scanner-job.ts
@@ -3,7 +3,7 @@
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
-import { and, eq, inArray, isNotNull, lt, or, sql } from 'drizzle-orm'
+import { and, eq, inArray, isNotNull, isNull, lt, or, sql } from 'drizzle-orm'
 import { resolveEffectiveSyncMode } from '../../providers/sync-mode-resolver'
 import { getQueue, Queues } from '../queues'
 
@@ -105,6 +105,7 @@ export const integrationTokenRefreshScannerJob = async (
           inArray(schema.Integration.provider, [...OAUTH_PROVIDERS]),
           isNotNull(schema.Integration.credentialId),
           eq(schema.Integration.enabled, true),
+          isNull(schema.Integration.deletedAt),
           // Token expires within buffer period OR no expiration set (needs refresh)
           or(
             lt(schema.Integration.expiresAt, tokenRefreshThreshold),
@@ -138,7 +139,8 @@ export const integrationTokenRefreshScannerJob = async (
         and(
           inArray(schema.Integration.provider, [...OAUTH_PROVIDERS]),
           isNotNull(schema.Integration.credentialId),
-          eq(schema.Integration.enabled, true)
+          eq(schema.Integration.enabled, true),
+          isNull(schema.Integration.deletedAt)
         )
       )
 

--- a/packages/lib/src/jobs/maintenance/storage-cleanup-job.ts
+++ b/packages/lib/src/jobs/maintenance/storage-cleanup-job.ts
@@ -1,0 +1,313 @@
+// packages/lib/src/jobs/maintenance/storage-cleanup-job.ts
+
+import { database as db, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getRedisClient } from '@auxx/redis'
+import { and, eq, isNotNull, sql } from 'drizzle-orm'
+import { clearImportCache } from '../../email/polling-import-cache'
+import { StorageManager } from '../../files/storage/storage-manager'
+import type { JobContext } from '../types/job-context'
+
+const logger = createScopedLogger('storage-cleanup-job')
+
+const S3_BATCH_DELETE_LIMIT = 1000
+
+export interface StorageCleanupJobData {
+  type: 'integration' | 'organization'
+  organizationId: string
+  integrationId?: string
+}
+
+interface CleanupResult {
+  storageLocationsDeleted: number
+  s3ObjectsDeleted: number
+  redisKeysCleared: number
+  integrationHardDeleted: boolean
+  errors: string[]
+}
+
+/**
+ * Async cleanup job for S3 objects, Redis keys, and BullMQ jobs
+ * after channel disconnect or organization deletion.
+ *
+ * Processes StorageLocation records marked with deletedAt, deletes the
+ * corresponding S3 objects, then hard-deletes the DB records.
+ */
+export async function storageCleanupJob(
+  ctx: JobContext<StorageCleanupJobData>
+): Promise<CleanupResult> {
+  const { type, organizationId, integrationId } = ctx.data
+
+  logger.info('Starting storage cleanup job', {
+    type,
+    organizationId,
+    integrationId,
+    jobId: ctx.jobId,
+  })
+
+  const result: CleanupResult = {
+    storageLocationsDeleted: 0,
+    s3ObjectsDeleted: 0,
+    redisKeysCleared: 0,
+    integrationHardDeleted: false,
+    errors: [],
+  }
+
+  try {
+    // Phase 1: Delete S3 objects for marked StorageLocations
+    await ctx.updateProgress(10)
+    await deleteMarkedStorageLocations(organizationId, result)
+
+    // Phase 2: Clear Redis polling cache
+    await ctx.updateProgress(50)
+    if (type === 'integration' && integrationId) {
+      await clearIntegrationRedisKeys(integrationId, result)
+    } else if (type === 'organization') {
+      await clearOrganizationRedisKeys(organizationId, result)
+    }
+
+    // Phase 3: Remove stale BullMQ jobs for the integration
+    await ctx.updateProgress(70)
+    if (type === 'integration' && integrationId) {
+      await removeStalePollingJobs(integrationId)
+    }
+
+    // Phase 4: Hard-delete the soft-deleted Integration record
+    await ctx.updateProgress(85)
+    if (type === 'integration' && integrationId) {
+      await hardDeleteIntegration(integrationId, result)
+    }
+
+    await ctx.updateProgress(100)
+
+    logger.info('Storage cleanup job completed', {
+      type,
+      organizationId,
+      integrationId,
+      result,
+      jobId: ctx.jobId,
+    })
+
+    return result
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    result.errors.push(message)
+    logger.error('Storage cleanup job failed', {
+      type,
+      organizationId,
+      integrationId,
+      error: message,
+      result,
+      jobId: ctx.jobId,
+    })
+    throw error
+  }
+}
+
+/**
+ * Find all StorageLocations marked as deleted for the given org,
+ * delete their S3 objects in batches, then hard-delete the DB records.
+ */
+async function deleteMarkedStorageLocations(
+  organizationId: string,
+  result: CleanupResult
+): Promise<void> {
+  let hasMore = true
+
+  while (hasMore) {
+    // Fetch a batch of marked-for-deletion StorageLocations
+    const markedLocations = await db
+      .select({
+        id: schema.StorageLocation.id,
+        provider: schema.StorageLocation.provider,
+        externalId: schema.StorageLocation.externalId,
+      })
+      .from(schema.StorageLocation)
+      .where(
+        and(
+          eq(schema.StorageLocation.organizationId, organizationId),
+          isNotNull(schema.StorageLocation.deletedAt)
+        )
+      )
+      .limit(S3_BATCH_DELETE_LIMIT)
+
+    if (markedLocations.length === 0) {
+      hasMore = false
+      break
+    }
+
+    // Delete S3 objects — group by provider for efficient batch deletion
+    const byProvider = new Map<string, typeof markedLocations>()
+    for (const loc of markedLocations) {
+      const group = byProvider.get(loc.provider) || []
+      group.push(loc)
+      byProvider.set(loc.provider, group)
+    }
+
+    const storageManager = new StorageManager(organizationId)
+    for (const [provider, locations] of byProvider) {
+      for (const loc of locations) {
+        try {
+          await storageManager.deleteByKey({
+            provider: provider as any,
+            key: loc.externalId,
+          })
+          result.s3ObjectsDeleted++
+        } catch (error) {
+          // Log but continue — the DB record will be cleaned up regardless
+          const message = error instanceof Error ? error.message : String(error)
+          logger.warn('Failed to delete S3 object, continuing', {
+            storageLocationId: loc.id,
+            externalId: loc.externalId,
+            error: message,
+          })
+          result.errors.push(`S3 delete failed for ${loc.id}: ${message}`)
+        }
+      }
+    }
+
+    // Hard-delete the StorageLocation DB records
+    const ids = markedLocations.map((loc) => loc.id)
+    await db.delete(schema.StorageLocation).where(
+      sql`${schema.StorageLocation.id} IN (${sql.join(
+        ids.map((id) => sql`${id}`),
+        sql`, `
+      )})`
+    )
+    result.storageLocationsDeleted += markedLocations.length
+
+    logger.info('Processed batch of marked StorageLocations', {
+      batchSize: markedLocations.length,
+      totalDeleted: result.storageLocationsDeleted,
+    })
+
+    // If we got a full batch, there might be more
+    hasMore = markedLocations.length === S3_BATCH_DELETE_LIMIT
+  }
+}
+
+/**
+ * Clear Redis polling cache keys for a single integration.
+ */
+async function clearIntegrationRedisKeys(
+  integrationId: string,
+  result: CleanupResult
+): Promise<void> {
+  try {
+    await clearImportCache(integrationId)
+    result.redisKeysCleared += 2 // main + processing keys
+    logger.info('Cleared Redis polling cache for integration', { integrationId })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    logger.warn('Failed to clear Redis keys for integration', { integrationId, error: message })
+    result.errors.push(`Redis clear failed for integration ${integrationId}: ${message}`)
+  }
+}
+
+/**
+ * Clear Redis polling cache keys for all integrations in an organization.
+ */
+async function clearOrganizationRedisKeys(
+  organizationId: string,
+  result: CleanupResult
+): Promise<void> {
+  try {
+    // Org may already be deleted at this point, so query integration IDs
+    // from Redis pattern scan instead
+    const redis = await getRedisClient()
+    if (!redis) return
+
+    // Use SCAN to find all polling cache keys for this org's integrations
+    // Since we can't know which integration IDs belonged to this org from Redis alone,
+    // the caller should have cleared these before org deletion.
+    // This is a best-effort sweep.
+    logger.info('Organization Redis cleanup is handled pre-deletion', { organizationId })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    logger.warn('Failed to clear Redis keys for organization', { organizationId, error: message })
+    result.errors.push(`Redis clear failed for org ${organizationId}: ${message}`)
+  }
+}
+
+/**
+ * Remove pending/scheduled BullMQ polling jobs for the integration.
+ */
+async function removeStalePollingJobs(integrationId: string): Promise<void> {
+  try {
+    const { getQueue } = await import('../queues')
+    const { Queues } = await import('../queues/types')
+    const queue = getQueue(Queues.pollingSyncQueue)
+
+    // Get waiting and delayed jobs and remove those matching this integration
+    const [waiting, delayed] = await Promise.all([
+      queue.getWaiting(0, 500),
+      queue.getDelayed(0, 500),
+    ])
+
+    const staleJobs = [...waiting, ...delayed].filter(
+      (job) => job.data?.integrationId === integrationId
+    )
+
+    for (const job of staleJobs) {
+      try {
+        await job.remove()
+      } catch {
+        // Job may have already been processed
+      }
+    }
+
+    if (staleJobs.length > 0) {
+      logger.info('Removed stale polling jobs', {
+        integrationId,
+        count: staleJobs.length,
+      })
+    }
+  } catch (error) {
+    // Non-critical — jobs will eventually expire or fail gracefully
+    logger.warn('Failed to remove stale polling jobs', {
+      integrationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * Hard-delete a soft-deleted Integration record after cleanup is complete.
+ */
+async function hardDeleteIntegration(integrationId: string, result: CleanupResult): Promise<void> {
+  try {
+    await db
+      .delete(schema.Integration)
+      .where(and(eq(schema.Integration.id, integrationId), isNotNull(schema.Integration.deletedAt)))
+    result.integrationHardDeleted = true
+    logger.info('Hard-deleted soft-deleted Integration', { integrationId })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    logger.warn('Failed to hard-delete Integration', { integrationId, error: message })
+    result.errors.push(`Hard-delete Integration failed: ${message}`)
+  }
+}
+
+/**
+ * Enqueue a storage cleanup job on the maintenance queue.
+ */
+export async function enqueueStorageCleanupJob(data: StorageCleanupJobData): Promise<void> {
+  const { getQueue } = await import('../queues')
+  const { Queues } = await import('../queues/types')
+  const queue = getQueue(Queues.maintenanceQueue)
+
+  const jobId = data.integrationId
+    ? `storage-cleanup:integration:${data.integrationId}`
+    : `storage-cleanup:org:${data.organizationId}`
+
+  await queue.add('storageCleanupJob', data, {
+    jobId,
+    attempts: 5,
+    backoff: { type: 'exponential', delay: 5000 },
+    removeOnComplete: { count: 100 },
+    removeOnFail: { count: 500 },
+    priority: 5,
+  })
+
+  logger.info('Enqueued storage cleanup job', { data, jobId })
+}

--- a/packages/lib/src/jobs/polling/message-list-fetch-job.ts
+++ b/packages/lib/src/jobs/polling/message-list-fetch-job.ts
@@ -3,7 +3,7 @@
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { MessageStorageService } from '../../email/email-storage'
 import { FolderDiscoveryService } from '../../email/labels/folder-discovery-service'
 import {
@@ -188,7 +188,7 @@ export const messageListFetchJob = async (job: Job<MessageListFetchJobData>) => 
       const [integration] = await db
         .select({ throttleFailureCount: schema.Integration.throttleFailureCount })
         .from(schema.Integration)
-        .where(eq(schema.Integration.id, integrationId))
+        .where(and(eq(schema.Integration.id, integrationId), isNull(schema.Integration.deletedAt)))
         .limit(1)
 
       const newCount = (integration?.throttleFailureCount ?? 0) + 1

--- a/packages/lib/src/jobs/polling/messages-import-job.ts
+++ b/packages/lib/src/jobs/polling/messages-import-job.ts
@@ -3,7 +3,7 @@
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import {
   acknowledgeImportBatch,
   claimImportBatch,
@@ -155,7 +155,7 @@ export const messagesImportJob = async (job: Job<MessagesImportJobData>) => {
       const [integration] = await db
         .select({ throttleFailureCount: schema.Integration.throttleFailureCount })
         .from(schema.Integration)
-        .where(eq(schema.Integration.id, integrationId))
+        .where(and(eq(schema.Integration.id, integrationId), isNull(schema.Integration.deletedAt)))
         .limit(1)
 
       const newCount = (integration?.throttleFailureCount ?? 0) + 1
@@ -398,7 +398,7 @@ export const imapImportBatchJob = async (job: Job<ImapImportBatchJobData>) => {
       const [integration] = await db
         .select({ throttleFailureCount: schema.Integration.throttleFailureCount })
         .from(schema.Integration)
-        .where(eq(schema.Integration.id, integrationId))
+        .where(and(eq(schema.Integration.id, integrationId), isNull(schema.Integration.deletedAt)))
         .limit(1)
 
       const newCount = (integration?.throttleFailureCount ?? 0) + 1

--- a/packages/lib/src/jobs/polling/polling-relaunch-failed-job.ts
+++ b/packages/lib/src/jobs/polling/polling-relaunch-failed-job.ts
@@ -3,7 +3,7 @@
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { getImportCacheSize, recoverProcessingBatch } from '../../email/polling-import-cache'
 import { resolveEffectiveSyncMode } from '../../providers/sync-mode-resolver'
 
@@ -38,7 +38,8 @@ export const pollingRelaunchFailedJob = async (job: Job<PollingRelaunchFailedJob
       and(
         eq(schema.Integration.enabled, true),
         eq(schema.Integration.syncStage, 'FAILED'),
-        inArray(schema.Integration.provider, ['google', 'outlook', 'imap'])
+        inArray(schema.Integration.provider, ['google', 'outlook', 'imap']),
+        isNull(schema.Integration.deletedAt)
       )
     )
 

--- a/packages/lib/src/jobs/polling/polling-stale-check-job.ts
+++ b/packages/lib/src/jobs/polling/polling-stale-check-job.ts
@@ -3,7 +3,7 @@
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
-import { and, eq, inArray, isNotNull, lt } from 'drizzle-orm'
+import { and, eq, inArray, isNotNull, isNull, lt } from 'drizzle-orm'
 import { getImportCacheSize, recoverProcessingBatch } from '../../email/polling-import-cache'
 import type { ImapFolderCheckpoint } from '../../providers/imap/types'
 import { getQueue } from '../queues'
@@ -52,7 +52,8 @@ export const pollingStaleCheckJob = async (job: Job<PollingStaleCheckJobData>) =
         eq(schema.Integration.enabled, true),
         inArray(schema.Integration.syncStage, ['MESSAGE_LIST_FETCH', 'MESSAGES_IMPORT']),
         isNotNull(schema.Integration.syncStageStartedAt),
-        lt(schema.Integration.syncStageStartedAt, staleThreshold)
+        lt(schema.Integration.syncStageStartedAt, staleThreshold),
+        isNull(schema.Integration.deletedAt)
       )
     )
 

--- a/packages/lib/src/jobs/polling/polling-sync-scanner-job.ts
+++ b/packages/lib/src/jobs/polling/polling-sync-scanner-job.ts
@@ -61,7 +61,8 @@ export const pollingSyncScannerJob = async (job: Job<PollingSyncScannerJobData>)
       .where(
         and(
           eq(schema.Integration.enabled, true),
-          inArray(schema.Integration.provider, ['google', 'outlook', 'imap'])
+          inArray(schema.Integration.provider, ['google', 'outlook', 'imap']),
+          isNull(schema.Integration.deletedAt)
         )
       )
 

--- a/packages/lib/src/messages/sync-messages.ts
+++ b/packages/lib/src/messages/sync-messages.ts
@@ -131,7 +131,8 @@ export class SyncMessages {
           and(
             eq(schema.Integration.id, integrationId),
             eq(schema.Integration.organizationId, organizationId),
-            eq(schema.Integration.enabled, true)
+            eq(schema.Integration.enabled, true),
+            isNull(schema.Integration.deletedAt)
           )
         )
         .limit(1)

--- a/packages/lib/src/organizations/organization-service.ts
+++ b/packages/lib/src/organizations/organization-service.ts
@@ -6,11 +6,13 @@ import { type Database, schema } from '@auxx/database'
 import { OrganizationRole, type OrganizationType } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, isNull, sql } from 'drizzle-orm'
 import { DehydrationService } from '../dehydration'
 import type { ForwardingIntegrationMetadata } from '../email/inbound'
 import { type IntegrationProviderType, MessageService } from '../email/message-service'
+import { clearImportCache } from '../email/polling-import-cache'
 import { InboxService } from '../inboxes'
+import { enqueueStorageCleanupJob } from '../jobs/maintenance/storage-cleanup-job'
 import { MemberService } from '../members/member-service'
 import { OrganizationSeeder } from '../seed/organization-seeder'
 import { SystemUserService } from '../users/system-user-service'
@@ -89,7 +91,8 @@ export class OrganizationService {
       .where(
         and(
           eq(schema.Integration.organizationId, params.organizationId),
-          eq(schema.Integration.provider, 'email')
+          eq(schema.Integration.provider, 'email'),
+          isNull(schema.Integration.deletedAt)
         )
       )
 
@@ -287,6 +290,42 @@ export class OrganizationService {
         `Organization ${organizationId} has ${allMemberIds.length} members identified for potential post-deletion checks.`
       )
     }
+    // --- Cancel Stripe subscription (synchronous, blocks deletion on failure) ---
+    const activeSubscription = await this.db.query.PlanSubscription.findFirst({
+      where: (sub, { eq: eqOp, and: andOp, or: orOp }) =>
+        andOp(
+          eqOp(sub.organizationId, organizationId),
+          orOp(eqOp(sub.status, 'active'), eqOp(sub.status, 'trialing'))
+        ),
+      columns: {
+        id: true,
+        stripeSubscriptionId: true,
+        status: true,
+      },
+    })
+
+    if (activeSubscription?.stripeSubscriptionId) {
+      try {
+        // Dynamically import to avoid circular dependency
+        const { stripeClient } = await import('@auxx/billing')
+        await stripeClient.getClient().subscriptions.cancel(activeSubscription.stripeSubscriptionId)
+        logger.info(
+          `Canceled Stripe subscription ${activeSubscription.stripeSubscriptionId} for org ${organizationId}`
+        )
+      } catch (stripeError) {
+        logger.error('Failed to cancel Stripe subscription before org deletion', {
+          organizationId,
+          stripeSubscriptionId: activeSubscription.stripeSubscriptionId,
+          error: stripeError instanceof Error ? stripeError.message : String(stripeError),
+        })
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message:
+            'Failed to cancel active subscription. Please cancel your subscription first or contact support.',
+        })
+      }
+    }
+
     // --- Begin Transaction ---
     try {
       await this.db.transaction(async (tx) => {
@@ -327,6 +366,22 @@ export class OrganizationService {
         await tx.delete(schema.ApiKey).where(eq(schema.ApiKey.organizationId, organizationId))
         logger.info(`[${txId}] Deleted API keys.`)
         // Add deletions for other models here if needed (e.g., custom integration settings)
+        // Step 5b: Mark ALL StorageLocations for this org as deleted (before cascade)
+        // S3 objects will be cleaned up asynchronously by storageCleanupJob
+        await tx
+          .update(schema.StorageLocation)
+          .set({ deletedAt: new Date() })
+          .where(eq(schema.StorageLocation.organizationId, organizationId))
+        logger.info(`[${txId}] Marked StorageLocations as deleted for async S3 cleanup.`)
+
+        // Step 5c: Clear Redis polling cache for all integrations
+        for (const integration of integrations) {
+          await clearImportCache(integration.id)
+        }
+        logger.info(
+          `[${txId}] Cleared Redis polling cache for ${integrations.length} integrations.`
+        )
+
         // Step 6: Delete the Organization itself (Trigger Cascades)
         // Cascades MUST handle deleting OrganizationMember records.
         logger.warn(
@@ -398,6 +453,13 @@ export class OrganizationService {
       logger.warn(
         `Organization ${organizationId} deletion process finished successfully by owner ${requestingUserId}. Requesting owner deleted: ${requestingUserWasDeleted}. Other users deleted: ${otherUsersDeletedCount}.`
       )
+
+      // Enqueue async S3 cleanup for marked StorageLocations
+      await enqueueStorageCleanupJob({
+        type: 'organization',
+        organizationId,
+      })
+
       // Return success status and whether the *requesting owner* was deleted
       return { success: true, userDeleted: requestingUserWasDeleted }
     } catch (error) {

--- a/packages/lib/src/providers/integration-cache.ts
+++ b/packages/lib/src/providers/integration-cache.ts
@@ -3,7 +3,7 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { getRedisClient } from '@auxx/redis'
-import { eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import type { IntegrationProviderType } from './types'
 
 /** Cache TTL - provider is immutable, only invalidate on add/remove */
@@ -41,7 +41,12 @@ export async function getOrgProviderMap(
   const integrations = await db
     .select({ id: schema.Integration.id, provider: schema.Integration.provider })
     .from(schema.Integration)
-    .where(eq(schema.Integration.organizationId, organizationId))
+    .where(
+      and(
+        eq(schema.Integration.organizationId, organizationId),
+        isNull(schema.Integration.deletedAt)
+      )
+    )
 
   const providerMap = new Map(integrations.map((i) => [i.id, i.provider]))
 

--- a/packages/lib/src/providers/integration-service.ts
+++ b/packages/lib/src/providers/integration-service.ts
@@ -1,9 +1,10 @@
 // packages/lib/src/providers/integration-service.ts
 import { type Database, schema } from '@auxx/database'
-import { and, count, desc, eq, inArray, isNotNull } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm'
 import { withAuthErrorHandling } from '../email/errors-handlers'
 import { type IntegrationProviderType, MessageService } from '../email/message-service'
-import { getImportCacheSize } from '../email/polling-import-cache'
+import { clearImportCache, getImportCacheSize } from '../email/polling-import-cache'
+import { enqueueStorageCleanupJob } from '../jobs/maintenance/storage-cleanup-job'
 import { createScopedLogger } from '../logger'
 import { SyncMessages } from '../messages/sync-messages'
 import { FacebookOAuthService } from './facebook/facebook-oauth'
@@ -96,7 +97,7 @@ export class IntegrationService {
       .select()
       .from(schema.Integration)
       .leftJoin(schema.ChatWidget, eq(schema.ChatWidget.integrationId, schema.Integration.id))
-      .where(eq(schema.Integration.id, integrationId))
+      .where(and(eq(schema.Integration.id, integrationId), isNull(schema.Integration.deletedAt)))
       .limit(1)
 
     if (
@@ -113,27 +114,86 @@ export class IntegrationService {
   }
 
   /**
-   * Delete threads and messages associated with an integration
+   * Delete threads and messages associated with an integration,
+   * cleaning up MediaAssets and marking StorageLocations for async S3 deletion.
    */
   private async deleteIntegrationData(tx: typeof this.db, integrationId: string, provider: string) {
     logger.warn(`Deleting data for integration: ${integrationId} (${provider})`)
 
     if (provider === 'chat') {
-      const deletedChatThreads = await tx
+      await tx
         .delete(schema.Thread)
         .where(and(eq(schema.Thread.integrationId, integrationId), whereThreadMessageType('CHAT')))
       logger.info(`Deleted CHAT threads for integration ${integrationId}`)
-    } else {
-      const deletedMessages = await tx
-        .delete(schema.Message)
-        .where(eq(schema.Message.integrationId, integrationId))
-      logger.info(`Deleted messages for integration ${integrationId}`)
-
-      const deletedThreads = await tx
-        .delete(schema.Thread)
-        .where(eq(schema.Thread.integrationId, integrationId))
-      logger.info(`Deleted threads for integration ${integrationId}`)
+      return
     }
+
+    // 1. Collect all messageIds for this integration
+    const messageRows = await tx
+      .select({ id: schema.Message.id })
+      .from(schema.Message)
+      .where(eq(schema.Message.integrationId, integrationId))
+    const messageIds = messageRows.map((r) => r.id)
+    logger.info(`Found ${messageIds.length} messages for integration ${integrationId}`)
+
+    if (messageIds.length > 0) {
+      // 2. Collect MediaAsset IDs via Attachment (polymorphic entityType='MESSAGE')
+      const assetRows = await tx
+        .selectDistinct({ assetId: schema.Attachment.assetId })
+        .from(schema.Attachment)
+        .where(
+          and(
+            eq(schema.Attachment.entityType, 'MESSAGE'),
+            inArray(schema.Attachment.entityId, messageIds),
+            isNotNull(schema.Attachment.assetId)
+          )
+        )
+      const mediaAssetIds = assetRows.map((r) => r.assetId).filter(Boolean) as string[]
+      logger.info(`Found ${mediaAssetIds.length} MediaAssets for integration ${integrationId}`)
+
+      // 3. Mark email body StorageLocations as deleted
+      await tx
+        .update(schema.StorageLocation)
+        .set({ deletedAt: new Date() })
+        .where(
+          sql`${schema.StorageLocation.id} IN (
+            SELECT ${schema.Message.htmlBodyStorageLocationId}
+            FROM ${schema.Message}
+            WHERE ${schema.Message.integrationId} = ${integrationId}
+            AND ${schema.Message.htmlBodyStorageLocationId} IS NOT NULL
+          )`
+        )
+
+      // 4. Mark attachment StorageLocations as deleted (via MediaAssetVersion)
+      if (mediaAssetIds.length > 0) {
+        await tx
+          .update(schema.StorageLocation)
+          .set({ deletedAt: new Date() })
+          .where(
+            sql`${schema.StorageLocation.id} IN (
+              SELECT ${schema.MediaAssetVersion.storageLocationId}
+              FROM ${schema.MediaAssetVersion}
+              WHERE ${schema.MediaAssetVersion.assetId} IN (${sql.join(
+                mediaAssetIds.map((id) => sql`${id}`),
+                sql`, `
+              )})
+              AND ${schema.MediaAssetVersion.storageLocationId} IS NOT NULL
+            )`
+          )
+
+        // 5. Delete MediaAssets (cascades to Attachment + MediaAssetVersion via FK)
+        await tx.delete(schema.MediaAsset).where(inArray(schema.MediaAsset.id, mediaAssetIds))
+        logger.info(`Deleted ${mediaAssetIds.length} MediaAssets for integration ${integrationId}`)
+      }
+    }
+
+    // 6. Delete Messages
+    await tx.delete(schema.Message).where(eq(schema.Message.integrationId, integrationId))
+    logger.info(`Deleted messages for integration ${integrationId}`)
+
+    // 7. Delete Threads
+    await tx.delete(schema.Thread).where(eq(schema.Thread.integrationId, integrationId))
+    logger.info(`Deleted threads for integration ${integrationId}`)
   }
 
   /**
@@ -240,7 +300,12 @@ export class IntegrationService {
           schema.InboxIntegration,
           eq(schema.InboxIntegration.integrationId, schema.Integration.id)
         )
-        .where(eq(schema.Integration.organizationId, this.organizationId))
+        .where(
+          and(
+            eq(schema.Integration.organizationId, this.organizationId),
+            isNull(schema.Integration.deletedAt)
+          )
+        )
         .orderBy(schema.Integration.provider, desc(schema.Integration.createdAt))
 
       const integrations = integrationsData
@@ -322,7 +387,8 @@ export class IntegrationService {
         .where(
           and(
             eq(schema.Integration.organizationId, this.organizationId),
-            inArray(schema.Integration.provider, getEmailProviders())
+            inArray(schema.Integration.provider, getEmailProviders()),
+            isNull(schema.Integration.deletedAt)
           )
         )
 
@@ -401,12 +467,19 @@ export class IntegrationService {
 
       // Perform database cleanup within a transaction
       await this.db.transaction(async (tx) => {
+        // Clean up MediaAssets, mark StorageLocations, delete Messages/Threads
         await this.deleteIntegrationData(tx, integrationId, integration.provider)
-        await tx.delete(schema.Integration).where(eq(schema.Integration.id, integrationId))
-        logger.info(
-          `Successfully deleted integration record ${integrationId} (${integration.provider}) from database.`
-        )
+
+        // Soft-delete Integration (partial unique index allows reconnect)
+        await tx
+          .update(schema.Integration)
+          .set({ deletedAt: new Date(), enabled: false })
+          .where(eq(schema.Integration.id, integrationId))
+        logger.info(`Soft-deleted integration record ${integrationId} (${integration.provider}).`)
       })
+
+      // Clear Redis polling cache inline (fast DEL operation)
+      await clearImportCache(integrationId)
 
       // Delete stale cached inbox counts for affected inboxes
       if (affectedInboxIds.length > 0) {
@@ -417,6 +490,13 @@ export class IntegrationService {
           `Deleted stale UserInboxUnreadCount rows for inboxes: ${affectedInboxIds.join(', ')}`
         )
       }
+
+      // Enqueue async job for S3 deletion, Redis cleanup, and hard-delete
+      await enqueueStorageCleanupJob({
+        type: 'integration',
+        organizationId: this.organizationId,
+        integrationId,
+      })
 
       return {
         success: true,
@@ -639,7 +719,8 @@ export class IntegrationService {
         .where(
           and(
             eq(schema.Integration.id, integrationId),
-            eq(schema.Integration.organizationId, this.organizationId)
+            eq(schema.Integration.organizationId, this.organizationId),
+            isNull(schema.Integration.deletedAt)
           )
         )
         .limit(1)

--- a/packages/lib/src/providers/integration-token-accessor.ts
+++ b/packages/lib/src/providers/integration-token-accessor.ts
@@ -3,7 +3,7 @@
 import { CredentialService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 
 const logger = createScopedLogger('integration-token-accessor')
 
@@ -35,7 +35,7 @@ export class IntegrationTokenAccessor {
         schema.WorkflowCredentials,
         eq(schema.Integration.credentialId, schema.WorkflowCredentials.id)
       )
-      .where(eq(schema.Integration.id, integrationId))
+      .where(and(eq(schema.Integration.id, integrationId), isNull(schema.Integration.deletedAt)))
       .limit(1)
 
     if (!row) throw new Error(`Integration ${integrationId} not found`)
@@ -76,7 +76,7 @@ export class IntegrationTokenAccessor {
           provider: schema.Integration.provider,
         })
         .from(schema.Integration)
-        .where(eq(schema.Integration.id, integrationId))
+        .where(and(eq(schema.Integration.id, integrationId), isNull(schema.Integration.deletedAt)))
         .limit(1)
 
       if (!integration) throw new Error(`Integration ${integrationId} not found`)

--- a/packages/lib/src/providers/provider-registry-service.ts
+++ b/packages/lib/src/providers/provider-registry-service.ts
@@ -9,7 +9,7 @@ import type {
   IntegrationProviderType,
 } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
-import { and, desc, eq } from 'drizzle-orm'
+import { and, desc, eq, isNull } from 'drizzle-orm'
 import type { ActiveIntegration, ProviderInstance } from '../email/message-service'
 import { EmailForwardingProvider } from './email/email-forwarding-provider'
 import { FacebookProvider } from './facebook/facebook-provider'
@@ -90,7 +90,8 @@ export class ProviderRegistryService {
         .where(
           and(
             eq(schema.Integration.organizationId, this.organizationId),
-            eq(schema.Integration.enabled, true)
+            eq(schema.Integration.enabled, true),
+            isNull(schema.Integration.deletedAt)
           )
         )
         .orderBy(desc(schema.Integration.updatedAt))
@@ -249,7 +250,8 @@ export class ProviderRegistryService {
         .where(
           and(
             eq(schema.Integration.id, integrationId),
-            eq(schema.Integration.organizationId, this.organizationId)
+            eq(schema.Integration.organizationId, this.organizationId),
+            isNull(schema.Integration.deletedAt)
           )
         )
         .limit(1)

--- a/packages/lib/src/providers/query-helpers.ts
+++ b/packages/lib/src/providers/query-helpers.ts
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@auxx/database'
-import { and, eq, exists, inArray, type SQL } from 'drizzle-orm'
+import { and, eq, exists, inArray, isNull, type SQL } from 'drizzle-orm'
 import type { IntegrationProviderType, MessageType } from './types'
 
 /**
@@ -40,7 +40,8 @@ export function whereThreadProvider(
     schema.Integration,
     and(
       eq(schema.Integration.id, schema.Thread.integrationId),
-      inArray(schema.Integration.provider, providers)
+      inArray(schema.Integration.provider, providers),
+      isNull(schema.Integration.deletedAt)
     )
   )
 }
@@ -70,7 +71,8 @@ export function whereMessageProvider(
     schema.Integration,
     and(
       eq(schema.Integration.id, schema.Message.integrationId),
-      inArray(schema.Integration.provider, providers)
+      inArray(schema.Integration.provider, providers),
+      isNull(schema.Integration.deletedAt)
     )
   )
 }
@@ -137,7 +139,8 @@ export function whereThreadMessageType(messageType: MessageType | MessageType[])
     schema.Integration,
     and(
       eq(schema.Integration.id, schema.Thread.integrationId),
-      inArray(schema.Integration.provider, uniqueProviders)
+      inArray(schema.Integration.provider, uniqueProviders),
+      isNull(schema.Integration.deletedAt)
     )
   )
 }
@@ -197,7 +200,8 @@ export function whereMessageMessageType(messageType: MessageType | MessageType[]
     schema.Integration,
     and(
       eq(schema.Integration.id, schema.Message.integrationId),
-      inArray(schema.Integration.provider, uniqueProviders)
+      inArray(schema.Integration.provider, uniqueProviders),
+      isNull(schema.Integration.deletedAt)
     )
   )
 }

--- a/packages/lib/src/users/user-avatar-service.ts
+++ b/packages/lib/src/users/user-avatar-service.ts
@@ -84,7 +84,9 @@ export class UserAvatarService {
         .insert(schema.StorageLocation)
         .values({
           provider: 'S3',
-          key: config.storageKey,
+          externalId: config.storageKey,
+          externalUrl: '',
+          externalRev: uploadResult?.etag || '',
           size: size,
           mimeType: contentType,
           organizationId,


### PR DESCRIPTION
feat: Implement storage cleanup job for async S3 object deletion and Redis cache clearing

- Added `storageCleanupJob` to handle cleanup of S3 objects and Redis keys for integrations and organizations.
- Updated `OrganizationService` to mark StorageLocations as deleted and enqueue storage cleanup jobs upon organization deletion.
- Enhanced `IntegrationService` to soft-delete integrations and enqueue storage cleanup jobs for associated data.
- Modified various database queries to include checks for `deletedAt` to avoid processing soft-deleted integrations.
- Improved error handling and logging throughout the cleanup process.