### PR TITLE
fix(auth): unify OAuth refresh-error handling and surface Workspace RAPT

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-tabs.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-tabs.tsx
@@ -129,6 +129,7 @@ export default function IntegrationTabs() {
                 lastAuthError: integration.lastAuthError,
                 lastAuthErrorAt: integration.lastAuthErrorAt!,
                 requiresReauth: true,
+                metadata: integration.metadata,
               }}
             />
           )}

--- a/apps/web/src/components/global/reauth-banner.tsx
+++ b/apps/web/src/components/global/reauth-banner.tsx
@@ -21,9 +21,26 @@ interface ReauthBannerProps {
     lastAuthError?: string
     lastAuthErrorAt?: Date
     requiresReauth?: boolean
+    metadata?: unknown
   }
   onDismiss?: () => void
   className?: string
+}
+
+/**
+ * Detect Google Workspace RAPT (Reauthentication Policy Token) failures.
+ * These come from a Workspace admin policy that expires sessions for sensitive
+ * scopes, *not* a revoked refresh token — the user can keep reauthing daily
+ * forever unless their admin extends the Google Cloud session length.
+ *
+ * @see https://support.google.com/a/answer/9368756
+ */
+function isRaptFailure(integration: ReauthBannerProps['integration']): boolean {
+  if (integration.provider !== 'google') return false
+  const subtype = (integration.metadata as any)?.auth?.googleErrorSubtype
+  if (subtype === 'invalid_rapt') return true
+  const lastErr = integration.lastAuthError?.toLowerCase() ?? ''
+  return lastErr.includes('invalid_rapt') || lastErr.includes('reauth related error')
 }
 
 /**
@@ -90,6 +107,8 @@ export function ReauthBanner({ integration, onDismiss, className }: ReauthBanner
     return null
   }
 
+  const isRapt = isRaptFailure(integration)
+
   return (
     <>
       <Alert
@@ -128,8 +147,27 @@ export function ReauthBanner({ integration, onDismiss, className }: ReauthBanner
                   'text-red-800 dark:text-red-200',
                   isSmallScreen ? 'text-xs leading-relaxed' : 'text-sm'
                 )}>
-                Email sync has stopped working due to expired authentication. Please re-authenticate
-                to resume email processing.
+                {isRapt ? (
+                  <>
+                    Your Google Workspace admin enforces periodic re-authentication for this
+                    account. Reconnect now to resume sync — and to stop the recurring prompts, ask
+                    your Workspace admin to extend{' '}
+                    <a
+                      href='https://admin.google.com/ac/security/contextawareaccess/sessioncontrols'
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='underline font-medium'>
+                      Google Cloud session control
+                    </a>{' '}
+                    (Security → Access and data control) to{' '}
+                    <span className='font-medium'>Session never expires</span>.
+                  </>
+                ) : (
+                  <>
+                    Email sync has stopped working due to expired authentication. Please
+                    re-authenticate to resume email processing.
+                  </>
+                )}
               </AlertDescription>
 
               {/* Action Buttons */}

--- a/packages/lib/src/jobs/calendar/calendar-sync-job.ts
+++ b/packages/lib/src/jobs/calendar/calendar-sync-job.ts
@@ -1,9 +1,8 @@
 // packages/lib/src/jobs/calendar/calendar-sync-job.ts
 
-import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
-import { eq } from 'drizzle-orm'
+import { AuthErrorHandler } from '../../providers/auth-error-handler'
 import { syncCalendarForIntegration } from '../../recording/calendar'
 
 /**
@@ -41,8 +40,14 @@ export const calendarSyncJob = async (jobOrCtx: Job<CalendarSyncJobData>) => {
   })
 
   if (result.isErr()) {
-    if (isAuthError(result.error)) {
-      await markCalendarSyncAuthFailure(integrationId, result.error)
+    // refreshTokens already routes through AuthErrorHandler — re-invoking here
+    // would double-count consecutiveFailures. Only handle locally if the auth
+    // failure surfaced from a direct API call (e.g. events.list 401) that
+    // bypassed the refresh path.
+    const alreadyHandled = result.error.message.includes('Failed to refresh Google access token')
+    if (!alreadyHandled && isAuthError(result.error)) {
+      const handler = new AuthErrorHandler('google', integrationId)
+      await handler.handleAuthError(result.error, 'calendar_sync')
     }
 
     logger.error('Calendar sync job failed', {
@@ -53,6 +58,8 @@ export const calendarSyncJob = async (jobOrCtx: Job<CalendarSyncJobData>) => {
 
     throw result.error
   }
+
+  await AuthErrorHandler.resetFailureCounter(integrationId)
 
   logger.info('Calendar sync job completed', {
     jobId: job.id,
@@ -68,57 +75,20 @@ export const calendarSyncJob = async (jobOrCtx: Job<CalendarSyncJobData>) => {
 
 /**
  * Detect whether an error indicates authentication or consent failure.
+ * The AuthErrorHandler does the precise classification (invalid_rapt vs hard
+ * invalid_grant vs insufficient scope); this is just the gate that decides
+ * whether the error is even auth-shaped.
  */
 function isAuthError(error: Error): boolean {
   const message = error.message.toLowerCase()
   return (
     message.includes('invalid_grant') ||
+    message.includes('invalid_rapt') ||
+    message.includes('reauth related error') ||
     message.includes('insufficient permissions') ||
     message.includes('insufficient authentication scopes') ||
+    message.includes('insufficient_scope') ||
     message.includes('missing refresh token') ||
     message.includes('unauthorized')
   )
-}
-
-/**
- * Mark the integration as needing re-auth and disable future calendar scans.
- */
-async function markCalendarSyncAuthFailure(integrationId: string, error: Error): Promise<void> {
-  const integration = await db.query.Integration.findFirst({
-    where: (integrations, { eq }) => eq(integrations.id, integrationId),
-  })
-
-  if (!integration) {
-    return
-  }
-
-  const metadata = readMetadata(integration.metadata)
-  await db
-    .update(schema.Integration)
-    .set({
-      metadata: {
-        ...metadata,
-        calendarSyncEnabled: false,
-        calendarSyncToken: null,
-      },
-      requiresReauth: true,
-      authStatus: error.message.toLowerCase().includes('insufficient')
-        ? 'INSUFFICIENT_SCOPE'
-        : 'INVALID_GRANT',
-      lastAuthError: error.message,
-      lastAuthErrorAt: new Date(),
-      updatedAt: new Date(),
-    })
-    .where(eq(schema.Integration.id, integrationId))
-}
-
-/**
- * Normalize integration metadata into a mutable record.
- */
-function readMetadata(metadata: unknown): Record<string, unknown> {
-  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
-    return {}
-  }
-
-  return metadata as Record<string, unknown>
 }

--- a/packages/lib/src/jobs/maintenance/channel-token-refresh-job.ts
+++ b/packages/lib/src/jobs/maintenance/channel-token-refresh-job.ts
@@ -5,6 +5,7 @@ import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
 import { and, eq, isNull } from 'drizzle-orm'
+import { AuthErrorHandler } from '../../providers/auth-error-handler'
 import { GoogleOAuthService } from '../../providers/google/google-oauth'
 import { OutlookOAuthService } from '../../providers/outlook/outlook-oauth'
 import { ProviderRegistryService } from '../../providers/provider-registry-service'
@@ -84,7 +85,7 @@ export const channelTokenRefreshJob = async (
           logger.info('Successfully refreshed Outlook token', { integrationId })
         }
 
-        // Update auth status to healthy
+        // Update auth status to healthy and clear any prior failure streak
         await db
           .update(schema.Integration)
           .set({
@@ -92,6 +93,7 @@ export const channelTokenRefreshJob = async (
             updatedAt: new Date(),
           })
           .where(eq(schema.Integration.id, integrationId))
+        await AuthErrorHandler.resetFailureCounter(integrationId)
       } catch (error: any) {
         result.errors.push(`Token refresh failed: ${error.message}`)
         logger.error('Failed to refresh token', {

--- a/packages/lib/src/providers/auth-error-handler.ts
+++ b/packages/lib/src/providers/auth-error-handler.ts
@@ -122,7 +122,21 @@ export class AuthErrorHandler {
     }
     // Outlook-specific error parsing
     else if (this.providerId === 'outlook') {
-      if (errorMessage.includes('invalid_grant') || errorCode === 'invalid_grant') {
+      // OutlookProviderError carries a normalized `code` (see outlook-errors.ts).
+      // Match those first so MSAL-classified failures route correctly.
+      if (errorCode === 'INVALID_REFRESH_TOKEN') {
+        type = AuthErrorType.INVALID_GRANT
+        requiresReauth = true
+        retryable = false
+      } else if (errorCode === 'INSUFFICIENT_PERMISSIONS') {
+        type = AuthErrorType.INSUFFICIENT_SCOPE
+        requiresReauth = true
+        retryable = false
+      } else if (errorCode === 'TEMPORARY_ERROR') {
+        type = AuthErrorType.PROVIDER_ERROR
+        requiresReauth = false
+        retryable = true
+      } else if (errorMessage.includes('invalid_grant') || errorCode === 'invalid_grant') {
         type = AuthErrorType.INVALID_GRANT
         requiresReauth = true
         retryable = false
@@ -382,6 +396,12 @@ export class AuthErrorHandler {
           .set({
             metadata: updatedMetadata,
             authStatus: IntegrationAuthStatus.AUTHENTICATED,
+            // A successful refresh proves the credential works — clear the
+            // banner so the user isn't asked to reauth for a transient blip
+            // that has already self-recovered.
+            requiresReauth: false,
+            lastAuthError: null,
+            lastAuthErrorAt: null,
           })
           .where(eq(schema.Integration.id, integrationId))
 

--- a/packages/lib/src/providers/google/google-oauth.ts
+++ b/packages/lib/src/providers/google/google-oauth.ts
@@ -8,6 +8,7 @@ import { and, desc, eq } from 'drizzle-orm'
 import { type Common, google } from 'googleapis'
 import { InboxService } from '../../inboxes/inbox-service'
 import { SettingsService } from '../../settings/settings-service'
+import { AuthErrorHandler } from '../auth-error-handler'
 import { ChannelTokenAccessor, type ChannelTokens } from '../channel-token-accessor'
 import { PROVIDER_CREDENTIAL_CONFIG } from '../provider-credentials-config'
 
@@ -566,6 +567,7 @@ export class GoogleOAuthService {
       }
 
       await ChannelTokenAccessor.setTokens(integrationId, tokenUpdate)
+      await AuthErrorHandler.resetFailureCounter(integrationId)
 
       const [updatedIntegration] = await db
         .select()
@@ -575,29 +577,9 @@ export class GoogleOAuthService {
 
       return updatedIntegration
     } catch (error: any) {
-      logger.error('Error refreshing Google access token:', {
-        error: error.message,
-        response: error.response?.data,
-        integrationId,
-      })
-      if (error.response?.data?.error === 'invalid_grant') {
-        logger.warn('Refresh token is invalid or revoked. Disabling integration.', {
-          integrationId,
-        })
-        await db
-          .update(schema.Integration)
-          .set({
-            enabled: false,
-            requiresReauth: true,
-            lastAuthError: 'Refresh token is invalid or revoked',
-            lastAuthErrorAt: new Date(),
-            authStatus: 'INVALID_GRANT',
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.Integration.id, integrationId))
-        throw new Error('Google refresh token is invalid or revoked.')
-      }
-      throw new Error(`Failed to refresh Google access token: ${error.message}`)
+      const handler = new AuthErrorHandler('google', integrationId)
+      const details = await handler.handleAuthError(error, 'token_refresh')
+      throw new Error(`Failed to refresh Google access token: ${details.message}`)
     }
   }
 

--- a/packages/lib/src/providers/google/google-provider.ts
+++ b/packages/lib/src/providers/google/google-provider.ts
@@ -346,27 +346,37 @@ export class GoogleProvider
   }
   /** Checks token validity and attempts refresh if nearing expiry */
   private async checkTokenValidity(): Promise<void> {
-    if (!this.client || !this.integration?.expiresAt) return
+    if (!this.client || !this.integration?.expiresAt || !this.integrationId) return
     // Check if token is expired or nearing expiry (e.g., within 5 minutes)
     const buffer = 5 * 60 * 1000
-    if (this.integration.expiresAt.getTime() - buffer < Date.now()) {
-      logger.info('Google access token nearing expiry or expired, attempting refresh...', {
-        integrationId: this.integrationId,
-      })
-      try {
-        await this.client.getAccessToken() // Triggers 'tokens' event listener on successful refresh
-        logger.info('Google access token refreshed successfully during validity check.', {
-          integrationId: this.integrationId,
-        })
-      } catch (error: any) {
-        // Use standardized error handling
-        const { AuthErrorHandler } = await import('../auth-error-handler')
-        const errorHandler = new AuthErrorHandler('google', this.integrationId || 'unknown')
-        const errorDetails = await errorHandler.handleAuthError(error, 'token_refresh')
-        // Throw standardized error for upstream handling
-        throw new Error(`Failed to refresh Google access token: ${errorDetails.message}`)
-      }
+    if (this.integration.expiresAt.getTime() - buffer >= Date.now()) return
+
+    logger.info('Google access token nearing expiry or expired, attempting refresh...', {
+      integrationId: this.integrationId,
+    })
+
+    // Use GoogleOAuthService.refreshTokens — it awaits the encrypted-credential
+    // write before returning, unlike the OAuth client's `tokens` event listener
+    // which fires-and-forgets the persistence and risks the next API call
+    // hitting an `invalid_grant` against a stale in-memory token.
+    // Errors here are already routed through AuthErrorHandler inside refreshTokens.
+    await GoogleOAuthService.refreshTokens(this.integrationId)
+
+    // Reload the persisted tokens into the in-memory OAuth2 client so the
+    // upcoming Gmail API call uses the freshly-rotated access token.
+    const tokens = await ChannelTokenAccessor.getTokens(this.integrationId)
+    this.client.setCredentials({
+      refresh_token: tokens.refreshToken || undefined,
+      access_token: tokens.accessToken || undefined,
+      expiry_date: tokens.expiresAt ? tokens.expiresAt.getTime() : undefined,
+    })
+    if (this.integration) {
+      this.integration.expiresAt = tokens.expiresAt
     }
+
+    logger.info('Google access token refreshed successfully during validity check.', {
+      integrationId: this.integrationId,
+    })
   }
   /**
    * Sends an email using the Gmail API.

--- a/packages/lib/src/providers/outlook/outlook-oauth.ts
+++ b/packages/lib/src/providers/outlook/outlook-oauth.ts
@@ -9,6 +9,7 @@ import { ConfidentialClientApplication, LogLevel } from '@azure/msal-node'
 import { Client } from '@microsoft/microsoft-graph-client'
 import { eq } from 'drizzle-orm'
 import { InboxService } from '../../inboxes/inbox-service'
+import { AuthErrorHandler } from '../auth-error-handler'
 import { ChannelTokenAccessor } from '../channel-token-accessor'
 import { PROVIDER_CREDENTIAL_CONFIG } from '../provider-credentials-config'
 import { parseMsalError } from './outlook-errors'
@@ -534,6 +535,7 @@ export class OutlookOAuthService {
       }
 
       await ChannelTokenAccessor.setTokens(integrationId, tokenUpdate)
+      await AuthErrorHandler.resetFailureCounter(integrationId)
 
       const [updatedIntegration] = await db
         .select()
@@ -543,33 +545,8 @@ export class OutlookOAuthService {
       return updatedIntegration
     } catch (error) {
       const parsed = parseMsalError(error)
-
-      logger.error('Error refreshing Outlook access token:', {
-        error: parsed.message,
-        code: parsed.code,
-        integrationId,
-      })
-
-      if (parsed.code === 'INVALID_REFRESH_TOKEN') {
-        logger.warn('Outlook refresh token is invalid or revoked. Disabling integration.', {
-          integrationId,
-        })
-        await db
-          .update(schema.Integration)
-          .set({
-            enabled: false,
-            requiresReauth: true,
-            lastAuthError: parsed.message,
-            lastAuthErrorAt: new Date(),
-            authStatus: 'INVALID_GRANT',
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.Integration.id, integrationId))
-          .catch((dbErr: unknown) =>
-            logger.error('Failed to disable integration after invalid grant', { dbErr })
-          )
-      }
-
+      const handler = new AuthErrorHandler('outlook', integrationId)
+      await handler.handleAuthError(parsed, 'token_refresh')
       throw parsed
     }
   }
@@ -661,28 +638,16 @@ export class OutlookOAuthService {
           done(null, response.accessToken)
         } catch (error) {
           const parsed = parseMsalError(error)
-          logger.error('Error refreshing token in Graph authProvider:', {
-            error: parsed.message,
-            code: parsed.code,
-            integrationId,
-          })
-
-          if (parsed.code === 'INVALID_REFRESH_TOKEN') {
-            logger.warn('Refresh token invalid. Disabling integration.', { integrationId })
-            db.update(schema.Integration)
-              .set({
-                enabled: false,
-                requiresReauth: true,
-                lastAuthError: parsed.message,
-                lastAuthErrorAt: new Date(),
-                authStatus: 'INVALID_GRANT',
-                updatedAt: new Date(),
-              })
-              .where(eq(schema.Integration.id, integrationId))
-              .catch((dbErr: unknown) =>
-                logger.error('Failed to disable integration after invalid grant', { dbErr })
-              )
-          }
+          const handler = new AuthErrorHandler('outlook', integrationId)
+          // Fire-and-forget here is acceptable: the Graph authProvider callback
+          // signature requires a synchronous `done()` call; the handler write
+          // is best-effort and the surfaced error still triggers the caller's
+          // own retry/failure path.
+          handler
+            .handleAuthError(parsed, 'graph_auth_provider')
+            .catch((handlerErr: unknown) =>
+              logger.error('AuthErrorHandler failed in Graph authProvider', { handlerErr })
+            )
 
           done(parsed, null)
         }


### PR DESCRIPTION
## Summary

- Google and Outlook token-refresh failures now route through \`AuthErrorHandler\` instead of duplicating the inline disable/banner logic in each OAuth service and the calendar sync job — avoids double-counting \`consecutiveFailures\`.
- Successful refresh clears \`requiresReauth\` / \`lastAuthError\` so the banner disappears the moment the credential self-recovers (no more sticky banners after a transient blip).
- Detects Google Workspace RAPT (\`invalid_rapt\` / \"reauth related error\") and shows admin-targeted banner copy with a deep-link to Google's session control page — root-cause fix for users stuck reauthing daily.

## Refresh-path correctness fixes

- **Google**: \`checkTokenValidity\` now calls \`GoogleOAuthService.refreshTokens\` (awaits the encrypted-credential write) instead of the OAuth client's fire-and-forget \`tokens\` event listener, then reloads the persisted tokens into the in-memory client. Closes a window where the next Gmail call could hit \`invalid_grant\` against a stale in-memory token.
- **Outlook**: both \`OAuthService\` and the Graph \`authProvider\` delegate to \`AuthErrorHandler\` so disable/banner writes are consistent.

## Files

- \`packages/lib/src/providers/auth-error-handler.ts\` — Outlook normalized-code routing + clear-on-success
- \`packages/lib/src/providers/google/google-oauth.ts\` + \`google-provider.ts\`
- \`packages/lib/src/providers/outlook/outlook-oauth.ts\`
- \`packages/lib/src/jobs/calendar/calendar-sync-job.ts\` — delegate to handler, recognize RAPT
- \`packages/lib/src/jobs/maintenance/channel-token-refresh-job.ts\` — reset failure counter on success
- \`apps/web/src/components/global/reauth-banner.tsx\` — RAPT-specific copy
- \`apps/web/src/app/(protected)/app/settings/channels/_components/integration-tabs.tsx\` — pass \`metadata\` to banner

## Test plan

- [ ] Trigger a Google refresh failure (revoked refresh token) → integration disabled, banner appears with standard copy
- [ ] Trigger a Google RAPT failure (Workspace policy) → banner shows admin-targeted copy with the session control link
- [ ] Successful refresh after a prior failure → banner clears, \`consecutiveFailures\` resets
- [ ] Trigger an Outlook \`INVALID_REFRESH_TOKEN\` → integration disabled
- [ ] Calendar sync job: API-level 401 (not refresh) → handler counts once, doesn't double-count

🤖 Generated with [Claude Code](https://claude.com/claude-code)