### PR TITLE
feat: add company enrichment fields and related event handling

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -98,6 +98,8 @@ jobs:
             GIT_SHA=${{ github.sha }}
             APP_VERSION=${{ needs.release-please.outputs.version }}
             BUILD_TIME=${{ steps.build_time.outputs.build_time }}
+            POSTHOG_KEY=${{ vars.POSTHOG_KEY }}
+            POSTHOG_HOST=${{ vars.POSTHOG_HOST }}
           cache-from: type=registry,ref=${{ matrix.image }}:buildcache
           cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=max
 

--- a/apps/web/src/components/custom-fields/ui/bulk-update-entity-instance-dialog.tsx
+++ b/apps/web/src/components/custom-fields/ui/bulk-update-entity-instance-dialog.tsx
@@ -55,7 +55,10 @@ export function BulkUpdateEntityInstanceDialog({
   const editableFields = useMemo(() => {
     if (!resource) return []
     return resource.fields
-      .filter((f): f is typeof f & { id: string } => f.capabilities?.creatable !== false && !!f.id)
+      .filter(
+        (f): f is typeof f & { id: string } =>
+          f.capabilities?.creatable !== false && !f.capabilities?.hidden && !!f.id
+      )
       .sort((a, b) => (a.sortOrder ?? '').localeCompare(b.sortOrder ?? ''))
   }, [resource])
 

--- a/apps/web/src/components/custom-fields/ui/custom-fields-list.tsx
+++ b/apps/web/src/components/custom-fields/ui/custom-fields-list.tsx
@@ -54,9 +54,12 @@ export function CustomFieldsList({ resource }: CustomFieldsListProps) {
   // Subscribe to store for live updates (optimistic updates propagate here)
   const { fields } = useResourceFields(resource.entityDefinitionId)
 
-  // Sort fields by sortOrder
+  // Sort fields by sortOrder; hidden fields never appear in the custom-fields settings list.
   const sortedFields = useMemo(
-    () => [...fields].sort((a, b) => (a.sortOrder ?? '').localeCompare(b.sortOrder ?? '')),
+    () =>
+      [...fields]
+        .filter((f) => !f.capabilities.hidden)
+        .sort((a, b) => (a.sortOrder ?? '').localeCompare(b.sortOrder ?? '')),
     [fields]
   )
 

--- a/apps/web/src/components/custom-fields/ui/entity-instance-dialog.tsx
+++ b/apps/web/src/components/custom-fields/ui/entity-instance-dialog.tsx
@@ -91,7 +91,10 @@ export function EntityInstanceDialog({
   const allEditableFields = useMemo(() => {
     if (!resource) return []
     return resource.fields
-      .filter((f): f is typeof f & { id: string } => f.capabilities?.creatable !== false && !!f.id)
+      .filter(
+        (f): f is typeof f & { id: string } =>
+          f.capabilities?.creatable !== false && !f.capabilities?.hidden && !!f.id
+      )
       .sort((a, b) => (a.sortOrder ?? '').localeCompare(b.sortOrder ?? ''))
   }, [resource])
 

--- a/apps/web/src/components/fields/hooks/use-field-view.ts
+++ b/apps/web/src/components/fields/hooks/use-field-view.ts
@@ -67,7 +67,9 @@ export function useFieldView({
   // Whether we're using a stored org view or the generated default
   const hasOrgView = !!view
 
-  // Get visible fields in configured order
+  // Get visible fields in configured order.
+  // Fields with `capabilities.hidden` are excluded unconditionally — they are
+  // system-internal and users must not see them in any view or configuration.
   const getVisibleFields = useCallback((): ResourceField[] => {
     const { fieldVisibility, fieldOrder } = config
 
@@ -81,6 +83,7 @@ export function useFieldView({
     for (const fieldId of fieldOrder) {
       const field = fieldMap.get(fieldId)
       if (!field) continue
+      if (field.capabilities.hidden) continue
       // When no org view exists, also respect showInPanel from field definitions
       if (fieldVisibility[fieldId] === false) continue
       if (!hasOrgView && field.showInPanel === false) continue
@@ -90,6 +93,7 @@ export function useFieldView({
 
     // Then add any remaining fields not in order (new fields added after view was configured)
     for (const [fieldId, field] of fieldMap) {
+      if (field.capabilities.hidden) continue
       if (fieldVisibility[fieldId] === false) continue
       if (!hasOrgView && field.showInPanel === false) continue
       orderedFields.push(field)
@@ -98,12 +102,17 @@ export function useFieldView({
     return orderedFields
   }, [config, fields, hasOrgView])
 
-  // Get all fields in configured order (for edit mode - includes hidden fields)
+  // Get all fields in configured order (for edit mode — includes fields the
+  // user has toggled off but NOT registry-hidden fields).
   const getAllFields = useCallback((): ResourceField[] => {
     const { fieldOrder } = config
 
-    // Create a map of fields by their ID
-    const fieldMap = new Map(fields.map((f) => [f.resourceFieldId ?? f.id ?? f.key, f]))
+    // Create a map of fields by their ID — exclude registry-hidden up front
+    const fieldMap = new Map(
+      fields
+        .filter((f) => !f.capabilities.hidden)
+        .map((f) => [f.resourceFieldId ?? f.id ?? f.key, f])
+    )
 
     const orderedFields: ResourceField[] = []
 

--- a/apps/web/src/components/records/records-searchbar.tsx
+++ b/apps/web/src/components/records/records-searchbar.tsx
@@ -26,7 +26,7 @@ interface RecordsSearchBarProps {
 /** Convert ResourceField[] to SearchFieldDefinition[] for suggestions */
 function toSearchFields(fields: ResourceField[]): SearchFieldDefinition[] {
   return fields
-    .filter((f) => f.capabilities.filterable && f.id !== 'displayName')
+    .filter((f) => f.capabilities.filterable && !f.capabilities.hidden && f.id !== 'displayName')
     .map((f) => ({
       id: f.id,
       label: f.label,
@@ -46,7 +46,7 @@ const DISPLAY_NAME_FIELD: FieldDefinition = {
 /** Convert ResourceField[] to FieldDefinition[] for ConditionProvider */
 function toConditionFields(fields: ResourceField[]): FieldDefinition[] {
   const mapped = fields
-    .filter((f) => f.capabilities.filterable)
+    .filter((f) => f.capabilities.filterable && !f.capabilities.hidden)
     .map((f) => ({
       id: f.id,
       label: f.label,

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -146,9 +146,13 @@ export function RecordsView({
   // Get resource with fields
   const { resource, isLoading } = useResource(slug)
 
-  // Derive custom fields from resource.fields (filter to fields with id = custom fields only)
+  // Derive custom fields from resource.fields (filter to fields with id = custom fields only).
+  // Hidden fields are excluded from every table surface — no column, no chooser entry.
   const customFields = useMemo(
-    () => resource?.fields.filter((f): f is ResourceField & { id: string } => !!f.id) ?? [],
+    () =>
+      resource?.fields.filter(
+        (f): f is ResourceField & { id: string } => !!f.id && !f.capabilities.hidden
+      ) ?? [],
     [resource?.fields]
   )
 

--- a/apps/web/src/components/workflow/nodes/core/list/hooks/use-filter-field-resolver.ts
+++ b/apps/web/src/components/workflow/nodes/core/list/hooks/use-filter-field-resolver.ts
@@ -71,7 +71,7 @@ export function useFilterFieldResolver({ nodeId, inputListValue }: UseFilterFiel
       const resource = useResourceStore.getState().resourceMap.get(itemVar.resourceId)
       if (resource) {
         const filterableFields = resource.fields
-          .filter((field) => field.capabilities.filterable) // Only filterable fields
+          .filter((field) => field.capabilities.filterable && !field.capabilities.hidden)
           .map(
             (field): FieldDefinition => ({
               id: toResourceFieldId(itemVar.resourceId!, field.key),

--- a/apps/web/src/components/workflow/nodes/core/list/hooks/use-sort-field-resolver.ts
+++ b/apps/web/src/components/workflow/nodes/core/list/hooks/use-sort-field-resolver.ts
@@ -89,7 +89,10 @@ export function useSortFieldResolver({ nodeId, inputListValue }: UseSortFieldRes
         if (resource) {
           resource.fields
             .filter(
-              (subField) => subField.capabilities.sortable && SORTABLE_TYPES.includes(subField.type)
+              (subField) =>
+                subField.capabilities.sortable &&
+                !subField.capabilities.hidden &&
+                SORTABLE_TYPES.includes(subField.type)
             )
             .forEach((subField) => {
               result.push({
@@ -124,7 +127,10 @@ export function useSortFieldResolver({ nodeId, inputListValue }: UseSortFieldRes
         if (resource) {
           resource.fields
             .filter(
-              (subField) => subField.capabilities.sortable && SORTABLE_TYPES.includes(subField.type)
+              (subField) =>
+                subField.capabilities.sortable &&
+                !subField.capabilities.hidden &&
+                SORTABLE_TYPES.includes(subField.type)
             )
             .forEach((subField) => {
               result.push({

--- a/packages/lib/src/events/handlers/publish-event-job.ts
+++ b/packages/lib/src/events/handlers/publish-event-job.ts
@@ -99,6 +99,10 @@ export const EventHandlers: IEventsHandlers = {
   'subpart:created': [handleEntityTriggers],
   'subpart:deleted': [handleEntityTriggers],
 
+  // Company events → TIMELINE + ENTITY TRIGGERS (website enrichment on create)
+  'company:created': [createTimelineEvent, handleEntityTriggers],
+  'company:deleted': [createTimelineEvent, handleEntityTriggers],
+
   // Field trigger events → FIELD TRIGGER HANDLERS
   'field:trigger': [handleFieldTriggerJob],
 

--- a/packages/lib/src/events/types.ts
+++ b/packages/lib/src/events/types.ts
@@ -65,6 +65,8 @@ export type Events =
   | 'vendor_part:deleted'
   | 'subpart:created'
   | 'subpart:deleted'
+  | 'company:created'
+  | 'company:deleted'
   | 'field:trigger'
   | 'integration:connected'
   | 'integration:connection_failed'
@@ -643,6 +645,30 @@ export type SubpartDeletedEvent = AuxxEventGeneric<
   }
 >
 
+// Company Events
+export type CompanyCreatedEvent = AuxxEventGeneric<
+  'company:created',
+  {
+    recordId: RecordId
+    entityDefinitionId: string
+    entitySlug: string
+    organizationId: string
+    userId: string
+    eventData: Record<string, unknown>
+  }
+>
+export type CompanyDeletedEvent = AuxxEventGeneric<
+  'company:deleted',
+  {
+    recordId: RecordId
+    entityDefinitionId: string
+    entitySlug: string
+    organizationId: string
+    userId: string
+    eventData: Record<string, unknown>
+  }
+>
+
 // Field Trigger Event — fired when a field with a registered trigger changes
 export type FieldTriggerJobEvent = AuxxEventGeneric<
   'field:trigger',
@@ -813,6 +839,8 @@ export type AuxxEvent =
   | VendorPartDeletedEvent
   | SubpartCreatedEvent
   | SubpartDeletedEvent
+  | CompanyCreatedEvent
+  | CompanyDeletedEvent
   | FieldTriggerJobEvent
   | IntegrationConnectedEvent
   | IntegrationConnectionFailedEvent
@@ -882,6 +910,8 @@ export interface IEventsHandlers {
   'vendor_part:deleted': EventHandler<VendorPartDeletedEvent>[]
   'subpart:created': EventHandler<SubpartCreatedEvent>[]
   'subpart:deleted': EventHandler<SubpartDeletedEvent>[]
+  'company:created': EventHandler<CompanyCreatedEvent>[]
+  'company:deleted': EventHandler<CompanyDeletedEvent>[]
   'field:trigger': EventHandler<FieldTriggerJobEvent>[]
   'integration:connected': EventHandler<IntegrationConnectedEvent>[]
   'integration:connection_failed': EventHandler<IntegrationConnectionFailedEvent>[]

--- a/packages/lib/src/field-triggers/entity-trigger-handler.ts
+++ b/packages/lib/src/field-triggers/entity-trigger-handler.ts
@@ -2,6 +2,8 @@
 
 import { createScopedLogger } from '@auxx/logger'
 import type {
+  CompanyCreatedEvent,
+  CompanyDeletedEvent,
   EntityInstanceCreatedEvent,
   EntityInstanceDeletedEvent,
   StockMovementCreatedEvent,
@@ -25,6 +27,8 @@ type EntityTriggerEvent =
   | VendorPartDeletedEvent
   | SubpartCreatedEvent
   | SubpartDeletedEvent
+  | CompanyCreatedEvent
+  | CompanyDeletedEvent
 
 /**
  * Event handler for entity lifecycle events (created/deleted).

--- a/packages/lib/src/field-triggers/register-triggers.ts
+++ b/packages/lib/src/field-triggers/register-triggers.ts
@@ -6,6 +6,7 @@ import {
   recalculatePartCostOnEntityChange,
 } from './triggers/bom-cost-triggers'
 import { explodeBomMovement } from './triggers/bom-movement-triggers'
+import { enrichCompanyOnCreate } from './triggers/company-triggers'
 import { recalculatePartQoH, recalculateStockStatus } from './triggers/inventory-triggers'
 import { clearOtherPreferred } from './triggers/vendor-part-triggers'
 
@@ -33,4 +34,7 @@ export function registerAllTriggers(): void {
 
   // Stock status trigger — fire when reorder point changes
   registerFieldTriggers('part_reorder_point', [recalculateStockStatus])
+
+  // Company enrichment — fetch website on company create to fill in name, notes, logo
+  registerEntityTriggers('companies', [enrichCompanyOnCreate])
 }

--- a/packages/lib/src/field-triggers/triggers/company-triggers.ts
+++ b/packages/lib/src/field-triggers/triggers/company-triggers.ts
@@ -1,0 +1,366 @@
+// packages/lib/src/field-triggers/triggers/company-triggers.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { toRecordId } from '@auxx/types/resource'
+import { load } from 'cheerio'
+import { createMediaAssetService } from '../../files/core/media-asset-service'
+import { createStorageManager } from '../../files/storage/storage-manager'
+import { UnifiedCrudHandler } from '../../resources/crud/unified-handler'
+import { SystemUserService } from '../../users/system-user-service'
+import type { EntityTriggerHandler } from '../types'
+
+const logger = createScopedLogger('field-triggers:company')
+
+const HTML_FETCH_TIMEOUT_MS = 8000
+const FAVICON_FETCH_TIMEOUT_MS = 5000
+const MAX_HTML_BYTES = 500_000
+const MAX_FAVICON_BYTES = 1_000_000
+const USER_AGENT = 'AuxxAi-Enrichment/1.0 (+https://auxx.ai/bot)'
+
+/**
+ * Enrich a company from its website on create.
+ *
+ * Fetches the company's homepage and extracts:
+ * - Clean site name (from og:site_name or <title>) → company_name
+ * - Description (from og:description or meta description) → company_notes
+ * - Logo (apple-touch-icon, og:image, favicon) → company_logo
+ *
+ * Never overwrites user-edited values: only replaces company_name when it
+ * equals the raw domain, and only fills company_notes / company_logo when empty.
+ */
+export const enrichCompanyOnCreate: EntityTriggerHandler = async (event) => {
+  if (event.action !== 'created') return
+
+  const domain = event.values.company_domain
+  if (!domain || typeof domain !== 'string') {
+    logger.debug('Skipping enrichment — no domain', { entityInstanceId: event.entityInstanceId })
+    return
+  }
+
+  const { organizationId, entityInstanceId, entityDefinitionId } = event
+  const recordId = toRecordId(entityDefinitionId, entityInstanceId)
+
+  const systemUserId = await SystemUserService.getSystemUserForActions(organizationId)
+  const crud = new UnifiedCrudHandler(organizationId, systemUserId)
+
+  const currentName = typeof event.values.company_name === 'string' ? event.values.company_name : ''
+  const currentNotes = event.values.company_notes
+  const currentLogo = event.values.company_logo
+
+  const websiteUrl = `https://${domain}`
+
+  try {
+    await crud.update(recordId, { company_enrichment_status: 'pending' })
+
+    const metadata = await fetchWebsiteMetadata(websiteUrl)
+    const logoAssetId = await fetchAndStoreLogo({
+      organizationId,
+      userId: systemUserId,
+      metadata,
+    })
+
+    const updates: Record<string, unknown> = {
+      company_enrichment_status: 'enriched',
+      company_enriched_at: new Date(),
+    }
+
+    if (metadata.siteName && currentName === domain) {
+      updates.company_name = metadata.siteName
+    }
+    if (metadata.description && !currentNotes) {
+      updates.company_notes = metadata.description
+    }
+    if (logoAssetId && !currentLogo) {
+      updates.company_logo = { ref: `asset:${logoAssetId}` }
+    }
+
+    await crud.update(recordId, updates)
+
+    logger.info('Company enriched', {
+      organizationId,
+      companyId: entityInstanceId,
+      domain,
+      applied: Object.keys(updates),
+    })
+  } catch (err) {
+    logger.error('Enrichment failed', {
+      organizationId,
+      companyId: entityInstanceId,
+      domain,
+      error: (err as Error).message,
+    })
+    await crud.update(recordId, {
+      company_enrichment_status: 'failed',
+      company_enriched_at: new Date(),
+    })
+  }
+}
+
+// ─── Metadata fetch ────────────────────────────────────────────────────
+
+interface WebsiteMetadata {
+  siteName: string | null
+  description: string | null
+  faviconUrl: string | null
+  appleTouchIconUrl: string | null
+  ogImageUrl: string | null
+}
+
+async function fetchWebsiteMetadata(url: string): Promise<WebsiteMetadata> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), HTML_FETCH_TIMEOUT_MS)
+
+  try {
+    assertPublicHost(url)
+
+    const res = await fetch(url, {
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: {
+        'user-agent': USER_AGENT,
+        accept: 'text/html,application/xhtml+xml',
+      },
+    })
+
+    if (!res.ok) {
+      logger.warn('Non-OK response fetching website', { url, status: res.status })
+      return emptyMetadata()
+    }
+
+    const reader = res.body?.getReader()
+    if (!reader) return emptyMetadata()
+
+    const chunks: Uint8Array[] = []
+    let total = 0
+    while (total < MAX_HTML_BYTES) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value)
+      total += value.byteLength
+    }
+    await reader.cancel()
+
+    const html = new TextDecoder('utf-8', { fatal: false }).decode(
+      Buffer.concat(chunks.map((c) => Buffer.from(c)))
+    )
+
+    const $ = load(html)
+
+    const rawTitle = $('title').first().text().trim()
+    const titleFirstSegment = rawTitle ? rawTitle.split(/[|\-—]/)[0]?.trim() : null
+
+    const siteName =
+      $('meta[property="og:site_name"]').attr('content')?.trim() ||
+      $('meta[name="application-name"]').attr('content')?.trim() ||
+      titleFirstSegment ||
+      null
+
+    const description =
+      $('meta[property="og:description"]').attr('content')?.trim() ||
+      $('meta[name="description"]').attr('content')?.trim() ||
+      null
+
+    const faviconUrl = resolveUrl(
+      url,
+      $('link[rel="icon"]').attr('href') ||
+        $('link[rel="shortcut icon"]').attr('href') ||
+        '/favicon.ico'
+    )
+
+    const appleTouchIconUrl = resolveUrl(url, $('link[rel="apple-touch-icon"]').attr('href'))
+    const ogImageUrl = resolveUrl(url, $('meta[property="og:image"]').attr('content'))
+
+    return {
+      siteName: truncate(siteName, 120),
+      description: truncate(description, 500),
+      faviconUrl,
+      appleTouchIconUrl,
+      ogImageUrl,
+    }
+  } catch (err) {
+    logger.warn('Fetch website metadata failed', { url, error: (err as Error).message })
+    return emptyMetadata()
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// ─── Logo fetch + store ────────────────────────────────────────────────
+
+async function fetchAndStoreLogo(args: {
+  organizationId: string
+  userId: string
+  metadata: WebsiteMetadata
+}): Promise<string | null> {
+  // apple-touch-icon is usually the cleanest "logo-like" asset, followed by
+  // og:image, then the tiny favicon as a last resort.
+  const candidates = [
+    args.metadata.appleTouchIconUrl,
+    args.metadata.ogImageUrl,
+    args.metadata.faviconUrl,
+  ].filter((v): v is string => typeof v === 'string' && v.length > 0)
+
+  for (const url of candidates) {
+    try {
+      assertPublicHost(url)
+
+      const res = await fetchWithTimeout(url, FAVICON_FETCH_TIMEOUT_MS)
+      if (!res.ok) continue
+
+      const contentType = (res.headers.get('content-type') || 'image/x-icon').split(';')[0]!.trim()
+      if (!contentType.startsWith('image/')) continue
+
+      const buf = Buffer.from(await res.arrayBuffer())
+      if (buf.byteLength === 0 || buf.byteLength > MAX_FAVICON_BYTES) continue
+
+      const storageManager = createStorageManager(args.organizationId)
+      const key = `${args.organizationId}/company-logos/${Date.now()}-${cryptoRandomHex()}${extensionFor(contentType)}`
+
+      const storageLocation = await storageManager.uploadContent({
+        provider: 'S3',
+        key,
+        content: buf,
+        mimeType: contentType,
+        size: buf.byteLength,
+        visibility: 'PUBLIC',
+        organizationId: args.organizationId,
+      })
+
+      const mediaAssetService = createMediaAssetService(args.organizationId, args.userId)
+      const { asset } = await mediaAssetService.createWithVersion(
+        {
+          kind: 'SYSTEM_BLOB',
+          purpose: 'company-logo',
+          name: 'company-logo',
+          mimeType: contentType,
+          size: BigInt(buf.byteLength),
+          isPrivate: false,
+          organizationId: args.organizationId,
+          createdById: args.userId,
+        },
+        storageLocation.id
+      )
+
+      return asset.id
+    } catch (err) {
+      logger.debug('Logo candidate failed', { url, error: (err as Error).message })
+    }
+  }
+
+  return null
+}
+
+async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, {
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: { 'user-agent': USER_AGENT },
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+
+function emptyMetadata(): WebsiteMetadata {
+  return {
+    siteName: null,
+    description: null,
+    faviconUrl: null,
+    appleTouchIconUrl: null,
+    ogImageUrl: null,
+  }
+}
+
+function resolveUrl(base: string, href: string | null | undefined): string | null {
+  if (!href) return null
+  try {
+    return new URL(href, base).toString()
+  } catch {
+    return null
+  }
+}
+
+function truncate(s: string | null, max: number): string | null {
+  if (!s) return null
+  const trimmed = s.trim()
+  if (trimmed.length === 0) return null
+  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed
+}
+
+function extensionFor(contentType: string): string {
+  switch (contentType) {
+    case 'image/png':
+      return '.png'
+    case 'image/jpeg':
+    case 'image/jpg':
+      return '.jpg'
+    case 'image/gif':
+      return '.gif'
+    case 'image/svg+xml':
+      return '.svg'
+    case 'image/webp':
+      return '.webp'
+    case 'image/x-icon':
+    case 'image/vnd.microsoft.icon':
+      return '.ico'
+    default:
+      return ''
+  }
+}
+
+function cryptoRandomHex(): string {
+  // 8 hex chars — plenty for per-second uniqueness inside an org.
+  return Math.floor(Math.random() * 0xffffffff)
+    .toString(16)
+    .padStart(8, '0')
+}
+
+/**
+ * Reject URLs that resolve to private/loopback/link-local IP addresses to
+ * avoid server-side request forgery against internal services.
+ * Also rejects non-http(s) protocols and bare hostnames that are explicitly
+ * private (localhost, *.local, *.internal).
+ */
+function assertPublicHost(urlStr: string): void {
+  const url = new URL(urlStr)
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Unsupported protocol: ${url.protocol}`)
+  }
+
+  const hostname = url.hostname.toLowerCase()
+  if (
+    hostname === 'localhost' ||
+    hostname.endsWith('.local') ||
+    hostname.endsWith('.internal') ||
+    hostname === '0.0.0.0'
+  ) {
+    throw new Error(`Refusing to fetch private hostname: ${hostname}`)
+  }
+
+  // Literal IPv4 check
+  const ipv4 = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  if (ipv4) {
+    const [a, b] = [Number(ipv4[1]), Number(ipv4[2])]
+    const isPrivate =
+      a === 10 ||
+      a === 127 ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      a === 0 ||
+      a >= 224
+    if (isPrivate) {
+      throw new Error(`Refusing to fetch private IP: ${hostname}`)
+    }
+  }
+
+  // Literal IPv6 loopback / link-local
+  if (hostname.startsWith('[::1]') || hostname === '::1' || hostname.startsWith('fe80:')) {
+    throw new Error(`Refusing to fetch private IPv6: ${hostname}`)
+  }
+}

--- a/packages/lib/src/import/fields/get-identifiable-fields.ts
+++ b/packages/lib/src/import/fields/get-identifiable-fields.ts
@@ -20,6 +20,8 @@ const IDENTIFIER_FIELD_KEYS = new Set(['id', 'externalId'])
 export function getIdentifiableFields(resource: Resource): ImportableField[] {
   return resource.fields
     .filter((field) => {
+      // Hidden fields are invisible to users — never offer them as identifiers
+      if (field.capabilities.hidden) return false
       // Must be filterable for lookups
       if (!field.capabilities.filterable) return false
       // Skip relation fields (except has_one which could be unique)

--- a/packages/lib/src/import/fields/get-importable-fields.ts
+++ b/packages/lib/src/import/fields/get-importable-fields.ts
@@ -63,9 +63,11 @@ export function getImportableFields(
     fields.push(...identifierFields)
   }
 
-  // 2. Add creatable scalar fields
+  // 2. Add creatable scalar fields (excluding hidden system fields)
   const scalarFields = resource.fields
-    .filter((field) => field.capabilities.creatable && !field.relationship)
+    .filter(
+      (field) => field.capabilities.creatable && !field.capabilities.hidden && !field.relationship
+    )
     .map((field) => {
       const isCustomField = !field.isSystem
       return {
@@ -82,10 +84,12 @@ export function getImportableFields(
     })
   fields.push(...scalarFields)
 
-  // 3. Add relationship fields if requested
+  // 3. Add relationship fields if requested (excluding hidden system fields)
   if (includeRelationships) {
     const relationFields = resource.fields
-      .filter((field) => field.capabilities.creatable && field.relationship)
+      .filter(
+        (field) => field.capabilities.creatable && !field.capabilities.hidden && field.relationship
+      )
       .map((field) => {
         const isCustomField = !field.isSystem
         return {
@@ -118,6 +122,9 @@ export function getImportableFields(
  */
 export function getRequiredFields(resource: Resource): string[] {
   return resource.fields
-    .filter((field) => field.capabilities.required && field.capabilities.creatable)
+    .filter(
+      (field) =>
+        field.capabilities.required && field.capabilities.creatable && !field.capabilities.hidden
+    )
     .map((field) => getFieldOutputKey(field))
 }

--- a/packages/lib/src/resources/capabilities/field-capabilities.ts
+++ b/packages/lib/src/resources/capabilities/field-capabilities.ts
@@ -3,6 +3,15 @@
 import type { ResourceField } from '../registry/field-types'
 
 /**
+ * Check if a field is hidden from user-facing UI.
+ * Hidden fields exist in the registry but never appear in pickers, forms,
+ * tables, or panels. System code can still read/write them.
+ */
+export function isFieldHidden(field: ResourceField | null | undefined): boolean {
+  return field?.capabilities.hidden === true
+}
+
+/**
  * Check if a field can be updated.
  * Returns false for computed fields or fields marked as non-updatable.
  */
@@ -13,17 +22,19 @@ export function canUpdateField(field: ResourceField | null | undefined): boolean
 }
 
 /**
- * Check if a field can be used for sorting
+ * Check if a field can be used for sorting in user-facing UI.
  */
 export function canSortField(field: ResourceField | null | undefined): boolean {
-  return field?.capabilities.sortable !== false
+  if (!field || field.capabilities.hidden) return false
+  return field.capabilities.sortable !== false
 }
 
 /**
- * Check if a field can be used in filters
+ * Check if a field can be used in filters in user-facing UI.
  */
 export function canFilterField(field: ResourceField | null | undefined): boolean {
-  return field?.capabilities.filterable !== false
+  if (!field || field.capabilities.hidden) return false
+  return field.capabilities.filterable !== false
 }
 
 /**

--- a/packages/lib/src/resources/index.ts
+++ b/packages/lib/src/resources/index.ts
@@ -6,6 +6,7 @@ export {
   canFilterField,
   canSortField,
   canUpdateField,
+  isFieldHidden,
 } from './capabilities/field-capabilities'
 export type {
   BulkResult,

--- a/packages/lib/src/resources/registry/field-types.ts
+++ b/packages/lib/src/resources/registry/field-types.ts
@@ -47,6 +47,13 @@ export interface FieldCapabilities {
   unique?: boolean
   /** Field is computed/derived and cannot be directly set */
   computed?: boolean
+  /**
+   * Field exists in the registry and database but is invisible in every
+   * user-facing UI (panel, column chooser, filter/sort pickers, import/export,
+   * workflow variable pickers, custom-field list). System code can still
+   * read/write it via Drizzle or UnifiedCrudHandler.
+   */
+  hidden?: boolean
 }
 
 /**

--- a/packages/lib/src/resources/registry/field-utils.ts
+++ b/packages/lib/src/resources/registry/field-utils.ts
@@ -207,7 +207,7 @@ export function isComputedField(field: ResourceField): boolean {
 
 /**
  * Sort fields: system fields first (by systemSortOrder), then custom fields by sortOrder.
- * Excludes 'id' field and inactive custom fields.
+ * Excludes 'id' field, inactive custom fields, and fields with `capabilities.hidden`.
  * Deduplicates by key to prevent React key conflicts.
  */
 export function sortFieldsForDisplay(fields: ResourceField[]): ResourceField[] {
@@ -220,11 +220,15 @@ export function sortFieldsForDisplay(fields: ResourceField[]): ResourceField[] {
   })
 
   const systemFields = deduped
-    .filter((f) => f.isSystem && f.key !== 'id' && f.showInPanel !== false)
+    .filter(
+      (f) => f.isSystem && f.key !== 'id' && f.showInPanel !== false && !f.capabilities.hidden
+    )
     .sort((a, b) => (a.systemSortOrder ?? '').localeCompare(b.systemSortOrder ?? ''))
 
   const customFields = deduped
-    .filter((f) => !f.isSystem && f.active !== false && f.showInPanel !== false)
+    .filter(
+      (f) => !f.isSystem && f.active !== false && f.showInPanel !== false && !f.capabilities.hidden
+    )
     .sort((a, b) => (a.sortOrder ?? '').localeCompare(b.sortOrder ?? ''))
 
   return [...systemFields, ...customFields]
@@ -235,5 +239,7 @@ export function sortFieldsForDisplay(fields: ResourceField[]): ResourceField[] {
  * Filters out hidden fields and sorts appropriately.
  */
 export function getDisplayFields(fields: ResourceField[]): ResourceField[] {
-  return sortFieldsForDisplay(fields.filter((f) => f.showInPanel !== false))
+  return sortFieldsForDisplay(
+    fields.filter((f) => f.showInPanel !== false && !f.capabilities.hidden)
+  )
 }

--- a/packages/lib/src/resources/registry/resource-registry-service.ts
+++ b/packages/lib/src/resources/registry/resource-registry-service.ts
@@ -856,6 +856,12 @@ export class ResourceRegistryService {
           placeholder: staticField.placeholder,
           nullable: staticField.nullable,
           defaultValue: staticField.defaultValue,
+          // Hidden is a static-only capability — not persisted in CustomField,
+          // but the static registry owns the UI visibility decision for system fields.
+          capabilities: {
+            ...dbField.capabilities,
+            hidden: staticField.capabilities.hidden,
+          },
           // Merge relationship config — DB object exists but inverseResourceFieldId may be null
           // when the seeder linker couldn't resolve it. Fall back to static definition.
           relationship:

--- a/packages/lib/src/resources/registry/resources/company-fields.ts
+++ b/packages/lib/src/resources/registry/resources/company-fields.ts
@@ -344,6 +344,56 @@ export const COMPANY_FIELDS: Record<string, ResourceField> = {
     description: 'Meetings associated with this company',
   },
 
+  enrichedAt: {
+    id: toFieldId('enrichedAt'),
+    key: 'enrichedAt',
+    label: 'Enriched At',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'company_enriched_at',
+    systemSortOrder: 'z8',
+    nullable: true,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: false,
+      updatable: true,
+      configurable: false,
+      hidden: true,
+    },
+    description: 'When this company was last enriched from its website.',
+  },
+
+  enrichmentStatus: {
+    id: toFieldId('enrichmentStatus'),
+    key: 'enrichmentStatus',
+    label: 'Enrichment Status',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'company_enrichment_status',
+    systemSortOrder: 'z9',
+    nullable: true,
+    options: {
+      options: [
+        { label: 'Pending', value: 'pending', color: 'gray' },
+        { label: 'Enriched', value: 'enriched', color: 'green' },
+        { label: 'Failed', value: 'failed', color: 'red' },
+        { label: 'Skipped', value: 'skipped', color: 'amber' },
+      ],
+    },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: false,
+      updatable: true,
+      configurable: false,
+      hidden: true,
+    },
+    description: 'Enrichment lifecycle marker.',
+  },
+
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/lib/src/resources/variable-generators.ts
+++ b/packages/lib/src/resources/variable-generators.ts
@@ -803,6 +803,9 @@ export function generateFindNodeVariablesFromFields(
   findMode: 'findOne' | 'findMany',
   options?: VariableGeneratorOptions
 ): UnifiedVariable[] {
+  // Hidden fields are system-internal — never surface as workflow variables.
+  fields = fields.filter((f) => !f.capabilities.hidden)
+
   const variables: UnifiedVariable[] = []
 
   if (fields.length === 0) {
@@ -989,6 +992,9 @@ export function generateCrudNodeVariablesFromFields(
   crudMode: 'create' | 'update' | 'delete',
   options?: VariableGeneratorOptions
 ): UnifiedVariable[] {
+  // Hidden fields are system-internal — never surface as workflow variables.
+  fields = fields.filter((f) => !f.capabilities.hidden)
+
   const variables: UnifiedVariable[] = []
 
   // Main resource variable (for create/update)
@@ -1156,6 +1162,9 @@ export function generateResourceTriggerVariablesFromFields(
   operation: 'created' | 'updated' | 'deleted' | 'manual',
   options?: VariableGeneratorOptions
 ): UnifiedVariable[] {
+  // Hidden fields are system-internal — never surface as workflow variables.
+  fields = fields.filter((f) => !f.capabilities.hidden)
+
   const variables: UnifiedVariable[] = []
 
   if (fields.length === 0) {

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -10,6 +10,7 @@ import { migration004Company } from './migrations/004-company'
 import { migration005Meeting } from './migrations/005-meeting'
 import { migration006CompanyDomainAndEmployerCardinality } from './migrations/006-company-domain-and-employer-cardinality'
 import { migration007EntityAvatarFields } from './migrations/007-entity-avatar-fields'
+import { migration008CompanyEnrichmentFields } from './migrations/008-company-enrichment-fields'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -25,6 +26,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration005Meeting,
   migration006CompanyDomainAndEmployerCardinality,
   migration007EntityAvatarFields,
+  migration008CompanyEnrichmentFields,
 ]
 
 // ─── Public API ──────────────────────────────────────────────────────

--- a/packages/lib/src/seed/entity-migrations/migrations/008-company-enrichment-fields.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/008-company-enrichment-fields.ts
@@ -1,0 +1,56 @@
+// packages/lib/src/seed/entity-migrations/migrations/008-company-enrichment-fields.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { COMPANY_FIELDS } from '../../../resources/registry/resources/company-fields'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:008')
+
+/**
+ * Migration 008: Add company enrichment tracking fields
+ *
+ * Adds `enrichedAt` and `enrichmentStatus` CustomFields on each org's company
+ * EntityDefinition. These are hidden fields written by the enrichment trigger
+ * when a new company is created from a domain.
+ */
+export const migration008CompanyEnrichmentFields: EntityMigration = {
+  id: '008-company-enrichment-fields',
+  description: 'Add enrichedAt and enrichmentStatus system fields to company entity',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const companyDef = existing.entityDefs.get('company')
+    if (!companyDef) {
+      logger.warn('No company entity found, skipping enrichment fields', { organizationId })
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    await ensureCustomFields(
+      db,
+      organizationId,
+      'company',
+      companyDef.id,
+      {
+        enrichedAt: COMPANY_FIELDS.enrichedAt!,
+        enrichmentStatus: COMPANY_FIELDS.enrichmentStatus!,
+      },
+      existing,
+      state
+    )
+
+    const alreadyUpToDate = state.fieldsCreated === 0
+
+    if (!alreadyUpToDate) {
+      logger.info('Migration 008 applied', {
+        organizationId,
+        fieldsCreated: state.fieldsCreated,
+      })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/lib/src/workflow-engine/query-builder/entity-condition-builder.ts
+++ b/packages/lib/src/workflow-engine/query-builder/entity-condition-builder.ts
@@ -102,7 +102,7 @@ export class EntityConditionBuilder extends BaseConditionBuilder<EntityQueryCont
     context: EntityQueryContext
   ): SQL<unknown>[] | undefined {
     const fieldDef = this.resolveFieldRef(field, context)
-    if (!fieldDef?.capabilities.sortable) {
+    if (!fieldDef?.capabilities.sortable || fieldDef.capabilities.hidden) {
       return undefined
     }
 

--- a/packages/lib/src/workflow-engine/query-builder/system-condition-builder.ts
+++ b/packages/lib/src/workflow-engine/query-builder/system-condition-builder.ts
@@ -97,7 +97,7 @@ export class SystemConditionBuilder extends BaseConditionBuilder<TableId> {
     resourceType: TableId
   ): SQL<unknown>[] | undefined {
     const fieldDef = RESOURCE_FIELD_REGISTRY[resourceType]?.[this.stripFieldPrefix(field)]
-    if (!fieldDef?.capabilities.sortable || !fieldDef.dbColumn) {
+    if (!fieldDef?.capabilities.sortable || fieldDef.capabilities.hidden || !fieldDef.dbColumn) {
       return undefined
     }
 
@@ -309,7 +309,7 @@ export class SystemConditionBuilder extends BaseConditionBuilder<TableId> {
     fieldId: string
   ): { columns: AnyColumn[]; type: string } | undefined {
     const field = RESOURCE_FIELD_REGISTRY[resourceType]?.[this.stripFieldPrefix(fieldId)]
-    if (!field || !field.capabilities.filterable || !field.dbColumn) {
+    if (!field || !field.capabilities.filterable || field.capabilities.hidden || !field.dbColumn) {
       return undefined
     }
 

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -139,6 +139,8 @@ export const SYSTEM_ATTRIBUTES = [
   'company_primary_contact',
   'company_employees',
   'company_meetings',
+  'company_enriched_at',
+  'company_enrichment_status',
 
   // ─── Meeting fields ────────────────────────────────────────────
   'meeting_title',


### PR DESCRIPTION
feat: Add company enrichment fields and related event handling

- Introduced `enrichedAt` and `enrichmentStatus` fields for company entities, which are hidden from user-facing UI.
- Implemented enrichment logic to fetch and store company data from websites upon creation.
- Updated event handlers to include new company events: `company:created` and `company:deleted`.
- Enhanced filtering logic across various components to exclude hidden fields from user interactions.
- Added migration to ensure new fields are created in existing company entity definitions.