### PR TITLE
feat: system tag read-only guards + BOM descendant explosion fix

### DIFF
--- a/apps/web/src/components/tags/ui/color-tag-picker.tsx
+++ b/apps/web/src/components/tags/ui/color-tag-picker.tsx
@@ -13,12 +13,17 @@ import { Check } from 'lucide-react'
 interface ColorPickerProps {
   value: SelectOptionColor
   onChange: (value: SelectOptionColor) => void
+  disabled?: boolean
 }
 
 /** ColorTagPicker component for selecting from predefined named colors */
-function ColorTagPicker({ onChange, value }: ColorPickerProps) {
+function ColorTagPicker({ onChange, value, disabled = false }: ColorPickerProps) {
   return (
-    <div className='flex flex-wrap items-center gap-2'>
+    <div
+      className={cn(
+        'flex flex-wrap items-center gap-2',
+        disabled && 'opacity-60 pointer-events-none'
+      )}>
       {OPTION_COLORS.map((color) => {
         const isSelected = value === color.id
         return (
@@ -31,6 +36,7 @@ function ColorTagPicker({ onChange, value }: ColorPickerProps) {
             )}
             onClick={() => onChange(color.id)}
             type='button'
+            disabled={disabled}
             aria-label={`Select ${color.label}`}>
             {isSelected && <Check className='size-4 text-white' />}
           </button>
@@ -45,17 +51,19 @@ export function FormColorTagPicker({
   value = DEFAULT_SELECT_OPTION_COLOR,
   onChange,
   onBlur,
+  disabled = false,
   ...props
 }: Omit<ColorPickerProps, 'value' | 'onChange'> & {
   value?: SelectOptionColor
   onChange?: (value: SelectOptionColor) => void
   onBlur?: () => void
+  disabled?: boolean
 }) {
   const handleChange = (color: SelectOptionColor) => {
     onChange?.(color)
   }
 
-  return <ColorTagPicker value={value} onChange={handleChange} {...props} />
+  return <ColorTagPicker value={value} onChange={handleChange} disabled={disabled} {...props} />
 }
 
 export { ColorTagPicker }

--- a/apps/web/src/components/tags/ui/tag-dialog.tsx
+++ b/apps/web/src/components/tags/ui/tag-dialog.tsx
@@ -78,6 +78,12 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
   // Fetch tag hierarchy for parent selection (includes fields map for saving)
   const { hierarchy, flatTags, tagMap, fields, entityDefinitionId, refresh } = useTagHierarchy()
 
+  // System tags are read-only: server rejects edits via field-hooks guard, and
+  // the dialog disables inputs + hides the save button as a UX safety net.
+  const isSystemTag =
+    isEditing && editingInstanceId ? tagMap.get(editingInstanceId)?.isSystemTag === true : false
+  const isReadOnly = isSystemTag
+
   // Track if dialog has been initialized
   const isInitialized = useRef(false)
 
@@ -280,13 +286,23 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent size='sm' position='tc'>
         <DialogHeader>
-          <DialogTitle>{isEditing ? 'Edit Tag' : 'Create New Tag'}</DialogTitle>
+          <DialogTitle>
+            {isReadOnly ? 'System Tag' : isEditing ? 'Edit Tag' : 'Create New Tag'}
+          </DialogTitle>
           <DialogDescription>
-            {isEditing
-              ? "Update this tag's details below."
-              : 'Fill out the form below to create a new tag.'}
+            {isReadOnly
+              ? 'Managed by Auxx — read-only.'
+              : isEditing
+                ? "Update this tag's details below."
+                : 'Fill out the form below to create a new tag.'}
           </DialogDescription>
         </DialogHeader>
+
+        {isReadOnly && (
+          <div className='rounded-md bg-amber-100 border border-amber-300 px-3 py-2 text-sm text-amber-900'>
+            This is a system tag. It cannot be modified or deleted.
+          </div>
+        )}
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(handleSubmit)}>
@@ -304,7 +320,11 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
                             value={field.value || ''}
                             onChange={field.onChange}
                             modal={false}>
-                            <Button variant='outline' size='icon' className='mt-px rounded-full'>
+                            <Button
+                              variant='outline'
+                              size='icon'
+                              className='mt-px rounded-full'
+                              disabled={isReadOnly}>
                               {field.value || <Tag />}
                             </Button>
                           </FormEmojiPicker>
@@ -320,7 +340,7 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
                     render={({ field }) => (
                       <FormItem>
                         <FormControl>
-                          <Input placeholder='Tag name' {...field} />
+                          <Input placeholder='Tag name' {...field} disabled={isReadOnly} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -341,6 +361,7 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
                         className='h-20 resize-none'
                         {...field}
                         value={field.value || ''}
+                        disabled={isReadOnly}
                       />
                     </FormControl>
                     <FormDescription>Brief description of this tag's purpose</FormDescription>
@@ -357,7 +378,11 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
                   <FormItem>
                     <FormLabel>Color</FormLabel>
                     <FormControl>
-                      <FormColorTagPicker value={field.value || 'gray'} onChange={field.onChange} />
+                      <FormColorTagPicker
+                        value={field.value || 'gray'}
+                        onChange={field.onChange}
+                        disabled={isReadOnly}
+                      />
                     </FormControl>
                     <FormDescription>Choose a color for this tag</FormDescription>
                     <FormMessage />
@@ -372,7 +397,10 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Parent Tag</FormLabel>
-                    <Select onValueChange={field.onChange} value={field.value || ''}>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value || ''}
+                      disabled={isReadOnly}>
                       <FormControl>
                         <SelectTrigger>
                           <SelectValue placeholder='No parent (root level)' />
@@ -421,24 +449,36 @@ export function TagDialog({ open, onOpenChange, recordId, onSaved }: TagDialogPr
 
               {/* Right side: Action buttons */}
               <div className='flex items-center gap-2'>
-                <Button
-                  type='button'
-                  size='sm'
-                  variant='ghost'
-                  onClick={() => onOpenChange(false)}
-                  disabled={isPending}>
-                  Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-                </Button>
-                <Button
-                  size='sm'
-                  variant='outline'
-                  type='submit'
-                  loading={isPending}
-                  loadingText={isEditing ? 'Saving...' : 'Creating...'}
-                  data-dialog-submit>
-                  {isEditing ? 'Save Changes' : 'Create Tag'}{' '}
-                  <KbdSubmit variant='outline' size='sm' />
-                </Button>
+                {isReadOnly ? (
+                  <Button
+                    type='button'
+                    size='sm'
+                    variant='outline'
+                    onClick={() => onOpenChange(false)}>
+                    Close <Kbd shortcut='esc' variant='outline' size='sm' />
+                  </Button>
+                ) : (
+                  <>
+                    <Button
+                      type='button'
+                      size='sm'
+                      variant='ghost'
+                      onClick={() => onOpenChange(false)}
+                      disabled={isPending}>
+                      Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+                    </Button>
+                    <Button
+                      size='sm'
+                      variant='outline'
+                      type='submit'
+                      loading={isPending}
+                      loadingText={isEditing ? 'Saving...' : 'Creating...'}
+                      data-dialog-submit>
+                      {isEditing ? 'Save Changes' : 'Create Tag'}{' '}
+                      <KbdSubmit variant='outline' size='sm' />
+                    </Button>
+                  </>
+                )}
               </div>
             </DialogFooter>
           </form>

--- a/apps/web/src/components/tags/ui/tags-list.tsx
+++ b/apps/web/src/components/tags/ui/tags-list.tsx
@@ -7,8 +7,9 @@ import { Button } from '@auxx/ui/components/button'
 import { Input } from '@auxx/ui/components/input'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
-import { ChevronDown, ChevronRight, Edit, Plus, SearchIcon, Trash } from 'lucide-react'
+import { ChevronDown, ChevronRight, Edit, Lock, Plus, SearchIcon, Trash } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useCallback, useEffect, useState } from 'react'
 import { useConfirm } from '~/hooks/use-confirm'
@@ -177,6 +178,19 @@ export function TagTreeView() {
 
             <span className='font-medium shrink-0'>{tag.title}</span>
 
+            {tag.isSystemTag && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Lock
+                    size={12}
+                    className='ml-1.5 shrink-0 text-muted-foreground'
+                    aria-label='System tag'
+                  />
+                </TooltipTrigger>
+                <TooltipContent>System tag — managed by Auxx, read-only.</TooltipContent>
+              </Tooltip>
+            )}
+
             {tag.tag_description && (
               <span className='ml-2 truncate text-sm text-muted-foreground'>
                 {tag.tag_description}
@@ -190,6 +204,7 @@ export function TagTreeView() {
               type='button'
               variant='ghost'
               size='icon-xs'
+              disabled={tag.isSystemTag}
               onClick={(e) => {
                 e.stopPropagation()
                 handleEditTag(tag)
@@ -203,6 +218,7 @@ export function TagTreeView() {
               variant='destructive-hover'
               size='icon-xs'
               className='border-transparent bg-transparent'
+              disabled={tag.isSystemTag}
               onClick={(e) => {
                 e.stopPropagation()
                 handleDeleteTag(tag)

--- a/packages/lib/src/field-hooks/post/bom-movement-triggers.ts
+++ b/packages/lib/src/field-hooks/post/bom-movement-triggers.ts
@@ -65,18 +65,22 @@ export const explodeBomMovement: EntityTriggerHandler = async (event) => {
     return
   }
 
-  // Flatten to leaf targets (in-memory)
-  const leafTargets = getDeductionTargets(partInstanceId, quantity, subpartGraph)
+  // Flatten to descendant targets (in-memory). The root is excluded — the
+  // user-submitted parent movement itself counts as the root's deduction.
+  const targets = getDeductionTargets(partInstanceId, quantity, subpartGraph)
 
-  if (leafTargets.length === 0) {
-    logger.warn('BOM explosion produced no leaf targets', { partInstanceId })
+  if (targets.length === 0) {
+    logger.warn('BOM explosion produced no descendant targets', { partInstanceId })
+    // Parent movement is the root's deduction — clear flag and recalc root.
+    await clearAdjustSubpartsFlag(organizationId, entityInstanceId)
+    await batchRecalculateQoH(organizationId, [partInstanceId])
     return
   }
 
-  logger.info('Exploding BOM movement to leaf parts', {
+  logger.info('Exploding BOM movement to descendant parts', {
     parentPart: partInstanceId,
     parentQuantity: quantity,
-    leafCount: leafTargets.length,
+    descendantCount: targets.length,
   })
 
   // Resolve IDs from cache (0 DB calls)
@@ -103,7 +107,7 @@ export const explodeBomMovement: EntityTriggerHandler = async (event) => {
   const insertedInstances = await database
     .insert(schema.EntityInstance)
     .values(
-      leafTargets.map(() => ({
+      targets.map(() => ({
         entityDefinitionId: stockMovementDefId,
         organizationId,
         createdById: userId || null,
@@ -115,8 +119,8 @@ export const explodeBomMovement: EntityTriggerHandler = async (event) => {
   // ── Batch INSERT: FieldValue rows (1 query) ──
   const fieldValueRows: Array<typeof schema.FieldValue.$inferInsert> = []
 
-  for (let i = 0; i < leafTargets.length; i++) {
-    const target = leafTargets[i]!
+  for (let i = 0; i < targets.length; i++) {
+    const target = targets[i]!
     const instanceId = insertedInstances[i]!.id
 
     // Define typed values for this child movement
@@ -176,15 +180,19 @@ export const explodeBomMovement: EntityTriggerHandler = async (event) => {
 
   await database.insert(schema.FieldValue).values(fieldValueRows)
 
-  // ── Batch recalculate QoH for all affected leaf parts ──
-  await batchRecalculateQoH(
-    organizationId,
-    leafTargets.map((t) => t.partInstanceId)
-  )
+  // Now that descendant movements are in place, clear the flag on the parent
+  // movement so it counts toward the root part's QoH directly.
+  await clearAdjustSubpartsFlag(organizationId, entityInstanceId)
+
+  // ── Batch recalculate QoH for the root part + all affected descendants ──
+  await batchRecalculateQoH(organizationId, [
+    partInstanceId,
+    ...targets.map((t) => t.partInstanceId),
+  ])
 
   logger.info('BOM explosion complete', {
     parentMovement: entityInstanceId,
-    childMovementsCreated: leafTargets.length,
+    childMovementsCreated: targets.length,
   })
 }
 
@@ -293,8 +301,10 @@ async function loadSubpartGraph(
 // ─── Leaf Target Calculation ───────────────────────────────────────────
 
 /**
- * Walk the BOM graph from root and collect all parts with multiplied quantities.
- * Both intermediate and leaf nodes are included (all have tracked inventory).
+ * Walk the BOM graph from root and collect all DESCENDANT parts with multiplied
+ * quantities. The root itself is excluded — the user-submitted parent movement
+ * already accounts for the root's deduction. Both intermediate and leaf
+ * descendants are included (all have tracked inventory).
  * Includes circular reference detection via visited Set and maxDepth safeguard.
  */
 function getDeductionTargets(
@@ -302,7 +312,8 @@ function getDeductionTargets(
   rootQuantity: number,
   graph: Map<string, { childId: string; qty: number }[]>,
   visited: Set<string> = new Set(),
-  depth: number = 0
+  depth: number = 0,
+  isRoot: boolean = true
 ): { partInstanceId: string; quantity: number }[] {
   // Circular reference protection — same pattern as cost-calculator.ts
   if (visited.has(rootPartId)) {
@@ -319,25 +330,32 @@ function getDeductionTargets(
       partId: rootPartId,
       depth,
     })
-    return [{ partInstanceId: rootPartId, quantity: rootQuantity }]
+    return isRoot ? [] : [{ partInstanceId: rootPartId, quantity: rootQuantity }]
   }
 
   visited.add(rootPartId)
 
   const children = graph.get(rootPartId)
 
-  // No children = leaf node, just return this part
+  // No children = leaf node. Skip if this is the root (parent movement covers it).
   if (!children || children.length === 0) {
-    return [{ partInstanceId: rootPartId, quantity: rootQuantity }]
+    return isRoot ? [] : [{ partInstanceId: rootPartId, quantity: rootQuantity }]
   }
 
-  // Has children = include this intermediate node AND recurse into children
-  const targets: { partInstanceId: string; quantity: number }[] = [
-    { partInstanceId: rootPartId, quantity: rootQuantity },
-  ]
+  // Has children = include this node (unless it's the root) AND recurse into children
+  const targets: { partInstanceId: string; quantity: number }[] = isRoot
+    ? []
+    : [{ partInstanceId: rootPartId, quantity: rootQuantity }]
   for (const child of children) {
     targets.push(
-      ...getDeductionTargets(child.childId, rootQuantity * child.qty, graph, visited, depth + 1)
+      ...getDeductionTargets(
+        child.childId,
+        rootQuantity * child.qty,
+        graph,
+        visited,
+        depth + 1,
+        false
+      )
     )
   }
 

--- a/packages/lib/src/field-hooks/pre/tag-system-guard.ts
+++ b/packages/lib/src/field-hooks/pre/tag-system-guard.ts
@@ -1,0 +1,64 @@
+// packages/lib/src/field-hooks/pre/tag-system-guard.ts
+
+import { database, schema } from '@auxx/database'
+import type { RecordId } from '@auxx/types/resource'
+import { and, eq } from 'drizzle-orm'
+import { ForbiddenError } from '../../errors'
+import { parseRecordId } from '../../resources/resource-id'
+import type { EntityPreDeleteHandler, FieldPreHookHandler } from '../types'
+
+/**
+ * Look up the `is_system_tag` boolean for a given tag record. One keyed
+ * FieldValue+CustomField join. Returns `false` when no value row exists
+ * (the field defaults to false on fresh records).
+ */
+async function readIsSystemTag(recordId: RecordId, organizationId: string): Promise<boolean> {
+  const { entityInstanceId } = parseRecordId(recordId)
+  const [row] = await database
+    .select({ valueBoolean: schema.FieldValue.valueBoolean })
+    .from(schema.FieldValue)
+    .innerJoin(schema.CustomField, eq(schema.FieldValue.fieldId, schema.CustomField.id))
+    .where(
+      and(
+        eq(schema.FieldValue.entityId, entityInstanceId),
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.CustomField.systemAttribute, 'is_system_tag')
+      )
+    )
+    .limit(1)
+  return row?.valueBoolean === true
+}
+
+/**
+ * Silently drop any user-supplied write to `is_system_tag`. Only the seeder
+ * (which puts `is_system_tag` in `ctx.bypassFieldGuards`) is allowed to set
+ * this flag — every other caller's value is discarded so the registry's
+ * `capabilities.creatable: false` is actually enforced.
+ *
+ * The framework already short-circuits this hook when the bypass set
+ * contains `is_system_tag`, so this body only runs for unauthorized writes.
+ */
+export const dropUnauthorizedSystemFlag: FieldPreHookHandler = async () => undefined
+
+/**
+ * Reject writes to a user-editable tag field (title, description, emoji,
+ * color, parent) when the underlying record is a system tag. Throws a 403;
+ * the tRPC surface returns it as FORBIDDEN.
+ */
+export const rejectIfSystemTag: FieldPreHookHandler = async (event) => {
+  const isSystem = await readIsSystemTag(event.recordId, event.organizationId)
+  if (isSystem) {
+    throw new ForbiddenError('System tags cannot be modified')
+  }
+  return event.newValue
+}
+
+/**
+ * Reject a delete when the target is a system tag. `event.values` is
+ * pre-captured by the pre-delete fire point, so no extra read is needed.
+ */
+export const rejectDeleteIfSystemTag: EntityPreDeleteHandler = async (event) => {
+  if (event.values.is_system_tag === true) {
+    throw new ForbiddenError('System tags cannot be deleted')
+  }
+}

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -5,7 +5,17 @@ import { explodeBomMovement } from './post/bom-movement-triggers'
 import { enrichCompanyOnCreate } from './post/company-triggers'
 import { recalculatePartQoH, recalculateStockStatus } from './post/inventory-triggers'
 import { clearOtherPreferred } from './post/vendor-part-triggers'
-import { registerEntityTriggers, registerFieldTriggers } from './registry'
+import {
+  dropUnauthorizedSystemFlag,
+  rejectDeleteIfSystemTag,
+  rejectIfSystemTag,
+} from './pre/tag-system-guard'
+import {
+  registerEntityPreDeleteHooks,
+  registerEntityTriggers,
+  registerFieldPreHooks,
+  registerFieldTriggers,
+} from './registry'
 
 /**
  * Register all field and entity hooks (pre + post).
@@ -42,9 +52,17 @@ export function registerAllHooks(): void {
   // ---------------------------------------------------------------------------
   // PRE-WRITE HOOKS
   // ---------------------------------------------------------------------------
-  //
-  // Per-field pre-hooks (registerFieldPreHooks) and pre-delete hooks
-  // (registerEntityPreDeleteHooks) are added by feature modules in this
-  // section as they come online. The system-tag guard is the first
-  // expected consumer.
+
+  // System tag guard — makes seeded tags read-only for end users.
+  // - is_system_tag: drop any write that isn't bypassed by the seeder.
+  // - title / description / emoji / color / parent: reject edits when the
+  //   record's is_system_tag is true.
+  // - pre-delete: reject deletes of system tags.
+  registerFieldPreHooks('tags', 'is_system_tag', [dropUnauthorizedSystemFlag])
+  registerFieldPreHooks('tags', 'title', [rejectIfSystemTag])
+  registerFieldPreHooks('tags', 'tag_description', [rejectIfSystemTag])
+  registerFieldPreHooks('tags', 'tag_emoji', [rejectIfSystemTag])
+  registerFieldPreHooks('tags', 'tag_color', [rejectIfSystemTag])
+  registerFieldPreHooks('tags', 'tag_parent', [rejectIfSystemTag])
+  registerEntityPreDeleteHooks('tags', [rejectDeleteIfSystemTag])
 }

--- a/packages/lib/src/resources/registry/resources/tag-fields.ts
+++ b/packages/lib/src/resources/registry/resources/tag-fields.ts
@@ -213,7 +213,6 @@ export const TAG_FIELDS: Record<string, ResourceField> = {
     systemAttribute: 'is_system_tag',
     systemSortOrder: 'a8',
     showInPanel: false,
-    dbColumn: 'isSystemTag',
     nullable: false,
     defaultValue: false,
     capabilities: {

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -16,6 +16,7 @@ import { migration010OrganizationAiQuota } from './migrations/010-organization-a
 import { migration011ExtensionExternalId } from './migrations/011-extension-external-id'
 import { migration012ContactEmailOptional } from './migrations/012-contact-email-optional'
 import { migration013ContactCompanyExternalIdFix } from './migrations/013-contact-company-external-id-fix'
+import { migration014BackfillSystemTags } from './migrations/014-backfill-system-tags'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -37,6 +38,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration011ExtensionExternalId,
   migration012ContactEmailOptional,
   migration013ContactCompanyExternalIdFix,
+  migration014BackfillSystemTags,
 ]
 
 // ─── Public API ──────────────────────────────────────────────────────

--- a/packages/lib/src/seed/entity-migrations/migrations/014-backfill-system-tags.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/014-backfill-system-tags.ts
@@ -1,0 +1,268 @@
+// packages/lib/src/seed/entity-migrations/migrations/014-backfill-system-tags.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { SystemAttribute } from '@auxx/types/system-attribute'
+import { generateKeyBetween } from '@auxx/utils/fractional-indexing'
+import { and, eq, inArray } from 'drizzle-orm'
+import { TAG_FIELDS } from '../../../resources/registry/resources/tag-fields'
+import { buildFieldOptions, mapCapabilities } from '../../entity-seeder/utils'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:014')
+
+/**
+ * Frozen-in-time snapshot of the titles `OrganizationSeeder.seedTags` creates.
+ * If the seeder's defaults change later, do NOT edit this list — write a new
+ * migration that flags the new titles. Migrations are historical.
+ */
+const CANONICAL_SYSTEM_TAG_TITLES = [
+  // Parent
+  'Topic Categorization',
+  // Children of "Topic Categorization"
+  'Account Management',
+  'Billing',
+  'Customer Feedback',
+  'Legal',
+  'Sales',
+  'Security',
+  'Shipping',
+  'Troubleshooting',
+  // Independent
+  'Support',
+  'Urgent',
+  'Orders',
+  'VIP',
+]
+
+/**
+ * Migration 014: Backfill `is_system_tag` for existing orgs.
+ *
+ * Two steps, both idempotent:
+ *   1. Ensure a `CustomField` row with `systemAttribute = 'is_system_tag'`
+ *      exists on the org's `tag` EntityDefinition.
+ *   2. For every tag instance whose `title` is in the canonical seeded list,
+ *      upsert the `is_system_tag` FieldValue to `true`.
+ *
+ * New orgs get `is_system_tag = true` directly from the seeder; this
+ * migration catches up the orgs seeded before the system-tags PR.
+ *
+ * Title-match risk: a user-created tag that happens to share a canonical
+ * title (e.g. "Billing") will be flagged as a system tag and locked down
+ * in the UI. Accepted per product decision — low user count, low impact.
+ */
+export const migration014BackfillSystemTags: EntityMigration = {
+  id: '014-backfill-system-tags',
+  description: 'Ensure tag.is_system_tag CustomField and flag canonical seeded tags',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+
+    // ── Step 0: find the tag EntityDefinition for this org ────────────────
+    const [tagDef] = await db
+      .select({ id: schema.EntityDefinition.id })
+      .from(schema.EntityDefinition)
+      .where(
+        and(
+          eq(schema.EntityDefinition.organizationId, organizationId),
+          eq(schema.EntityDefinition.entityType, 'tag')
+        )
+      )
+      .limit(1)
+
+    if (!tagDef) {
+      // No tag entity — nothing to migrate. Pre-seed or manually pruned.
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    // ── Step 1: ensure the is_system_tag CustomField exists ───────────────
+    const isSystemTagFieldId = await ensureIsSystemTagField(db, organizationId, tagDef.id, state)
+
+    // ── Step 2: flag canonical tags ───────────────────────────────────────
+    const { flagged, alreadyFlagged } = await flagCanonicalTags(
+      db,
+      organizationId,
+      tagDef.id,
+      isSystemTagFieldId
+    )
+
+    const alreadyUpToDate = state.fieldsCreated === 0 && flagged === 0
+
+    if (!alreadyUpToDate) {
+      logger.info('Migration 014 applied', {
+        organizationId,
+        customFieldCreated: state.fieldsCreated > 0,
+        tagsFlagged: flagged,
+        tagsAlreadyFlagged: alreadyFlagged,
+      })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}
+
+/**
+ * Insert the is_system_tag CustomField if missing. Returns the field id.
+ */
+async function ensureIsSystemTagField(
+  db: Database,
+  organizationId: string,
+  tagDefId: string,
+  state: { fieldsCreated: number }
+): Promise<string> {
+  const field = TAG_FIELDS.is_system_tag
+  if (!field) {
+    throw new Error('TAG_FIELDS.is_system_tag is missing from the registry')
+  }
+
+  const [existing] = await db
+    .select({ id: schema.CustomField.id })
+    .from(schema.CustomField)
+    .where(
+      and(
+        eq(schema.CustomField.organizationId, organizationId),
+        eq(schema.CustomField.entityDefinitionId, tagDefId),
+        eq(schema.CustomField.systemAttribute, 'is_system_tag')
+      )
+    )
+    .limit(1)
+
+  if (existing) return existing.id
+
+  const [created] = await db
+    .insert(schema.CustomField)
+    .values({
+      organizationId,
+      entityDefinitionId: tagDefId,
+      modelType: 'tag',
+      name: field.label,
+      type: field.fieldType!,
+      description: field.description,
+      systemAttribute: field.systemAttribute as SystemAttribute,
+      sortOrder: field.systemSortOrder ?? 'a8',
+      options: buildFieldOptions(field),
+      isCustom: false,
+      updatedAt: new Date(),
+      ...mapCapabilities(field.capabilities),
+    })
+    .returning({ id: schema.CustomField.id })
+
+  if (!created) throw new Error('Failed to create tag.is_system_tag CustomField')
+
+  state.fieldsCreated++
+  logger.debug('Created tag.is_system_tag CustomField', {
+    id: created.id,
+    organizationId,
+  })
+  return created.id
+}
+
+/**
+ * Upsert `is_system_tag = true` on every tag instance whose title matches
+ * the canonical seeded list. Returns counts for logging.
+ */
+async function flagCanonicalTags(
+  db: Database,
+  organizationId: string,
+  tagDefId: string,
+  isSystemTagFieldId: string
+): Promise<{ flagged: number; alreadyFlagged: number }> {
+  // Resolve the title fieldId on this org's tag entity.
+  const [titleField] = await db
+    .select({ id: schema.CustomField.id })
+    .from(schema.CustomField)
+    .where(
+      and(
+        eq(schema.CustomField.organizationId, organizationId),
+        eq(schema.CustomField.entityDefinitionId, tagDefId),
+        eq(schema.CustomField.systemAttribute, 'title')
+      )
+    )
+    .limit(1)
+
+  if (!titleField) {
+    // Tag entity exists but has no title field — structural problem, not
+    // ours to fix. Bail gracefully.
+    logger.warn('No title CustomField on tag entity; skipping flag step', { organizationId })
+    return { flagged: 0, alreadyFlagged: 0 }
+  }
+
+  // Find canonical-titled tag instances.
+  const canonicalRows = await db
+    .select({ entityId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, titleField.id),
+        inArray(schema.FieldValue.valueText, CANONICAL_SYSTEM_TAG_TITLES)
+      )
+    )
+
+  if (canonicalRows.length === 0) {
+    return { flagged: 0, alreadyFlagged: 0 }
+  }
+
+  const canonicalInstanceIds = canonicalRows.map((r) => r.entityId)
+
+  // Find which ones already have an is_system_tag FieldValue row.
+  const existingFlagRows = await db
+    .select({
+      id: schema.FieldValue.id,
+      entityId: schema.FieldValue.entityId,
+      valueBoolean: schema.FieldValue.valueBoolean,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, isSystemTagFieldId),
+        inArray(schema.FieldValue.entityId, canonicalInstanceIds)
+      )
+    )
+
+  const existingByEntity = new Map(existingFlagRows.map((r) => [r.entityId, r]))
+
+  const idsToFlip: string[] = []
+  const instancesToInsert: string[] = []
+  let alreadyFlagged = 0
+
+  for (const entityId of canonicalInstanceIds) {
+    const existing = existingByEntity.get(entityId)
+    if (!existing) {
+      instancesToInsert.push(entityId)
+    } else if (existing.valueBoolean === true) {
+      alreadyFlagged++
+    } else {
+      idsToFlip.push(existing.id)
+    }
+  }
+
+  const now = new Date()
+
+  if (idsToFlip.length > 0) {
+    await db
+      .update(schema.FieldValue)
+      .set({ valueBoolean: true, updatedAt: now })
+      .where(inArray(schema.FieldValue.id, idsToFlip))
+  }
+
+  if (instancesToInsert.length > 0) {
+    await db.insert(schema.FieldValue).values(
+      instancesToInsert.map((entityId) => ({
+        organizationId,
+        entityId,
+        entityDefinitionId: tagDefId,
+        fieldId: isSystemTagFieldId,
+        sortKey: generateKeyBetween(null, null),
+        valueBoolean: true,
+        updatedAt: now,
+      }))
+    )
+  }
+
+  return {
+    flagged: idsToFlip.length + instancesToInsert.length,
+    alreadyFlagged,
+  }
+}

--- a/packages/lib/src/seed/organization-seeder.ts
+++ b/packages/lib/src/seed/organization-seeder.ts
@@ -237,7 +237,13 @@ export class OrganizationSeeder {
    * and child tags, plus independent top-level tags.
    */
   private async seedTags(organizationId: string) {
-    const handler = new UnifiedCrudHandler(organizationId, this.userId, this.db)
+    // Dedicated handler with `is_system_tag` bypass — the tag-system-guard
+    // pre-hook drops any write of this flag unless the caller is in the
+    // bypass set. Keeping the bypass scoped to this block (rather than the
+    // whole seed run) documents the privilege boundary.
+    const handler = new UnifiedCrudHandler(organizationId, this.userId, this.db, undefined, {
+      bypassFieldGuards: new Set(['is_system_tag']),
+    })
 
     // Skip snapshot invalidation and events during seeding — no active users to notify,
     // and each invalidation attempt costs 5s on Lambda when Redis is slow/unavailable
@@ -252,6 +258,7 @@ export class OrganizationSeeder {
         tag_description: 'Top-level categorization for support tickets',
         tag_emoji: '🏷️',
         tag_color: 'blue',
+        is_system_tag: true,
       },
       seedOpts
     )
@@ -275,6 +282,7 @@ export class OrganizationSeeder {
         {
           ...tag,
           tag_parent: topicResult.recordId, // Link to parent via RecordId
+          is_system_tag: true,
         },
         seedOpts
       )
@@ -288,7 +296,9 @@ export class OrganizationSeeder {
       { title: 'VIP', tag_emoji: '⭐', tag_color: 'orange' },
     ]
 
-    await Promise.all(independentTags.map((tag) => handler.create('tag', tag, seedOpts)))
+    await Promise.all(
+      independentTags.map((tag) => handler.create('tag', { ...tag, is_system_tag: true }, seedOpts))
+    )
   }
   // Create ticket sequence for the organization
   /**


### PR DESCRIPTION
## Summary

Two unrelated change sets bundled together — split into two PRs if preferred.

### System tags read-only
- New pre-write field hooks (`packages/lib/src/field-hooks/pre/tag-system-guard.ts`) registered against `tags`: drop unauthorized writes to `is_system_tag`, reject edits to title/description/emoji/color/parent on flagged rows, reject deletes of flagged rows.
- `OrganizationSeeder.seedTags` now uses a scoped `bypassFieldGuards: new Set(['is_system_tag'])` and seeds canonical tags with `is_system_tag = true`.
- Migration `014-backfill-system-tags` ensures the `is_system_tag` CustomField exists on existing orgs and flags any tag whose title matches the canonical seeded list (idempotent).
- Tag dialog (`tag-dialog.tsx`) and tag tree (`tags-list.tsx`) disable inputs, hide destructive actions, and show a lock affordance / amber notice for system tags. `ColorTagPicker` gained a `disabled` prop.
- Removed stale `dbColumn: 'isSystemTag'` from the tag-fields registry entry.

### BOM movement explosion fix (`bom-movement-triggers.ts`)
- `getDeductionTargets` now excludes the root part — the user-submitted parent movement already counts as the root's deduction, so it shouldn't be double-counted by an additional child movement against the same part.
- After children are written, the parent movement's `adjust_subparts` flag is cleared and root QoH is recalculated alongside descendants.

## Test plan

- [ ] Seed a fresh org and confirm the canonical tags are created with `is_system_tag = true` and render with the lock icon in the tag tree.
- [ ] Open a system tag from the tag list — dialog should show the read-only banner, all inputs disabled, only a Close button visible.
- [ ] Attempt to update / delete a system tag via tRPC directly — server returns FORBIDDEN.
- [ ] Run migration 014 against an org seeded before this PR — confirm `is_system_tag` CustomField is created and canonical-titled tags are flagged.
- [ ] Submit a BOM movement on a parent part with descendants — confirm the parent movement keeps its quantity (no double-deduction on the root) and child movements are created for descendants only.
- [ ] Submit a BOM movement on a part with no children — confirm no child movements are created and the root recalculates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)