### PR TITLE
feat: add installed apps and workflow apps providers to cache

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -23,7 +23,7 @@
     "chrome-devtools": {
       "type": "stdio",
       "command": "npx",
-      "args": ["chrome-devtools-mcp@latest", "--autoConnect", "--channel=beta"]
+      "args": ["chrome-devtools-mcp@latest", "--autoConnect", "--channel=stable"]
     }
   }
 }

--- a/apps/api/src/routes/deployments.ts
+++ b/apps/api/src/routes/deployments.ts
@@ -2,6 +2,7 @@
 // Deployment management routes
 
 import { database, schema } from '@auxx/database'
+import { invalidateOrgsByDeploymentId, onCacheEvent } from '@auxx/lib/cache'
 import { calculateNextVersion } from '@auxx/services/app-versions'
 import { verifyAppAccess } from '@auxx/services/developer-accounts'
 import { and, eq } from 'drizzle-orm'
@@ -166,6 +167,9 @@ deployments.post('/:appId/deployments', requireScope(['developer', 'apps:write']
       return deployment
     })
 
+    // Invalidate: auto-install + deployment switch for this org
+    await onCacheEvent('app.installed', { orgId: targetOrganizationId })
+
     return c.json({ deploymentId: result.id, version: result.version })
   }
 
@@ -290,6 +294,8 @@ deployments.patch(
       .set({ status })
       .where(eq(schema.AppDeployment.id, deploymentId))
       .returning()
+
+    await invalidateOrgsByDeploymentId(deploymentId, database)
 
     return c.json({ deployment: updated })
   }

--- a/apps/build/src/server/api/routers/apps.ts
+++ b/apps/build/src/server/api/routers/apps.ts
@@ -3,6 +3,7 @@
 
 import { WEBAPP_URL } from '@auxx/config/urls'
 import { schema } from '@auxx/database'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { createScopedLogger } from '@auxx/logger'
 import {
   checkAppSlugExists,
@@ -756,6 +757,8 @@ export const appsRouter = createTRPCRouter({
         },
       })
 
+      await onCacheEvent('app.installed', { orgId: input.organizationId })
+
       return { installation }
     }),
 
@@ -803,6 +806,8 @@ export const appsRouter = createTRPCRouter({
           message: 'No active development installation found for this organization',
         })
       }
+
+      await onCacheEvent('app.uninstalled', { orgId: input.organizationId })
 
       return { success: true }
     }),

--- a/apps/build/src/server/api/routers/connections.ts
+++ b/apps/build/src/server/api/routers/connections.ts
@@ -2,6 +2,7 @@
 // Connections tRPC router
 
 import { App, ConnectionDefinition, DeveloperAccountMember } from '@auxx/database'
+import { invalidateOrgsByAppId } from '@auxx/lib/cache'
 import { TRPCError } from '@trpc/server'
 import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
@@ -214,6 +215,7 @@ export const connectionsRouter = createTRPCRouter({
         createdById: ctx.session.userId,
       }
 
+      let result
       if (existing) {
         // Update existing connection
         const [updated] = await ctx.db
@@ -225,12 +227,16 @@ export const connectionsRouter = createTRPCRouter({
           .where(eq(ConnectionDefinition.id, existing.id))
           .returning()
 
-        return updated
+        result = updated
       } else {
         // Create new connection
         const [created] = await ctx.db.insert(ConnectionDefinition).values(data).returning()
 
-        return created
+        result = created
       }
+
+      await invalidateOrgsByAppId(input.appId, ctx.db)
+
+      return result
     }),
 })

--- a/apps/build/src/server/api/routers/versions.ts
+++ b/apps/build/src/server/api/routers/versions.ts
@@ -1,5 +1,6 @@
 // apps/build/src/server/api/routers/versions.ts
 
+import { invalidateOrgsByDeploymentId } from '@auxx/lib/cache'
 import { createScopedLogger } from '@auxx/logger'
 import {
   calculateNextVersion,
@@ -100,6 +101,8 @@ export const versionsRouter = createTRPCRouter({
           deploymentWithApp.app.developerAccountId
         )
       }
+
+      await invalidateOrgsByDeploymentId(input.deploymentId, ctx.db)
 
       return result.value
     }),

--- a/apps/web/src/app/admin/organizations/[id]/_components/subscription-management-section.tsx
+++ b/apps/web/src/app/admin/organizations/[id]/_components/subscription-management-section.tsx
@@ -21,7 +21,7 @@ import {
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
 import { format } from 'date-fns'
-import { AlertCircle, Ban, DollarSign, RefreshCw } from 'lucide-react'
+import { AlertCircle, Ban, DollarSign, Plus, RefreshCw } from 'lucide-react'
 import { useState } from 'react'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
@@ -186,13 +186,92 @@ export function SubscriptionManagementSection({
     }
   }
 
+  const [selectedPlan, setSelectedPlan] = useState('')
+  const [selectedBillingCycle, setSelectedBillingCycle] = useState<'MONTHLY' | 'ANNUAL'>('MONTHLY')
+
+  const plansQuery = api.admin.getPlans.useQuery(undefined, { enabled: !subscription })
+
+  const createSubscription = api.admin.billing.createSubscription.useMutation({
+    onSuccess: () => {
+      utils.admin.getOrganization.invalidate({ id: organizationId })
+    },
+    onError: (error) =>
+      toastError({ title: 'Failed to create subscription', description: error.message }),
+  })
+
+  const handleCreateSubscription = async () => {
+    if (!selectedPlan) {
+      toastError({ title: 'Missing plan', description: 'Please select a plan' })
+      return
+    }
+
+    const confirmed = await confirm({
+      title: 'Create Subscription?',
+      description: `This will create a new ${selectedBillingCycle.toLowerCase()} subscription on the "${selectedPlan}" plan for "${organizationName}".`,
+      confirmText: 'Create Subscription',
+      cancelText: 'Cancel',
+    })
+
+    if (confirmed) {
+      createSubscription.mutate({
+        organizationId,
+        planName: selectedPlan,
+        billingCycle: selectedBillingCycle,
+      })
+    }
+  }
+
   if (!subscription) {
     return (
-      <Card>
-        <CardContent className='py-8 text-center text-muted-foreground'>
-          No subscription found
-        </CardContent>
-      </Card>
+      <>
+        <ConfirmDialog />
+        <Card>
+          <CardHeader>
+            <CardTitle>Create Subscription</CardTitle>
+            <CardDescription>
+              This organization has no subscription. Create one to enable plan features.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div>
+              <Label htmlFor='create-plan'>Plan</Label>
+              <Select value={selectedPlan} onValueChange={setSelectedPlan}>
+                <SelectTrigger>
+                  <SelectValue placeholder='Select a plan' />
+                </SelectTrigger>
+                <SelectContent>
+                  {plansQuery.data?.map((plan) => (
+                    <SelectItem key={plan.id} value={plan.name}>
+                      {plan.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor='create-billing-cycle'>Billing Cycle</Label>
+              <Select
+                value={selectedBillingCycle}
+                onValueChange={(v) => setSelectedBillingCycle(v as 'MONTHLY' | 'ANNUAL')}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value='MONTHLY'>Monthly</SelectItem>
+                  <SelectItem value='ANNUAL'>Annual</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              onClick={handleCreateSubscription}
+              loading={createSubscription.isPending}
+              disabled={!selectedPlan}>
+              <Plus />
+              Create Subscription
+            </Button>
+          </CardContent>
+        </Card>
+      </>
     )
   }
 

--- a/apps/web/src/app/admin/organizations/[id]/page.tsx
+++ b/apps/web/src/app/admin/organizations/[id]/page.tsx
@@ -642,7 +642,15 @@ export default function OrganizationDetailsPage() {
                         </Table>
                       </div>
                     ) : (
-                      <div className='text-muted-foreground'>No subscription</div>
+                      <div className='text-muted-foreground'>
+                        No subscription.{' '}
+                        <button
+                          type='button'
+                          className='text-primary underline underline-offset-4 hover:text-primary/80'
+                          onClick={() => setActiveTab('billing')}>
+                          Create one
+                        </button>
+                      </div>
                     )}
                   </CardContent>
                 </Card>
@@ -697,21 +705,23 @@ export default function OrganizationDetailsPage() {
 
               {/* Subscription & Enterprise Management - Side by Side */}
               <div className='grid gap-4 md:grid-cols-2'>
-                {org.subscription && (
-                  <SubscriptionManagementSection
-                    organizationId={org.id}
-                    organizationName={org.name}
-                    subscription={{
-                      id: org.subscription.id,
-                      status: org.subscription.status,
-                      plan: org.subscription.plan,
-                      canceledAt: org.subscription.canceledAt,
-                      cancelAtPeriodEnd: org.subscription.cancelAtPeriodEnd,
-                      periodEnd: org.subscription.periodEnd,
-                      creditsBalance: org.subscription.creditsBalance,
-                    }}
-                  />
-                )}
+                <SubscriptionManagementSection
+                  organizationId={org.id}
+                  organizationName={org.name}
+                  subscription={
+                    org.subscription
+                      ? {
+                          id: org.subscription.id,
+                          status: org.subscription.status,
+                          plan: org.subscription.plan,
+                          canceledAt: org.subscription.canceledAt,
+                          cancelAtPeriodEnd: org.subscription.cancelAtPeriodEnd,
+                          periodEnd: org.subscription.periodEnd,
+                          creditsBalance: org.subscription.creditsBalance,
+                        }
+                      : null
+                  }
+                />
 
                 {org.subscription && (
                   <EnterpriseManagementSection

--- a/apps/web/src/auth/server.ts
+++ b/apps/web/src/auth/server.ts
@@ -306,31 +306,13 @@ export const auth = betterAuth({
       //   avatarUrl = await mediaAssetService.getDownloadUrl(extendedUser.avatarAssetId)
       // }
 
-      // Get user's authentication providers
-      const accounts = await database
-        .select({ providerId: schema.account.providerId })
-        .from(schema.account)
-        .where(eq(schema.account.userId, extendedUser.id))
+      // Get user's authentication providers from cache (avoids 12+ redundant DB queries per page load)
+      const { getUserCache } = await import('@auxx/lib/cache')
+      const userProfile = await getUserCache().get(extendedUser.id, 'userProfile')
 
-      const providers = accounts.map((account) => account.providerId)
-      const hasPassword = providers.includes('credential')
-      const oauthProviders = providers.filter((p) => p !== 'credential')
-
-      // Determine registration method
-      const authMethodCount =
-        (hasPassword ? 1 : 0) +
-        (oauthProviders.length > 0 ? 1 : 0) +
-        (extendedUser.phoneNumberVerified ? 1 : 0)
-
-      let registrationMethod: 'oauth' | 'email' | 'phone' | 'mixed' = 'oauth'
-
-      if (authMethodCount > 1) {
-        registrationMethod = 'mixed'
-      } else if (hasPassword) {
-        registrationMethod = 'email'
-      } else if (extendedUser.phoneNumberVerified) {
-        registrationMethod = 'phone'
-      }
+      const oauthProviders = userProfile?.providers ?? []
+      const hasPassword = userProfile?.hasPassword ?? false
+      const registrationMethod = userProfile?.registrationMethod ?? 'oauth'
 
       return {
         ...session,

--- a/apps/web/src/server/api/routers/admin-apps.ts
+++ b/apps/web/src/server/api/routers/admin-apps.ts
@@ -2,6 +2,7 @@
 
 import { database, schema } from '@auxx/database'
 import { AdminService } from '@auxx/lib/admin'
+import { invalidateOrgsByAppId, invalidateOrgsByDeploymentId, onCacheEvent } from '@auxx/lib/cache'
 import {
   adminApproveDeployment,
   adminDeleteDeployment,
@@ -155,6 +156,8 @@ export const adminAppsRouter = createTRPCRouter({
         await invalidateBuildCacheForDeveloperAccount(deployment.app.developerAccountId)
       }
 
+      await invalidateOrgsByDeploymentId(input.deploymentId, database)
+
       return { success: true }
     }),
 
@@ -189,6 +192,8 @@ export const adminAppsRouter = createTRPCRouter({
         await invalidateBuildCacheForDeveloperAccount(deployment.app.developerAccountId)
       }
 
+      await invalidateOrgsByDeploymentId(input.deploymentId, database)
+
       return { success: true }
     }),
 
@@ -221,6 +226,8 @@ export const adminAppsRouter = createTRPCRouter({
         await invalidateBuildCacheForDeveloperAccount(deployment.app.developerAccountId)
       }
 
+      await invalidateOrgsByDeploymentId(input.deploymentId, database)
+
       return { success: true }
     }),
 
@@ -234,6 +241,14 @@ export const adminAppsRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      // Query affected orgs BEFORE delete — the fan-out helper queries
+      // AppInstallation.currentDeploymentId which won't match after the deployment is gone
+      const affectedOrgs = await database.query.AppInstallation.findMany({
+        where: (t, { eq, and, isNull }) =>
+          and(eq(t.currentDeploymentId, input.deploymentId), isNull(t.uninstalledAt)),
+        columns: { organizationId: true },
+      })
+
       const result = await adminDeleteDeployment({
         deploymentId: input.deploymentId,
         adminUserId: ctx.session.user.id,
@@ -242,6 +257,10 @@ export const adminAppsRouter = createTRPCRouter({
       if (result.isErr()) {
         throw new Error(result.error.message)
       }
+
+      // Fan-out invalidation using the pre-queried org IDs
+      const orgIds = [...new Set(affectedOrgs.map((a) => a.organizationId))]
+      await Promise.all(orgIds.map((orgId) => onCacheEvent('app.deployment.changed', { orgId })))
 
       return { success: true }
     }),
@@ -323,11 +342,28 @@ export const adminAppsRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const adminService = new AdminService(ctx.db)
-      return adminService.importApps(input.exportData, ctx.session.user.id, {
+      const result = await adminService.importApps(input.exportData, ctx.session.user.id, {
         targetDeveloperAccountId: input.targetDeveloperAccountId,
         selectedSlugs: input.selectedSlugs,
         slugOverrides: input.slugOverrides,
       })
+
+      // Invalidate installedApps for all orgs that have any imported app installed
+      // (connection definitions may have changed during import)
+      for (const app of result.apps) {
+        if (app.connectionDefinitions.length > 0) {
+          // Look up the appId by slug to fan-out invalidation
+          const appRow = await database.query.App.findFirst({
+            where: (t, { eq }) => eq(t.slug, app.slug),
+            columns: { id: true },
+          })
+          if (appRow) {
+            await invalidateOrgsByAppId(appRow.id, database)
+          }
+        }
+      }
+
+      return result
     }),
 
   /**

--- a/apps/web/src/server/api/routers/admin.ts
+++ b/apps/web/src/server/api/routers/admin.ts
@@ -491,6 +491,66 @@ export const adminRouter = createTRPCRouter({
     // ========== Subscription Management ==========
 
     /**
+     * Create subscription for an organization that doesn't have one
+     */
+    createSubscription: superAdminProcedure
+      .input(
+        z.object({
+          organizationId: z.string(),
+          planName: z.string(),
+          billingCycle: z.enum(['MONTHLY', 'ANNUAL']).default('MONTHLY'),
+          status: z.string().default('active'),
+        })
+      )
+      .mutation(async ({ ctx, input }) => {
+        // Verify org exists
+        const org = await ctx.db
+          .select({ id: schema.Organization.id })
+          .from(schema.Organization)
+          .where(eq(schema.Organization.id, input.organizationId))
+          .then((rows) => rows[0])
+
+        if (!org) {
+          throw new Error('Organization not found')
+        }
+
+        // Check no subscription already exists
+        const existing = await ctx.db
+          .select({ id: schema.PlanSubscription.id })
+          .from(schema.PlanSubscription)
+          .where(eq(schema.PlanSubscription.organizationId, input.organizationId))
+          .then((rows) => rows[0])
+
+        if (existing) {
+          throw new Error('Organization already has a subscription')
+        }
+
+        // Resolve plan
+        const planService = new PlanService(ctx.db)
+        const plans = await planService.getPlans()
+        const plan = plans.find((p) => p.name === input.planName.toLowerCase())
+
+        if (!plan) {
+          throw new Error(`Plan ${input.planName} not found`)
+        }
+
+        // Insert subscription
+        await ctx.db.insert(schema.PlanSubscription).values({
+          organizationId: input.organizationId,
+          planId: plan.id,
+          plan: input.planName,
+          status: input.status,
+          billingCycle: input.billingCycle,
+          seats: 1,
+          periodStart: new Date(),
+        })
+
+        await onCacheEvent('plan.changed', { orgId: input.organizationId })
+
+        return { success: true }
+      }),
+
+    /**
      * Cancel subscription immediately
      */
     cancelImmediately: superAdminProcedure

--- a/apps/web/src/server/api/routers/apps.ts
+++ b/apps/web/src/server/api/routers/apps.ts
@@ -1,5 +1,6 @@
 // apps/web/src/server/api/routers/apps.ts
 
+import { getOrgCache, onCacheEvent } from '@auxx/lib/cache'
 import { createScopedLogger } from '@auxx/logger'
 import {
   deleteAppConnection,
@@ -7,7 +8,6 @@ import {
   renameAppConnection,
   saveAppConnection,
 } from '@auxx/services/app-connections'
-import { getInstalledApps } from '@auxx/services/app-installations'
 import { getAppSettings, saveAppSettings, schemaToZod } from '@auxx/services/app-settings'
 import {
   getAppDeployments,
@@ -66,29 +66,30 @@ export const appsRouter = createTRPCRouter({
   }),
 
   /**
-   * List installed apps for the organization
+   * List installed apps for the organization (cached)
    */
   listInstalled: protectedProcedure
     .input(listInstalledAppsQuerySchema)
     .query(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
+      const orgCache = getOrgCache()
+      const { installedApps } = await orgCache.getOrRecompute(organizationId, ['installedApps'])
 
-      const result = await getInstalledApps({
-        organizationId,
-        filters: input.type ? { installationType: input.type } : undefined,
-      })
+      // Apply type filter if provided
+      const filtered = input.type
+        ? installedApps.filter((a) => a.installationType === input.type)
+        : installedApps
 
-      if (result.isErr()) {
-        const error = result.error
-        logger.error('Failed to get installed apps', { error, organizationId })
+      // Rehydrate dates for SuperJSON compatibility
+      const installations = filtered.map((app) => ({
+        ...app,
+        installedAt: new Date(app.installedAt),
+        currentDeployment: app.currentDeployment
+          ? { ...app.currentDeployment, createdAt: new Date(app.currentDeployment.createdAt) }
+          : null,
+      }))
 
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: error.message,
-        })
-      }
-
-      return result.value
+      return { installations }
     }),
 
   /**
@@ -156,6 +157,8 @@ export const appsRouter = createTRPCRouter({
         })
       }
 
+      await onCacheEvent('app.installed', { orgId: organizationId })
+
       return result.value
     }),
 
@@ -190,6 +193,8 @@ export const appsRouter = createTRPCRouter({
           message: error.message,
         })
       }
+
+      await onCacheEvent('app.uninstalled', { orgId: organizationId })
 
       return result.value
     }),

--- a/apps/web/src/server/api/routers/billing.ts
+++ b/apps/web/src/server/api/routers/billing.ts
@@ -4,7 +4,7 @@ import { BillingPortalService, SubscriptionService, stripeClient } from '@auxx/b
 import { WEBAPP_URL } from '@auxx/config/server'
 import { schema } from '@auxx/database'
 import { isSelfHosted } from '@auxx/deployment'
-import { getAppCache, onCacheEvent } from '@auxx/lib/cache'
+import { getAppCache, getOrgCache, onCacheEvent } from '@auxx/lib/cache'
 import { getUserOrganizationId } from '@auxx/lib/email'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
@@ -25,13 +25,18 @@ const cloudOnlyProcedure = protectedProcedure.use(async ({ next }) => {
   return next()
 })
 
+/** Read the cached subscription for the current org, or null */
+async function getCachedSubscription(orgId: string) {
+  return getOrgCache().from(orgId, 'subscription').value()
+}
+
 export const billingRouter = createTRPCRouter({
   // Get all available plans (cached, non-legacy, ordered by hierarchy)
   getPlans: cloudOnlyProcedure.query(async () => {
     return getAppCache().get('plans')
   }),
 
-  // Get current subscription
+  // Get current subscription (cached subscription + plan from app cache)
   getCurrentSubscription: cloudOnlyProcedure.query(async ({ ctx }) => {
     try {
       const organizationId = getUserOrganizationId(ctx.session)
@@ -39,15 +44,14 @@ export const billingRouter = createTRPCRouter({
         throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Organization ID not found' })
       }
 
-      // Use Drizzle query API with relations
-      const subscription = await ctx.db.query.PlanSubscription.findFirst({
-        where: (planSubscription, { eq }) => eq(planSubscription.organizationId, organizationId),
-        with: {
-          plan: true,
-        },
-      })
+      const subscription = await getCachedSubscription(organizationId)
+      if (!subscription) return null
 
-      return subscription || null
+      // Enrich with plan data from app cache
+      const planMap = await getAppCache().get('planMap')
+      const plan = subscription.planId ? (planMap[subscription.planId] ?? null) : null
+
+      return { ...subscription, plan }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : ''
 
@@ -113,7 +117,7 @@ export const billingRouter = createTRPCRouter({
       }
     }),
 
-  // Check trial status
+  // Check trial status (cached)
   checkTrialStatus: cloudOnlyProcedure.query(async ({ ctx }) => {
     try {
       const organizationId = getUserOrganizationId(ctx.session)
@@ -121,13 +125,7 @@ export const billingRouter = createTRPCRouter({
         throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Organization ID not found' })
       }
 
-      // Use Drizzle query API with relations
-      const subscription = await ctx.db.query.PlanSubscription.findFirst({
-        where: (planSubscription, { eq }) => eq(planSubscription.organizationId, organizationId),
-        with: {
-          plan: true,
-        },
-      })
+      const subscription = await getCachedSubscription(organizationId)
 
       // If no subscription or not in trial state, return null
       if (!subscription || subscription.status !== 'trialing') {
@@ -136,12 +134,10 @@ export const billingRouter = createTRPCRouter({
 
       // Calculate if trial has expired
       const now = new Date()
-      const hasExpired = subscription.trialEnd ? subscription.trialEnd < now : true
-      const daysRemaining = subscription.trialEnd
-        ? Math.max(
-            0,
-            Math.ceil((subscription.trialEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
-          )
+      const trialEnd = subscription.trialEnd ? new Date(subscription.trialEnd) : null
+      const hasExpired = trialEnd ? trialEnd < now : true
+      const daysRemaining = trialEnd
+        ? Math.max(0, Math.ceil((trialEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)))
         : 0
 
       return {
@@ -160,7 +156,7 @@ export const billingRouter = createTRPCRouter({
     }
   }),
 
-  // Check trial eligibility
+  // Check trial eligibility (cached)
   checkTrialEligibility: cloudOnlyProcedure
     .input(z.object({ planId: z.string() }))
     .query(async ({ ctx }) => {
@@ -170,12 +166,7 @@ export const billingRouter = createTRPCRouter({
           throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Organization ID not found' })
         }
 
-        // Get subscription
-        const [subscription] = await ctx.db
-          .select()
-          .from(schema.PlanSubscription)
-          .where(eq(schema.PlanSubscription.organizationId, organizationId))
-          .limit(1)
+        const subscription = await getCachedSubscription(organizationId)
 
         // If no subscription, they're eligible
         if (!subscription) {
@@ -361,7 +352,7 @@ export const billingRouter = createTRPCRouter({
       }
     }),
 
-  // Get billing details from Stripe customer
+  // Get billing details from Stripe customer (cached stripeCustomerId)
   getBillingDetails: cloudOnlyProcedure.query(async ({ ctx }) => {
     try {
       const organizationId = getUserOrganizationId(ctx.session)
@@ -369,9 +360,7 @@ export const billingRouter = createTRPCRouter({
         throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Organization ID not found' })
       }
 
-      const subscription = await ctx.db.query.PlanSubscription.findFirst({
-        where: (planSubscription, { eq }) => eq(planSubscription.organizationId, organizationId),
-      })
+      const subscription = await getCachedSubscription(organizationId)
 
       if (!subscription?.stripeCustomerId) {
         return null
@@ -400,7 +389,7 @@ export const billingRouter = createTRPCRouter({
     }
   }),
 
-  // Update billing address in Stripe
+  // Update billing address in Stripe (cached stripeCustomerId)
   updateBillingAddress: cloudOnlyProcedure
     .input(
       z.object({
@@ -423,9 +412,7 @@ export const billingRouter = createTRPCRouter({
           throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Organization ID not found' })
         }
 
-        const subscription = await ctx.db.query.PlanSubscription.findFirst({
-          where: (planSubscription, { eq }) => eq(planSubscription.organizationId, organizationId),
-        })
+        const subscription = await getCachedSubscription(organizationId)
 
         if (!subscription?.stripeCustomerId) {
           throw new TRPCError({ code: 'NOT_FOUND', message: 'No Stripe customer found' })
@@ -457,7 +444,7 @@ export const billingRouter = createTRPCRouter({
       }
     }),
 
-  // Get payment methods from Stripe
+  // Get payment methods from Stripe (cached stripeCustomerId)
   getPaymentMethods: cloudOnlyProcedure.query(async ({ ctx }) => {
     try {
       const organizationId = getUserOrganizationId(ctx.session)
@@ -465,9 +452,7 @@ export const billingRouter = createTRPCRouter({
         throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Organization ID not found' })
       }
 
-      const subscription = await ctx.db.query.PlanSubscription.findFirst({
-        where: (planSubscription, { eq }) => eq(planSubscription.organizationId, organizationId),
-      })
+      const subscription = await getCachedSubscription(organizationId)
 
       if (!subscription?.stripeCustomerId) {
         return []
@@ -505,7 +490,7 @@ export const billingRouter = createTRPCRouter({
     }
   }),
 
-  // Create setup intent for adding payment method
+  // Create setup intent for adding payment method (cached stripeCustomerId)
   createSetupIntent: cloudOnlyProcedure.mutation(async ({ ctx }) => {
     try {
       const organizationId = getUserOrganizationId(ctx.session)
@@ -513,9 +498,7 @@ export const billingRouter = createTRPCRouter({
         throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Organization ID not found' })
       }
 
-      const subscription = await ctx.db.query.PlanSubscription.findFirst({
-        where: (planSubscription, { eq }) => eq(planSubscription.organizationId, organizationId),
-      })
+      const subscription = await getCachedSubscription(organizationId)
 
       if (!subscription?.stripeCustomerId) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'No Stripe customer found' })
@@ -539,7 +522,7 @@ export const billingRouter = createTRPCRouter({
     }
   }),
 
-  // Set default payment method
+  // Set default payment method (cached stripeCustomerId)
   setDefaultPaymentMethod: cloudOnlyProcedure
     .input(z.object({ paymentMethodId: z.string() }))
     .mutation(async ({ ctx, input }) => {
@@ -549,9 +532,7 @@ export const billingRouter = createTRPCRouter({
           throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Organization ID not found' })
         }
 
-        const subscription = await ctx.db.query.PlanSubscription.findFirst({
-          where: (planSubscription, { eq }) => eq(planSubscription.organizationId, organizationId),
-        })
+        const subscription = await getCachedSubscription(organizationId)
 
         if (!subscription?.stripeCustomerId) {
           throw new TRPCError({ code: 'NOT_FOUND', message: 'No Stripe customer found' })
@@ -641,7 +622,7 @@ export const billingRouter = createTRPCRouter({
       }
     }),
 
-  // Cancel scheduled plan change
+  // Cancel scheduled plan change (cached read, DB write)
   cancelScheduledChange: cloudOnlyProcedure.mutation(async ({ ctx }) => {
     try {
       const organizationId = getUserOrganizationId(ctx.session)
@@ -649,19 +630,16 @@ export const billingRouter = createTRPCRouter({
         throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Organization ID not found' })
       }
 
-      const subscription = await ctx.db.query.PlanSubscription.findFirst({
-        where: (sub, { eq }) => eq(sub.organizationId, organizationId),
-        with: { plan: true },
-      })
+      const cachedSub = await getCachedSubscription(organizationId)
 
-      if (!subscription?.scheduledPlanId) {
+      if (!cachedSub?.scheduledPlanId) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'No scheduled change found',
         })
       }
 
-      // Clear scheduled change
+      // Clear scheduled change in DB
       await ctx.db
         .update(schema.PlanSubscription)
         .set({
@@ -672,31 +650,36 @@ export const billingRouter = createTRPCRouter({
           scheduledChangeAt: null,
           updatedAt: new Date(),
         })
-        .where(eq(schema.PlanSubscription.id, subscription.id))
+        .where(eq(schema.PlanSubscription.id, cachedSub.id))
 
       // Revert Stripe subscription to current plan
-      if (subscription.plan && subscription.stripeSubscriptionId) {
-        const priceId =
-          subscription.billingCycle === 'ANNUAL'
-            ? subscription.plan.stripePriceIdAnnual
-            : subscription.plan.stripePriceIdMonthly
+      if (cachedSub.planId && cachedSub.stripeSubscriptionId) {
+        const planMap = await getAppCache().get('planMap')
+        const plan = planMap[cachedSub.planId]
 
-        if (priceId) {
-          const stripe = stripeClient.getClient()
-          const stripeSubscription = await stripe.subscriptions.retrieve(
-            subscription.stripeSubscriptionId
-          )
+        if (plan) {
+          const priceId =
+            cachedSub.billingCycle === 'ANNUAL'
+              ? plan.stripePriceIdAnnual
+              : plan.stripePriceIdMonthly
 
-          await stripe.subscriptions.update(subscription.stripeSubscriptionId, {
-            items: [
-              {
-                id: stripeSubscription.items.data[0]!.id,
-                price: priceId,
-                quantity: subscription.seats,
-              },
-            ],
-            proration_behavior: 'none',
-          })
+          if (priceId) {
+            const stripe = stripeClient.getClient()
+            const stripeSubscription = await stripe.subscriptions.retrieve(
+              cachedSub.stripeSubscriptionId
+            )
+
+            await stripe.subscriptions.update(cachedSub.stripeSubscriptionId, {
+              items: [
+                {
+                  id: stripeSubscription.items.data[0]!.id,
+                  price: priceId,
+                  quantity: cachedSub.seats,
+                },
+              ],
+              proration_behavior: 'none',
+            })
+          }
         }
       }
 

--- a/packages/lib/src/cache/accessor-map.ts
+++ b/packages/lib/src/cache/accessor-map.ts
@@ -12,7 +12,8 @@ import type {
   RecordAccessor,
   ScalarAccessor,
 } from './accessors'
-import type { DehydratedOrgProfile, DehydratedSubscription, OrgMemberInfo } from './org-cache-keys'
+import type { CachedSubscription, DehydratedOrgProfile, OrgMemberInfo } from './org-cache-keys'
+import type { CachedWorkflowApp } from './providers/workflow-apps-provider'
 
 /**
  * Maps each cache key to its accessor type.
@@ -37,8 +38,11 @@ export interface OrgCacheAccessorMap {
 
   // Scalar
   systemUser: ScalarAccessor<string>
-  subscription: ScalarAccessor<DehydratedSubscription | null>
+  subscription: ScalarAccessor<CachedSubscription | null>
   orgProfile: ScalarAccessor<DehydratedOrgProfile>
+
+  // Custom accessor (provider-defined)
+  workflowApps: WorkflowAppsAccessor
 }
 
 /** Resource accessor — ArrayAccessor + custom sugar methods */
@@ -62,4 +66,19 @@ export interface CustomFieldAccessor extends NestedRecordAccessor<CustomFieldEnt
 export interface CustomFieldGroupAccessor extends ArrayAccessor<CustomFieldEntity> {
   /** Find field by systemAttribute within this entity */
   bySystemAttribute(attr: string): Promise<CustomFieldEntity | null>
+}
+
+/** WorkflowApps accessor — ArrayAccessor + trigger matching sugar methods */
+export interface WorkflowAppsAccessor extends ArrayAccessor<CachedWorkflowApp> {
+  /** Find enabled apps matching trigger criteria */
+  byTrigger(triggerType: string, entityDefinitionId?: string): Promise<CachedWorkflowApp[]>
+  /** Find enabled app by ID */
+  byAppId(workflowAppId: string): Promise<CachedWorkflowApp | null>
+  /** Find enabled apps matching app trigger fields */
+  byAppTrigger(params: {
+    appId: string
+    triggerId: string
+    installationId: string
+    connectionId?: string
+  }): Promise<CachedWorkflowApp[]>
 }

--- a/packages/lib/src/cache/app-invalidation-helpers.ts
+++ b/packages/lib/src/cache/app-invalidation-helpers.ts
@@ -1,0 +1,28 @@
+// packages/lib/src/cache/app-invalidation-helpers.ts
+
+import type { Database } from '@auxx/database'
+import { onCacheEvent } from './invalidate'
+
+/** Invalidate installedApps for all orgs affected by a deployment change */
+export async function invalidateOrgsByDeploymentId(
+  deploymentId: string,
+  db: Database
+): Promise<void> {
+  const affected = await db.query.AppInstallation.findMany({
+    where: (t, { eq, and, isNull }) =>
+      and(eq(t.currentDeploymentId, deploymentId), isNull(t.uninstalledAt)),
+    columns: { organizationId: true },
+  })
+  const orgIds = [...new Set(affected.map((a) => a.organizationId))]
+  await Promise.all(orgIds.map((orgId) => onCacheEvent('app.deployment.changed', { orgId })))
+}
+
+/** Invalidate installedApps for all orgs that have a specific app installed */
+export async function invalidateOrgsByAppId(appId: string, db: Database): Promise<void> {
+  const affected = await db.query.AppInstallation.findMany({
+    where: (t, { eq, and, isNull }) => and(eq(t.appId, appId), isNull(t.uninstalledAt)),
+    columns: { organizationId: true },
+  })
+  const orgIds = [...new Set(affected.map((a) => a.organizationId))]
+  await Promise.all(orgIds.map((orgId) => onCacheEvent('app.connection-def.changed', { orgId })))
+}

--- a/packages/lib/src/cache/index.ts
+++ b/packages/lib/src/cache/index.ts
@@ -6,6 +6,7 @@ export type {
   CustomFieldGroupAccessor,
   OrgCacheAccessorMap,
   ResourceAccessor,
+  WorkflowAppsAccessor,
 } from './accessor-map'
 export { ArrayAccessor, NestedRecordAccessor, RecordAccessor, ScalarAccessor } from './accessors'
 // ── App Cache Service ──
@@ -17,6 +18,8 @@ export type {
 } from './app-cache-keys'
 export type { AppCacheProvider } from './app-cache-provider'
 export { AppCacheService } from './app-cache-service'
+// ── Organization Cache Service ──
+export { invalidateOrgsByAppId, invalidateOrgsByDeploymentId } from './app-invalidation-helpers'
 export type { CacheEntry, CacheOptions } from './base-cache-service'
 export { BaseCacheService } from './base-cache-service'
 export {
@@ -40,13 +43,25 @@ export {
   getCachedResources,
   requireCachedEntityDefId,
 } from './org-cache-helpers'
-// ── Organization Cache Service ──
-export type { CachedGroup, OrgCacheDataMap, OrgCacheKeyName, OrgMemberInfo } from './org-cache-keys'
+export type {
+  CachedGroup,
+  CachedInstalledApp,
+  CachedSubscription,
+  OrgCacheDataMap,
+  OrgCacheKeyName,
+  OrgMemberInfo,
+} from './org-cache-keys'
 export type { CacheProvider } from './org-cache-provider'
 export { OrganizationCacheService } from './org-cache-service'
 export { PromiseMemoizer } from './promise-memoizer'
+export type { CachedPublishedWorkflow, CachedWorkflowApp } from './providers/workflow-apps-provider'
 export type { CachedTableView, UserCacheDataMap, UserCacheKeyName } from './user-cache-keys'
 export { UserCacheService } from './user-cache-service'
+export {
+  getCachedWorkflowApp,
+  getCachedWorkflowAppsByAppTrigger,
+  getCachedWorkflowAppsByTrigger,
+} from './workflow-app-queries'
 
 import { AppCacheService } from './app-cache-service'
 import { OrganizationCacheService } from './org-cache-service'

--- a/packages/lib/src/cache/invalidation-graph.ts
+++ b/packages/lib/src/cache/invalidation-graph.ts
@@ -48,6 +48,18 @@ export const INVALIDATION_GRAPH: Record<string, InvalidationMapping> = {
   'inbox.updated': ['inboxes'],
   'inbox.deleted': ['inboxes'],
 
+  // Workflow lifecycle events
+  'workflow.published': ['workflowApps'],
+  'workflow.enabled': ['workflowApps'],
+  'workflow.created': ['workflowApps'],
+  'workflow.deleted': ['workflowApps'],
+
+  // App lifecycle events
+  'app.installed': ['installedApps'],
+  'app.uninstalled': ['installedApps'],
+  'app.deployment.changed': ['installedApps'],
+  'app.connection-def.changed': ['installedApps'],
+
   // ── Mixed events (org + user keys) ──
   'member.added': {
     user: ['userMemberships'],

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -11,6 +11,7 @@ import type { Overage } from '../permissions/overage-detection-service'
 import type { FeatureMapObject } from '../permissions/types'
 import type { Resource } from '../resources/registry/types'
 import type { SettingValue } from '../settings/types'
+import type { CachedWorkflowApp } from './providers/workflow-apps-provider'
 
 /** Member info cached with joined user data */
 export interface OrgMemberInfo extends OrganizationMemberInfo {
@@ -23,8 +24,56 @@ export interface OrgMemberInfo extends OrganizationMemberInfo {
   } | null
 }
 
-/** Dehydrated subscription shape (serializable) */
+/** Dehydrated subscription shape (client-safe, serializable) */
 export type DehydratedSubscription = NonNullable<DehydratedOrganization['subscription']>
+
+/** Full cached subscription shape (server-only, JSON-serializable) */
+export interface CachedSubscription {
+  id: string
+  organizationId: string
+  status: string
+  plan: string
+  planId: string | null
+  seats: number
+  billingCycle: 'MONTHLY' | 'ANNUAL'
+  periodStart: string | null
+  periodEnd: string | null
+  endDate: string | null
+  cancelAtPeriodEnd: boolean
+  canceledAt: string | null
+  creditsBalance: number
+
+  // Stripe identifiers (server-only — never send to client)
+  stripeCustomerId: string | null
+  stripeSubscriptionId: string | null
+
+  // Trial
+  trialStart: string | null
+  trialEnd: string | null
+  hasTrialEnded: boolean
+  trialConversionStatus: string | null
+  isEligibleForTrial: boolean
+  trialEligibilityReason: string | null
+
+  // Scheduled changes
+  scheduledPlanId: string | null
+  scheduledPlan: string | null
+  scheduledBillingCycle: 'MONTHLY' | 'ANNUAL' | null
+  scheduledSeats: number | null
+  scheduledChangeAt: string | null
+
+  // Deletion
+  lastDeletionNotificationSent: string | null
+  lastDeletionNotificationDate: string | null
+  deletionScheduledDate: string | null
+  deletionReason: string | null
+
+  // Custom/enterprise
+  customFeatureLimits: unknown | null
+  customPricingMonthly: number | null
+  customPricingAnnual: number | null
+  customPricingNotes: string | null
+}
 
 /** Dehydrated org profile (serializable) */
 export interface DehydratedOrgProfile {
@@ -53,6 +102,39 @@ export interface CachedGroup {
   }
 }
 
+/** Cached installed app shape (JSON-serializable) */
+export interface CachedInstalledApp {
+  installationId: string
+  installationType: 'development' | 'production'
+  installedAt: string // ISO string — rehydrate to Date before returning
+
+  app: {
+    id: string
+    slug: string
+    title: string
+    description: string | null
+    avatarUrl: string | null
+    category: string | null
+  }
+
+  currentDeployment: {
+    id: string
+    version: string | null
+    deploymentType: string
+    status: string
+    clientBundleSha: string
+    createdAt: string // ISO string — rehydrate to Date before returning
+  } | null
+
+  /** Full ConnectionDefinitionSummary shape including oauth2Features */
+  connectionDefinition?: {
+    label: string | null
+    global: boolean | null
+    connectionType: string
+    oauth2Features: Record<string, unknown> | null
+  }
+}
+
 /** All org-scoped cache keys and their data types */
 export interface OrgCacheDataMap {
   // Near-immutable
@@ -67,7 +149,7 @@ export interface OrgCacheDataMap {
 
   // Business data
   features: FeatureMapObject
-  subscription: DehydratedSubscription | null
+  subscription: CachedSubscription | null
   orgProfile: DehydratedOrgProfile
   resources: Resource[]
   customFields: Record<string, CustomFieldEntity[]> // entityDefId → fields
@@ -75,6 +157,8 @@ export interface OrgCacheDataMap {
   inboxes: Inbox[]
   overages: Overage[]
   orgSettings: Record<string, SettingValue> // key → value (org defaults only)
+  installedApps: CachedInstalledApp[]
+  workflowApps: CachedWorkflowApp[]
 }
 
 export type OrgCacheKeyName = keyof OrgCacheDataMap
@@ -107,4 +191,6 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   inboxes: { prefix: 'org:inboxes', ttlSeconds: ONE_DAY },
   overages: { prefix: 'org:overages', ttlSeconds: 900 },
   orgSettings: { prefix: 'org:settings', ttlSeconds: ONE_DAY },
+  installedApps: { prefix: 'org:installed-apps', ttlSeconds: 900 },
+  workflowApps: { prefix: 'org:workflow-apps', ttlSeconds: ONE_DAY },
 }

--- a/packages/lib/src/cache/providers/installed-apps-provider.ts
+++ b/packages/lib/src/cache/providers/installed-apps-provider.ts
@@ -1,0 +1,83 @@
+// packages/lib/src/cache/providers/installed-apps-provider.ts
+
+import type { CachedInstalledApp } from '../org-cache-keys'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Computes installed apps with connection definitions for an organization */
+export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
+  async compute(orgId, db) {
+    // 1. Query installations with relations (same query as getInstalledApps)
+    const installations = await db.query.AppInstallation.findMany({
+      where: (t, { eq, and, isNull }) => and(eq(t.organizationId, orgId), isNull(t.uninstalledAt)),
+      with: {
+        app: true,
+        currentDeployment: {
+          with: { clientBundle: true },
+        },
+      },
+      orderBy: (t, { desc }) => desc(t.installedAt),
+    })
+
+    // 2. Batch-fetch connection definitions for all installed app IDs
+    //    Replaces the N+1 getAppConnectionDefinition pattern
+    const appIds = installations.map((i) => i.app.id)
+    const connectionDefs =
+      appIds.length > 0
+        ? await db.query.ConnectionDefinition.findMany({
+            where: (t, { inArray }) => inArray(t.appId, appIds),
+            columns: {
+              appId: true,
+              label: true,
+              global: true,
+              connectionType: true,
+              oauth2Features: true,
+            },
+          })
+        : []
+
+    // Index by appId (prefer user-scoped over org-scoped, matching getInstalledApps logic)
+    const connDefMap = new Map<string, (typeof connectionDefs)[0]>()
+    for (const def of connectionDefs) {
+      const existing = connDefMap.get(def.appId)
+      // Prefer non-global (user-scoped) — same priority as getInstalledApps
+      if (!existing || (existing.global && !def.global)) {
+        connDefMap.set(def.appId, def)
+      }
+    }
+
+    // 3. Build serializable output
+    return installations.map((inst) => ({
+      installationId: inst.id,
+      installationType: inst.installationType as 'development' | 'production',
+      installedAt: inst.installedAt.toISOString(),
+      app: {
+        id: inst.app.id,
+        slug: inst.app.slug,
+        title: inst.app.title,
+        description: inst.app.description,
+        avatarUrl: inst.app.avatarUrl,
+        category: inst.app.category,
+      },
+      currentDeployment: inst.currentDeployment
+        ? {
+            id: inst.currentDeployment.id,
+            version: inst.currentDeployment.version,
+            deploymentType: inst.currentDeployment.deploymentType,
+            status: inst.currentDeployment.status,
+            clientBundleSha: inst.currentDeployment.clientBundle.sha256,
+            createdAt: inst.currentDeployment.createdAt.toISOString(),
+          }
+        : null,
+      connectionDefinition: (() => {
+        const def = connDefMap.get(inst.app.id)
+        if (!def) return undefined
+        return {
+          label: def.label,
+          global: def.global,
+          connectionType: def.connectionType,
+          oauth2Features: def.oauth2Features as Record<string, unknown> | null,
+        }
+      })(),
+    }))
+  },
+}

--- a/packages/lib/src/cache/providers/subscription-provider.ts
+++ b/packages/lib/src/cache/providers/subscription-provider.ts
@@ -2,11 +2,11 @@
 
 import { schema } from '@auxx/database'
 import { eq } from 'drizzle-orm'
-import type { DehydratedSubscription } from '../org-cache-keys'
+import type { CachedSubscription } from '../org-cache-keys'
 import type { CacheProvider } from '../org-cache-provider'
 
-/** Computes the dehydrated subscription for an organization */
-export const subscriptionProvider: CacheProvider<DehydratedSubscription | null> = {
+/** Computes the full cached subscription for an organization */
+export const subscriptionProvider: CacheProvider<CachedSubscription | null> = {
   async compute(orgId, db) {
     const [subscription] = await db
       .select()
@@ -18,6 +18,7 @@ export const subscriptionProvider: CacheProvider<DehydratedSubscription | null> 
 
     return {
       id: subscription.id,
+      organizationId: subscription.organizationId,
       status: subscription.status,
       plan: subscription.plan,
       planId: subscription.planId,
@@ -25,17 +26,37 @@ export const subscriptionProvider: CacheProvider<DehydratedSubscription | null> 
       billingCycle: subscription.billingCycle,
       periodStart: subscription.periodStart?.toISOString() ?? null,
       periodEnd: subscription.periodEnd?.toISOString() ?? null,
+      endDate: subscription.endDate?.toISOString() ?? null,
       cancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
       canceledAt: subscription.canceledAt?.toISOString() ?? null,
+      creditsBalance: subscription.creditsBalance,
+
+      stripeCustomerId: subscription.stripeCustomerId,
+      stripeSubscriptionId: subscription.stripeSubscriptionId,
+
       trialStart: subscription.trialStart?.toISOString() ?? null,
       trialEnd: subscription.trialEnd?.toISOString() ?? null,
       hasTrialEnded: subscription.hasTrialEnded,
+      trialConversionStatus: subscription.trialConversionStatus,
       isEligibleForTrial: subscription.isEligibleForTrial,
+      trialEligibilityReason: subscription.trialEligibilityReason,
+
       scheduledPlanId: subscription.scheduledPlanId,
       scheduledPlan: subscription.scheduledPlan,
       scheduledBillingCycle: subscription.scheduledBillingCycle,
       scheduledSeats: subscription.scheduledSeats,
       scheduledChangeAt: subscription.scheduledChangeAt?.toISOString() ?? null,
+
+      lastDeletionNotificationSent: subscription.lastDeletionNotificationSent,
+      lastDeletionNotificationDate:
+        subscription.lastDeletionNotificationDate?.toISOString() ?? null,
+      deletionScheduledDate: subscription.deletionScheduledDate?.toISOString() ?? null,
+      deletionReason: subscription.deletionReason,
+
+      customFeatureLimits: subscription.customFeatureLimits,
+      customPricingMonthly: subscription.customPricingMonthly,
+      customPricingAnnual: subscription.customPricingAnnual,
+      customPricingNotes: subscription.customPricingNotes,
     }
   },
 }

--- a/packages/lib/src/cache/providers/workflow-apps-provider.ts
+++ b/packages/lib/src/cache/providers/workflow-apps-provider.ts
@@ -1,0 +1,137 @@
+// packages/lib/src/cache/providers/workflow-apps-provider.ts
+
+import { ArrayAccessor } from '../accessors'
+import type { CacheProvider } from '../org-cache-provider'
+
+/** Cached workflow app shape — only fields needed by trigger matching + execution hot paths */
+export interface CachedWorkflowApp {
+  id: string
+  organizationId: string
+  enabled: boolean
+  workflowId: string | null
+
+  publishedWorkflow: CachedPublishedWorkflow | null
+}
+
+/** Cached published workflow — execution-critical fields only */
+export interface CachedPublishedWorkflow {
+  id: string
+  version: number
+  triggerType: string | null
+  entityDefinitionId: string | null
+
+  // App trigger fields (for dispatchAppTrigger matching)
+  triggerAppId: string | null
+  triggerTriggerId: string | null
+  triggerInstallationId: string | null
+  triggerConnectionId: string | null
+
+  // Execution data
+  graph: any
+  envVars: any | null
+  variables: any | null
+  createdById: string | null
+}
+
+/** Narrow a DB WorkflowApp + publishedWorkflow to the serializable cache shape */
+function dehydrateWorkflowApp(app: {
+  id: string
+  organizationId: string
+  enabled: boolean
+  workflowId: string | null
+  publishedWorkflow: {
+    id: string
+    version: number
+    triggerType: string | null
+    entityDefinitionId: string | null
+    triggerAppId: string | null
+    triggerTriggerId: string | null
+    triggerInstallationId: string | null
+    triggerConnectionId: string | null
+    graph: unknown
+    envVars: unknown
+    variables: unknown
+    createdById: string | null
+  } | null
+}): CachedWorkflowApp {
+  return {
+    id: app.id,
+    organizationId: app.organizationId,
+    enabled: app.enabled,
+    workflowId: app.workflowId,
+    publishedWorkflow: app.publishedWorkflow
+      ? {
+          id: app.publishedWorkflow.id,
+          version: app.publishedWorkflow.version,
+          triggerType: app.publishedWorkflow.triggerType,
+          entityDefinitionId: app.publishedWorkflow.entityDefinitionId,
+          triggerAppId: app.publishedWorkflow.triggerAppId,
+          triggerTriggerId: app.publishedWorkflow.triggerTriggerId,
+          triggerInstallationId: app.publishedWorkflow.triggerInstallationId,
+          triggerConnectionId: app.publishedWorkflow.triggerConnectionId,
+          graph: app.publishedWorkflow.graph,
+          envVars: app.publishedWorkflow.envVars,
+          variables: app.publishedWorkflow.variables,
+          createdById: app.publishedWorkflow.createdById,
+        }
+      : null,
+  }
+}
+
+/** Computes all workflow apps with published workflows for an organization */
+export const workflowAppsProvider: CacheProvider<CachedWorkflowApp[]> = {
+  async compute(orgId, db) {
+    const apps = await db.query.WorkflowApp.findMany({
+      where: (t, { eq }) => eq(t.organizationId, orgId),
+      with: {
+        publishedWorkflow: true,
+      },
+    })
+    return apps.map(dehydrateWorkflowApp)
+  },
+
+  createAccessor(dataFn: () => Promise<CachedWorkflowApp[]>) {
+    const accessor = new ArrayAccessor(dataFn)
+
+    return Object.assign(accessor, {
+      /** Find enabled apps matching trigger criteria */
+      async byTrigger(
+        triggerType: string,
+        entityDefinitionId?: string
+      ): Promise<CachedWorkflowApp[]> {
+        const data = await dataFn()
+        return data.filter(
+          (app) =>
+            app.enabled &&
+            app.publishedWorkflow?.triggerType === triggerType &&
+            (!entityDefinitionId || app.publishedWorkflow.entityDefinitionId === entityDefinitionId)
+        )
+      },
+
+      /** Find enabled app by ID */
+      async byAppId(workflowAppId: string): Promise<CachedWorkflowApp | null> {
+        const data = await dataFn()
+        return data.find((app) => app.id === workflowAppId && app.enabled) ?? null
+      },
+
+      /** Find enabled apps matching app trigger fields */
+      async byAppTrigger(params: {
+        appId: string
+        triggerId: string
+        installationId: string
+        connectionId?: string
+      }): Promise<CachedWorkflowApp[]> {
+        const data = await dataFn()
+        return data.filter(
+          (app) =>
+            app.enabled &&
+            app.publishedWorkflow?.triggerAppId === params.appId &&
+            app.publishedWorkflow?.triggerTriggerId === params.triggerId &&
+            app.publishedWorkflow?.triggerInstallationId === params.installationId &&
+            (!params.connectionId ||
+              app.publishedWorkflow?.triggerConnectionId === params.connectionId)
+        )
+      },
+    })
+  },
+}

--- a/packages/lib/src/cache/register-providers.ts
+++ b/packages/lib/src/cache/register-providers.ts
@@ -8,6 +8,7 @@ import { entityDefsProvider } from './providers/entity-defs-provider'
 import { featuresProvider } from './providers/features-provider'
 import { groupsProvider } from './providers/groups-provider'
 import { inboxesProvider } from './providers/inboxes-provider'
+import { installedAppsProvider } from './providers/installed-apps-provider'
 import { integrationProvidersProvider } from './providers/integration-providers-provider'
 import { memberRoleMapProvider, membersProvider } from './providers/members-provider'
 import { orgProfileProvider } from './providers/org-profile-provider'
@@ -23,6 +24,7 @@ import { userMembershipsProvider } from './providers/user-memberships-provider'
 import { userProfileProvider } from './providers/user-profile-provider'
 import { userSettingsProvider } from './providers/user-settings-provider'
 import { userTableViewsProvider } from './providers/user-table-views-provider'
+import { workflowAppsProvider } from './providers/workflow-apps-provider'
 import { workflowTemplatesProvider } from './providers/workflow-templates-provider'
 import type { UserCacheService } from './user-cache-service'
 
@@ -52,6 +54,8 @@ export function registerAllProviders(
   orgCache.register('inboxes', inboxesProvider)
   orgCache.register('overages', overagesProvider)
   orgCache.register('orgSettings', orgSettingsProvider)
+  orgCache.register('installedApps', installedAppsProvider)
+  orgCache.register('workflowApps', workflowAppsProvider)
 
   // User-scoped
   userCache.register('userProfile', userProfileProvider)

--- a/packages/lib/src/cache/workflow-app-queries.ts
+++ b/packages/lib/src/cache/workflow-app-queries.ts
@@ -1,0 +1,46 @@
+// packages/lib/src/cache/workflow-app-queries.ts
+
+import { getOrgCache } from '.'
+import type { CachedWorkflowApp } from './providers/workflow-apps-provider'
+
+/**
+ * Get a single enabled workflow app by ID from cache.
+ * Returns null if not found or not enabled.
+ */
+export async function getCachedWorkflowApp(
+  workflowAppId: string,
+  organizationId: string
+): Promise<CachedWorkflowApp | null> {
+  return getOrgCache().from(organizationId, 'workflowApps').byAppId(workflowAppId)
+}
+
+/**
+ * Get all enabled workflow apps matching trigger criteria from cache.
+ */
+export async function getCachedWorkflowAppsByTrigger(params: {
+  organizationId: string
+  triggerType: string
+  entityDefinitionId?: string
+}): Promise<CachedWorkflowApp[]> {
+  return getOrgCache()
+    .from(params.organizationId, 'workflowApps')
+    .byTrigger(params.triggerType, params.entityDefinitionId)
+}
+
+/**
+ * Get all enabled workflow apps matching app trigger fields from cache.
+ */
+export async function getCachedWorkflowAppsByAppTrigger(params: {
+  organizationId: string
+  appId: string
+  triggerId: string
+  installationId: string
+  connectionId?: string
+}): Promise<CachedWorkflowApp[]> {
+  return getOrgCache().from(params.organizationId, 'workflowApps').byAppTrigger({
+    appId: params.appId,
+    triggerId: params.triggerId,
+    installationId: params.installationId,
+    connectionId: params.connectionId,
+  })
+}

--- a/packages/lib/src/custom-fields/custom-field-service.ts
+++ b/packages/lib/src/custom-fields/custom-field-service.ts
@@ -12,6 +12,7 @@ import {
 } from '@auxx/services/custom-fields'
 import type { CurrencyOptions } from '@auxx/types/custom-field'
 import type { ResourceFieldId } from '@auxx/types/field'
+import { onCacheEvent } from '../cache/invalidate'
 
 /**
  * Service for managing custom fields and their values across different models
@@ -77,6 +78,7 @@ export class CustomFieldService {
       throw new Error(result.error.message, { cause: { code: result.error.code } })
     }
 
+    await onCacheEvent('custom-field.created', { orgId: this.organizationId })
     return result.value
   }
 
@@ -114,6 +116,7 @@ export class CustomFieldService {
       throw new Error(result.error.message, { cause: result.error.cause })
     }
 
+    await onCacheEvent('custom-field.updated', { orgId: this.organizationId })
     return result.value
   }
 
@@ -133,6 +136,7 @@ export class CustomFieldService {
       throw new Error(result.error.message, { cause: result.error.cause })
     }
 
+    await onCacheEvent('custom-field.deleted', { orgId: this.organizationId })
     return result.value
   }
 

--- a/packages/lib/src/dehydration/service.ts
+++ b/packages/lib/src/dehydration/service.ts
@@ -5,6 +5,7 @@ import { configService } from '@auxx/credentials'
 import { getDeploymentMode } from '@auxx/deployment'
 import { execSync } from 'child_process'
 import { getOrgCache, getUserCache } from '../cache'
+import type { CachedSubscription } from '../cache/org-cache-keys'
 import { SETTINGS_CATALOG } from '../settings'
 import type { DehydratedEnvironment, DehydratedOrganization, DehydratedState } from './types'
 
@@ -141,7 +142,7 @@ export class DehydrationService {
       about: orgProfile.about,
       createdAt: orgProfile.createdAt,
       completedOnboarding: orgProfile.completedOnboarding,
-      subscription,
+      subscription: toClientSubscription(subscription),
       features: features ?? {},
       overages,
       settings: userData.userSettings,
@@ -197,5 +198,33 @@ export class DehydrationService {
     // Fetch members from cache and invalidate each user
     const { members } = await this.orgCache.getOrRecompute(organizationId, ['members'])
     await Promise.all(members.map((m) => this.userCache.invalidateUser(m.userId)))
+  }
+}
+
+/** Strip server-only fields from CachedSubscription for client delivery */
+function toClientSubscription(
+  sub: CachedSubscription | null
+): DehydratedOrganization['subscription'] {
+  if (!sub) return null
+  return {
+    id: sub.id,
+    status: sub.status,
+    plan: sub.plan,
+    planId: sub.planId,
+    seats: sub.seats,
+    billingCycle: sub.billingCycle,
+    periodStart: sub.periodStart,
+    periodEnd: sub.periodEnd,
+    cancelAtPeriodEnd: sub.cancelAtPeriodEnd,
+    canceledAt: sub.canceledAt,
+    trialStart: sub.trialStart,
+    trialEnd: sub.trialEnd,
+    hasTrialEnded: sub.hasTrialEnded,
+    isEligibleForTrial: sub.isEligibleForTrial,
+    scheduledPlanId: sub.scheduledPlanId,
+    scheduledPlan: sub.scheduledPlan,
+    scheduledBillingCycle: sub.scheduledBillingCycle,
+    scheduledSeats: sub.scheduledSeats,
+    scheduledChangeAt: sub.scheduledChangeAt,
   }
 }

--- a/packages/lib/src/entity-definitions/entity-definition-service.ts
+++ b/packages/lib/src/entity-definitions/entity-definition-service.ts
@@ -9,6 +9,7 @@ import {
   updateEntityDefinition,
 } from '@auxx/services/entity-definitions'
 import type { Result } from 'neverthrow'
+import { onCacheEvent } from '../cache/invalidate'
 import { DisplayFieldService, type DisplayFieldType } from '../field-values'
 import type { CreateEntityDefinitionInput, UpdateEntityDefinitionInput } from './types'
 
@@ -98,7 +99,9 @@ export class EntityDefinitionService {
       entityType: input.entityType ?? null,
       standardType: input.standardType ?? null,
     })
-    return unwrapResult(result)
+    const value = unwrapResult(result)
+    await onCacheEvent('entity-def.created', { orgId: this.organizationId })
+    return value
   }
 
   /**
@@ -159,6 +162,7 @@ export class EntityDefinitionService {
       }
     }
 
+    await onCacheEvent('entity-def.updated', { orgId: this.organizationId })
     return result.value
   }
 
@@ -187,6 +191,8 @@ export class EntityDefinitionService {
       id,
       organizationId: this.organizationId,
     })
-    return unwrapResult(result)
+    const value = unwrapResult(result)
+    await onCacheEvent('entity-def.deleted', { orgId: this.organizationId })
+    return value
   }
 }

--- a/packages/lib/src/entity-templates/template-installer.ts
+++ b/packages/lib/src/entity-templates/template-installer.ts
@@ -4,6 +4,7 @@ import { database, schema } from '@auxx/database'
 import { createCustomField } from '@auxx/services/custom-fields'
 import { checkSlugExists, createEntityDefinition } from '@auxx/services/entity-definitions'
 import { eq } from 'drizzle-orm'
+import { onCacheEvent } from '../cache/invalidate'
 import { getTemplatesByIds } from './template-registry'
 import type { EntityTemplateField } from './types'
 import { isSymbolicRef, parseSymbolicRef } from './types'
@@ -311,6 +312,7 @@ export async function installTemplates(
     }
   }
 
+  await onCacheEvent('entity-def.created', { orgId: organizationId })
   return { created, linked, skippedRelationships }
 }
 

--- a/packages/lib/src/events/handlers/trigger-resource-workflows.ts
+++ b/packages/lib/src/events/handlers/trigger-resource-workflows.ts
@@ -1,8 +1,8 @@
 // packages/lib/src/events/handlers/trigger-resource-workflows.ts
 
 import { createScopedLogger } from '@auxx/logger'
-import { getWorkflowAppsByTrigger } from '@auxx/services/workflows'
 import { toRecordId } from '@auxx/types/resource'
+import { getCachedWorkflowAppsByTrigger } from '../../cache'
 import { getQueue } from '../../jobs/queues'
 import { Queues } from '../../jobs/queues/types'
 import {
@@ -44,24 +44,19 @@ export const triggerResourceWorkflows = async ({ data: event }: { data: AuxxEven
 
   const { triggerType, entityDefinitionId } = mapping
 
-  // 2. Query workflows using NEW service signature
-  const workflowAppsResult = await getWorkflowAppsByTrigger({
+  // 2. Query workflows via org cache
+  const matchingApps = await getCachedWorkflowAppsByTrigger({
     organizationId: event.data.organizationId,
     triggerType,
     entityDefinitionId,
   })
 
-  if (workflowAppsResult.isErr()) {
-    logger.error('Failed to query workflow apps', {
-      error: workflowAppsResult.error.message,
-      triggerType,
-      entityDefinitionId,
-      eventType: event.type,
-    })
-    throw new Error(`Database error: ${workflowAppsResult.error.message}`)
-  }
-
-  const matchingWorkflows = workflowAppsResult.value
+  const matchingWorkflows = matchingApps
+    .filter((app) => app.publishedWorkflow)
+    .map((app) => ({
+      workflowApp: app,
+      publishedWorkflow: app.publishedWorkflow!,
+    }))
 
   if (matchingWorkflows.length === 0) {
     logger.debug('No enabled workflows found', { triggerType, entityDefinitionId })

--- a/packages/lib/src/files/upload/__tests__/unified-upload-integration.test.ts
+++ b/packages/lib/src/files/upload/__tests__/unified-upload-integration.test.ts
@@ -19,7 +19,11 @@ const { ticketSelectRowsRef, createSelectBuilder, selectMock } = vi.hoisted(() =
     const builder: Record<string, any> = {}
     builder.from = vi.fn().mockReturnValue(builder)
     builder.where = vi.fn().mockReturnValue(builder)
-    builder.limit = vi.fn().mockImplementation(async () => ticketSelectRowsRef.value)
+    builder.limit = vi.fn().mockReturnValue(builder)
+    builder.prepare = vi.fn().mockReturnValue({
+      execute: vi.fn().mockResolvedValue(ticketSelectRowsRef.value),
+    })
+    builder.then = vi.fn().mockImplementation((resolve: any) => resolve(ticketSelectRowsRef.value))
     return builder
   }
 

--- a/packages/lib/src/jobs/workflow/app-trigger-dispatch-job.ts
+++ b/packages/lib/src/jobs/workflow/app-trigger-dispatch-job.ts
@@ -1,9 +1,8 @@
 // packages/lib/src/jobs/workflow/app-trigger-dispatch-job.ts
 
-import { database as db, schema } from '@auxx/database'
 import { getRedisClient } from '@auxx/redis'
 import type { Job } from 'bullmq'
-import { and, eq, inArray } from 'drizzle-orm'
+import { getOrgCache } from '../../cache'
 import { createScopedLogger } from '../../logger'
 import { executeAppTriggeredWorkflow } from '../../workflow-engine/execution/trigger-app-workflow'
 
@@ -23,7 +22,7 @@ export type AppTriggerDispatchJobData = {
  * BullMQ job handler: dispatch an app trigger to all matching workflows.
  *
  * 1. Dedup check via Redis NX key (5-minute TTL)
- * 2. Query all published + enabled workflows matching the app trigger
+ * 2. Query all published + enabled workflows matching the app trigger (via cache)
  * 3. Execute each matching workflow with the trigger data
  */
 export async function dispatchAppTrigger(job: Job<AppTriggerDispatchJobData>) {
@@ -68,33 +67,16 @@ export async function dispatchAppTrigger(job: Job<AppTriggerDispatchJobData>) {
     })
   }
 
-  // 2. Query matching workflows
-  // Find all published, enabled workflows that match the specific app + trigger + installation
+  // 2. Query matching workflows via cache
   try {
-    // Build query conditions — match by connectionId when provided
-    const conditions = [
-      eq(schema.Workflow.organizationId, organizationId),
-      inArray(schema.Workflow.triggerType, ['app-trigger', 'app-polling-trigger']),
-      eq(schema.Workflow.triggerAppId, appId),
-      eq(schema.Workflow.triggerTriggerId, triggerId),
-      eq(schema.Workflow.triggerInstallationId, appInstallationId),
-      eq(schema.WorkflowApp.enabled, true),
-    ]
+    const matchingApps = await getOrgCache().from(organizationId, 'workflowApps').byAppTrigger({
+      appId,
+      triggerId,
+      installationId: appInstallationId,
+      connectionId,
+    })
 
-    if (connectionId) {
-      conditions.push(eq(schema.Workflow.triggerConnectionId, connectionId))
-    }
-
-    const matchingWorkflows = await db
-      .select({
-        workflowAppId: schema.WorkflowApp.id,
-        workflowId: schema.WorkflowApp.workflowId,
-      })
-      .from(schema.Workflow)
-      .innerJoin(schema.WorkflowApp, eq(schema.WorkflowApp.workflowId, schema.Workflow.id))
-      .where(and(...conditions))
-
-    if (matchingWorkflows.length === 0) {
+    if (matchingApps.length === 0) {
       logger.info('No matching workflows found for app trigger', {
         appId,
         triggerId,
@@ -105,7 +87,7 @@ export async function dispatchAppTrigger(job: Job<AppTriggerDispatchJobData>) {
     }
 
     logger.info('Found matching workflows for app trigger', {
-      count: matchingWorkflows.length,
+      count: matchingApps.length,
       appId,
       triggerId,
       appInstallationId,
@@ -114,16 +96,16 @@ export async function dispatchAppTrigger(job: Job<AppTriggerDispatchJobData>) {
     // 3. Execute each matching workflow
     const workflowRunIds: string[] = []
 
-    for (const workflow of matchingWorkflows) {
-      if (!workflow.workflowId) {
+    for (const app of matchingApps) {
+      if (!app.workflowId) {
         logger.warn('Workflow has no published version, skipping', {
-          workflowAppId: workflow.workflowAppId,
+          workflowAppId: app.id,
         })
         continue
       }
 
       const result = await executeAppTriggeredWorkflow({
-        workflowAppId: workflow.workflowAppId,
+        workflowAppId: app.id,
         organizationId,
         triggerData,
         appId,
@@ -136,7 +118,7 @@ export async function dispatchAppTrigger(job: Job<AppTriggerDispatchJobData>) {
         workflowRunIds.push(result.value.workflowRunId)
       } else {
         logger.error('Failed to execute app-triggered workflow', {
-          workflowAppId: workflow.workflowAppId,
+          workflowAppId: app.id,
           error: result.error,
         })
       }
@@ -144,7 +126,7 @@ export async function dispatchAppTrigger(job: Job<AppTriggerDispatchJobData>) {
 
     logger.info('App trigger dispatch complete', {
       triggeredWorkflows: workflowRunIds.length,
-      totalMatching: matchingWorkflows.length,
+      totalMatching: matchingApps.length,
       appId,
       triggerId,
       eventId,

--- a/packages/lib/src/jobs/workflow/polling-trigger-job.ts
+++ b/packages/lib/src/jobs/workflow/polling-trigger-job.ts
@@ -3,6 +3,7 @@
 import { database as db, schema } from '@auxx/database'
 import type { Job } from 'bullmq'
 import { and, eq } from 'drizzle-orm'
+import { onCacheEvent } from '../../cache/invalidate'
 import { createScopedLogger } from '../../logger'
 import { PollingTriggerService } from '../../workflows/polling-trigger-service'
 import { WorkflowRunStatus } from '../../workflows/types'
@@ -307,6 +308,8 @@ export async function executePollingTrigger(job: Job<PollingTriggerJobData>) {
         .where(eq(schema.WorkflowApp.id, workflowAppId))
 
       await cancelInvalidPollingScheduler(workflowAppId, `Unrecoverable error: ${errorCode}`)
+
+      await onCacheEvent('workflow.enabled', { orgId: organizationId })
 
       logger.warn('Auto-paused workflow due to unrecoverable error', {
         workflowAppId,

--- a/packages/lib/src/jobs/workflow/resource-trigger-job.ts
+++ b/packages/lib/src/jobs/workflow/resource-trigger-job.ts
@@ -2,8 +2,8 @@
 
 import { database as db } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { getWorkflowApp } from '@auxx/services/workflows'
 import type { Job } from 'bullmq'
+import { getCachedWorkflowApp } from '../../cache'
 import { SystemUserService } from '../../users/system-user-service'
 import { RedisWorkflowExecutionReporter } from '../../workflow-engine'
 import { WorkflowExecutionService } from '../../workflows/workflow-execution-service'
@@ -39,33 +39,36 @@ export async function executeResourceTrigger(job: Job<ResourceTriggerJobData>) {
   })
 
   try {
-    // 1. Fetch workflow app using service method
-    const workflowAppResult = await getWorkflowApp({ workflowAppId, organizationId })
+    // 1. Fetch workflow app from cache
+    const workflowApp = await getCachedWorkflowApp(workflowAppId, organizationId)
 
-    if (workflowAppResult.isErr()) {
-      const error = workflowAppResult.error
-
-      // Log and skip if workflow not found/disabled (expected scenarios)
-      if (error.code === 'WORKFLOW_APP_NOT_FOUND' || error.code === 'WORKFLOW_NOT_PUBLISHED') {
-        logger.warn('Workflow not found or disabled, skipping', {
-          error: error.code,
-          message: error.message,
-          workflowAppId,
-          organizationId,
-          jobId: job.id,
-        })
-        return {
-          skipped: true,
-          reason: error.message,
-          workflowAppId,
-        }
+    if (!workflowApp) {
+      logger.warn('Workflow not found or disabled, skipping', {
+        workflowAppId,
+        organizationId,
+        jobId: job.id,
+      })
+      return {
+        skipped: true,
+        reason: `Workflow app ${workflowAppId} not found or not enabled`,
+        workflowAppId,
       }
-
-      // Throw for database errors (will retry)
-      throw new Error(`Failed to fetch workflow app: ${error.message}`)
     }
 
-    const { publishedWorkflow, organization } = workflowAppResult.value
+    const publishedWorkflow = workflowApp.publishedWorkflow
+
+    if (!publishedWorkflow) {
+      logger.warn('Workflow not published, skipping', {
+        workflowAppId,
+        organizationId,
+        jobId: job.id,
+      })
+      return {
+        skipped: true,
+        reason: `Workflow app ${workflowAppId} does not have a published workflow`,
+        workflowAppId,
+      }
+    }
 
     // 2. Create workflow run
     const executionService = new WorkflowExecutionService(db)

--- a/packages/lib/src/resources/crud/unified-handler-queries.ts
+++ b/packages/lib/src/resources/crud/unified-handler-queries.ts
@@ -23,8 +23,8 @@ import { FieldValueService, formatToRawValue } from '../../field-values'
 import {
   type EntityQueryContext,
   entityConditionBuilder,
-  systemConditionBuilder,
-} from '../../workflow-engine'
+} from '../../workflow-engine/query-builder/entity-condition-builder'
+import { systemConditionBuilder } from '../../workflow-engine/query-builder/system-condition-builder'
 import type { ResourceField } from '../registry'
 import { RESOURCE_TABLE_MAP, RESOURCE_TABLE_REGISTRY } from '../registry'
 import type { TableId } from '../registry/field-registry'

--- a/packages/lib/src/threads/__tests__/thread-query.service.test.ts
+++ b/packages/lib/src/threads/__tests__/thread-query.service.test.ts
@@ -11,46 +11,18 @@ vi.mock('@auxx/redis', () => ({
   getRedisClient: vi.fn(),
 }))
 
-// No longer need to mock config since feature flag is removed
-
-vi.mock('@auxx/database', () => ({
-  database: {},
-  schema: {
-    Thread: {
-      id: 'id',
-      lastMessageAt: 'lastMessageAt',
-      organizationId: 'organizationId',
-    },
-    Message: {
-      threadId: 'threadId',
-      id: 'id',
-      subject: 'subject',
-      sentAt: 'sentAt',
-      snippet: 'snippet',
-      isInbound: 'isInbound',
-      fromId: 'fromId',
-      createdById: 'createdById',
-      isFirstInThread: 'isFirstInThread',
-    },
-    ThreadReadStatus: {
-      threadId: 'threadId',
-      userId: 'userId',
-    },
-  },
-}))
-
 vi.mock('../../mail-views/mail-view-service', () => ({
   MailViewService: class {
     getMailView = vi.fn().mockResolvedValue(null)
   },
 }))
 
-vi.mock('@auxx/database/enums', () => ({
-  ModelTypeValues: ['contact', 'ticket', 'thread', 'user', 'inbox', 'message'],
-  ModelTypeMeta: {},
-  FieldType: {},
-  ThreadStatus: { OPEN: 'OPEN', ARCHIVED: 'ARCHIVED', SPAM: 'SPAM', TRASH: 'TRASH' },
-}))
+vi.mock('@auxx/database/enums', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@auxx/database/enums')>()
+  return {
+    ...actual,
+  }
+})
 
 vi.mock('@auxx/database/models', () => ({
   Thread: {},
@@ -76,13 +48,21 @@ vi.mock('../../resources/registry/resource-registry-service', () => ({
   },
 }))
 
-vi.mock('@auxx/types/actor', () => ({
-  toActorId: vi.fn((type: string, id: string) => `${type}:${id}`),
-}))
+vi.mock('@auxx/types/actor', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@auxx/types/actor')>()
+  return {
+    ...actual,
+    toActorId: vi.fn((type: string, id: string) => `${type}:${id}`),
+  }
+})
 
-vi.mock('@auxx/types/resource', () => ({
-  toRecordId: vi.fn((type: string, id: string) => `${type}:${id}`),
-}))
+vi.mock('@auxx/types/resource', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@auxx/types/resource')>()
+  return {
+    ...actual,
+    toRecordId: vi.fn((type: string, id: string) => `${type}:${id}`),
+  }
+})
 
 vi.mock('@auxx/logger', () => ({
   createScopedLogger: () => ({

--- a/packages/lib/src/workflow-engine/execution/trigger-app-workflow.ts
+++ b/packages/lib/src/workflow-engine/execution/trigger-app-workflow.ts
@@ -2,8 +2,8 @@
 
 import { database as db } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { getWorkflowApp } from '@auxx/services/workflows'
 import { err, ok } from 'neverthrow'
+import { getCachedWorkflowApp } from '../../cache'
 import { WorkflowExecutionService } from '../../workflows/workflow-execution-service'
 import { RedisWorkflowExecutionReporter } from '../execution-reporter'
 
@@ -36,22 +36,24 @@ export async function executeAppTriggeredWorkflow(params: {
     eventId,
   })
 
-  // 1. Fetch and validate workflow
-  const workflowResult = await getWorkflowApp({
-    workflowAppId,
-    organizationId,
-  })
+  // 1. Fetch and validate workflow from cache
+  const workflowApp = await getCachedWorkflowApp(workflowAppId, organizationId)
 
-  if (workflowResult.isErr()) {
-    return err(workflowResult.error)
+  if (!workflowApp) {
+    return err({
+      code: 'WORKFLOW_APP_NOT_FOUND' as const,
+      message: `Workflow app ${workflowAppId} not found or not enabled in organization ${organizationId}`,
+      workflowAppId,
+      organizationId,
+    })
   }
 
-  const { workflowApp, publishedWorkflow } = workflowResult.value
+  const publishedWorkflow = workflowApp.publishedWorkflow
 
-  if (!workflowApp.enabled) {
+  if (!publishedWorkflow) {
     return err({
-      code: 'WORKFLOW_NOT_ENABLED' as const,
-      message: `Workflow ${workflowAppId} is not enabled`,
+      code: 'WORKFLOW_NOT_PUBLISHED' as const,
+      message: `Workflow app ${workflowAppId} does not have a published workflow`,
       workflowAppId,
     })
   }

--- a/packages/lib/src/workflow-engine/execution/trigger-manual-resource-workflow-bulk.ts
+++ b/packages/lib/src/workflow-engine/execution/trigger-manual-resource-workflow-bulk.ts
@@ -2,11 +2,10 @@
 
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { getWorkflowApp } from '@auxx/services/workflows'
 import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
 import { inArray } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
-import { getCachedResource } from '../../cache'
+import { getCachedResource, getCachedWorkflowApp } from '../../cache'
 import { isCustomResourceId } from '../../resources/client'
 import { isSystemResourceId } from '../../resources/registry/types'
 import { executeResourceQuery, fetchResourceById } from '../../resources/resource-fetcher'
@@ -116,22 +115,23 @@ export async function triggerManualResourceWorkflowBulk(params: {
     createdBy,
   })
 
-  // 1. Validate workflow (shared validation for all resources)
-  const workflowResult = await getWorkflowApp({
-    workflowAppId,
-    organizationId,
-  })
+  // 1. Validate workflow (shared validation for all resources) — from cache
+  const workflowApp = await getCachedWorkflowApp(workflowAppId, organizationId)
 
-  if (workflowResult.isErr()) {
-    return err(workflowResult.error)
+  if (!workflowApp) {
+    return err({
+      code: 'WORKFLOW_APP_NOT_FOUND',
+      message: `Workflow app ${workflowAppId} not found or not enabled in organization ${organizationId}`,
+      workflowAppId,
+    })
   }
 
-  const { workflowApp, publishedWorkflow } = workflowResult.value
+  const publishedWorkflow = workflowApp.publishedWorkflow
 
-  if (!workflowApp.enabled) {
+  if (!publishedWorkflow) {
     return err({
-      code: 'WORKFLOW_NOT_ENABLED',
-      message: `Workflow ${workflowAppId} is not enabled`,
+      code: 'WORKFLOW_NOT_PUBLISHED',
+      message: `Workflow app ${workflowAppId} does not have a published workflow`,
       workflowAppId,
     })
   }

--- a/packages/lib/src/workflow-engine/execution/trigger-manual-resource-workflow.ts
+++ b/packages/lib/src/workflow-engine/execution/trigger-manual-resource-workflow.ts
@@ -2,9 +2,9 @@
 
 import { database as db } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { getWorkflowApp } from '@auxx/services/workflows'
 import { parseRecordId, type RecordId } from '@auxx/types/resource'
 import { err, ok } from 'neverthrow'
+import { getCachedWorkflowApp } from '../../cache'
 import { fetchResourceById } from '../../resources'
 import { WorkflowExecutionService } from '../../workflows/workflow-execution-service'
 import { RedisWorkflowExecutionReporter } from '../execution-reporter'
@@ -49,22 +49,24 @@ export async function triggerManualResourceWorkflow(params: {
     createdBy,
   })
 
-  // 1. Fetch and validate workflow
-  const workflowResult = await getWorkflowApp({
-    workflowAppId,
-    organizationId,
-  })
+  // 1. Fetch and validate workflow from cache
+  const workflowApp = await getCachedWorkflowApp(workflowAppId, organizationId)
 
-  if (workflowResult.isErr()) {
-    return err(workflowResult.error)
+  if (!workflowApp) {
+    return err({
+      code: 'WORKFLOW_APP_NOT_FOUND' as const,
+      message: `Workflow app ${workflowAppId} not found or not enabled in organization ${organizationId}`,
+      workflowAppId,
+      organizationId,
+    })
   }
 
-  const { workflowApp, publishedWorkflow, organization } = workflowResult.value
+  const publishedWorkflow = workflowApp.publishedWorkflow
 
-  if (!workflowApp.enabled) {
+  if (!publishedWorkflow) {
     return err({
-      code: 'WORKFLOW_NOT_ENABLED' as const,
-      message: `Workflow ${workflowAppId} is not enabled`,
+      code: 'WORKFLOW_NOT_PUBLISHED' as const,
+      message: `Workflow app ${workflowAppId} does not have a published workflow`,
       workflowAppId,
     })
   }

--- a/packages/lib/src/workflows/workflow-service.ts
+++ b/packages/lib/src/workflows/workflow-service.ts
@@ -3,6 +3,7 @@
 import { type Database, schema, type Transaction } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, count, desc, eq, ilike, inArray, or, type SQL } from 'drizzle-orm'
+import { onCacheEvent } from '../cache/invalidate'
 import { getQueue, Queues } from '../jobs/queues'
 import { WorkflowEngine } from '../workflow-engine/core/workflow-engine'
 import { PollingTriggerService } from './polling-trigger-service'
@@ -310,6 +311,8 @@ export class WorkflowService {
         organizationId,
       })
 
+      await onCacheEvent('workflow.created', { orgId: organizationId })
+
       if (result) {
         // Transform to match expected structure
         // Use draft workflow for editing
@@ -562,6 +565,8 @@ export class WorkflowService {
           })
           // Don't fail the update operation if scheduling fails
         }
+
+        await onCacheEvent('workflow.enabled', { orgId: organizationId })
       }
 
       if (result) {
@@ -800,6 +805,8 @@ export class WorkflowService {
 
       logger.info('Workflow app deleted successfully', { workflowAppId: id, organizationId })
 
+      await onCacheEvent('workflow.deleted', { orgId: organizationId })
+
       // 6. Cancel BullMQ jobs (fire-and-forget, non-blocking)
       // Jobs are idempotent - they check DB first and no-op if records don't exist
       this.cancelWorkflowJobs(id, workflowRunIds).catch((error) => {
@@ -907,6 +914,8 @@ export class WorkflowService {
         newId: result?.id,
         organizationId,
       })
+
+      await onCacheEvent('workflow.created', { orgId: organizationId })
 
       return result
     } catch (error) {

--- a/packages/lib/src/workflows/workflow-version-service.ts
+++ b/packages/lib/src/workflows/workflow-version-service.ts
@@ -3,6 +3,7 @@
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
+import { onCacheEvent } from '../cache/invalidate'
 import { PollingTriggerService } from './polling-trigger-service'
 import { ScheduledTriggerService } from './scheduled-trigger-service'
 import { WorkflowTriggerType, type WorkflowVersion } from './types'
@@ -147,6 +148,8 @@ export class WorkflowVersionService {
         })
         // Don't fail the publish operation if scheduling fails
       }
+
+      await onCacheEvent('workflow.published', { orgId: organizationId })
 
       return {
         id: newVersion.id,


### PR DESCRIPTION
feat: add installed apps and workflow apps providers to cache

- Implemented `installedAppsProvider` to compute installed apps with connection definitions for an organization.
- Created `workflowAppsProvider` to compute all workflow apps with published workflows for an organization.
- Updated `register-providers.ts` to register the new providers.
- Added caching queries for workflow apps in `workflow-app-queries.ts`.
- Refactored various services and jobs to utilize cached workflow apps instead of direct database queries.
- Enhanced subscription provider to include additional fields and renamed types for clarity.
- Introduced cache invalidation events in custom field and entity definition services.
- Updated workflow execution logic to improve performance and reliability by leveraging cached data.