### PR TITLE
feat: refactor subscription handling and introduce recovery for past_due status

### DIFF
--- a/apps/web/src/app/(protected)/app/_components/app-layout-wrapper.tsx
+++ b/apps/web/src/app/(protected)/app/_components/app-layout-wrapper.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import type { DehydratedOrganization } from '@auxx/lib/dehydration'
+import { BLOCKED_SUBSCRIPTION_STATUSES } from '@auxx/types/billing'
 import { TooltipProvider } from '@auxx/ui/components/tooltip'
 import type { ReactNode } from 'react'
 import { ChannelProvider } from '~/components/channels/providers/channel-provider'
@@ -26,8 +27,9 @@ interface AppLayoutWrapperProps {
 /** Helper function to check if subscription is expired */
 function isSubscriptionExpired(subscription: DehydratedOrganization['subscription']): boolean {
   if (!subscription) return false
-  const expiredStatuses = ['canceled', 'unpaid', 'past_due', 'incomplete_expired']
-  return expiredStatuses.includes(subscription.status.toLowerCase())
+  return (BLOCKED_SUBSCRIPTION_STATUSES as readonly string[]).includes(
+    subscription.status.toLowerCase()
+  )
 }
 
 /** Helper function to check if trial is expired */

--- a/apps/web/src/app/(protected)/organizations/page.tsx
+++ b/apps/web/src/app/(protected)/organizations/page.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import type { DehydratedOrganization } from '@auxx/lib/dehydration'
+import { BLOCKED_SUBSCRIPTION_STATUSES } from '@auxx/types/billing'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@auxx/ui/components/card'
@@ -29,8 +30,9 @@ function getSubscriptionStatus(org: DehydratedOrganization) {
     return { label: 'No Subscription', isActive: false }
   }
 
-  const expiredStatuses = ['canceled', 'unpaid', 'past_due', 'incomplete_expired']
-  const isExpired = expiredStatuses.includes(org.subscription.status.toLowerCase())
+  const isExpired = (BLOCKED_SUBSCRIPTION_STATUSES as readonly string[]).includes(
+    org.subscription.status.toLowerCase()
+  )
   const isTrialEnded = org.subscription.hasTrialEnded
 
   if (isExpired) {

--- a/apps/web/src/app/api/billing/webhook/route.ts
+++ b/apps/web/src/app/api/billing/webhook/route.ts
@@ -7,6 +7,7 @@ import { WebhookService } from '@auxx/billing'
 import { configService } from '@auxx/credentials'
 import { database } from '@auxx/database'
 import { isSelfHosted } from '@auxx/deployment'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { handlePlanDowngrade } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { type NextRequest, NextResponse } from 'next/server'
@@ -41,17 +42,41 @@ export async function POST(req: NextRequest) {
       database,
       configService.get<string>('STRIPE_WEBHOOK_SECRET')!,
       {
-        /**
-         * Logs successful invoice payments for observability.
-         */
-        onInvoicePaid: async (event) => {
-          logger.info('Invoice paid event processed', { eventId: event.id })
+        onCheckoutSessionCompleted: async (event, ctx) => {
+          if (ctx.organizationId) {
+            await onCacheEvent('plan.subscribed', { orgId: ctx.organizationId })
+          }
+          logger.info('Checkout session completed, cache invalidated', { eventId: event.id })
         },
-        /**
-         * Warns about failed invoice payments so they can be retried manually.
-         */
-        onInvoicePaymentFailed: async (event) => {
-          logger.warn('Invoice payment failed', { eventId: event.id })
+        onSubscriptionCreated: async (event, ctx) => {
+          if (ctx.organizationId) {
+            await onCacheEvent('plan.subscribed', { orgId: ctx.organizationId })
+          }
+          logger.info('Subscription created, cache invalidated', { eventId: event.id })
+        },
+        onSubscriptionUpdated: async (event, ctx) => {
+          if (ctx.organizationId) {
+            await onCacheEvent('plan.changed', { orgId: ctx.organizationId })
+          }
+          logger.info('Subscription updated, cache invalidated', { eventId: event.id })
+        },
+        onSubscriptionDeleted: async (event, ctx) => {
+          if (ctx.organizationId) {
+            await onCacheEvent('plan.canceled', { orgId: ctx.organizationId })
+          }
+          logger.info('Subscription deleted, cache invalidated', { eventId: event.id })
+        },
+        onInvoicePaid: async (event, ctx) => {
+          if (ctx.organizationId) {
+            await onCacheEvent('plan.changed', { orgId: ctx.organizationId })
+          }
+          logger.info('Invoice paid, cache invalidated', { eventId: event.id })
+        },
+        onInvoicePaymentFailed: async (event, ctx) => {
+          if (ctx.organizationId) {
+            await onCacheEvent('plan.changed', { orgId: ctx.organizationId })
+          }
+          logger.warn('Invoice payment failed, cache invalidated', { eventId: event.id })
         },
       },
       handlePlanDowngrade

--- a/apps/web/src/hooks/use-subscription.ts
+++ b/apps/web/src/hooks/use-subscription.ts
@@ -1,5 +1,6 @@
 // apps/web/src/hooks/use-subscription.ts
 
+import { BLOCKED_SUBSCRIPTION_STATUSES } from '@auxx/types/billing'
 import { useIsSelfHosted } from '~/hooks/use-deployment-mode'
 import {
   useDehydratedOrganization,
@@ -42,9 +43,9 @@ export function useIsSubscriptionExpired(): boolean {
   if (selfHosted) return false // Never expired for self-hosted
   if (!subscription) return false
 
-  // Expired/inactive statuses
-  const expiredStatuses = ['canceled', 'unpaid', 'past_due', 'incomplete_expired']
-  return expiredStatuses.includes(subscription.status.toLowerCase())
+  return (BLOCKED_SUBSCRIPTION_STATUSES as readonly string[]).includes(
+    subscription.status.toLowerCase()
+  )
 }
 
 /**

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@auxx/credentials": "workspace:*",
     "@auxx/database": "workspace:*",
+    "@auxx/types": "workspace:*",
     "@auxx/deployment": "workspace:*",
     "@auxx/logger": "workspace:*",
     "drizzle-orm": "catalog:",

--- a/packages/billing/src/hooks/checkout-session.ts
+++ b/packages/billing/src/hooks/checkout-session.ts
@@ -15,13 +15,13 @@ const logger = createScopedLogger('webhook:checkout-session')
 export async function handleCheckoutSessionCompleted(
   db: Database,
   event: Stripe.Event
-): Promise<void> {
+): Promise<{ organizationId: string | null }> {
   try {
     const checkoutSession = event.data.object as Stripe.Checkout.Session
 
     // Skip setup mode sessions
     if (checkoutSession.mode === 'setup') {
-      return
+      return { organizationId: null }
     }
 
     // if (!checkoutSession.subscription) {
@@ -58,7 +58,7 @@ export async function handleCheckoutSessionCompleted(
         subscriptionMetadata: subscription.metadata,
         sessionMetadata: checkoutSession.metadata,
       })
-      return
+      return { organizationId: null }
     }
 
     // Get price and plan info from subscription
@@ -165,6 +165,8 @@ export async function handleCheckoutSessionCompleted(
       plan: plan?.name,
       status: subscription.status,
     })
+
+    return { organizationId: referenceId }
   } catch (error: any) {
     logger.error('Stripe webhook failed in checkout session', { error: error.message })
     throw error

--- a/packages/billing/src/hooks/invoice-paid.ts
+++ b/packages/billing/src/hooks/invoice-paid.ts
@@ -23,7 +23,10 @@ const logger = createScopedLogger('webhook:invoice-paid')
  * @param event Stripe webhook event carrying the paid invoice payload.
  * @throws Error Re-throws any underlying error to allow upstream retry or alerting flows.
  */
-export async function handleInvoicePaid(db: Database, event: Stripe.Event): Promise<void> {
+export async function handleInvoicePaid(
+  db: Database,
+  event: Stripe.Event
+): Promise<{ organizationId: string | null }> {
   try {
     const invoice = event.data.object as Stripe.Invoice
     const stripeInvoiceId = invoice.id!
@@ -35,7 +38,7 @@ export async function handleInvoicePaid(db: Database, event: Stripe.Event): Prom
       logger.warn('Invoice not associated with subscription', {
         stripeInvoiceId,
       })
-      return
+      return { organizationId: null }
     }
 
     // Extract subscription ID (can be string or object)
@@ -52,7 +55,7 @@ export async function handleInvoicePaid(db: Database, event: Stripe.Event): Prom
         stripeSubscriptionId,
         stripeInvoiceId,
       })
-      return
+      return { organizationId: null }
     }
 
     // Check if invoice already exists
@@ -100,6 +103,8 @@ export async function handleInvoicePaid(db: Database, event: Stripe.Event): Prom
         organizationId: localSub.organizationId,
       })
     }
+
+    return { organizationId: localSub.organizationId }
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : ''
     logger.error('Stripe webhook failed in invoice paid', { error: message })

--- a/packages/billing/src/hooks/invoice-payment-failed.ts
+++ b/packages/billing/src/hooks/invoice-payment-failed.ts
@@ -23,7 +23,10 @@ const logger = createScopedLogger('webhook:invoice-payment-failed')
  * @param event Stripe webhook event carrying the failed invoice payload.
  * @throws Error Propagates any thrown error so upstream handlers can manage retries.
  */
-export async function handleInvoicePaymentFailed(db: Database, event: Stripe.Event): Promise<void> {
+export async function handleInvoicePaymentFailed(
+  db: Database,
+  event: Stripe.Event
+): Promise<{ organizationId: string | null }> {
   try {
     const invoice = event.data.object as Stripe.Invoice
     const stripeInvoiceId = invoice.id!
@@ -35,7 +38,7 @@ export async function handleInvoicePaymentFailed(db: Database, event: Stripe.Eve
       logger.warn('Invoice not associated with subscription', {
         stripeInvoiceId,
       })
-      return
+      return { organizationId: null }
     }
 
     // Extract subscription ID (can be string or object)
@@ -52,7 +55,7 @@ export async function handleInvoicePaymentFailed(db: Database, event: Stripe.Eve
         stripeSubscriptionId,
         stripeInvoiceId,
       })
-      return
+      return { organizationId: null }
     }
 
     // Check if invoice exists
@@ -103,6 +106,8 @@ export async function handleInvoicePaymentFailed(db: Database, event: Stripe.Eve
       invoiceId: stripeInvoiceId,
       attemptCount: invoice.attempt_count,
     })
+
+    return { organizationId: localSub.organizationId }
   } catch (error: any) {
     logger.error('Stripe webhook failed in invoice payment failed', { error: error.message })
     throw error

--- a/packages/billing/src/hooks/subscription-deleted.ts
+++ b/packages/billing/src/hooks/subscription-deleted.ts
@@ -23,7 +23,10 @@ const logger = createScopedLogger('webhook:subscription-deleted')
  * @returns Promise that resolves once the local subscription (if found) is marked as canceled.
  * @throws Error when database interactions or input parsing fails, allowing the caller to handle retries.
  */
-export async function handleSubscriptionDeleted(db: Database, event: Stripe.Event): Promise<void> {
+export async function handleSubscriptionDeleted(
+  db: Database,
+  event: Stripe.Event
+): Promise<{ organizationId: string | null }> {
   try {
     const subscriptionDeleted = event.data.object as Stripe.Subscription
     const subscriptionId = subscriptionDeleted.id
@@ -37,7 +40,7 @@ export async function handleSubscriptionDeleted(db: Database, event: Stripe.Even
       logger.warn('Subscription not found in database', {
         stripeSubscriptionId: subscriptionId,
       })
-      return
+      return { organizationId: null }
     }
 
     // Mark as canceled
@@ -53,6 +56,8 @@ export async function handleSubscriptionDeleted(db: Database, event: Stripe.Even
     logger.info('Subscription deleted', {
       subscriptionId: subscription.id,
     })
+
+    return { organizationId: subscription.organizationId }
   } catch (error: any) {
     logger.error('Stripe webhook failed in subscription deletion', { error: error.message })
     throw error

--- a/packages/billing/src/hooks/subscription-updated.ts
+++ b/packages/billing/src/hooks/subscription-updated.ts
@@ -33,7 +33,7 @@ async function syncStripeSubscription(
   stripeSubscription: Stripe.Subscription,
   eventType: string,
   onPlanChange?: PlanChangeHandler
-): Promise<void> {
+): Promise<{ organizationId: string | null }> {
   const firstItem = stripeSubscription.items.data.at(0)
   const priceId = firstItem?.price.id ?? null
   const priceLookupKey = firstItem?.price.lookup_key ?? null
@@ -107,7 +107,7 @@ async function syncStripeSubscription(
             foundOrgIds: subs.map((s) => s.organizationId),
           })
           // Don't fall back to wrong org - return early
-          return
+          return { organizationId: null }
         }
       } else {
         const preferred = subs.find((s) => s.status === 'active' || s.status === 'trialing')
@@ -145,7 +145,7 @@ async function syncStripeSubscription(
       organizationId,
       subscriptionId,
     })
-    return
+    return { organizationId: null }
   }
 
   const periodStart = firstItem?.current_period_start
@@ -306,6 +306,8 @@ async function syncStripeSubscription(
       }
     }
   }
+
+  return { organizationId: localSubscription.organizationId }
 }
 
 /**
@@ -325,10 +327,10 @@ async function processSubscriptionWebhook(
   event: Stripe.Event,
   eventType: 'customer.subscription.updated' | 'customer.subscription.created',
   onPlanChange?: PlanChangeHandler
-): Promise<void> {
+): Promise<{ organizationId: string | null }> {
   try {
     const stripeSubscription = event.data.object as Stripe.Subscription
-    await syncStripeSubscription(db, stripeSubscription, eventType, onPlanChange)
+    return await syncStripeSubscription(db, stripeSubscription, eventType, onPlanChange)
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : ''
     logger.error('Stripe webhook subscription sync failed', {
@@ -341,30 +343,22 @@ async function processSubscriptionWebhook(
 
 /**
  * Public webhook entry point for handling `customer.subscription.updated` events emitted by Stripe.
- *
- * @param db Database client used to synchronize the subscription with the local data store
- * @param event Stripe webhook event that encapsulates the updated subscription payload
- * @returns Promise that resolves once the subscription has been brought up to date locally
  */
 export async function handleSubscriptionUpdated(
   db: Database,
   event: Stripe.Event,
   onPlanChange?: PlanChangeHandler
-): Promise<void> {
-  await processSubscriptionWebhook(db, event, 'customer.subscription.updated', onPlanChange)
+): Promise<{ organizationId: string | null }> {
+  return await processSubscriptionWebhook(db, event, 'customer.subscription.updated', onPlanChange)
 }
 
 /**
  * Public webhook entry point for handling `customer.subscription.created` events emitted by Stripe.
- *
- * @param db Database client used to synchronize the subscription with the local data store
- * @param event Stripe webhook event that encapsulates the newly created subscription payload
- * @returns Promise that resolves once the subscription creation has been mirrored locally
  */
 export async function handleSubscriptionCreated(
   db: Database,
   event: Stripe.Event,
   onPlanChange?: PlanChangeHandler
-): Promise<void> {
-  await processSubscriptionWebhook(db, event, 'customer.subscription.created', onPlanChange)
+): Promise<{ organizationId: string | null }> {
+  return await processSubscriptionWebhook(db, event, 'customer.subscription.created', onPlanChange)
 }

--- a/packages/billing/src/services/subscription-service.ts
+++ b/packages/billing/src/services/subscription-service.ts
@@ -6,6 +6,7 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { isUsableSubscriptionStatus } from '@auxx/types/billing'
 import { eq } from 'drizzle-orm'
 import type Stripe from 'stripe'
 import type {
@@ -933,6 +934,12 @@ export class SubscriptionService {
         stripeSubscriptionId: currentSubscription.stripeSubscriptionId,
       })
 
+      // Capture past_due + trial state BEFORE any recovery or mutation.
+      // After recovery, status will be 'active' and isTrialing will be false,
+      // so this must be checked upfront.
+      const isPastDue = currentSubscription.status === 'past_due'
+      const isPastDueFromTrial = isPastDue && currentSubscription.hasTrialEnded
+
       // Determine change type
       const currentPlanLevel = currentSubscription.plan.hierarchyLevel
       const targetPlanLevel = targetPlan.hierarchyLevel
@@ -964,6 +971,21 @@ export class SubscriptionService {
       if (isUpgrade || isMonthlyToAnnual || (isBillingCycleChange && isTrialing)) {
         // UPGRADE, MONTHLY→ANNUAL, or TRIAL BILLING CYCLE CHANGE: Bill immediately with proration
         logger.info('Processing as upgrade - billing immediately')
+
+        // Recover from past_due before applying upgrade
+        if (isPastDue) {
+          if (!input.paymentMethodId) {
+            throw new Error('A payment method is required to recover a past_due subscription.')
+          }
+          await this.recoverPastDueSubscription(
+            stripe,
+            currentSubscription.stripeSubscriptionId,
+            currentSubscription.stripeCustomerId,
+            input.paymentMethodId,
+            input.organizationId,
+            currentSubscription.id
+          )
+        }
 
         // If subscription was canceled, restore it first
         if (currentSubscription.cancelAtPeriodEnd) {
@@ -1002,7 +1024,7 @@ export class SubscriptionService {
         // Determine if this is a trial→paid conversion
         const wasTrialing = isTrialing
         const isNowActive = updatedStripeSubscription.status === 'active'
-        const isTrialConversion = wasTrialing && isNowActive
+        const isTrialConversion = isNowActive && (wasTrialing || isPastDueFromTrial)
 
         // Update database with actual status from Stripe
         await this.db
@@ -1018,7 +1040,7 @@ export class SubscriptionService {
             updatedAt: new Date(),
             cancelAtPeriodEnd: updatedStripeSubscription.cancel_at_period_end,
             canceledAt: null,
-            // Handle trial→paid conversion
+            // Handle trial→paid conversion (including past_due from trial)
             ...(isTrialConversion
               ? {
                   hasTrialEnded: true,
@@ -1027,6 +1049,7 @@ export class SubscriptionService {
                   trialEligibilityReason: 'Already converted from trial',
                 }
               : {}),
+            ...this.buildConversionFields(isPastDueFromTrial, updatedStripeSubscription.status),
           })
           .where(eq(schema.PlanSubscription.id, currentSubscription.id))
 
@@ -1062,6 +1085,21 @@ export class SubscriptionService {
           scheduledFor: currentSubscription.periodEnd,
         })
 
+        // Recover from past_due before scheduling downgrade
+        if (isPastDue) {
+          if (!input.paymentMethodId) {
+            throw new Error('A payment method is required to recover a past_due subscription.')
+          }
+          await this.recoverPastDueSubscription(
+            stripe,
+            currentSubscription.stripeSubscriptionId,
+            currentSubscription.stripeCustomerId,
+            input.paymentMethodId,
+            input.organizationId,
+            currentSubscription.id
+          )
+        }
+
         // If subscription was canceled, restore it first since downgrade means continuing service
         if (currentSubscription.cancelAtPeriodEnd) {
           logger.info('Restoring canceled subscription before scheduling downgrade')
@@ -1076,6 +1114,7 @@ export class SubscriptionService {
           {
             items: [{ id: subscriptionItemId, price: priceId, quantity: input.seats }],
             proration_behavior: 'none',
+            ...(input.paymentMethodId ? { default_payment_method: input.paymentMethodId } : {}),
             ...(isBillingCycleChange ? {} : { billing_cycle_anchor: 'unchanged' }),
           }
         )
@@ -1091,6 +1130,10 @@ export class SubscriptionService {
           input.paymentMethodId
         )
 
+        // Determine if recovery made this a trial conversion
+        const isNowActive = updatedStripeSubscription.status === 'active'
+        const isTrialConversion = isNowActive && isPastDueFromTrial
+
         // Store the scheduled change in database and update status from Stripe
         await this.db
           .update(schema.PlanSubscription)
@@ -1104,6 +1147,7 @@ export class SubscriptionService {
             updatedAt: new Date(),
             cancelAtPeriodEnd: updatedStripeSubscription.cancel_at_period_end,
             canceledAt: null,
+            ...this.buildConversionFields(isPastDueFromTrial, updatedStripeSubscription.status),
           })
           .where(eq(schema.PlanSubscription.id, currentSubscription.id))
 
@@ -1112,7 +1156,7 @@ export class SubscriptionService {
           subscriptionId: currentSubscription.id,
           organizationId: input.organizationId,
           userId: input.userId,
-          changeType: 'downgrade',
+          changeType: isTrialConversion ? 'trial_conversion' : 'downgrade',
           fromPlan: currentSubscription.plan?.name,
           toPlan: targetPlan.name,
           fromBillingCycle: currentSubscription.billingCycle,
@@ -1123,7 +1167,10 @@ export class SubscriptionService {
           scheduledFor: currentSubscription.periodEnd ?? undefined,
         })
 
-        logger.info('Downgrade scheduled successfully')
+        logger.info('Downgrade scheduled successfully', {
+          isTrialConversion,
+          newStatus: updatedStripeSubscription.status,
+        })
 
         return {
           success: true,
@@ -1132,14 +1179,85 @@ export class SubscriptionService {
           scheduledFor: currentSubscription.periodEnd ?? undefined,
         }
       } else {
-        // Same plan, just seat or billing cycle change (or trial conversion on same plan)
+        // Same plan — seat change, billing cycle change, or past_due recovery
+        const hasActualChanges =
+          input.seats !== currentSubscription.seats ||
+          input.billingCycle !== currentSubscription.billingCycle
+
+        // Guard: past_due requires a payment method — fail fast if missing
+        if (isPastDue && !input.paymentMethodId) {
+          throw new Error('A payment method is required to recover a past_due subscription.')
+        }
+
+        // Phase 1: Recover from past_due (if applicable)
+        let recoveredSubscription: Stripe.Subscription | null = null
+        if (isPastDue && input.paymentMethodId) {
+          recoveredSubscription = await this.recoverPastDueSubscription(
+            stripe,
+            currentSubscription.stripeSubscriptionId,
+            currentSubscription.stripeCustomerId,
+            input.paymentMethodId,
+            input.organizationId,
+            currentSubscription.id
+          )
+        }
+
+        // Pure recovery (no actual changes) — write DB and return early
+        if (recoveredSubscription && !hasActualChanges) {
+          const firstItem = recoveredSubscription.items.data[0]!
+          const isSuccessfulConversion =
+            isPastDueFromTrial && recoveredSubscription.status === 'active'
+
+          await this.db
+            .update(schema.PlanSubscription)
+            .set({
+              status: recoveredSubscription.status,
+              periodStart: new Date(firstItem.current_period_start * 1000),
+              periodEnd: new Date(firstItem.current_period_end * 1000),
+              cancelAtPeriodEnd: recoveredSubscription.cancel_at_period_end,
+              updatedAt: new Date(),
+              ...this.buildConversionFields(isPastDueFromTrial, recoveredSubscription.status),
+            })
+            .where(eq(schema.PlanSubscription.id, currentSubscription.id))
+
+          await this.detachPreviousPaymentMethod(
+            stripe,
+            input.previousPaymentMethodId,
+            input.paymentMethodId
+          )
+
+          await this.recordSubscriptionChange({
+            subscriptionId: currentSubscription.id,
+            organizationId: input.organizationId,
+            userId: input.userId,
+            changeType: isSuccessfulConversion ? 'trial_conversion' : 'reactivation',
+            fromPlan: currentSubscription.plan?.name,
+            toPlan: currentSubscription.plan?.name,
+            fromBillingCycle: currentSubscription.billingCycle,
+            toBillingCycle: input.billingCycle,
+            fromSeats: currentSubscription.seats,
+            toSeats: input.seats,
+            immediate: true,
+          })
+
+          return {
+            success: true,
+            subscriptionId: currentSubscription.id,
+            immediate: true,
+          }
+        }
+
+        // Phase 2: Apply seat/billing-cycle changes (normal path)
+        // This runs for:
+        // - Non-past-due subscriptions (normal seat/billing changes)
+        // - Recovered subscriptions that also have seat/billing changes
         logger.info('Processing same-plan change', {
           isTrialing,
+          isPastDueFromTrial,
           seats: input.seats,
           billingCycle: input.billingCycle,
         })
 
-        // If trialing, end the trial immediately to trigger first payment
         const updatedStripeSubscription = await stripe.subscriptions.update(
           currentSubscription.stripeSubscriptionId,
           {
@@ -1161,22 +1279,23 @@ export class SubscriptionService {
           input.paymentMethodId
         )
 
-        // Get period info from Stripe response
         const firstItem = updatedStripeSubscription.items.data[0]!
 
-        // Determine if this is a trial→paid conversion
+        // Determine if this is a trial→paid conversion.
+        // Both conditions require the post-mutation status to be 'active' —
+        // if the mutation results in past_due/incomplete/etc., it's NOT a successful conversion.
         const wasTrialing = isTrialing
         const isNowActive = updatedStripeSubscription.status === 'active'
-        const isTrialConversion = wasTrialing && isNowActive
+        const isTrialConversion = isNowActive && (wasTrialing || isPastDueFromTrial)
 
         logger.info('Stripe subscription updated (same-plan path)', {
           stripeStatus: updatedStripeSubscription.status,
           wasTrialing,
+          isPastDueFromTrial,
           isNowActive,
           isTrialConversion,
         })
 
-        // Determine change type for history
         const isSeatChange = input.seats !== currentSubscription.seats
         const changeType = isTrialConversion
           ? 'trial_conversion'
@@ -1196,19 +1315,10 @@ export class SubscriptionService {
             periodEnd: new Date(firstItem.current_period_end * 1000),
             cancelAtPeriodEnd: updatedStripeSubscription.cancel_at_period_end,
             updatedAt: new Date(),
-            // Handle trial→paid conversion
-            ...(isTrialConversion
-              ? {
-                  hasTrialEnded: true,
-                  trialConversionStatus: 'CONVERTED_TO_PAID' as const,
-                  isEligibleForTrial: false,
-                  trialEligibilityReason: 'Already converted from trial',
-                }
-              : {}),
+            ...this.buildConversionFields(isPastDueFromTrial, updatedStripeSubscription.status),
           })
           .where(eq(schema.PlanSubscription.id, currentSubscription.id))
 
-        // Record subscription history
         await this.recordSubscriptionChange({
           subscriptionId: currentSubscription.id,
           organizationId: input.organizationId,
@@ -1232,6 +1342,175 @@ export class SubscriptionService {
     }
 
     throw new BillingError(ErrorCode.SUBSCRIPTION_NOT_FOUND)
+  }
+
+  /**
+   * Attempts to recover a past_due subscription by paying outstanding invoices.
+   * Pays invoices oldest-first, stopping as soon as the subscription reaches a usable status.
+   *
+   * @returns The refreshed Stripe subscription in a usable state.
+   * @throws If payment fails or subscription does not reach a usable state.
+   */
+  private async recoverPastDueSubscription(
+    stripe: Stripe,
+    stripeSubscriptionId: string,
+    stripeCustomerId: string | null,
+    paymentMethodId: string,
+    organizationId: string,
+    localSubscriptionId: string
+  ): Promise<Stripe.Subscription> {
+    logger.info('Attempting past_due recovery', {
+      organizationId,
+      stripeSubscriptionId,
+    })
+
+    // 1. Attach payment method to customer + subscription
+    await this.setCustomerDefaultPaymentMethod(stripe, stripeCustomerId, paymentMethodId)
+    await stripe.subscriptions.update(stripeSubscriptionId, {
+      default_payment_method: paymentMethodId,
+    })
+
+    // 2. Find open invoices for this subscription
+    const openInvoices = await stripe.invoices.list({
+      subscription: stripeSubscriptionId,
+      status: 'open',
+      limit: 10,
+    })
+
+    // 3. Pay oldest first (Stripe returns newest-first), stop when subscription is usable
+    const sortedOldestFirst = [...openInvoices.data].reverse()
+
+    for (const invoice of sortedOldestFirst) {
+      const paidInvoice = await stripe.invoices.pay(invoice.id, {
+        payment_method: paymentMethodId,
+      })
+
+      logger.info('Paid outstanding invoice', {
+        invoiceId: invoice.id,
+        amount: invoice.amount_due,
+        billingReason: invoice.billing_reason,
+      })
+
+      // Persist invoice locally so the UI reflects it immediately
+      // (webhook may arrive later or not at all in dev)
+      await this.syncPaidInvoice(paidInvoice, organizationId, localSubscriptionId)
+
+      // Check if subscription has recovered — stop when it reaches a usable status
+      const refreshed = await stripe.subscriptions.retrieve(stripeSubscriptionId)
+      if (isUsableSubscriptionStatus(refreshed.status)) {
+        logger.info('Subscription recovered', {
+          organizationId,
+          newStatus: refreshed.status,
+        })
+        return refreshed
+      }
+    }
+
+    // 4. All invoices paid but subscription is still in a blocked status — abort
+    const finalState = await stripe.subscriptions.retrieve(stripeSubscriptionId)
+    if (!isUsableSubscriptionStatus(finalState.status)) {
+      logger.error('Subscription still blocked after paying all open invoices', {
+        organizationId,
+        stripeSubscriptionId,
+        finalStatus: finalState.status,
+      })
+      throw new Error(
+        `Subscription could not be recovered. Status is '${finalState.status}' after paying all outstanding invoices.`
+      )
+    }
+
+    return finalState
+  }
+
+  /**
+   * Persists a paid Stripe invoice to the local database.
+   * Idempotent — if the invoice already exists (e.g. from a webhook), it updates it.
+   */
+  private async syncPaidInvoice(
+    invoice: Stripe.Invoice,
+    organizationId: string,
+    subscriptionId: string
+  ): Promise<void> {
+    const stripeInvoiceId = invoice.id!
+
+    try {
+      const existing = await this.db.query.Invoice.findFirst({
+        where: (inv, { eq }) => eq(inv.stripeInvoiceId, stripeInvoiceId),
+      })
+
+      if (existing) {
+        await this.db
+          .update(schema.Invoice)
+          .set({
+            status: 'PAID',
+            paidDate: new Date(),
+            pdfUrl: invoice.invoice_pdf ?? undefined,
+            amount: invoice.amount_paid,
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.Invoice.id, existing.id))
+
+        logger.info('Invoice updated during recovery', {
+          invoiceId: existing.id,
+          stripeInvoiceId,
+        })
+      } else {
+        await this.db.insert(schema.Invoice).values({
+          organizationId,
+          subscriptionId,
+          stripeInvoiceId,
+          invoiceNumber: invoice.number ?? `INV-${stripeInvoiceId}`,
+          amount: invoice.amount_paid,
+          status: 'PAID',
+          invoiceDate: new Date(invoice.created * 1000),
+          dueDate: invoice.due_date ? new Date(invoice.due_date * 1000) : new Date(),
+          paidDate: new Date(),
+          currency: invoice.currency.toUpperCase(),
+          billingReason: invoice.billing_reason ?? undefined,
+          pdfUrl: invoice.invoice_pdf ?? undefined,
+          updatedAt: new Date(),
+        })
+
+        logger.info('Invoice created during recovery', {
+          stripeInvoiceId,
+          organizationId,
+        })
+      }
+    } catch (error) {
+      // Don't fail recovery if invoice sync fails
+      logger.error('Failed to sync invoice during recovery', {
+        stripeInvoiceId,
+        organizationId,
+        error,
+      })
+    }
+  }
+
+  /**
+   * Builds DB fields for trial→paid conversion bookkeeping.
+   * Only sets `CONVERTED_TO_PAID` when the final Stripe status is `active` —
+   * recovery reaching a usable but non-active status (e.g., `incomplete`, `paused`)
+   * is NOT a successful paid conversion.
+   */
+  private buildConversionFields(
+    isPastDueFromTrial: boolean,
+    finalStatus: string
+  ): Record<string, unknown> {
+    if (isPastDueFromTrial && finalStatus === 'active') {
+      return {
+        hasTrialEnded: true,
+        trialConversionStatus: 'CONVERTED_TO_PAID' as const,
+        isEligibleForTrial: false,
+        trialEligibilityReason: 'Already converted from trial',
+      }
+    }
+    // Trial ended but NOT successfully converted (recovered to incomplete, paused, etc.)
+    if (isPastDueFromTrial) {
+      return {
+        hasTrialEnded: true,
+      }
+    }
+    return {}
   }
 
   /**

--- a/packages/billing/src/services/webhook-service.ts
+++ b/packages/billing/src/services/webhook-service.ts
@@ -45,10 +45,6 @@ export class WebhookService {
   /**
    * Validates the Stripe webhook signature and dispatches the event to first-party and custom handlers.
    *
-   * Successful processing returns a confirmation payload; failures log detailed diagnostics and rethrow so the
-   * integration layer can respond appropriately (e.g., HTTP 500). Unsupported event types are acknowledged via
-   * informational logging without raising errors.
-   *
    * @param body Raw request body as received from Stripe.
    * @param signature `Stripe-Signature` header string used for signature verification.
    * @returns Object indicating the webhook event was processed successfully.
@@ -69,39 +65,57 @@ export class WebhookService {
     // Process event
     try {
       switch (event.type) {
-        case 'checkout.session.completed':
-          await handleCheckoutSessionCompleted(this.db, event)
-          await this.customHandlers?.onCheckoutSessionCompleted?.(event)
+        case 'checkout.session.completed': {
+          const result = await handleCheckoutSessionCompleted(this.db, event)
+          await this.customHandlers?.onCheckoutSessionCompleted?.(event, {
+            organizationId: result?.organizationId ?? null,
+          })
           break
+        }
 
-        case 'customer.subscription.updated':
-          await handleSubscriptionUpdated(this.db, event, this.onPlanChange)
-          await this.customHandlers?.onSubscriptionUpdated?.(event)
+        case 'customer.subscription.updated': {
+          const result = await handleSubscriptionUpdated(this.db, event, this.onPlanChange)
+          await this.customHandlers?.onSubscriptionUpdated?.(event, {
+            organizationId: result?.organizationId ?? null,
+          })
           break
+        }
 
-        case 'customer.subscription.created':
-          await handleSubscriptionCreated(this.db, event, this.onPlanChange)
-          await this.customHandlers?.onSubscriptionCreated?.(event)
+        case 'customer.subscription.created': {
+          const result = await handleSubscriptionCreated(this.db, event, this.onPlanChange)
+          await this.customHandlers?.onSubscriptionCreated?.(event, {
+            organizationId: result?.organizationId ?? null,
+          })
           break
+        }
 
-        case 'customer.subscription.deleted':
-          await handleSubscriptionDeleted(this.db, event)
-          await this.customHandlers?.onSubscriptionDeleted?.(event)
+        case 'customer.subscription.deleted': {
+          const result = await handleSubscriptionDeleted(this.db, event)
+          await this.customHandlers?.onSubscriptionDeleted?.(event, {
+            organizationId: result?.organizationId ?? null,
+          })
           break
+        }
 
         case 'customer.created':
           await this.customHandlers?.onCustomerCreated?.(event)
           break
 
-        case 'invoice.paid':
-          await handleInvoicePaid(this.db, event)
-          await this.customHandlers?.onInvoicePaid?.(event)
+        case 'invoice.paid': {
+          const result = await handleInvoicePaid(this.db, event)
+          await this.customHandlers?.onInvoicePaid?.(event, {
+            organizationId: result?.organizationId ?? null,
+          })
           break
+        }
 
-        case 'invoice.payment_failed':
-          await handleInvoicePaymentFailed(this.db, event)
-          await this.customHandlers?.onInvoicePaymentFailed?.(event)
+        case 'invoice.payment_failed': {
+          const result = await handleInvoicePaymentFailed(this.db, event)
+          await this.customHandlers?.onInvoicePaymentFailed?.(event, {
+            organizationId: result?.organizationId ?? null,
+          })
           break
+        }
 
         default:
           logger.info('Unhandled webhook event', { type: event.type })

--- a/packages/billing/src/types/index.ts
+++ b/packages/billing/src/types/index.ts
@@ -3,35 +3,7 @@
  * Shared types for billing package.
  */
 
+export * from '@auxx/types/billing'
 export * from './plan'
 export * from './subscription'
 export * from './webhook'
-
-export type BillingCycle = 'MONTHLY' | 'ANNUAL'
-
-export type SubscriptionStatus =
-  | 'ACTIVE'
-  | 'CANCELED'
-  | 'PAST_DUE'
-  | 'UNPAID'
-  | 'TRIALING'
-  | 'INCOMPLETE'
-  | 'INCOMPLETE_EXPIRED'
-  | 'PAUSED'
-
-export type TrialConversionStatus = 'PENDING' | 'CONVERTED' | 'EXPIRED' | 'CANCELED'
-
-export interface PlanLimits {
-  TEAMMATES?: number
-  CHANNELS?: number
-  MONTHLY_EMAILS?: number
-  AI_REQUESTS?: number
-  [key: string]: number | undefined
-}
-
-export interface PlanFeature {
-  name: string
-  description?: string
-  included: boolean
-  limit?: number
-}

--- a/packages/billing/src/types/plan.ts
+++ b/packages/billing/src/types/plan.ts
@@ -3,30 +3,7 @@
  * Plan-related types for billing package.
  */
 
-/** Extended plan configuration with runtime behavior */
-export interface BillingPlan {
-  /** Database plan reference */
-  id: string
-  /** Plan name (e.g., "starter", "pro", "enterprise") */
-  name: string
-  /** Monthly Stripe price ID */
-  stripePriceIdMonthly?: string
-  /** Annual Stripe price ID */
-  stripePriceIdAnnual?: string
-  /** Monthly lookup key (alternative to price ID) */
-  lookupKeyMonthly?: string
-  /** Annual lookup key (alternative to price ID) */
-  lookupKeyAnnual?: string
-  /** Feature limits (e.g., { emails: 1000, users: 5 }) */
-  limits?: Record<string, number>
-  /** Trial configuration */
-  trial?: {
-    days: number
-    onTrialStart?: (subscriptionId: string) => Promise<void>
-    onTrialEnd?: (subscriptionId: string) => Promise<void>
-    onTrialExpired?: (subscriptionId: string) => Promise<void>
-  }
-}
+// BillingPlan is now exported from @auxx/types/billing
 
 /** Plan lookup options */
 export interface PlanLookupOptions {

--- a/packages/billing/src/types/subscription.ts
+++ b/packages/billing/src/types/subscription.ts
@@ -3,10 +3,7 @@
  * Subscription-related types for billing package.
  */
 
-import type { PlanSubscription } from '@auxx/database'
-
-/** Inferred type from PlanSubscription table */
-type PlanSubscriptionType = typeof PlanSubscription.$inferSelect
+// SubscriptionWithPlan is now exported from @auxx/types/billing
 
 /** Subscription creation input */
 export interface CreateSubscriptionInput {
@@ -69,13 +66,4 @@ export interface UpdateSubscriptionDirectResult {
   clientSecret?: string
   immediate?: boolean
   scheduledFor?: Date
-}
-
-/** Subscription with plan details */
-export interface SubscriptionWithPlan extends PlanSubscriptionType {
-  planDetails?: {
-    name: string
-    limits?: Record<string, number>
-    priceId?: string
-  }
 }

--- a/packages/billing/src/types/webhook.ts
+++ b/packages/billing/src/types/webhook.ts
@@ -13,15 +13,20 @@ export type PlanChangeHandler = (
   newPlanId: string
 ) => Promise<void>
 
+/** Context passed to webhook callbacks after the billing handler runs. */
+export interface WebhookEventContext {
+  organizationId: string | null
+}
+
 /** Webhook event handlers */
 export interface WebhookHandlers {
-  onCheckoutSessionCompleted?: (event: Stripe.Event) => Promise<void>
-  onSubscriptionCreated?: (event: Stripe.Event) => Promise<void>
-  onSubscriptionUpdated?: (event: Stripe.Event) => Promise<void>
-  onSubscriptionDeleted?: (event: Stripe.Event) => Promise<void>
+  onCheckoutSessionCompleted?: (event: Stripe.Event, ctx: WebhookEventContext) => Promise<void>
+  onSubscriptionCreated?: (event: Stripe.Event, ctx: WebhookEventContext) => Promise<void>
+  onSubscriptionUpdated?: (event: Stripe.Event, ctx: WebhookEventContext) => Promise<void>
+  onSubscriptionDeleted?: (event: Stripe.Event, ctx: WebhookEventContext) => Promise<void>
   onCustomerCreated?: (event: Stripe.Event) => Promise<void>
-  onInvoicePaid?: (event: Stripe.Event) => Promise<void>
-  onInvoicePaymentFailed?: (event: Stripe.Event) => Promise<void>
+  onInvoicePaid?: (event: Stripe.Event, ctx: WebhookEventContext) => Promise<void>
+  onInvoicePaymentFailed?: (event: Stripe.Event, ctx: WebhookEventContext) => Promise<void>
 }
 
 /** Invoice sync result */

--- a/packages/types/billing/common.ts
+++ b/packages/types/billing/common.ts
@@ -1,0 +1,30 @@
+// packages/types/billing/common.ts
+
+export type BillingCycle = 'MONTHLY' | 'ANNUAL'
+
+export type SubscriptionStatus =
+  | 'ACTIVE'
+  | 'CANCELED'
+  | 'PAST_DUE'
+  | 'UNPAID'
+  | 'TRIALING'
+  | 'INCOMPLETE'
+  | 'INCOMPLETE_EXPIRED'
+  | 'PAUSED'
+
+export type TrialConversionStatus = 'PENDING' | 'CONVERTED' | 'EXPIRED' | 'CANCELED'
+
+export interface PlanLimits {
+  TEAMMATES?: number
+  CHANNELS?: number
+  MONTHLY_EMAILS?: number
+  AI_REQUESTS?: number
+  [key: string]: number | undefined
+}
+
+export interface PlanFeature {
+  name: string
+  description?: string
+  included: boolean
+  limit?: number
+}

--- a/packages/types/billing/index.ts
+++ b/packages/types/billing/index.ts
@@ -1,0 +1,16 @@
+// packages/types/billing/index.ts
+
+export type {
+  BillingCycle,
+  PlanFeature,
+  PlanLimits,
+  SubscriptionStatus,
+  TrialConversionStatus,
+} from './common'
+export type { BillingPlan } from './plan'
+export {
+  BLOCKED_SUBSCRIPTION_STATUSES,
+  type BlockedSubscriptionStatus,
+  isUsableSubscriptionStatus,
+} from './status'
+export type { SubscriptionWithPlan } from './subscription'

--- a/packages/types/billing/plan.ts
+++ b/packages/types/billing/plan.ts
@@ -1,0 +1,26 @@
+// packages/types/billing/plan.ts
+
+/** Extended plan configuration with runtime behavior */
+export interface BillingPlan {
+  /** Database plan reference */
+  id: string
+  /** Plan name (e.g., "starter", "pro", "enterprise") */
+  name: string
+  /** Monthly Stripe price ID */
+  stripePriceIdMonthly?: string
+  /** Annual Stripe price ID */
+  stripePriceIdAnnual?: string
+  /** Monthly lookup key (alternative to price ID) */
+  lookupKeyMonthly?: string
+  /** Annual lookup key (alternative to price ID) */
+  lookupKeyAnnual?: string
+  /** Feature limits (e.g., { emails: 1000, users: 5 }) */
+  limits?: Record<string, number>
+  /** Trial configuration */
+  trial?: {
+    days: number
+    onTrialStart?: (subscriptionId: string) => Promise<void>
+    onTrialEnd?: (subscriptionId: string) => Promise<void>
+    onTrialExpired?: (subscriptionId: string) => Promise<void>
+  }
+}

--- a/packages/types/billing/status.ts
+++ b/packages/types/billing/status.ts
@@ -1,0 +1,14 @@
+// packages/types/billing/status.ts
+
+/** Subscription statuses the app considers unusable — user is blocked from the app. */
+export const BLOCKED_SUBSCRIPTION_STATUSES = [
+  'canceled',
+  'unpaid',
+  'past_due',
+  'incomplete_expired',
+] as const
+export type BlockedSubscriptionStatus = (typeof BLOCKED_SUBSCRIPTION_STATUSES)[number]
+
+export function isUsableSubscriptionStatus(status: string): boolean {
+  return !BLOCKED_SUBSCRIPTION_STATUSES.includes(status.toLowerCase() as BlockedSubscriptionStatus)
+}

--- a/packages/types/billing/subscription.ts
+++ b/packages/types/billing/subscription.ts
@@ -1,0 +1,15 @@
+// packages/types/billing/subscription.ts
+
+import type { PlanSubscription } from '@auxx/database'
+
+/** Inferred type from PlanSubscription table */
+type PlanSubscriptionType = typeof PlanSubscription.$inferSelect
+
+/** Subscription with plan details */
+export interface SubscriptionWithPlan extends PlanSubscriptionType {
+  planDetails?: {
+    name: string
+    limits?: Record<string, number>
+    priceId?: string
+  }
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -75,6 +75,12 @@
       "source": "./config/index.ts",
       "import": "./dist/config/index.mjs",
       "default": "./config/index.ts"
+    },
+    "./billing": {
+      "types": "./billing/index.ts",
+      "source": "./billing/index.ts",
+      "import": "./dist/billing/index.mjs",
+      "default": "./billing/index.ts"
     }
   },
   "scripts": {

--- a/packages/types/tsdown.config.ts
+++ b/packages/types/tsdown.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     'draft/index.ts',
     'signature/index.ts',
     'config/index.ts',
+    'billing/index.ts',
   ],
   format: 'esm',
   target: 'es2022',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1304,6 +1304,9 @@ importers:
       '@auxx/logger':
         specifier: workspace:*
         version: link:../logger
+      '@auxx/types':
+        specifier: workspace:*
+        version: link:../types
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.44.5(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.19.0)(postgres@3.4.8)
@@ -20569,6 +20572,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
@@ -27077,7 +27088,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18


### PR DESCRIPTION
feat(billing): refactor subscription handling and introduce recovery for past_due status

- Added BLOCKED_SUBSCRIPTION_STATUSES to centralize subscription status management.
- Updated useIsSubscriptionExpired hook to utilize BLOCKED_SUBSCRIPTION_STATUSES.
- Modified checkout session and invoice handling hooks to return organizationId.
- Enhanced subscription service to recover past_due subscriptions and manage trial conversions.
- Refactored webhook service to pass organizationId context to custom handlers.
- Consolidated billing types into a new @auxx/types/billing package for better type management.
- Removed redundant types from billing package and replaced them with imports from @auxx/types/billing.