### PR TITLE
feat(mail): enable thread action shortcuts in split view

### DIFF
--- a/apps/web/src/components/mail/thread-header.tsx
+++ b/apps/web/src/components/mail/thread-header.tsx
@@ -228,7 +228,7 @@ export function ThreadHeader() {
             <ThreadTicketControl />
           </div>
           <div data-slot='thread-header-actions' className=' flex items-center '>
-            <Tooltip content={isDone ? 'Unarchive' : 'Archive'}>
+            <Tooltip content={isDone ? 'Unarchive' : 'Archive'} shortcut='D'>
               <Button
                 variant='ghost'
                 size='icon'
@@ -240,7 +240,7 @@ export function ThreadHeader() {
               </Button>
             </Tooltip>
 
-            <Tooltip content={isTrash ? 'Restore from trash' : 'Trash Thread'}>
+            <Tooltip content={isTrash ? 'Restore from trash' : 'Trash Thread'} shortcut='#'>
               <Button
                 variant='ghost'
                 size='icon'
@@ -251,7 +251,7 @@ export function ThreadHeader() {
                 <span className='sr-only'>{isTrash ? 'Restore' : 'Delete'}</span>
               </Button>
             </Tooltip>
-            <Tooltip content={isSpam ? 'Not spam' : 'Mark as spam'}>
+            <Tooltip content={isSpam ? 'Not spam' : 'Mark as spam'} shortcut='!'>
               <Button
                 variant='ghost'
                 size='icon'
@@ -263,7 +263,7 @@ export function ThreadHeader() {
               </Button>
             </Tooltip>
 
-            <Tooltip content='Apply Tags'>
+            <Tooltip content='Apply Tags' shortcut='L'>
               <Button
                 ref={tagButtonRef}
                 variant='ghost'
@@ -287,7 +287,7 @@ export function ThreadHeader() {
               />
             )}
             <ManualTriggerButton recordId={toRecordId('thread', thread.id)}>
-              <Tooltip content='Run workflow'>
+              <Tooltip content='Run workflow' shortcut='W'>
                 <Button
                   variant='ghost'
                   size='icon'
@@ -307,7 +307,7 @@ export function ThreadHeader() {
               target='user'
               emptyLabel='Assign'>
               <div>
-                <Tooltip content={assignee ? assignee.name || 'Assigned' : 'Assign'}>
+                <Tooltip content={assignee ? assignee.name || 'Assigned' : 'Assign'} shortcut='A'>
                   <Button
                     variant='ghost'
                     size='icon'

--- a/apps/web/src/components/threads/hooks/use-focused-thread-shortcuts.ts
+++ b/apps/web/src/components/threads/hooks/use-focused-thread-shortcuts.ts
@@ -4,6 +4,7 @@
 import { useHotkey } from '@tanstack/react-hotkeys'
 import { useCallback, useState } from 'react'
 import {
+  useActiveThreadId,
   useFocusedThreadId,
   useHasMultipleSelected,
   useThreadSelectionStore,
@@ -12,12 +13,15 @@ import {
 import { useThreadMutation } from './use-thread-mutation'
 
 /**
- * Registers action shortcuts (D, #, !, W, L) for the focused thread in compact view.
+ * Registers action shortcuts (D, #, !, W, L, A) for the focused thread (compact/list view)
+ * or the active thread (split view) when no focus cursor is set.
  * Disabled when bulk mode is active so bulk shortcuts take priority.
  * Returns UI state (workflow dialog, tag picker) for rendering by the parent component.
  */
 export function useFocusedThreadShortcuts() {
   const focusedThreadId = useFocusedThreadId()
+  const activeThreadId = useActiveThreadId()
+  const targetThreadId = focusedThreadId ?? activeThreadId
   const hasMultipleSelected = useHasMultipleSelected()
   const viewMode = useViewMode()
   const { update, isUpdating } = useThreadMutation()
@@ -28,24 +32,33 @@ export function useFocusedThreadShortcuts() {
   const [workflowDialogOpen, setWorkflowDialogOpen] = useState(false)
   const [workflowThreadId, setWorkflowThreadId] = useState<string | null>(null)
 
-  const enabled = !!focusedThreadId && !hasMultipleSelected && viewMode !== 'edit'
+  const enabled = !!targetThreadId && !hasMultipleSelected && viewMode !== 'edit'
   const actionsEnabled = enabled && !isFocusLocked
 
+  // Advance to the next thread after a destructive action.
+  // In list/compact view (focusedThreadId set), move the focus cursor.
+  // In split view (only activeThreadId set), move the active thread so the
+  // next one auto-opens via the URL sync.
   const advanceFocus = useCallback(() => {
     const store = useThreadSelectionStore.getState()
-    const { listThreadIds, focusedThreadId: currentId } = store
+    const { listThreadIds, focusedThreadId: currentFocused, activeThreadId: currentActive } = store
+    const currentId = currentFocused ?? currentActive
     if (!currentId) return
     const idx = listThreadIds.indexOf(currentId)
     const nextId = listThreadIds[idx + 1] ?? listThreadIds[idx - 1] ?? null
-    store.setFocusedThread(nextId)
+    if (currentFocused) {
+      store.setFocusedThread(nextId)
+    } else {
+      store.setActiveThread(nextId)
+    }
   }, [])
 
   // D — Archive
   useHotkey(
     'D',
     () => {
-      if (focusedThreadId && !isUpdating) {
-        update(focusedThreadId, { status: 'ARCHIVED' })
+      if (targetThreadId && !isUpdating) {
+        update(targetThreadId, { status: 'ARCHIVED' })
         advanceFocus()
       }
     },
@@ -56,8 +69,8 @@ export function useFocusedThreadShortcuts() {
   useHotkey(
     'Shift+3',
     () => {
-      if (focusedThreadId && !isUpdating) {
-        update(focusedThreadId, { status: 'TRASH' })
+      if (targetThreadId && !isUpdating) {
+        update(targetThreadId, { status: 'TRASH' })
         advanceFocus()
       }
     },
@@ -68,8 +81,8 @@ export function useFocusedThreadShortcuts() {
   useHotkey(
     'Shift+1',
     () => {
-      if (focusedThreadId && !isUpdating) {
-        update(focusedThreadId, { status: 'SPAM' })
+      if (targetThreadId && !isUpdating) {
+        update(targetThreadId, { status: 'SPAM' })
         advanceFocus()
       }
     },
@@ -80,8 +93,8 @@ export function useFocusedThreadShortcuts() {
   useHotkey(
     'W',
     () => {
-      if (focusedThreadId) {
-        setWorkflowThreadId(focusedThreadId)
+      if (targetThreadId) {
+        setWorkflowThreadId(targetThreadId)
         setWorkflowDialogOpen(true)
         setFocusLocked(true)
       }
@@ -104,8 +117,8 @@ export function useFocusedThreadShortcuts() {
   useHotkey(
     'A',
     () => {
-      if (focusedThreadId) {
-        setAssignPickerThreadId(focusedThreadId)
+      if (targetThreadId) {
+        setAssignPickerThreadId(targetThreadId)
         setAssignPickerOpen(true)
         setFocusLocked(true)
       }
@@ -138,8 +151,8 @@ export function useFocusedThreadShortcuts() {
   useHotkey(
     'L',
     () => {
-      if (focusedThreadId) {
-        setTagPickerThreadId(focusedThreadId)
+      if (targetThreadId) {
+        setTagPickerThreadId(targetThreadId)
         setTagPickerOpen(true)
         setFocusLocked(true)
       }


### PR DESCRIPTION
## Summary
- Thread action shortcuts (D archive, # trash, ! spam, L tags, A assign, W workflow) only fired in the compact/list view because they were gated on `focusedThreadId`. In split view arrow nav mutates `activeThreadId` and never sets `focusedThreadId`, so the shortcuts did nothing.
- `useFocusedThreadShortcuts` now falls back to `activeThreadId` when no focus cursor is set; after destructive actions the active thread is advanced so the next thread auto-opens via the existing URL sync.
- Surfaced the same shortcuts in the `ThreadHeader` button tooltips so they're discoverable from the toolbar.

## Test plan
- [ ] In split view, open a thread and press D → it archives and the next thread opens.
- [ ] Same flow with #, ! → trash / spam, advance to next thread.
- [ ] L opens the tag picker anchored on the open thread's row.
- [ ] A opens the assign picker; W opens the workflow dialog.
- [ ] List view behavior is unchanged (focus cursor still drives shortcuts and advances after archive/trash/spam).
- [ ] Bulk action shortcuts still take priority when multiple threads are checked / edit mode is on.
- [ ] Tooltips on archive/trash/spam/tags/workflow/assign buttons in `ThreadHeader` show the correct shortcut keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)