### PR TITLE
feat: cache permissions and member queries to utilize organization cache

### DIFF
--- a/apps/web/src/server/api/routers/admin.ts
+++ b/apps/web/src/server/api/routers/admin.ts
@@ -4,7 +4,7 @@ import { AdminBillingService, PlanAdminService, PlanService } from '@auxx/billin
 import { WEBAPP_URL } from '@auxx/config/server'
 import { schema } from '@auxx/database'
 import { AdminService } from '@auxx/lib/admin'
-import { DehydrationService } from '@auxx/lib/dehydration'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { FeatureKey, FeaturePermissionService, handlePlanDowngrade } from '@auxx/lib/permissions'
 import { createUsageGuard, type UsageMetric, type UsageStatus } from '@auxx/lib/usage'
 import { and, eq, ilike, or, sql } from 'drizzle-orm'
@@ -268,14 +268,8 @@ export const adminRouter = createTRPCRouter({
         .set(updateData)
         .where(eq(schema.PlanSubscription.organizationId, input.organizationId))
 
-      // Invalidate cached feature permissions so new plan limits take effect immediately
-      const featureService = new FeaturePermissionService(ctx.db)
-      await featureService.invalidateCache(input.organizationId)
-
-      // Invalidate dehydrated state cache so org members see new features on next load
-      const { DehydrationCacheService } = await import('@auxx/lib/dehydration')
-      const dehydrationCache = new DehydrationCacheService()
-      await dehydrationCache.invalidateOrganization(input.organizationId)
+      // Invalidate cached feature permissions and dehydrated state
+      await onCacheEvent('plan.changed', { orgId: input.organizationId })
 
       return { success: true }
     }),
@@ -587,10 +581,7 @@ export const adminRouter = createTRPCRouter({
           ...input,
           adminUserId: ctx.session.user.id,
         })
-        const featureService = new FeaturePermissionService(ctx.db)
-        await featureService.invalidateCache(input.organizationId)
-        const dehydrationService = new DehydrationService(ctx.db)
-        await dehydrationService.refreshOrganization(input.organizationId)
+        await onCacheEvent('plan.changed', { orgId: input.organizationId })
         return { success: true }
       }),
 
@@ -605,10 +596,7 @@ export const adminRouter = createTRPCRouter({
           ...input,
           adminUserId: ctx.session.user.id,
         })
-        const featureService = new FeaturePermissionService(ctx.db)
-        await featureService.invalidateCache(input.organizationId)
-        const dehydrationService = new DehydrationService(ctx.db)
-        await dehydrationService.refreshOrganization(input.organizationId)
+        await onCacheEvent('plan.changed', { orgId: input.organizationId })
         return { success: true }
       }),
 

--- a/apps/web/src/server/api/routers/billing.ts
+++ b/apps/web/src/server/api/routers/billing.ts
@@ -4,7 +4,7 @@ import { BillingPortalService, SubscriptionService, stripeClient } from '@auxx/b
 import { WEBAPP_URL } from '@auxx/config/server'
 import { schema } from '@auxx/database'
 import { isSelfHosted } from '@auxx/deployment'
-import { DehydrationService } from '@auxx/lib/dehydration'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { getUserOrganizationId } from '@auxx/lib/email'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
@@ -306,8 +306,7 @@ export const billingRouter = createTRPCRouter({
         returnUrl: '', // No longer needed
       })
 
-      const dehydrationService = new DehydrationService(ctx.db)
-      await dehydrationService.refreshOrganization(organizationId)
+      await onCacheEvent('plan.canceled', { orgId: organizationId })
 
       return { success: true }
     } catch (error: unknown) {
@@ -333,8 +332,7 @@ export const billingRouter = createTRPCRouter({
 
       await subscriptionService.restoreSubscription({ organizationId })
 
-      const dehydrationService = new DehydrationService(ctx.db)
-      await dehydrationService.refreshOrganization(organizationId)
+      await onCacheEvent('plan.changed', { orgId: organizationId })
 
       return { success: true }
     } catch (error: unknown) {
@@ -646,9 +644,7 @@ export const billingRouter = createTRPCRouter({
           ...input,
         })
 
-        // Invalidate dehydration cache so app-layout-wrapper gets fresh subscription data
-        const dehydrationService = new DehydrationService(ctx.db)
-        await dehydrationService.refreshOrganization(organizationId)
+        await onCacheEvent('plan.changed', { orgId: organizationId })
 
         return result
       } catch (error: unknown) {
@@ -721,8 +717,7 @@ export const billingRouter = createTRPCRouter({
         }
       }
 
-      const dehydrationService = new DehydrationService(ctx.db)
-      await dehydrationService.refreshOrganization(organizationId)
+      await onCacheEvent('plan.changed', { orgId: organizationId })
 
       return { success: true }
     } catch (error: unknown) {

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -2,8 +2,8 @@
 
 import { CredentialService } from '@auxx/credentials'
 import { type Database, schema } from '@auxx/database'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { ChatWidgetService } from '@auxx/lib/chat'
-import { DehydrationService } from '@auxx/lib/dehydration'
 import { getUserOrganizationId, requireAdminAccess } from '@auxx/lib/email'
 import { SyncMessages } from '@auxx/lib/messages'
 import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
@@ -148,8 +148,7 @@ export const channelRouter = createTRPCRouter({
       const service = new IntegrationService(ctx.db, organizationId, userId)
       const result = await service.disconnect(input.integrationId)
 
-      const dehydrationService = new DehydrationService(ctx.db)
-      await dehydrationService.refreshOrganization(organizationId)
+      await onCacheEvent('integration.disconnected', { orgId: organizationId })
 
       return result
     }),
@@ -225,8 +224,7 @@ export const channelRouter = createTRPCRouter({
       const service = new IntegrationService(ctx.db, organizationId, userId)
       const result = await service.addOpenPhoneIntegration(input)
 
-      const dehydrationService = new DehydrationService(ctx.db)
-      await dehydrationService.refreshOrganization(organizationId)
+      await onCacheEvent('integration.connected', { orgId: organizationId })
 
       return result
     }),
@@ -265,8 +263,7 @@ export const channelRouter = createTRPCRouter({
       const service = new ChatWidgetService(ctx.db, organizationId)
       const result = await service.addChatWidgetIntegration(input)
 
-      const dehydrationService = new DehydrationService(ctx.db)
-      await dehydrationService.refreshOrganization(organizationId)
+      await onCacheEvent('integration.connected', { orgId: organizationId })
 
       return result
     }),

--- a/apps/web/src/server/api/routers/member.ts
+++ b/apps/web/src/server/api/routers/member.ts
@@ -2,6 +2,7 @@
 
 import { schema } from '@auxx/database'
 import { MemberType, OrganizationRole } from '@auxx/database/enums'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { DehydrationService } from '@auxx/lib/dehydration'
 import { MemberService } from '@auxx/lib/members'
 import { createScopedLogger } from '@auxx/logger'
@@ -167,8 +168,10 @@ export const memberRouter = createTRPCRouter({
         memberToRemoveId: input.memberId,
       })
 
-      const dehydrationService = new DehydrationService(ctx.db)
-      await dehydrationService.refreshUser(input.memberId)
+      await onCacheEvent('member.removed', {
+        orgId: ctx.session.organizationId,
+        userId: input.memberId,
+      })
 
       return result
     }),
@@ -190,8 +193,10 @@ export const memberRouter = createTRPCRouter({
         newRole: input.role,
       })
 
-      const dehydrationService = new DehydrationService(ctx.db)
-      await dehydrationService.refreshUser(input.memberId)
+      await onCacheEvent('member.role.changed', {
+        orgId: ctx.session.organizationId,
+        userId: input.memberId,
+      })
 
       return result
     }),

--- a/apps/web/src/server/api/routers/organization.ts
+++ b/apps/web/src/server/api/routers/organization.ts
@@ -3,6 +3,7 @@
 import { RESERVED_ORGANIZATION_HANDLES } from '@auxx/config'
 import { schema } from '@auxx/database'
 import { OrganizationType } from '@auxx/database/enums'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { DehydrationService } from '@auxx/lib/dehydration'
 import { MemberService } from '@auxx/lib/members'
 import { OrganizationService } from '@auxx/lib/organizations'
@@ -139,8 +140,7 @@ export const organizationRouter = createTRPCRouter({
       }
 
       // Invalidate dehydration cache for all org members (org data visible to all)
-      const dehydrationService = new DehydrationService(ctx.db)
-      await dehydrationService.refreshOrganization(organizationId)
+      await onCacheEvent('org.updated', { orgId: organizationId })
 
       return organization
     }),
@@ -389,8 +389,7 @@ export const organizationRouter = createTRPCRouter({
           .where(eq(schema.User.id, userId))
       }
 
-      const dehydrationService = new DehydrationService(ctx.db)
-      await dehydrationService.refreshUser(userId)
+      await onCacheEvent('member.removed', { orgId: organizationId, userId })
 
       return { success: true }
     }),

--- a/apps/web/src/server/api/routers/user.ts
+++ b/apps/web/src/server/api/routers/user.ts
@@ -1,5 +1,5 @@
 import { database as db, schema } from '@auxx/database'
-import { DehydrationService } from '@auxx/lib/dehydration'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { MediaAssetService } from '@auxx/lib/files'
 import { FeaturePermissionService } from '@auxx/lib/permissions'
 import { SettingsService, UserSettingsService } from '@auxx/lib/settings'
@@ -50,8 +50,10 @@ export const userRouter = createTRPCRouter({
         .where(eq(schema.User.id, ctx.session.user.id))
         .returning()
 
-      const dehydrationService = new DehydrationService(db)
-      await dehydrationService.refreshUser(ctx.session.user.id)
+      await onCacheEvent('user.updated', {
+        orgId: ctx.session.organizationId,
+        userId: ctx.session.user.id,
+      })
 
       return updatedUser
     }),
@@ -208,8 +210,7 @@ export const userRouter = createTRPCRouter({
       .set({ avatarAssetId: null, updatedAt: new Date() })
       .where(eq(schema.User.id, userId))
 
-    const dehydrationService = new DehydrationService(db)
-    await dehydrationService.refreshUser(userId)
+    await onCacheEvent('user.updated', { orgId: ctx.session.organizationId, userId })
 
     return { success: true }
   }),
@@ -241,8 +242,7 @@ export const userRouter = createTRPCRouter({
         .where(eq(schema.User.id, userId))
         .returning()
 
-      const dehydrationService = new DehydrationService(db)
-      await dehydrationService.refreshUser(userId)
+      await onCacheEvent('user.updated', { orgId: ctx.session.organizationId, userId })
 
       return updatedUser
     }),

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -58,6 +58,12 @@
       "import": "./dist/bom/index.mjs",
       "default": "./src/bom/index.ts"
     },
+    "./cache": {
+      "types": "./src/cache/index.ts",
+      "source": "./src/cache/index.ts",
+      "import": "./dist/cache/index.mjs",
+      "default": "./src/cache/index.ts"
+    },
     "./chat": {
       "types": "./src/chat/index.ts",
       "source": "./src/chat/index.ts",

--- a/packages/lib/src/cache/index.ts
+++ b/packages/lib/src/cache/index.ts
@@ -2,4 +2,35 @@
 
 export type { CacheEntry, CacheOptions } from './base-cache-service'
 export { BaseCacheService } from './base-cache-service'
+export { flushOrganization, onCacheEvent } from './invalidate'
+export type { CacheEvent } from './invalidation-graph'
+// ── Organization Cache Service ──
+export type { OrgCacheDataMap, OrgCacheKeyName } from './org-cache-keys'
+export type { CacheProvider } from './org-cache-provider'
+export { OrganizationCacheService } from './org-cache-service'
 export { PromiseMemoizer } from './promise-memoizer'
+export type { UserCacheDataMap, UserCacheKeyName } from './user-cache-keys'
+export { UserCacheService } from './user-cache-service'
+
+import { OrganizationCacheService } from './org-cache-service'
+import { registerAllProviders } from './register-providers'
+import { UserCacheService } from './user-cache-service'
+
+let orgCacheInstance: OrganizationCacheService | undefined
+let userCacheInstance: UserCacheService | undefined
+
+/** Get the singleton org cache service (lazily initialized with all providers) */
+export function getOrgCache(): OrganizationCacheService {
+  if (!orgCacheInstance) {
+    orgCacheInstance = new OrganizationCacheService()
+    userCacheInstance = new UserCacheService()
+    registerAllProviders(orgCacheInstance, userCacheInstance)
+  }
+  return orgCacheInstance
+}
+
+/** Get the singleton user cache service (lazily initialized with all providers) */
+export function getUserCache(): UserCacheService {
+  if (!userCacheInstance) getOrgCache() // triggers init
+  return userCacheInstance!
+}

--- a/packages/lib/src/cache/invalidate.ts
+++ b/packages/lib/src/cache/invalidate.ts
@@ -1,0 +1,49 @@
+// packages/lib/src/cache/invalidate.ts
+
+import { getOrgCache, getUserCache } from './index'
+import type { CacheEvent } from './invalidation-graph'
+import { INVALIDATION_GRAPH, isMixedMapping, isOrgOnlyMapping } from './invalidation-graph'
+
+/**
+ * Declarative cache invalidation helper.
+ * Call AFTER the DB transaction commits, never inside it.
+ *
+ * @example
+ * ```ts
+ * await db.transaction(async (tx) => {
+ *   await tx.update(schema.PlanSubscription).set({ ... })
+ * })
+ * await onCacheEvent('plan.changed', { orgId })
+ * ```
+ */
+export async function onCacheEvent(
+  event: CacheEvent,
+  context: { orgId: string; userId?: string }
+): Promise<void> {
+  const mapping = INVALIDATION_GRAPH[event]
+  if (!mapping) return
+
+  if (isOrgOnlyMapping(mapping)) {
+    if (mapping.length > 0) {
+      await getOrgCache().invalidateAndRecompute(context.orgId, mapping)
+    }
+  } else if (isMixedMapping(mapping)) {
+    const promises: Promise<void>[] = []
+
+    if ('org' in mapping && mapping.org && mapping.org.length > 0) {
+      promises.push(getOrgCache().invalidateAndRecompute(context.orgId, mapping.org))
+    }
+    if ('user' in mapping && mapping.user && mapping.user.length > 0 && context.userId) {
+      promises.push(
+        getUserCache().invalidateAndRecompute(context.userId, mapping.user, context.orgId)
+      )
+    }
+
+    await Promise.all(promises)
+  }
+}
+
+/** Flush everything for an org (e.g. org deletion) */
+export async function flushOrganization(orgId: string): Promise<void> {
+  await getOrgCache().flush(orgId)
+}

--- a/packages/lib/src/cache/invalidation-graph.ts
+++ b/packages/lib/src/cache/invalidation-graph.ts
@@ -1,0 +1,74 @@
+// packages/lib/src/cache/invalidation-graph.ts
+
+import type { OrgCacheKeyName } from './org-cache-keys'
+import type { UserCacheKeyName } from './user-cache-keys'
+
+/** Org-only mapping: array of org cache keys */
+type OrgOnlyMapping = readonly OrgCacheKeyName[]
+
+/** Mixed mapping: has org and/or user cache keys */
+interface MixedMapping {
+  readonly user?: readonly UserCacheKeyName[]
+  readonly org?: readonly OrgCacheKeyName[]
+}
+
+type InvalidationMapping = OrgOnlyMapping | MixedMapping
+
+/**
+ * Maps domain events to the cache keys they affect.
+ * Single source of truth for cache dependencies.
+ */
+export const INVALIDATION_GRAPH: Record<string, InvalidationMapping> = {
+  // ── Org-scoped events ──
+  'plan.changed': ['features', 'subscription', 'overages'],
+  'plan.subscribed': ['features', 'subscription', 'overages'],
+  'plan.canceled': ['features', 'subscription', 'overages'],
+
+  'org.updated': ['orgProfile'],
+  'org.deleted': [], // flush all, handled specially
+
+  'custom-field.created': ['resources', 'customFields'],
+  'custom-field.updated': ['resources', 'customFields'],
+  'custom-field.deleted': ['resources', 'customFields'],
+
+  // entityDefs/entityDefSlugs are near-immutable — only invalidate on create/delete
+  'entity-def.created': ['resources', 'entityDefs', 'entityDefSlugs', 'customFields'],
+  'entity-def.updated': ['resources'], // slug/type don't change
+  'entity-def.deleted': ['resources', 'entityDefs', 'entityDefSlugs', 'customFields'],
+
+  'integration.connected': ['integrationProviders', 'inboxes'],
+  'integration.disconnected': ['integrationProviders', 'inboxes'],
+
+  'inbox.created': ['inboxes'],
+  'inbox.updated': ['inboxes'],
+  'inbox.deleted': ['inboxes'],
+
+  // ── Mixed events (org + user keys) ──
+  'member.added': {
+    user: ['userMemberships'],
+    org: ['members', 'memberRoleMap', 'overages'],
+  },
+  'member.removed': {
+    user: ['userMemberships'],
+    org: ['members', 'memberRoleMap', 'overages'],
+  },
+  'member.role.changed': {
+    user: ['userMemberships'],
+    org: ['members', 'memberRoleMap'],
+  },
+
+  // ── User-scoped events ──
+  'user.updated': { user: ['userProfile'] },
+  'user.settings.changed': { user: ['userSettings'] },
+  'mail-view.changed': { user: ['userMailViews'] },
+}
+
+export type CacheEvent = keyof typeof INVALIDATION_GRAPH
+
+export function isOrgOnlyMapping(mapping: InvalidationMapping): mapping is OrgOnlyMapping {
+  return Array.isArray(mapping)
+}
+
+export function isMixedMapping(mapping: InvalidationMapping): mapping is MixedMapping {
+  return !Array.isArray(mapping) && typeof mapping === 'object'
+}

--- a/packages/lib/src/cache/local-cache.ts
+++ b/packages/lib/src/cache/local-cache.ts
@@ -1,0 +1,71 @@
+// packages/lib/src/cache/local-cache.ts
+
+/** Entry stored in the local in-process cache */
+export interface LocalCacheEntry<T> {
+  value: T
+  /** When this entry was written (ms since epoch) */
+  writtenAt: number
+  /** Hash from Redis — used to detect cross-process invalidation */
+  hash: string
+}
+
+/**
+ * LRU-evicting local cache backed by a Map.
+ * Entries are considered stale after `ttlMs` milliseconds.
+ * When max capacity is reached, the oldest entries are evicted.
+ */
+export class LocalCache {
+  private cache = new Map<string, LocalCacheEntry<any>>()
+
+  constructor(
+    private ttlMs: number = 100,
+    private maxEntries: number = 1000
+  ) {}
+
+  get<T>(key: string): LocalCacheEntry<T> | undefined {
+    const entry = this.cache.get(key)
+    if (!entry) return undefined
+
+    // Check if entry is stale
+    if (Date.now() - entry.writtenAt > this.ttlMs) {
+      return undefined // Stale — caller should check Redis hash
+    }
+
+    return entry
+  }
+
+  set<T>(key: string, value: T, hash: string): void {
+    // Evict oldest entries if at capacity
+    if (this.cache.size >= this.maxEntries && !this.cache.has(key)) {
+      const firstKey = this.cache.keys().next().value
+      if (firstKey) this.cache.delete(firstKey)
+    }
+
+    this.cache.set(key, {
+      value,
+      writtenAt: Date.now(),
+      hash,
+    })
+  }
+
+  delete(key: string): void {
+    this.cache.delete(key)
+  }
+
+  /** Delete all entries matching a prefix */
+  deleteByPrefix(prefix: string): void {
+    for (const key of this.cache.keys()) {
+      if (key.startsWith(prefix)) {
+        this.cache.delete(key)
+      }
+    }
+  }
+
+  clear(): void {
+    this.cache.clear()
+  }
+
+  get size(): number {
+    return this.cache.size
+  }
+}

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -1,0 +1,89 @@
+// packages/lib/src/cache/org-cache-keys.ts
+
+import type {
+  CustomFieldEntity,
+  OrganizationMemberInfo,
+  OrganizationRole,
+} from '@auxx/database/types'
+import type { DehydratedOrganization } from '../dehydration/types'
+import type { Inbox } from '../inboxes/types'
+import type { Overage } from '../permissions/overage-detection-service'
+import type { FeatureMapObject } from '../permissions/types'
+import type { Resource } from '../resources/registry/types'
+
+/** Member info cached with joined user data */
+export interface OrgMemberInfo extends OrganizationMemberInfo {
+  user: {
+    id: string
+    name: string | null
+    email: string | null
+    image: string | null
+    userType: string
+  } | null
+}
+
+/** Dehydrated subscription shape (serializable) */
+export type DehydratedSubscription = NonNullable<DehydratedOrganization['subscription']>
+
+/** Dehydrated org profile (serializable) */
+export interface DehydratedOrgProfile {
+  id: string
+  name: string | null
+  website: string | null
+  emailDomain: string | null
+  handle: string | null
+  about: string | null
+  createdAt: string
+  completedOnboarding: boolean
+}
+
+/** All org-scoped cache keys and their data types */
+export interface OrgCacheDataMap {
+  // Near-immutable
+  entityDefs: Record<string, string> // entityType → entityDefId
+  entityDefSlugs: Record<string, string> // apiSlug → entityDefId
+  systemUser: string // system user ID
+  integrationProviders: Record<string, string> // integrationId → provider
+
+  // Membership & permissions
+  members: OrgMemberInfo[]
+  memberRoleMap: Record<string, OrganizationRole>
+
+  // Business data
+  features: FeatureMapObject
+  subscription: DehydratedSubscription | null
+  orgProfile: DehydratedOrgProfile
+  resources: Resource[]
+  customFields: Record<string, CustomFieldEntity[]> // entityDefId → fields
+  inboxes: Inbox[]
+  overages: Overage[]
+}
+
+export type OrgCacheKeyName = keyof OrgCacheDataMap
+
+const THIRTY_DAYS = 60 * 60 * 24 * 30
+
+/** Key configuration: prefix for Redis keys, TTL, and local-only flag */
+export const ORG_CACHE_KEY_CONFIG: Record<
+  OrgCacheKeyName,
+  { prefix: string; ttlSeconds: number; localOnly?: boolean }
+> = {
+  // Near-immutable (30-day TTL, invalidated only on create/delete)
+  entityDefs: { prefix: 'org:entity-defs', ttlSeconds: THIRTY_DAYS },
+  entityDefSlugs: { prefix: 'org:entity-def-slugs', ttlSeconds: THIRTY_DAYS },
+  systemUser: { prefix: 'org:system-user', ttlSeconds: THIRTY_DAYS },
+  integrationProviders: { prefix: 'org:int-providers', ttlSeconds: 86400 },
+
+  // Membership & permissions (15m TTL)
+  members: { prefix: 'org:members', ttlSeconds: 900 },
+  memberRoleMap: { prefix: 'org:member-roles', ttlSeconds: 900 },
+
+  // Business data
+  features: { prefix: 'org:features', ttlSeconds: 3600 },
+  subscription: { prefix: 'org:subscription', ttlSeconds: 3600 },
+  orgProfile: { prefix: 'org:profile', ttlSeconds: 3600 },
+  resources: { prefix: 'org:resources', ttlSeconds: 900 },
+  customFields: { prefix: 'org:custom-fields', ttlSeconds: 900 },
+  inboxes: { prefix: 'org:inboxes', ttlSeconds: 300 },
+  overages: { prefix: 'org:overages', ttlSeconds: 300 },
+}

--- a/packages/lib/src/cache/org-cache-provider.ts
+++ b/packages/lib/src/cache/org-cache-provider.ts
@@ -1,0 +1,8 @@
+// packages/lib/src/cache/org-cache-provider.ts
+
+import type { Database } from '@auxx/database'
+
+/** Provider interface for computing cache values from the database */
+export interface CacheProvider<T> {
+  compute(orgId: string, db: Database): Promise<T>
+}

--- a/packages/lib/src/cache/org-cache-service.ts
+++ b/packages/lib/src/cache/org-cache-service.ts
@@ -1,0 +1,327 @@
+// packages/lib/src/cache/org-cache-service.ts
+
+import { type Database, database as ddb } from '@auxx/database'
+import { getRedisClient, type RedisClient } from '@auxx/redis'
+import { randomUUID } from 'crypto'
+import { createScopedLogger } from '../logger'
+import { LocalCache } from './local-cache'
+import type { OrgCacheDataMap, OrgCacheKeyName } from './org-cache-keys'
+import { ORG_CACHE_KEY_CONFIG } from './org-cache-keys'
+import type { CacheProvider } from './org-cache-provider'
+import { PromiseMemoizer } from './promise-memoizer'
+
+const logger = createScopedLogger('OrgCache', { color: 'green' })
+
+/** Lock TTL in seconds — auto-releases if holder crashes */
+const LOCK_TTL_SECONDS = 5
+/** Max retry attempts when waiting for a lock */
+const LOCK_MAX_RETRIES = 50
+/** Delay between lock retries in ms */
+const LOCK_RETRY_DELAY_MS = 100
+
+/**
+ * Organization Cache Service — multi-tier, type-safe caching for org-scoped data.
+ *
+ * Read path (4 stages):
+ *   1. Local Map (100ms TTL)
+ *   2. Redis hash check (detect cross-process invalidation)
+ *   3. Redis data fetch
+ *   4. Provider.compute() from DB
+ *
+ * Write-back: stores in Local + Redis (data + hash)
+ * Invalidation: clears local + Redis, recomputes from provider
+ */
+export class OrganizationCacheService {
+  private providers = new Map<OrgCacheKeyName, CacheProvider<any>>()
+  private localCache = new LocalCache(100, 1000) // 100ms TTL, 1000 max entries
+  private memoizer = new PromiseMemoizer<any>()
+  private redis: RedisClient | undefined
+  private redisReady: Promise<void>
+  private db: Database
+
+  constructor(db?: Database) {
+    this.db = db ?? (ddb as Database)
+    this.redisReady = this.initRedis()
+  }
+
+  private async initRedis(): Promise<void> {
+    try {
+      this.redis = await getRedisClient(false)
+    } catch {
+      logger.warn('Redis unavailable, org cache running in local-only mode')
+    }
+  }
+
+  private async getRedis(): Promise<RedisClient | undefined> {
+    await this.redisReady
+    return this.redis
+  }
+
+  /** Register a provider for a cache key */
+  register<K extends OrgCacheKeyName>(key: K, provider: CacheProvider<OrgCacheDataMap[K]>): void {
+    this.providers.set(key, provider)
+  }
+
+  /** Redis key for the cached data */
+  private dataKey(keyName: OrgCacheKeyName, scopeId: string): string {
+    return `${ORG_CACHE_KEY_CONFIG[keyName].prefix}:${scopeId}:data`
+  }
+
+  /** Redis key for the hash (used for cross-process invalidation detection) */
+  private hashKey(keyName: OrgCacheKeyName, scopeId: string): string {
+    return `${ORG_CACHE_KEY_CONFIG[keyName].prefix}:${scopeId}:hash`
+  }
+
+  /** Redis key for the distributed lock */
+  private lockKey(keyName: OrgCacheKeyName, scopeId: string): string {
+    return `${ORG_CACHE_KEY_CONFIG[keyName].prefix}:${scopeId}:lock`
+  }
+
+  /** Local cache key */
+  private localKey(keyName: OrgCacheKeyName, scopeId: string): string {
+    return `${ORG_CACHE_KEY_CONFIG[keyName].prefix}:${scopeId}`
+  }
+
+  /**
+   * Main read path — type-safe multi-key fetch.
+   * Fetches multiple keys for a single org in one call.
+   */
+  async getOrRecompute<K extends OrgCacheKeyName[]>(
+    orgId: string,
+    keys: readonly [...K]
+  ): Promise<{ [P in K[number]]: OrgCacheDataMap[P] }> {
+    const result = {} as { [P in K[number]]: OrgCacheDataMap[P] }
+
+    // Fetch all keys in parallel
+    const entries = await Promise.all(keys.map((key) => this.getSingle(orgId, key)))
+
+    for (let i = 0; i < keys.length; i++) {
+      ;(result as any)[keys[i]!] = entries[i]
+    }
+
+    return result
+  }
+
+  /** Convenience: single key fetch */
+  async get<K extends OrgCacheKeyName>(orgId: string, key: K): Promise<OrgCacheDataMap[K]> {
+    return this.getSingle(orgId, key)
+  }
+
+  /**
+   * 4-stage read for a single key.
+   * Deduplicates concurrent calls via PromiseMemoizer.
+   */
+  private async getSingle<K extends OrgCacheKeyName>(
+    orgId: string,
+    keyName: K
+  ): Promise<OrgCacheDataMap[K]> {
+    const memoKey = `${keyName}:${orgId}`
+
+    return this.memoizer.memoize(memoKey, async () => {
+      const lk = this.localKey(keyName, orgId)
+
+      // Stage 1: Local cache check
+      const localEntry = this.localCache.get<OrgCacheDataMap[K]>(lk)
+      if (localEntry) {
+        return localEntry.value
+      }
+
+      const redis = await this.getRedis()
+
+      if (redis) {
+        try {
+          // Stage 2: Redis hash check
+          const [storedHash, localStaleEntry] = await Promise.all([
+            redis.get(this.hashKey(keyName, orgId)),
+            Promise.resolve(this.localCache.get<OrgCacheDataMap[K]>(lk)), // re-check after await
+          ])
+
+          // If we have a stale local entry with matching hash, it's still valid
+          if (localStaleEntry && storedHash && localStaleEntry.hash === storedHash) {
+            // Refresh the local entry timestamp
+            this.localCache.set(lk, localStaleEntry.value, storedHash)
+            return localStaleEntry.value
+          }
+
+          // Stage 3: Redis data fetch
+          if (storedHash) {
+            const config = ORG_CACHE_KEY_CONFIG[keyName]
+            if (!config.localOnly) {
+              const rawData = await redis.get(this.dataKey(keyName, orgId))
+              if (rawData) {
+                const value = JSON.parse(rawData) as OrgCacheDataMap[K]
+                this.localCache.set(lk, value, storedHash)
+                return value
+              }
+            }
+          }
+        } catch (error) {
+          logger.warn(`Redis error reading ${keyName} for org ${orgId}`, {
+            error: error instanceof Error ? error.message : String(error),
+          })
+          // Fall through to recompute
+        }
+      }
+
+      // Stage 4: Recompute from provider
+      return this.recompute(orgId, keyName)
+    })
+  }
+
+  /**
+   * Compute value from provider and write back to cache.
+   * Uses distributed lock to prevent thundering herd.
+   */
+  private async recompute<K extends OrgCacheKeyName>(
+    orgId: string,
+    keyName: K
+  ): Promise<OrgCacheDataMap[K]> {
+    const provider = this.providers.get(keyName)
+    if (!provider) {
+      throw new Error(`No provider registered for cache key: ${keyName}`)
+    }
+
+    const redis = await this.getRedis()
+
+    // Try to acquire distributed lock
+    if (redis) {
+      const lock = this.lockKey(keyName, orgId)
+      try {
+        const acquired = await redis.set(lock, '1', 'EX', LOCK_TTL_SECONDS, 'NX')
+
+        if (!acquired) {
+          // Another process is computing — wait and retry from Redis
+          for (let i = 0; i < LOCK_MAX_RETRIES; i++) {
+            await new Promise((r) => setTimeout(r, LOCK_RETRY_DELAY_MS))
+
+            const rawData = await redis.get(this.dataKey(keyName, orgId))
+            if (rawData) {
+              const hash = (await redis.get(this.hashKey(keyName, orgId))) || randomUUID()
+              const value = JSON.parse(rawData) as OrgCacheDataMap[K]
+              this.localCache.set(this.localKey(keyName, orgId), value, hash)
+              return value
+            }
+          }
+          // Lock holder may have failed — fall through to compute anyway
+        }
+      } catch {
+        // Lock acquisition failed — proceed without lock
+      }
+    }
+
+    try {
+      const value = await provider.compute(orgId, this.db)
+      await this.writeBack(orgId, keyName, value)
+      return value
+    } finally {
+      // Release lock
+      if (redis) {
+        try {
+          await redis.del(this.lockKey(keyName, orgId))
+        } catch {
+          // Ignore lock release errors
+        }
+      }
+    }
+  }
+
+  /** Write computed value back to local cache and Redis */
+  private async writeBack<K extends OrgCacheKeyName>(
+    orgId: string,
+    keyName: K,
+    value: OrgCacheDataMap[K]
+  ): Promise<void> {
+    const hash = randomUUID()
+    const config = ORG_CACHE_KEY_CONFIG[keyName]
+    const lk = this.localKey(keyName, orgId)
+
+    // Write to local cache
+    this.localCache.set(lk, value, hash)
+
+    // Write to Redis
+    const redis = await this.getRedis()
+    if (redis) {
+      try {
+        const pipeline = redis.pipeline()
+
+        // Always store hash in Redis (for cross-process invalidation)
+        pipeline.set(this.hashKey(keyName, orgId), hash)
+        pipeline.expire(this.hashKey(keyName, orgId), config.ttlSeconds)
+
+        // Store data in Redis unless local-only
+        if (!config.localOnly) {
+          const serialized = JSON.stringify(value)
+          pipeline.set(this.dataKey(keyName, orgId), serialized)
+          pipeline.expire(this.dataKey(keyName, orgId), config.ttlSeconds)
+        }
+
+        await pipeline.exec()
+      } catch (error) {
+        logger.warn(`Redis write error for ${keyName}:${orgId}`, {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+  }
+
+  /**
+   * Invalidate specific keys and recompute them.
+   * MUST be called AFTER the DB transaction commits.
+   */
+  async invalidateAndRecompute(orgId: string, keys: readonly OrgCacheKeyName[]): Promise<void> {
+    const redis = await this.getRedis()
+
+    await Promise.all(
+      keys.map(async (keyName) => {
+        const lk = this.localKey(keyName, orgId)
+
+        // Clear local cache
+        this.localCache.delete(lk)
+
+        // Delete Redis keys (data + hash)
+        if (redis) {
+          try {
+            await redis.del(this.dataKey(keyName, orgId))
+            await redis.del(this.hashKey(keyName, orgId))
+          } catch {
+            // Ignore Redis errors during invalidation
+          }
+        }
+
+        // Recompute if provider is registered
+        if (this.providers.has(keyName)) {
+          try {
+            await this.recompute(orgId, keyName)
+          } catch (error) {
+            logger.warn(`Recompute failed for ${keyName}:${orgId}`, {
+              error: error instanceof Error ? error.message : String(error),
+            })
+            // Next read will retry
+          }
+        }
+      })
+    )
+  }
+
+  /**
+   * Flush all (or specific) keys for an org.
+   * Does NOT recompute — next read will trigger recompute.
+   */
+  async flush(orgId: string, keys?: readonly OrgCacheKeyName[]): Promise<void> {
+    const keysToFlush = keys ?? (Object.keys(ORG_CACHE_KEY_CONFIG) as OrgCacheKeyName[])
+    const redis = await this.getRedis()
+
+    for (const keyName of keysToFlush) {
+      this.localCache.delete(this.localKey(keyName, orgId))
+
+      if (redis) {
+        try {
+          await redis.del(this.dataKey(keyName, orgId))
+          await redis.del(this.hashKey(keyName, orgId))
+        } catch {
+          // Ignore
+        }
+      }
+    }
+  }
+}

--- a/packages/lib/src/cache/providers/custom-fields-provider.ts
+++ b/packages/lib/src/cache/providers/custom-fields-provider.ts
@@ -1,0 +1,37 @@
+// packages/lib/src/cache/providers/custom-fields-provider.ts
+
+import { schema } from '@auxx/database'
+import type { CustomFieldEntity } from '@auxx/database/types'
+import { eq } from 'drizzle-orm'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes custom fields grouped by entityDefId for an organization */
+export const customFieldsProvider: CacheProvider<Record<string, CustomFieldEntity[]>> = {
+  async compute(orgId, db) {
+    // Get all entity definition IDs for this org
+    const entityDefs = await db
+      .select({ id: schema.EntityDefinition.id })
+      .from(schema.EntityDefinition)
+      .where(eq(schema.EntityDefinition.organizationId, orgId))
+
+    const entityDefIds = entityDefs.map((e) => e.id)
+    if (entityDefIds.length === 0) return {}
+
+    // Fetch all custom fields for these entity definitions
+    const fields = await db
+      .select()
+      .from(schema.CustomField)
+      .where(eq(schema.CustomField.organizationId, orgId))
+
+    // Group by entityDefinitionId
+    const grouped: Record<string, CustomFieldEntity[]> = {}
+    for (const field of fields) {
+      const edId = field.entityDefinitionId
+      if (!edId) continue
+      if (!grouped[edId]) grouped[edId] = []
+      grouped[edId].push(field)
+    }
+
+    return grouped
+  },
+}

--- a/packages/lib/src/cache/providers/entity-def-slugs-provider.ts
+++ b/packages/lib/src/cache/providers/entity-def-slugs-provider.ts
@@ -1,0 +1,26 @@
+// packages/lib/src/cache/providers/entity-def-slugs-provider.ts
+
+import { schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes apiSlug → entityDefId map for an organization */
+export const entityDefSlugsProvider: CacheProvider<Record<string, string>> = {
+  async compute(orgId, db) {
+    const rows = await db
+      .select({
+        id: schema.EntityDefinition.id,
+        apiSlug: schema.EntityDefinition.apiSlug,
+      })
+      .from(schema.EntityDefinition)
+      .where(eq(schema.EntityDefinition.organizationId, orgId))
+
+    const map: Record<string, string> = {}
+    for (const row of rows) {
+      if (row.apiSlug) {
+        map[row.apiSlug] = row.id
+      }
+    }
+    return map
+  },
+}

--- a/packages/lib/src/cache/providers/entity-defs-provider.ts
+++ b/packages/lib/src/cache/providers/entity-defs-provider.ts
@@ -1,0 +1,26 @@
+// packages/lib/src/cache/providers/entity-defs-provider.ts
+
+import { schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes entityType → entityDefId map for an organization */
+export const entityDefsProvider: CacheProvider<Record<string, string>> = {
+  async compute(orgId, db) {
+    const rows = await db
+      .select({
+        id: schema.EntityDefinition.id,
+        entityType: schema.EntityDefinition.entityType,
+      })
+      .from(schema.EntityDefinition)
+      .where(eq(schema.EntityDefinition.organizationId, orgId))
+
+    const map: Record<string, string> = {}
+    for (const row of rows) {
+      if (row.entityType) {
+        map[row.entityType] = row.id
+      }
+    }
+    return map
+  },
+}

--- a/packages/lib/src/cache/providers/features-provider.ts
+++ b/packages/lib/src/cache/providers/features-provider.ts
@@ -1,0 +1,102 @@
+// packages/lib/src/cache/providers/features-provider.ts
+
+import { schema } from '@auxx/database'
+import { isSelfHosted } from '@auxx/deployment'
+import { eq } from 'drizzle-orm'
+import { createScopedLogger } from '../../logger'
+import type { FeatureDefinition, FeatureLimit, FeatureMapObject } from '../../permissions/types'
+import { DEFAULT_FREE_PLAN_FEATURES, FeatureKey } from '../../permissions/types'
+import type { CacheProvider } from '../org-cache-provider'
+
+const logger = createScopedLogger('features-provider')
+
+/** Computes feature permission map for an organization */
+export const featuresProvider: CacheProvider<FeatureMapObject> = {
+  async compute(orgId, db) {
+    if (isSelfHosted()) {
+      // Self-hosted: all features unlimited
+      const obj: Record<string, FeatureLimit> = {}
+      for (const key of Object.values(FeatureKey)) {
+        obj[key] = '+'
+      }
+      return obj
+    }
+
+    // Fetch subscription
+    const [subscription] = await db
+      .select({
+        status: schema.PlanSubscription.status,
+        hasTrialEnded: schema.PlanSubscription.hasTrialEnded,
+        planId: schema.PlanSubscription.planId,
+        customFeatureLimits: schema.PlanSubscription.customFeatureLimits,
+      })
+      .from(schema.PlanSubscription)
+      .where(eq(schema.PlanSubscription.organizationId, orgId))
+      .limit(1)
+
+    let featureDefinitions: FeatureDefinition[] = DEFAULT_FREE_PLAN_FEATURES
+
+    if (subscription?.planId) {
+      const [plan] = await db
+        .select({
+          featureLimits: schema.Plan.featureLimits,
+          trialFeatureLimits: schema.Plan.trialFeatureLimits,
+        })
+        .from(schema.Plan)
+        .where(eq(schema.Plan.id, subscription.planId))
+        .limit(1)
+
+      if (subscription.status === 'trialing' && !subscription.hasTrialEnded) {
+        const trialSource = plan?.trialFeatureLimits ?? plan?.featureLimits
+        featureDefinitions = parseFeaturesFromJson(trialSource)
+      } else if (subscription.status === 'active') {
+        featureDefinitions = parseFeaturesFromJson(plan?.featureLimits)
+      }
+    }
+
+    // Build feature map
+    const result: Record<string, FeatureLimit> = {}
+    for (const def of featureDefinitions) {
+      if (def && typeof def.key === 'string') {
+        result[def.key] = def.limit === -1 ? '+' : def.limit
+      }
+    }
+
+    // Apply custom feature limits (Enterprise customers)
+    if (subscription?.customFeatureLimits) {
+      try {
+        const customLimits =
+          typeof subscription.customFeatureLimits === 'string'
+            ? JSON.parse(subscription.customFeatureLimits)
+            : subscription.customFeatureLimits
+
+        if (customLimits && typeof customLimits === 'object') {
+          for (const [key, limit] of Object.entries(customLimits as Record<string, unknown>)) {
+            if (typeof limit === 'number') {
+              result[key] = limit === -1 ? '+' : limit
+            } else if (typeof limit === 'boolean') {
+              result[key] = limit
+            }
+          }
+        }
+      } catch (error) {
+        logger.warn('Failed to parse custom feature limits', {
+          orgId,
+          error: (error as Error).message,
+        })
+      }
+    }
+
+    return result
+  },
+}
+
+function parseFeaturesFromJson(featuresJson: unknown): FeatureDefinition[] {
+  if (!featuresJson) return DEFAULT_FREE_PLAN_FEATURES
+  try {
+    const parsed = typeof featuresJson === 'string' ? JSON.parse(featuresJson) : featuresJson
+    return Array.isArray(parsed) ? (parsed as FeatureDefinition[]) : DEFAULT_FREE_PLAN_FEATURES
+  } catch {
+    return DEFAULT_FREE_PLAN_FEATURES
+  }
+}

--- a/packages/lib/src/cache/providers/inboxes-provider.ts
+++ b/packages/lib/src/cache/providers/inboxes-provider.ts
@@ -1,0 +1,13 @@
+// packages/lib/src/cache/providers/inboxes-provider.ts
+
+import { InboxService } from '../../inboxes/inbox-service'
+import type { Inbox } from '../../inboxes/types'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes all inboxes for an organization */
+export const inboxesProvider: CacheProvider<Inbox[]> = {
+  async compute(orgId, db) {
+    const inboxService = new InboxService(db, orgId)
+    return inboxService.getInboxes()
+  },
+}

--- a/packages/lib/src/cache/providers/integration-providers-provider.ts
+++ b/packages/lib/src/cache/providers/integration-providers-provider.ts
@@ -1,0 +1,26 @@
+// packages/lib/src/cache/providers/integration-providers-provider.ts
+
+import { schema } from '@auxx/database'
+import { and, eq, isNull } from 'drizzle-orm'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes integrationId → provider type map for an organization */
+export const integrationProvidersProvider: CacheProvider<Record<string, string>> = {
+  async compute(orgId, db) {
+    const integrations = await db
+      .select({
+        id: schema.Integration.id,
+        provider: schema.Integration.provider,
+      })
+      .from(schema.Integration)
+      .where(
+        and(eq(schema.Integration.organizationId, orgId), isNull(schema.Integration.deletedAt))
+      )
+
+    const map: Record<string, string> = {}
+    for (const i of integrations) {
+      map[i.id] = i.provider
+    }
+    return map
+  },
+}

--- a/packages/lib/src/cache/providers/members-provider.ts
+++ b/packages/lib/src/cache/providers/members-provider.ts
@@ -1,0 +1,45 @@
+// packages/lib/src/cache/providers/members-provider.ts
+
+import { schema } from '@auxx/database'
+import type { OrganizationRole } from '@auxx/database/types'
+import { eq } from 'drizzle-orm'
+import type { OrgMemberInfo } from '../org-cache-keys'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes all org members with joined user info */
+export const membersProvider: CacheProvider<OrgMemberInfo[]> = {
+  async compute(orgId, db) {
+    const rows = await db
+      .select({
+        id: schema.OrganizationMember.id,
+        userId: schema.OrganizationMember.userId,
+        organizationId: schema.OrganizationMember.organizationId,
+        role: schema.OrganizationMember.role,
+        status: schema.OrganizationMember.status,
+        user: {
+          id: schema.User.id,
+          name: schema.User.name,
+          email: schema.User.email,
+          image: schema.User.image,
+          userType: schema.User.userType,
+        },
+      })
+      .from(schema.OrganizationMember)
+      .leftJoin(schema.User, eq(schema.User.id, schema.OrganizationMember.userId))
+      .where(eq(schema.OrganizationMember.organizationId, orgId))
+
+    return rows as OrgMemberInfo[]
+  },
+}
+
+/** Derives userId → role map from members (computed independently for independent invalidation) */
+export const memberRoleMapProvider: CacheProvider<Record<string, OrganizationRole>> = {
+  async compute(orgId, db) {
+    const members = await membersProvider.compute(orgId, db)
+    const map: Record<string, OrganizationRole> = {}
+    for (const m of members) {
+      map[m.userId] = m.role
+    }
+    return map
+  },
+}

--- a/packages/lib/src/cache/providers/org-profile-provider.ts
+++ b/packages/lib/src/cache/providers/org-profile-provider.ts
@@ -1,0 +1,32 @@
+// packages/lib/src/cache/providers/org-profile-provider.ts
+
+import { schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import type { DehydratedOrgProfile } from '../org-cache-keys'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes the dehydrated org profile */
+export const orgProfileProvider: CacheProvider<DehydratedOrgProfile> = {
+  async compute(orgId, db) {
+    const [org] = await db
+      .select()
+      .from(schema.Organization)
+      .where(eq(schema.Organization.id, orgId))
+      .limit(1)
+
+    if (!org) {
+      throw new Error(`Organization not found: ${orgId}`)
+    }
+
+    return {
+      id: org.id,
+      name: org.name,
+      website: org.website,
+      emailDomain: org.emailDomain,
+      handle: org.handle,
+      about: org.about,
+      createdAt: org.createdAt.toISOString(),
+      completedOnboarding: org.completedOnboarding ?? false,
+    }
+  },
+}

--- a/packages/lib/src/cache/providers/overages-provider.ts
+++ b/packages/lib/src/cache/providers/overages-provider.ts
@@ -1,0 +1,16 @@
+// packages/lib/src/cache/providers/overages-provider.ts
+
+import { type Overage, OverageDetectionService } from '../../permissions/overage-detection-service'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes current overages for an organization */
+export const overagesProvider: CacheProvider<Overage[]> = {
+  async compute(orgId, db) {
+    const overageService = new OverageDetectionService(db)
+    try {
+      return await overageService.detectCurrentOverages(orgId)
+    } catch {
+      return []
+    }
+  },
+}

--- a/packages/lib/src/cache/providers/resources-provider.ts
+++ b/packages/lib/src/cache/providers/resources-provider.ts
@@ -1,0 +1,13 @@
+// packages/lib/src/cache/providers/resources-provider.ts
+
+import { ResourceRegistryService } from '../../resources/registry/resource-registry-service'
+import type { Resource } from '../../resources/registry/types'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes the full resource registry for an organization */
+export const resourcesProvider: CacheProvider<Resource[]> = {
+  async compute(orgId, db) {
+    const registry = new ResourceRegistryService(orgId, db)
+    return registry.getAll()
+  },
+}

--- a/packages/lib/src/cache/providers/subscription-provider.ts
+++ b/packages/lib/src/cache/providers/subscription-provider.ts
@@ -1,0 +1,41 @@
+// packages/lib/src/cache/providers/subscription-provider.ts
+
+import { schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import type { DehydratedSubscription } from '../org-cache-keys'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes the dehydrated subscription for an organization */
+export const subscriptionProvider: CacheProvider<DehydratedSubscription | null> = {
+  async compute(orgId, db) {
+    const [subscription] = await db
+      .select()
+      .from(schema.PlanSubscription)
+      .where(eq(schema.PlanSubscription.organizationId, orgId))
+      .limit(1)
+
+    if (!subscription) return null
+
+    return {
+      id: subscription.id,
+      status: subscription.status,
+      plan: subscription.plan,
+      planId: subscription.planId,
+      seats: subscription.seats,
+      billingCycle: subscription.billingCycle,
+      periodStart: subscription.periodStart?.toISOString() ?? null,
+      periodEnd: subscription.periodEnd?.toISOString() ?? null,
+      cancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
+      canceledAt: subscription.canceledAt?.toISOString() ?? null,
+      trialStart: subscription.trialStart?.toISOString() ?? null,
+      trialEnd: subscription.trialEnd?.toISOString() ?? null,
+      hasTrialEnded: subscription.hasTrialEnded,
+      isEligibleForTrial: subscription.isEligibleForTrial,
+      scheduledPlanId: subscription.scheduledPlanId,
+      scheduledPlan: subscription.scheduledPlan,
+      scheduledBillingCycle: subscription.scheduledBillingCycle,
+      scheduledSeats: subscription.scheduledSeats,
+      scheduledChangeAt: subscription.scheduledChangeAt?.toISOString() ?? null,
+    }
+  },
+}

--- a/packages/lib/src/cache/providers/system-user-provider.ts
+++ b/packages/lib/src/cache/providers/system-user-provider.ts
@@ -1,0 +1,22 @@
+// packages/lib/src/cache/providers/system-user-provider.ts
+
+import { schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes the system user ID for an organization */
+export const systemUserProvider: CacheProvider<string> = {
+  async compute(orgId, db) {
+    const [org] = await db
+      .select({ systemUserId: schema.Organization.systemUserId })
+      .from(schema.Organization)
+      .where(eq(schema.Organization.id, orgId))
+      .limit(1)
+
+    if (!org?.systemUserId) {
+      throw new Error(`No system user found for organization ${orgId}`)
+    }
+
+    return org.systemUserId
+  },
+}

--- a/packages/lib/src/cache/providers/user-mail-views-provider.ts
+++ b/packages/lib/src/cache/providers/user-mail-views-provider.ts
@@ -1,0 +1,34 @@
+// packages/lib/src/cache/providers/user-mail-views-provider.ts
+
+import { MailViewService } from '../../mail-views'
+import type { CacheProvider } from '../org-cache-provider'
+import type { CachedMailView } from '../user-cache-keys'
+
+/** Computes mail views for a user in a specific org. Receives "userId:orgId" as the compute ID. */
+export const userMailViewsProvider: CacheProvider<CachedMailView[]> = {
+  async compute(compositeId, db) {
+    const [userId, organizationId] = compositeId.split(':')
+    if (!userId || !organizationId) {
+      throw new Error(`Invalid composite ID for userMailViews: ${compositeId}`)
+    }
+
+    const mailViewService = new MailViewService(organizationId, db, { enableCache: false })
+    const views = await mailViewService.getAllUserAccessibleMailViews(userId)
+
+    return views.map((v) => ({
+      id: v.id,
+      name: v.name,
+      description: v.description,
+      isDefault: v.isDefault,
+      isPinned: v.isPinned,
+      isShared: v.isShared,
+      filterGroups: v.filterGroups as unknown[],
+      sortField: v.sortField,
+      sortDirection: v.sortDirection,
+      organizationId: v.organizationId,
+      userId: v.userId,
+      createdAt: v.createdAt instanceof Date ? v.createdAt.toISOString() : String(v.createdAt),
+      updatedAt: v.updatedAt instanceof Date ? v.updatedAt.toISOString() : String(v.updatedAt),
+    }))
+  },
+}

--- a/packages/lib/src/cache/providers/user-memberships-provider.ts
+++ b/packages/lib/src/cache/providers/user-memberships-provider.ts
@@ -1,0 +1,24 @@
+// packages/lib/src/cache/providers/user-memberships-provider.ts
+
+import { schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import type { CacheProvider } from '../org-cache-provider'
+import type { UserMembership } from '../user-cache-keys'
+
+/** Computes all memberships for a user */
+export const userMembershipsProvider: CacheProvider<UserMembership[]> = {
+  async compute(userId, db) {
+    const memberships = await db
+      .select({
+        id: schema.OrganizationMember.id,
+        userId: schema.OrganizationMember.userId,
+        organizationId: schema.OrganizationMember.organizationId,
+        role: schema.OrganizationMember.role,
+        status: schema.OrganizationMember.status,
+      })
+      .from(schema.OrganizationMember)
+      .where(eq(schema.OrganizationMember.userId, userId))
+
+    return memberships
+  },
+}

--- a/packages/lib/src/cache/providers/user-profile-provider.ts
+++ b/packages/lib/src/cache/providers/user-profile-provider.ts
@@ -1,0 +1,97 @@
+// packages/lib/src/cache/providers/user-profile-provider.ts
+
+import { schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import type { DehydratedUser } from '../../dehydration/types'
+import { MediaAssetService } from '../../files'
+import { createScopedLogger } from '../../logger'
+import type { CacheProvider } from '../org-cache-provider'
+
+const logger = createScopedLogger('user-profile-provider')
+
+/** Computes the dehydrated user profile */
+export const userProfileProvider: CacheProvider<DehydratedUser> = {
+  async compute(userId, db) {
+    const [user] = await db.select().from(schema.User).where(eq(schema.User.id, userId)).limit(1)
+
+    if (!user) {
+      throw new Error(`User not found: ${userId}`)
+    }
+
+    // Fetch memberships
+    const memberships = await db
+      .select({
+        id: schema.OrganizationMember.id,
+        userId: schema.OrganizationMember.userId,
+        organizationId: schema.OrganizationMember.organizationId,
+        role: schema.OrganizationMember.role,
+        status: schema.OrganizationMember.status,
+      })
+      .from(schema.OrganizationMember)
+      .where(eq(schema.OrganizationMember.userId, userId))
+
+    // Fetch avatar URL
+    let avatarUrl: string | null = null
+    if (user.avatarAssetId && user.defaultOrganizationId) {
+      const mediaAssetService = new MediaAssetService(user.defaultOrganizationId, userId, db)
+      try {
+        avatarUrl = await mediaAssetService.getDownloadUrl(user.avatarAssetId)
+      } catch (error) {
+        logger.warn(`Failed to fetch avatar URL for user ${userId}`, {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+
+    // Fetch auth providers
+    const accounts = await db
+      .select({ providerId: schema.account.providerId })
+      .from(schema.account)
+      .where(eq(schema.account.userId, userId))
+
+    const providerIds = accounts.map((a) => a.providerId)
+    const hasPassword = providerIds.includes('credential')
+    const oauthProviders = providerIds.filter((p) => p !== 'credential')
+
+    const authMethodCount =
+      (hasPassword ? 1 : 0) +
+      (oauthProviders.length > 0 ? 1 : 0) +
+      (user.phoneNumberVerified ? 1 : 0)
+
+    let registrationMethod: 'oauth' | 'email' | 'phone' | 'mixed' = 'oauth'
+    if (authMethodCount > 1) {
+      registrationMethod = 'mixed'
+    } else if (hasPassword) {
+      registrationMethod = 'email'
+    } else if (user.phoneNumberVerified) {
+      registrationMethod = 'phone'
+    }
+
+    return {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      emailVerified: user.emailVerified,
+      image: avatarUrl,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      phoneNumber: user.phoneNumber,
+      phoneNumberVerified: user.phoneNumberVerified,
+      completedOnboarding: user.completedOnboarding,
+      defaultOrganizationId: user.defaultOrganizationId,
+      lastLoginAt: user.lastLoginAt,
+      preferredTimezone: user.preferredTimezone,
+      providers: oauthProviders,
+      hasPassword,
+      isSuperAdmin: user.isSuperAdmin,
+      registrationMethod,
+      memberships: memberships.map((m) => ({
+        id: m.id,
+        userId: m.userId,
+        organizationId: m.organizationId,
+        role: m.role,
+        status: m.status,
+      })),
+    }
+  },
+}

--- a/packages/lib/src/cache/providers/user-settings-provider.ts
+++ b/packages/lib/src/cache/providers/user-settings-provider.ts
@@ -1,0 +1,18 @@
+// packages/lib/src/cache/providers/user-settings-provider.ts
+
+import { SettingsService } from '../../settings'
+import type { SettingValue } from '../../settings/types'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes user settings for a specific org. Receives "userId:orgId" as the compute ID. */
+export const userSettingsProvider: CacheProvider<Record<string, SettingValue>> = {
+  async compute(compositeId, db) {
+    const [userId, organizationId] = compositeId.split(':')
+    if (!userId || !organizationId) {
+      throw new Error(`Invalid composite ID for userSettings: ${compositeId}`)
+    }
+
+    const settingsService = new SettingsService(db)
+    return settingsService.getAllUserSettings({ userId, organizationId })
+  },
+}

--- a/packages/lib/src/cache/register-providers.ts
+++ b/packages/lib/src/cache/register-providers.ts
@@ -1,0 +1,51 @@
+// packages/lib/src/cache/register-providers.ts
+
+import type { OrganizationCacheService } from './org-cache-service'
+import { customFieldsProvider } from './providers/custom-fields-provider'
+import { entityDefSlugsProvider } from './providers/entity-def-slugs-provider'
+import { entityDefsProvider } from './providers/entity-defs-provider'
+import { featuresProvider } from './providers/features-provider'
+import { inboxesProvider } from './providers/inboxes-provider'
+import { integrationProvidersProvider } from './providers/integration-providers-provider'
+import { memberRoleMapProvider, membersProvider } from './providers/members-provider'
+import { orgProfileProvider } from './providers/org-profile-provider'
+import { overagesProvider } from './providers/overages-provider'
+import { resourcesProvider } from './providers/resources-provider'
+import { subscriptionProvider } from './providers/subscription-provider'
+import { systemUserProvider } from './providers/system-user-provider'
+import { userMailViewsProvider } from './providers/user-mail-views-provider'
+import { userMembershipsProvider } from './providers/user-memberships-provider'
+import { userProfileProvider } from './providers/user-profile-provider'
+import { userSettingsProvider } from './providers/user-settings-provider'
+import type { UserCacheService } from './user-cache-service'
+
+/** Register all cache providers. Called once at service startup. */
+export function registerAllProviders(
+  orgCache: OrganizationCacheService,
+  userCache: UserCacheService
+): void {
+  // Org-scoped: near-immutable
+  orgCache.register('entityDefs', entityDefsProvider)
+  orgCache.register('entityDefSlugs', entityDefSlugsProvider)
+  orgCache.register('systemUser', systemUserProvider)
+  orgCache.register('integrationProviders', integrationProvidersProvider)
+
+  // Org-scoped: membership & permissions
+  orgCache.register('members', membersProvider)
+  orgCache.register('memberRoleMap', memberRoleMapProvider)
+
+  // Org-scoped: business data
+  orgCache.register('features', featuresProvider)
+  orgCache.register('subscription', subscriptionProvider)
+  orgCache.register('orgProfile', orgProfileProvider)
+  orgCache.register('resources', resourcesProvider)
+  orgCache.register('customFields', customFieldsProvider)
+  orgCache.register('inboxes', inboxesProvider)
+  orgCache.register('overages', overagesProvider)
+
+  // User-scoped
+  userCache.register('userProfile', userProfileProvider)
+  userCache.register('userSettings', userSettingsProvider)
+  userCache.register('userMemberships', userMembershipsProvider)
+  userCache.register('userMailViews', userMailViewsProvider)
+}

--- a/packages/lib/src/cache/user-cache-keys.ts
+++ b/packages/lib/src/cache/user-cache-keys.ts
@@ -1,0 +1,54 @@
+// packages/lib/src/cache/user-cache-keys.ts
+
+import type { DehydratedUser } from '../dehydration/types'
+import type { SettingValue } from '../settings/types'
+
+/** Membership info for user cache */
+export interface UserMembership {
+  id: string
+  userId: string
+  organizationId: string
+  role: string
+  status: string
+}
+
+/** Mail view for user cache */
+export interface CachedMailView {
+  id: string
+  name: string
+  description: string | null
+  isDefault: boolean
+  isPinned: boolean
+  isShared: boolean
+  filterGroups: unknown[]
+  sortField: string | null
+  sortDirection: 'asc' | 'desc' | null
+  organizationId: string
+  userId: string
+  createdAt: string
+  updatedAt: string
+}
+
+/** All user-scoped cache keys and their data types */
+export interface UserCacheDataMap {
+  userProfile: DehydratedUser
+  userSettings: Record<string, SettingValue> // keyed by orgId at lookup time
+  userMemberships: UserMembership[]
+  userMailViews: CachedMailView[]
+}
+
+export type UserCacheKeyName = keyof UserCacheDataMap
+
+/** Keys that require orgId as a secondary scope */
+export const ORG_SCOPED_USER_KEYS = new Set<UserCacheKeyName>(['userSettings', 'userMailViews'])
+
+/** Key configuration for user-scoped cache */
+export const USER_CACHE_KEY_CONFIG: Record<
+  UserCacheKeyName,
+  { prefix: string; ttlSeconds: number }
+> = {
+  userProfile: { prefix: 'user:profile', ttlSeconds: 600 },
+  userSettings: { prefix: 'user:settings', ttlSeconds: 600 },
+  userMemberships: { prefix: 'user:memberships', ttlSeconds: 600 },
+  userMailViews: { prefix: 'user:mail-views', ttlSeconds: 300 },
+}

--- a/packages/lib/src/cache/user-cache-service.ts
+++ b/packages/lib/src/cache/user-cache-service.ts
@@ -1,0 +1,276 @@
+// packages/lib/src/cache/user-cache-service.ts
+
+import { type Database, database as ddb } from '@auxx/database'
+import { getRedisClient, type RedisClient } from '@auxx/redis'
+import { randomUUID } from 'crypto'
+import { createScopedLogger } from '../logger'
+import { LocalCache } from './local-cache'
+import type { CacheProvider } from './org-cache-provider'
+import { PromiseMemoizer } from './promise-memoizer'
+import type { UserCacheDataMap, UserCacheKeyName } from './user-cache-keys'
+import { ORG_SCOPED_USER_KEYS, USER_CACHE_KEY_CONFIG } from './user-cache-keys'
+
+const logger = createScopedLogger('UserCache', { color: 'green' })
+
+/**
+ * User Cache Service — same multi-tier pattern as OrganizationCacheService
+ * but keyed by userId (or userId:orgId for org-scoped user data).
+ */
+export class UserCacheService {
+  private providers = new Map<UserCacheKeyName, CacheProvider<any>>()
+  private localCache = new LocalCache(100, 1000)
+  private memoizer = new PromiseMemoizer<any>()
+  private redis: RedisClient | undefined
+  private redisReady: Promise<void>
+  private db: Database
+
+  constructor(db?: Database) {
+    this.db = db ?? (ddb as Database)
+    this.redisReady = this.initRedis()
+  }
+
+  private async initRedis(): Promise<void> {
+    try {
+      this.redis = await getRedisClient(false)
+    } catch {
+      logger.warn('Redis unavailable, user cache running in local-only mode')
+    }
+  }
+
+  private async getRedis(): Promise<RedisClient | undefined> {
+    await this.redisReady
+    return this.redis
+  }
+
+  register<K extends UserCacheKeyName>(key: K, provider: CacheProvider<UserCacheDataMap[K]>): void {
+    this.providers.set(key, provider)
+  }
+
+  /** Build the scope ID based on whether the key is org-scoped */
+  private scopeId(userId: string, keyName: UserCacheKeyName, orgId?: string): string {
+    if (ORG_SCOPED_USER_KEYS.has(keyName)) {
+      if (!orgId) throw new Error(`orgId required for org-scoped user cache key: ${keyName}`)
+      return `${userId}:${orgId}`
+    }
+    return userId
+  }
+
+  private dataKey(keyName: UserCacheKeyName, scopeId: string): string {
+    return `${USER_CACHE_KEY_CONFIG[keyName].prefix}:${scopeId}:data`
+  }
+
+  private hashKey(keyName: UserCacheKeyName, scopeId: string): string {
+    return `${USER_CACHE_KEY_CONFIG[keyName].prefix}:${scopeId}:hash`
+  }
+
+  private localKey(keyName: UserCacheKeyName, scopeId: string): string {
+    return `${USER_CACHE_KEY_CONFIG[keyName].prefix}:${scopeId}`
+  }
+
+  /**
+   * Multi-key fetch for a single user.
+   * @param orgId Required for org-scoped keys (userSettings, userMailViews)
+   */
+  async getOrRecompute<K extends UserCacheKeyName[]>(
+    userId: string,
+    keys: readonly [...K],
+    orgId?: string
+  ): Promise<{ [P in K[number]]: UserCacheDataMap[P] }> {
+    const result = {} as { [P in K[number]]: UserCacheDataMap[P] }
+
+    const entries = await Promise.all(keys.map((key) => this.getSingle(userId, key, orgId)))
+
+    for (let i = 0; i < keys.length; i++) {
+      ;(result as any)[keys[i]!] = entries[i]
+    }
+
+    return result
+  }
+
+  async get<K extends UserCacheKeyName>(
+    userId: string,
+    key: K,
+    orgId?: string
+  ): Promise<UserCacheDataMap[K]> {
+    return this.getSingle(userId, key, orgId)
+  }
+
+  private async getSingle<K extends UserCacheKeyName>(
+    userId: string,
+    keyName: K,
+    orgId?: string
+  ): Promise<UserCacheDataMap[K]> {
+    const sid = this.scopeId(userId, keyName, orgId)
+    const memoKey = `${keyName}:${sid}`
+
+    return this.memoizer.memoize(memoKey, async () => {
+      const lk = this.localKey(keyName, sid)
+
+      // Stage 1: Local cache
+      const localEntry = this.localCache.get<UserCacheDataMap[K]>(lk)
+      if (localEntry) return localEntry.value
+
+      const redis = await this.getRedis()
+
+      if (redis) {
+        try {
+          // Stage 2: Redis hash check
+          const storedHash = await redis.get(this.hashKey(keyName, sid))
+
+          // Stage 3: Redis data fetch
+          if (storedHash) {
+            const rawData = await redis.get(this.dataKey(keyName, sid))
+            if (rawData) {
+              const value = JSON.parse(rawData) as UserCacheDataMap[K]
+              this.localCache.set(lk, value, storedHash)
+              return value
+            }
+          }
+        } catch (error) {
+          logger.warn(`Redis error reading ${keyName} for user ${userId}`, {
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+      }
+
+      // Stage 4: Recompute
+      return this.recompute(userId, keyName, orgId)
+    })
+  }
+
+  private async recompute<K extends UserCacheKeyName>(
+    userId: string,
+    keyName: K,
+    orgId?: string
+  ): Promise<UserCacheDataMap[K]> {
+    const provider = this.providers.get(keyName)
+    if (!provider) {
+      throw new Error(`No provider registered for user cache key: ${keyName}`)
+    }
+
+    // For user cache, compute receives userId as the "orgId" parameter
+    // Org-scoped keys pass orgId as well (via a combined ID)
+    const computeId = orgId ? `${userId}:${orgId}` : userId
+    const value = await provider.compute(computeId, this.db)
+
+    const sid = this.scopeId(userId, keyName, orgId)
+    await this.writeBack(sid, keyName, value)
+
+    return value
+  }
+
+  private async writeBack<K extends UserCacheKeyName>(
+    scopeId: string,
+    keyName: K,
+    value: UserCacheDataMap[K]
+  ): Promise<void> {
+    const hash = randomUUID()
+    const config = USER_CACHE_KEY_CONFIG[keyName]
+    const lk = this.localKey(keyName, scopeId)
+
+    this.localCache.set(lk, value, hash)
+
+    const redis = await this.getRedis()
+    if (redis) {
+      try {
+        const pipeline = redis.pipeline()
+        pipeline.set(this.hashKey(keyName, scopeId), hash)
+        pipeline.expire(this.hashKey(keyName, scopeId), config.ttlSeconds)
+        pipeline.set(this.dataKey(keyName, scopeId), JSON.stringify(value))
+        pipeline.expire(this.dataKey(keyName, scopeId), config.ttlSeconds)
+        await pipeline.exec()
+      } catch (error) {
+        logger.warn(`Redis write error for ${keyName}:${scopeId}`, {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+  }
+
+  /**
+   * Invalidate and recompute specific keys for a user.
+   */
+  async invalidateAndRecompute(
+    userId: string,
+    keys: readonly UserCacheKeyName[],
+    orgId?: string
+  ): Promise<void> {
+    const redis = await this.getRedis()
+
+    await Promise.all(
+      keys.map(async (keyName) => {
+        const sid = this.scopeId(userId, keyName, orgId)
+        const lk = this.localKey(keyName, sid)
+
+        this.localCache.delete(lk)
+
+        if (redis) {
+          try {
+            await redis.del(this.dataKey(keyName, sid))
+            await redis.del(this.hashKey(keyName, sid))
+          } catch {
+            // Ignore
+          }
+        }
+
+        if (this.providers.has(keyName)) {
+          try {
+            await this.recompute(userId, keyName, orgId)
+          } catch (error) {
+            logger.warn(`Recompute failed for ${keyName}:${userId}`, {
+              error: error instanceof Error ? error.message : String(error),
+            })
+          }
+        }
+      })
+    )
+  }
+
+  /** Flush all keys for a user */
+  async invalidateUser(userId: string): Promise<void> {
+    const allKeys = Object.keys(USER_CACHE_KEY_CONFIG) as UserCacheKeyName[]
+    const redis = await this.getRedis()
+
+    for (const keyName of allKeys) {
+      // For non-org-scoped keys, flush directly
+      if (!ORG_SCOPED_USER_KEYS.has(keyName)) {
+        const sid = userId
+        this.localCache.delete(this.localKey(keyName, sid))
+        if (redis) {
+          try {
+            await redis.del(this.dataKey(keyName, sid))
+            await redis.del(this.hashKey(keyName, sid))
+          } catch {
+            // Ignore
+          }
+        }
+      }
+    }
+
+    // For org-scoped keys, clear by prefix from local cache
+    for (const keyName of ORG_SCOPED_USER_KEYS) {
+      const prefix = `${USER_CACHE_KEY_CONFIG[keyName].prefix}:${userId}`
+      this.localCache.deleteByPrefix(prefix)
+      // Note: Redis org-scoped keys can't be efficiently cleared without SCAN.
+      // They will expire naturally via TTL.
+    }
+  }
+
+  /** Flush org-scoped keys for a user in a specific org */
+  async invalidateUserForOrg(userId: string, orgId: string): Promise<void> {
+    const redis = await this.getRedis()
+
+    for (const keyName of ORG_SCOPED_USER_KEYS) {
+      const sid = `${userId}:${orgId}`
+      this.localCache.delete(this.localKey(keyName, sid))
+      if (redis) {
+        try {
+          await redis.del(this.dataKey(keyName, sid))
+          await redis.del(this.hashKey(keyName, sid))
+        } catch {
+          // Ignore
+        }
+      }
+    }
+  }
+}

--- a/packages/lib/src/dehydration/service.ts
+++ b/packages/lib/src/dehydration/service.ts
@@ -2,24 +2,11 @@
 
 import { API_URL, DEV_PORTAL_URL, DOCS_URL, HOMEPAGE_URL, WEBAPP_URL } from '@auxx/config/client'
 import { configService } from '@auxx/credentials'
-import { type Database, database as ddb, schema } from '@auxx/database'
 import { getDeploymentMode } from '@auxx/deployment'
 import { execSync } from 'child_process'
-import { count, eq } from 'drizzle-orm'
-import { PromiseMemoizer } from '../cache/promise-memoizer'
-import { MediaAssetService } from '../files'
-import { createScopedLogger } from '../logger'
-import { FeaturePermissionService, OverageDetectionService } from '../permissions'
-import { SETTINGS_CATALOG, SettingsService } from '../settings'
-import { DehydrationCacheService } from './cache'
-import type {
-  DehydratedEnvironment,
-  DehydratedOrganization,
-  DehydratedState,
-  DehydratedUser,
-} from './types'
-
-const logger = createScopedLogger('DehydrationService', { color: 'blue' })
+import { getOrgCache, getUserCache } from '../cache'
+import { SETTINGS_CATALOG } from '../settings'
+import type { DehydratedEnvironment, DehydratedOrganization, DehydratedState } from './types'
 
 /** Cached local git info so we only shell out once per process */
 let cachedGitInfo: { sha: string; branch: string } | null = null
@@ -83,286 +70,81 @@ export function buildEnvironment(): DehydratedEnvironment {
 }
 
 /**
- * Service for generating dehydrated state on the server
- * Aggregates user, organization, subscription, and feature data
+ * Service for generating dehydrated state on the server.
+ * Now assembles state from individual org/user cache reads instead of
+ * a monolithic fetch-everything approach.
  */
 export class DehydrationService {
-  private cache: DehydrationCacheService
-  private db: Database
-  private memoizer = new PromiseMemoizer<DehydratedState>()
-
-  constructor(db?: unknown) {
-    this.db = db && typeof (db as any).select === 'function' ? (db as Database) : (ddb as Database)
-    this.cache = new DehydrationCacheService()
-  }
+  private orgCache = getOrgCache()
+  private userCache = getUserCache()
 
   /**
-   * Get complete dehydrated state for a user
-   * Uses cache with fallback to database.
-   * Concurrent requests for the same user share a single in-flight fetch.
-   * @param userId - User ID
-   * @returns Complete dehydrated state
+   * Get complete dehydrated state for a user.
+   * Reads from individual caches — no direct DB queries.
    */
   async getState(userId: string): Promise<DehydratedState> {
-    return this.memoizer.memoize(`user:${userId}`, async () => {
-      // Try cache first
-      const cached = await this.cache.getState(userId)
-      if (cached) {
-        logger.debug(`Cache hit for user ${userId}`)
-        return cached
-      }
-
-      logger.debug(`Cache miss for user ${userId}, fetching fresh data`)
-
-      // Fetch fresh data
-      const state = await this.fetchState(userId)
-
-      // Cache it
-      await this.cache.setState(userId, state)
-
-      return state
-    })
-  }
-
-  /**
-   * Fetch fresh state from database
-   * @private
-   */
-  private async fetchState(userId: string): Promise<DehydratedState> {
     // Ensure ConfigService is initialized (SST Resource + DB cache)
     await configService.init()
 
-    // Fetch user with memberships
-    const user = await this.fetchUser(userId)
+    // 1. Fetch user-level data (single call, multi-key)
+    const { userProfile, userMemberships } = await this.userCache.getOrRecompute(userId, [
+      'userProfile',
+      'userMemberships',
+    ])
 
-    // Fetch all organizations user is member of
-    const organizations = await this.fetchOrganizations(userId)
+    // 2. Fetch per-org data in parallel
+    const orgIds = userMemberships.map((m) => m.organizationId)
+    const organizations = await Promise.all(
+      orgIds.map((orgId) => this.assembleOrganization(userId, orgId))
+    )
 
-    // Build environment config
-    const environment = this.buildEnvironment()
-
+    // 3. Assemble (pure function, no DB calls)
     return {
-      user,
-      organizationId: user.defaultOrganizationId,
+      user: userProfile,
+      organizationId: userProfile.defaultOrganizationId,
       organizations,
       settingsCatalog: SETTINGS_CATALOG,
-      environment,
+      environment: buildEnvironment(),
       timestamp: Date.now(),
     }
   }
 
   /**
-   * Fetch user data with memberships and avatar
-   * @private
+   * Assemble a single organization's dehydrated state from cache reads.
    */
-  private async fetchUser(userId: string): Promise<DehydratedUser> {
-    // Fetch user
-    const [user] = await this.db
-      .select()
-      .from(schema.User)
-      .where(eq(schema.User.id, userId))
-      .limit(1)
-
-    if (!user) {
-      throw new Error(`User not found: ${userId}`)
-    }
-
-    // Fetch memberships
-    const memberships = await this.db
-      .select({
-        id: schema.OrganizationMember.id,
-        userId: schema.OrganizationMember.userId,
-        organizationId: schema.OrganizationMember.organizationId,
-        role: schema.OrganizationMember.role,
-        status: schema.OrganizationMember.status,
-      })
-      .from(schema.OrganizationMember)
-      .where(eq(schema.OrganizationMember.userId, userId))
-
-    // Fetch avatar URL if available
-    let avatarUrl: string | null = null
-    if (user.avatarAssetId && user.defaultOrganizationId) {
-      const mediaAssetService = new MediaAssetService(user.defaultOrganizationId, userId, this.db)
-      try {
-        avatarUrl = await mediaAssetService.getDownloadUrl(user.avatarAssetId)
-      } catch (error) {
-        logger.warn(`Failed to fetch avatar URL for user ${userId}`, {
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
-    }
-
-    // Fetch user's authentication providers (same logic as customSession)
-    const accounts = await this.db
-      .select({ providerId: schema.account.providerId })
-      .from(schema.account)
-      .where(eq(schema.account.userId, userId))
-
-    const providerIds = accounts.map((a) => a.providerId)
-    const hasPassword = providerIds.includes('credential')
-    const oauthProviders = providerIds.filter((p) => p !== 'credential')
-
-    // Determine registration method
-    const authMethodCount =
-      (hasPassword ? 1 : 0) +
-      (oauthProviders.length > 0 ? 1 : 0) +
-      (user.phoneNumberVerified ? 1 : 0)
-
-    let registrationMethod: 'oauth' | 'email' | 'phone' | 'mixed' = 'oauth'
-
-    if (authMethodCount > 1) {
-      registrationMethod = 'mixed'
-    } else if (hasPassword) {
-      registrationMethod = 'email'
-    } else if (user.phoneNumberVerified) {
-      registrationMethod = 'phone'
-    }
-
-    return {
-      id: user.id,
-      name: user.name,
-      email: user.email,
-      emailVerified: user.emailVerified,
-      image: avatarUrl,
-      firstName: user.firstName,
-      lastName: user.lastName,
-      phoneNumber: user.phoneNumber,
-      phoneNumberVerified: user.phoneNumberVerified,
-      completedOnboarding: user.completedOnboarding,
-      defaultOrganizationId: user.defaultOrganizationId,
-      lastLoginAt: user.lastLoginAt,
-      preferredTimezone: user.preferredTimezone,
-      providers: oauthProviders,
-      hasPassword,
-      isSuperAdmin: user.isSuperAdmin,
-      registrationMethod,
-      memberships: memberships.map((m) => ({
-        id: m.id,
-        userId: m.userId,
-        organizationId: m.organizationId,
-        role: m.role,
-        status: m.status,
-      })),
-    }
-  }
-
-  /**
-   * Fetch all organizations for a user with subscriptions, features, and settings
-   * @private
-   */
-  private async fetchOrganizations(userId: string): Promise<DehydratedOrganization[]> {
-    // Get all organization IDs from memberships
-    const memberships = await this.db
-      .select({ organizationId: schema.OrganizationMember.organizationId })
-      .from(schema.OrganizationMember)
-      .where(eq(schema.OrganizationMember.userId, userId))
-
-    const organizationIds = memberships.map((m) => m.organizationId)
-
-    // Fetch each organization with all its data
-    const organizations = await Promise.all(
-      organizationIds.map((orgId) => this.fetchOrganization(userId, orgId))
-    )
-
-    return organizations
-  }
-
-  /**
-   * Fetch a single organization with all related data
-   * @private
-   */
-  private async fetchOrganization(
+  private async assembleOrganization(
     userId: string,
-    organizationId: string
+    orgId: string
   ): Promise<DehydratedOrganization> {
-    // Fetch organization
-    const [org] = await this.db
-      .select()
-      .from(schema.Organization)
-      .where(eq(schema.Organization.id, organizationId))
-      .limit(1)
+    const [orgData, userData] = await Promise.all([
+      // Org-scoped: features, subscription, profile, overages, integrationProviders
+      this.orgCache.getOrRecompute(orgId, [
+        'features',
+        'subscription',
+        'orgProfile',
+        'overages',
+        'integrationProviders',
+      ]),
+      // User+org-scoped: settings
+      this.userCache.getOrRecompute(userId, ['userSettings'], orgId),
+    ])
 
-    if (!org) {
-      throw new Error(`Organization not found: ${organizationId}`)
-    }
-
-    // Fetch subscription
-    const [subscription] = await this.db
-      .select()
-      .from(schema.PlanSubscription)
-      .where(eq(schema.PlanSubscription.organizationId, organizationId))
-      .limit(1)
-
-    // Fetch features
-    const featureService = new FeaturePermissionService(this.db)
-    const features = (await featureService.getOrganizationFeaturesMap(organizationId)) || {}
-
-    // Fetch user settings for this org
-    const settingsService = new SettingsService(this.db)
-    const settings = await settingsService.getAllUserSettings({ userId, organizationId })
-
-    // Check for integrations
-    const [{ integrationCount }] = await this.db
-      .select({ integrationCount: count() })
-      .from(schema.Integration)
-      .where(eq(schema.Integration.organizationId, organizationId))
-    const hasIntegrations = integrationCount > 0
-
-    // Detect overages against current plan (only for cloud with active subscriptions)
-    let overages: Array<{
-      key: string
-      label: string
-      current: number
-      limit: number
-      excess: number
-    }> = []
-    if (subscription?.planId) {
-      try {
-        const overageService = new OverageDetectionService(this.db)
-        overages = await overageService.detectCurrentOverages(organizationId)
-      } catch (error) {
-        logger.warn('Failed to detect overages for dehydration', {
-          organizationId,
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
-    }
+    const { features, subscription, orgProfile, overages, integrationProviders } = orgData
+    const hasIntegrations = Object.keys(integrationProviders).length > 0
 
     return {
-      id: org.id,
-      name: org.name,
-      website: org.website,
-      emailDomain: org.emailDomain,
-      handle: org.handle,
-      about: org.about,
-      createdAt: org.createdAt.toISOString(),
-      completedOnboarding: org.completedOnboarding ?? false,
-      subscription: subscription
-        ? {
-            id: subscription.id,
-            status: subscription.status,
-            plan: subscription.plan,
-            planId: subscription.planId,
-            seats: subscription.seats,
-            billingCycle: subscription.billingCycle,
-            periodStart: subscription.periodStart?.toISOString() ?? null,
-            periodEnd: subscription.periodEnd?.toISOString() ?? null,
-            cancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
-            canceledAt: subscription.canceledAt?.toISOString() ?? null,
-            trialStart: subscription.trialStart?.toISOString() ?? null,
-            trialEnd: subscription.trialEnd?.toISOString() ?? null,
-            hasTrialEnded: subscription.hasTrialEnded,
-            isEligibleForTrial: subscription.isEligibleForTrial,
-            scheduledPlanId: subscription.scheduledPlanId,
-            scheduledPlan: subscription.scheduledPlan,
-            scheduledBillingCycle: subscription.scheduledBillingCycle,
-            scheduledSeats: subscription.scheduledSeats,
-            scheduledChangeAt: subscription.scheduledChangeAt?.toISOString() ?? null,
-          }
-        : null,
-      features,
+      id: orgProfile.id,
+      name: orgProfile.name,
+      website: orgProfile.website,
+      emailDomain: orgProfile.emailDomain,
+      handle: orgProfile.handle,
+      about: orgProfile.about,
+      createdAt: orgProfile.createdAt,
+      completedOnboarding: orgProfile.completedOnboarding,
+      subscription,
+      features: features ?? {},
       overages,
-      settings,
+      settings: userData.userSettings,
       hasIntegrations,
     }
   }
@@ -379,68 +161,41 @@ export class DehydrationService {
       organizationId: null,
       organizations: [],
       settingsCatalog: {},
-      environment: this.buildEnvironment(),
+      environment: buildEnvironment(),
       timestamp: Date.now(),
     }
   }
 
   /**
-   * Build environment configuration from env vars and build info
-   * @private — delegates to the standalone buildEnvironment() function
+   * Temporary compat — invalidate + eager recompute for a single user.
+   * Callers should eventually use specific onCacheEvent() calls.
    */
-  private buildEnvironment(): DehydratedEnvironment {
-    return buildEnvironment()
-  }
-
-  /**
-   * Invalidate cache for a specific user
-   */
-  async invalidateUser(userId: string): Promise<void> {
-    await this.cache.invalidateUser(userId)
-  }
-
-  /**
-   * Invalidate cache for all users in an organization
-   */
-  async invalidateOrganization(organizationId: string): Promise<void> {
-    await this.cache.invalidateOrganization(organizationId)
-  }
-
-  /**
-   * Invalidate all members of an organization
-   */
-  async invalidateOrganizationMembers(organizationId: string): Promise<void> {
-    const members = await this.db
-      .select({ userId: schema.OrganizationMember.userId })
-      .from(schema.OrganizationMember)
-      .where(eq(schema.OrganizationMember.organizationId, organizationId))
-
-    await Promise.all(members.map((m) => this.cache.invalidateUser(m.userId)))
-  }
-
-  /**
-   * RULE: Any tRPC mutation that modifies data returned by fetchState() MUST
-   * call refreshUser() or refreshOrganization() before returning.
-   *
-   * Dehydrated state includes: User (profile, auth, memberships), Organization
-   * (name, handle, website, completedOnboarding), PlanSubscription (all fields),
-   * feature permissions, user settings, Integration count (hasIntegrations).
-   */
-
-  /** Invalidate + eager recompute for a single user */
   async refreshUser(userId: string): Promise<void> {
-    await this.cache.invalidateUser(userId)
-    try {
-      const state = await this.fetchState(userId)
-      await this.cache.setState(userId, state)
-    } catch {
-      // Eager recompute failed — next read will rebuild from DB
-    }
+    await this.userCache.invalidateUser(userId)
   }
 
-  /** Invalidate all members of an org (org-visible data changed) */
+  /**
+   * Temporary compat — invalidate all org keys.
+   * Callers should eventually use specific onCacheEvent() calls.
+   */
   async refreshOrganization(organizationId: string): Promise<void> {
-    await this.cache.invalidateOrganization(organizationId)
-    // Eager recompute is per-user; just invalidate. Next read per user rebuilds.
+    await this.orgCache.flush(organizationId)
+  }
+
+  /** @deprecated Use onCacheEvent() instead */
+  async invalidateUser(userId: string): Promise<void> {
+    await this.userCache.invalidateUser(userId)
+  }
+
+  /** @deprecated Use onCacheEvent() instead */
+  async invalidateOrganization(organizationId: string): Promise<void> {
+    await this.orgCache.flush(organizationId)
+  }
+
+  /** @deprecated Use onCacheEvent() with member events instead */
+  async invalidateOrganizationMembers(organizationId: string): Promise<void> {
+    // Fetch members from cache and invalidate each user
+    const { members } = await this.orgCache.getOrRecompute(organizationId, ['members'])
+    await Promise.all(members.map((m) => this.userCache.invalidateUser(m.userId)))
   }
 }

--- a/packages/lib/src/groups/permissions.ts
+++ b/packages/lib/src/groups/permissions.ts
@@ -1,20 +1,21 @@
 // packages/lib/src/groups/permissions.ts
 
-import { schema } from '@auxx/database'
 import { ResourcePermission } from '@auxx/database/enums'
 import type { GroupContext } from '@auxx/types/groups'
 import { toRecordId } from '@auxx/types/resource'
-import { and, eq } from 'drizzle-orm'
+import { getOrgCache } from '../cache'
 import { ForbiddenError } from '../errors'
 import { checkAccess, hasPermission as resourceHasPermission } from '../resource-access'
-import { ResourceRegistryService } from '../resources/registry'
 
 /**
- * Get the entity_group entityDefinitionId using efficient cached resolution
+ * Get the entity_group entityDefinitionId using cached entity defs
  */
 async function getGroupEntityDefId(ctx: GroupContext): Promise<string> {
-  const registry = new ResourceRegistryService(ctx.organizationId, ctx.db)
-  return registry.resolveEntityDefId('entity_group')
+  const { entityDefs } = await getOrgCache().getOrRecompute(ctx.organizationId, ['entityDefs'])
+  const defId = entityDefs.entity_group
+  if (!defId)
+    throw new Error(`entity_group EntityDefinition not found for org ${ctx.organizationId}`)
+  return defId
 }
 
 /**
@@ -27,20 +28,15 @@ export async function getGroupPermission(
 ): Promise<ResourcePermission | null> {
   const { db, userId, organizationId } = ctx
 
-  // Check org role first (owners/admins get admin)
-  const member = await db.query.OrganizationMember.findFirst({
-    where: and(
-      eq(schema.OrganizationMember.userId, userId),
-      eq(schema.OrganizationMember.organizationId, organizationId)
-    ),
-    columns: { role: true },
-  })
+  // Check org role from cache (no DB query)
+  const { memberRoleMap } = await getOrgCache().getOrRecompute(organizationId, ['memberRoleMap'])
+  const role = memberRoleMap[userId]
 
-  if (member && ['OWNER', 'ADMIN'].includes(member.role)) {
+  if (role === 'OWNER' || role === 'ADMIN') {
     return ResourcePermission.admin
   }
 
-  // Get entity_group entityDefinitionId (cached for 30 days)
+  // Get entity_group entityDefinitionId (cached)
   const entityDefinitionId = await getGroupEntityDefId(ctx)
 
   // Check ResourceAccess
@@ -65,20 +61,15 @@ export async function hasGroupPermission(
 ): Promise<boolean> {
   const { db, organizationId, userId } = ctx
 
-  // Check org role first (owners/admins have admin)
-  const member = await db.query.OrganizationMember.findFirst({
-    where: and(
-      eq(schema.OrganizationMember.userId, userId),
-      eq(schema.OrganizationMember.organizationId, organizationId)
-    ),
-    columns: { role: true },
-  })
+  // Check org role from cache (no DB query)
+  const { memberRoleMap } = await getOrgCache().getOrRecompute(organizationId, ['memberRoleMap'])
+  const role = memberRoleMap[userId]
 
-  if (member && ['OWNER', 'ADMIN'].includes(member.role)) {
+  if (role === 'OWNER' || role === 'ADMIN') {
     return true // Admin satisfies any permission
   }
 
-  // Get entity_group entityDefinitionId (cached for 30 days)
+  // Get entity_group entityDefinitionId (cached)
   const entityDefinitionId = await getGroupEntityDefId(ctx)
 
   // Use ResourceAccess hasPermission

--- a/packages/lib/src/members/member-queries.ts
+++ b/packages/lib/src/members/member-queries.ts
@@ -3,40 +3,46 @@
 import { type Database, database as defaultDb, schema } from '@auxx/database'
 import type { OrganizationMemberInfo } from '@auxx/database/types'
 import { and, eq } from 'drizzle-orm'
+import { getOrgCache } from '../cache'
 
-/** Find membership for a user within an organization */
+/** Find membership for a user within an organization (uses org cache) */
 export async function findMemberByUser(
   organizationId: string,
   userId: string,
-  db: Database = defaultDb
+  db?: Database
 ): Promise<OrganizationMemberInfo | null> {
-  const [row] = await db
-    .select({
-      id: schema.OrganizationMember.id,
-      userId: schema.OrganizationMember.userId,
-      organizationId: schema.OrganizationMember.organizationId,
-      role: schema.OrganizationMember.role,
-      status: schema.OrganizationMember.status,
-    })
-    .from(schema.OrganizationMember)
-    .where(
-      and(
-        eq(schema.OrganizationMember.organizationId, organizationId),
-        eq(schema.OrganizationMember.userId, userId)
-      )
-    )
-    .limit(1)
-  return (row as OrganizationMemberInfo) ?? null
+  // If a specific db instance is passed (e.g. inside a transaction), query directly
+  if (db && db !== defaultDb) {
+    return findMemberByUserDirect(organizationId, userId, db)
+  }
+
+  const { members } = await getOrgCache().getOrRecompute(organizationId, ['members'])
+  const member = members.find((m) => m.userId === userId)
+  if (!member) return null
+  return {
+    id: member.id,
+    userId: member.userId,
+    organizationId: member.organizationId,
+    role: member.role,
+    status: member.status,
+  }
 }
 
-/** Check if a user is OWNER or ADMIN within an organization */
+/** Check if a user is OWNER or ADMIN within an organization (uses org cache) */
 export async function isAdminOrOwner(
   organizationId: string,
   userId: string,
-  db: Database = defaultDb
+  db?: Database
 ): Promise<boolean> {
-  const member = await findMemberByUser(organizationId, userId, db)
-  return member?.role === 'OWNER' || member?.role === 'ADMIN'
+  // If a specific db instance is passed (e.g. inside a transaction), query directly
+  if (db && db !== defaultDb) {
+    const member = await findMemberByUserDirect(organizationId, userId, db)
+    return member?.role === 'OWNER' || member?.role === 'ADMIN'
+  }
+
+  const { memberRoleMap } = await getOrgCache().getOrRecompute(organizationId, ['memberRoleMap'])
+  const role = memberRoleMap[userId]
+  return role === 'OWNER' || role === 'ADMIN'
 }
 
 /** List members with basic user info, optionally filtered by name/email */
@@ -81,4 +87,29 @@ export async function listMembersWithUser(
       (r.user?.name || '').toLowerCase().includes(needle) ||
       (r.user?.email || '').toLowerCase().includes(needle)
   ) as any
+}
+
+/** Direct DB query — used inside transactions where cache reads are unsafe */
+async function findMemberByUserDirect(
+  organizationId: string,
+  userId: string,
+  db: Database
+): Promise<OrganizationMemberInfo | null> {
+  const [row] = await db
+    .select({
+      id: schema.OrganizationMember.id,
+      userId: schema.OrganizationMember.userId,
+      organizationId: schema.OrganizationMember.organizationId,
+      role: schema.OrganizationMember.role,
+      status: schema.OrganizationMember.status,
+    })
+    .from(schema.OrganizationMember)
+    .where(
+      and(
+        eq(schema.OrganizationMember.organizationId, organizationId),
+        eq(schema.OrganizationMember.userId, userId)
+      )
+    )
+    .limit(1)
+  return (row as OrganizationMemberInfo) ?? null
 }

--- a/packages/lib/src/members/member-service.ts
+++ b/packages/lib/src/members/member-service.ts
@@ -14,6 +14,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import crypto from 'crypto'
 import { and, asc, count, eq, gt, ilike, sql } from 'drizzle-orm'
+import { getOrgCache } from '../cache'
 import { publisher } from '../events'
 import { enqueueEmailJob } from '../jobs/email'
 import { FeaturePermissionService } from '../permissions/feature-permission-service'
@@ -95,24 +96,23 @@ export class MemberService {
   /**
    * Static version: Checks if a user is a member of the specified organization.
    */
-  static async isMember(
-    userId: string,
-    organizationId: string,
-    db: Database = database
-  ): Promise<boolean> {
-    const membership = await MemberService.getMembership(userId, organizationId, db)
-    if (!membership) {
-      return false
+  static async isMember(userId: string, organizationId: string, db?: Database): Promise<boolean> {
+    // If a specific db instance is passed (e.g. inside a transaction), query directly
+    if (db && db !== database) {
+      const membership = await MemberService.getMembership(userId, organizationId, db)
+      if (!membership) return false
+      const [user] = await db
+        .select({ userType: schema.User.userType })
+        .from(schema.User)
+        .where(eq(schema.User.id, userId))
+        .limit(1)
+      return user?.userType === 'USER'
     }
 
-    // Additional check for user type - need to query user table
-    const [user] = await db
-      .select({ userType: schema.User.userType })
-      .from(schema.User)
-      .where(eq(schema.User.id, userId))
-      .limit(1)
-
-    return user?.userType === 'USER'
+    // Use org cache — zero DB queries
+    const { members } = await getOrgCache().getOrRecompute(organizationId, ['members'])
+    const member = members.find((m) => m.userId === userId)
+    return !!member && member.user?.userType === 'USER'
   }
 
   // --- Core Member Operations ---
@@ -826,8 +826,8 @@ export class MemberService {
 
     // 5. Cache Invalidation
     try {
-      await featureService.invalidateCache(organizationId)
-      // Invalidate other relevant caches (e.g., member lists) if necessary
+      const { onCacheEvent } = await import('../cache')
+      await onCacheEvent('member.removed', { orgId: organizationId })
       logger.info('Helper: Relevant caches invalidated.', { organizationId })
     } catch (cacheError) {
       logger.warn('Helper: Failed to invalidate cache.', { organizationId, error: cacheError })

--- a/packages/lib/src/permissions/feature-permission-service.ts
+++ b/packages/lib/src/permissions/feature-permission-service.ts
@@ -1,209 +1,42 @@
 // packages/lib/src/permissions/feature-permission-service.ts
-import { type Database, database as ddb, schema } from '@auxx/database'
+
 import { isSelfHosted } from '@auxx/deployment'
-import { getRedisClient } from '@auxx/redis'
-import { eq } from 'drizzle-orm'
+import { getOrgCache, onCacheEvent } from '../cache'
 import { ForbiddenError } from '../errors'
-import { createScopedLogger } from '../logger'
-import type { FeatureDefinition, FeatureLimit, FeatureMapObject } from './types'
-import { DEFAULT_FREE_PLAN_FEATURES, FEATURE_REGISTRY_MAP, FeatureKey } from './types'
+import type { FeatureLimit, FeatureMapObject } from './types'
+import { FEATURE_REGISTRY_MAP, FeatureKey } from './types'
 
-const logger = createScopedLogger('feature-permission-service')
-
-// Define a type for the parsed feature map
 export type FeatureMap = Map<string, FeatureLimit>
 
-const mapToObject = (map: Map<string, FeatureLimit> | null): FeatureMapObject => {
-  if (!map) return null
-  const obj: Record<string, FeatureLimit> = {}
-  map.forEach((value, key) => {
-    obj[key] = value
-  })
-  return obj
-}
-
 export class FeaturePermissionService {
-  /** Injected Drizzle database connection */
-  private db: Database
-  private cachePrefix = 'feature-perms:'
-  private cacheTTL = 3600 // 1 hour in seconds
+  // biome-ignore lint/complexity/noUselessConstructor: backward compat — callers pass db
+  constructor(_db?: unknown) {}
 
-  constructor(db?: unknown) {
-    // Accept either an injected Drizzle db or fall back to the default singleton
-    this.db = db && typeof (db as any).select === 'function' ? (db as Database) : (ddb as Database)
+  async getOrganizationFeaturesMap(organizationId: string): Promise<FeatureMapObject | null> {
+    if (isSelfHosted()) return this.createUnlimitedFeaturesObject()
+
+    const { features } = await getOrgCache().getOrRecompute(organizationId, ['features'])
+    return features
   }
 
-  async getOrganizationFeaturesMap(organizationId: string): Promise<FeatureMap | null> {
-    if (isSelfHosted()) return mapToObject(this.createUnlimitedFeatureMap())
-    const features = await this.getOrganizationFeatures(organizationId)
-    if (!features) return null
-    return mapToObject(features)
-  }
-
-  /**
-   * Gets the feature map (key -> limit) for a given organization.
-   * Uses Redis caching with fallback to database.
-   * @param organizationId The ID of the organization.
-   * @returns A Map of feature keys to their limits, or null if an error occurs.
-   */
   async getOrganizationFeatures(organizationId: string): Promise<FeatureMap | null> {
     if (isSelfHosted()) return this.createUnlimitedFeatureMap()
 
-    const cacheKey = `${this.cachePrefix}${organizationId}`
-
-    try {
-      // Get Redis client (non-required, won't fail if Redis unavailable)
-      const redis = await getRedisClient(false)
-
-      // 1. Check cache if Redis is available
-      if (redis) {
-        try {
-          const cachedData = await redis.get(cacheKey)
-          if (cachedData) {
-            logger.debug(`Cache hit for organization ${organizationId}`)
-            const parsedMap = new Map(Object.entries(JSON.parse(cachedData))) as FeatureMap
-            return parsedMap
-          }
-          logger.debug(`Cache miss for organization ${organizationId}`)
-        } catch (error) {
-          logger.warn('Redis error when fetching cached features', {
-            organizationId,
-            error: (error as Error).message,
-          })
-          // Continue to DB lookup on Redis error
-        }
-      }
-
-      // 2. Fetch from DB on cache miss or Redis unavailable (Drizzle)
-      const [subscription] = await this.db
-        .select({
-          status: schema.PlanSubscription.status,
-          hasTrialEnded: schema.PlanSubscription.hasTrialEnded,
-          planId: schema.PlanSubscription.planId,
-          customFeatureLimits: schema.PlanSubscription.customFeatureLimits,
-        })
-        .from(schema.PlanSubscription)
-        .where(eq(schema.PlanSubscription.organizationId, organizationId))
-        .limit(1)
-
-      let featureDefinitions: FeatureDefinition[] = DEFAULT_FREE_PLAN_FEATURES // Default to free plan
-
-      if (subscription?.planId) {
-        const [plan] = await this.db
-          .select({
-            featureLimits: schema.Plan.featureLimits,
-            trialFeatureLimits: schema.Plan.trialFeatureLimits,
-          })
-          .from(schema.Plan)
-          .where(eq(schema.Plan.id, subscription.planId))
-          .limit(1)
-
-        if (subscription.status === 'trialing' && !subscription.hasTrialEnded) {
-          logger.info(`Using trial plan features for org ${organizationId}`)
-          // Prefer trial-specific limits, fall back to regular limits
-          const trialSource = plan?.trialFeatureLimits ?? plan?.featureLimits
-          featureDefinitions = this.parseFeaturesFromJson(trialSource)
-        } else if (subscription.status === 'active') {
-          logger.info(`Using active plan features for org ${organizationId}`)
-          featureDefinitions = this.parseFeaturesFromJson(plan?.featureLimits)
-        } else {
-          logger.warn(
-            `Subscription for org ${organizationId} is not active or trialing (status: ${subscription.status}). Falling back to default.`
-          )
-          // Fallback to default if status is CANCELED, PAST_DUE etc.
-        }
-      } else {
-        logger.info(
-          `No active subscription found for org ${organizationId}. Using default free features.`
-        )
-      }
-
-      // 3. Convert definitions to Map
-      const featureMap = this.createMapFromDefinitions(featureDefinitions)
-
-      // 4. Apply custom feature limits if present (for Enterprise customers)
-      if (subscription?.customFeatureLimits) {
-        try {
-          const customLimits =
-            typeof subscription.customFeatureLimits === 'string'
-              ? JSON.parse(subscription.customFeatureLimits)
-              : subscription.customFeatureLimits
-
-          if (customLimits && typeof customLimits === 'object') {
-            logger.info(`Applying custom feature limits for org ${organizationId}`)
-            Object.entries(customLimits).forEach(([key, limit]) => {
-              if (typeof limit === 'number') {
-                // Convert -1 to '+' for unlimited, otherwise use the number
-                featureMap.set(key, limit === -1 ? '+' : limit)
-              } else if (typeof limit === 'boolean') {
-                featureMap.set(key, limit)
-              }
-            })
-          }
-        } catch (error) {
-          logger.warn('Failed to parse custom feature limits', {
-            organizationId,
-            error: (error as Error).message,
-          })
-        }
-      }
-
-      // 5. Store in cache if Redis is available
-      if (redis) {
-        try {
-          // Use Map -> Object -> JSON string for storage
-          await redis.set(
-            cacheKey,
-            JSON.stringify(Object.fromEntries(featureMap)),
-            'EX',
-            this.cacheTTL
-          )
-          logger.debug(`Stored features in cache for organization ${organizationId}`)
-        } catch (error) {
-          logger.warn('Redis error when storing features', {
-            organizationId,
-            error: (error as Error).message,
-          })
-          // Continue even if caching fails
-        }
-      }
-
-      return featureMap
-    } catch (error) {
-      logger.error('Error fetching organization features', {
-        organizationId,
-        error: (error as Error).message,
-      })
-      return null // Return null on error to indicate failure
-    }
+    const { features } = await getOrgCache().getOrRecompute(organizationId, ['features'])
+    if (!features) return null
+    return new Map(Object.entries(features))
   }
 
-  /**
-   * Checks if an organization has access to a specific feature.
-   * @param organizationId The organization ID.
-   * @param featureKey The feature key (enum or string).
-   * @returns True if access is granted, false otherwise.
-   */
   async hasAccess(organizationId: string, featureKey: FeatureKey | string): Promise<boolean> {
     if (isSelfHosted()) return true
     const features = await this.getOrganizationFeatures(organizationId)
-    if (!features) return false // Default to no access on error
+    if (!features) return false
 
     const limit = features.get(featureKey)
-
-    if (limit === undefined || limit === false || limit === 0) {
-      return false
-    }
-    // Access granted if true, '+', or a number > 0
+    if (limit === undefined || limit === false || limit === 0) return false
     return true
   }
 
-  /**
-   * Gets the limit for a specific feature for an organization.
-   * @param organizationId The organization ID.
-   * @param featureKey The feature key (enum or string).
-   * @returns The limit ('+', number, true) or null if no access or error.
-   */
   async getLimit(
     organizationId: string,
     featureKey: FeatureKey | string
@@ -213,22 +46,10 @@ export class FeaturePermissionService {
     if (!features) return null
 
     const limit = features.get(featureKey)
-
-    // Return null if feature doesn't exist, is explicitly false, or limit is 0
-    if (limit === undefined || limit === false || limit === 0) {
-      return null
-    }
-
+    if (limit === undefined || limit === false || limit === 0) return null
     return limit
   }
 
-  /**
-   * Checks if the current usage is within the allowed limit for a feature.
-   * @param organizationId The organization ID.
-   * @param featureKey The feature key (enum or string).
-   * @param currentUsage The current number of items used for this feature.
-   * @returns True if usage is within limits, false otherwise.
-   */
   async checkLimit(
     organizationId: string,
     featureKey: FeatureKey | string,
@@ -237,33 +58,15 @@ export class FeaturePermissionService {
     if (isSelfHosted()) return true
     const limit = await this.getLimit(organizationId, featureKey)
 
-    if (limit === null || limit === false) {
-      return false // No access or limit is 0
-    }
-    if (limit === '+') {
-      return true // Unlimited access
-    }
-    if (typeof limit === 'number') {
-      return currentUsage < limit // Check against numeric limit (use <= if limit means 'up to')
-    }
-    if (limit === true) {
-      // For boolean features, checkLimit might mean "is the feature on?"
-      // If currentUsage > 0 implies they are trying to use it, allow if true.
-      // Or, maybe checkLimit isn't applicable to boolean features. Adjust as needed.
-      return true
-    }
-
-    return false // Should not happen with current types, but default to false
+    if (limit === null || limit === false) return false
+    if (limit === '+') return true
+    if (typeof limit === 'number') return currentUsage < limit
+    if (limit === true) return true
+    return false
   }
 
   // ── Guard methods (throw on denial) ──
 
-  /**
-   * Throws ForbiddenError if the organization does not have access to the feature.
-   *
-   * @example
-   * await featureService.requireAccess(orgId, FeatureKey.datasets)
-   */
   async requireAccess(organizationId: string, featureKey: FeatureKey | string): Promise<void> {
     const allowed = await this.hasAccess(organizationId, featureKey)
     if (!allowed) {
@@ -272,24 +75,14 @@ export class FeaturePermissionService {
     }
   }
 
-  /**
-   * Throws ForbiddenError if the organization has reached the limit for the feature.
-   * The `countFn` callback should return the current count of the resource.
-   *
-   * @example
-   * await featureService.requireLimit(orgId, FeatureKey.datasetsLimit, async () => {
-   *   const [{ value }] = await db.select({ value: count() }).from(schema.Dataset).where(...)
-   *   return value
-   * })
-   */
   async requireLimit(
     organizationId: string,
     featureKey: FeatureKey | string,
     countFn: () => Promise<number>
   ): Promise<void> {
     const limit = await this.getLimit(organizationId, featureKey)
-    if (limit === null || limit === false) return // no numeric limit to enforce
-    if (limit === '+' || limit === true) return // unlimited
+    if (limit === null || limit === false) return
+    if (limit === '+' || limit === true) return
     if (typeof limit === 'number') {
       const current = await countFn()
       if (current >= limit) {
@@ -299,18 +92,6 @@ export class FeaturePermissionService {
     }
   }
 
-  /**
-   * Combined guard: checks boolean access + numeric limit in one call.
-   * Throws ForbiddenError on either denial.
-   *
-   * @example
-   * await featureService.requireAccessAndLimit(
-   *   orgId,
-   *   FeatureKey.datasets,
-   *   FeatureKey.datasetsLimit,
-   *   async () => datasetCount
-   * )
-   */
   async requireAccessAndLimit(
     organizationId: string,
     accessKey: FeatureKey | string,
@@ -321,35 +102,11 @@ export class FeaturePermissionService {
     await this.requireLimit(organizationId, limitKey, countFn)
   }
 
-  /**
-   * Invalidates the Redis cache for a specific organization's features.
-   * @param organizationId The organization ID.
-   */
+  /** @deprecated Use onCacheEvent('plan.changed', { orgId }) instead */
   async invalidateCache(organizationId: string): Promise<void> {
-    const cacheKey = `${this.cachePrefix}${organizationId}`
-    try {
-      const redis = await getRedisClient(false)
-      if (!redis) {
-        logger.debug(`Redis unavailable, skipping cache invalidation for ${organizationId}`)
-        return
-      }
-
-      await redis.del(cacheKey)
-      logger.info(`Invalidated feature cache for organization ${organizationId}`)
-    } catch (error) {
-      logger.warn('Error invalidating feature cache', {
-        organizationId,
-        cacheKey,
-        error: (error as Error).message,
-      })
-      // Continue without error propagation
-    }
+    await onCacheEvent('plan.changed', { orgId: organizationId })
   }
 
-  /**
-   * Creates a feature map with all features set to unlimited.
-   * Used for self-hosted deployments where there are no plan restrictions.
-   */
   private createUnlimitedFeatureMap(): FeatureMap {
     const map: FeatureMap = new Map()
     for (const key of Object.values(FeatureKey)) {
@@ -358,52 +115,11 @@ export class FeaturePermissionService {
     return map
   }
 
-  // --- Helper Methods ---
-
-  /**
-   * Safely parses the features JSON from the Plan model.
-   * @param featuresJson The JSON value from Plan.features.
-   * @returns An array of FeatureDefinition, or default features if parsing fails or input is invalid.
-   */
-  private parseFeaturesFromJson(featuresJson: any): FeatureDefinition[] {
-    if (!featuresJson) {
-      logger.warn('Plan features JSON is null or empty, using default.')
-      return DEFAULT_FREE_PLAN_FEATURES
+  private createUnlimitedFeaturesObject(): FeatureMapObject {
+    const obj: Record<string, FeatureLimit> = {}
+    for (const key of Object.values(FeatureKey)) {
+      obj[key] = '+'
     }
-
-    try {
-      const parsed = typeof featuresJson === 'string' ? JSON.parse(featuresJson) : featuresJson
-      if (Array.isArray(parsed)) {
-        // Basic validation could be added here to ensure items match FeatureDefinition structure
-        return parsed as FeatureDefinition[]
-      } else {
-        logger.warn('Parsed plan features is not an array, using default.', { parsed })
-        return DEFAULT_FREE_PLAN_FEATURES
-      }
-    } catch (error) {
-      logger.error('Failed to parse Plan features JSON, using default.', { error })
-      return DEFAULT_FREE_PLAN_FEATURES
-    }
-  }
-
-  /**
-   * Converts an array of FeatureDefinition into a Map.
-   * @param definitions Array of feature definitions.
-   * @returns A Map where keys are feature keys and values are limits.
-   */
-  private createMapFromDefinitions(definitions: FeatureDefinition[]): FeatureMap {
-    const map: FeatureMap = new Map()
-    if (!definitions) return map
-
-    definitions.forEach((def) => {
-      if (def && typeof def.key === 'string') {
-        // Convert -1 to '+' for unlimited, matching customFeatureLimits behavior
-        const limit = def.limit === -1 ? '+' : def.limit
-        map.set(def.key, limit)
-      } else {
-        logger.warn('Invalid feature definition skipped', { definition: def })
-      }
-    })
-    return map
+    return obj
   }
 }

--- a/packages/lib/src/permissions/overage-handler.ts
+++ b/packages/lib/src/permissions/overage-handler.ts
@@ -2,10 +2,9 @@
 
 import { type Database, schema } from '@auxx/database'
 import { and, eq, inArray } from 'drizzle-orm'
-import { DehydrationCacheService } from '../dehydration/cache'
+import { onCacheEvent } from '../cache'
 import { createScopedLogger } from '../logger'
 import { NotificationService } from '../notifications/notification-service'
-import { FeaturePermissionService } from './feature-permission-service'
 import { type Overage, OverageDetectionService } from './overage-detection-service'
 
 const logger = createScopedLogger('overage-handler')
@@ -37,7 +36,7 @@ export async function handlePlanDowngrade(
     // Send notifications to all admins/owners in parallel with cache invalidation
     await Promise.all([
       sendOverageNotifications(db, organizationId, overages),
-      invalidateCaches(db, organizationId),
+      onCacheEvent('plan.changed', { orgId: organizationId }),
     ])
   } catch (error) {
     // Don't let overage detection failures break the plan change flow
@@ -102,15 +101,4 @@ async function sendOverageNotifications(
         })
     )
   )
-}
-
-/**
- * Invalidate both dehydration and feature permission caches.
- */
-async function invalidateCaches(db: Database, organizationId: string): Promise<void> {
-  const dehydrationCache = new DehydrationCacheService()
-  await dehydrationCache.invalidateOrganization(organizationId)
-
-  const featureService = new FeaturePermissionService(db)
-  await featureService.invalidateCache(organizationId)
 }

--- a/packages/lib/src/permissions/permission-service.ts
+++ b/packages/lib/src/permissions/permission-service.ts
@@ -5,6 +5,7 @@ import { schema } from '@auxx/database'
 import { OrganizationRole } from '@auxx/database/enums'
 import { TRPCError } from '@trpc/server'
 import { and, eq, inArray, placeholder } from 'drizzle-orm'
+import { getOrgCache } from '../cache'
 import { createScopedLogger } from '../logger'
 import { SystemUserService } from '../users/system-user-service'
 
@@ -164,11 +165,11 @@ export class PermissionService {
   }
 
   async isAdmin(): Promise<boolean> {
-    const membership = await this.statements.isAdminStatement.execute({
-      userId: this.userId,
-      organizationId: this.organizationId,
-    })
-    return !!membership
+    const { memberRoleMap } = await getOrgCache().getOrRecompute(this.organizationId, [
+      'memberRoleMap',
+    ])
+    const role = memberRoleMap[this.userId]
+    return role === 'OWNER' || role === 'ADMIN'
   }
   /**
    * Check if user can access an entity (ticket, thread, contact, etc.)

--- a/packages/lib/src/providers/integration-cache.ts
+++ b/packages/lib/src/providers/integration-cache.ts
@@ -1,81 +1,29 @@
 // packages/lib/src/providers/integration-cache.ts
 
 import type { Database } from '@auxx/database'
-import { schema } from '@auxx/database'
-import { getRedisClient } from '@auxx/redis'
-import { and, eq, isNull } from 'drizzle-orm'
+import { getOrgCache, onCacheEvent } from '../cache'
 import type { IntegrationProviderType } from './types'
-
-/** Cache TTL - provider is immutable, only invalidate on add/remove */
-const PROVIDER_MAP_TTL = 86400 // 24 hours
 
 /**
  * Get cached provider map for an organization.
  * Maps integrationId -> provider type.
- *
- * @param organizationId - The ID of the organization
- * @param db - Database instance
- * @returns Map of integrationId to provider type
+ * Now served from the org cache.
  */
 export async function getOrgProviderMap(
   organizationId: string,
-  db: Database
+  _db: Database
 ): Promise<Map<string, IntegrationProviderType>> {
-  const cacheKey = `org:${organizationId}:integration:providers`
-
-  // Try cache first
-  try {
-    const redis = await getRedisClient(false)
-    if (redis) {
-      const cached = await redis.get(cacheKey)
-      if (cached) {
-        const parsed = JSON.parse(cached) as Record<string, IntegrationProviderType>
-        return new Map(Object.entries(parsed))
-      }
-    }
-  } catch {
-    // Redis unavailable, fall through to DB
-  }
-
-  // Fetch from DB
-  const integrations = await db
-    .select({ id: schema.Integration.id, provider: schema.Integration.provider })
-    .from(schema.Integration)
-    .where(
-      and(
-        eq(schema.Integration.organizationId, organizationId),
-        isNull(schema.Integration.deletedAt)
-      )
-    )
-
-  const providerMap = new Map(integrations.map((i) => [i.id, i.provider]))
-
-  // Cache result
-  try {
-    const redis = await getRedisClient(false)
-    if (redis) {
-      await redis.setex(cacheKey, PROVIDER_MAP_TTL, JSON.stringify(Object.fromEntries(providerMap)))
-    }
-  } catch {
-    // Cache write failed, continue
-  }
-
-  return providerMap
+  const { integrationProviders } = await getOrgCache().getOrRecompute(organizationId, [
+    'integrationProviders',
+  ])
+  return new Map(Object.entries(integrationProviders)) as Map<string, IntegrationProviderType>
 }
 
 /**
  * Invalidate cached provider map for an organization.
  * Call when integrations are added or removed.
- *
- * @param organizationId - The ID of the organization
+ * @deprecated Use onCacheEvent('integration.connected', { orgId }) instead
  */
 export async function invalidateOrgProviderMap(organizationId: string): Promise<void> {
-  try {
-    const redis = await getRedisClient(false)
-    if (redis) {
-      await redis.del(`org:${organizationId}:integration:providers`)
-    }
-  } catch {
-    // Ignore cache invalidation errors
-  }
+  await onCacheEvent('integration.connected', { orgId: organizationId })
 }

--- a/packages/lib/src/resources/registry/entity-def-resolver.ts
+++ b/packages/lib/src/resources/registry/entity-def-resolver.ts
@@ -1,56 +1,30 @@
 // packages/lib/src/resources/registry/entity-def-resolver.ts
 
 import type { Database } from '@auxx/database'
-import { getRedisClient } from '@auxx/redis'
 import type { EntityDefinitionType } from '@auxx/types/resource'
-
-/** Cache key format: entity-def:{organizationId}:{entityType} */
-const ENTITY_DEF_CACHE_PREFIX = 'entity-def'
-
-/** TTL: 30 days (2592000 seconds) - these values never change */
-const ENTITY_DEF_CACHE_TTL = 60 * 60 * 24 * 30
+import { getOrgCache } from '../../cache'
 
 /**
  * Resolves an EntityDefinitionType to its entityDefinitionId (CUID).
- * Uses Redis caching with long TTL since these values never change.
+ * Now served from the org cache (30-day TTL, near-immutable).
  *
  * @param organizationId - The organization ID
  * @param entityType - The entity definition type (contact, part, ticket, etc.)
- * @param db - Database instance
+ * @param _db - Database instance (no longer used, kept for backward compat)
  * @returns The entityDefinitionId (CUID)
  * @throws Error if EntityDefinition not found (indicates seeding problem)
  */
 export async function resolveEntityDefTypeId(
   organizationId: string,
   entityType: EntityDefinitionType,
-  db: Database
+  _db: Database
 ): Promise<string> {
-  const cacheKey = `${ENTITY_DEF_CACHE_PREFIX}:${organizationId}:${entityType}`
+  const { entityDefs } = await getOrgCache().getOrRecompute(organizationId, ['entityDefs'])
+  const resolved = entityDefs[entityType]
 
-  // Try cache first
-  const redis = await getRedisClient(false)
-  if (redis) {
-    const cached = await redis.get(cacheKey)
-    if (cached) {
-      return cached
-    }
-  }
-
-  // Query database
-  const entityDef = await db.query.EntityDefinition.findFirst({
-    where: (defs, { eq, and }) =>
-      and(eq(defs.organizationId, organizationId), eq(defs.entityType, entityType)),
-    columns: { id: true },
-  })
-
-  if (!entityDef) {
+  if (!resolved) {
     throw new Error(`EntityDefinition not found for entityType: ${entityType}`)
   }
 
-  // Cache the result with long TTL
-  if (redis) {
-    await redis.setex(cacheKey, ENTITY_DEF_CACHE_TTL, entityDef.id)
-  }
-
-  return entityDef.id
+  return resolved
 }


### PR DESCRIPTION
Refactor permissions and member queries to utilize organization cache

- Updated `getGroupEntityDefId` to retrieve entity definition IDs from cache.
- Modified `getGroupPermission` and `hasGroupPermission` to check organization roles from cache instead of querying the database.
- Refactored `findMemberByUser` and `isAdminOrOwner` to leverage organization cache for member roles.
- Enhanced `MemberService.isMember` to use cached member data, reducing database queries.
- Simplified `FeaturePermissionService` to fetch organization features from cache, removing Redis dependency.
- Streamlined `getOrgProviderMap` to utilize organization cache for integration providers.
- Removed redundant Redis caching logic from various services, replacing it with organization cache access.
- Updated cache invalidation methods to use centralized cache event handling.