### PR TITLE
fix(posthog): strip Cloudflare proxy headers before forwarding

### DIFF
--- a/apps/web/src/app/ph/[[...path]]/route.ts
+++ b/apps/web/src/app/ph/[[...path]]/route.ts
@@ -5,6 +5,25 @@ import type { NextRequest } from 'next/server'
 const POSTHOG_INGEST = 'https://us.i.posthog.com'
 const POSTHOG_ASSETS = 'https://us-assets.i.posthog.com'
 
+// Cloudflare and proxy-injected headers must be stripped before forwarding to
+// PostHog (also behind Cloudflare). Forwarding cf-connecting-ip from one CF zone
+// to another trips Error 1000 ("DNS points to prohibited IP") on us-assets.
+const STRIPPED_HEADERS = new Set([
+  'host',
+  'connection',
+  'cf-connecting-ip',
+  'cf-ray',
+  'cf-visitor',
+  'cf-ipcountry',
+  'cf-worker',
+  'cdn-loop',
+  'x-forwarded-for',
+  'x-forwarded-proto',
+  'x-forwarded-host',
+  'x-real-ip',
+  'forwarded',
+])
+
 async function handler(request: NextRequest) {
   const path = request.nextUrl.pathname.replace(/^\/ph/, '')
   const search = request.nextUrl.search
@@ -13,9 +32,11 @@ async function handler(request: NextRequest) {
   const origin = isAsset ? POSTHOG_ASSETS : POSTHOG_INGEST
   const destinationUrl = `${origin}${path}${search}`
 
-  const headers = new Headers(request.headers)
+  const headers = new Headers()
+  for (const [key, value] of request.headers) {
+    if (!STRIPPED_HEADERS.has(key.toLowerCase())) headers.set(key, value)
+  }
   headers.set('host', new URL(origin).host)
-  headers.delete('connection')
 
   const body = ['GET', 'HEAD'].includes(request.method) ? undefined : await request.blob()
 


### PR DESCRIPTION
## Summary

Forwarding `cf-connecting-ip` from our Cloudflare zone to PostHog (also behind Cloudflare) trips **Error 1000 — \"DNS points to prohibited IP\"** on `us-assets.i.posthog.com`. The previous code copied every incoming header and only deleted `connection`, so all the CF-injected headers leaked through.

This switches to an explicit strip-list approach: build the outgoing header set from scratch and skip any header in the list. Drops `cf-connecting-ip`, `cf-ray`, `cf-visitor`, `cf-ipcountry`, `cf-worker`, `cdn-loop`, `x-forwarded-for`, `x-forwarded-proto`, `x-forwarded-host`, `x-real-ip`, `forwarded`, plus the existing `host` and `connection` it already handled.

## Test plan

- [ ] Hit `/ph/<path>` from the browser and confirm requests reach PostHog (no CF Error 1000 in the response)
- [ ] Verify PostHog still attributes events correctly without the proxy headers (PostHog uses request-body fields for IP/UA, not these headers)
- [ ] Inspect a forwarded request via PostHog's debugger or local tcpdump to confirm none of the stripped headers appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)