### PR TITLE
feat(sidebar): unify Mail group with animated collapse sections

### DIFF
--- a/apps/web/src/components/global/sidebar/collapsible-sidebar-section.tsx
+++ b/apps/web/src/components/global/sidebar/collapsible-sidebar-section.tsx
@@ -1,19 +1,27 @@
 // components/global/sidebar/collapsible-sidebar-section.tsx
 'use client'
 
+import { Button } from '@auxx/ui/components/button'
+import { Checkbox } from '@auxx/ui/components/checkbox'
+import { CollapsibleChevron } from '@auxx/ui/components/collapsible'
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@auxx/ui/components/collapsible'
-import { SidebarMenuButton, SidebarMenuItem, SidebarMenuSub } from '@auxx/ui/components/sidebar'
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import {
+  SidebarGroupCollapse,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+} from '@auxx/ui/components/sidebar'
 import { cn } from '@auxx/ui/lib/utils'
-import { ChevronRight } from 'lucide-react'
+import { MoreVertical } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { type MouseEvent, memo, type ReactNode, useCallback, useEffect, useState } from 'react'
 import { useSidebarState } from '~/hooks/use-sidebar-state'
 
-// CollapsibleSidebarSectionProps describes the inputs accepted by the collapsible sidebar section component.
 interface CollapsibleSidebarSectionProps {
   title: string
   icon?: ReactNode
@@ -22,15 +30,21 @@ interface CollapsibleSidebarSectionProps {
   isEditMode: boolean
   defaultOpen?: boolean
   count?: number
+  /** @deprecated Children are now always mounted via the animated wrapper. Kept for backward compatibility. */
   alwaysShowChildren?: boolean
   href?: string
   isActive: boolean
   preventNavigation?: boolean
   /** Optional unique identifier for localStorage persistence of open/closed state */
   sectionId?: string
+  /** Dropdown content rendered inside a hover-revealed More button (e.g. "Create view"). */
+  actions?: ReactNode
+  /** Whole-section visibility, edit-mode only. Defaults to true. */
+  isVisible?: boolean
+  /** Called when the edit-mode visibility checkbox is toggled. */
+  onToggleVisibility?: () => void
 }
 
-// CollapsibleSidebarSectionComponent renders a collapsible sidebar group with optional navigation behavior and edit mode support.
 function CollapsibleSidebarSectionComponent({
   title,
   icon,
@@ -39,53 +53,46 @@ function CollapsibleSidebarSectionComponent({
   isEditMode,
   defaultOpen = false,
   count,
-  alwaysShowChildren = false,
   href,
   isActive,
   preventNavigation = false,
   sectionId,
+  actions,
+  isVisible = true,
+  onToggleVisibility,
 }: CollapsibleSidebarSectionProps) {
   const router = useRouter()
 
-  // If sectionId is provided, use localStorage-backed state via the hook
   const sidebarState = useSidebarState()
 
-  // Get persisted open state if sectionId is provided
   const persistedOpen = sectionId ? sidebarState.getSectionOpen(sectionId, defaultOpen) : null
 
-  // Local state fallback for components that don't use persistence
   const [localOpen, setLocalOpen] = useState(defaultOpen)
 
-  // Use persisted state if available, otherwise use local state
   const isOpen = persistedOpen ?? localOpen
 
-  // Always open when in edit mode without triggering redundant renders.
+  const [actionsOpen, setActionsOpen] = useState(false)
+
   useEffect(() => {
     if (isEditMode && !sectionId) {
       setLocalOpen(true)
     }
   }, [isEditMode, sectionId])
 
-  // Keep local state aligned with defaultOpen when the prop changes outside edit mode.
   useEffect(() => {
     if (!isEditMode && !sectionId) {
       setLocalOpen((previous) => (previous === defaultOpen ? previous : defaultOpen))
     }
   }, [defaultOpen, isEditMode, sectionId])
 
-  // handleOpenChange stabilizes external open state updates emitted by Radix Collapsible.
-  const handleOpenChange = useCallback(
-    (nextState: boolean) => {
-      if (sectionId) {
-        sidebarState.setSectionOpen(sectionId, nextState)
-      } else {
-        setLocalOpen((previous) => (previous === nextState ? previous : nextState))
-      }
-    },
-    [sectionId, sidebarState]
-  )
+  const toggleOpen = useCallback(() => {
+    if (sectionId) {
+      sidebarState.toggleSection(sectionId)
+    } else {
+      setLocalOpen((previous) => !previous)
+    }
+  }, [sectionId, sidebarState])
 
-  // handleContainerClick manages toggling open state or routing depending on navigation settings.
   const handleContainerClick = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
       let element = event.target as HTMLElement | null
@@ -95,11 +102,7 @@ function CollapsibleSidebarSectionComponent({
       }
 
       if (preventNavigation) {
-        if (sectionId) {
-          sidebarState.toggleSection(sectionId)
-        } else {
-          setLocalOpen((previous) => !previous)
-        }
+        toggleOpen()
         return
       }
 
@@ -107,59 +110,117 @@ function CollapsibleSidebarSectionComponent({
         router.push(href)
       }
     },
-    [href, preventNavigation, router, sectionId, sidebarState]
+    [href, preventNavigation, router, toggleOpen]
   )
 
   const computedOpen = isEditMode ? true : isOpen
-  const shouldRenderChildren = computedOpen || alwaysShowChildren
+
+  // Hide the entire section when whole-section visibility is off and we're not editing.
+  if (!isVisible && !isEditMode) {
+    return null
+  }
+
+  const showVisibilityCheckbox = isEditMode && !!onToggleVisibility
+  const showActionsButton = !!actions && !isEditMode
 
   return (
-    <Collapsible open={computedOpen} onOpenChange={isEditMode ? undefined : handleOpenChange}>
-      <SidebarMenuItem>
-        <SidebarMenuButton asChild className='h-7 py-0' tooltip={title}>
-          <div
-            onClick={handleContainerClick}
-            className={cn('cursor-pointer group/collapsible relative', {
-              'font-bold': isActive,
-              // 'bg-foreground/10': isActive,
-            })}>
-            <CollapsibleTrigger
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild className='h-7 py-0 pe-[3px]' tooltip={title}>
+        <div
+          onClick={handleContainerClick}
+          className={cn('group/collapsible relative cursor-pointer', {
+            'font-bold': isActive,
+            'opacity-50': isEditMode && !isVisible,
+          })}>
+          {showVisibilityCheckbox && (
+            <span
               data-selectable={false}
               onClick={(e) => {
                 e.stopPropagation()
-              }}>
-              <ChevronRight
-                className={cn(
-                  'size-4 transition-transform duration-200 group-data-[collapsible=icon]:hidden',
-                  isOpen && 'rotate-90'
-                )}
+                e.preventDefault()
+              }}
+              className='flex items-center'>
+              <Checkbox
+                checked={isVisible}
+                className='border-blue-500 data-[state=checked]:border-info data-[state=checked]:bg-info'
+                onCheckedChange={onToggleVisibility}
               />
-            </CollapsibleTrigger>
+            </span>
+          )}
 
-            {avatar ? avatar : icon ? <span className='[&_svg]:size-4'>{icon}</span> : null}
-            <span className='group-data-[collapsible=icon]:hidden'>{title}</span>
-            {count ? (
-              <div className='pointer-events-none absolute right-[11px] top-1/2 flex -translate-y-1/2 text-right text-xs group-hover/item:opacity-0'>
+          {avatar ? avatar : icon ? <span className='[&_svg]:size-4'>{icon}</span> : null}
+          <span className='group-data-[collapsible=icon]:hidden'>{title}</span>
+
+          {!isEditMode && (
+            <button
+              type='button'
+              data-selectable={false}
+              onClick={(e) => {
+                e.stopPropagation()
+                toggleOpen()
+              }}
+              className='inline-flex items-center text-muted-foreground group-data-[collapsible=icon]:hidden'>
+              <CollapsibleChevron open={isOpen} />
+            </button>
+          )}
+
+          <div className='ml-auto flex items-center group-data-[collapsible=icon]:hidden'>
+            {typeof count === 'number' && count > 0 && (
+              <span
+                className={cn(
+                  'pointer-events-none text-xs text-muted-foreground',
+                  showActionsButton &&
+                    'transition-opacity sm:group-hover/collapsible:opacity-0 sm:absolute sm:right-[11px] sm:top-1/2 sm:-translate-y-1/2'
+                )}>
                 {count}
-              </div>
-            ) : // <Badge className="ml-auto group-data-[collapsible=icon]:hidden" variant="secondary">
-            //   {count}
-            // </Badge>
-            null}
-          </div>
-        </SidebarMenuButton>
+              </span>
+            )}
 
-        {shouldRenderChildren && (
-          <CollapsibleContent>
-            <SidebarMenuSub className={cn('me-0 pe-0', { 'mx-0 border-l-0 px-0': isEditMode })}>
-              {children}
-            </SidebarMenuSub>
-          </CollapsibleContent>
-        )}
-      </SidebarMenuItem>
-    </Collapsible>
+            {showActionsButton && (
+              <div
+                data-selectable={false}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  e.preventDefault()
+                }}>
+                <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant='ghost'
+                      size='icon'
+                      className={cn(
+                        'size-6 rounded-md opacity-100 sm:opacity-0 hover:bg-primary/10 hover:text-foreground/50 focus-visible:ring-primary/10 hover:bg-primary-200/50',
+                        {
+                          'bg-primary-200 opacity-100': actionsOpen,
+                          'sm:group-hover/collapsible:opacity-100': !actionsOpen,
+                        }
+                      )}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        e.preventDefault()
+                        setActionsOpen(!actionsOpen)
+                      }}>
+                      <MoreVertical className='size-3.5' />
+                      <span className='sr-only'>Options</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent className='w-50' align='start'>
+                    <DropdownMenuGroup>{actions}</DropdownMenuGroup>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            )}
+          </div>
+        </div>
+      </SidebarMenuButton>
+
+      <SidebarGroupCollapse open={computedOpen}>
+        <SidebarMenuSub className={cn('me-0 pe-0', { 'mx-0 border-l-0 px-0': isEditMode })}>
+          {children}
+        </SidebarMenuSub>
+      </SidebarGroupCollapse>
+    </SidebarMenuItem>
   )
 }
 
-// CollapsibleSidebarSection memoizes the sidebar section to avoid unnecessary rerenders driven by parent state changes.
 export const CollapsibleSidebarSection = memo(CollapsibleSidebarSectionComponent)

--- a/apps/web/src/components/global/sidebar/entity-sidebar-nav.tsx
+++ b/apps/web/src/components/global/sidebar/entity-sidebar-nav.tsx
@@ -9,6 +9,7 @@ import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dro
 import { EntityIcon } from '@auxx/ui/components/icons'
 import {
   SidebarGroup,
+  SidebarGroupCollapse,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -346,7 +347,7 @@ export function EntitySidebarNav() {
         />
 
         {/* Empty state when all items hidden (but group is visible) */}
-        {allItemsHidden && !isEditMode && isOpen && isGroupVisible && (
+        <SidebarGroupCollapse open={allItemsHidden && !isEditMode && isOpen && isGroupVisible}>
           <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton onClick={toggleEditMode}>
@@ -355,15 +356,17 @@ export function EntitySidebarNav() {
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>
-        )}
+        </SidebarGroupCollapse>
 
         {/* Entity list - only show when group is visible or in edit mode */}
-        {(isEditMode || (isOpen && isGroupVisible)) && !allItemsHidden && (
+        <SidebarGroupCollapse open={(isEditMode || (isOpen && isGroupVisible)) && !allItemsHidden}>
           <SidebarMenu>{isEditMode ? renderEditModeList() : renderNormalModeList()}</SidebarMenu>
-        )}
+        </SidebarGroupCollapse>
 
         {/* Edit mode list when all items are hidden */}
-        {isEditMode && allItemsHidden && <SidebarMenu>{renderEditModeList()}</SidebarMenu>}
+        <SidebarGroupCollapse open={isEditMode && allItemsHidden}>
+          <SidebarMenu>{renderEditModeList()}</SidebarMenu>
+        </SidebarGroupCollapse>
       </SidebarGroup>
 
       {/* Done button footer for edit mode */}

--- a/apps/web/src/components/global/sidebar/mail-sidebar.tsx
+++ b/apps/web/src/components/global/sidebar/mail-sidebar.tsx
@@ -1,22 +1,16 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
-import { Separator } from '@auxx/ui/components/separator'
-import {
-  SidebarGroup,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-} from '@auxx/ui/components/sidebar'
-import { Settings2 } from 'lucide-react'
-import { useCallback, useEffect, useMemo } from 'react'
-import { PersonalMailGroup } from '~/components/global/sidebar/personal-mail-group'
-import { SharedInboxesGroup } from '~/components/global/sidebar/shared-inbox-group'
+import { SidebarGroup, SidebarGroupCollapse, SidebarMenu } from '@auxx/ui/components/sidebar'
+import { useCallback, useEffect } from 'react'
+import { PersonalMailItems } from '~/components/global/sidebar/personal-mail-group'
+import { SharedInboxesSection } from '~/components/global/sidebar/shared-inbox-group'
 import { useMailSidebar } from '~/hooks/use-mail-sidebar'
-import { ViewsGroup } from './views-group'
+import { SidebarGroupHeader } from './sidebar-group-header'
+import { useSidebarStateContext } from './sidebar-state-context'
+import { ViewsSection } from './views-group'
 
 export function MailSidebar() {
-  // Use the hook to get all state and functions
   const {
     isEditMode,
     inboxes,
@@ -35,17 +29,13 @@ export function MailSidebar() {
     toggleGroupVisibility,
   } = useMailSidebar()
 
-  // Check if all groups are hidden
-  const allGroupsHidden = useMemo(
-    () => !groupVisibility.personal && !groupVisibility.views && !groupVisibility.shared,
-    [groupVisibility]
-  )
+  const { getGroupOpen, toggleGroup } = useSidebarStateContext()
+  const isMailOpen = getGroupOpen('mail')
 
-  // Create stable toggle handlers for each group
-  const togglePersonalVisibility = useCallback(
-    () => toggleGroupVisibility('personal'),
-    [toggleGroupVisibility]
-  )
+  const handleToggleMailOpen = useCallback(() => {
+    toggleGroup('mail')
+  }, [toggleGroup])
+
   const toggleViewsVisibility = useCallback(
     () => toggleGroupVisibility('views'),
     [toggleGroupVisibility]
@@ -62,68 +52,51 @@ export function MailSidebar() {
         toggleEditMode()
       }
     }
-    // Adding toggleEditMode to the dependency array is safe because it's memoized
   }, [isEditMode, toggleEditMode])
 
   return (
-    <div className='flex flex-col'>
-      <div className=''>
-        {/* Empty state when all groups are hidden */}
-        {allGroupsHidden && !isEditMode && (
-          <SidebarGroup className='group'>
-            <SidebarMenu className='gap-0'>
-              <SidebarMenuItem>
-                <SidebarMenuButton asChild className='h-7 py-0 pe-[3px]' tooltip='Edit Sidebar'>
-                  <button
-                    onClick={toggleEditMode}
-                    className='group/item flex h-7 w-full items-center'>
-                    <span className='[&_svg]:size-4 mr-2'>
-                      <Settings2 />
-                    </span>
-                    <span className='group-data-[collapsible=icon]:hidden'>Edit Sidebar</span>
-                  </button>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroup>
-        )}
-
-        {/* Personal Mail Group */}
-        <PersonalMailGroup
+    <>
+      <SidebarGroup className='group'>
+        <SidebarGroupHeader
+          title='Mail'
           isEditMode={isEditMode}
           onToggleEditMode={toggleEditMode}
-          settings={personalItems}
-          onUpdateSettings={updatePersonalItems}
-          settingsLoading={settingsLoading}
-          isGroupVisible={groupVisibility.personal}
-          onToggleGroupVisibility={togglePersonalVisibility}
+          isOpen={isMailOpen}
+          toggleOpen={handleToggleMailOpen}
         />
+        <SidebarGroupCollapse open={isEditMode || isMailOpen}>
+          <SidebarMenu className='gap-0'>
+            <PersonalMailItems
+              isEditMode={isEditMode}
+              onToggleEditMode={toggleEditMode}
+              settings={personalItems}
+              onUpdateSettings={updatePersonalItems}
+              settingsLoading={settingsLoading}
+            />
+            <ViewsSection
+              views={mailViews}
+              isLoading={mailViewsLoading}
+              isEditMode={isEditMode}
+              onToggleEditMode={toggleEditMode}
+              onUpdateViewsVisibility={updateViewsVisibility}
+              onReorderViews={updateViewsOrder}
+              isSectionVisible={groupVisibility.views}
+              onToggleSectionVisibility={toggleViewsVisibility}
+            />
+            <SharedInboxesSection
+              inboxes={inboxes}
+              isLoading={inboxesLoading}
+              isEditMode={isEditMode}
+              onToggleEditMode={toggleEditMode}
+              onUpdateInboxVisibility={updateInboxVisibility}
+              onReorderInboxes={updateInboxOrder}
+              isSectionVisible={groupVisibility.shared}
+              onToggleSectionVisibility={toggleSharedVisibility}
+            />
+          </SidebarMenu>
+        </SidebarGroupCollapse>
+      </SidebarGroup>
 
-        <ViewsGroup
-          views={mailViews}
-          isLoading={mailViewsLoading}
-          isEditMode={isEditMode}
-          onToggleEditMode={toggleEditMode}
-          onUpdateViewsVisibility={updateViewsVisibility}
-          onReorderViews={updateViewsOrder}
-          isGroupVisible={groupVisibility.views}
-          onToggleGroupVisibility={toggleViewsVisibility}
-        />
-
-        {/* Shared Inboxes Group */}
-        <SharedInboxesGroup
-          inboxes={inboxes}
-          isLoading={inboxesLoading}
-          isEditMode={isEditMode}
-          onToggleEditMode={toggleEditMode}
-          onUpdateInboxVisibility={updateInboxVisibility}
-          onReorderInboxes={updateInboxOrder}
-          isGroupVisible={groupVisibility.shared}
-          onToggleGroupVisibility={toggleSharedVisibility}
-        />
-      </div>
-
-      {/* Footer section for Done button */}
       {isEditMode && (
         <div className='flex shrink-0 items-center justify-end gap-2 border-t p-2'>
           <Button className='w-full rounded-md' size='sm' onClick={toggleEditMode}>
@@ -131,7 +104,6 @@ export function MailSidebar() {
           </Button>
         </div>
       )}
-      <Separator className='mt-1 mb-2' />
-    </div>
+    </>
   )
 }

--- a/apps/web/src/components/global/sidebar/nav-main.tsx
+++ b/apps/web/src/components/global/sidebar/nav-main.tsx
@@ -3,6 +3,7 @@
 
 import {
   SidebarGroup,
+  SidebarGroupCollapse,
   SidebarMenu,
   SidebarMenuItem,
   SidebarMenuSubItem,
@@ -97,7 +98,7 @@ export function NavMain({ menu, itemActions }: Props) {
         toggleOpen={handleToggleOpen}
         hideEditOption
       />
-      {isOpen && (
+      <SidebarGroupCollapse open={isOpen}>
         <SidebarMenu>
           {menu.items.map((item) => (
             <div key={item.id}>
@@ -133,7 +134,6 @@ export function NavMain({ menu, itemActions }: Props) {
                     href={item.url!}
                     icon={item.icon}
                     isActive={isActive(item)}
-                    className='ps-[30px]'
                     editItems={itemActions?.[item.id]?.()}
                   />
                 </SidebarMenuItem>
@@ -141,7 +141,7 @@ export function NavMain({ menu, itemActions }: Props) {
             </div>
           ))}
         </SidebarMenu>
-      )}
+      </SidebarGroupCollapse>
     </SidebarGroup>
   )
 }

--- a/apps/web/src/components/global/sidebar/personal-mail-group.tsx
+++ b/apps/web/src/components/global/sidebar/personal-mail-group.tsx
@@ -1,9 +1,8 @@
 // ~/components/global/sidebar/personal-mail-group.tsx
 'use client'
 
-import { SidebarGroup, SidebarMenu, SidebarMenuItem } from '@auxx/ui/components/sidebar'
+import { SidebarMenuItem } from '@auxx/ui/components/sidebar'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-// Import necessary DnD Kit components
 import {
   closestCenter,
   DndContext,
@@ -24,10 +23,8 @@ import { FileEdit, Inbox as InboxIcon, Send } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 import { EditableSidebarItem } from '~/components/global/sidebar/editable-sidebar-item'
-import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
 import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
 import { useMailCountsStore } from '~/components/mail/store'
-import { useSidebarStateContext } from './sidebar-state-context'
 
 export interface PersonalMenuItem {
   id: string
@@ -38,17 +35,14 @@ export interface PersonalMenuItem {
   count?: number
 }
 
-interface PersonalMailGroupProps {
+interface PersonalMailItemsProps {
   isEditMode: boolean
   onToggleEditMode: () => void
   settings?: PersonalMenuItem[]
   onUpdateSettings: (items: PersonalMenuItem[]) => void
   settingsLoading: boolean
-  isGroupVisible: boolean
-  onToggleGroupVisibility: () => void
 }
 
-// Default items if none exist in settings
 const DEFAULT_PERSONAL_ITEMS: PersonalMenuItem[] = [
   {
     id: 'inbox',
@@ -76,52 +70,39 @@ const DEFAULT_PERSONAL_ITEMS: PersonalMenuItem[] = [
   },
 ]
 
-export function PersonalMailGroup({
+export function PersonalMailItems({
   isEditMode,
   onToggleEditMode,
   settings,
   onUpdateSettings,
   settingsLoading,
-  isGroupVisible,
-  onToggleGroupVisibility,
-}: PersonalMailGroupProps) {
+}: PersonalMailItemsProps) {
   const pathname = usePathname()
-  const { getGroupOpen, toggleGroup } = useSidebarStateContext()
-  const isOpen = getGroupOpen('personal')
-
-  // Use settings if available, otherwise use defaults
   const [items, setItems] = useState<PersonalMenuItem[]>(DEFAULT_PERSONAL_ITEMS)
 
-  // Use the mail counts store for counts
   const inboxCount = useMailCountsStore((s) => s.counts.inbox)
   const draftsCount = useMailCountsStore((s) => s.counts.drafts)
   const isInitialLoading = useMailCountsStore((s) => s.isInitialLoading)
 
-  // Setup DnD sensors
   const sensors = useSensors(
     useSensor(PointerSensor, {
-      // Require a small movement to start dragging (prevents accidental drags)
       activationConstraint: { distance: 5 },
     }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 
-  // Update items when settings or counts change
   useEffect(() => {
     if (settings) {
-      // Merge default items with settings and apply correct counts from store
       const mergedItems = DEFAULT_PERSONAL_ITEMS.map((defaultItem) => {
         const settingItem = settings.find((s) => s.id === defaultItem.id)
         const baseItem = settingItem ? { ...defaultItem, ...settingItem } : defaultItem
 
-        // Apply correct counts from store
         let count: number | undefined
         if (defaultItem.id === 'inbox') {
           count = inboxCount
         } else if (defaultItem.id === 'drafts') {
           count = draftsCount > 0 ? draftsCount : undefined
         }
-        // sent has no count
 
         return { ...baseItem, count }
       })
@@ -131,19 +112,15 @@ export function PersonalMailGroup({
   }, [settings, inboxCount, draftsCount])
 
   const getItemHref = (item: PersonalMenuItem): string => {
-    // Drafts and Sent go directly to their base path
     if (item.id === 'drafts' || item.id === 'sent') {
       return `/app/mail/${item.id}`
     }
-    // Inbox goes to its base path + '/open' by default
     if (item.id === 'inbox') {
       return `/app/mail/${item.id}/open`
     }
-    // Fallback
     return '/app/mail'
   }
 
-  // Toggle visibility of an item
   const toggleItemVisibility = (itemId: string) => {
     if (isEditMode) {
       const updatedItems = items.map((item) =>
@@ -151,7 +128,6 @@ export function PersonalMailGroup({
       )
 
       setItems(updatedItems)
-      // Save to settings
       const itemsToSave = updatedItems.map((item) => {
         const { icon, ...itemWithoutIcon } = item
         return itemWithoutIcon
@@ -160,7 +136,6 @@ export function PersonalMailGroup({
     }
   }
 
-  // Handle drag end event
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event
@@ -170,19 +145,14 @@ export function PersonalMailGroup({
         const newIndex = items.findIndex((item) => item.id === over.id)
 
         if (oldIndex !== -1 && newIndex !== -1) {
-          // Create a new array with the moved item
           const newOrderedItems = arrayMove(items, oldIndex, newIndex)
-
-          // Update order values based on new positions
           const updatedItems = newOrderedItems.map((item, index) => ({
             ...item,
             order: index,
           }))
 
-          // Update local state
           setItems(updatedItems)
 
-          // Save the updated settings
           const itemsToSave = updatedItems.map((item) => {
             const { icon, ...itemWithoutIcon } = item
             return itemWithoutIcon
@@ -194,111 +164,77 @@ export function PersonalMailGroup({
     [items, onUpdateSettings]
   )
 
-  // Filter visible items (in normal mode)
   const visibleItems = isEditMode ? items : items.filter((item) => item.visible)
-
-  // Get IDs for the sortable context
   const itemIds = items.map((item) => item.id)
-
-  function handleToggleOpen() {
-    toggleGroup('personal')
-  }
-
-  // Don't render the group if it's hidden (unless in edit mode)
-  if (!isGroupVisible && !isEditMode) {
-    return null
-  }
 
   if (settingsLoading || isInitialLoading) {
     return (
-      <SidebarGroup className='group'>
-        <SidebarGroupHeader
-          title='Me'
-          isEditMode={isEditMode}
-          onToggleEditMode={onToggleEditMode}
-          toggleOpen={handleToggleOpen}
-          isOpen={isOpen}
-          isGroupVisible={isGroupVisible}
-          onToggleGroupVisibility={onToggleGroupVisibility}
-        />
-        <SidebarMenu className='gap-0'>
-          {Array(3)
-            .fill(0)
-            .map((_, i) => (
-              <SidebarMenuItem key={i}>
-                <div className='flex items-center space-x-2 px-2 py-1.5'>
-                  <Skeleton className='h-4 w-4 rounded-full' />
-                  <Skeleton className='h-4 w-24' />
-                </div>
+      <>
+        {Array(3)
+          .fill(0)
+          .map((_, i) => (
+            <SidebarMenuItem key={i}>
+              <div className='flex items-center space-x-2 px-2 py-1.5'>
+                <Skeleton className='h-4 w-4 rounded-full' />
+                <Skeleton className='h-4 w-24' />
+              </div>
+            </SidebarMenuItem>
+          ))}
+      </>
+    )
+  }
+
+  if (isEditMode) {
+    return (
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+        modifiers={[restrictToVerticalAxis]}>
+        <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+          {items
+            .sort((a, b) => a.order - b.order)
+            .map((item) => (
+              <SidebarMenuItem key={item.id}>
+                <EditableSidebarItem
+                  id={item.id}
+                  name={item.name}
+                  icon={item.icon}
+                  count={item.count}
+                  isVisible={item.visible}
+                  onToggleVisibility={toggleItemVisibility}
+                  isDraggable={true}
+                />
               </SidebarMenuItem>
             ))}
-        </SidebarMenu>
-      </SidebarGroup>
+        </SortableContext>
+      </DndContext>
     )
   }
 
   return (
-    <SidebarGroup className='group'>
-      <SidebarGroupHeader
-        title='Me'
-        isEditMode={isEditMode}
-        onToggleEditMode={onToggleEditMode}
-        toggleOpen={handleToggleOpen}
-        isOpen={isOpen}
-        isGroupVisible={isGroupVisible}
-        onToggleGroupVisibility={onToggleGroupVisibility}
-      />
-      {(isEditMode || isOpen) && (
-        <SidebarMenu className='gap-0'>
-          {isEditMode ? (
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
-              modifiers={[restrictToVerticalAxis]}>
-              <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
-                {items
-                  .sort((a, b) => a.order - b.order)
-                  .map((item) => (
-                    <SidebarMenuItem key={item.id}>
-                      <EditableSidebarItem
-                        id={item.id}
-                        name={item.name}
-                        icon={item.icon}
-                        count={item.count}
-                        isVisible={item.visible}
-                        onToggleVisibility={toggleItemVisibility}
-                        isDraggable={true}
-                      />
-                    </SidebarMenuItem>
-                  ))}
-              </SortableContext>
-            </DndContext>
-          ) : (
-            visibleItems
-              .sort((a, b) => a.order - b.order)
-              .map((item) => {
-                const itemHref = getItemHref(item)
-                const isActive =
-                  pathname === itemHref || pathname?.startsWith(itemHref.replace(/\/open$/, '/'))
+    <>
+      {visibleItems
+        .sort((a, b) => a.order - b.order)
+        .map((item) => {
+          const itemHref = getItemHref(item)
+          const isActive =
+            pathname === itemHref || pathname?.startsWith(itemHref.replace(/\/open$/, '/'))
 
-                return (
-                  <SidebarMenuItem key={item.id}>
-                    <SidebarItem
-                      id={item.id}
-                      name={item.name}
-                      href={itemHref}
-                      icon={item.icon}
-                      count={item.count}
-                      isActive={isActive}
-                      onToggleEditMode={onToggleEditMode}
-                    />
-                  </SidebarMenuItem>
-                )
-              })
-          )}
-        </SidebarMenu>
-      )}
-    </SidebarGroup>
+          return (
+            <SidebarMenuItem key={item.id}>
+              <SidebarItem
+                id={item.id}
+                name={item.name}
+                href={itemHref}
+                icon={item.icon}
+                count={item.count}
+                isActive={isActive}
+                onToggleEditMode={onToggleEditMode}
+              />
+            </SidebarMenuItem>
+          )
+        })}
+    </>
   )
 }

--- a/apps/web/src/components/global/sidebar/shared-inbox-group.tsx
+++ b/apps/web/src/components/global/sidebar/shared-inbox-group.tsx
@@ -1,8 +1,8 @@
 // ~/components/global/sidebar/shared-inbox-group.tsx
 'use client'
 
-import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
-import { SidebarGroup, SidebarMenu, SidebarMenuSubItem } from '@auxx/ui/components/sidebar'
+import { DropdownMenuItem } from '@auxx/ui/components/dropdown-menu'
+import { SidebarMenu, SidebarMenuSubItem } from '@auxx/ui/components/sidebar'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
 import {
@@ -22,38 +22,34 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { Inbox, Mail } from 'lucide-react'
+import { Inbox as InboxIcon, Mail } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useCallback, useState } from 'react'
 import { useDndState } from '~/app/context/dnd-state-context'
 import { CollapsibleSidebarSection } from '~/components/global/sidebar/collapsible-sidebar-section'
 import { EditableSidebarItem } from '~/components/global/sidebar/editable-sidebar-item'
-import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
 import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
 import { InboxDialog } from '~/components/inbox/inbox-dialog'
 import { selectSharedInboxesTotal, useMailCountsStore } from '~/components/mail/store'
-import { useSidebarStateContext } from './sidebar-state-context'
-
-// import { useDndState } from '~/context/dnd-state-context'; // <-- IMPORT NEW HOOK
 
 export interface Inbox {
   id: string
   name: string
   color: string
   unassignedCount?: number
-  isVisible?: boolean // Keep isVisible as it's managed by settings
+  isVisible?: boolean
 }
 
-interface SharedInboxesGroupProps {
-  inboxes: Inbox[] // Use the processed inboxes from the hook
+interface SharedInboxesSectionProps {
+  inboxes: Inbox[]
   isLoading: boolean
   isEditMode: boolean
   onToggleEditMode: () => void
   onUpdateInboxVisibility?: (inboxId: string, isVisible: boolean) => void
-  onReorderInboxes?: (orderedInboxIds: string[]) => void // New prop for saving order
-  isGroupVisible: boolean
-  onToggleGroupVisibility: () => void
+  onReorderInboxes?: (orderedInboxIds: string[]) => void
+  isSectionVisible: boolean
+  onToggleSectionVisibility: () => void
 }
 
 /**
@@ -70,42 +66,37 @@ const DroppableInboxSidebarItem = ({
   isEditMode: boolean
   onToggleEditMode: () => void
 }) => {
-  // const { activeDragItem } = useMailFilter()
-  // const isDraggingThread = activeDragItem?.data.current?.type === 'thread'
-  const { activeDndItem } = useDndState() // <-- Use new hook
+  const { activeDndItem } = useDndState()
 
   const isDraggingThread = activeDndItem?.data.current?.type === 'thread'
 
   const { setNodeRef, isOver } = useDroppable({
-    id: `shared-inbox-${inbox.id}`, // Unique ID for the drop target
+    id: `shared-inbox-${inbox.id}`,
     data: {
-      type: 'shared-inbox-target', // Identify the drop target type
+      type: 'shared-inbox-target',
       inboxId: inbox.id,
     },
-    disabled: !isDraggingThread || isEditMode, // Disable dropping while sidebar is in edit mode
+    disabled: !isDraggingThread || isEditMode,
   })
 
-  const itemHref = `/app/mail/inboxes/${inbox.id}/unassigned` // Your existing logic
-  const pathname = usePathname() // Get pathname if needed for isActive
+  const itemHref = `/app/mail/inboxes/${inbox.id}/unassigned`
+  const pathname = usePathname()
   const isActive = pathname?.startsWith(`/app/mail/inboxes/${inbox.id}`)
 
   const editItems = (
-    <>
-      <DropdownMenuItem asChild>
-        <Link href={`/app/settings/inbox/${inbox.id}?tab=settings`}>Edit Inbox</Link>
-      </DropdownMenuItem>
-    </>
+    <DropdownMenuItem asChild>
+      <Link href={`/app/settings/inbox/${inbox.id}?tab=settings`}>Edit Inbox</Link>
+    </DropdownMenuItem>
   )
 
   return (
     <div
-      ref={setNodeRef} // Assign the node ref for dnd-kit
+      ref={setNodeRef}
       className={cn(
-        'rounded-md transition-colors duration-150 ease-in-out', // Base styles for the droppable area
+        'rounded-md transition-colors duration-150 ease-in-out',
         isDraggingThread && 'outline-dashed outline-1 outline-primary/30',
         isDraggingThread && isOver && 'bg-primary/20 outline-primary/80 ring-2 ring-primary/60'
       )}>
-      {/* Render the actual SidebarItem inside */}
       <SidebarItem
         id={inbox.id}
         name={inbox.name}
@@ -121,49 +112,32 @@ const DroppableInboxSidebarItem = ({
   )
 }
 
-export function SharedInboxesGroup({
-  inboxes, // This list is now pre-sorted and visibility-marked
+export function SharedInboxesSection({
+  inboxes,
   isLoading,
   isEditMode,
   onToggleEditMode,
   onUpdateInboxVisibility,
-  onReorderInboxes, // Receive the handler
-  isGroupVisible,
-  onToggleGroupVisibility,
-}: SharedInboxesGroupProps) {
+  onReorderInboxes,
+  isSectionVisible,
+  onToggleSectionVisibility,
+}: SharedInboxesSectionProps) {
   const pathname = usePathname()
-  const { getGroupOpen, toggleGroup } = useSidebarStateContext()
-  const isOpen = getGroupOpen('shared')
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
-  const getInboxHref = (inboxId: string): string => {
-    // Default to the "unassigned" view for a specific inbox
-    return `/app/mail/inboxes/${inboxId}/unassigned`
-  }
 
-  const getAllInboxesHref = (): string => {
-    // Default to the "unassigned" view for the "all inboxes" aggregate
-    return `/app/mail/inboxes/all/unassigned`
-  }
-
-  // Use the mail counts store for counts
   const sharedInboxCounts = useMailCountsStore((s) => s.counts.sharedInboxes)
   const totalSharedCount = useMailCountsStore(selectSharedInboxesTotal)
 
-  // Dnd-kit sensors setup
   const sensors = useSensors(
     useSensor(PointerSensor, {
-      // Require the mouse to move by 10 pixels before starting a drag
-      // helps prevent drags initiated accidentally on click
       activationConstraint: { distance: 5 },
     }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 
-  // Toggle inbox visibility (pass through to hook via prop)
   const handleToggleVisibility = useCallback(
     (inboxId: string) => {
       if (onUpdateInboxVisibility) {
-        // Find the current state to toggle it
         const currentInbox = inboxes.find((i) => i.id === inboxId)
         if (currentInbox) {
           onUpdateInboxVisibility(inboxId, !(currentInbox.isVisible ?? true))
@@ -173,7 +147,6 @@ export function SharedInboxesGroup({
     [inboxes, onUpdateInboxVisibility]
   )
 
-  // Handle drag end event
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event
@@ -189,12 +162,10 @@ export function SharedInboxesGroup({
         }
       }
     },
-    [inboxes, onReorderInboxes] // Depend on current inboxes and the callback
+    [inboxes, onReorderInboxes]
   )
 
-  // Determine which inboxes to show in non-edit mode
   const visibleInboxes = inboxes.filter((inbox) => inbox.isVisible)
-  // All inboxes are needed for edit mode (DndContext needs all potential items)
   const allInboxIds = inboxes.map((inbox) => inbox.id)
 
   const renderInboxList = () => {
@@ -212,13 +183,8 @@ export function SharedInboxesGroup({
     }
 
     if (!isEditMode) {
-      // Regular display mode (only visible items)
       return visibleInboxes && visibleInboxes.length > 0 ? (
         visibleInboxes.map((inbox) => {
-          const itemHref = getInboxHref(inbox.id)
-          // Check if the current path *starts with* the specific inbox base URL
-          // This handles /inboxes/[id]/unassigned, /inboxes/[id]/assigned, /inboxes/[id]/assigned/[threadId] etc.
-          const isActive = pathname?.startsWith(`/app/mail/inboxes/${inbox.id}`)
           const count = sharedInboxCounts[inbox.id] ?? 0
 
           return (
@@ -237,105 +203,73 @@ export function SharedInboxesGroup({
           <div className='px-2 py-1.5 text-sm text-muted-foreground'>No visible shared inboxes</div>
         </SidebarMenuSubItem>
       )
-    } else {
-      // Edit mode: Render all inboxes within Dnd context
-      return inboxes.length > 0 ? (
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleDragEnd}
-          modifiers={[restrictToVerticalAxis]}>
-          <SortableContext
-            items={allInboxIds} // Use IDs of all inboxes for context
-            strategy={verticalListSortingStrategy}>
-            {inboxes.map((inbox) => (
-              // Use SidebarMenuSubItem to maintain visual structure if needed,
-              // or directly render EditableSidebarItem if SubItem adds unwanted padding/styles in edit mode.
-              // Let's keep SubItem for now for consistency.
-              <SidebarMenuSubItem key={inbox.id} className='p-0'>
-                <EditableSidebarItem
-                  id={inbox.id}
-                  name={inbox.name}
-                  count={inbox.unassignedCount}
-                  isVisible={inbox.isVisible || false}
-                  isLocked={false} // Assuming shared inboxes aren't lockable for now
-                  onToggleVisibility={handleToggleVisibility}
-                  isDraggable={true} // Enable dragging features
-                  // Pass color if needed for display in EditableSidebarItem
-                  // color={inbox.color}
-                />
-              </SidebarMenuSubItem>
-            ))}
-          </SortableContext>
-        </DndContext>
-      ) : (
-        <SidebarMenuSubItem>
-          <div className='px-2 py-1.5 text-sm text-muted-foreground'>No shared inboxes to edit</div>
-        </SidebarMenuSubItem>
-      )
     }
+
+    return inboxes.length > 0 ? (
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+        modifiers={[restrictToVerticalAxis]}>
+        <SortableContext items={allInboxIds} strategy={verticalListSortingStrategy}>
+          {inboxes.map((inbox) => (
+            <SidebarMenuSubItem key={inbox.id} className='p-0'>
+              <EditableSidebarItem
+                id={inbox.id}
+                name={inbox.name}
+                count={inbox.unassignedCount}
+                isVisible={inbox.isVisible || false}
+                isLocked={false}
+                onToggleVisibility={handleToggleVisibility}
+                isDraggable={true}
+              />
+            </SidebarMenuSubItem>
+          ))}
+        </SortableContext>
+      </DndContext>
+    ) : (
+      <SidebarMenuSubItem>
+        <div className='px-2 py-1.5 text-sm text-muted-foreground'>No shared inboxes to edit</div>
+      </SidebarMenuSubItem>
+    )
   }
 
-  const allInboxesHref = getAllInboxesHref()
-  const isSharedSectionActive = pathname?.startsWith('/app/mail/inboxes/') // Active if any inbox route is active
+  const allInboxesHref = '/app/mail/inboxes/all/unassigned'
+  const isSharedSectionActive = pathname?.startsWith('/app/mail/inboxes/')
+  const isHeaderActive =
+    pathname?.startsWith(allInboxesHref) ||
+    (isSharedSectionActive &&
+      !visibleInboxes.some((inbox) => pathname?.startsWith(`/app/mail/inboxes/${inbox.id}`)))
 
-  function handleToggleOpen() {
-    toggleGroup('shared')
-  }
-
-  const additionalOptions = (
-    <>
-      <DropdownMenuItem onSelect={() => setIsCreateDialogOpen(true)}>
-        <Inbox />
-        Create inbox
-      </DropdownMenuItem>
-      <DropdownMenuSeparator />
-    </>
+  const actions = (
+    <DropdownMenuItem onSelect={() => setIsCreateDialogOpen(true)}>
+      <InboxIcon />
+      Create inbox
+    </DropdownMenuItem>
   )
-
-  // Don't render the group if it's hidden (unless in edit mode)
-  if (!isGroupVisible && !isEditMode) {
-    return null
-  }
 
   return (
     <>
-      <SidebarGroup className='group'>
-        <SidebarGroupHeader
-          title='Shared'
+      <SidebarMenu className='gap-0'>
+        <CollapsibleSidebarSection
+          title='Shared Inboxes'
+          avatar={
+            <div className='flex size-5 shrink-0 items-center justify-center rounded-md bg-info'>
+              <Mail className='size-3 text-white/80' />
+            </div>
+          }
+          href={allInboxesHref}
           isEditMode={isEditMode}
-          onToggleEditMode={onToggleEditMode}
-          additionalOptions={additionalOptions}
-          toggleOpen={handleToggleOpen}
-          isOpen={isOpen}
-          isGroupVisible={isGroupVisible}
-          onToggleGroupVisibility={onToggleGroupVisibility}
-        />
-        {(isEditMode || isOpen) && (
-          <SidebarMenu className='gap-0'>
-            <CollapsibleSidebarSection
-              title='Shared Inboxes'
-              avatar={
-                <div className='flex size-5 shrink-0 items-center justify-center rounded-md bg-info'>
-                  <Mail className='size-3 text-white/80' />
-                </div>
-              }
-              href='/app/mail/inboxes/all/unassigned'
-              isEditMode={isEditMode}
-              defaultOpen // Keep open by default
-              alwaysShowChildren // Content needs to be mounted for dnd-kit even if visually collapsed
-              isActive={
-                pathname?.startsWith(allInboxesHref) ||
-                (isSharedSectionActive &&
-                  !visibleInboxes.some((inbox) =>
-                    pathname?.startsWith(`/app/mail/inboxes/${inbox.id}`)
-                  ))
-              }>
-              {renderInboxList()}
-            </CollapsibleSidebarSection>
-          </SidebarMenu>
-        )}
-      </SidebarGroup>
+          defaultOpen
+          sectionId='mail.shared'
+          actions={actions}
+          isVisible={isSectionVisible}
+          onToggleVisibility={onToggleSectionVisibility}
+          count={totalSharedCount}
+          isActive={!!isHeaderActive}>
+          {renderInboxList()}
+        </CollapsibleSidebarSection>
+      </SidebarMenu>
 
       {isCreateDialogOpen && (
         <InboxDialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen} />

--- a/apps/web/src/components/global/sidebar/sidebar-group-header.tsx
+++ b/apps/web/src/components/global/sidebar/sidebar-group-header.tsx
@@ -3,6 +3,7 @@
 
 import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
+import { CollapsibleChevron } from '@auxx/ui/components/collapsible'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,7 +13,7 @@ import {
 } from '@auxx/ui/components/dropdown-menu'
 import { SidebarGroupLabel } from '@auxx/ui/components/sidebar'
 import { cn } from '@auxx/ui/lib/utils'
-import { Check, ChevronRight, MoreVertical, Pencil } from 'lucide-react'
+import { Check, MoreVertical, Pencil } from 'lucide-react'
 import React from 'react'
 
 interface SidebarGroupHeaderProps {
@@ -71,9 +72,7 @@ export function SidebarGroupHeader({
       ) : (
         <SidebarGroupLabel className='cursor-pointer select-none'>
           {title}
-          <ChevronRight
-            className={cn('transition-transform duration-200', isOpen && 'rotate-90')}
-          />
+          <CollapsibleChevron open={isOpen} />
         </SidebarGroupLabel>
       )}
       {!isEditMode && (additionalOptions || !hideEditOption) && (

--- a/apps/web/src/components/global/sidebar/sidebar-item-actions.tsx
+++ b/apps/web/src/components/global/sidebar/sidebar-item-actions.tsx
@@ -3,9 +3,10 @@
 
 import { AnimatedGradientText } from '@auxx/ui/components/animated-gradient-text'
 import { DropdownMenuItem } from '@auxx/ui/components/dropdown-menu'
-import { LayoutTemplate, Workflow } from 'lucide-react'
+import { CheckSquare, LayoutTemplate, Workflow } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useState } from 'react'
+import { useCreateTaskStore } from '~/components/tasks/stores/create-task-store'
 import { WorkflowFormDialog } from '~/components/workflow/dialogs/workflow-form-dialog'
 import { WorkflowTemplateDialog } from '~/components/workflow/dialogs/workflow-template-dialog'
 import { useOrganization } from '~/hooks/use-organization'
@@ -47,6 +48,15 @@ export function useSidebarItemActions(): SidebarItemActionsResult {
             <AnimatedGradientText>Create from template</AnimatedGradientText>
           </DropdownMenuItem>
         </>
+      ),
+      tasks: () => (
+        <DropdownMenuItem
+          onClick={(e) => {
+            e.stopPropagation()
+            useCreateTaskStore.getState().openDialog()
+          }}>
+          <CheckSquare /> Create task
+        </DropdownMenuItem>
       ),
     },
     dialogs: (

--- a/apps/web/src/components/global/sidebar/views-group.tsx
+++ b/apps/web/src/components/global/sidebar/views-group.tsx
@@ -1,13 +1,8 @@
 // ~/components/global/sidebar/views-group.tsx
 'use client'
 
-import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
-import {
-  SidebarGroup,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-} from '@auxx/ui/components/sidebar'
+import { DropdownMenuItem } from '@auxx/ui/components/dropdown-menu'
+import { SidebarMenu, SidebarMenuButton, SidebarMenuSubItem } from '@auxx/ui/components/sidebar'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
@@ -32,38 +27,35 @@ import { TableProperties, Trash2 } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import { useCallback, useState } from 'react'
 import { useDndState } from '~/app/context/dnd-state-context'
+import { CollapsibleSidebarSection } from '~/components/global/sidebar/collapsible-sidebar-section'
 import { EditableSidebarItem } from '~/components/global/sidebar/editable-sidebar-item'
-import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
 import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
 import { useMailCountsStore } from '~/components/mail/store'
 import { MailViewDialog } from '~/components/mail-views/mail-view-dialog'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
-import { useSidebarStateContext } from './sidebar-state-context'
-
-// import { useDndState } from '~/context/dnd-state-context'; // <-- IMPORT NEW HOOK
 
 export interface MailView {
   id: string
   name: string
   color: string
   unassignedCount?: number
-  isVisible?: boolean // Keep isVisible as it's managed by settings
+  isVisible?: boolean
 }
 
-interface ViewsGroupProps {
-  views: MailView[] // Use the processed inboxes from the hook
+interface ViewsSectionProps {
+  views: MailView[]
   isLoading: boolean
   isEditMode: boolean
   onToggleEditMode: () => void
   onUpdateViewsVisibility?: (viewId: string, isVisible: boolean) => void
-  onReorderViews?: (orderedViewIds: string[]) => void // New prop for saving order
-  isGroupVisible: boolean
-  onToggleGroupVisibility: () => void
+  onReorderViews?: (orderedViewIds: string[]) => void
+  isSectionVisible: boolean
+  onToggleSectionVisibility: () => void
 }
 
 /**
- * Wrapper component to make a SidebarItem representing a shared inbox droppable.
+ * Wrapper component to make a SidebarItem representing a mail view droppable.
  */
 const DroppableViewSidebarItem = ({
   view,
@@ -76,9 +68,7 @@ const DroppableViewSidebarItem = ({
   isEditMode: boolean
   onToggleEditMode: () => void
 }) => {
-  // const { activeDragItem } = useMailFilter()
-  // const isDraggingThread = activeDragItem?.data.current?.type === 'thread'
-  const { activeDndItem } = useDndState() // <-- Use new hook
+  const { activeDndItem } = useDndState()
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [confirm, ConfirmDialog] = useConfirm()
   const isDraggingThread = activeDndItem?.data.current?.type === 'thread'
@@ -94,7 +84,6 @@ const DroppableViewSidebarItem = ({
     },
   })
 
-  /** Handles the delete action with confirmation */
   const handleDelete = async () => {
     const confirmed = await confirm({
       title: 'Delete this view?',
@@ -110,16 +99,16 @@ const DroppableViewSidebarItem = ({
   }
 
   const { setNodeRef, isOver } = useDroppable({
-    id: `view-${view.id}`, // Unique ID for the drop target
+    id: `view-${view.id}`,
     data: {
-      type: 'view-target', // Identify the drop target type
+      type: 'view-target',
       viewId: view.id,
     },
-    disabled: !isDraggingThread || isEditMode, // Disable dropping while sidebar is in edit mode
+    disabled: !isDraggingThread || isEditMode,
   })
 
-  const itemHref = `/app/mail/views/${view.id}/unassigned` // Your existing logic
-  const pathname = usePathname() // Get pathname if needed for isActive
+  const itemHref = `/app/mail/views/${view.id}/unassigned`
+  const pathname = usePathname()
   const isActive = pathname?.startsWith(`/app/mail/views/${view.id}`)
 
   const editItems = (
@@ -139,9 +128,9 @@ const DroppableViewSidebarItem = ({
     <>
       <ConfirmDialog />
       <div
-        ref={setNodeRef} // Assign the node ref for dnd-kit
+        ref={setNodeRef}
         className={cn(
-          'rounded-md transition-colors duration-150 ease-in-out', // Base styles for the droppable area
+          'rounded-md transition-colors duration-150 ease-in-out',
           isDraggingThread && 'outline-solid outline-dashed outline-1 outline-primary/30',
           isDraggingThread && isOver && 'bg-primary/20 outline-primary/80 ring-2 ring-primary/60'
         )}>
@@ -150,7 +139,6 @@ const DroppableViewSidebarItem = ({
           isOpen={isDialogOpen}
           onClose={() => setIsDialogOpen(false)}
         />
-        {/* Render the actual SidebarItem inside */}
         <SidebarItem
           id={view.id}
           name={view.name}
@@ -167,53 +155,40 @@ const DroppableViewSidebarItem = ({
   )
 }
 
-export function ViewsGroup({
-  views, // This list is now pre-sorted and visibility-marked
+export function ViewsSection({
+  views,
   isLoading,
   isEditMode,
   onToggleEditMode,
   onUpdateViewsVisibility,
-  onReorderViews, // Receive the handler
-  isGroupVisible,
-  onToggleGroupVisibility,
-}: ViewsGroupProps) {
+  onReorderViews,
+  isSectionVisible,
+  onToggleSectionVisibility,
+}: ViewsSectionProps) {
   const pathname = usePathname()
-  const { getGroupOpen, toggleGroup } = useSidebarStateContext()
-  const isOpen = getGroupOpen('views')
   const [showCreateView, setShowCreateView] = useState(false)
-  const getViewHref = (inboxId: string): string => {
-    // Default to the "unassigned" view for a specific inbox
-    return `/app/mail/views/${inboxId}/unassigned`
-  }
 
-  // Use the mail counts store for view counts
   const viewCounts = useMailCountsStore((s) => s.counts.views)
 
-  // Dnd-kit sensors setup
   const sensors = useSensors(
     useSensor(PointerSensor, {
-      // Require the mouse to move by 10 pixels before starting a drag
-      // helps prevent drags initiated accidentally on click
       activationConstraint: { distance: 5 },
     }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 
-  // Toggle inbox visibility (pass through to hook via prop)
   const handleToggleVisibility = useCallback(
-    (inboxId: string) => {
+    (viewId: string) => {
       if (onUpdateViewsVisibility) {
-        // Find the current state to toggle it
-        const currentInbox = views.find((i) => i.id === inboxId)
-        if (currentInbox) {
-          onUpdateViewsVisibility(inboxId, !(currentInbox.isVisible ?? true))
+        const currentView = views.find((i) => i.id === viewId)
+        if (currentView) {
+          onUpdateViewsVisibility(viewId, !(currentView.isVisible ?? true))
         }
       }
     },
     [views, onUpdateViewsVisibility]
   )
 
-  // Handle drag end event
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event
@@ -229,131 +204,115 @@ export function ViewsGroup({
         }
       }
     },
-    [views, onReorderViews] // Depend on current inboxes and the callback
+    [views, onReorderViews]
   )
 
-  // Determine which inboxes to show in non-edit mode
-  const visibleViews = views?.filter((view) => view.isVisible)
-  const allViewsIds = views?.map((view) => view.id)
-
-  function handleToggleOpen() {
-    toggleGroup('views')
-  }
+  const visibleViews = views?.filter((view) => view.isVisible) ?? []
+  const allViewsIds = views?.map((view) => view.id) ?? []
 
   const renderViewList = () => {
     if (isLoading) {
       return Array(3)
         .fill(0)
         .map((_, i) => (
-          <SidebarMenuItem key={`skeleton-${i}`}>
+          <SidebarMenuSubItem key={`skeleton-${i}`}>
             <div className='flex items-center space-x-2 px-2 py-1.5'>
               <Skeleton className='h-4 w-4 rounded-full' />
               <Skeleton className='h-4 w-24' />
             </div>
-          </SidebarMenuItem>
+          </SidebarMenuSubItem>
         ))
     }
 
     if (!isEditMode) {
       if (visibleViews.length === 0) {
         return (
-          <SidebarMenuButton
-            variant='dashed'
-            size='sm'
-            onClick={() => setShowCreateView(true)}
-            className='group-data-[collapsible=icon]:hidden'>
-            Create a view
-          </SidebarMenuButton>
+          <SidebarMenuSubItem>
+            <SidebarMenuButton
+              variant='dashed'
+              size='sm'
+              onClick={() => setShowCreateView(true)}
+              className='group-data-[collapsible=icon]:hidden'>
+              Create a view
+            </SidebarMenuButton>
+          </SidebarMenuSubItem>
         )
       }
 
       return visibleViews.map((view) => {
-        const itemHref = getViewHref(view.id)
-        // Check if the current path *starts with* the specific view base URL
-        // This handles /views/[id]/unassigned, /views/[id]/assigned, etc.
-        const isActive = pathname?.startsWith(`/app/mail/views/${view.id}`)
         const count = viewCounts[view.id] ?? 0
 
         return (
-          <SidebarMenuItem key={view.id}>
+          <SidebarMenuSubItem key={view.id}>
             <DroppableViewSidebarItem
               onToggleEditMode={onToggleEditMode}
               view={view}
               count={count}
               isEditMode={isEditMode}
             />
-          </SidebarMenuItem>
+          </SidebarMenuSubItem>
         )
       })
-    } else {
-      // Edit mode: Render all inboxes within Dnd context
-      return views.length > 0 ? (
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleDragEnd}
-          modifiers={[restrictToVerticalAxis]}>
-          <SortableContext
-            items={allViewsIds} // Use IDs of all inboxes for context
-            strategy={verticalListSortingStrategy}>
-            {views.map((view) => (
-              <SidebarMenuItem key={view.id} className='p-0'>
-                <EditableSidebarItem
-                  id={view.id}
-                  name={view.name}
-                  count={view.unassignedCount}
-                  isVisible={view.isVisible || false}
-                  isLocked={false} // Assuming shared inboxes aren't lockable for now
-                  onToggleVisibility={handleToggleVisibility}
-                  isDraggable={true} // Enable dragging features
-                />
-              </SidebarMenuItem>
-            ))}
-          </SortableContext>
-        </DndContext>
-      ) : (
-        <SidebarMenuItem>
-          <div className='px-2 py-1.5 text-sm text-muted-foreground'>No views to edit</div>
-        </SidebarMenuItem>
-      )
     }
+
+    return views.length > 0 ? (
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+        modifiers={[restrictToVerticalAxis]}>
+        <SortableContext items={allViewsIds} strategy={verticalListSortingStrategy}>
+          {views.map((view) => (
+            <SidebarMenuSubItem key={view.id} className='p-0'>
+              <EditableSidebarItem
+                id={view.id}
+                name={view.name}
+                count={view.unassignedCount}
+                isVisible={view.isVisible || false}
+                isLocked={false}
+                onToggleVisibility={handleToggleVisibility}
+                isDraggable={true}
+              />
+            </SidebarMenuSubItem>
+          ))}
+        </SortableContext>
+      </DndContext>
+    ) : (
+      <SidebarMenuSubItem>
+        <div className='px-2 py-1.5 text-sm text-muted-foreground'>No views to edit</div>
+      </SidebarMenuSubItem>
+    )
   }
 
-  const additionalOptions = (
-    <>
-      <DropdownMenuItem
-        onClick={() => setShowCreateView(true)}
-        className='group-data-[collapsible=icon]:hidden!'>
-        <TableProperties />
-        Create view
-      </DropdownMenuItem>
-      <DropdownMenuSeparator />
-    </>
+  const isAnyViewActive = pathname?.startsWith('/app/mail/views/')
+
+  const actions = (
+    <DropdownMenuItem
+      onClick={() => setShowCreateView(true)}
+      className='group-data-[collapsible=icon]:hidden!'>
+      <TableProperties />
+      Create view
+    </DropdownMenuItem>
   )
-
-  const isSharedSectionActive = pathname?.startsWith('/app/mail/views/') // Active if any inbox route is active
-
-  // Don't render the group if it's hidden (unless in edit mode)
-  if (!isGroupVisible && !isEditMode) {
-    return null
-  }
 
   return (
     <>
       <MailViewDialog isOpen={showCreateView} onClose={() => setShowCreateView(false)} />
-      <SidebarGroup className='group'>
-        <SidebarGroupHeader
+      <SidebarMenu className='gap-0'>
+        <CollapsibleSidebarSection
           title='Views'
+          icon={<TableProperties />}
+          preventNavigation
           isEditMode={isEditMode}
-          onToggleEditMode={onToggleEditMode}
-          toggleOpen={handleToggleOpen}
-          additionalOptions={additionalOptions}
-          isOpen={isOpen}
-          isGroupVisible={isGroupVisible}
-          onToggleGroupVisibility={onToggleGroupVisibility}
-        />
-        {(isEditMode || isOpen) && <SidebarMenu className='gap-0'>{renderViewList()}</SidebarMenu>}
-      </SidebarGroup>
+          isActive={!!isAnyViewActive}
+          defaultOpen
+          sectionId='mail.views'
+          actions={actions}
+          isVisible={isSectionVisible}
+          onToggleVisibility={onToggleSectionVisibility}>
+          {renderViewList()}
+        </CollapsibleSidebarSection>
+      </SidebarMenu>
     </>
   )
 }

--- a/apps/web/src/components/merge/merge-preview-panel.tsx
+++ b/apps/web/src/components/merge/merge-preview-panel.tsx
@@ -49,17 +49,8 @@ export function MergePreviewPanel({
     sourceRecordIds,
     fields: resource?.fields ?? [],
   })
-  console.log(
-    'MergePreviewPanel mergedFields:',
-    mergedFields,
-    targetRecordId,
-    sourceRecordIds,
-    resource?.fields
-  )
   // Get target record info
   const targetRecord = useMemo(() => records[0], [records])
-
-  console.log('mergedFields:', mergedFields, records)
 
   return (
     <div className='flex-1 flex flex-col border rounded-2xl bg-muted max-h-[400px]'>

--- a/apps/web/src/hooks/use-mail-sidebar.tsx
+++ b/apps/web/src/hooks/use-mail-sidebar.tsx
@@ -18,9 +18,8 @@ const INBOX_VISIBILITY_SETTING_KEY = 'sidebar.inboxes'
 const PERSONAL_ITEMS_SETTING_KEY = 'sidebar.personalItems'
 const GROUP_VISIBILITY_SETTING_KEY = 'sidebar.groupVisibility'
 
-// Group visibility type
+// Group visibility type — drives whole-section visibility for the unified Mail sidebar.
 export interface GroupVisibilitySettings {
-  personal: boolean
   views: boolean
   shared: boolean
 }
@@ -90,10 +89,6 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
     return sortedInboxes
   }, [rawInboxes, getSetting])
 
-  const viewsOrder = (getSetting(VIEWS_ORDER_SETTING_KEY) as string[]) || []
-  const viewsVisibilitySettings =
-    (getSetting(VIEWS_VISIBILITY_SETTING_KEY) as Record<string, boolean>) || {}
-
   // Process mail views: apply saved order and visibility
   const processedViews = useMemo((): Inbox[] => {
     if (!mailViews) return []
@@ -143,7 +138,6 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
   const groupVisibility = useMemo((): GroupVisibilitySettings => {
     const settings = (getSetting(GROUP_VISIBILITY_SETTING_KEY) as Record<string, boolean>) || {}
     return {
-      personal: settings.personal !== false, // Default true
       views: settings.views !== false, // Default true
       shared: settings.shared !== false, // Default true
     }
@@ -213,7 +207,7 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
 
   // Update group visibility
   const updateGroupVisibility = useCallback(
-    (groupId: 'personal' | 'views' | 'shared', isVisible: boolean) => {
+    (groupId: 'views' | 'shared', isVisible: boolean) => {
       const currentSettings =
         (getSetting(GROUP_VISIBILITY_SETTING_KEY) as Record<string, boolean>) || {}
       const updatedSettings = { ...currentSettings, [groupId]: isVisible }
@@ -224,7 +218,7 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
 
   // Toggle group visibility
   const toggleGroupVisibility = useCallback(
-    (groupId: 'personal' | 'views' | 'shared') => {
+    (groupId: 'views' | 'shared') => {
       const currentSettings =
         (getSetting(GROUP_VISIBILITY_SETTING_KEY) as Record<string, boolean>) || {}
       const currentValue = currentSettings[groupId] !== false

--- a/apps/web/src/hooks/use-sidebar-state.ts
+++ b/apps/web/src/hooks/use-sidebar-state.ts
@@ -7,7 +7,7 @@ const SIDEBAR_STATE_KEY = 'auxx:sidebar-state'
 
 /** Represents the persisted state of sidebar groups and sections */
 interface SidebarState {
-  /** Group headers: PersonalMailGroup, ViewsGroup, SharedInboxesGroup */
+  /** Sidebar group headers (e.g. unified Mail group, Records group) */
   groups: Record<string, boolean>
   /** Collapsible sections within NavMain (by item id) */
   sections: Record<string, boolean>
@@ -15,9 +15,7 @@ interface SidebarState {
 
 const DEFAULT_STATE: SidebarState = {
   groups: {
-    personal: true,
-    views: true,
-    shared: true,
+    mail: true,
   },
   sections: {},
 }

--- a/packages/lib/src/resources/registry/resources/company-fields.ts
+++ b/packages/lib/src/resources/registry/resources/company-fields.ts
@@ -475,6 +475,7 @@ export const COMPANY_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'created_at',
     systemSortOrder: 'aD',
+    dbColumn: 'createdAt',
     nullable: false,
     capabilities: {
       filterable: true,
@@ -495,6 +496,7 @@ export const COMPANY_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'updated_at',
     systemSortOrder: 'aE',
+    dbColumn: 'updatedAt',
     nullable: false,
     capabilities: {
       filterable: true,

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -16,6 +16,7 @@ import { useIsMobile } from '@auxx/ui/hooks/use-mobile'
 import { cn } from '@auxx/ui/lib/utils'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { PanelLeft } from 'lucide-react'
+import { motion } from 'motion/react'
 import { Slot as SlotPrimitive } from 'radix-ui'
 import * as React from 'react'
 
@@ -366,7 +367,7 @@ function SidebarContent({ className, children, ...props }: React.ComponentProps<
       {...props}>
       <div
         data-sidebar='content'
-        className='flex flex-col gap-2 py-2 pe-0.5 sm:pe-2 group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:pe-0'>
+        className='flex flex-col gap-0.5 py-2 pe-0.5 sm:pe-2 group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:pe-0'>
         {children}
       </div>
     </ScrollArea>
@@ -430,6 +431,35 @@ function SidebarGroupAction({
 
 function SidebarGroupContent({ className, ...props }: React.ComponentProps<'div'>) {
   return <div data-sidebar='group-content' className={cn('w-full text-sm', className)} {...props} />
+}
+
+interface SidebarGroupCollapseProps {
+  /** Whether the collapsed content is visible. */
+  open: boolean
+  className?: string
+  children: React.ReactNode
+}
+
+/**
+ * Always-mounted collapse container for sidebar groups and sub-sections.
+ * Animates height + opacity + blur with the same spring as `AnimatedCollapsibleContent`,
+ * but keeps children mounted so DnD contexts and other always-on subscriptions keep working.
+ */
+function SidebarGroupCollapse({ open, className, children }: SidebarGroupCollapseProps) {
+  return (
+    <motion.div
+      initial={false}
+      animate={{
+        height: open ? 'auto' : 0,
+        opacity: open ? 1 : 0,
+        filter: open ? 'blur(0px)' : 'blur(3px)',
+      }}
+      transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+      style={{ overflow: 'hidden' }}
+      className={className}>
+      {children}
+    </motion.div>
+  )
 }
 
 function SidebarMenu({ className, ...props }: React.ComponentProps<'ul'>) {
@@ -672,6 +702,7 @@ export {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupAction,
+  SidebarGroupCollapse,
   SidebarGroupContent,
   SidebarGroupLabel,
   SidebarHeader,


### PR DESCRIPTION
## Summary
- Collapse Personal/Views/Shared mail groups into a single **Mail** group whose children are `CollapsibleSidebarSection`s, with hover-revealed action dropdowns on each section header (Create view, Create inbox, Create task).
- Add `SidebarGroupCollapse` — an always-mounted, spring-animated height/opacity/blur wrapper — so DnD contexts and other always-on subscriptions keep working across open/close transitions. `NavMain`, `EntitySidebarNav`, and the new mail group all use it instead of conditional mounts.
- Cleanup: drop debug `console.log`s from `merge-preview-panel`, and add `dbColumn` mappings for company `createdAt`/`updatedAt` system fields.

## Test plan
- [ ] Mail sidebar opens/closes smoothly; Personal/Views/Shared sections animate on toggle
- [ ] Drag-and-drop reorder still works for views and shared inboxes after expanding/collapsing
- [ ] Section action dropdowns (Create view, Create inbox, Create task) appear on hover and fire correctly
- [ ] Edit mode: per-section visibility checkboxes hide the whole section when off
- [ ] Persisted open/closed state survives a page reload (mail group + section IDs `mail.views`, `mail.shared`)
- [ ] Existing routes (`/app/mail/inboxes/...`, `/app/mail/views/...`) still highlight active section/item

🤖 Generated with [Claude Code](https://claude.com/claude-code)