### PR TITLE
feat: implement app-wide caching for plans and workflow templates

### DIFF
--- a/apps/web/src/server/api/routers/admin-workflow-templates.ts
+++ b/apps/web/src/server/api/routers/admin-workflow-templates.ts
@@ -1,5 +1,6 @@
 // apps/web/src/server/api/routers/admin-workflow-templates.ts
 
+import { invalidateWorkflowTemplates } from '@auxx/lib/cache'
 import {
   createTemplate,
   deleteTemplate,
@@ -87,6 +88,7 @@ export const adminWorkflowTemplatesRouter = createTRPCRouter({
       if (result.isErr()) {
         throw new Error(result.error.message)
       }
+      await invalidateWorkflowTemplates()
       return result.value
     }),
 
@@ -125,6 +127,7 @@ export const adminWorkflowTemplatesRouter = createTRPCRouter({
       if (result.isErr()) {
         throw new Error(result.error.message)
       }
+      await invalidateWorkflowTemplates()
       return result.value
     }),
 
@@ -142,6 +145,7 @@ export const adminWorkflowTemplatesRouter = createTRPCRouter({
       if (result.isErr()) {
         throw new Error(result.error.message)
       }
+      await invalidateWorkflowTemplates()
       return { success: true }
     }),
 
@@ -159,6 +163,7 @@ export const adminWorkflowTemplatesRouter = createTRPCRouter({
       if (result.isErr()) {
         throw new Error(result.error.message)
       }
+      await invalidateWorkflowTemplates()
       return result.value
     }),
 })

--- a/apps/web/src/server/api/routers/admin.ts
+++ b/apps/web/src/server/api/routers/admin.ts
@@ -4,7 +4,7 @@ import { AdminBillingService, PlanAdminService, PlanService } from '@auxx/billin
 import { WEBAPP_URL } from '@auxx/config/server'
 import { schema } from '@auxx/database'
 import { AdminService } from '@auxx/lib/admin'
-import { onCacheEvent } from '@auxx/lib/cache'
+import { invalidatePlans, onCacheEvent } from '@auxx/lib/cache'
 import { FeatureKey, FeaturePermissionService, handlePlanDowngrade } from '@auxx/lib/permissions'
 import { createUsageGuard, type UsageMetric, type UsageStatus } from '@auxx/lib/usage'
 import { and, eq, ilike, or, sql } from 'drizzle-orm'
@@ -932,7 +932,9 @@ export const adminRouter = createTRPCRouter({
       )
       .mutation(async ({ ctx, input }) => {
         const service = new PlanAdminService(ctx.db)
-        return service.createPlan(input)
+        const result = await service.createPlan(input)
+        await invalidatePlans()
+        return result
       }),
 
     /**
@@ -969,7 +971,9 @@ export const adminRouter = createTRPCRouter({
       .mutation(async ({ ctx, input }) => {
         const service = new PlanAdminService(ctx.db)
         const { id, ...data } = input
-        return service.updatePlan(id, data)
+        const result = await service.updatePlan(id, data)
+        await invalidatePlans()
+        return result
       }),
 
     /**
@@ -986,7 +990,9 @@ export const adminRouter = createTRPCRouter({
       .mutation(async ({ ctx, input }) => {
         const service = new PlanAdminService(ctx.db)
         const { id, ...pricing } = input
-        return service.updatePricing(id, pricing)
+        const result = await service.updatePricing(id, pricing)
+        await invalidatePlans()
+        return result
       }),
 
     /**
@@ -996,7 +1002,9 @@ export const adminRouter = createTRPCRouter({
       .input(z.object({ id: z.string() }))
       .mutation(async ({ ctx, input }) => {
         const service = new PlanAdminService(ctx.db)
-        return service.markAsLegacy(input.id)
+        const result = await service.markAsLegacy(input.id)
+        await invalidatePlans()
+        return result
       }),
 
     /**
@@ -1006,7 +1014,9 @@ export const adminRouter = createTRPCRouter({
       .input(z.object({ id: z.string() }))
       .mutation(async ({ ctx, input }) => {
         const service = new PlanAdminService(ctx.db)
-        return service.restoreLegacyPlan(input.id)
+        const result = await service.restoreLegacyPlan(input.id)
+        await invalidatePlans()
+        return result
       }),
 
     /**
@@ -1065,6 +1075,7 @@ export const adminRouter = createTRPCRouter({
 
       const billingDomain = new BillingDomain(scenario, context, { plansOnly: false })
       const plansCreated = await billingDomain.insertDirectly(ctx.db)
+      await invalidatePlans()
 
       return {
         success: true,
@@ -1097,6 +1108,7 @@ export const adminRouter = createTRPCRouter({
 
       const billingDomain = new BillingDomain(scenario, context)
       const plansUpdated = await billingDomain.updateFeatureLimitsOnly(ctx.db)
+      await invalidatePlans()
 
       return {
         success: true,

--- a/apps/web/src/server/api/routers/billing.ts
+++ b/apps/web/src/server/api/routers/billing.ts
@@ -4,7 +4,7 @@ import { BillingPortalService, SubscriptionService, stripeClient } from '@auxx/b
 import { WEBAPP_URL } from '@auxx/config/server'
 import { schema } from '@auxx/database'
 import { isSelfHosted } from '@auxx/deployment'
-import { onCacheEvent } from '@auxx/lib/cache'
+import { getAppCache, onCacheEvent } from '@auxx/lib/cache'
 import { getUserOrganizationId } from '@auxx/lib/email'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
@@ -26,26 +26,9 @@ const cloudOnlyProcedure = protectedProcedure.use(async ({ next }) => {
 })
 
 export const billingRouter = createTRPCRouter({
-  // Get all available plans
-  getPlans: cloudOnlyProcedure.query(async ({ ctx }) => {
-    try {
-      return await ctx.db.query.Plan.findMany({
-        orderBy: (plans, { asc }) => [asc(plans.hierarchyLevel)],
-      })
-
-      // return await ctx.db.query.Plan.findMany(
-      //   orderBy: (customers, { asc, desc }) => [
-      //   ]
-      //   .orderBy(schema.Plan.hierarchyLevel.asc())
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : ''
-
-      logger.error('Error fetching plans', { error: message })
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: `Error fetching plans: ${message}`,
-      })
-    }
+  // Get all available plans (cached, filtered to non-legacy)
+  getPlans: cloudOnlyProcedure.query(async () => {
+    return getAppCache().get('plans')
   }),
 
   // Get current subscription

--- a/apps/web/src/server/api/routers/resource.ts
+++ b/apps/web/src/server/api/routers/resource.ts
@@ -1,6 +1,6 @@
 // apps/web/src/server/api/routers/resource.ts
 
-import { ResourceRegistryService } from '@auxx/lib/resources'
+import { getOrgCache } from '@auxx/lib/cache'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '../trpc'
@@ -20,9 +20,7 @@ export const resourceRouter = createTRPCRouter({
     const { organizationId } = ctx.session
 
     try {
-      const service = new ResourceRegistryService(organizationId, ctx.db)
-      const resources = await service.getAll()
-      return resources
+      return await getOrgCache().from(organizationId, 'resources').all()
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error'
       throw new TRPCError({
@@ -40,8 +38,7 @@ export const resourceRouter = createTRPCRouter({
     const { organizationId } = ctx.session
 
     try {
-      const service = new ResourceRegistryService(organizationId, ctx.db)
-      const resource = await service.getById(input.id)
+      const resource = await getOrgCache().from(organizationId, 'resources').byId(input.id)
 
       if (!resource) {
         throw new TRPCError({

--- a/apps/web/src/server/api/routers/workflow-templates.ts
+++ b/apps/web/src/server/api/routers/workflow-templates.ts
@@ -1,5 +1,6 @@
 // apps/web/src/server/api/routers/workflow-templates.ts
 
+import { getAppCache } from '@auxx/lib/cache'
 import { getAllTemplates, getTemplateById } from '@auxx/services/workflow-templates'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
@@ -10,7 +11,8 @@ import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
  */
 export const workflowTemplatesRouter = createTRPCRouter({
   /**
-   * Get public workflow templates with filtering
+   * Get public workflow templates with filtering.
+   * Uses app-wide cache for unfiltered requests; falls back to DB for search/category queries.
    */
   getPublic: protectedProcedure
     .input(
@@ -21,16 +23,23 @@ export const workflowTemplatesRouter = createTRPCRouter({
       })
     )
     .query(async ({ input }) => {
-      const result = await getAllTemplates({
-        ...input,
-        status: 'public', // IMPORTANT: Only return public templates
-      })
+      const hasFilters = input.search || (input.categories && input.categories.length > 0)
 
-      if (result.isErr()) {
-        throw new Error(result.error.message)
+      // Filtered queries hit DB directly for accurate search/category matching
+      if (hasFilters) {
+        const result = await getAllTemplates({
+          ...input,
+          status: 'public',
+        })
+        if (result.isErr()) {
+          throw new Error(result.error.message)
+        }
+        return result.value
       }
 
-      return result.value
+      // Unfiltered listing served from cache
+      const templates = await getAppCache().get('workflowTemplates')
+      return templates.slice(0, input.limit)
     }),
 
   /**

--- a/packages/lib/src/cache/accessor-map.ts
+++ b/packages/lib/src/cache/accessor-map.ts
@@ -1,0 +1,65 @@
+// packages/lib/src/cache/accessor-map.ts
+
+import type { CustomFieldEntity, OrganizationRole } from '@auxx/database/types'
+import type { Inbox } from '../inboxes/types'
+import type { Overage } from '../permissions/overage-detection-service'
+import type { FeatureMapObject } from '../permissions/types'
+import type { ResourceField } from '../resources/registry/field-types'
+import type { Resource } from '../resources/registry/types'
+import type {
+  ArrayAccessor,
+  NestedRecordAccessor,
+  RecordAccessor,
+  ScalarAccessor,
+} from './accessors'
+import type { DehydratedOrgProfile, DehydratedSubscription, OrgMemberInfo } from './org-cache-keys'
+
+/**
+ * Maps each cache key to its accessor type.
+ * This drives the return type of orgCache.from(orgId, key).
+ */
+export interface OrgCacheAccessorMap {
+  // Array-shaped
+  resources: ResourceAccessor
+  members: ArrayAccessor<OrgMemberInfo>
+  inboxes: ArrayAccessor<Inbox>
+  overages: ArrayAccessor<Overage>
+
+  // Record-shaped
+  entityDefs: RecordAccessor<string>
+  entityDefSlugs: RecordAccessor<string>
+  memberRoleMap: RecordAccessor<OrganizationRole>
+  integrationProviders: RecordAccessor<string>
+  features: ScalarAccessor<FeatureMapObject>
+
+  // Nested record
+  customFields: CustomFieldAccessor
+
+  // Scalar
+  systemUser: ScalarAccessor<string>
+  subscription: ScalarAccessor<DehydratedSubscription | null>
+  orgProfile: ScalarAccessor<DehydratedOrgProfile>
+}
+
+/** Resource accessor — ArrayAccessor + custom sugar methods */
+export interface ResourceAccessor extends ArrayAccessor<Resource> {
+  /** Find resource by apiSlug (e.g., 'contacts', 'tickets') */
+  bySlug(slug: string): Promise<Resource | null>
+  /** Get fields for a specific resource */
+  fieldsFor(resourceId: string): Promise<ResourceField[]>
+}
+
+/** CustomField accessor — NestedRecordAccessor + custom sugar methods */
+export interface CustomFieldAccessor extends NestedRecordAccessor<CustomFieldEntity> {
+  /** Scope to entity, then find by systemAttribute */
+  in(entityDefId: string): CustomFieldGroupAccessor
+  /** Deep search by systemAttribute across all entities */
+  bySystemAttribute(attr: string): Promise<CustomFieldEntity | null>
+  /** Deep search by field ID across all entities */
+  byId(fieldId: string): Promise<CustomFieldEntity | null>
+}
+
+export interface CustomFieldGroupAccessor extends ArrayAccessor<CustomFieldEntity> {
+  /** Find field by systemAttribute within this entity */
+  bySystemAttribute(attr: string): Promise<CustomFieldEntity | null>
+}

--- a/packages/lib/src/cache/accessors.ts
+++ b/packages/lib/src/cache/accessors.ts
@@ -1,0 +1,127 @@
+// packages/lib/src/cache/accessors.ts
+
+/**
+ * Accessor for array-shaped cache values (resources, members, inboxes, overages).
+ * Provides .all(), .byId(), .find(), .filter() and custom aliases.
+ */
+export class ArrayAccessor<T extends { id: string }> {
+  constructor(private dataFn: () => Promise<T[]>) {}
+
+  /** Get all items */
+  async all(): Promise<T[]> {
+    return this.dataFn()
+  }
+
+  /** Find by id */
+  async byId(id: string): Promise<T | null> {
+    const data = await this.dataFn()
+    return data.find((item) => item.id === id) ?? null
+  }
+
+  /** Find first matching predicate */
+  async find(predicate: (item: T) => boolean): Promise<T | null> {
+    const data = await this.dataFn()
+    return data.find(predicate) ?? null
+  }
+
+  /** Filter by predicate */
+  async filter(predicate: (item: T) => boolean): Promise<T[]> {
+    const data = await this.dataFn()
+    return data.filter(predicate)
+  }
+
+  /** Count items (optionally filtered) */
+  async count(predicate?: (item: T) => boolean): Promise<number> {
+    const data = await this.dataFn()
+    return predicate ? data.filter(predicate).length : data.length
+  }
+
+  /** Check if item exists */
+  async has(id: string): Promise<boolean> {
+    return (await this.byId(id)) !== null
+  }
+}
+
+/**
+ * Accessor for record-shaped cache values (entityDefs, memberRoleMap, etc.).
+ * Provides .all(), .byKey(), .values(), .has().
+ */
+export class RecordAccessor<T> {
+  constructor(private dataFn: () => Promise<Record<string, T>>) {}
+
+  /** Get full record */
+  async all(): Promise<Record<string, T>> {
+    return this.dataFn()
+  }
+
+  /** Get value by key */
+  async byKey(key: string): Promise<T | null> {
+    const data = await this.dataFn()
+    return data[key] ?? null
+  }
+
+  /** Get all values as array */
+  async values(): Promise<T[]> {
+    const data = await this.dataFn()
+    return Object.values(data)
+  }
+
+  /** Get all keys */
+  async keys(): Promise<string[]> {
+    const data = await this.dataFn()
+    return Object.keys(data)
+  }
+
+  /** Check if key exists */
+  async has(key: string): Promise<boolean> {
+    const data = await this.dataFn()
+    return key in data
+  }
+}
+
+/**
+ * Accessor for nested record-shaped cache values (customFields: Record<string, T[]>).
+ * Provides .in(scope) to drill into a specific group, and .deep() to search across all groups.
+ */
+export class NestedRecordAccessor<T extends { id: string }> {
+  constructor(private dataFn: () => Promise<Record<string, T[]>>) {}
+
+  /** Get full grouped record */
+  async all(): Promise<Record<string, T[]>> {
+    return this.dataFn()
+  }
+
+  /** Scope into a specific group — returns ArrayAccessor for that group */
+  in(groupKey: string): ArrayAccessor<T> {
+    return new ArrayAccessor(async () => {
+      const data = await this.dataFn()
+      return data[groupKey] ?? []
+    })
+  }
+
+  /** Search across ALL groups (flattened) */
+  deep(): ArrayAccessor<T> {
+    return new ArrayAccessor(async () => {
+      const data = await this.dataFn()
+      return Object.values(data).flat()
+    })
+  }
+
+  /** Get keys (group IDs) */
+  async keys(): Promise<string[]> {
+    const data = await this.dataFn()
+    return Object.keys(data)
+  }
+}
+
+/**
+ * Accessor for scalar cache values (systemUser: string, subscription: T | null).
+ */
+export class ScalarAccessor<T> {
+  constructor(private dataFn: () => Promise<T>) {}
+
+  /** Get the value */
+  async value(): Promise<T> {
+    return this.dataFn()
+  }
+}

--- a/packages/lib/src/cache/app-cache-keys.ts
+++ b/packages/lib/src/cache/app-cache-keys.ts
@@ -1,0 +1,60 @@
+// packages/lib/src/cache/app-cache-keys.ts
+
+/** Cached plan row (serializable) */
+export interface CachedPlan {
+  id: string
+  name: string
+  description: string | null
+  features: unknown
+  monthlyPrice: number
+  annualPrice: number
+  isCustomPricing: boolean
+  hasTrial: boolean
+  trialDays: number
+  minSeats: number
+  maxSeats: number
+  isMostPopular: boolean
+  isFree: boolean
+  featureLimits: unknown
+  trialFeatureLimits: unknown
+  stripeProductId: string | null
+  stripePriceIdMonthly: string | null
+  stripePriceIdAnnual: string | null
+  hierarchyLevel: number
+  selfServed: boolean
+}
+
+/** Serializable workflow template list item (no graph blob) */
+export interface CachedWorkflowTemplate {
+  id: string
+  name: string
+  description: string
+  categories: string[]
+  imgUrl: string | null
+  version: number
+  status: string
+  triggerType: string | null
+  popularity: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** All app-wide (non-scoped) cache keys and their data types */
+export interface AppCacheDataMap {
+  plans: CachedPlan[]
+  planMap: Record<string, CachedPlan>
+  workflowTemplates: CachedWorkflowTemplate[]
+}
+
+export type AppCacheKeyName = keyof AppCacheDataMap
+
+const ONE_DAY = 86400
+const ONE_HOUR = 3600
+
+/** Key configuration: prefix for Redis keys and TTL */
+export const APP_CACHE_KEY_CONFIG: Record<AppCacheKeyName, { prefix: string; ttlSeconds: number }> =
+  {
+    plans: { prefix: 'app:plans', ttlSeconds: ONE_DAY },
+    planMap: { prefix: 'app:plan-map', ttlSeconds: ONE_DAY },
+    workflowTemplates: { prefix: 'app:wf-templates', ttlSeconds: ONE_HOUR },
+  }

--- a/packages/lib/src/cache/app-cache-provider.ts
+++ b/packages/lib/src/cache/app-cache-provider.ts
@@ -1,0 +1,8 @@
+// packages/lib/src/cache/app-cache-provider.ts
+
+import type { Database } from '@auxx/database'
+
+/** Provider interface for computing global (non-scoped) cache values */
+export interface AppCacheProvider<T> {
+  compute(db: Database): Promise<T>
+}

--- a/packages/lib/src/cache/app-cache-service.ts
+++ b/packages/lib/src/cache/app-cache-service.ts
@@ -1,0 +1,253 @@
+// packages/lib/src/cache/app-cache-service.ts
+
+import { type Database, database as ddb } from '@auxx/database'
+import { getRedisClient, type RedisClient } from '@auxx/redis'
+import { randomUUID } from 'crypto'
+import { createScopedLogger } from '../logger'
+import type { APP_CACHE_KEY_CONFIG, AppCacheDataMap, AppCacheKeyName } from './app-cache-keys'
+import { APP_CACHE_KEY_CONFIG as keyConfig } from './app-cache-keys'
+import type { AppCacheProvider } from './app-cache-provider'
+import { LocalCache } from './local-cache'
+import { PromiseMemoizer } from './promise-memoizer'
+
+const logger = createScopedLogger('AppCache', { color: 'blue' })
+
+/**
+ * Application-wide cache for global (non-scoped) data.
+ *
+ * Simplified version of OrganizationCacheService:
+ * - No scope ID — keys are singleton
+ * - Higher local TTL (5s) — global data has no cross-org staleness concerns
+ * - No distributed lock — global data is idempotent to compute
+ * - Same Redis hash check for cross-process invalidation detection
+ *
+ * Read path (4 stages):
+ *   1. Local Map (5s TTL)
+ *   2. Redis hash check (detect cross-process invalidation)
+ *   3. Redis data fetch
+ *   4. Provider.compute() from DB
+ */
+export class AppCacheService {
+  private providers = new Map<AppCacheKeyName, AppCacheProvider<any>>()
+  private localCache = new LocalCache(5000, 50) // 5s TTL, 50 max entries
+  private memoizer = new PromiseMemoizer<any>()
+  private redis: RedisClient | undefined
+  private redisReady: Promise<void>
+  private db: Database
+
+  constructor(db?: Database) {
+    this.db = db ?? (ddb as Database)
+    this.redisReady = this.initRedis()
+  }
+
+  private async initRedis(): Promise<void> {
+    try {
+      this.redis = await getRedisClient(false)
+    } catch {
+      logger.warn('Redis unavailable, app cache running in local-only mode')
+    }
+  }
+
+  private async getRedis(): Promise<RedisClient | undefined> {
+    await this.redisReady
+    return this.redis
+  }
+
+  /** Register a provider for a cache key */
+  register<K extends AppCacheKeyName>(
+    key: K,
+    provider: AppCacheProvider<AppCacheDataMap[K]>
+  ): void {
+    this.providers.set(key, provider)
+  }
+
+  /** Redis key for the cached data */
+  private dataKey(keyName: AppCacheKeyName): string {
+    return `${keyConfig[keyName].prefix}:data`
+  }
+
+  /** Redis key for the hash (used for cross-process invalidation detection) */
+  private hashKey(keyName: AppCacheKeyName): string {
+    return `${keyConfig[keyName].prefix}:hash`
+  }
+
+  /** Local cache key */
+  private localKey(keyName: AppCacheKeyName): string {
+    return keyConfig[keyName].prefix
+  }
+
+  /** Convenience: single key fetch */
+  async get<K extends AppCacheKeyName>(key: K): Promise<AppCacheDataMap[K]> {
+    return this.getSingle(key)
+  }
+
+  /**
+   * Multi-key fetch — type-safe.
+   * Fetches multiple keys in parallel in one call.
+   */
+  async getOrRecompute<K extends AppCacheKeyName[]>(
+    keys: readonly [...K]
+  ): Promise<{ [P in K[number]]: AppCacheDataMap[P] }> {
+    const result = {} as { [P in K[number]]: AppCacheDataMap[P] }
+    const entries = await Promise.all(keys.map((key) => this.getSingle(key)))
+
+    for (let i = 0; i < keys.length; i++) {
+      ;(result as any)[keys[i]!] = entries[i]
+    }
+
+    return result
+  }
+
+  /**
+   * 4-stage read for a single key.
+   * Deduplicates concurrent calls via PromiseMemoizer.
+   */
+  private async getSingle<K extends AppCacheKeyName>(keyName: K): Promise<AppCacheDataMap[K]> {
+    return this.memoizer.memoize(keyName, async () => {
+      const lk = this.localKey(keyName)
+
+      // Stage 1: Local cache check
+      const localEntry = this.localCache.get<AppCacheDataMap[K]>(lk)
+      if (localEntry) {
+        return localEntry.value
+      }
+
+      const redis = await this.getRedis()
+
+      if (redis) {
+        try {
+          // Stage 2: Redis hash check
+          const [storedHash, localStaleEntry] = await Promise.all([
+            redis.get(this.hashKey(keyName)),
+            Promise.resolve(this.localCache.get<AppCacheDataMap[K]>(lk)),
+          ])
+
+          // If we have a stale local entry with matching hash, it's still valid
+          if (localStaleEntry && storedHash && localStaleEntry.hash === storedHash) {
+            this.localCache.set(lk, localStaleEntry.value, storedHash)
+            return localStaleEntry.value
+          }
+
+          // Stage 3: Redis data fetch
+          if (storedHash) {
+            const rawData = await redis.get(this.dataKey(keyName))
+            if (rawData) {
+              const value = JSON.parse(rawData) as AppCacheDataMap[K]
+              this.localCache.set(lk, value, storedHash)
+              return value
+            }
+          }
+        } catch (error) {
+          logger.warn(`Redis error reading ${keyName}`, {
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+      }
+
+      // Stage 4: Recompute from provider
+      return this.recompute(keyName)
+    })
+  }
+
+  /** Compute value from provider and write back to cache */
+  private async recompute<K extends AppCacheKeyName>(keyName: K): Promise<AppCacheDataMap[K]> {
+    const provider = this.providers.get(keyName)
+    if (!provider) {
+      throw new Error(`No provider registered for app cache key: ${keyName}`)
+    }
+
+    const value = await provider.compute(this.db)
+    await this.writeBack(keyName, value)
+    return value
+  }
+
+  /** Write computed value back to local cache and Redis */
+  private async writeBack<K extends AppCacheKeyName>(
+    keyName: K,
+    value: AppCacheDataMap[K]
+  ): Promise<void> {
+    const hash = randomUUID()
+    const config = keyConfig[keyName]
+    const lk = this.localKey(keyName)
+
+    // Write to local cache
+    this.localCache.set(lk, value, hash)
+
+    // Write to Redis
+    const redis = await this.getRedis()
+    if (redis) {
+      try {
+        const pipeline = redis.pipeline()
+        pipeline.set(this.hashKey(keyName), hash)
+        pipeline.expire(this.hashKey(keyName), config.ttlSeconds)
+        pipeline.set(this.dataKey(keyName), JSON.stringify(value))
+        pipeline.expire(this.dataKey(keyName), config.ttlSeconds)
+        await pipeline.exec()
+      } catch (error) {
+        logger.warn(`Redis write error for ${keyName}`, {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+  }
+
+  /**
+   * Invalidate specific keys and recompute them.
+   * MUST be called AFTER the DB transaction commits.
+   */
+  async invalidateAndRecompute(keys: readonly AppCacheKeyName[]): Promise<void> {
+    const redis = await this.getRedis()
+
+    await Promise.all(
+      keys.map(async (keyName) => {
+        const lk = this.localKey(keyName)
+
+        // Clear local cache
+        this.localCache.delete(lk)
+
+        // Delete Redis keys (data + hash)
+        if (redis) {
+          try {
+            await redis.del(this.dataKey(keyName))
+            await redis.del(this.hashKey(keyName))
+          } catch {
+            // Ignore Redis errors during invalidation
+          }
+        }
+
+        // Recompute if provider is registered
+        if (this.providers.has(keyName)) {
+          try {
+            await this.recompute(keyName)
+          } catch (error) {
+            logger.warn(`Recompute failed for app cache key ${keyName}`, {
+              error: error instanceof Error ? error.message : String(error),
+            })
+          }
+        }
+      })
+    )
+  }
+
+  /**
+   * Flush all (or specific) keys.
+   * Does NOT recompute — next read will trigger recompute.
+   */
+  async flush(keys?: readonly AppCacheKeyName[]): Promise<void> {
+    const keysToFlush = keys ?? (Object.keys(keyConfig) as AppCacheKeyName[])
+    const redis = await this.getRedis()
+
+    for (const keyName of keysToFlush) {
+      this.localCache.delete(this.localKey(keyName))
+
+      if (redis) {
+        try {
+          await redis.del(this.dataKey(keyName))
+          await redis.del(this.hashKey(keyName))
+        } catch {
+          // Ignore
+        }
+      }
+    }
+  }
+}

--- a/packages/lib/src/cache/index.ts
+++ b/packages/lib/src/cache/index.ts
@@ -1,8 +1,30 @@
 // packages/lib/src/cache/index.ts
 
+// ── Accessor types ──
+export type {
+  CustomFieldAccessor,
+  CustomFieldGroupAccessor,
+  OrgCacheAccessorMap,
+  ResourceAccessor,
+} from './accessor-map'
+export { ArrayAccessor, NestedRecordAccessor, RecordAccessor, ScalarAccessor } from './accessors'
+// ── App Cache Service ──
+export type {
+  AppCacheDataMap,
+  AppCacheKeyName,
+  CachedPlan,
+  CachedWorkflowTemplate,
+} from './app-cache-keys'
+export type { AppCacheProvider } from './app-cache-provider'
+export { AppCacheService } from './app-cache-service'
 export type { CacheEntry, CacheOptions } from './base-cache-service'
 export { BaseCacheService } from './base-cache-service'
-export { flushOrganization, onCacheEvent } from './invalidate'
+export {
+  flushOrganization,
+  invalidatePlans,
+  invalidateWorkflowTemplates,
+  onCacheEvent,
+} from './invalidate'
 export type { CacheEvent } from './invalidation-graph'
 // ── Organization Cache Service ──
 export type { OrgCacheDataMap, OrgCacheKeyName } from './org-cache-keys'
@@ -12,12 +34,24 @@ export { PromiseMemoizer } from './promise-memoizer'
 export type { UserCacheDataMap, UserCacheKeyName } from './user-cache-keys'
 export { UserCacheService } from './user-cache-service'
 
+import { AppCacheService } from './app-cache-service'
 import { OrganizationCacheService } from './org-cache-service'
+import { registerAppProviders } from './register-app-providers'
 import { registerAllProviders } from './register-providers'
 import { UserCacheService } from './user-cache-service'
 
+let appCacheInstance: AppCacheService | undefined
 let orgCacheInstance: OrganizationCacheService | undefined
 let userCacheInstance: UserCacheService | undefined
+
+/** Get the singleton app-wide cache service (lazily initialized with all providers) */
+export function getAppCache(): AppCacheService {
+  if (!appCacheInstance) {
+    appCacheInstance = new AppCacheService()
+    registerAppProviders(appCacheInstance)
+  }
+  return appCacheInstance
+}
 
 /** Get the singleton org cache service (lazily initialized with all providers) */
 export function getOrgCache(): OrganizationCacheService {

--- a/packages/lib/src/cache/invalidate.ts
+++ b/packages/lib/src/cache/invalidate.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/cache/invalidate.ts
 
-import { getOrgCache, getUserCache } from './index'
+import { getAppCache, getOrgCache, getUserCache } from './index'
 import type { CacheEvent } from './invalidation-graph'
 import { INVALIDATION_GRAPH, isMixedMapping, isOrgOnlyMapping } from './invalidation-graph'
 
@@ -46,4 +46,14 @@ export async function onCacheEvent(
 /** Flush everything for an org (e.g. org deletion) */
 export async function flushOrganization(orgId: string): Promise<void> {
   await getOrgCache().flush(orgId)
+}
+
+/** Invalidate and recompute cached plans (call after plan admin mutations) */
+export async function invalidatePlans(): Promise<void> {
+  await getAppCache().invalidateAndRecompute(['plans', 'planMap'])
+}
+
+/** Invalidate and recompute cached workflow templates (call after template admin mutations) */
+export async function invalidateWorkflowTemplates(): Promise<void> {
+  await getAppCache().invalidateAndRecompute(['workflowTemplates'])
 }

--- a/packages/lib/src/cache/org-cache-provider.ts
+++ b/packages/lib/src/cache/org-cache-provider.ts
@@ -5,4 +5,7 @@ import type { Database } from '@auxx/database'
 /** Provider interface for computing cache values from the database */
 export interface CacheProvider<T> {
   compute(orgId: string, db: Database): Promise<T>
+
+  /** Optional: factory to create the fluent accessor for this key's data */
+  createAccessor?: (dataFn: () => Promise<T>) => any
 }

--- a/packages/lib/src/cache/org-cache-service.ts
+++ b/packages/lib/src/cache/org-cache-service.ts
@@ -4,6 +4,8 @@ import { type Database, database as ddb } from '@auxx/database'
 import { getRedisClient, type RedisClient } from '@auxx/redis'
 import { randomUUID } from 'crypto'
 import { createScopedLogger } from '../logger'
+import type { OrgCacheAccessorMap } from './accessor-map'
+import { ArrayAccessor, NestedRecordAccessor, RecordAccessor, ScalarAccessor } from './accessors'
 import { LocalCache } from './local-cache'
 import type { OrgCacheDataMap, OrgCacheKeyName } from './org-cache-keys'
 import { ORG_CACHE_KEY_CONFIG } from './org-cache-keys'
@@ -105,6 +107,40 @@ export class OrganizationCacheService {
   /** Convenience: single key fetch */
   async get<K extends OrgCacheKeyName>(orgId: string, key: K): Promise<OrgCacheDataMap[K]> {
     return this.getSingle(orgId, key)
+  }
+
+  /** Fluent accessor for a single cache key */
+  from<K extends OrgCacheKeyName>(orgId: string, key: K): OrgCacheAccessorMap[K] {
+    const dataFn = () => this.get(orgId, key)
+    const provider = this.providers.get(key)
+
+    if (provider?.createAccessor) {
+      return provider.createAccessor(dataFn) as OrgCacheAccessorMap[K]
+    }
+
+    return this.createDefaultAccessor(key, dataFn) as OrgCacheAccessorMap[K]
+  }
+
+  /** Infer accessor type from cache key when provider doesn't define createAccessor */
+  private createDefaultAccessor<K extends OrgCacheKeyName>(
+    key: K,
+    dataFn: () => Promise<OrgCacheDataMap[K]>
+  ): unknown {
+    const ARRAY_KEYS: OrgCacheKeyName[] = ['resources', 'members', 'inboxes', 'overages']
+    const NESTED_RECORD_KEYS: OrgCacheKeyName[] = ['customFields']
+    const SCALAR_KEYS: OrgCacheKeyName[] = ['systemUser', 'subscription', 'orgProfile', 'features']
+
+    if (ARRAY_KEYS.includes(key)) {
+      return new ArrayAccessor(dataFn as () => Promise<any[]>)
+    }
+    if (NESTED_RECORD_KEYS.includes(key)) {
+      return new NestedRecordAccessor(dataFn as () => Promise<Record<string, any[]>>)
+    }
+    if (SCALAR_KEYS.includes(key)) {
+      return new ScalarAccessor(dataFn)
+    }
+    // Default: RecordAccessor
+    return new RecordAccessor(dataFn as () => Promise<Record<string, any>>)
   }
 
   /**

--- a/packages/lib/src/cache/providers/custom-fields-provider.ts
+++ b/packages/lib/src/cache/providers/custom-fields-provider.ts
@@ -3,6 +3,7 @@
 import { schema } from '@auxx/database'
 import type { CustomFieldEntity } from '@auxx/database/types'
 import { eq } from 'drizzle-orm'
+import { ArrayAccessor, NestedRecordAccessor } from '../accessors'
 import type { CacheProvider } from '../org-cache-provider'
 
 /** Computes custom fields grouped by entityDefId for an organization */
@@ -33,5 +34,43 @@ export const customFieldsProvider: CacheProvider<Record<string, CustomFieldEntit
     }
 
     return grouped
+  },
+
+  createAccessor(dataFn: () => Promise<Record<string, CustomFieldEntity[]>>) {
+    const accessor = new NestedRecordAccessor(dataFn)
+
+    return Object.assign(accessor, {
+      // Override .in() to return enhanced group accessor with bySystemAttribute
+      in(entityDefId: string) {
+        const groupAccessor = new ArrayAccessor<CustomFieldEntity>(async () => {
+          const data = await dataFn()
+          return data[entityDefId] ?? []
+        })
+        return Object.assign(groupAccessor, {
+          async bySystemAttribute(attr: string): Promise<CustomFieldEntity | null> {
+            const fields = await groupAccessor.all()
+            return fields.find((f) => f.systemAttribute === attr) ?? null
+          },
+        })
+      },
+      // Deep sugar: search by systemAttribute across all entities
+      async bySystemAttribute(attr: string): Promise<CustomFieldEntity | null> {
+        const data = await dataFn()
+        for (const fields of Object.values(data)) {
+          const found = fields.find((f) => f.systemAttribute === attr)
+          if (found) return found
+        }
+        return null
+      },
+      // Deep sugar: search by field ID across all entities
+      async byId(fieldId: string): Promise<CustomFieldEntity | null> {
+        const data = await dataFn()
+        for (const fields of Object.values(data)) {
+          const found = fields.find((f) => f.id === fieldId)
+          if (found) return found
+        }
+        return null
+      },
+    })
   },
 }

--- a/packages/lib/src/cache/providers/features-provider.ts
+++ b/packages/lib/src/cache/providers/features-provider.ts
@@ -6,6 +6,7 @@ import { eq } from 'drizzle-orm'
 import { createScopedLogger } from '../../logger'
 import type { FeatureDefinition, FeatureLimit, FeatureMapObject } from '../../permissions/types'
 import { DEFAULT_FREE_PLAN_FEATURES, FeatureKey } from '../../permissions/types'
+import { getAppCache } from '../index'
 import type { CacheProvider } from '../org-cache-provider'
 
 const logger = createScopedLogger('features-provider')
@@ -37,14 +38,9 @@ export const featuresProvider: CacheProvider<FeatureMapObject> = {
     let featureDefinitions: FeatureDefinition[] = DEFAULT_FREE_PLAN_FEATURES
 
     if (subscription?.planId) {
-      const [plan] = await db
-        .select({
-          featureLimits: schema.Plan.featureLimits,
-          trialFeatureLimits: schema.Plan.trialFeatureLimits,
-        })
-        .from(schema.Plan)
-        .where(eq(schema.Plan.id, subscription.planId))
-        .limit(1)
+      // Use planMap from appCache instead of querying Plan table directly
+      const { planMap } = await getAppCache().getOrRecompute(['planMap'])
+      const plan = planMap[subscription.planId]
 
       if (subscription.status === 'trialing' && !subscription.hasTrialEnded) {
         const trialSource = plan?.trialFeatureLimits ?? plan?.featureLimits

--- a/packages/lib/src/cache/providers/plan-map-provider.ts
+++ b/packages/lib/src/cache/providers/plan-map-provider.ts
@@ -1,0 +1,20 @@
+// packages/lib/src/cache/providers/plan-map-provider.ts
+
+import { schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import type { CachedPlan } from '../app-cache-keys'
+import type { AppCacheProvider } from '../app-cache-provider'
+import { serializePlan } from './plans-provider'
+
+/** Computes all non-legacy plans indexed by ID */
+export const planMapProvider: AppCacheProvider<Record<string, CachedPlan>> = {
+  async compute(db) {
+    const plans = await db.select().from(schema.Plan).where(eq(schema.Plan.isLegacy, false))
+
+    const map: Record<string, CachedPlan> = {}
+    for (const p of plans) {
+      map[p.id] = serializePlan(p)
+    }
+    return map
+  },
+}

--- a/packages/lib/src/cache/providers/plans-provider.ts
+++ b/packages/lib/src/cache/providers/plans-provider.ts
@@ -1,0 +1,47 @@
+// packages/lib/src/cache/providers/plans-provider.ts
+
+import { schema } from '@auxx/database'
+import { asc, eq } from 'drizzle-orm'
+import type { CachedPlan } from '../app-cache-keys'
+import type { AppCacheProvider } from '../app-cache-provider'
+
+/** Serializes a plan row to a cache-safe shape */
+function serializePlan(plan: typeof schema.Plan.$inferSelect): CachedPlan {
+  return {
+    id: plan.id,
+    name: plan.name,
+    description: plan.description,
+    features: plan.features,
+    monthlyPrice: plan.monthlyPrice,
+    annualPrice: plan.annualPrice,
+    isCustomPricing: plan.isCustomPricing,
+    hasTrial: plan.hasTrial,
+    trialDays: plan.trialDays,
+    minSeats: plan.minSeats,
+    maxSeats: plan.maxSeats,
+    isMostPopular: plan.isMostPopular,
+    isFree: plan.isFree,
+    featureLimits: plan.featureLimits,
+    trialFeatureLimits: plan.trialFeatureLimits,
+    stripeProductId: plan.stripeProductId,
+    stripePriceIdMonthly: plan.stripePriceIdMonthly,
+    stripePriceIdAnnual: plan.stripePriceIdAnnual,
+    hierarchyLevel: plan.hierarchyLevel,
+    selfServed: plan.selfServed,
+  }
+}
+
+export { serializePlan }
+
+/** Computes all non-legacy plans ordered by hierarchy level */
+export const plansProvider: AppCacheProvider<CachedPlan[]> = {
+  async compute(db) {
+    const plans = await db
+      .select()
+      .from(schema.Plan)
+      .where(eq(schema.Plan.isLegacy, false))
+      .orderBy(asc(schema.Plan.hierarchyLevel))
+
+    return plans.map(serializePlan)
+  },
+}

--- a/packages/lib/src/cache/providers/resources-provider.ts
+++ b/packages/lib/src/cache/providers/resources-provider.ts
@@ -1,13 +1,29 @@
 // packages/lib/src/cache/providers/resources-provider.ts
 
-import { ResourceRegistryService } from '../../resources/registry/resource-registry-service'
+import type { ResourceField } from '../../resources/registry/field-types'
+import { computeAllResources } from '../../resources/registry/resource-registry-compute'
 import type { Resource } from '../../resources/registry/types'
+import { ArrayAccessor } from '../accessors'
 import type { CacheProvider } from '../org-cache-provider'
 
 /** Computes the full resource registry for an organization */
 export const resourcesProvider: CacheProvider<Resource[]> = {
   async compute(orgId, db) {
-    const registry = new ResourceRegistryService(orgId, db)
-    return registry.getAll()
+    return computeAllResources(orgId, db)
+  },
+
+  createAccessor(dataFn: () => Promise<Resource[]>) {
+    const accessor = new ArrayAccessor(dataFn)
+
+    return Object.assign(accessor, {
+      async bySlug(slug: string): Promise<Resource | null> {
+        const data = await dataFn()
+        return data.find((r) => r.apiSlug === slug) ?? null
+      },
+      async fieldsFor(resourceId: string): Promise<ResourceField[]> {
+        const data = await dataFn()
+        return data.find((r) => r.id === resourceId)?.fields ?? []
+      },
+    })
   },
 }

--- a/packages/lib/src/cache/providers/workflow-templates-provider.ts
+++ b/packages/lib/src/cache/providers/workflow-templates-provider.ts
@@ -1,0 +1,36 @@
+// packages/lib/src/cache/providers/workflow-templates-provider.ts
+
+import { schema } from '@auxx/database'
+import { desc, eq } from 'drizzle-orm'
+import type { CachedWorkflowTemplate } from '../app-cache-keys'
+import type { AppCacheProvider } from '../app-cache-provider'
+
+/** Computes public workflow templates (no graph blob) sorted by popularity */
+export const workflowTemplatesProvider: AppCacheProvider<CachedWorkflowTemplate[]> = {
+  async compute(db) {
+    const templates = await db
+      .select({
+        id: schema.WorkflowTemplate.id,
+        name: schema.WorkflowTemplate.name,
+        description: schema.WorkflowTemplate.description,
+        categories: schema.WorkflowTemplate.categories,
+        imgUrl: schema.WorkflowTemplate.imgUrl,
+        version: schema.WorkflowTemplate.version,
+        status: schema.WorkflowTemplate.status,
+        triggerType: schema.WorkflowTemplate.triggerType,
+        popularity: schema.WorkflowTemplate.popularity,
+        createdAt: schema.WorkflowTemplate.createdAt,
+        updatedAt: schema.WorkflowTemplate.updatedAt,
+      })
+      .from(schema.WorkflowTemplate)
+      .where(eq(schema.WorkflowTemplate.status, 'public'))
+      .orderBy(desc(schema.WorkflowTemplate.popularity), desc(schema.WorkflowTemplate.createdAt))
+
+    return templates.map((t) => ({
+      ...t,
+      categories: (t.categories ?? []) as string[],
+      createdAt: t.createdAt.toISOString(),
+      updatedAt: t.updatedAt.toISOString(),
+    }))
+  },
+}

--- a/packages/lib/src/cache/register-app-providers.ts
+++ b/packages/lib/src/cache/register-app-providers.ts
@@ -1,0 +1,13 @@
+// packages/lib/src/cache/register-app-providers.ts
+
+import type { AppCacheService } from './app-cache-service'
+import { planMapProvider } from './providers/plan-map-provider'
+import { plansProvider } from './providers/plans-provider'
+import { workflowTemplatesProvider } from './providers/workflow-templates-provider'
+
+/** Register all app-wide cache providers. Called once at service startup. */
+export function registerAppProviders(appCache: AppCacheService): void {
+  appCache.register('plans', plansProvider)
+  appCache.register('planMap', planMapProvider)
+  appCache.register('workflowTemplates', workflowTemplatesProvider)
+}

--- a/packages/lib/src/resources/registry/index.ts
+++ b/packages/lib/src/resources/registry/index.ts
@@ -231,7 +231,8 @@ export {
   setResourceVariables,
   sortFieldsForDisplay,
 } from './field-utils'
-// Re-export resource registry service and types
+// Re-export resource computation and service
+export { computeAllResources } from './resource-registry-compute'
 export { ResourceRegistryService } from './resource-registry-service'
 export type {
   CustomResource,

--- a/packages/lib/src/resources/registry/resource-registry-compute.ts
+++ b/packages/lib/src/resources/registry/resource-registry-compute.ts
@@ -1,0 +1,15 @@
+// packages/lib/src/resources/registry/resource-registry-compute.ts
+
+import type { Database } from '@auxx/database'
+import { ResourceRegistryService } from './resource-registry-service'
+import type { Resource } from './types'
+
+/**
+ * Raw computation of all resources for an org.
+ * Directly queries DB — no caching.
+ * Used by the cache provider as the compute function.
+ */
+export async function computeAllResources(orgId: string, db: Database): Promise<Resource[]> {
+  const registry = new ResourceRegistryService(orgId, db)
+  return registry.getAll()
+}


### PR DESCRIPTION
feat(cache): implement app-wide caching for plans and workflow templates

- Introduced AppCacheService to manage global cache for plans and workflow templates.
- Added providers for plans and workflow templates to compute and cache data.
- Implemented cache invalidation methods for plans and workflow templates after mutations.
- Refactored admin and workflow template routers to utilize caching.
- Enhanced resource registry to support caching and optimized data retrieval.
- Created accessors for easier data manipulation from cache.