### PR TITLE
feat: field-change post-hooks + ticket/entity field-updated events

### DIFF
--- a/apps/web/src/components/timeline/event-description.tsx
+++ b/apps/web/src/components/timeline/event-description.tsx
@@ -208,24 +208,6 @@ export function EventDescription({ event, onToggleExpand }: EventDescriptionProp
         </div>
       )
 
-    case ContactEventType.FIELD_UPDATED:
-      return (
-        <div className='flex flex-wrap items-center gap-2'>
-          <span>
-            <span className='emphasis'>{event.actor.name || 'Someone'}</span> updated{' '}
-            <span className='font-medium'>{event.eventData.fieldName}</span>
-          </span>
-          {hasExpandableContent && (
-            <button
-              type='button'
-              onClick={onToggleExpand}
-              className='inline-flex items-center rounded bg-accent-50 px-2 py-0.5 text-xs font-medium text-accent-700 transition-colors hover:bg-accent-100'>
-              View changes
-            </button>
-          )}
-        </div>
-      )
-
     case ContactEventType.ASSIGNED:
       return (
         <>
@@ -456,24 +438,6 @@ export function EventDescription({ event, onToggleExpand }: EventDescriptionProp
         </div>
       )
 
-    case TicketEventType.FIELD_UPDATED:
-      return (
-        <div className='flex flex-wrap items-center gap-2'>
-          <span>
-            <span className='emphasis'>{event.actor.name || 'Someone'}</span> updated{' '}
-            <span className='font-medium'>{event.eventData.fieldName}</span>
-          </span>
-          {hasExpandableContent && (
-            <button
-              type='button'
-              onClick={onToggleExpand}
-              className='inline-flex items-center rounded bg-accent-50 px-2 py-0.5 text-xs font-medium text-accent-700 transition-colors hover:bg-accent-100'>
-              View changes
-            </button>
-          )}
-        </div>
-      )
-
     case TicketEventType.WORKFLOW_TRIGGERED:
       return (
         <>
@@ -505,6 +469,9 @@ export function EventDescription({ event, onToggleExpand }: EventDescriptionProp
         </>
       )
 
+    // Field-updated: identical rendering for contact / ticket / custom entity
+    case ContactEventType.FIELD_UPDATED:
+    case TicketEventType.FIELD_UPDATED:
     case EntityInstanceEventType.FIELD_UPDATED:
       return (
         <div className='flex flex-wrap items-center gap-2'>

--- a/apps/web/src/components/timeline/event-icon.tsx
+++ b/apps/web/src/components/timeline/event-icon.tsx
@@ -55,7 +55,6 @@ export function getEventIcon(eventType: string) {
     case ContactEventType.CREATED:
       return Plus
     case ContactEventType.UPDATED:
-    case ContactEventType.FIELD_UPDATED:
       return Edit
     case ContactEventType.MERGED:
       return Users
@@ -87,7 +86,6 @@ export function getEventIcon(eventType: string) {
     case TicketEventType.CREATED:
       return Plus
     case TicketEventType.UPDATED:
-    case TicketEventType.FIELD_UPDATED:
       return Edit
     case TicketEventType.STATUS_CHANGED:
       return AlertCircle
@@ -121,8 +119,14 @@ export function getEventIcon(eventType: string) {
     case EntityInstanceEventType.CREATED:
       return Plus
     case EntityInstanceEventType.UPDATED:
+      return Edit
+
+    // Field updates — identical Edit icon across contact / ticket / custom entity
+    case ContactEventType.FIELD_UPDATED:
+    case TicketEventType.FIELD_UPDATED:
     case EntityInstanceEventType.FIELD_UPDATED:
       return Edit
+
     case EntityInstanceEventType.DELETED:
       return Trash2
     case EntityInstanceEventType.ARCHIVED:
@@ -152,7 +156,6 @@ export function getEventColor(eventType: string) {
     case ContactEventType.CREATED:
       return 'bg-good-100 text-good-600'
     case ContactEventType.UPDATED:
-    case ContactEventType.FIELD_UPDATED:
     case ContactEventType.GROUP_REMOVED:
     case ContactEventType.TAG_REMOVED:
     case ContactEventType.UNASSIGNED:
@@ -182,7 +185,6 @@ export function getEventColor(eventType: string) {
     case TicketEventType.RESTORED:
       return 'bg-good-100 text-good-600'
     case TicketEventType.UPDATED:
-    case TicketEventType.FIELD_UPDATED:
     case TicketEventType.UNASSIGNED:
       return 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-100'
     case TicketEventType.STATUS_CHANGED:
@@ -213,6 +215,11 @@ export function getEventColor(eventType: string) {
     case EntityInstanceEventType.RESTORED:
       return 'bg-good-100 text-good-600'
     case EntityInstanceEventType.UPDATED:
+      return 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-100'
+
+    // Field updates — identical neutral-gray styling across contact / ticket / custom entity
+    case ContactEventType.FIELD_UPDATED:
+    case TicketEventType.FIELD_UPDATED:
     case EntityInstanceEventType.FIELD_UPDATED:
       return 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-100'
     case EntityInstanceEventType.DELETED:

--- a/apps/web/src/components/timeline/group-description.tsx
+++ b/apps/web/src/components/timeline/group-description.tsx
@@ -21,73 +21,26 @@ interface GroupDescriptionProps {
  */
 export function GroupDescription({ eventType, events }: GroupDescriptionProps) {
   const firstEvent = events[0]
+  const actor = <span className='emphasis'>{firstEvent?.actor.name || 'Someone'}</span>
 
   switch (eventType) {
-    // Contact field updates
+    // Field updates — identical across contact / ticket / custom entity
     case ContactEventType.FIELD_UPDATED:
-      return (
-        <span>
-          <span className='emphasis'>{firstEvent?.actor.name || 'Someone'}</span> updated multiple
-          fields
-        </span>
-      )
-
-    case ContactEventType.TAG_ADDED:
-      return (
-        <span>
-          <span className='emphasis'>{firstEvent?.actor.name || 'Someone'}</span> added multiple
-          tags
-        </span>
-      )
-
-    case ContactEventType.TAG_REMOVED:
-      return (
-        <span>
-          <span className='emphasis'>{firstEvent?.actor.name || 'Someone'}</span> removed multiple
-          tags
-        </span>
-      )
-
-    // Ticket field updates
     case TicketEventType.FIELD_UPDATED:
-      return (
-        <span>
-          <span className='emphasis'>{firstEvent?.actor.name || 'Someone'}</span> updated multiple
-          fields
-        </span>
-      )
-
-    case TicketEventType.TAG_ADDED:
-      return (
-        <span>
-          <span className='emphasis'>{firstEvent?.actor.name || 'Someone'}</span> added multiple
-          tags
-        </span>
-      )
-
-    case TicketEventType.TAG_REMOVED:
-      return (
-        <span>
-          <span className='emphasis'>{firstEvent?.actor.name || 'Someone'}</span> removed multiple
-          tags
-        </span>
-      )
-
-    // Entity instance field updates
     case EntityInstanceEventType.FIELD_UPDATED:
-      return (
-        <span>
-          <span className='emphasis'>{firstEvent?.actor.name || 'Someone'}</span> updated multiple
-          fields
-        </span>
-      )
+      return <span>{actor} updated multiple fields</span>
+
+    // Tag adds — identical across contact / ticket
+    case ContactEventType.TAG_ADDED:
+    case TicketEventType.TAG_ADDED:
+      return <span>{actor} added multiple tags</span>
+
+    // Tag removes — identical across contact / ticket
+    case ContactEventType.TAG_REMOVED:
+    case TicketEventType.TAG_REMOVED:
+      return <span>{actor} removed multiple tags</span>
 
     default:
-      return (
-        <span>
-          <span className='emphasis'>{firstEvent?.actor.name || 'Someone'}</span> made multiple
-          changes
-        </span>
-      )
+      return <span>{actor} made multiple changes</span>
   }
 }

--- a/packages/lib/src/events/handlers/create-timeline-event.ts
+++ b/packages/lib/src/events/handlers/create-timeline-event.ts
@@ -2,7 +2,7 @@
 
 import { database as db } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { toRecordId } from '@auxx/types/resource'
+import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import {
   ContactEventType,
   EntityInstanceEventType,
@@ -25,11 +25,13 @@ import type {
   ContactUpdatedEvent,
   EntityInstanceCreatedEvent,
   EntityInstanceDeletedEvent,
+  EntityInstanceFieldUpdatedEvent,
   EntityInstanceUpdatedEvent,
   MessageReceivedEvent,
   MessageSentEvent,
   TicketCreatedEvent,
   TicketDeletedEvent,
+  TicketFieldUpdatedEvent,
   TicketStatusChangedEvent,
   TicketUpdatedEvent,
 } from '../types'
@@ -299,33 +301,26 @@ function mapEventToTimeline(event: AuxxEvent): CreateTimelineEventInput[] {
       ]
     }
 
-    case 'contact:field:updated': {
-      const data = event.data as ContactFieldUpdatedEvent['data']
+    case 'contact:field:updated':
+      return mapFieldUpdated(
+        event as ContactFieldUpdatedEvent,
+        ContactEventType.FIELD_UPDATED,
+        'contact'
+      )
 
-      return [
-        {
-          eventType: ContactEventType.FIELD_UPDATED,
-          recordId: toRecordId('contact', data.contactId),
-          relatedRecordId: toRecordId('custom_field', data.fieldId),
-          actorType: TimelineActorType.USER,
-          actorId: data.userId,
-          eventData: {
-            contactId: data.contactId,
-            fieldId: data.fieldId,
-            fieldName: data.fieldName,
-            fieldType: data.fieldType,
-          },
-          changes: [
-            {
-              field: data.fieldName,
-              oldValue: data.oldValue,
-              newValue: data.newValue,
-            },
-          ],
-          organizationId: data.organizationId,
-        },
-      ]
-    }
+    case 'ticket:field:updated':
+      return mapFieldUpdated(
+        event as TicketFieldUpdatedEvent,
+        TicketEventType.FIELD_UPDATED,
+        'ticket'
+      )
+
+    case 'entity:field:updated':
+      return mapFieldUpdated(
+        event as EntityInstanceFieldUpdatedEvent,
+        EntityInstanceEventType.FIELD_UPDATED,
+        null
+      )
 
     case 'contact:group:added': {
       const data = event.data as ContactGroupAddedEvent['data']
@@ -526,4 +521,57 @@ function mapEventToTimeline(event: AuxxEvent): CreateTimelineEventInput[] {
     default:
       return []
   }
+}
+
+/**
+ * Build a timeline event for any `<prefix>:field:updated` variant.
+ *
+ * The timeline row's `recordId` column is parsed by storage into entityType
+ * + entityId columns and is queried as an exact match. Existing reads on the
+ * contact and ticket detail pages query with `toRecordId('contact', id)` /
+ * `toRecordId('ticket', id)`, so the row must keep that legacy-prefixed
+ * shape for those entities. Custom entities have no legacy form and use the
+ * canonical RecordId (`<entityDefinitionId>:<entityInstanceId>`) directly.
+ *
+ * The canonical recordId is preserved in `eventData.recordId` for any
+ * future reader. When the read-side migration to canonical IDs lands, drop
+ * the `legacyPrefix` arg and use `data.recordId` for both columns.
+ */
+function mapFieldUpdated(
+  event: ContactFieldUpdatedEvent | TicketFieldUpdatedEvent | EntityInstanceFieldUpdatedEvent,
+  eventType:
+    | ContactEventType.FIELD_UPDATED
+    | TicketEventType.FIELD_UPDATED
+    | EntityInstanceEventType.FIELD_UPDATED,
+  legacyPrefix: 'contact' | 'ticket' | null
+): CreateTimelineEventInput[] {
+  const data = event.data
+  const rowRecordId = legacyPrefix
+    ? toRecordId(legacyPrefix, parseRecordId(data.recordId).entityInstanceId)
+    : data.recordId
+  return [
+    {
+      eventType,
+      recordId: rowRecordId,
+      relatedRecordId: toRecordId('custom_field', data.fieldId),
+      actorType: TimelineActorType.USER,
+      actorId: data.userId,
+      eventData: {
+        recordId: data.recordId,
+        entityDefinitionId: data.entityDefinitionId,
+        entitySlug: data.entitySlug,
+        fieldId: data.fieldId,
+        fieldName: data.fieldName,
+        fieldType: data.fieldType,
+      },
+      changes: [
+        {
+          field: data.fieldName,
+          oldValue: data.oldValue,
+          newValue: data.newValue,
+        },
+      ],
+      organizationId: data.organizationId,
+    },
+  ]
 }

--- a/packages/lib/src/events/handlers/publish-event-job.ts
+++ b/packages/lib/src/events/handlers/publish-event-job.ts
@@ -77,6 +77,7 @@ export const EventHandlers: IEventsHandlers = {
   'contact:field:updated': [createTimelineEvent],
   'contact:group:added': [createTimelineEvent],
   'contact:group:removed': [createTimelineEvent],
+  'ticket:field:updated': [createTimelineEvent],
 
   // Comment events → CREATE TIMELINE
   'comment:created': [createTimelineEvent],
@@ -88,6 +89,7 @@ export const EventHandlers: IEventsHandlers = {
   'entity:created': [createTimelineEvent, handleEntityTriggers],
   'entity:updated': [createTimelineEvent],
   'entity:deleted': [createTimelineEvent, handleEntityTriggers],
+  'entity:field:updated': [createTimelineEvent],
 
   // Stock movement events → ENTITY TRIGGERS (inventory QoH recalculation)
   'stock_movement:created': [handleEntityTriggers],

--- a/packages/lib/src/events/types.ts
+++ b/packages/lib/src/events/types.ts
@@ -59,6 +59,8 @@ export type Events =
   | 'entity:created'
   | 'entity:updated'
   | 'entity:deleted'
+  | 'entity:field:updated'
+  | 'ticket:field:updated'
   | 'stock_movement:created'
   | 'stock_movement:deleted'
   | 'vendor_part:created'
@@ -445,20 +447,34 @@ export type ContactMergedEvent = AuxxEventGeneric<
     totalMerged: number
   }
 >
+/**
+ * Shared payload for `<prefix>:field:updated` events. Identical shape across
+ * contact, ticket, and custom-entity variants — only the event `type` differs.
+ * Consumers that need entity-specific rendering switch on the event type.
+ */
+export type FieldUpdatedData = {
+  recordId: RecordId
+  entityDefinitionId: string
+  entitySlug: string
+  organizationId: string
+  userId: string
+  fieldId: string
+  fieldName: string
+  fieldType: string
+  oldValue?: any
+  newValue: any
+}
+
 // Contact Field Updated Event
-export type ContactFieldUpdatedEvent = AuxxEventGeneric<
-  'contact:field:updated',
-  {
-    contactId: string
-    organizationId: string
-    userId: string
-    // Timeline metadata
-    fieldId: string
-    fieldName: string
-    fieldType: string
-    oldValue?: any
-    newValue: any
-  }
+export type ContactFieldUpdatedEvent = AuxxEventGeneric<'contact:field:updated', FieldUpdatedData>
+
+// Ticket Field Updated Event
+export type TicketFieldUpdatedEvent = AuxxEventGeneric<'ticket:field:updated', FieldUpdatedData>
+
+// Entity Instance Field Updated Event (custom entities + any built-in type without a dedicated prefix)
+export type EntityInstanceFieldUpdatedEvent = AuxxEventGeneric<
+  'entity:field:updated',
+  FieldUpdatedData
 >
 // Contact Group Added Event
 export type ContactGroupAddedEvent = AuxxEventGeneric<
@@ -826,6 +842,7 @@ export type AuxxEvent =
   | ContactFieldUpdatedEvent
   | ContactGroupAddedEvent
   | ContactGroupRemovedEvent
+  | TicketFieldUpdatedEvent
   | CommentCreatedEvent
   | CommentUpdatedEvent
   | CommentDeletedEvent
@@ -833,6 +850,7 @@ export type AuxxEvent =
   | EntityInstanceCreatedEvent
   | EntityInstanceUpdatedEvent
   | EntityInstanceDeletedEvent
+  | EntityInstanceFieldUpdatedEvent
   | StockMovementCreatedEvent
   | StockMovementDeletedEvent
   | VendorPartCreatedEvent
@@ -897,6 +915,7 @@ export interface IEventsHandlers {
   'contact:field:updated': EventHandler<ContactFieldUpdatedEvent>[]
   'contact:group:added': EventHandler<ContactGroupAddedEvent>[]
   'contact:group:removed': EventHandler<ContactGroupRemovedEvent>[]
+  'ticket:field:updated': EventHandler<TicketFieldUpdatedEvent>[]
   'comment:created': EventHandler<CommentCreatedEvent>[]
   'comment:updated': EventHandler<CommentUpdatedEvent>[]
   'comment:deleted': EventHandler<CommentDeletedEvent>[]
@@ -904,6 +923,7 @@ export interface IEventsHandlers {
   'entity:created': EventHandler<EntityInstanceCreatedEvent>[]
   'entity:updated': EventHandler<EntityInstanceUpdatedEvent>[]
   'entity:deleted': EventHandler<EntityInstanceDeletedEvent>[]
+  'entity:field:updated': EventHandler<EntityInstanceFieldUpdatedEvent>[]
   'stock_movement:created': EventHandler<StockMovementCreatedEvent>[]
   'stock_movement:deleted': EventHandler<StockMovementDeletedEvent>[]
   'vendor_part:created': EventHandler<VendorPartCreatedEvent>[]

--- a/packages/lib/src/field-hooks/index.ts
+++ b/packages/lib/src/field-hooks/index.ts
@@ -8,18 +8,23 @@ export { registerAllHooks } from './register-hooks'
 export {
   ENTITY_TRIGGERS,
   FIELD_TRIGGERS,
+  getEntityFieldChangeHooks,
   getEntityPreDeleteHooks,
   getEntityTriggers,
   getFieldPreHooks,
   getFieldTriggers,
+  hasEntityFieldChangeHooks,
   hasFieldPreHooks,
   hasFieldTriggers,
+  registerEntityFieldChangeHooks,
   registerEntityPreDeleteHooks,
   registerEntityTriggers,
   registerFieldPreHooks,
   registerFieldTriggers,
 } from './registry'
 export type {
+  EntityFieldChangeEvent,
+  EntityFieldChangeHandler,
   EntityPreDeleteEvent,
   EntityPreDeleteHandler,
   EntityTriggerEvent,

--- a/packages/lib/src/field-hooks/post/publish-field-change-event.ts
+++ b/packages/lib/src/field-hooks/post/publish-field-change-event.ts
@@ -1,0 +1,50 @@
+// packages/lib/src/field-hooks/post/publish-field-change-event.ts
+
+import { publisher } from '../../events'
+import type {
+  ContactFieldUpdatedEvent,
+  EntityInstanceFieldUpdatedEvent,
+  TicketFieldUpdatedEvent,
+} from '../../events/types'
+import type { EntityFieldChangeHandler } from '../types'
+
+/**
+ * Emit `<prefix>:field:updated` after every field write, mirroring the
+ * lifecycle prefix convention used elsewhere in the events module.
+ *
+ * - entityType === 'contact' → 'contact:field:updated'
+ * - entityType === 'ticket'  → 'ticket:field:updated'
+ * - any other / null         → 'entity:field:updated'
+ *
+ * The data payload is identical across all three variants — only `type`
+ * differs. Consumers that need entity-specific rendering (e.g. timeline)
+ * switch on the event type; the shape is uniform.
+ *
+ * Registered globally ('*') so it fires for every entity write.
+ */
+export const publishFieldChangeEvent: EntityFieldChangeHandler = async (event) => {
+  const data = {
+    recordId: event.recordId,
+    entityDefinitionId: event.entityDefinitionId,
+    entitySlug: event.entitySlug,
+    organizationId: event.organizationId,
+    userId: event.userId,
+    fieldId: event.field.id,
+    fieldName: event.field.name,
+    fieldType: event.field.type,
+    oldValue: event.oldValue,
+    newValue: event.newValue,
+  }
+
+  const type =
+    event.entityType === 'contact'
+      ? ('contact:field:updated' as const)
+      : event.entityType === 'ticket'
+        ? ('ticket:field:updated' as const)
+        : ('entity:field:updated' as const)
+
+  await publisher.publishLater({ type, data } as
+    | ContactFieldUpdatedEvent
+    | TicketFieldUpdatedEvent
+    | EntityInstanceFieldUpdatedEvent)
+}

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -4,6 +4,7 @@ import { recalculatePartCost, recalculatePartCostOnEntityChange } from './post/b
 import { explodeBomMovement } from './post/bom-movement-triggers'
 import { enrichCompanyOnCreate } from './post/company-triggers'
 import { recalculatePartQoH, recalculateStockStatus } from './post/inventory-triggers'
+import { publishFieldChangeEvent } from './post/publish-field-change-event'
 import { clearOtherPreferred } from './post/vendor-part-triggers'
 import {
   dropUnauthorizedSystemFlag,
@@ -11,6 +12,7 @@ import {
   rejectIfSystemTag,
 } from './pre/tag-system-guard'
 import {
+  registerEntityFieldChangeHooks,
   registerEntityPreDeleteHooks,
   registerEntityTriggers,
   registerFieldPreHooks,
@@ -48,6 +50,11 @@ export function registerAllHooks(): void {
 
   // Company enrichment — fetch website on company create to fill in name, notes, logo
   registerEntityTriggers('companies', [enrichCompanyOnCreate])
+
+  // Field-change post-hook — fires `<prefix>:field:updated` after every field
+  // write. Registered globally so contacts, tickets, companies, and custom
+  // entities all produce timeline entries.
+  registerEntityFieldChangeHooks('*', [publishFieldChangeEvent])
 
   // ---------------------------------------------------------------------------
   // PRE-WRITE HOOKS

--- a/packages/lib/src/field-hooks/registry.ts
+++ b/packages/lib/src/field-hooks/registry.ts
@@ -3,6 +3,7 @@
 import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { registerAllHooks } from './register-hooks'
 import type {
+  EntityFieldChangeHandler,
   EntityPreDeleteHandler,
   EntityTriggerHandler,
   FieldPreHookHandler,
@@ -38,6 +39,14 @@ const FIELD_PRE_HOOKS: Map<string, FieldPreHookHandler[]> = new Map()
 
 /** Pre-delete entity hooks keyed by entitySlug. */
 const ENTITY_PRE_DELETE_HOOKS: Map<string, EntityPreDeleteHandler[]> = new Map()
+
+/**
+ * Per-entity field-change post-hooks. Keyed by entitySlug, with the sentinel
+ * `'*'` reserved for handlers that fire on every field write regardless of
+ * entity. Entity-scoped handlers run before global handlers in the composed
+ * chain.
+ */
+const ENTITY_FIELD_CHANGE_HOOKS: Map<string, EntityFieldChangeHandler[]> = new Map()
 
 // =============================================================================
 // LAZY INIT
@@ -160,4 +169,47 @@ export function registerEntityPreDeleteHooks(
 export function getEntityPreDeleteHooks(entitySlug: string): EntityPreDeleteHandler[] {
   ensureInitialized()
   return ENTITY_PRE_DELETE_HOOKS.get(entitySlug) ?? []
+}
+
+// =============================================================================
+// POST-WRITE FIELD-CHANGE HOOK ACCESSORS
+// =============================================================================
+
+/**
+ * Register entity field-change handlers. Use the sentinel `'*'` for
+ * `entitySlug` to register a global handler that fires on every field write
+ * regardless of entity. Appends to any existing handlers.
+ */
+export function registerEntityFieldChangeHooks(
+  entitySlug: string | '*',
+  handlers: EntityFieldChangeHandler[]
+): void {
+  if (handlers.length === 0) return
+  const existing = ENTITY_FIELD_CHANGE_HOOKS.get(entitySlug) ?? []
+  ENTITY_FIELD_CHANGE_HOOKS.set(entitySlug, [...existing, ...handlers])
+}
+
+/**
+ * Get the composed field-change hook chain for a given entitySlug.
+ * Entity-scoped handlers run first, global (`'*'`) handlers run after.
+ */
+export function getEntityFieldChangeHooks(entitySlug: string): EntityFieldChangeHandler[] {
+  ensureInitialized()
+  const scoped = ENTITY_FIELD_CHANGE_HOOKS.get(entitySlug) ?? []
+  const global = ENTITY_FIELD_CHANGE_HOOKS.get('*') ?? []
+  if (scoped.length === 0) return global
+  if (global.length === 0) return scoped
+  return [...scoped, ...global]
+}
+
+/**
+ * Cheap probe used at the fire point to skip the oldValue pre-fetch when
+ * nobody is listening for this entity (and no global handler is registered).
+ */
+export function hasEntityFieldChangeHooks(entitySlug: string): boolean {
+  ensureInitialized()
+  return (
+    (ENTITY_FIELD_CHANGE_HOOKS.get(entitySlug)?.length ?? 0) > 0 ||
+    (ENTITY_FIELD_CHANGE_HOOKS.get('*')?.length ?? 0) > 0
+  )
 }

--- a/packages/lib/src/field-hooks/types.ts
+++ b/packages/lib/src/field-hooks/types.ts
@@ -111,3 +111,42 @@ export interface EntityPreDeleteEvent {
 }
 
 export type EntityPreDeleteHandler = (event: EntityPreDeleteEvent) => Promise<void>
+
+// =============================================================================
+// POST-WRITE FIELD-CHANGE HOOK TYPES
+// =============================================================================
+
+/**
+ * Event passed to a post-write field-change hook after a value lands.
+ *
+ * Fires from setValueWithBuiltIn once the write and its realtime publish
+ * are complete. Handler failures are logged and swallowed — they must not
+ * break the write.
+ */
+export interface EntityFieldChangeEvent {
+  recordId: RecordId
+  entityDefinitionId: string
+  /** entityType from EntityDefinition (e.g. 'contact', 'ticket'); null for custom entities. */
+  entityType: string | null
+  entitySlug: string
+  field: CachedField
+  /**
+   * Pre-write value on the record. `null` if the field had no value before
+   * this write. For array-return fields (FILE, TAGS, MULTI_SELECT,
+   * RELATIONSHIP, multi-ACTOR) this is the full array pre-write.
+   */
+  oldValue: unknown
+  /**
+   * Post-write value. For array-return fields, the full array that the
+   * write produced. `null` if the write deleted the only row.
+   */
+  newValue: unknown
+  organizationId: string
+  userId: string
+}
+
+/**
+ * Async handler invoked after a successful field write. Errors are logged
+ * and swallowed by the dispatcher — handlers must not break the write.
+ */
+export type EntityFieldChangeHandler = (event: EntityFieldChangeEvent) => Promise<void>

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -2,6 +2,7 @@
 
 import { schema } from '@auxx/database'
 import type { FieldType } from '@auxx/database/types'
+import { createScopedLogger } from '@auxx/logger'
 import {
   batchInsertFieldValues,
   deleteFieldValues,
@@ -29,14 +30,17 @@ import {
 } from '../custom-fields/built-in-fields'
 import { checkUniqueValueTyped } from '../custom-fields/check-unique-value-typed'
 import { BadRequestError } from '../errors'
-import { publisher } from '../events'
-import type { ContactFieldUpdatedEvent } from '../events/types'
 import {
   collectTriggeredFields,
   deduplicateBySystemAttribute,
 } from '../field-hooks/collect-triggers'
 import { publishBatchFieldTriggerEvents, publishFieldTriggerEvents } from '../field-hooks/publish'
-import { getFieldPreHooks, hasFieldPreHooks } from '../field-hooks/registry'
+import {
+  getEntityFieldChangeHooks,
+  getFieldPreHooks,
+  hasEntityFieldChangeHooks,
+  hasFieldPreHooks,
+} from '../field-hooks/registry'
 import type { FieldPreHookEvent } from '../field-hooks/types'
 import { getRealtimeService, publishFieldValueUpdates } from '../realtime'
 import { getModelType, isRecordId, parseRecordId, toRecordId } from '../resources/resource-id'
@@ -84,6 +88,8 @@ import type {
   SetValueWithTypeInput,
 } from './types'
 
+const logger = createScopedLogger('field-value-mutations')
+
 // =============================================================================
 // FIELD PRE-HOOKS
 // =============================================================================
@@ -121,6 +127,10 @@ async function fireFieldPreHooks(
     typedValue: TypedFieldValueInput | TypedFieldValueInput[] | null
     existingValue: unknown
     allValues: ReadonlyMap<string, unknown>
+    /** Pre-resolved entitySlug. When provided, skips the cache lookup. */
+    entitySlug?: string
+    /** Pre-resolved entityType. When provided, skips the cache lookup. */
+    entityType?: string | null
   }
 ): Promise<FieldPreHookOutcome> {
   if (ctx.skipPreHooks) return { kind: 'continue', value: args.typedValue }
@@ -135,8 +145,13 @@ async function fireFieldPreHooks(
   const entityDefinitionId = args.field.entityDefinition?.id ?? args.field.entityDefinitionId
   if (!entityDefinitionId) return { kind: 'continue', value: args.typedValue }
 
-  const resource = await getCachedResource(ctx.organizationId, entityDefinitionId)
-  const entitySlug = resource?.apiSlug
+  let entitySlug = args.entitySlug
+  let entityType = args.entityType
+  if (entitySlug === undefined || entityType === undefined) {
+    const resource = await getCachedResource(ctx.organizationId, entityDefinitionId)
+    entitySlug = resource?.apiSlug
+    entityType = resource?.entityType ?? null
+  }
   if (!entitySlug) return { kind: 'continue', value: args.typedValue }
 
   if (!hasFieldPreHooks(entitySlug, systemAttribute)) {
@@ -147,7 +162,7 @@ async function fireFieldPreHooks(
   const event: Omit<FieldPreHookEvent, 'newValue'> = {
     recordId: args.recordId,
     entityDefinitionId,
-    entityType: resource?.entityType ?? null,
+    entityType,
     entitySlug,
     fieldId: args.field.id,
     systemAttribute,
@@ -1606,6 +1621,12 @@ export async function setValueWithBuiltIn(
   // 2. Get field definition (cached)
   const field = await getField(ctx, fieldId)
 
+  // Resolve entity metadata once — shared by pre-hook, oldValue gate, and
+  // post-hook so we hit the resource cache a single time per write.
+  const resource = await getCachedResource(ctx.organizationId, entityDefinitionId)
+  const entitySlug = resource?.apiSlug ?? ''
+  const entityType = resource?.entityType ?? null
+
   // 3. Validate and convert raw value to typed input using FieldValueValidator
   const coercedValue = await validateAndConvertValue(ctx, value, field.type, field)
 
@@ -1618,11 +1639,48 @@ export async function setValueWithBuiltIn(
     typedValue: coercedValue,
     existingValue: undefined,
     allValues: new Map<string, unknown>([[fieldId, coercedValue]]),
+    entitySlug,
+    entityType,
   })
   if (hookOutcome.kind === 'drop') {
     return { state: 'complete', performedAt: new Date().toISOString(), values: [] }
   }
   const typedValue = hookOutcome.value
+
+  // 3.6. Capture oldValue BEFORE the null-delete branch — both set and clear
+  // paths need it to fire post-hooks identically. Gated on
+  // `hasEntityFieldChangeHooks` so entities without listeners pay nothing.
+  const willFirePostHook =
+    publishEvents && ctx.userId !== undefined && hasEntityFieldChangeHooks(entitySlug)
+  const oldValue: TypedFieldValue | TypedFieldValue[] | null = willFirePostHook
+    ? await getValue(ctx, { recordId, fieldId })
+    : null
+
+  // Closure so set + clear branches fire the post-hook chain identically.
+  const firePostHook = async (newValue: unknown): Promise<void> => {
+    if (!willFirePostHook) return
+    for (const handler of getEntityFieldChangeHooks(entitySlug)) {
+      try {
+        await handler({
+          recordId,
+          entityDefinitionId,
+          entityType,
+          entitySlug,
+          field,
+          oldValue,
+          newValue,
+          organizationId: ctx.organizationId,
+          userId: ctx.userId!,
+        })
+      } catch (error) {
+        logger.error(`Field-change handler failed for ${entitySlug}`, {
+          fieldId: field.id,
+          recordId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+  }
 
   // Handle null values (deletion)
   if (typedValue === null) {
@@ -1634,6 +1692,7 @@ export async function setValueWithBuiltIn(
         excludeSocketId: ctx.socketId,
       }).catch(() => {})
     }
+    await firePostHook(null)
     return { state: 'complete', performedAt: new Date().toISOString(), values: [] }
   }
 
@@ -1652,12 +1711,6 @@ export async function setValueWithBuiltIn(
     )
   }
 
-  // 5. Get old value for event (only if publishing for contacts)
-  let oldValue: TypedFieldValue | TypedFieldValue[] | null = null
-  if (publishEvents && modelType === 'contact') {
-    oldValue = await getValue(ctx, { recordId, fieldId })
-  }
-
   // 6. Set the value
   const result = await setValueWithType(ctx, {
     recordId,
@@ -1668,29 +1721,14 @@ export async function setValueWithBuiltIn(
     aiGeneration: params.aiGeneration,
   })
 
-  // 7. Publish event for contacts. For multi-value fields (MULTI_SELECT, TAGS,
-  // RELATIONSHIP, FILE, or scalar types with options.multi=true) publish the
-  // full result array so the timeline handler can render every value. Taking
-  // only result[0] here silently truncated multi-value writes.
-  if (publishEvents && modelType === 'contact' && ctx.userId) {
-    const eventFieldOptions = field.options as
-      | { actor?: { multiple?: boolean }; multi?: boolean }
-      | undefined
-    const isArrayReturn = isArrayReturnFieldType(field.type as FieldType, eventFieldOptions)
-    await publisher.publishLater({
-      type: 'contact:field:updated',
-      data: {
-        contactId: entityInstanceId,
-        organizationId: ctx.organizationId,
-        userId: ctx.userId,
-        fieldId: field.id,
-        fieldName: field.name,
-        fieldType: field.type,
-        oldValue,
-        newValue: isArrayReturn ? result : (result[0] ?? null),
-      },
-    } as ContactFieldUpdatedEvent)
-  }
+  // 7. Fire field-change post-hooks. For multi-value fields (MULTI_SELECT,
+  // TAGS, RELATIONSHIP, FILE, or scalar types with options.multi=true) we
+  // pass the full result array so handlers can render every value.
+  const eventFieldOptions = field.options as
+    | { actor?: { multiple?: boolean }; multi?: boolean }
+    | undefined
+  const isArrayReturn = isArrayReturnFieldType(field.type as FieldType, eventFieldOptions)
+  await firePostHook(isArrayReturn ? result : (result[0] ?? null))
 
   // 8. Check for field triggers (only when publishing events, to avoid double-fire from setBulkValues)
   if (publishEvents && ctx.userId) {
@@ -1712,11 +1750,7 @@ export async function setValueWithBuiltIn(
   // single value.
   if (publishEvents && result.length > 0) {
     const key = buildFieldValueKey(recordId, fieldId as FieldId)
-    const fieldType = field.type as FieldType
-    const fieldOptions = field.options as
-      | { actor?: { multiple?: boolean }; multi?: boolean }
-      | undefined
-    const storeValue = isArrayReturnFieldType(fieldType, fieldOptions) ? result : result[0]
+    const storeValue = isArrayReturn ? result : result[0]
     // When this write is an AI stage-2 commit, piggyback the `result`
     // marker onto the same realtime so clients see value + AI state in
     // one message. Manual writes carry aiStatus=null to clear any prior

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -17,6 +17,8 @@ import { migration011ExtensionExternalId } from './migrations/011-extension-exte
 import { migration012ContactEmailOptional } from './migrations/012-contact-email-optional'
 import { migration013ContactCompanyExternalIdFix } from './migrations/013-contact-company-external-id-fix'
 import { migration014BackfillSystemTags } from './migrations/014-backfill-system-tags'
+import { migration015BackfillFieldUpdatedEventData } from './migrations/015-backfill-field-updated-event-data'
+import { migration016StripLegacyContactIdFromFieldUpdated } from './migrations/016-strip-legacy-contact-id-from-field-updated'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -39,6 +41,8 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration012ContactEmailOptional,
   migration013ContactCompanyExternalIdFix,
   migration014BackfillSystemTags,
+  migration015BackfillFieldUpdatedEventData,
+  migration016StripLegacyContactIdFromFieldUpdated,
 ]
 
 // ─── Public API ──────────────────────────────────────────────────────

--- a/packages/lib/src/seed/entity-migrations/migrations/015-backfill-field-updated-event-data.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/015-backfill-field-updated-event-data.ts
@@ -1,0 +1,104 @@
+// packages/lib/src/seed/entity-migrations/migrations/015-backfill-field-updated-event-data.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { toRecordId } from '@auxx/types/resource'
+import { and, eq, sql } from 'drizzle-orm'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:015')
+
+/**
+ * Migration 015: Backfill `recordId` / `entityDefinitionId` / `entitySlug`
+ * onto legacy `contact:field:updated` timeline rows.
+ *
+ * Why: the contact-field-updated event payload was reshaped from
+ * `{ contactId, ... }` to a uniform `{ recordId, entityDefinitionId,
+ * entitySlug, ... }` shape (shared with the new `ticket:field:updated`
+ * and `entity:field:updated` events). Existing rows still carry the old
+ * `eventData` shape; this migration converges them on the new shape so a
+ * future read-side switch to canonical RecordIds works without a special
+ * case for legacy rows.
+ *
+ * Scope: only `contact:field:updated` rows exist today — the ticket and
+ * entity variants were never emitted before this change. The legacy
+ * `contactId` key is preserved during this migration; a follow-up
+ * migration can strip it after a soak window confirms no readers remain.
+ *
+ * Idempotent via `NOT (eventData ? 'recordId')` — re-runs skip rows that
+ * already carry the new fields.
+ */
+export const migration015BackfillFieldUpdatedEventData: EntityMigration = {
+  id: '015-backfill-field-updated-event-data',
+  description:
+    'Backfill recordId/entityDefinitionId/entitySlug on legacy contact:field:updated timeline rows',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state: EntityMigrationResult = {
+      entityDefsCreated: 0,
+      fieldsCreated: 0,
+      relationshipsLinked: 0,
+      alreadyUpToDate: true,
+    }
+
+    // 1. Resolve the contact EntityDefinition for this org.
+    const [contactDef] = await db
+      .select({ id: schema.EntityDefinition.id, apiSlug: schema.EntityDefinition.apiSlug })
+      .from(schema.EntityDefinition)
+      .where(
+        and(
+          eq(schema.EntityDefinition.organizationId, organizationId),
+          eq(schema.EntityDefinition.entityType, 'contact')
+        )
+      )
+      .limit(1)
+
+    if (!contactDef) return state
+
+    // 2. Find legacy rows: contact:field:updated where eventData.recordId is missing.
+    const legacyRows = await db
+      .select({
+        id: schema.TimelineEvent.id,
+        entityId: schema.TimelineEvent.entityId,
+        eventData: schema.TimelineEvent.eventData,
+      })
+      .from(schema.TimelineEvent)
+      .where(
+        and(
+          eq(schema.TimelineEvent.organizationId, organizationId),
+          eq(schema.TimelineEvent.eventType, 'contact:field:updated'),
+          sql`NOT (${schema.TimelineEvent.eventData} ? 'recordId')`
+        )
+      )
+
+    if (legacyRows.length === 0) return state
+
+    // 3. Backfill — chunk to bound the in-flight UPDATE count.
+    const CHUNK = 500
+    for (let i = 0; i < legacyRows.length; i += CHUNK) {
+      const batch = legacyRows.slice(i, i + CHUNK)
+      await Promise.all(
+        batch.map((row) => {
+          const recordId = toRecordId(contactDef.id, row.entityId)
+          const merged = {
+            ...((row.eventData as Record<string, unknown>) ?? {}),
+            recordId,
+            entityDefinitionId: contactDef.id,
+            entitySlug: contactDef.apiSlug,
+          }
+          return db
+            .update(schema.TimelineEvent)
+            .set({ eventData: merged, updatedAt: new Date() })
+            .where(eq(schema.TimelineEvent.id, row.id))
+        })
+      )
+    }
+
+    logger.info('Migration 015 applied', {
+      organizationId,
+      rowsBackfilled: legacyRows.length,
+    })
+
+    return { ...state, alreadyUpToDate: false }
+  },
+}

--- a/packages/lib/src/seed/entity-migrations/migrations/016-strip-legacy-contact-id-from-field-updated.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/016-strip-legacy-contact-id-from-field-updated.ts
@@ -1,0 +1,67 @@
+// packages/lib/src/seed/entity-migrations/migrations/016-strip-legacy-contact-id-from-field-updated.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, sql } from 'drizzle-orm'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:016')
+
+/**
+ * Migration 016: Strip the legacy `contactId` key from
+ * `contact:field:updated` timeline rows.
+ *
+ * Why: migration 015 added the new `recordId` / `entityDefinitionId` /
+ * `entitySlug` keys but left the old `contactId` key in place during the
+ * UI-audit soak. With the audit complete (no UI consumer reads
+ * `eventData.contactId`) this migration converges the row shape.
+ *
+ * Order matters: this MUST run after 015. The migration list in
+ * `entity-migrations/index.ts` enforces ordering. We additionally guard
+ * against running on a row that hasn't been backfilled yet by requiring
+ * `eventData.recordId` to exist.
+ *
+ * Idempotent via `eventData ? 'contactId'` — re-runs skip rows that no
+ * longer carry the legacy key.
+ */
+export const migration016StripLegacyContactIdFromFieldUpdated: EntityMigration = {
+  id: '016-strip-legacy-contact-id-from-field-updated',
+  description: 'Strip legacy contactId key from contact:field:updated timeline rows',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state: EntityMigrationResult = {
+      entityDefsCreated: 0,
+      fieldsCreated: 0,
+      relationshipsLinked: 0,
+      alreadyUpToDate: true,
+    }
+
+    // Single SQL UPDATE: remove the contactId key from eventData JSONB on
+    // every contact:field:updated row that still carries it AND has been
+    // backfilled by migration 015. Returns row count for logging.
+    const result = await db
+      .update(schema.TimelineEvent)
+      .set({
+        eventData: sql`${schema.TimelineEvent.eventData} - 'contactId'`,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(schema.TimelineEvent.organizationId, organizationId),
+          eq(schema.TimelineEvent.eventType, 'contact:field:updated'),
+          sql`${schema.TimelineEvent.eventData} ? 'contactId'`,
+          sql`${schema.TimelineEvent.eventData} ? 'recordId'`
+        )
+      )
+      .returning({ id: schema.TimelineEvent.id })
+
+    if (result.length === 0) return state
+
+    logger.info('Migration 016 applied', {
+      organizationId,
+      rowsStripped: result.length,
+    })
+
+    return { ...state, alreadyUpToDate: false }
+  },
+}

--- a/packages/lib/src/timeline/timeline-service.ts
+++ b/packages/lib/src/timeline/timeline-service.ts
@@ -33,6 +33,8 @@ const GROUPING_CONFIG = {
     'contact:tag:added',
     'contact:tag:removed',
     'contact:group:added',
+    // Ticket events
+    'ticket:field:updated',
     // Custom entity events
     'entity:field:updated',
   ] as TimelineEventType[],


### PR DESCRIPTION
## Summary

- Adds a global `EntityFieldChangeHandler` registry (sentinel `'*'` for global handlers, plus per-entity scoping) that fires after every field write, replacing the contact-only inline `publisher.publishLater` in `setValueWithBuiltIn`. The new `publishFieldChangeEvent` post-hook routes to `contact:field:updated`, `ticket:field:updated`, or `entity:field:updated` based on `entityType`, all sharing one uniform `FieldUpdatedData` payload.
- Extends timeline rendering (`event-description`, `event-icon`, `group-description`) to handle the ticket and entity variants identically to contacts, and enables grouping for `ticket:field:updated` / `entity:field:updated` in `timeline-service`.
- Adds two entity migrations: 015 backfills `recordId` / `entityDefinitionId` / `entitySlug` onto legacy `contact:field:updated` rows, 016 strips the now-unused `contactId` key after the soak.

The `mapFieldUpdated` helper in `create-timeline-event` keeps `recordId` column writes legacy-prefixed for contact/ticket (so existing detail-page reads via `toRecordId('contact'|'ticket', id)` continue to match) while preserving the canonical `RecordId` on `eventData.recordId` for a future converged read path.

## Test plan

- [ ] Edit a contact custom field → `contact:field:updated` event fires and renders on contact timeline
- [ ] Edit a ticket custom field → `ticket:field:updated` event fires and renders on ticket timeline
- [ ] Edit a custom-entity instance field → `entity:field:updated` event fires and renders on entity timeline
- [ ] Edit multiple fields in quick succession → grouped "updated multiple fields" rendering for all three entity types
- [ ] Run migrations 015 and 016 against an org with legacy `contact:field:updated` rows; verify rows now carry `recordId` / `entityDefinitionId` / `entitySlug` and no longer carry `contactId`
- [ ] Set a field value to null (clear) → post-hook still fires with `newValue: null`
- [ ] Multi-value field write (TAGS, MULTI_SELECT, RELATIONSHIP, FILE) → `newValue` carries the full result array, not just the first element