### PR TITLE
feat: implement org-level config management for Google and Outlook integrations

### DIFF
--- a/apps/docs/content/docs/help/channels/chat-widget.mdx
+++ b/apps/docs/content/docs/help/channels/chat-widget.mdx
@@ -1,0 +1,8 @@
+---
+title: Chat Widget
+description: Connect a chat widget to Auxx.ai to manage live conversations from a unified inbox.
+---
+
+<Callout type="warn" title="Coming soon">
+  This channel is not yet available. Check back for updates.
+</Callout>

--- a/apps/docs/content/docs/help/channels/facebook.mdx
+++ b/apps/docs/content/docs/help/channels/facebook.mdx
@@ -1,0 +1,8 @@
+---
+title: Facebook
+description: Connect Facebook Messenger to Auxx.ai to manage conversations from a unified inbox.
+---
+
+<Callout type="warn" title="Coming soon">
+  This channel is not yet available. Check back for updates.
+</Callout>

--- a/apps/docs/content/docs/help/channels/gmail.mdx
+++ b/apps/docs/content/docs/help/channels/gmail.mdx
@@ -1,0 +1,166 @@
+---
+title: Gmail
+description: Connect your Gmail inbox to Auxx.ai using Google OAuth, including how to set up your own credentials.
+---
+
+Gmail is one of the primary email channels in Auxx.ai. Once connected, incoming messages sync into your shared inbox and you can reply directly from the platform. Auxx.ai supports both platform-managed credentials and bring-your-own-credentials (BYOC) for Google OAuth.
+
+## Connect Gmail
+
+The quickest way to connect is through the standard OAuth flow using Auxx.ai's platform credentials.
+
+<Tabs items={['During onboarding', 'From settings']}>
+  <Tab value="During onboarding">
+    1. On the **Connect an inbox** onboarding step, click **Connect Google**.
+    2. Sign in to your Google account if prompted.
+    3. Review the permissions Auxx.ai is requesting and click **Allow**.
+    4. You'll be redirected back to the onboarding flow. A checkmark confirms the connection.
+  </Tab>
+  <Tab value="From settings">
+    1. Go to **Settings > Channels**.
+    2. Click **New Channel**.
+    3. Select **Gmail**.
+    4. Sign in to your Google account if prompted.
+    5. Review the permissions and click **Allow**.
+    6. You'll be redirected to a confirmation page showing the connected email address.
+  </Tab>
+</Tabs>
+
+For detailed steps on linking your channel to a shared inbox and configuring settings, see [Connect your first inbox](/help/getting-started/connect-inbox).
+
+### Permissions requested
+
+Auxx.ai requests the following access to your Google account:
+
+| Permission | Why it's needed |
+|-----------|----------------|
+| Read emails | Sync incoming messages into your Auxx.ai inbox |
+| Send emails | Send replies from Auxx.ai on your behalf |
+| Manage labels | Organize synced messages with labels |
+| Modify emails | Mark messages as read, archive, etc. |
+
+### Offline access
+
+Auxx.ai requests offline access so it can continue syncing messages in the background using a refresh token, even when you're not actively signed in. This is how background sync and real-time notifications work.
+
+## Set up your own Google credentials (BYOC)
+
+<Callout type="info">
+  This section is only needed if Auxx.ai's platform credentials are not yet available for your account. When platform credentials are approved, you can skip this and use the standard Connect flow above.
+</Callout>
+
+### Prerequisites
+
+- A Google Cloud project (new or existing)
+- Access to the [Google Cloud Console](https://console.cloud.google.com/)
+
+### Step-by-step
+
+1. **Create a Google Cloud project** (or use an existing one)
+   - Go to [Google Cloud Console](https://console.cloud.google.com/)
+   - Click the project dropdown at the top and select **New Project**
+   - Give it a name (e.g., "Auxx Mail Integration") and click **Create**
+
+2. **Enable the Gmail API**
+   - In your project, go to **APIs & Services > Library**
+   - Search for "Gmail API" and click **Enable**
+
+3. **Configure the OAuth consent screen**
+   - Go to **APIs & Services > OAuth consent screen**
+   - Select **External** user type and click **Create**
+   - Fill in the required fields:
+     - **App name**: e.g., "Auxx Mail Integration"
+     - **User support email**: your email address
+     - **Developer contact information**: your email address
+   - On the **Scopes** step, click **Add or Remove Scopes** and add:
+     - `https://www.googleapis.com/auth/gmail.modify`
+     - `https://www.googleapis.com/auth/gmail.send`
+     - `https://www.googleapis.com/auth/gmail.labels`
+   - On the **Test users** step, click **Add users** and enter the Gmail address you'll be connecting
+   - Click **Save and Continue** through the remaining steps
+
+4. **Create OAuth credentials**
+   - Go to **APIs & Services > Credentials**
+   - Click **Create Credentials > OAuth client ID**
+   - Application type: **Web application**
+   - Under **Authorized redirect URIs**, click **Add URI** and enter:
+     ```
+     https://app.auxx.ai/api/google/oauth2/callback
+     ```
+   - Click **Create**
+   - Copy the **Client ID** and **Client Secret** from the confirmation dialog
+
+5. **Enter credentials in Auxx.ai**
+   - Go to **Settings > Channels > New Channel > Gmail**
+   - You'll see the BYOC credential form
+   - Paste your **Client ID** and **Client Secret**
+   - Confirm you've added the redirect URI shown in the form
+   - Click **Save & Connect**
+   - Complete the Google OAuth consent flow
+
+### Troubleshooting BYOC
+
+<Accordions type="single">
+  <Accordion title="'Access denied' or 'Error 403'">
+    Your Gmail address isn't listed as a test user. Go to the Google Cloud Console > **APIs & Services > OAuth consent screen > Test users** and add your Gmail address.
+  </Accordion>
+  <Accordion title="'Redirect URI mismatch'">
+    The redirect URI in your Google Cloud credentials doesn't match exactly. Verify it's `https://app.auxx.ai/api/google/oauth2/callback` — including `https` and the full path. No trailing slash.
+  </Accordion>
+  <Accordion title="'This app isn't verified' warning">
+    This is expected when your app is in **Testing** mode. Click **Advanced** > **Go to [app name] (unsafe)** to proceed. This warning goes away if you publish the app and complete Google's verification process.
+  </Accordion>
+  <Accordion title="'Gmail API has not been enabled'">
+    You forgot to enable the Gmail API in step 2. Go to **APIs & Services > Library**, search for "Gmail API", and click **Enable**.
+  </Accordion>
+</Accordions>
+
+## Features
+
+### Sync modes
+
+How messages sync depends on which credentials you're using:
+
+| Credential type | Sync mode | How it works |
+|----------------|-----------|--------------|
+| Platform credentials | Push notifications | Real-time delivery via Google Pub/Sub |
+| Custom credentials (BYOC) | Polling | Checks for new messages periodically |
+
+Push notifications deliver messages faster, but polling still keeps your inbox up to date within a short delay.
+
+### Labels
+
+Gmail labels are synced and available as filters in Auxx.ai. When a label is applied or removed in Gmail, the change is reflected in Auxx.ai and vice versa.
+
+### Email aliases
+
+If your Gmail account has send-as aliases configured, Auxx.ai detects them during the connection process. You can send replies from any of your verified aliases.
+
+## Re-authentication
+
+Your Gmail connection may need to be re-authenticated if:
+
+- Your Google refresh token expires or is revoked
+- You change your Google account password
+- You remove Auxx.ai's access from your [Google account permissions](https://myaccount.google.com/permissions)
+- You rotate your BYOC Client ID or Client Secret
+
+When re-authentication is needed, Auxx.ai shows a banner prompting you to reconnect. Click the banner and complete the OAuth flow again — your existing settings and inbox links are preserved.
+
+<Callout type="info">
+  If you're using BYOC credentials and rotate your Client ID or Secret in Google Cloud Console, you'll need to update them in Auxx.ai **and** reconnect each channel that uses those credentials.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Outlook channel" href="/help/channels/outlook">
+    Connect your Outlook inbox to Auxx.ai.
+  </Card>
+  <Card title="Connect Shopify" href="/help/getting-started/connect-shopify">
+    Sync customer, order, and product data from your store.
+  </Card>
+  <Card title="Troubleshooting email sync" href="/help/troubleshooting/email-sync">
+    Fix common email sync issues.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/channels/instagram.mdx
+++ b/apps/docs/content/docs/help/channels/instagram.mdx
@@ -1,0 +1,8 @@
+---
+title: Instagram
+description: Connect Instagram Direct Messages to Auxx.ai to manage conversations from a unified inbox.
+---
+
+<Callout type="warn" title="Coming soon">
+  This channel is not yet available. Check back for updates.
+</Callout>

--- a/apps/docs/content/docs/help/channels/meta.json
+++ b/apps/docs/content/docs/help/channels/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Channels",
+  "pages": ["gmail", "outlook", "chat-widget", "openphone", "facebook", "instagram"]
+}

--- a/apps/docs/content/docs/help/channels/openphone.mdx
+++ b/apps/docs/content/docs/help/channels/openphone.mdx
@@ -1,0 +1,8 @@
+---
+title: OpenPhone
+description: Connect OpenPhone to Auxx.ai to manage phone and SMS conversations from a unified inbox.
+---
+
+<Callout type="warn" title="Coming soon">
+  This channel is not yet available. Check back for updates.
+</Callout>

--- a/apps/docs/content/docs/help/channels/outlook.mdx
+++ b/apps/docs/content/docs/help/channels/outlook.mdx
@@ -1,0 +1,153 @@
+---
+title: Outlook
+description: Connect your Outlook inbox to Auxx.ai using Microsoft OAuth, including how to set up your own credentials.
+---
+
+Outlook is one of the primary email channels in Auxx.ai. Once connected, incoming messages sync into your shared inbox and you can reply directly from the platform. Auxx.ai supports both platform-managed credentials and bring-your-own-credentials (BYOC) for Microsoft OAuth.
+
+## Connect Outlook
+
+The quickest way to connect is through the standard OAuth flow using Auxx.ai's platform credentials.
+
+<Tabs items={['During onboarding', 'From settings']}>
+  <Tab value="During onboarding">
+    1. On the **Connect an inbox** onboarding step, click **Connect Outlook**.
+    2. Sign in to your Microsoft account if prompted.
+    3. Review the permissions Auxx.ai is requesting and click **Accept**.
+    4. You'll be redirected back to the onboarding flow. A checkmark confirms the connection.
+  </Tab>
+  <Tab value="From settings">
+    1. Go to **Settings > Channels**.
+    2. Click **New Channel**.
+    3. Select **Outlook**.
+    4. Sign in to your Microsoft account if prompted.
+    5. Review the permissions and click **Accept**.
+    6. You'll be redirected to a confirmation page showing the connected email address.
+  </Tab>
+</Tabs>
+
+For detailed steps on linking your channel to a shared inbox and configuring settings, see [Connect your first inbox](/help/getting-started/connect-inbox).
+
+### Permissions requested
+
+| Permission | Why it's needed |
+|-----------|----------------|
+| Read and write emails (Mail.ReadWrite) | Sync messages and update their status |
+| Send emails (Mail.Send) | Send replies from Auxx.ai on your behalf |
+| Read your profile (User.Read) | Identify your email address and any aliases |
+
+## Set up your own Microsoft credentials (BYOC)
+
+<Callout type="info">
+  This section is only needed if Auxx.ai's platform credentials are not yet available for your account. When platform credentials are approved, you can skip this and use the standard Connect flow above.
+</Callout>
+
+### Prerequisites
+
+- Access to the [Azure Portal](https://portal.azure.com/)
+- An Azure AD tenant (personal or organizational)
+
+### Step-by-step
+
+1. **Register an app in Azure Portal**
+   - Go to [Azure Portal](https://portal.azure.com/) > **Azure Active Directory > App registrations**
+   - Click **New registration**
+   - Fill in the details:
+     - **Name**: e.g., "Auxx Mail Integration"
+     - **Supported account types**: select based on your needs — "Accounts in any organizational directory and personal Microsoft accounts" for broadest access
+     - **Redirect URI**: select **Web** and enter:
+       ```
+       https://app.auxx.ai/api/outlook/oauth2/callback
+       ```
+   - Click **Register**
+
+2. **Add API permissions**
+   - Go to **API permissions > Add a permission > Microsoft Graph**
+   - Select **Delegated permissions** and add:
+     - `Mail.ReadWrite`
+     - `Mail.Send`
+     - `User.Read`
+   - If you have admin access, click **Grant admin consent for [your tenant]**
+
+3. **Create a client secret**
+   - Go to **Certificates & secrets > New client secret**
+   - Enter a description (e.g., "Auxx.ai integration")
+   - Set expiration (recommended: 24 months)
+   - Click **Add**
+   - Copy the **Value** immediately — it's only shown once
+
+<Callout type="warn" title="Copy the secret now">
+  The client secret value is only displayed once. If you navigate away without copying it, you'll need to create a new one.
+</Callout>
+
+4. **Copy the Application (client) ID**
+   - On the app's **Overview** page, copy the **Application (client) ID**
+
+5. **Enter credentials in Auxx.ai**
+   - Go to **Settings > Channels > New Channel > Outlook**
+   - You'll see the BYOC credential form
+   - Paste your **Client ID** and **Client Secret**
+   - Confirm you've added the redirect URI shown in the form
+   - Click **Save & Connect**
+   - Complete the Microsoft OAuth consent flow
+
+### Troubleshooting BYOC
+
+<Accordions type="single">
+  <Accordion title="AADSTS error codes">
+    Most `AADSTS` errors relate to the redirect URI not matching. Verify the redirect URI in your app registration is exactly `https://app.auxx.ai/api/outlook/oauth2/callback` — check for typos, missing `https`, or a trailing slash.
+  </Accordion>
+  <Accordion title="'Insufficient privileges' or 'Need admin approval'">
+    The required API permissions haven't been granted. Go to **API permissions** in your app registration and check that all three permissions are listed and have a green checkmark under **Status**. If they show "Not granted", click **Grant admin consent**.
+  </Accordion>
+  <Accordion title="Client secret expired">
+    Azure client secrets expire based on the duration you chose. Create a new secret in **Certificates & secrets**, update it in Auxx.ai's channel settings, and reconnect the channel.
+  </Accordion>
+  <Accordion title="'Application not found in tenant'">
+    Make sure you selected the correct supported account types during registration. If you chose "Single tenant" but are signing in with a personal Microsoft account, the auth will fail.
+  </Accordion>
+</Accordions>
+
+## Features
+
+### Sync
+
+Outlook channels use webhook-based real-time sync for both platform and custom credentials. Microsoft Graph subscriptions notify Auxx.ai of new messages as they arrive.
+
+### Email aliases
+
+If your Microsoft account has email aliases configured, Auxx.ai automatically discovers them during the connection process. You can send replies from any of your verified aliases.
+
+### Batch operations
+
+The Microsoft Graph API supports batch requests, which Auxx.ai uses for efficient bulk operations like syncing large numbers of messages or updating multiple items at once.
+
+## Re-authentication
+
+Your Outlook connection may need to be re-authenticated if:
+
+- Your Microsoft refresh token expires or is revoked
+- You change your Microsoft account password
+- You remove Auxx.ai's access from your [Microsoft account app permissions](https://account.live.com/consent/Manage)
+- Your Azure client secret expires
+- You rotate your BYOC Client ID or Client Secret
+
+When re-authentication is needed, Auxx.ai shows a banner prompting you to reconnect. Click the banner and complete the OAuth flow again — your existing settings and inbox links are preserved.
+
+<Callout type="info">
+  If you're using BYOC credentials and your Azure client secret expires, you'll need to create a new one in Azure Portal, update it in Auxx.ai, and reconnect each channel that uses those credentials.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Gmail channel" href="/help/channels/gmail">
+    Connect your Gmail inbox to Auxx.ai.
+  </Card>
+  <Card title="Connect Shopify" href="/help/getting-started/connect-shopify">
+    Sync customer, order, and product data from your store.
+  </Card>
+  <Card title="Troubleshooting email sync" href="/help/troubleshooting/email-sync">
+    Fix common email sync issues.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/getting-started/connect-inbox.mdx
+++ b/apps/docs/content/docs/help/getting-started/connect-inbox.mdx
@@ -37,6 +37,8 @@ You can connect an inbox in two places:
   </Tab>
 </Tabs>
 
+For detailed setup instructions including BYOC (bring your own credentials), see the [Gmail channel guide](/help/channels/gmail).
+
 ### Gmail permissions
 
 Auxx.ai requests the following access to your Google account:
@@ -68,6 +70,8 @@ Auxx.ai uses offline access so it can continue syncing messages in the backgroun
     6. You'll be redirected to a confirmation page showing the connected email address.
   </Tab>
 </Tabs>
+
+For detailed setup instructions including BYOC (bring your own credentials), see the [Outlook channel guide](/help/channels/outlook).
 
 ### Outlook permissions
 

--- a/apps/docs/content/docs/help/meta.json
+++ b/apps/docs/content/docs/help/meta.json
@@ -8,6 +8,7 @@
     "---Reference Documents---",
     "getting-started",
     "workspace",
+    "channels",
     "tickets",
     "apps",
     "ai",

--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-form.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-form.tsx
@@ -1,3 +1,4 @@
+// apps/web/src/app/(protected)/app/settings/channels/_components/integration-form.tsx
 'use client'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -15,6 +16,7 @@ import SettingsPage from '~/components/global/settings-page'
 import { api } from '~/trpc/react'
 import ImapConnectForm from './imap-connect-form'
 import { getIntegrationProviderIcon } from './integration-table'
+import ProviderCredentialsForm from './provider-credentials-form'
 
 interface IntegrationFormProps {
   type: string
@@ -32,11 +34,19 @@ export default function IntegrationForm({ type }: IntegrationFormProps) {
     },
   })
 
+  // For OAuth providers (google/outlook), check credential status
+  const isOAuthProvider = type === 'google' || type === 'outlook'
+  const { data: credentialStatus, isLoading: isLoadingStatus } =
+    api.channel.getProviderCredentialStatus.useQuery(
+      { provider: type as 'google' | 'outlook' },
+      { enabled: isOAuthProvider }
+    )
+
   // Handle OAuth connection
   const handleOAuthConnect = () => {
     getAuthUrl.mutate(
       {
-        provider: type as any, // Cast to expected enum type
+        provider: type as any,
         redirectPath: '/app/settings/channels',
       },
       {
@@ -57,9 +67,78 @@ export default function IntegrationForm({ type }: IntegrationFormProps) {
   // Render the form based on integration type
   const renderForm = () => {
     switch (type.toLowerCase()) {
-      // OAuth-based integrations
+      // OAuth-based integrations that support BYOC
       case 'google':
-      case 'outlook':
+      case 'outlook': {
+        if (isLoadingStatus) {
+          return (
+            <div className='flex items-center justify-center p-8'>
+              <div className='text-sm text-muted-foreground'>Loading...</div>
+            </div>
+          )
+        }
+
+        // Show credential form if platform credentials aren't available and org has no custom creds
+        const needsCustomCredentials =
+          !credentialStatus?.platformCredentialsAvailable && !credentialStatus?.hasCustomCredentials
+
+        if (needsCustomCredentials) {
+          return (
+            <ProviderCredentialsForm
+              provider={type as 'google' | 'outlook'}
+              onCredentialsSaved={handleOAuthConnect}
+              onBack={handleBack}
+            />
+          )
+        }
+
+        // Platform credentials available or org already has custom creds — show normal connect
+        return (
+          <div className='flex flex-col space-y-1.5 p-3'>
+            <div className='flex flex-col space-y-1.5'>
+              <div className='flex items-center space-x-2'>
+                {getIntegrationProviderIcon(type, 'size-6')}
+                <div className='font-semibold leading-none tracking-tight'>Connect {type}</div>
+              </div>
+              <div className='text-sm text-muted-foreground'>
+                Connect your {type} account to start receiving and managing messages
+              </div>
+            </div>
+            {credentialStatus?.hasCustomCredentials && (
+              <div className='rounded-md border p-2 text-xs text-muted-foreground'>
+                Using your {credentialStatus.displayName} credentials
+                {credentialStatus.clientId && (
+                  <span className='ml-1 font-mono'>
+                    ({credentialStatus.clientId.slice(0, 12)}...)
+                  </span>
+                )}
+              </div>
+            )}
+            <div className='flex items-center '>
+              <p className='mb-4 text-sm text-muted-foreground'>
+                Click the button below to authorize access to your {type} account. You will be
+                redirected to {type} to complete the authorization process.
+              </p>
+            </div>
+            <div className='flex justify-between'>
+              <Button type='button' variant='outline' onClick={handleBack}>
+                <ArrowLeft />
+                Back
+              </Button>
+              <Button
+                variant='info'
+                onClick={handleOAuthConnect}
+                disabled={getAuthUrl.isPending}
+                loading={getAuthUrl.isPending}
+                loadingText='Connecting...'>
+                {`Connect to ${type}`}
+              </Button>
+            </div>
+          </div>
+        )
+      }
+
+      // Other OAuth-based integrations (no BYOC support yet)
       case 'facebook':
       case 'instagram':
         return (

--- a/apps/web/src/app/(protected)/app/settings/channels/_components/provider-credentials-form.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/provider-credentials-form.tsx
@@ -1,0 +1,236 @@
+// apps/web/src/app/(protected)/app/settings/channels/_components/provider-credentials-form.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Checkbox } from '@auxx/ui/components/checkbox'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@auxx/ui/components/form'
+import { Input } from '@auxx/ui/components/input'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@auxx/ui/components/input-group'
+import { toastError } from '@auxx/ui/components/toast'
+import { useCopy } from '@auxx/ui/hooks/use-copy'
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
+import { ArrowLeft, Check, Copy, ExternalLink } from 'lucide-react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { useEnv } from '~/providers/dehydrated-state-provider'
+import { api } from '~/trpc/react'
+
+const credentialSchema = z.object({
+  clientId: z.string().min(1, 'Client ID is required'),
+  clientSecret: z.string().min(1, 'Client Secret is required'),
+  redirectUriConfirmed: z.literal(true, {
+    errorMap: () => ({ message: 'Please confirm you have added the redirect URI' }),
+  }),
+})
+
+type CredentialFormValues = z.infer<typeof credentialSchema>
+
+interface ProviderCredentialsFormProps {
+  provider: 'google' | 'outlook'
+  onCredentialsSaved: () => void
+  onBack: () => void
+}
+
+export default function ProviderCredentialsForm({
+  provider,
+  onCredentialsSaved,
+  onBack,
+}: ProviderCredentialsFormProps) {
+  const { docsUrl } = useEnv()
+  const { copied, copy } = useCopy({ toastMessage: 'Redirect URI copied to clipboard' })
+
+  const { data: status, isLoading } = api.channel.getProviderCredentialStatus.useQuery({
+    provider,
+  })
+
+  const setCredentials = api.channel.setProviderCredentials.useMutation({
+    onError: (error) => {
+      toastError({ title: 'Error saving credentials', description: error.message })
+    },
+  })
+
+  const form = useForm<CredentialFormValues>({
+    resolver: standardSchemaResolver(credentialSchema),
+    defaultValues: {
+      clientId: '',
+      clientSecret: '',
+      redirectUriConfirmed: undefined as any,
+    },
+  })
+
+  const redirectUri = status ? `${window.location.origin}${status.callbackPath}` : ''
+
+  const handleSubmit = async (values: CredentialFormValues) => {
+    await setCredentials.mutateAsync({
+      provider,
+      clientId: values.clientId,
+      clientSecret: values.clientSecret,
+    })
+    onCredentialsSaved()
+  }
+
+  if (isLoading) {
+    return (
+      <div className='flex items-center justify-center p-8'>
+        <div className='text-sm text-muted-foreground'>Loading...</div>
+      </div>
+    )
+  }
+
+  // If credentials already exist, show summary with option to change
+  if (status?.hasCustomCredentials) {
+    return (
+      <div className='flex flex-col space-y-4 p-3'>
+        <div className='flex flex-col space-y-1.5'>
+          <div className='font-semibold leading-none tracking-tight'>
+            Connect {status.displayName}
+          </div>
+          <div className='text-sm text-muted-foreground'>
+            Using your {status.displayName} credentials
+          </div>
+        </div>
+        <div className='rounded-md border p-3'>
+          <div className='text-sm'>
+            <span className='text-muted-foreground'>Client ID: </span>
+            <span className='font-mono text-xs'>
+              {status.clientId
+                ? `${status.clientId.slice(0, 12)}...${status.clientId.slice(-6)}`
+                : '(set)'}
+            </span>
+          </div>
+        </div>
+        <div className='flex justify-between'>
+          <Button type='button' variant='outline' onClick={onBack}>
+            <ArrowLeft />
+            Back
+          </Button>
+          <Button variant='info' onClick={onCredentialsSaved}>
+            Connect
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className='flex flex-col space-y-4 p-3'>
+        <div className='flex flex-col space-y-1.5'>
+          <div className='font-semibold leading-none tracking-tight'>
+            Connect {status?.displayName ?? provider}
+          </div>
+          <div className='text-sm text-muted-foreground'>
+            To connect {status?.displayName ?? provider}, provide your own OAuth credentials.
+          </div>
+        </div>
+
+        {status?.helpDocsPath && (
+          <a
+            href={docsUrl ? `${docsUrl}${status.helpDocsPath}` : status.helpDocsPath}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='inline-flex items-center gap-1 text-sm text-primary-500 hover:underline'>
+            How to set up {status?.displayName ?? provider} credentials
+            <ExternalLink className='size-3.5' />
+          </a>
+        )}
+
+        <FormField
+          control={form.control}
+          name='clientId'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Client ID</FormLabel>
+              <FormControl>
+                <Input placeholder='Enter your OAuth Client ID' {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name='clientSecret'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Client Secret</FormLabel>
+              <FormControl>
+                <Input type='password' placeholder='Enter your OAuth Client Secret' {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {redirectUri && (
+          <div className='space-y-1.5'>
+            <FormLabel>Redirect URI</FormLabel>
+            <div className='text-xs text-muted-foreground'>
+              Add this redirect URI to your OAuth app configuration
+            </div>
+            <InputGroup>
+              <InputGroupInput value={redirectUri} readOnly />
+              <InputGroupAddon align='inline-end'>
+                <InputGroupButton
+                  className='mr-1 rounded-xl'
+                  aria-label='Copy redirect URI'
+                  title='Copy'
+                  size='icon-xs'
+                  onClick={() => copy(redirectUri)}>
+                  {copied ? <Check /> : <Copy />}
+                </InputGroupButton>
+              </InputGroupAddon>
+            </InputGroup>
+          </div>
+        )}
+
+        <FormField
+          control={form.control}
+          name='redirectUriConfirmed'
+          render={({ field }) => (
+            <FormItem>
+              <label className='flex items-start gap-2 cursor-pointer'>
+                <Checkbox
+                  checked={field.value === true}
+                  onCheckedChange={(checked) => field.onChange(checked ? true : undefined)}
+                  className='mt-0.5'
+                />
+                <span className='text-sm text-muted-foreground'>
+                  I have added the redirect URI above to my OAuth app configuration
+                </span>
+              </label>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className='flex justify-between pt-2'>
+          <Button type='button' variant='outline' onClick={onBack}>
+            <ArrowLeft />
+            Back
+          </Button>
+          <Button
+            type='submit'
+            variant='info'
+            loading={setCredentials.isPending}
+            loadingText='Saving...'>
+            Save & Connect
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/apps/web/src/app/api/google/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/google/oauth2/callback/route.ts
@@ -90,8 +90,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Handle the OAuth2 callback
-    const oauthService = GoogleOAuthService.getInstance()
-    const result = await oauthService.handleCallback(code, stateString)
+    const result = await GoogleOAuthService.handleCallback(code, stateString)
 
     await publisher.publishLater({
       type: 'integration:connected',

--- a/apps/web/src/app/api/outlook/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/outlook/oauth2/callback/route.ts
@@ -91,8 +91,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const oauthService = OutlookOAuthService.getInstance()
-    const result = await oauthService.handleCallback(code, state)
+    const result = await OutlookOAuthService.handleCallback(code, state)
 
     // Extract identifier (email) from metadata for the redirect URL
     let identifier = 'unknown'

--- a/apps/web/src/server/api/routers/channel-reauth.ts
+++ b/apps/web/src/server/api/routers/channel-reauth.ts
@@ -59,8 +59,7 @@ export const channelReauthRouter = createTRPCRouter({
       try {
         switch (integration.provider) {
           case 'google': {
-            const googleOAuthService = GoogleOAuthService.getInstance()
-            authUrl = googleOAuthService.getAuthUrl(organizationId, userId, {
+            authUrl = await GoogleOAuthService.getAuthUrl(organizationId, userId, {
               integrationId: integration.id,
               isReauth: true,
               type: 'reauth',
@@ -70,8 +69,7 @@ export const channelReauthRouter = createTRPCRouter({
           }
 
           case 'outlook': {
-            const outlookOAuthService = OutlookOAuthService.getInstance()
-            authUrl = await outlookOAuthService.getAuthUrl(organizationId, userId, {
+            authUrl = await OutlookOAuthService.getAuthUrl(organizationId, userId, {
               integrationId: integration.id,
               isReauth: true,
               type: 'reauth',

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -1,7 +1,7 @@
 // src/server/api/routers/channel.ts
 
-import { CredentialService } from '@auxx/credentials'
-import { type Database, schema } from '@auxx/database'
+import { ConfigStorage, CredentialService, configService } from '@auxx/credentials'
+import { type Database, database, schema } from '@auxx/database'
 import { onCacheEvent, storeOAuthCsrfToken } from '@auxx/lib/cache'
 import { ChatWidgetService } from '@auxx/lib/chat'
 import { getUserOrganizationId, requireAdminAccess } from '@auxx/lib/email'
@@ -13,13 +13,14 @@ import {
   ImapClientProvider,
   ImapSmtpSendService,
   LdapAuthService,
+  PROVIDER_CREDENTIAL_CONFIG,
 } from '@auxx/lib/providers'
 import { widgetSchema as chatWidgetInputSchema } from '@auxx/lib/widgets/types'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { and, asc, count, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
-import { createTRPCRouter, protectedProcedure } from '../trpc'
+import { adminProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
 
 const logger = createScopedLogger('channel-router')
 
@@ -605,6 +606,97 @@ export const channelRouter = createTRPCRouter({
       })
 
       return { success: true }
+    }),
+
+  /**
+   * Check if org has custom OAuth credentials for a provider.
+   */
+  getProviderCredentialStatus: protectedProcedure
+    .input(z.object({ provider: z.enum(['google', 'outlook']) }))
+    .query(async ({ ctx, input }) => {
+      const organizationId = getUserOrganizationId(ctx.session)
+      const config = PROVIDER_CREDENTIAL_CONFIG[input.provider]
+      const overrides = await new ConfigStorage().getAllForOrg(organizationId)
+      const hasClientId = overrides.some((o) => o.key === config.clientIdKey)
+      const hasClientSecret = overrides.some((o) => o.key === config.clientSecretKey)
+      const clientIdEntry = overrides.find((o) => o.key === config.clientIdKey)
+      const platformApproved = configService.get<boolean>(config.approvalFlagKey)
+
+      return {
+        hasCustomCredentials: hasClientId && hasClientSecret,
+        clientId: clientIdEntry?.value as string | undefined,
+        platformCredentialsAvailable: !!platformApproved,
+        callbackPath: config.callbackPath,
+        displayName: config.displayName,
+        helpDocsPath: config.helpDocsPath,
+      }
+    }),
+
+  /**
+   * Save org's OAuth credentials for a provider — atomic write of both values.
+   */
+  setProviderCredentials: adminProcedure
+    .input(
+      z.object({
+        provider: z.enum(['google', 'outlook']),
+        clientId: z.string().min(1),
+        clientSecret: z.string().min(1),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      const config = PROVIDER_CREDENTIAL_CONFIG[input.provider]
+      const storage = new ConfigStorage()
+
+      // Wrap both writes in a transaction so neither is persisted alone
+      await database.transaction(async (tx) => {
+        await storage.setForOrg(organizationId, config.clientIdKey, input.clientId, userId, tx)
+        await storage.setForOrg(
+          organizationId,
+          config.clientSecretKey,
+          input.clientSecret,
+          userId,
+          tx
+        )
+      })
+    }),
+
+  /**
+   * Delete org's custom OAuth credentials for a provider.
+   */
+  deleteProviderCredentials: adminProcedure
+    .input(z.object({ provider: z.enum(['google', 'outlook']) }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const config = PROVIDER_CREDENTIAL_CONFIG[input.provider]
+
+      // Check for active integrations using these credentials
+      const activeIntegrations = await ctx.db
+        .select({ id: schema.Integration.id })
+        .from(schema.Integration)
+        .where(
+          and(
+            eq(schema.Integration.organizationId, organizationId),
+            eq(schema.Integration.provider, input.provider),
+            eq(schema.Integration.enabled, true),
+            isNull(schema.Integration.deletedAt)
+          )
+        )
+        .limit(1)
+
+      if (activeIntegrations.length > 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            'Cannot delete credentials while active channels exist. Disconnect all channels for this provider first.',
+        })
+      }
+
+      const storage = new ConfigStorage()
+      await database.transaction(async (tx) => {
+        await storage.deleteForOrg(organizationId, config.clientIdKey, tx)
+        await storage.deleteForOrg(organizationId, config.clientSecretKey, tx)
+      })
     }),
 
   /**

--- a/packages/credentials/src/config/config-registry.ts
+++ b/packages/credentials/src/config/config-registry.ts
@@ -332,6 +332,15 @@ export const CONFIG_VARIABLES = {
     isSensitive: true,
     isEnvOnly: false,
   },
+  GOOGLE_PLATFORM_CREDENTIALS_APPROVED: {
+    key: 'GOOGLE_PLATFORM_CREDENTIALS_APPROVED',
+    description: 'Whether platform Google OAuth credentials are approved for Gmail scopes',
+    type: ConfigVariableType.BOOLEAN,
+    group: ConfigVariableGroup.GOOGLE_WORKSPACE,
+    isSensitive: false,
+    isEnvOnly: false,
+    defaultValue: false,
+  },
 
   // ── OUTLOOK ───────────────────────────────────────────────
   OUTLOOK_CLIENT_ID: {
@@ -357,6 +366,15 @@ export const CONFIG_VARIABLES = {
     group: ConfigVariableGroup.OUTLOOK,
     isSensitive: true,
     isEnvOnly: false,
+  },
+  OUTLOOK_PLATFORM_CREDENTIALS_APPROVED: {
+    key: 'OUTLOOK_PLATFORM_CREDENTIALS_APPROVED',
+    description: 'Whether platform Outlook OAuth credentials are approved for Mail scopes',
+    type: ConfigVariableType.BOOLEAN,
+    group: ConfigVariableGroup.OUTLOOK,
+    isSensitive: false,
+    isEnvOnly: false,
+    defaultValue: false,
   },
 
   // ── DROPBOX ──────────────────────────────────────────────

--- a/packages/credentials/src/config/config-service.ts
+++ b/packages/credentials/src/config/config-service.ts
@@ -151,6 +151,33 @@ export class ConfigService {
   }
 
   /**
+   * Get a config value with org-level override priority.
+   * Resolution: org DB override → system DB override → env → SST → default → fallback
+   *
+   * Unlike get(), this is async because it queries the DB for org overrides
+   * (org overrides are NOT cached in-memory since they're per-org).
+   */
+  async getForOrg<T extends string | number | boolean | string[] = string>(
+    organizationId: string,
+    key: ConfigKey | (string & {}),
+    fallback?: T
+  ): Promise<T | undefined> {
+    const definition = getConfigDefinition(key)
+
+    // 1. Try org-level DB override
+    if (this.isDbEnabled && definition && !definition.isEnvOnly) {
+      const orgOverrides = await this.storage.getAllForOrg(organizationId)
+      const match = orgOverrides.find((o) => o.key === key)
+      if (match?.value !== undefined) {
+        return match.value as T
+      }
+    }
+
+    // 2. Fall through to existing resolution (system DB → env → SST → default)
+    return this.get<T>(key, fallback)
+  }
+
+  /**
    * Set a DB override for a config variable.
    * Validates against the registry definition.
    * Cache updates immediately — takes effect on next get() call.

--- a/packages/credentials/src/config/config-storage.ts
+++ b/packages/credentials/src/config/config-storage.ts
@@ -1,7 +1,7 @@
 // packages/credentials/src/config/config-storage.ts
 
 import type { KeyValuePairEntity } from '@auxx/database'
-import { database as db, schema } from '@auxx/database'
+import { database as db, schema, type Transaction } from '@auxx/database'
 import { and, eq, isNull, sql } from 'drizzle-orm'
 import { CredentialService } from '../service/credential-service'
 import { getConfigDefinition } from './config-registry'
@@ -106,6 +106,61 @@ export class ConfigStorage {
           eq(schema.KeyValuePair.key, key),
           eq(schema.KeyValuePair.type, CONFIG_TYPE),
           isNull(schema.KeyValuePair.organizationId),
+          isNull(schema.KeyValuePair.userId)
+        )
+      )
+  }
+
+  /**
+   * Set (upsert) an org-level config override.
+   * Uses unique index: (key, organizationId) WHERE userId IS NULL
+   */
+  async setForOrg(
+    organizationId: string,
+    key: string,
+    value: unknown,
+    updatedById?: string,
+    tx?: Transaction
+  ): Promise<void> {
+    const definition = getConfigDefinition(key)
+    const shouldEncrypt = definition?.isSensitive ?? false
+    const storedValue = shouldEncrypt ? CredentialService.encrypt({ value } as any) : value
+
+    await (tx ?? db)
+      .insert(schema.KeyValuePair)
+      .values({
+        key,
+        value: storedValue as any,
+        type: CONFIG_TYPE,
+        isEncrypted: shouldEncrypt ? 'true' : 'false',
+        organizationId,
+        userId: null,
+        updatedById,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [schema.KeyValuePair.key, schema.KeyValuePair.organizationId],
+        targetWhere: sql`"userId" IS NULL`,
+        set: {
+          value: storedValue as any,
+          isEncrypted: shouldEncrypt ? 'true' : 'false',
+          updatedById,
+          updatedAt: new Date(),
+        },
+      })
+  }
+
+  /**
+   * Delete an org-level config override (revert to system/env/default).
+   */
+  async deleteForOrg(organizationId: string, key: string, tx?: Transaction): Promise<void> {
+    await (tx ?? db)
+      .delete(schema.KeyValuePair)
+      .where(
+        and(
+          eq(schema.KeyValuePair.key, key),
+          eq(schema.KeyValuePair.type, CONFIG_TYPE),
+          eq(schema.KeyValuePair.organizationId, organizationId),
           isNull(schema.KeyValuePair.userId)
         )
       )

--- a/packages/lib/src/email/labels/gmail-label-provider.ts
+++ b/packages/lib/src/email/labels/gmail-label-provider.ts
@@ -16,12 +16,10 @@ export class GmailLabelProvider implements LabelProvider {
   private client: any
   private organizationId: string
   private integrationId: string
-  private oauthService: GoogleOAuthService
 
   constructor(organizationId: string, integrationId: string) {
     this.organizationId = organizationId
     this.integrationId = integrationId
-    this.oauthService = GoogleOAuthService.getInstance()
   }
 
   async initialize(): Promise<void> {
@@ -41,7 +39,11 @@ export class GmailLabelProvider implements LabelProvider {
       const tokens = await ChannelTokenAccessor.getTokens(this.integrationId)
 
       // Get authenticated client from the OAuth service
-      this.client = this.oauthService.getAuthenticatedClient(tokens)
+      const { client: authClient } = await GoogleOAuthService.getAuthenticatedClientForOrg(
+        this.organizationId,
+        tokens
+      )
+      this.client = authClient
 
       // Initialize Gmail API with the authenticated client
       this.gmail = google.gmail({ version: 'v1', auth: this.client })
@@ -53,7 +55,7 @@ export class GmailLabelProvider implements LabelProvider {
 
   async refreshAccessToken(): Promise<void> {
     try {
-      await this.oauthService.refreshTokens(this.integrationId)
+      await GoogleOAuthService.refreshTokens(this.integrationId)
 
       // Re-initialize with refreshed token
       await this.initialize()

--- a/packages/lib/src/email/labels/outlook-label-provider.ts
+++ b/packages/lib/src/email/labels/outlook-label-provider.ts
@@ -18,12 +18,10 @@ export class OutlookLabelProvider implements LabelProvider {
   private client: Client | null = null
   private organizationId: string
   private integrationId: string
-  private oauthService: OutlookOAuthService
 
   constructor(organizationId: string, integrationId: string) {
     this.organizationId = organizationId
     this.integrationId = integrationId
-    this.oauthService = OutlookOAuthService.getInstance()
   }
 
   async initialize(): Promise<void> {
@@ -50,8 +48,9 @@ export class OutlookLabelProvider implements LabelProvider {
         throw new Error('Missing homeAccountId in Outlook integration metadata')
       }
 
-      this.client = this.oauthService.getAuthenticatedClient({
+      this.client = await OutlookOAuthService.getAuthenticatedClient({
         integrationId: integration.id,
+        organizationId: this.organizationId,
         refreshToken: tokens.refreshToken,
         accessToken: tokens.accessToken,
         expiresAt: tokens.expiresAt,

--- a/packages/lib/src/jobs/maintenance/channel-token-refresh-job.ts
+++ b/packages/lib/src/jobs/maintenance/channel-token-refresh-job.ts
@@ -75,13 +75,11 @@ export const channelTokenRefreshJob = async (
     if (refreshToken) {
       try {
         if (provider === 'google') {
-          const googleOAuth = GoogleOAuthService.getInstance()
-          await googleOAuth.refreshTokens(integrationId)
+          await GoogleOAuthService.refreshTokens(integrationId)
           result.tokenRefreshed = true
           logger.info('Successfully refreshed Google token', { integrationId })
         } else if (provider === 'outlook') {
-          const outlookOAuth = OutlookOAuthService.getInstance()
-          await outlookOAuth.refreshTokens(integrationId)
+          await OutlookOAuthService.refreshTokens(integrationId)
           result.tokenRefreshed = true
           logger.info('Successfully refreshed Outlook token', { integrationId })
         }

--- a/packages/lib/src/providers/channel-service.ts
+++ b/packages/lib/src/providers/channel-service.ts
@@ -217,16 +217,14 @@ export class ChannelService {
 
       switch (provider) {
         case 'google': {
-          const googleOAuthService = GoogleOAuthService.getInstance()
-          authUrl = googleOAuthService.getAuthUrl(this.organizationId, this.userId, {
+          authUrl = await GoogleOAuthService.getAuthUrl(this.organizationId, this.userId, {
             redirectPath,
             csrfToken,
           })
           break
         }
         case 'outlook': {
-          const outlookOAuthService = OutlookOAuthService.getInstance()
-          authUrl = await outlookOAuthService.getAuthUrl(this.organizationId, this.userId, {
+          authUrl = await OutlookOAuthService.getAuthUrl(this.organizationId, this.userId, {
             redirectPath,
             csrfToken,
           })
@@ -431,25 +429,22 @@ export class ChannelService {
       const channel = await this.validateChannelOwnership(channelId)
 
       // Revoke external access if applicable
-      let oauthService
-      switch (channel.provider) {
-        case 'google':
-          oauthService = GoogleOAuthService.getInstance()
-          break
-        case 'outlook':
-          oauthService = OutlookOAuthService.getInstance()
-          break
-        case 'facebook':
-          oauthService = FacebookOAuthService.getInstance()
-          break
-        case 'instagram':
-          oauthService = InstagramOAuthService.getInstance()
-          break
-      }
-
-      if (oauthService) {
+      if (channel.provider) {
         try {
-          await oauthService.revokeAccess(channelId)
+          switch (channel.provider) {
+            case 'google':
+              await GoogleOAuthService.revokeAccess(channelId)
+              break
+            case 'outlook':
+              await OutlookOAuthService.revokeAccess(channelId)
+              break
+            case 'facebook':
+              await FacebookOAuthService.getInstance().revokeAccess(channelId)
+              break
+            case 'instagram':
+              await InstagramOAuthService.getInstance().revokeAccess(channelId)
+              break
+          }
           logger.info(
             `Successfully revoked access for channel ${channelId} via ${channel.provider} service.`
           )

--- a/packages/lib/src/providers/google/google-oauth.ts
+++ b/packages/lib/src/providers/google/google-oauth.ts
@@ -1,83 +1,98 @@
-// src/lib/email/providers/google-oauth.ts
+// packages/lib/src/providers/google/google-oauth.ts
 
 import { WEBAPP_URL } from '@auxx/config/server'
-import { configService } from '@auxx/credentials'
+import { ConfigStorage, configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, desc, eq } from 'drizzle-orm'
 import { type Common, google } from 'googleapis'
 import { InboxService } from '../../inboxes/inbox-service'
 import { ChannelTokenAccessor, type ChannelTokens } from '../channel-token-accessor'
+import { PROVIDER_CREDENTIAL_CONFIG } from '../provider-credentials-config'
 
 type GaxiosError = Common.GaxiosError
 
 const logger = createScopedLogger('google-oauth')
 
 export class GoogleOAuthService {
-  private static instance: GoogleOAuthService
-  private clientId: string
-  private clientSecret: string
-  private redirectUri: string
-
   /**
-   * Private constructor for the Google OAuth provider.
+   * Resolve OAuth credentials for a specific organization.
+   * Checks org-level overrides first, falls back to platform credentials.
    */
-  private constructor() {
-    this.clientId = configService.get<string>('GOOGLE_CLIENT_ID') || ''
-    this.clientSecret = configService.get<string>('GOOGLE_CLIENT_SECRET') || ''
-    this.redirectUri = `${WEBAPP_URL}/api/google/oauth2/callback` // env.GOOGLE_REDIRECT_URI || ''
+  public static async resolveCredentials(organizationId: string): Promise<{
+    clientId: string
+    clientSecret: string
+    redirectUri: string
+    isCustom: boolean
+  }> {
+    const config = PROVIDER_CREDENTIAL_CONFIG.google
+    const clientId = await configService.getForOrg<string>(organizationId, config.clientIdKey)
+    const clientSecret = await configService.getForOrg<string>(
+      organizationId,
+      config.clientSecretKey
+    )
 
-    if (!this.clientId || !this.clientSecret || !this.redirectUri) {
-      throw new Error('Google OAuth credentials not properly configured')
+    const orgOverrides = await new ConfigStorage().getAllForOrg(organizationId)
+    const hasOrgOverride = orgOverrides.some((o) => o.key === config.clientIdKey)
+
+    return {
+      clientId: clientId || '',
+      clientSecret: clientSecret || '',
+      redirectUri: `${WEBAPP_URL}${config.callbackPath}`,
+      isCustom: hasOrgOverride,
     }
   }
 
   /**
-   * Gets the singleton instance of the GoogleOAuthService.
+   * Create an OAuth2 client for a specific organization.
    */
-  public static getInstance(): GoogleOAuthService {
-    if (!GoogleOAuthService.instance) {
-      GoogleOAuthService.instance = new GoogleOAuthService()
+  public static async getOAuthClientForOrg(organizationId: string) {
+    const creds = await GoogleOAuthService.resolveCredentials(organizationId)
+    if (!creds.clientId || !creds.clientSecret) {
+      throw new Error('Google OAuth credentials not configured for this organization')
     }
-    return GoogleOAuthService.instance
+    return {
+      client: new google.auth.OAuth2(creds.clientId, creds.clientSecret, creds.redirectUri),
+      isCustom: creds.isCustom,
+    }
   }
 
   /**
-   * Creates and returns an OAuth2 client instance for Google authentication.
+   * Creates an authenticated OAuth2 client using decrypted tokens for a specific org.
    */
-  public getOAuthClient(): any {
-    // Type should be google.auth.OAuth2
-    return new google.auth.OAuth2(this.clientId, this.clientSecret, this.redirectUri)
-  }
-
-  /**
-   * Creates an authenticated OAuth2 client using decrypted tokens.
-   */
-  public getAuthenticatedClient(tokens: ChannelTokens): any {
-    const oauth2Client = this.getOAuthClient()
-    oauth2Client.setCredentials({
+  public static async getAuthenticatedClientForOrg(organizationId: string, tokens: ChannelTokens) {
+    const { client, isCustom } = await GoogleOAuthService.getOAuthClientForOrg(organizationId)
+    client.setCredentials({
       refresh_token: tokens.refreshToken || undefined,
       access_token: tokens.accessToken || undefined,
       expiry_date: tokens.expiresAt ? tokens.expiresAt.getTime() : undefined,
     })
-    return oauth2Client
+    return { client, isCustom }
   }
 
   /**
-   * Finds an integration by ID and returns an authenticated OAuth client.
+   * Finds an integration by ID, resolves the org's credentials, and returns
+   * an authenticated client.
    */
-  public async getClientFromIntegrationId(integrationId: string): Promise<any> {
+  public static async getClientFromIntegrationId(integrationId: string) {
+    const [integration] = await db
+      .select({ organizationId: schema.Integration.organizationId })
+      .from(schema.Integration)
+      .where(eq(schema.Integration.id, integrationId))
+      .limit(1)
+
+    if (!integration) throw new Error('Integration not found')
+
     const tokens = await ChannelTokenAccessor.getTokens(integrationId)
-    if (!tokens.refreshToken) {
-      throw new Error('Integration not found or missing refresh token')
-    }
-    return this.getAuthenticatedClient(tokens)
+    if (!tokens.refreshToken) throw new Error('Missing refresh token')
+
+    return GoogleOAuthService.getAuthenticatedClientForOrg(integration.organizationId, tokens)
   }
 
   /**
    * Finds the active Google integration for an organization and returns an authenticated client.
    */
-  public async getClientForOrganization(organizationId: string): Promise<any> {
+  public static async getClientForOrganization(organizationId: string) {
     const [integration] = await db
       .select({ id: schema.Integration.id })
       .from(schema.Integration)
@@ -99,41 +114,39 @@ export class GoogleOAuthService {
     if (!tokens.refreshToken) {
       throw new Error('No active Google integration found for this organization')
     }
-    return this.getAuthenticatedClient(tokens)
+    const { client } = await GoogleOAuthService.getAuthenticatedClientForOrg(organizationId, tokens)
+    return client
   }
 
   /**
    * Generates a Google OAuth URL for authorizing access to Gmail APIs.
    * Enhanced to support both initial authentication and re-authentication flows.
    */
-  public getAuthUrl(
+  public static async getAuthUrl(
     organizationId: string,
     userId: string,
     options: {
       redirectPath?: string
-      integrationId?: string // For re-auth context
-      isReauth?: boolean // Force consent for re-auth
-      type?: 'initial' | 'reauth' // Auth type for callback handling
-      csrfToken?: string // Externally provided CSRF token (for cookie-based verification)
+      integrationId?: string
+      isReauth?: boolean
+      type?: 'initial' | 'reauth'
+      csrfToken?: string
     } = {}
-  ): string {
-    const oauth2Client = this.getOAuthClient()
+  ): Promise<string> {
+    const { client } = await GoogleOAuthService.getOAuthClientForOrg(organizationId)
     const stateWithContext = {
       orgId: organizationId,
       userId: userId,
       timestamp: Date.now(),
       redirectPath: options.redirectPath,
-      // Add re-auth specific context
       ...(options.integrationId && { integrationId: options.integrationId }),
       ...(options.isReauth && { type: 'reauth' }),
       ...(options.type && { type: options.type }),
       ...(options.csrfToken && { csrfToken: options.csrfToken }),
     }
 
-    const url = oauth2Client.generateAuthUrl({
+    const url = client.generateAuthUrl({
       access_type: 'offline',
-      // Always force consent to ensure we receive a refresh token
-      // Google only returns refresh_token on first auth or when prompt=consent
       prompt: 'consent',
       scope: [
         'https://www.googleapis.com/auth/gmail.readonly',
@@ -141,10 +154,10 @@ export class GoogleOAuthService {
         'https://www.googleapis.com/auth/gmail.labels',
         'https://www.googleapis.com/auth/gmail.modify',
         'https://www.googleapis.com/auth/pubsub',
-        'https://www.googleapis.com/auth/userinfo.email', // Request email scope
+        'https://www.googleapis.com/auth/userinfo.email',
       ],
       state: JSON.stringify(stateWithContext),
-      include_granted_scopes: true, // Ensure we get fresh permissions
+      include_granted_scopes: true,
     })
 
     logger.info('Generated Google OAuth URL', {
@@ -160,7 +173,7 @@ export class GoogleOAuthService {
   /**
    * Handles the OAuth callback from Google.
    */
-  public async handleCallback(
+  public static async handleCallback(
     code: string,
     stateString: string
   ): Promise<{ success: boolean; integration: any; isReauth?: boolean }> {
@@ -181,7 +194,8 @@ export class GoogleOAuthService {
       const isReauth = type === 'reauth'
       logger.info('Handling Google OAuth callback', { orgId, userId, isReauth, integrationId })
 
-      const oauth2Client = this.getOAuthClient()
+      const { client: oauth2Client, isCustom } =
+        await GoogleOAuthService.getOAuthClientForOrg(orgId)
       const { tokens } = await oauth2Client.getToken(code)
 
       if (!tokens.refresh_token) {
@@ -200,8 +214,15 @@ export class GoogleOAuthService {
         throw new Error('Could not retrieve email address from Google')
       }
 
-      // Prepare metadata including the email address
-      const integrationMetadata = { email: email } // Store email in metadata
+      // Resolve the current client ID to store as credential snapshot
+      const creds = await GoogleOAuthService.resolveCredentials(orgId)
+
+      // Prepare metadata including the email address and credential snapshot
+      const integrationMetadata = {
+        email,
+        isCustomCredentials: isCustom,
+        credentialClientId: creds.clientId,
+      }
 
       // Handle re-authentication flow
       if (isReauth && integrationId) {
@@ -236,13 +257,15 @@ export class GoogleOAuthService {
         logger.info('Re-authentication successful', { integrationId, email })
 
         // Set up Gmail webhooks (push notifications) - may have expired
-        try {
-          await this.setupPushNotifications(integrationId)
-        } catch (webhookError) {
-          logger.warn('Failed to setup webhooks during re-auth', {
-            integrationId,
-            error: (webhookError as Error).message,
-          })
+        if (!isCustom) {
+          try {
+            await GoogleOAuthService.setupPushNotifications(integrationId)
+          } catch (webhookError) {
+            logger.warn('Failed to setup webhooks during re-auth', {
+              integrationId,
+              error: (webhookError as Error).message,
+            })
+          }
         }
 
         return {
@@ -313,15 +336,23 @@ export class GoogleOAuthService {
       const inboxService = new InboxService(db, orgId, userId)
       await inboxService.addIntegrationToDefaultInbox(integration!.id)
 
+      // Force polling for custom credentials (PubSub won't work with custom OAuth apps)
+      if (isCustom) {
+        await db
+          .update(schema.Integration)
+          .set({ syncMode: 'polling', updatedAt: new Date() })
+          .where(eq(schema.Integration.id, integration!.id))
+      }
+
       // Set up Gmail webhooks (push notifications) or kick off polling
       const { resolveEffectiveSyncMode } = await import('../sync-mode-resolver')
       const effectiveMode = resolveEffectiveSyncMode({
-        syncMode: integration!.syncMode ?? 'auto',
+        syncMode: isCustom ? 'polling' : (integration!.syncMode ?? 'auto'),
         provider: 'google',
       })
 
       if (effectiveMode === 'webhook') {
-        await this.setupPushNotifications(integration!.id)
+        await GoogleOAuthService.setupPushNotifications(integration!.id)
       } else {
         // Kick off polling pipeline immediately for new integrations
         const { getQueue, Queues } = await import('../../jobs/queues')
@@ -367,14 +398,46 @@ export class GoogleOAuthService {
   /**
    * Refreshes OAuth tokens for a Google integration.
    */
-  public async refreshTokens(integrationId: string): Promise<any> {
+  public static async refreshTokens(integrationId: string): Promise<any> {
     try {
+      // Look up the org from the integration
+      const [integration] = await db
+        .select({
+          organizationId: schema.Integration.organizationId,
+          metadata: schema.Integration.metadata,
+        })
+        .from(schema.Integration)
+        .where(eq(schema.Integration.id, integrationId))
+        .limit(1)
+
+      if (!integration) throw new Error('Integration not found')
+
+      // Check for credential rotation
+      const { clientId } = await GoogleOAuthService.resolveCredentials(integration.organizationId)
+      const metadata = integration.metadata as any
+      if (metadata?.credentialClientId && metadata.credentialClientId !== clientId) {
+        // Credentials were rotated — token can't be refreshed with new client
+        await db
+          .update(schema.Integration)
+          .set({
+            authStatus: 'AUTH_ERROR',
+            requiresReauth: true,
+            lastAuthError: 'OAuth credentials were changed. Please reconnect this channel.',
+            lastAuthErrorAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.Integration.id, integrationId))
+        throw new Error('OAuth credentials were rotated. Channel requires reconnection.')
+      }
+
       const tokens = await ChannelTokenAccessor.getTokens(integrationId)
       if (!tokens.refreshToken) {
         throw new Error('Integration not found or missing refresh token')
       }
 
-      const oauth2Client = this.getOAuthClient()
+      const { client: oauth2Client } = await GoogleOAuthService.getOAuthClientForOrg(
+        integration.organizationId
+      )
       oauth2Client.setCredentials({ refresh_token: tokens.refreshToken })
 
       const { credentials } = await oauth2Client.refreshAccessToken()
@@ -428,17 +491,27 @@ export class GoogleOAuthService {
   /**
    * Revokes access to a Google OAuth integration.
    */
-  public async revokeAccess(integrationId: string): Promise<boolean> {
+  public static async revokeAccess(integrationId: string): Promise<boolean> {
     try {
+      const [integration] = await db
+        .select({ organizationId: schema.Integration.organizationId })
+        .from(schema.Integration)
+        .where(eq(schema.Integration.id, integrationId))
+        .limit(1)
+
+      if (!integration) throw new Error('Integration not found')
+
       const tokens = await ChannelTokenAccessor.getTokens(integrationId)
 
       // Disable inbox watching first
       if (tokens.refreshToken) {
-        await this.disablePushNotifications(integrationId, tokens)
+        await GoogleOAuthService.disablePushNotifications(integrationId, tokens)
       }
 
       // Revoke tokens with Google's API
-      const oauth2Client = this.getOAuthClient()
+      const { client: oauth2Client } = await GoogleOAuthService.getOAuthClientForOrg(
+        integration.organizationId
+      )
       const tokensToRevoke = [tokens.accessToken, tokens.refreshToken].filter(Boolean)
 
       for (const token of tokensToRevoke) {
@@ -478,11 +551,10 @@ export class GoogleOAuthService {
   /**
    * Sets up Gmail push notifications for a specific integration.
    */
-  private async setupPushNotifications(integrationId: string): Promise<void> {
+  private static async setupPushNotifications(integrationId: string): Promise<void> {
     try {
-      // Get client using the integration ID, which handles fetching/auth
-      const oauth2Client = await this.getClientFromIntegrationId(integrationId)
-      const gmail = google.gmail({ version: 'v1', auth: oauth2Client })
+      const { client } = await GoogleOAuthService.getClientFromIntegrationId(integrationId)
+      const gmail = google.gmail({ version: 'v1', auth: client })
 
       const topicName = `projects/${configService.get<string>('GOOGLE_PROJECT_ID')}/topics/${configService.get<string>('GOOGLE_PUBSUB_TOPIC')}`
 
@@ -503,9 +575,6 @@ export class GoogleOAuthService {
         data: gaxiosError.response?.data,
         integrationId,
       })
-      // Don't throw from private helper during callback, but log severity.
-      // Throwing here would fail the initial OAuth connection.
-      // Maybe re-throw if called explicitly later?
       throw new Error(`Failed to set up Gmail push notifications: ${gaxiosError.message}`)
     }
   }
@@ -513,16 +582,32 @@ export class GoogleOAuthService {
   /**
    * Disables Gmail push notifications for a given integration.
    */
-  private async disablePushNotifications(
+  private static async disablePushNotifications(
     integrationId: string,
     tokens?: ChannelTokens
   ): Promise<void> {
     try {
       let oauth2Client: any
       if (tokens?.refreshToken) {
-        oauth2Client = this.getAuthenticatedClient(tokens)
-      } else {
-        oauth2Client = await this.getClientFromIntegrationId(integrationId)
+        // Look up org for this integration to resolve credentials
+        const [integration] = await db
+          .select({ organizationId: schema.Integration.organizationId })
+          .from(schema.Integration)
+          .where(eq(schema.Integration.id, integrationId))
+          .limit(1)
+
+        if (integration) {
+          const result = await GoogleOAuthService.getAuthenticatedClientForOrg(
+            integration.organizationId,
+            tokens
+          )
+          oauth2Client = result.client
+        }
+      }
+
+      if (!oauth2Client) {
+        const result = await GoogleOAuthService.getClientFromIntegrationId(integrationId)
+        oauth2Client = result.client
       }
 
       const gmail = google.gmail({ version: 'v1', auth: oauth2Client })
@@ -532,16 +617,13 @@ export class GoogleOAuthService {
       logger.info('Gmail push notifications (watch) disabled successfully', { integrationId })
     } catch (error: any) {
       const gaxiosError = error as GaxiosError
-      // Common errors: 401 (invalid_grant/expired token), 404 (no watch active)
       if (gaxiosError.response?.status === 404) {
         logger.warn('No active Gmail watch found to disable.', { integrationId })
-        // Not an error in this context.
       } else if (gaxiosError.response?.data?.error === 'invalid_grant') {
         logger.warn(
           'Invalid grant while trying to disable push notifications (token likely expired/revoked).',
           { integrationId }
         )
-        // Cannot disable if token is bad, but proceed with cleanup.
       } else {
         logger.error('Error disabling Gmail push notifications:', {
           message: gaxiosError.message,
@@ -549,7 +631,6 @@ export class GoogleOAuthService {
           data: gaxiosError.response?.data,
           integrationId,
         })
-        // Log warning, don't throw during cleanup like revokeAccess
         logger.warn('Continuing cleanup despite push notification disabling error.', {
           integrationId,
         })

--- a/packages/lib/src/providers/google/google-provider.ts
+++ b/packages/lib/src/providers/google/google-provider.ts
@@ -56,14 +56,12 @@ export class GoogleProvider
   private integration:
     | (typeof schema.Integration.$inferSelect & { inboxIntegration?: any })
     | null = null
-  private oauthService: GoogleOAuthService
   private storageService: MessageStorageService
   private userEmails: string[] = []
   private throttler: UniversalThrottler | null = null
 
   constructor(organizationId: string) {
     super(IntegrationProviderType.google, '', organizationId)
-    this.oauthService = GoogleOAuthService.getInstance()
     this.storageService = new MessageStorageService(organizationId)
   }
   /**
@@ -131,7 +129,11 @@ export class GoogleProvider
       }
     }
     // Get authenticated client from OAuth service using decrypted tokens
-    this.client = this.oauthService.getAuthenticatedClient(tokens)
+    const { client: authClient } = await GoogleOAuthService.getAuthenticatedClientForOrg(
+      this.organizationId,
+      tokens
+    )
+    this.client = authClient
     this.setupTokenListener() // Set up listener for token updates
     // Initialize Gmail API client
     this.gmail = google.gmail({ version: 'v1', auth: this.client })

--- a/packages/lib/src/providers/index.ts
+++ b/packages/lib/src/providers/index.ts
@@ -19,6 +19,8 @@ export { InstagramOAuthService } from './instagram/instagram-oauth'
 export type { OutlookErrorCode } from './outlook/outlook-errors'
 export { OutlookProviderError, parseGraphApiError, parseMsalError } from './outlook/outlook-errors'
 export { OutlookOAuthService } from './outlook/outlook-oauth'
+export type { BYOCProvider } from './provider-credentials-config'
+export { PROVIDER_CREDENTIAL_CONFIG } from './provider-credentials-config'
 export { ProviderRegistryService } from './provider-registry-service'
 // Query helpers - replace removed integrationType/messageType columns
 export {

--- a/packages/lib/src/providers/outlook/outlook-oauth.ts
+++ b/packages/lib/src/providers/outlook/outlook-oauth.ts
@@ -1,7 +1,7 @@
-// src/lib/providers/outlook/outlook-oauth.ts
+// packages/lib/src/providers/outlook/outlook-oauth.ts
 
 import { WEBAPP_URL } from '@auxx/config/server'
-import { configService } from '@auxx/credentials'
+import { ConfigStorage, configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import type { IntegrationEntity } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
@@ -10,6 +10,7 @@ import { Client } from '@microsoft/microsoft-graph-client'
 import { eq } from 'drizzle-orm'
 import { InboxService } from '../../inboxes/inbox-service'
 import { ChannelTokenAccessor } from '../channel-token-accessor'
+import { PROVIDER_CREDENTIAL_CONFIG } from '../provider-credentials-config'
 import { parseMsalError } from './outlook-errors'
 
 const logger = createScopedLogger('outlook-oauth')
@@ -19,54 +20,82 @@ export interface OutlookIntegrationMetadata {
   email: string
   homeAccountId: string
   emailAliases?: string[]
+  isCustomCredentials?: boolean
+  credentialClientId?: string
 }
 
 /** Context needed to create an authenticated Graph client */
 export interface OutlookClientContext {
   integrationId: string
+  organizationId: string
   refreshToken: string
   accessToken?: string | null
   expiresAt?: Date | null
   homeAccountId?: string
   email?: string
 }
+
 export class OutlookOAuthService {
-  private static instance: OutlookOAuthService | null = null
-  private clientId: string
-  private clientSecret: string
-  private redirectUri: string
-  private msalClient: ConfidentialClientApplication
-  private initialized: boolean = false
   static scopes = [
     'https://graph.microsoft.com/Mail.ReadWrite',
     'https://graph.microsoft.com/Mail.Send',
-    'offline_access', // For refresh tokens
-    'User.Read', // To get user profile (email)
+    'offline_access',
+    'User.Read',
   ]
-  private constructor() {
-    this.clientId = configService.get<string>('OUTLOOK_CLIENT_ID') || ''
-    this.clientSecret = configService.get<string>('OUTLOOK_CLIENT_SECRET') || ''
-    this.redirectUri = `${WEBAPP_URL}/api/outlook/oauth2/callback`
-    if (!this.clientId || !this.clientSecret || !this.redirectUri) {
-      throw new Error('Outlook OAuth credentials not properly configured')
+
+  /**
+   * Resolve OAuth credentials for a specific organization.
+   */
+  public static async resolveCredentials(organizationId: string): Promise<{
+    clientId: string
+    clientSecret: string
+    redirectUri: string
+    isCustom: boolean
+  }> {
+    const config = PROVIDER_CREDENTIAL_CONFIG.outlook
+    const clientId = await configService.getForOrg<string>(organizationId, config.clientIdKey)
+    const clientSecret = await configService.getForOrg<string>(
+      organizationId,
+      config.clientSecretKey
+    )
+
+    const orgOverrides = await new ConfigStorage().getAllForOrg(organizationId)
+    const hasOrgOverride = orgOverrides.some((o) => o.key === config.clientIdKey)
+
+    return {
+      clientId: clientId || '',
+      clientSecret: clientSecret || '',
+      redirectUri: `${WEBAPP_URL}${config.callbackPath}`,
+      isCustom: hasOrgOverride,
     }
+  }
+
+  /**
+   * Create an MSAL ConfidentialClientApplication for a specific organization.
+   * A new MSAL instance is created per call — no caching, since different orgs
+   * may have different credentials.
+   */
+  public static async getMsalClientForOrg(organizationId: string) {
+    const creds = await OutlookOAuthService.resolveCredentials(organizationId)
+    if (!creds.clientId || !creds.clientSecret) {
+      throw new Error('Outlook OAuth credentials not configured for this organization')
+    }
+
     if (
       configService.get<string>('NODE_ENV') === 'production' &&
-      !this.redirectUri.startsWith('https')
+      !creds.redirectUri.startsWith('https')
     ) {
       logger.error('Outlook OAuth redirect URI MUST be HTTPS in production.')
     }
-    const msalConfig = {
+
+    const msalClient = new ConfidentialClientApplication({
       auth: {
-        clientId: this.clientId,
-        clientSecret: this.clientSecret,
+        clientId: creds.clientId,
+        clientSecret: creds.clientSecret,
         authority: 'https://login.microsoftonline.com/common',
       },
       system: {
-        // Increase the offset to handle potential time differences
-        // This triggers token renewal 10 minutes before expiration instead of the default 5
         tokenRenewalOffsetSeconds: 600,
-        // Add logging level if needed for debugging
         loggerOptions: {
           logLevel:
             configService.get<string>('NODE_ENV') === 'development'
@@ -75,67 +104,72 @@ export class OutlookOAuthService {
           piiLoggingEnabled: false,
         },
       },
+    })
+
+    return {
+      client: msalClient,
+      redirectUri: creds.redirectUri,
+      isCustom: creds.isCustom,
     }
-    this.msalClient = new ConfidentialClientApplication(msalConfig)
-    this.initialized = true
   }
-  public static getInstance(): OutlookOAuthService {
-    if (!OutlookOAuthService.instance) {
-      OutlookOAuthService.instance = new OutlookOAuthService()
-    }
-    return OutlookOAuthService.instance
-  }
+
   /**
-   * Generates the OAuth authorization URL
-   * Enhanced to support both initial authentication and re-authentication flows.
+   * Generates the OAuth authorization URL.
    */
-  public async getAuthUrl(
+  public static async getAuthUrl(
     organizationId: string,
     userId: string,
     options: {
       redirectPath?: string
-      integrationId?: string // For re-auth context
-      isReauth?: boolean // Force consent for re-auth
-      type?: 'initial' | 'reauth' // Auth type for callback handling
-      csrfToken?: string // Externally provided CSRF token (for cookie-based verification)
+      integrationId?: string
+      isReauth?: boolean
+      type?: 'initial' | 'reauth'
+      csrfToken?: string
     } = {}
   ): Promise<string> {
+    const { client: msalClient, redirectUri } =
+      await OutlookOAuthService.getMsalClientForOrg(organizationId)
+
     const stateWithContext = {
       orgId: organizationId,
       userId: userId,
       timestamp: Date.now(),
       redirectPath: options.redirectPath,
-      // Add re-auth specific context
       ...(options.integrationId && { integrationId: options.integrationId }),
       ...(options.isReauth && { type: 'reauth' }),
       ...(options.type && { type: options.type }),
       ...(options.csrfToken && { csrfToken: options.csrfToken }),
     }
+
     const authCodeUrlParameters = {
       scopes: OutlookOAuthService.scopes,
-      redirectUri: this.redirectUri,
+      redirectUri,
       state: JSON.stringify(stateWithContext),
-      prompt: 'consent', // Always force consent to ensure refresh token
+      prompt: 'consent',
     }
+
     logger.info('Generated Outlook OAuth URL', {
       organizationId,
       userId,
       isReauth: options.isReauth,
       integrationId: options.integrationId,
     })
-    return this.msalClient.getAuthCodeUrl(authCodeUrlParameters)
+
+    return msalClient.getAuthCodeUrl(authCodeUrlParameters)
   }
+
   /** Handles the OAuth callback from Microsoft */
-  public async handleCallback(
+  public static async handleCallback(
     code: string,
     stateString: string
   ): Promise<{
     success: boolean
     integration: IntegrationEntity
+    isReauth?: boolean
   }> {
     let state: Record<string, unknown>
     try {
-      state = JSON.parse(stateString) // Should contain orgId, userId
+      state = JSON.parse(stateString)
     } catch (e: unknown) {
       logger.error('Invalid state parameter in Outlook callback:', { stateString, error: e })
       throw new Error('Invalid state parameter.')
@@ -146,20 +180,31 @@ export class OutlookOAuthService {
     }
     const isReauth = type === 'reauth'
     logger.info('Handling Outlook OAuth callback', { orgId, userId, isReauth, integrationId })
+
     try {
+      const {
+        client: msalClient,
+        redirectUri,
+        isCustom,
+      } = await OutlookOAuthService.getMsalClientForOrg(orgId as string)
+
       // 1. Exchange authorization code for tokens
       const tokenRequest = {
         code: code,
         scopes: OutlookOAuthService.scopes,
-        redirectUri: this.redirectUri,
+        redirectUri,
       }
-      const response = await this.msalClient.acquireTokenByCode(tokenRequest)
+      const response = await msalClient.acquireTokenByCode(tokenRequest)
       if (!response || !response.accessToken || !response.account?.homeAccountId) {
         logger.error('Failed to acquire token or essential account info missing.', { response })
         throw new Error('Outlook token acquisition failed: Missing token or account details.')
       }
+
       // 2. Extract Refresh Token
-      const refreshToken = this.extractRefreshToken(response.account.homeAccountId)
+      const refreshToken = OutlookOAuthService.extractRefreshToken(
+        msalClient,
+        response.account.homeAccountId
+      )
       if (!refreshToken) {
         logger.error('Could not extract refresh token from MSAL cache after code acquisition.', {
           homeAccountId: response.account.homeAccountId,
@@ -168,14 +213,16 @@ export class OutlookOAuthService {
           'Refresh token not obtained from Microsoft. Ensure offline_access scope was granted.'
         )
       }
+
       // 3. Get User's Email via Graph API
-      const graphClient = this.createTemporaryGraphClient(response.accessToken)
+      const graphClient = OutlookOAuthService.createTemporaryGraphClient(response.accessToken)
       const userProfile = await graphClient.api('/me').select('mail,userPrincipalName').get()
       const email = userProfile.mail || userProfile.userPrincipalName
       if (!email) {
         throw new Error('Could not retrieve email address from Microsoft Graph.')
       }
       logger.info('Successfully retrieved user email', { email })
+
       // 3b. Discover email aliases
       let emailAliases: string[] = []
       try {
@@ -193,15 +240,22 @@ export class OutlookOAuthService {
           error: aliasError.message,
         })
       }
+
+      // Resolve the current client ID to store as credential snapshot
+      const creds = await OutlookOAuthService.resolveCredentials(orgId as string)
+
       // 4. Prepare Metadata
       const integrationMetadata: OutlookIntegrationMetadata = {
         email: email,
         homeAccountId: response.account.homeAccountId,
         emailAliases,
+        isCustomCredentials: isCustom,
+        credentialClientId: creds.clientId,
       }
       const expiresOn = response.expiresOn
         ? new Date(response.expiresOn)
         : new Date(Date.now() + 3600 * 1000)
+
       // Handle re-authentication flow
       if (isReauth && integrationId) {
         logger.info('Processing re-authentication for existing Outlook integration', {
@@ -364,10 +418,14 @@ export class OutlookOAuthService {
       throw new Error(`Outlook OAuth callback failed: ${err.message || err.errorCode}`)
     }
   }
+
   /** Extract refresh token from cache by homeAccountId (used during OAuth callback) */
-  private extractRefreshToken(homeAccountId: string): string | undefined {
+  private static extractRefreshToken(
+    msalClient: ConfidentialClientApplication,
+    homeAccountId: string
+  ): string | undefined {
     try {
-      const tokenCache = this.msalClient.getTokenCache().serialize()
+      const tokenCache = msalClient.getTokenCache().serialize()
       const parsedCache = JSON.parse(tokenCache)
       if (parsedCache.RefreshToken) {
         const keys = Object.keys(parsedCache.RefreshToken)
@@ -384,10 +442,13 @@ export class OutlookOAuthService {
       return undefined
     }
   }
+
   /** Extract the most recent refresh token from the MSAL cache (used after acquireTokenByRefreshToken) */
-  private extractRefreshTokenFromCache(): string | undefined {
+  private static extractRefreshTokenFromCache(
+    msalClient: ConfidentialClientApplication
+  ): string | undefined {
     try {
-      const tokenCache = JSON.parse(this.msalClient.getTokenCache().serialize())
+      const tokenCache = JSON.parse(msalClient.getTokenCache().serialize())
       const refreshTokens = tokenCache.RefreshToken
       if (!refreshTokens) return undefined
       const firstKey = Object.keys(refreshTokens)[0]
@@ -397,16 +458,18 @@ export class OutlookOAuthService {
       return undefined
     }
   }
+
   /** Helper to create a temporary Graph client with a specific token */
-  private createTemporaryGraphClient(accessToken: string): Client {
+  private static createTemporaryGraphClient(accessToken: string): Client {
     return Client.init({
       authProvider: (done) => {
         done(null, accessToken)
       },
     })
   }
-  /** Refreshes the access token using acquireTokenByRefreshToken (no cache injection needed) */
-  public async refreshTokens(integrationId: string): Promise<IntegrationEntity> {
+
+  /** Refreshes the access token using acquireTokenByRefreshToken */
+  public static async refreshTokens(integrationId: string): Promise<IntegrationEntity> {
     try {
       const [integration] = await db
         .select()
@@ -417,14 +480,35 @@ export class OutlookOAuthService {
         throw new Error('Integration not found')
       }
 
+      // Check for credential rotation
+      const { clientId } = await OutlookOAuthService.resolveCredentials(integration.organizationId)
+      const metadata = integration.metadata as any
+      if (metadata?.credentialClientId && metadata.credentialClientId !== clientId) {
+        await db
+          .update(schema.Integration)
+          .set({
+            authStatus: 'AUTH_ERROR',
+            requiresReauth: true,
+            lastAuthError: 'OAuth credentials were changed. Please reconnect this channel.',
+            lastAuthErrorAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(eq(schema.Integration.id, integrationId))
+        throw new Error('OAuth credentials were rotated. Channel requires reconnection.')
+      }
+
       const tokens = await ChannelTokenAccessor.getTokens(integrationId)
       if (!tokens.refreshToken) {
         throw new Error('Integration missing refresh token')
       }
 
+      const { client: msalClient } = await OutlookOAuthService.getMsalClientForOrg(
+        integration.organizationId
+      )
+
       logger.debug('Attempting token refresh via acquireTokenByRefreshToken', { integrationId })
 
-      const response = await this.msalClient.acquireTokenByRefreshToken({
+      const response = await msalClient.acquireTokenByRefreshToken({
         refreshToken: tokens.refreshToken,
         scopes: OutlookOAuthService.scopes,
         forceCache: true,
@@ -439,7 +523,7 @@ export class OutlookOAuthService {
         ? new Date(response.expiresOn)
         : new Date(Date.now() + 3600 * 1000)
 
-      const newRefreshToken = this.extractRefreshTokenFromCache()
+      const newRefreshToken = OutlookOAuthService.extractRefreshTokenFromCache(msalClient)
 
       const tokenUpdate: Parameters<typeof ChannelTokenAccessor.setTokens>[1] = {
         accessToken: response.accessToken,
@@ -489,8 +573,9 @@ export class OutlookOAuthService {
       throw parsed
     }
   }
+
   /** Revokes access (clears encrypted tokens and disables). */
-  public async revokeAccess(integrationId: string): Promise<boolean> {
+  public static async revokeAccess(integrationId: string): Promise<boolean> {
     try {
       logger.warn('Attempting to revoke Outlook access (clearing tokens & disabling)', {
         integrationId,
@@ -517,11 +602,17 @@ export class OutlookOAuthService {
       throw new Error(`Failed to revoke Outlook access: ${err.message}`)
     }
   }
-  public getAuthenticatedClient(ctx: OutlookClientContext): Client {
+
+  /**
+   * Creates an authenticated Graph client for a given context.
+   * The MSAL client is created per-call to use the correct org credentials.
+   */
+  public static async getAuthenticatedClient(ctx: OutlookClientContext): Promise<Client> {
     if (!ctx.integrationId || !ctx.refreshToken) {
       throw new Error('Cannot create authenticated client: Missing integrationId or refreshToken.')
     }
 
+    const { client: msalClient } = await OutlookOAuthService.getMsalClientForOrg(ctx.organizationId)
     const { integrationId, refreshToken } = ctx
     let currentAccessToken = ctx.accessToken || ''
     let currentExpiresAt = ctx.expiresAt
@@ -539,7 +630,7 @@ export class OutlookOAuthService {
           }
 
           // Refresh via acquireTokenByRefreshToken
-          const response = await this.msalClient.acquireTokenByRefreshToken({
+          const response = await msalClient.acquireTokenByRefreshToken({
             refreshToken,
             scopes: OutlookOAuthService.scopes,
             forceCache: true,
@@ -555,7 +646,7 @@ export class OutlookOAuthService {
             : new Date(Date.now() + 3600 * 1000)
 
           // Update encrypted tokens in background
-          const newRefreshToken = this.extractRefreshTokenFromCache()
+          const newRefreshToken = OutlookOAuthService.extractRefreshTokenFromCache(msalClient)
           const tokenUpdate: Parameters<typeof ChannelTokenAccessor.setTokens>[1] = {
             accessToken: response.accessToken,
             expiresAt: currentExpiresAt,
@@ -598,9 +689,5 @@ export class OutlookOAuthService {
       },
     })
     return client
-  }
-  /** Returns the configured MSAL client instance */
-  public getMSALClient(): ConfidentialClientApplication {
-    return this.msalClient
   }
 }

--- a/packages/lib/src/providers/outlook/outlook-provider.ts
+++ b/packages/lib/src/providers/outlook/outlook-provider.ts
@@ -114,11 +114,9 @@ export class OutlookProvider
         inboxIntegration?: any
       })
     | null = null
-  private oauthService: OutlookOAuthService
   private storageService: MessageStorageService
   constructor(organizationId: string) {
     super(IntegrationProviderType.outlook, '', organizationId)
-    this.oauthService = OutlookOAuthService.getInstance()
     this.storageService = new MessageStorageService(organizationId)
   }
   /**
@@ -173,13 +171,14 @@ export class OutlookProvider
 
     const clientCtx: OutlookClientContext = {
       integrationId: dbIntegration.id,
+      organizationId: this.organizationId,
       refreshToken: tokens.refreshToken,
       accessToken: tokens.accessToken,
       expiresAt: tokens.expiresAt,
       homeAccountId: metadata?.homeAccountId,
       email: metadata?.email || '',
     }
-    this.client = this.oauthService.getAuthenticatedClient(clientCtx)
+    this.client = await OutlookOAuthService.getAuthenticatedClient(clientCtx)
     logger.info(`OutlookProvider initialized successfully for integration: ${integrationId}`)
   }
   /** Resets internal state */

--- a/packages/lib/src/providers/provider-credentials-config.ts
+++ b/packages/lib/src/providers/provider-credentials-config.ts
@@ -1,0 +1,28 @@
+// packages/lib/src/providers/provider-credentials-config.ts
+
+/**
+ * Maps channel providers to their OAuth config variable keys.
+ * Used by both frontend (credential form) and backend (credential resolution).
+ */
+export const PROVIDER_CREDENTIAL_CONFIG = {
+  google: {
+    clientIdKey: 'GOOGLE_CLIENT_ID',
+    clientSecretKey: 'GOOGLE_CLIENT_SECRET',
+    approvalFlagKey: 'GOOGLE_PLATFORM_CREDENTIALS_APPROVED',
+    callbackPath: '/api/google/oauth2/callback',
+    displayName: 'Google',
+    /** Docs path relative to docsUrl — use with useEnv().docsUrl to build full URL */
+    helpDocsPath: '/help/channels/gmail',
+  },
+  outlook: {
+    clientIdKey: 'OUTLOOK_CLIENT_ID',
+    clientSecretKey: 'OUTLOOK_CLIENT_SECRET',
+    approvalFlagKey: 'OUTLOOK_PLATFORM_CREDENTIALS_APPROVED',
+    callbackPath: '/api/outlook/oauth2/callback',
+    displayName: 'Microsoft Outlook',
+    /** Docs path relative to docsUrl — use with useEnv().docsUrl to build full URL */
+    helpDocsPath: '/help/channels/outlook',
+  },
+} as const
+
+export type BYOCProvider = keyof typeof PROVIDER_CREDENTIAL_CONFIG


### PR DESCRIPTION
feat: Implement organization-level config management for Google and Outlook integrations

- Added `setForOrg` and `deleteForOrg` methods in `ConfigStorage` to manage organization-specific configurations.
- Refactored Google and Outlook OAuth services to resolve credentials based on organization context.
- Updated `GmailLabelProvider` and `OutlookLabelProvider` to utilize new credential resolution methods.
- Enhanced token refresh logic in `channel-token-refresh-job` to handle organization-specific tokens.
- Introduced `PROVIDER_CREDENTIAL_CONFIG` to centralize OAuth configuration keys for Google and Outlook.
- Updated related classes to remove singleton patterns in favor of instance-based credential management.