### PR TITLE
chore(kopilot): improve assignee resolution for create_task

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/tasks/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/tasks/index.ts
@@ -9,7 +9,7 @@ export function createTaskCapabilities(getDeps: GetToolDeps): PageCapability {
     page: '__global__',
     tools: [createListTasksTool(getDeps), createCreateTaskTool(getDeps)],
     systemPromptAddition:
-      'You can create and search tasks. Tasks have a title, optional description, deadline (natural language like "next Friday", "in 3 days", "end of week"), priority (low/medium/high), and can be assigned to users or groups. Before creating a task: use list_members to find assignee IDs for specific people, and use search_entities to find linkedRecordIds for any referenced entities (e.g. products, orders, contacts mentioned in the task).',
+      'You can create and search tasks. Tasks have a title, optional description, deadline (natural language like "next Friday", "in 3 days", "end of week"), priority (low/medium/high), and can be assigned to users or groups. Resolving names for a task: (1) call list_members first to find assignee IDs for workspace members, (2) if a name does not match any member, call search_entities — the person is likely a contact (or the subject is a company/order/etc.). When search_entities returns a match, pass its recordId to linkedRecordIds and leave assigneeIds empty so the task is assigned to the current user. Only ask the user to clarify if both list_members and search_entities come back empty. Always use search_entities for any other referenced records mentioned in the task (products, orders, etc.).',
     capabilities: ['Create and search tasks'],
   }
 }

--- a/packages/lib/src/ai/kopilot/capabilities/tasks/tools/create-task.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/tasks/tools/create-task.ts
@@ -13,7 +13,7 @@ export function createCreateTaskTool(getDeps: GetToolDeps): AgentToolDefinition 
   return {
     name: 'create_task',
     description:
-      'Create a new task. Before calling: use list_members to find user IDs for assignment, and use search_entities to find linkedRecordIds for any referenced entities (products, orders, contacts, etc.). Supports natural language deadlines like "next Friday", "in 3 days", "end of week".',
+      'Create a new task. Resolving names: try list_members first for the assignee. If the name does not match any workspace member, fall back to search_entities — they are likely a contact (or the subject is a company/record). Pass the matched recordId to linkedRecordIds and leave assigneeIds empty so the task is assigned to the current user. Use search_entities for any other referenced records (products, orders, etc.). Supports natural language deadlines like "next Friday", "in 3 days", "end of week".',
     requiresApproval: true,
     usageNotes: "Emits an `action-result` block automatically. Don't re-embed anything for it.",
     parameters: {


### PR DESCRIPTION
## Summary

Tightens the \`create_task\` prompt and tool description so the model:

1. Tries \`list_members\` first for the assignee name
2. Falls back to \`search_entities\` when no workspace member matches — the named person is likely a contact, or the subject is an entity (company/order/etc.)
3. Uses the matched \`recordId\` as \`linkedRecordIds\` and leaves \`assigneeIds\` empty, so the task is assigned to the current user

## Why

Cuts down on cases where the model gives up or asks for clarification when the name is a contact rather than a teammate.

## Test plan

- [ ] \"Create a task for Jane Doe to follow up\" where Jane is a contact → linked to the contact, assigned to current user
- [ ] \"Create a task for Bob to review\" where Bob is a workspace member → assigned to Bob
- [ ] Name matches neither → model asks for clarification

🤖 Generated with [Claude Code](https://claude.com/claude-code)