### PR TITLE
feat(extension): allow multiple extension IDs (Web Store + local unpacked)

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -46,18 +46,25 @@ running with `DOMAIN` set (any value — it flips `SameSite=None; Secure` on
 the session cookie). In `apps/web/.env.local`:
 
 ```bash
-# Extension ID derived from manifest "key" (see below)
-NEXT_PUBLIC_EXTENSION_ID=<your-extension-id>
+# Extension ID(s) the web app accepts via CORS / frame-ancestors.
+# Comma-separated so the Web Store ID and a local unpacked dev ID can coexist.
+# Find each ID at chrome://extensions on the relevant install.
+NEXT_PUBLIC_EXTENSION_ID=<web-store-id>,<local-unpacked-id>
 # Flip session cookie to SameSite=None; Secure so chrome-extension:// can read it
 DOMAIN=localhost
 ```
 
-### Pinned extension ID
+### Extension IDs (Web Store vs local unpacked)
 
-The manifest already has a stable `key` baked in, so the extension ID is the
-same in dev, staging, prod, and the Web Store. The matching private `.pem`
-must be kept somewhere safe (1Password / shared vault) — losing it means
-losing the ability to publish updates under the same extension ID.
+The committed manifest has a stable `key` baked in, so the unpacked dev
+install always derives the same ID across machines. The Web Store assigns
+its own ID at publish time (the packaging script strips `key` before upload),
+so the published ID generally differs from the unpacked one. Both are
+supported simultaneously via the comma-separated `NEXT_PUBLIC_EXTENSION_ID`.
+
+The matching private `.pem` for the unpacked `key` must be kept somewhere
+safe (1Password / shared vault) — losing it changes the unpacked ID for
+every developer.
 
 If you ever need to regenerate (only if the private key is lost AND we accept
 a new extension ID):
@@ -230,9 +237,9 @@ and zipped `dist/` manually. Run `pnpm package` instead.
 rejects re-uploads with the same version string.
 
 **Iframe shows "Sign in to Auxx.ai"** — the bearer-token mint failed. Confirm
-you're logged into auxx.ai in the same browser profile, and that
-`NEXT_PUBLIC_EXTENSION_ID` matches the actual loaded extension ID
-(`chrome://extensions` → copy the ID under the Auxx.ai card).
+you're logged into auxx.ai in the same browser profile, and that the loaded
+extension's ID is included in `NEXT_PUBLIC_EXTENSION_ID` (comma-separated;
+copy the ID from `chrome://extensions` and add it to the list).
 
 **Content script not loading after a manifest change** — reload the
 extension card on `chrome://extensions` AND reload the host page. Manifest

--- a/apps/web/src/app/api/extension/embed-token/route.ts
+++ b/apps/web/src/app/api/extension/embed-token/route.ts
@@ -23,8 +23,13 @@ import { auth } from '~/auth/server'
  * via CORS, then handed off through a URL query param consumed once.
  */
 
-const EXTENSION_ID = configService.get<string>('NEXT_PUBLIC_EXTENSION_ID') ?? ''
-const EXTENSION_ORIGIN = EXTENSION_ID ? `chrome-extension://${EXTENSION_ID}` : null
+const EXTENSION_ORIGINS = new Set(
+  (configService.get<string>('NEXT_PUBLIC_EXTENSION_ID') ?? '')
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean)
+    .map((id) => `chrome-extension://${id}`)
+)
 
 const SECURE_COOKIE_PREFIX = '__Secure-'
 const SESSION_COOKIE_NAMES = [
@@ -33,7 +38,7 @@ const SESSION_COOKIE_NAMES = [
 ]
 
 function corsHeaders(origin: string | null): Record<string, string> {
-  if (!origin || origin !== EXTENSION_ORIGIN) return {}
+  if (!origin || !EXTENSION_ORIGINS.has(origin)) return {}
   return {
     'Access-Control-Allow-Origin': origin,
     'Access-Control-Allow-Credentials': 'true',

--- a/apps/web/src/app/api/extension/session/route.ts
+++ b/apps/web/src/app/api/extension/session/route.ts
@@ -19,11 +19,16 @@ import { auth } from '~/auth/server'
  * the Redis-backed cache. Called once per iframe mount — not on a timer.
  */
 
-const EXTENSION_ID = configService.get<string>('NEXT_PUBLIC_EXTENSION_ID') ?? ''
-const EXTENSION_ORIGIN = EXTENSION_ID ? `chrome-extension://${EXTENSION_ID}` : null
+const EXTENSION_ORIGINS = new Set(
+  (configService.get<string>('NEXT_PUBLIC_EXTENSION_ID') ?? '')
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean)
+    .map((id) => `chrome-extension://${id}`)
+)
 
 function corsHeaders(origin: string | null): Record<string, string> {
-  if (!origin || origin !== EXTENSION_ORIGIN) return {}
+  if (!origin || !EXTENSION_ORIGINS.has(origin)) return {}
   return {
     'Access-Control-Allow-Origin': origin,
     'Access-Control-Allow-Credentials': 'true',

--- a/apps/web/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/web/src/app/api/trpc/[trpc]/route.ts
@@ -6,13 +6,18 @@ import type { NextRequest } from 'next/server'
 import { appRouter } from '~/server/api/root'
 import { createTRPCContext } from '~/server/api/trpc'
 
-const EXTENSION_ID = configService.get<string>('NEXT_PUBLIC_EXTENSION_ID') ?? ''
-const EXTENSION_ORIGIN = EXTENSION_ID ? `chrome-extension://${EXTENSION_ID}` : null
+const EXTENSION_ORIGINS = new Set(
+  (configService.get<string>('NEXT_PUBLIC_EXTENSION_ID') ?? '')
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean)
+    .map((id) => `chrome-extension://${id}`)
+)
 
 /** Headers that allow the Auxx Chrome extension to call tRPC with credentials. */
 function buildCorsHeaders(origin: string | null): Record<string, string> {
   if (!origin) return {}
-  if (origin !== EXTENSION_ORIGIN) return {}
+  if (!EXTENSION_ORIGINS.has(origin)) return {}
   return {
     'Access-Control-Allow-Origin': origin,
     'Access-Control-Allow-Credentials': 'true',

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -69,14 +69,21 @@ const EXTENSION_HOST_FRAME_ANCESTORS = [
 
 /**
  * Allowed `frame-ancestors` for the extension's embed iframe. CSP doesn't
- * allow wildcards on the chrome-extension scheme, so the published Web Store
- * ID is listed explicitly. Unpacked dev installs reuse the same ID via the
- * manifest's `key`, so a single env var covers both surfaces.
+ * allow wildcards on the chrome-extension scheme, so each allowed extension
+ * ID is listed explicitly. `NEXT_PUBLIC_EXTENSION_ID` is comma-separated so
+ * the Web Store ID and a local unpacked dev ID can coexist.
  */
-const EXTENSION_ID = process.env.NEXT_PUBLIC_EXTENSION_ID ?? ''
-const EMBED_FRAME_ANCESTORS = EXTENSION_ID
-  ? [`chrome-extension://${EXTENSION_ID}`, ...EXTENSION_HOST_FRAME_ANCESTORS].join(' ')
-  : ''
+const EXTENSION_IDS = (process.env.NEXT_PUBLIC_EXTENSION_ID ?? '')
+  .split(',')
+  .map((id) => id.trim())
+  .filter(Boolean)
+const EMBED_FRAME_ANCESTORS =
+  EXTENSION_IDS.length > 0
+    ? [
+        ...EXTENSION_IDS.map((id) => `chrome-extension://${id}`),
+        ...EXTENSION_HOST_FRAME_ANCESTORS,
+      ].join(' ')
+    : ''
 
 export async function proxy(req: NextRequest) {
   const { pathname, search } = req.nextUrl


### PR DESCRIPTION
## Summary

- \`NEXT_PUBLIC_EXTENSION_ID\` is now comma-separated, so the published Web Store ID and a local unpacked dev install can both be authorized at the same time.
- The Web Store assigns its own ID at publish time (the packaging script strips the manifest \`key\`), so the published ID generally differs from the unpacked one. Previously developers had to choose between dev and prod auth.

## Files

- \`apps/extension/README.md\` — env-var docs + troubleshooting note
- \`apps/web/src/app/api/extension/embed-token/route.ts\` — CORS allow-list
- \`apps/web/src/app/api/extension/session/route.ts\` — CORS allow-list
- \`apps/web/src/app/api/trpc/[trpc]/route.ts\` — CORS allow-list
- \`apps/web/src/proxy.ts\` — CSP frame-ancestors

## Test plan

- [ ] Set \`NEXT_PUBLIC_EXTENSION_ID=<web-store-id>,<unpacked-id>\` and verify both extensions can mint embed tokens, hit tRPC, and load the iframe
- [ ] Set only the Web Store ID; the unpacked install fails CORS as expected
- [ ] Empty value: extensions cannot call protected endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)