### PR TITLE
feat: kopilot LLM-rendered blocks + mail Ignore-from + chat scroll pin

### DIFF
--- a/apps/web/src/components/kopilot/ui/kopilot-chat.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-chat.tsx
@@ -10,7 +10,7 @@ import { useKopilotStore } from '../stores/kopilot-store'
 import './blocks/register-blocks'
 import { api } from '~/trpc/react'
 import { KopilotComposer, type KopilotComposerHandle } from './kopilot-composer'
-import { KopilotMessageList } from './kopilot-message-list'
+import { KopilotMessageList, type KopilotMessageListHandle } from './kopilot-message-list'
 import { KopilotStatusBar } from './kopilot-status-bar'
 
 export interface KopilotChatProps {
@@ -41,6 +41,7 @@ export function KopilotChat({
   const addMessage = useKopilotStore((s) => s.addMessage)
 
   const composerRef = useRef<KopilotComposerHandle>(null)
+  const messageListRef = useRef<KopilotMessageListHandle>(null)
   const [pendingRequest, setPendingRequest] = useState<KopilotRequest | null>(null)
 
   // SSE hook
@@ -148,6 +149,7 @@ export function KopilotChat({
   return (
     <>
       <KopilotMessageList
+        ref={messageListRef}
         contentClassName={contentClassName}
         onApprovalAction={handleApprovalAction}
         onEditMessage={handleEditMessage}

--- a/apps/web/src/components/kopilot/ui/kopilot-message-list.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-message-list.tsx
@@ -7,9 +7,17 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { cn } from '@auxx/ui/lib/utils'
 import { ArrowDown } from 'lucide-react'
 import { motion } from 'motion/react'
-import { useCallback, useEffect, useRef } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import type { KopilotRequest } from '../hooks/use-kopilot-sse'
-import { useKopilotStore } from '../stores/kopilot-store'
+import { type KopilotMessage, useKopilotStore } from '../stores/kopilot-store'
 import { getApprovalCard } from './blocks/approval-card-registry'
 import { AuxxBlock } from './blocks/auxx-block'
 import { GenericApprovalCard } from './blocks/generic-approval-card'
@@ -20,7 +28,13 @@ import { ThinkingSteps } from './messages/thinking-steps'
 import { UserMessage } from './messages/user-message'
 import { SparkleIcon } from './sparkle-icon'
 
+export interface KopilotMessageListHandle {
+  pinNewestTurn: (behavior?: ScrollBehavior) => void
+  scrollToBottom: (behavior?: ScrollBehavior) => void
+}
+
 interface KopilotMessageListProps {
+  ref?: React.Ref<KopilotMessageListHandle>
   onApprovalAction: (request: KopilotRequest) => void
   onEditMessage?: (messageId: string) => void
   onRetryMessage?: (messageId: string) => void
@@ -30,7 +44,43 @@ interface KopilotMessageListProps {
   contentClassName?: string
 }
 
+interface TurnGroup {
+  key: string
+  messages: KopilotMessage[]
+}
+
+/**
+ * Subtracted from the viewport height when inflating the last turn group's
+ * min-height. Accounts for the inner container's vertical padding (p-4 → 32)
+ * so the freshly-pinned user message lands at its natural padding-top inset
+ * (~16px below the viewport top, clear of the top fade mask).
+ */
+const PIN_INFLATE_OFFSET = 32
+
+/**
+ * Group consecutive messages into turn groups: a turn starts at each user
+ * message and absorbs every following non-user message until the next user.
+ */
+function groupTurns(messages: KopilotMessage[]): TurnGroup[] {
+  const groups: TurnGroup[] = []
+  let current: TurnGroup | null = null
+  for (const m of messages) {
+    if (m.role === 'user') {
+      current = { key: m.id, messages: [m] }
+      groups.push(current)
+    } else {
+      if (!current) {
+        current = { key: m.id, messages: [] }
+        groups.push(current)
+      }
+      current.messages.push(m)
+    }
+  }
+  return groups
+}
+
 export function KopilotMessageList({
+  ref,
   onApprovalAction,
   onEditMessage,
   onRetryMessage,
@@ -50,32 +100,144 @@ export function KopilotMessageList({
   const activeThinkingGroupId = useKopilotStore((s) => s.activeThinkingGroupId)
   const activeThinkingGroup = activeThinkingGroupId ? thinkingGroups[activeThinkingGroupId] : null
 
-  const viewportRef = useRef<HTMLDivElement>(null)
+  const [viewportEl, setViewportElState] = useState<HTMLDivElement | null>(null)
   const isAtBottom = useRef(true)
+  const [showScrollDown, setShowScrollDown] = useState(false)
+  const [viewportPx, setViewportPx] = useState<number | null>(null)
+  const [inflateLast, setInflateLast] = useState(() => messages.length <= 1)
+  const [pinTick, setPinTick] = useState(0)
+  const pinBehaviorRef = useRef<ScrollBehavior>('smooth')
+  const lastUserIdRef = useRef<string | null>(null)
+  const prevLenRef = useRef(0)
+  const sessionMountedRef = useRef(false)
 
-  // Track scroll position to know if user is at the bottom
+  // Callback ref so viewport setup re-runs whenever the scroll node mounts/unmounts
+  // (the empty-state branch unmounts the ScrollArea, so this matters).
+  const setViewportRef = useCallback((node: HTMLDivElement | null) => {
+    setViewportElState(node)
+    if (node) setViewportPx(node.clientHeight)
+  }, [])
+
+  const visibleMessages = useMemo(() => {
+    if (!editingMessageId) return messages
+    const editIndex = messages.findIndex((m) => m.id === editingMessageId)
+    if (editIndex === -1) return messages
+    return messages.slice(0, editIndex)
+  }, [messages, editingMessageId])
+
+  const groups = useMemo(() => groupTurns(visibleMessages), [visibleMessages])
+  const showEmptyState = messages.length === 0 && !isStreaming
+
+  // Track scroll position + observe viewport size; keyed on the actual node.
   useEffect(() => {
-    const vp = viewportRef.current
-    if (!vp) return
+    if (!viewportEl) return
+    setViewportPx(viewportEl.clientHeight)
+
+    // ResizeObserver fires per layout tick; coalesce to one rAF so dragging
+    // the window edge doesn't trigger a render storm.
+    let rafId = 0
+    let lastPx = viewportEl.clientHeight
+    const ro = new ResizeObserver(() => {
+      if (rafId) cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(() => {
+        rafId = 0
+        const next = viewportEl.clientHeight
+        if (next !== lastPx) {
+          lastPx = next
+          setViewportPx(next)
+        }
+      })
+    })
+    ro.observe(viewportEl)
+
     const onScroll = () => {
-      isAtBottom.current = vp.scrollHeight - vp.scrollTop - vp.clientHeight < 20
+      const distance = viewportEl.scrollHeight - viewportEl.scrollTop - viewportEl.clientHeight
+      isAtBottom.current = distance < 20
+      setShowScrollDown(distance >= 20)
     }
-    vp.addEventListener('scroll', onScroll, { passive: true })
-    return () => vp.removeEventListener('scroll', onScroll)
-  }, [])
+    viewportEl.addEventListener('scroll', onScroll, { passive: true })
 
-  // Auto-scroll when new messages arrive or streaming updates
+    // First-paint: snap to bottom of the existing transcript.
+    viewportEl.scrollTo({ top: viewportEl.scrollHeight })
+
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId)
+      ro.disconnect()
+      viewportEl.removeEventListener('scroll', onScroll)
+    }
+  }, [viewportEl])
+
+  // Follow the stream: stay pinned to bottom while content grows, if user was at bottom.
+  // messages/streamingContent are trigger-only deps — we don't read them inside.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: trigger-only deps
   useEffect(() => {
-    if (isAtBottom.current && viewportRef.current) {
-      viewportRef.current.scrollTop = viewportRef.current.scrollHeight
+    if (!viewportEl) return
+    if (isAtBottom.current) {
+      viewportEl.scrollTop = viewportEl.scrollHeight
     }
-  }, [messages, streamingContent])
+    const distance = viewportEl.scrollHeight - viewportEl.scrollTop - viewportEl.clientHeight
+    setShowScrollDown(distance >= 20)
+  }, [messages, streamingContent, viewportEl])
 
-  const scrollToBottom = useCallback(() => {
-    if (viewportRef.current) {
-      viewportRef.current.scrollTo({ top: viewportRef.current.scrollHeight, behavior: 'smooth' })
+  // Deflate when switching sessions (not on initial mount). activeSessionId
+  // is intentionally a trigger-only dep — we don't read it inside the effect.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: trigger-only dep
+  useEffect(() => {
+    if (!sessionMountedRef.current) {
+      sessionMountedRef.current = true
+      return
     }
+    setInflateLast(false)
+  }, [activeSessionId])
+
+  // Pin scroll: runs after the inflated min-height commits to layout, so
+  // scrollHeight reflects the fully-grown last group. Intentionally NOT
+  // dependent on viewportPx — we only want to scroll on actual pin events,
+  // not on every resize tick.
+  useLayoutEffect(() => {
+    if (pinTick === 0) return
+    if (!viewportEl) return
+    viewportEl.scrollTo({ top: viewportEl.scrollHeight, behavior: pinBehaviorRef.current })
+  }, [pinTick, viewportEl])
+
+  const pinNewestTurn = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    pinBehaviorRef.current = behavior
+    setInflateLast(true)
+    setPinTick((t) => t + 1)
   }, [])
+
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior = 'smooth') => {
+      if (!viewportEl) return
+      viewportEl.scrollTo({ top: viewportEl.scrollHeight, behavior })
+    },
+    [viewportEl]
+  )
+
+  // Detect fresh user submissions (composer / suggestion / any other addMessage path)
+  // and pin the new turn to the top of the viewport.
+  useEffect(() => {
+    let lastUserId: string | null = null
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]!.role === 'user') {
+        lastUserId = messages[i]!.id
+        break
+      }
+    }
+    const grew = messages.length === prevLenRef.current + 1
+
+    if (grew && lastUserId && lastUserId !== lastUserIdRef.current) {
+      pinNewestTurn('smooth')
+    }
+
+    lastUserIdRef.current = lastUserId
+    prevLenRef.current = messages.length
+  }, [messages, pinNewestTurn])
+
+  useImperativeHandle(ref, () => ({ pinNewestTurn, scrollToBottom }), [
+    pinNewestTurn,
+    scrollToBottom,
+  ])
 
   const handleApproval = useCallback(
     (
@@ -100,129 +262,153 @@ export function KopilotMessageList({
     [activeSessionId, messages, updateMessage, onApprovalAction]
   )
 
-  if (messages.length === 0 && !isStreaming) {
+  const renderMessage = (message: KopilotMessage): React.ReactNode => {
+    const parentKey = message.parentId ?? 'root'
+    const siblings = childrenMap[parentKey] ?? []
+    const hasBranches = siblings.length > 1
+
+    let messageEl: React.ReactNode = null
+
+    if (message.approval) {
+      const ApprovalCard = getApprovalCard(message.approval.toolName) ?? GenericApprovalCard
+      messageEl = (
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95, y: 8 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          transition={{ type: 'spring', stiffness: 400, damping: 25 }}>
+          <ApprovalCard
+            toolName={message.approval.toolName}
+            toolCallId={message.approval.toolCallId}
+            args={message.approval.args}
+            status={message.approval.status}
+            onApprove={(inputAmendment) => handleApproval(message.id, 'approved', inputAmendment)}
+            onReject={() => handleApproval(message.id, 'rejected')}
+          />
+        </motion.div>
+      )
+    } else {
+      switch (message.role) {
+        case 'user':
+          messageEl = (
+            <UserMessage
+              message={message}
+              onEdit={onEditMessage ? () => onEditMessage(message.id) : undefined}
+              onRetry={onRetryMessage ? () => onRetryMessage(message.id) : undefined}
+            />
+          )
+          break
+        case 'assistant':
+          messageEl = (
+            <AssistantMessage
+              message={message}
+              feedback={message.feedback}
+              onThumbsUp={onFeedback ? () => onFeedback(message.id, true) : undefined}
+              onThumbsDown={onFeedback ? () => onFeedback(message.id, false) : undefined}
+            />
+          )
+          break
+        case 'tool':
+          return null
+        case 'block':
+          if (!message.block) return null
+          messageEl = <AuxxBlock type={message.block.type} data={message.block.data} />
+          break
+        default:
+          break
+      }
+    }
+
+    if (!messageEl) return null
+
+    return (
+      <div key={message.id}>
+        {messageEl}
+        {hasBranches && !isStreaming && (
+          <BranchNavigator
+            currentChildId={message.id}
+            siblings={siblings}
+            onNavigate={(childId) => setActiveBranch(parentKey, childId)}
+          />
+        )}
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
     return <KopilotEmptyState onSuggestionClick={onSuggestionClick} />
   }
 
+  const showOrphanStreaming = groups.length === 0 && isStreaming
+
   return (
-    <ScrollArea viewportRef={viewportRef} className='flex-1'>
-      <div className={cn('space-y-3 p-4 pr-5!', contentClassName)}>
-        {messages.map((message, index) => {
-          // During editing, hide the edited message and everything after it
-          if (editingMessageId) {
-            const editIndex = messages.findIndex((m) => m.id === editingMessageId)
-            if (editIndex !== -1 && index >= editIndex) return null
-          }
-
-          const parentKey = message.parentId ?? 'root'
-          const siblings = childrenMap[parentKey] ?? []
-          const hasBranches = siblings.length > 1
-
-          let messageEl: React.ReactNode = null
-
-          if (message.approval) {
-            const ApprovalCard = getApprovalCard(message.approval.toolName) ?? GenericApprovalCard
-            messageEl = (
-              <motion.div
-                initial={{ opacity: 0, scale: 0.95, y: 8 }}
-                animate={{ opacity: 1, scale: 1, y: 0 }}
-                transition={{ type: 'spring', stiffness: 400, damping: 25 }}>
-                <ApprovalCard
-                  key={message.id}
-                  toolName={message.approval.toolName}
-                  toolCallId={message.approval.toolCallId}
-                  args={message.approval.args}
-                  status={message.approval.status}
-                  onApprove={(inputAmendment) =>
-                    handleApproval(message.id, 'approved', inputAmendment)
-                  }
-                  onReject={() => handleApproval(message.id, 'rejected')}
-                />
-              </motion.div>
-            )
-          } else {
-            switch (message.role) {
-              case 'user':
-                messageEl = (
-                  <UserMessage
-                    key={message.id}
-                    message={message}
-                    onEdit={onEditMessage ? () => onEditMessage(message.id) : undefined}
-                    onRetry={onRetryMessage ? () => onRetryMessage(message.id) : undefined}
-                  />
-                )
-                break
-              case 'assistant':
-                messageEl = (
-                  <AssistantMessage
-                    key={message.id}
-                    message={message}
-                    feedback={message.feedback}
-                    onThumbsUp={onFeedback ? () => onFeedback(message.id, true) : undefined}
-                    onThumbsDown={onFeedback ? () => onFeedback(message.id, false) : undefined}
-                  />
-                )
-                break
-              case 'tool':
-                // Tool messages are now shown in ThinkingSteps, not as individual messages
-                return null
-              case 'block':
-                if (!message.block) return null
-                messageEl = (
-                  <AuxxBlock key={message.id} type={message.block.type} data={message.block.data} />
-                )
-                break
-              default:
-                break
-            }
-          }
-
-          if (!messageEl) return null
-
-          return (
-            <div key={message.id}>
-              {messageEl}
-              {hasBranches && !isStreaming && (
-                <BranchNavigator
-                  currentChildId={message.id}
-                  siblings={siblings}
-                  onNavigate={(childId) => setActiveBranch(parentKey, childId)}
-                />
-              )}
-            </div>
-          )
-        })}
-
-        {/* Show thinking steps while executor is running (before responder streams) */}
-        {isStreaming &&
-          !streamingContent &&
-          activeThinkingGroup &&
-          activeThinkingGroup.steps.length > 0 && (
-            <div className='flex gap-2'>
-              <SparkleIcon />
-              <div className='min-w-0 flex-1'>
-                <ThinkingSteps group={activeThinkingGroup} />
+    <div className='relative flex min-h-0 flex-1 flex-col'>
+      <ScrollArea viewportRef={setViewportRef} className='min-h-0 flex-1'>
+        <div className={cn('flex flex-col gap-3 p-4 pr-5!', contentClassName)}>
+          {groups.map((group, i) => {
+            const isLast = i === groups.length - 1
+            const minH =
+              isLast && inflateLast && viewportPx !== null
+                ? `${viewportPx - PIN_INFLATE_OFFSET}px`
+                : undefined
+            return (
+              <div
+                key={group.key}
+                className='flex flex-col gap-3'
+                style={minH ? { minHeight: minH } : undefined}>
+                {group.messages.map((m) => renderMessage(m))}
+                {isLast &&
+                  isStreaming &&
+                  !streamingContent &&
+                  activeThinkingGroup &&
+                  activeThinkingGroup.steps.length > 0 && (
+                    <div className='flex gap-2'>
+                      <SparkleIcon />
+                      <div className='min-w-0 flex-1'>
+                        <ThinkingSteps group={activeThinkingGroup} />
+                      </div>
+                    </div>
+                  )}
+                {isLast && isStreaming && streamingContent && (
+                  <AssistantMessage streamingContent={streamingContent} />
+                )}
               </div>
+            )
+          })}
+          {showOrphanStreaming && (
+            <div
+              className='flex flex-col gap-3'
+              style={
+                inflateLast && viewportPx !== null
+                  ? { minHeight: `${viewportPx - PIN_INFLATE_OFFSET}px` }
+                  : undefined
+              }>
+              {!streamingContent && activeThinkingGroup && activeThinkingGroup.steps.length > 0 && (
+                <div className='flex gap-2'>
+                  <SparkleIcon />
+                  <div className='min-w-0 flex-1'>
+                    <ThinkingSteps group={activeThinkingGroup} />
+                  </div>
+                </div>
+              )}
+              {streamingContent && <AssistantMessage streamingContent={streamingContent} />}
             </div>
           )}
+        </div>
+      </ScrollArea>
 
-        {/* Streaming assistant message (responder output) */}
-        {isStreaming && streamingContent && (
-          <AssistantMessage streamingContent={streamingContent} />
-        )}
-      </div>
-
-      {/* Scroll to bottom — visible only when BaseScrollArea sets data-overflow-y-end */}
-      <div className='pointer-events-none sticky bottom-2 flex justify-center opacity-0 transition-opacity duration-300 [[data-overflow-y-end]_&]:pointer-events-auto [[data-overflow-y-end]_&]:opacity-100'>
-        <Button
-          size='sm'
-          variant='outline'
-          className='h-7 gap-1 rounded-full shadow-md'
-          onClick={scrollToBottom}>
-          <ArrowDown className='size-3' />
-          New messages
-        </Button>
-      </div>
-    </ScrollArea>
+      {/* Scroll to bottom — overlays the ScrollArea, doesn't contribute to scrollHeight */}
+      {showScrollDown && (
+        <div className='pointer-events-none absolute inset-x-0 bottom-2 flex justify-center'>
+          <Button
+            size='sm'
+            variant='outline'
+            className='pointer-events-auto h-7 gap-1 rounded-full shadow-md'
+            onClick={() => scrollToBottom('smooth')}>
+            <ArrowDown className='size-3' />
+            New messages
+          </Button>
+        </div>
+      )}
+    </div>
   )
 }

--- a/apps/web/src/components/mail/email-display.tsx
+++ b/apps/web/src/components/mail/email-display.tsx
@@ -33,7 +33,12 @@ import { AnimatePresence, motion } from 'motion/react'
 import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AttachmentDisplay } from '~/components/files/utils/attachment-display'
-import { useMessage, useMessageParticipants, useThreadReadStatus } from '~/components/threads/hooks'
+import {
+  useMessage,
+  useMessageParticipants,
+  useThread,
+  useThreadReadStatus,
+} from '~/components/threads/hooks'
 import type { MessageMeta } from '~/components/threads/store'
 import { api } from '~/trpc/react'
 import { Tooltip } from '../global/tooltip'
@@ -68,6 +73,12 @@ const EmailDisplay = ({ messageId, messageActions, isOpen, isLastMessage }: Emai
 
   // Fetch message from store
   const { message, isLoading } = useMessage({ messageId })
+
+  // Resolve thread to surface integrationId for the participant "Ignore from" submenu
+  const { thread } = useThread({
+    threadId: message?.threadId ?? null,
+    enabled: !!message?.threadId,
+  })
 
   // Get read status mutation for this thread
   const { markAsUnread } = useThreadReadStatus(message?.threadId ?? null)
@@ -239,7 +250,11 @@ const EmailDisplay = ({ messageId, messageActions, isOpen, isLastMessage }: Emai
                   e.stopPropagation()
                 }
               }}>
-              <ParticipantList participants={participantEntries} />
+              <ParticipantList
+                participants={participantEntries}
+                integrationId={thread?.integrationId}
+                threadId={message.threadId}
+              />
               <AnimatePresence initial={false}>
                 {selected && (
                   <motion.div

--- a/apps/web/src/components/mail/participant-display.tsx
+++ b/apps/web/src/components/mail/participant-display.tsx
@@ -1,14 +1,24 @@
 // apps/web/src/components/mail/participant-display.tsx
 'use client'
 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
 import { titleize } from '@auxx/utils/strings'
+import { Ban, Copy, User } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import React from 'react'
-import { ContactHoverCard } from '~/components/contacts/contact-hover-card'
-import { useParticipant } from '~/components/threads/hooks'
+import { useParticipant, useThreadMutation } from '~/components/threads/hooks'
 import type { ParticipantMeta } from '~/components/threads/store'
+import { api } from '~/trpc/react'
 
 /** Role types for message participants */
 type ParticipantRole = 'FROM' | 'TO' | 'CC' | 'BCC'
@@ -28,6 +38,10 @@ interface ParticipantDisplayProps {
   className?: string
   /** Control whether to show the email/phone details */
   showDetails?: boolean
+  /** Channel integration ID — required to enable "Ignore from" on FROM participants */
+  integrationId?: string
+  /** Thread ID — used to flip the thread to IGNORED on successful sender exclusion */
+  threadId?: string
 }
 
 /**
@@ -40,6 +54,8 @@ export const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({
   role,
   className,
   showDetails = true,
+  integrationId,
+  threadId,
 }) => {
   // Fetch from store only if participant object not provided
   const { participant: fetchedParticipant, isLoading } = useParticipant({
@@ -50,16 +66,14 @@ export const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({
   const participant = providedParticipant ?? fetchedParticipant
   const isPrimary = role === 'FROM'
 
-  const [activeContactId, setContactId] = useQueryState('contactId', { defaultValue: '' })
+  const [, setContactId] = useQueryState('contactId', { defaultValue: '' })
+  const { update } = useThreadMutation()
 
-  /** Handle click to select/deselect contact */
-  function handleContactClick(e: React.MouseEvent) {
-    e.stopPropagation()
-    const contactId = participant?.entityInstanceId
-    if (!contactId) return
-    const isAlreadySelected = contactId === activeContactId
-    setContactId(isAlreadySelected ? '' : contactId)
-  }
+  const addExcludedSender = api.channel.addExcludedSender.useMutation({
+    onSuccess: () => {
+      if (threadId) update(threadId, { status: 'IGNORED' })
+    },
+  })
 
   // Loading state
   if (isLoading && !participant) {
@@ -71,18 +85,73 @@ export const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({
     return null
   }
 
-  const { identifier, identifierType, name, displayName, entityInstanceId } = participant
+  const { identifier, identifierType, name, displayName, entityInstanceId, isInternal } =
+    participant
   const displayLabel = displayName || name || identifier
+
+  const senderDomain =
+    identifierType === 'EMAIL' ? (identifier.split('@')[1] ?? undefined) : undefined
+  const showIgnoreFrom =
+    role === 'FROM' &&
+    identifierType === 'EMAIL' &&
+    !!integrationId &&
+    !!senderDomain &&
+    !isInternal
+
+  function handleShowDetails() {
+    if (!entityInstanceId) return
+    void setContactId(entityInstanceId)
+  }
 
   return (
     <div className={cn('flex gap-2 truncate text-sm', isPrimary && 'font-medium', className)}>
-      <ContactHoverCard contactId={entityInstanceId ?? undefined}>
-        <button
-          onClick={handleContactClick}
-          className={cn('text-foreground cursor-pointer hover:text-blue-500')}>
-          {displayLabel}
-        </button>
-      </ContactHoverCard>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type='button'
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            className={cn('text-foreground cursor-pointer hover:text-blue-500')}>
+            {displayLabel}
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align='start' sideOffset={5}>
+          <DropdownMenuItem onSelect={() => navigator.clipboard.writeText(identifier)}>
+            <Copy />
+            Copy '{identifier}'
+          </DropdownMenuItem>
+          {name && (
+            <DropdownMenuItem onSelect={() => navigator.clipboard.writeText(name)}>
+              <Copy />
+              Copy '{name}'
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem onSelect={handleShowDetails} disabled={!entityInstanceId}>
+            <User />
+            Show details
+          </DropdownMenuItem>
+          {showIgnoreFrom && (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <Ban />
+                Ignore from
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem
+                  onClick={() => addExcludedSender.mutate({ integrationId, entry: identifier })}
+                  disabled={addExcludedSender.isPending}>
+                  {identifier}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => addExcludedSender.mutate({ integrationId, entry: senderDomain })}
+                  disabled={addExcludedSender.isPending}>
+                  @{senderDomain}
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       {showDetails &&
         (identifierType === 'EMAIL' ? (
@@ -143,12 +212,21 @@ interface ParticipantListProps {
   participants: ParticipantListEntry[]
   /** Additional CSS classes */
   className?: string
+  /** Channel integration ID — forwarded so the FROM participant can offer "Ignore from" */
+  integrationId?: string
+  /** Thread ID — forwarded so the FROM participant can flip thread status on ignore */
+  threadId?: string
 }
 
 /**
  * Displays a list of participants with their roles.
  */
-export const ParticipantList: React.FC<ParticipantListProps> = ({ participants, className }) => {
+export const ParticipantList: React.FC<ParticipantListProps> = ({
+  participants,
+  className,
+  integrationId,
+  threadId,
+}) => {
   const [showDetails, setShowDetails] = React.useState(false)
 
   // Group participants by role, preserving display order
@@ -185,6 +263,8 @@ export const ParticipantList: React.FC<ParticipantListProps> = ({ participants, 
                   participant={entry.participant}
                   role={entry.role}
                   showDetails={showDetails}
+                  integrationId={integrationId}
+                  threadId={threadId}
                 />
                 {i < entries.length - 1 && <span className='text-muted-foreground text-sm'>,</span>}
               </React.Fragment>

--- a/apps/web/src/components/mail/thread-messages.tsx
+++ b/apps/web/src/components/mail/thread-messages.tsx
@@ -1,9 +1,19 @@
 // apps/web/src/components/mail/thread-messages.tsx
 'use client'
 
+import { Alert, AlertDescription } from '@auxx/ui/components/alert'
+import { Button } from '@auxx/ui/components/button'
 import { Skeleton } from '@auxx/ui/components/skeleton'
+import { Ban } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
-import { useMessages, useThread } from '~/components/threads/hooks'
+import { useChannel } from '~/components/channels/hooks/use-channels'
+import {
+  useMessage,
+  useMessageParticipants,
+  useMessages,
+  useThread,
+  useThreadMutation,
+} from '~/components/threads/hooks'
 import { useThreadStore } from '~/components/threads/store'
 import type { ScheduledMessageMeta } from '~/components/threads/store/thread-store'
 import { getThreadStoreState } from '~/components/threads/store/thread-store'
@@ -39,6 +49,43 @@ export function ThreadMessages() {
   }, [scheduledMessagesMap, threadId])
   const [confirm, ConfirmDialog] = useConfirm()
   const { openDraft } = useCompose()
+  const { update: updateThread } = useThreadMutation()
+  const removeExcludedSender = api.channel.removeExcludedSender.useMutation()
+
+  const channel = useChannel(thread?.integrationId)
+  const { message: latestMessage } = useMessage({
+    messageId: thread?.latestMessageId,
+    enabled: !!thread?.latestMessageId,
+  })
+  const { from: latestFrom } = useMessageParticipants(latestMessage?.participants ?? [])
+
+  /**
+   * Entries in the channel's excludeSenders list that match this thread's latest sender —
+   * either the exact email or its @domain. Used to keep "Restore" honest by also lifting
+   * the exclusion that caused the thread to be ignored in the first place.
+   */
+  const matchingExcludedEntries = useMemo(() => {
+    const excludeSenders = channel?.settings?.excludeSenders ?? []
+    if (excludeSenders.length === 0) return []
+    if (!latestFrom || latestFrom.identifierType !== 'EMAIL') return []
+    const email = latestFrom.identifier.toLowerCase()
+    const domain = email.split('@')[1]
+    const candidates = new Set<string>([email])
+    if (domain) candidates.add(`@${domain}`).add(domain)
+    return excludeSenders.filter((entry) => candidates.has(entry.toLowerCase()))
+  }, [channel?.settings?.excludeSenders, latestFrom])
+
+  const handleRestore = useCallback(async () => {
+    if (!thread) return
+    if (channel?.id && matchingExcludedEntries.length > 0) {
+      await Promise.all(
+        matchingExcludedEntries.map((entry) =>
+          removeExcludedSender.mutateAsync({ integrationId: channel.id, entry })
+        )
+      )
+    }
+    updateThread(thread.id, { status: 'OPEN' })
+  }, [thread, channel?.id, matchingExcludedEntries, removeExcludedSender, updateThread])
 
   const cancelMutation = api.thread.cancelScheduledMessage.useMutation({
     onSuccess: (_data, variables) => {
@@ -126,13 +173,39 @@ export function ThreadMessages() {
     )
   }
 
+  const isMuted = thread.status === 'TRASH' || thread.status === 'IGNORED'
+
   return (
     <div className='flex flex-col'>
       <ConfirmDialog />
       <div className='flex flex-1 flex-col space-y-4'>
+        {thread.status === 'IGNORED' && (
+          <div className='px-4 pt-2'>
+            <Alert variant='warning' className='flex items-center justify-between gap-3'>
+              <div className='flex items-center gap-2'>
+                <Ban className='size-4 shrink-0' />
+                <AlertDescription className='opacity-100'>
+                  This thread is being ignored.
+                  {matchingExcludedEntries.length > 0 && (
+                    <>
+                      {' '}
+                      Future emails matching {matchingExcludedEntries.join(', ')} will be ignored.
+                    </>
+                  )}
+                </AlertDescription>
+              </div>
+              <Button
+                variant='outline'
+                size='xs'
+                onClick={handleRestore}
+                loading={removeExcludedSender.isPending}>
+                Restore
+              </Button>
+            </Alert>
+          </div>
+        )}
         {/* Email messages */}
-        <div
-          className={`flex flex-col gap-4 px-4 py-2 ${thread.status === 'TRASH' ? 'opacity-50' : ''}`}>
+        <div className={`flex flex-col gap-4 px-4 py-2 ${isMuted ? 'opacity-50' : ''}`}>
           {messages.map((message, index) => {
             // Check if this is the last message in the array
             const isLastMessage = index === messages.length - 1 && scheduledMessages.length === 0

--- a/packages/lib/src/ai/kopilot/agents/agent.ts
+++ b/packages/lib/src/ai/kopilot/agents/agent.ts
@@ -10,6 +10,7 @@ import type {
   AgentToolDefinition,
 } from '../../agent-framework/types'
 import type { Message, ToolCall } from '../../clients/base/types'
+import { transformAssistantContentForLLM } from '../blocks/transform-for-llm'
 import { createSubmitFinalAnswerTool } from '../meta-tools/submit-final-answer'
 import { buildAgentSystemPrompt, type CurrentUserInfo } from '../prompts/agent-prompt'
 import type { KopilotDomainState } from '../types'
@@ -73,13 +74,23 @@ export function createKopilotAgent(
       )
 
       // Full conversation for tool-loop continuity.
+      // Final-prose assistant messages run through transformAssistantContentForLLM
+      // so `auxx:*` reference fences become numbered text the model can index by
+      // ordinal (e.g. "delete the second one"). Persisted content is unchanged —
+      // this is a per-call view transform.
       const rawMessages: Message[] = state.messages
         .filter((m) => m.role !== 'system')
         .map((m) => {
+          const isAssistantWithTools = m.role === 'assistant' && m.toolCalls?.length
+          const isAssistantFinal = m.role === 'assistant' && !m.toolCalls?.length
+          const content = isAssistantWithTools
+            ? m.content || null
+            : isAssistantFinal
+              ? transformAssistantContentForLLM(m.content || '')
+              : m.content || ''
           const msg: Message = {
             role: m.role as 'user' | 'assistant' | 'tool',
-            content:
-              m.role === 'assistant' && m.toolCalls?.length ? m.content || null : m.content || '',
+            content,
             tool_call_id: m.toolCallId,
             reasoning_content: m.reasoning_content,
           }

--- a/packages/lib/src/ai/kopilot/blocks/inject-snapshots.ts
+++ b/packages/lib/src/ai/kopilot/blocks/inject-snapshots.ts
@@ -154,13 +154,14 @@ export function buildFallbackFence(
 function buildFenceForBlock(block: ToolOutputBlock, snapshots: TurnSnapshots): string | null {
   switch (block) {
     case 'entity-card':
-    case 'entity-list': {
-      const ids = Object.keys(snapshots.records)
-      if (ids.length === 0) return null
-      const snap: Record<string, unknown> = {}
-      for (const id of ids) snap[id] = snapshots.records[id]
-      return `\`\`\`auxx:entity-list\n${JSON.stringify({ recordIds: ids, snapshot: snap })}\n\`\`\``
-    }
+    case 'entity-list':
+      // Opt-in: the LLM must emit `auxx:entity-card` (single) or
+      // `auxx:entity-list` (multiple) explicitly with the recordIds it
+      // actually wants surfaced. The shared `snapshots.records` pool
+      // accumulates across every record-returning tool in the turn, so
+      // auto-emitting from it re-surfaces tangentially-relevant matches
+      // the LLM filtered out in prose.
+      return null
     case 'thread-list': {
       const ids = Object.keys(snapshots.threads)
       if (ids.length === 0) return null

--- a/packages/lib/src/ai/kopilot/blocks/transform-for-llm.ts
+++ b/packages/lib/src/ai/kopilot/blocks/transform-for-llm.ts
@@ -1,0 +1,100 @@
+// packages/lib/src/ai/kopilot/blocks/transform-for-llm.ts
+
+/**
+ * Transform `auxx:*` reference-block fences inside an assistant message
+ * into a numbered, displayName-paired text representation that small LLMs
+ * can index by ordinal without parsing JSON.
+ *
+ * Used at the LLM-call boundary only — the persisted message content
+ * keeps the original fence so the UI renders the rich card unchanged.
+ */
+
+const FENCE_RE = /```auxx:([a-z-]+)\n([\s\S]*?)\n```/g
+
+type Transformer = (data: Record<string, unknown>) => string | null
+
+const TRANSFORMERS: Record<string, Transformer> = {
+  'entity-list': transformEntityList,
+  'entity-card': transformEntityCard,
+  'thread-list': transformThreadList,
+  'task-list': transformTaskList,
+}
+
+export function transformAssistantContentForLLM(content: string): string {
+  if (!content || !content.includes('```auxx:')) return content
+  return content.replace(FENCE_RE, (match, type: string, body: string) => {
+    const fn = TRANSFORMERS[type]
+    if (!fn) return match
+    let data: Record<string, unknown>
+    try {
+      data = JSON.parse(body) as Record<string, unknown>
+    } catch {
+      return match
+    }
+    const transformed = fn(data)
+    return transformed ?? match
+  })
+}
+
+function transformEntityList(data: Record<string, unknown>): string | null {
+  const recordIds = Array.isArray(data.recordIds)
+    ? (data.recordIds as unknown[]).filter((id): id is string => typeof id === 'string')
+    : []
+  if (recordIds.length === 0) return null
+  const snapshot = (data.snapshot as Record<string, unknown> | undefined) ?? {}
+  const lines = recordIds.map((id, i) => {
+    const entry = snapshot[id] as Record<string, unknown> | undefined
+    const displayName = typeof entry?.displayName === 'string' ? entry.displayName : null
+    const summary = typeof entry?.summary === 'string' ? entry.summary : null
+    const left = displayName ?? '(unknown record)'
+    const middle = summary ? ` — ${summary}` : ''
+    return `  ${i + 1}. ${left}${middle} (recordId: ${id})`
+  })
+  return `[Showed entity-list to user (${recordIds.length} record${recordIds.length === 1 ? '' : 's'}):\n${lines.join('\n')}]`
+}
+
+function transformEntityCard(data: Record<string, unknown>): string | null {
+  const recordId = typeof data.recordId === 'string' ? data.recordId : null
+  if (!recordId) return null
+  const snapshot = (data.snapshot as Record<string, unknown> | undefined) ?? {}
+  const entry = snapshot[recordId] as Record<string, unknown> | undefined
+  const displayName = typeof entry?.displayName === 'string' ? entry.displayName : null
+  const summary = typeof entry?.summary === 'string' ? entry.summary : null
+  const left = displayName ?? '(unknown record)'
+  const middle = summary ? ` — ${summary}` : ''
+  return `[Showed entity-card to user: ${left}${middle} (recordId: ${recordId})]`
+}
+
+function transformThreadList(data: Record<string, unknown>): string | null {
+  const threadIds = Array.isArray(data.threadIds)
+    ? (data.threadIds as unknown[]).filter((id): id is string => typeof id === 'string')
+    : []
+  if (threadIds.length === 0) return null
+  const snapshot = (data.snapshot as Record<string, unknown> | undefined) ?? {}
+  const lines = threadIds.map((id, i) => {
+    const entry = snapshot[id] as Record<string, unknown> | undefined
+    const subject = typeof entry?.subject === 'string' ? entry.subject : null
+    const sender = typeof entry?.sender === 'string' ? entry.sender : null
+    const left = subject ? `"${subject}"` : '(no subject)'
+    const middle = sender ? ` — from ${sender}` : ''
+    return `  ${i + 1}. ${left}${middle} (threadId: ${id})`
+  })
+  return `[Showed thread-list to user (${threadIds.length} thread${threadIds.length === 1 ? '' : 's'}):\n${lines.join('\n')}]`
+}
+
+function transformTaskList(data: Record<string, unknown>): string | null {
+  const taskIds = Array.isArray(data.taskIds)
+    ? (data.taskIds as unknown[]).filter((id): id is string => typeof id === 'string')
+    : []
+  if (taskIds.length === 0) return null
+  const snapshot = (data.snapshot as Record<string, unknown> | undefined) ?? {}
+  const lines = taskIds.map((id, i) => {
+    const entry = snapshot[id] as Record<string, unknown> | undefined
+    const title = typeof entry?.title === 'string' ? entry.title : null
+    const completedAt = typeof entry?.completedAt === 'string' ? entry.completedAt : null
+    const left = title ? `"${title}"` : '(untitled)'
+    const middle = completedAt ? ' — done' : ' — open'
+    return `  ${i + 1}. ${left}${middle} (taskId: ${id})`
+  })
+  return `[Showed task-list to user (${taskIds.length} task${taskIds.length === 1 ? '' : 's'}):\n${lines.join('\n')}]`
+}

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-entity.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/create-entity.ts
 
-import { findCachedResource } from '../../../../../cache/org-cache-helpers'
+import { findCachedResource, getCachedResources } from '../../../../../cache/org-cache-helpers'
 import { UnprocessableEntityError } from '../../../../../errors'
 import { UnifiedCrudHandler } from '../../../../../resources/crud'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
@@ -17,9 +17,18 @@ export function createCreateEntityTool(getDeps: GetToolDeps): AgentToolDefinitio
 
 REQUIRED BEFORE CALLING: Call \`search_entities\` with the proposed values (name,
 email, SKU, etc.) scoped to this \`entityDefinitionId\` to check for duplicates.
-If a likely match exists, surface it to the user before proceeding instead of
-creating a new record. Skip only if the user explicitly asked to create a new
-one even if it exists.
+
+A search result is a duplicate only if it probably represents the SAME entity:
+same full name, same email, or same phone (for people/companies); same SKU or
+identifier (for things). Partial overlap is NOT a duplicate — searching
+"Cornelia Klooth" and getting back "Lutz Klooth" or "Carolin Klooth" is just a
+last-name match; proceed with creation.
+
+Only stop and ask the user if at least one search result has the same full name
+OR the same email/phone/identifier as the entity you're creating. Otherwise
+proceed straight to \`list_entity_fields\` → \`create_entity\`. Skip the dedupe
+prompt entirely if the user explicitly said "create a new one even if it
+exists" or similar.
 
 REQUIRED BEFORE CALLING: If you have NOT already called \`list_entity_fields\` for this
 entityDefinitionId in the current turn, call it first. Do NOT guess field ids from prior
@@ -42,7 +51,8 @@ Example (ids match list_entity_fields output):
       properties: {
         entityDefinitionId: {
           type: 'string',
-          description: 'Entity definition ID (from list_entities)',
+          description:
+            'Entity type — pass the apiSlug from the entity catalog (e.g. "contact", "company").',
         },
         values: {
           type: 'object',
@@ -76,10 +86,12 @@ Example (ids match list_entity_fields output):
 
       const resource = await findCachedResource(agentDeps.organizationId, key)
       if (!resource) {
+        const allResources = await getCachedResources(agentDeps.organizationId)
+        const validSlugs = allResources.map((r) => r.apiSlug).join(', ')
         return {
           success: false,
           output: null,
-          error: `Entity type "${key}" not found. Call list_entities to discover available entity types.`,
+          error: `Entity type "${key}" not found. Use one of these apiSlugs: ${validSlugs}.`,
         }
       }
 

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
 
-import { findCachedResource } from '../../../../../cache/org-cache-helpers'
+import { findCachedResource, getCachedResources } from '../../../../../cache/org-cache-helpers'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
 import { buildListEntityFieldsOutput } from './list-entity-fields-output'
@@ -27,7 +27,8 @@ Response shape:
       properties: {
         entityDefinitionId: {
           type: 'string',
-          description: 'Entity definition ID, apiSlug, or entityType (from list_entities result)',
+          description:
+            'Entity type — pass the apiSlug from the entity catalog (e.g. "contact", "company").',
         },
         query: {
           type: 'string',
@@ -43,10 +44,12 @@ Response shape:
 
       const resource = await findCachedResource(agentDeps.organizationId, key)
       if (!resource) {
+        const allResources = await getCachedResources(agentDeps.organizationId)
+        const validSlugs = allResources.map((r) => r.apiSlug).join(', ')
         return {
           success: false,
           output: null,
-          error: `Entity type "${key}" not found. Call list_entities to discover available entity types.`,
+          error: `Entity type "${key}" not found. Use one of these apiSlugs: ${validSlugs}.`,
         }
       }
 

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
@@ -49,7 +49,7 @@ export function createQueryRecordsTool(getDeps: GetToolDeps): AgentToolDefinitio
     idempotent: true,
     outputBlock: 'entity-list',
     usageNotes:
-      'Inspect `warnings[]` before trusting the result — each entry means a filter was rejected and dropped. `returned_count` is items in this page, `total_matching` is the full count for the query.',
+      'Inspect `warnings[]` before trusting the result — each entry means a filter was rejected and dropped. `returned_count` is items in this page, `total_matching` is the full count for the query. When you reach `submit_final_answer`, embed the records you are referring to in an `auxx:entity-card` (1) or `auxx:entity-list` (2+) fence inside `content`. Records mentioned in prose without a fence will not be visible to the user.',
     description: `Query entity records with field-level filters, sorting, and pagination.
 Use list_entity_fields first to discover available fields and their valid option values.
 

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
@@ -78,7 +78,7 @@ Examples:
         entity: {
           type: 'string',
           description:
-            'Entity type to query — use the apiSlug (e.g. "contact", "ticket") or entity definition ID from the entity catalog.',
+            'Entity type to query — pass the apiSlug from the entity catalog (e.g. "contact", "ticket").',
         },
         filters: {
           type: 'array',

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
@@ -17,7 +17,7 @@ export function createSearchEntitiesTool(getDeps: GetToolDeps): AgentToolDefinit
     idempotent: true,
     outputBlock: 'entity-list',
     usageNotes:
-      'For field-value comparisons, follow up with `get_entity` per record — this tool only enriches fields when matches ≤5.',
+      'For field-value comparisons, follow up with `get_entity` per record — this tool only enriches fields when matches ≤5. When you reach `submit_final_answer`, embed the records you are referring to in an `auxx:entity-card` (1) or `auxx:entity-list` (2+) fence inside `content`. Records mentioned in prose without a fence will not be visible to the user.',
     description:
       'Search for records by name or text across all entity types, or within a specific entity type. Returns matching records with display names. If you know the entity type, pass entityDefinitionId for faster results.',
     parameters: {

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
@@ -26,7 +26,7 @@ export function createSearchEntitiesTool(getDeps: GetToolDeps): AgentToolDefinit
         entityDefinitionId: {
           type: 'string',
           description:
-            'Optional. Entity definition ID, apiSlug, or entityType. Omit to search across ALL entity types.',
+            'Optional. Entity type — pass the apiSlug from the entity catalog (e.g. "contact", "company"). Omit to search across ALL entity types.',
         },
         query: {
           type: 'string',
@@ -65,10 +65,11 @@ export function createSearchEntitiesTool(getDeps: GetToolDeps): AgentToolDefinit
         // Scoped search — single entity type
         const resource = await findCachedResource(agentDeps.organizationId, key)
         if (!resource) {
+          const validSlugs = allResources.map((r) => r.apiSlug).join(', ')
           return {
             success: false,
             output: null,
-            error: `Entity type "${key}" not found. Check the entity catalog in your system prompt for available types.`,
+            error: `Entity type "${key}" not found. Use one of these apiSlugs: ${validSlugs}.`,
           }
         }
         searchParams = {

--- a/packages/lib/src/ai/kopilot/meta-tools/submit-final-answer.ts
+++ b/packages/lib/src/ai/kopilot/meta-tools/submit-final-answer.ts
@@ -6,17 +6,30 @@ import type { AgentToolDefinition, AgentToolResult } from '../../agent-framework
  * The terminator tool for a Kopilot turn.
  *
  * The solo agent is expected to call this exactly once at the end of its turn,
- * passing a short prose wrap-up as `content`. The query loop detects the
- * `__terminate` marker on the output and emits a `final-message` SSE event.
+ * passing prose plus any `auxx:*` reference-block fences as `content`. The
+ * query loop detects the `__terminate` marker on the output and emits a
+ * `final-message` SSE event.
  *
- * Rich data (records, drafts, tables) is already rendered as `auxx:*` blocks
- * attached to prior tool results — this content must be prose only.
+ * The LLM controls UI rendering: if a record/thread/task should appear in
+ * the chat, it must be embedded as a fence in `content`. Prose-only mentions
+ * render as text only — the user sees no card/list/table.
  */
 export function createSubmitFinalAnswerTool(): AgentToolDefinition {
   return {
     name: 'submit_final_answer',
-    description:
-      'Send your final message to the user. Exactly once, at the end of the turn. Content is prose plus any `auxx:*` fences that the tool guidance told you to emit. Copy IDs verbatim from tool results — never invent them.',
+    description: `Send your final message to the user. Exactly once, at the end of the turn.
+
+\`content\` is prose plus any \`auxx:*\` fences. Markdown supported. IDs inside fences must be copied verbatim from tool results — never invent them.
+
+REQUIRED: If \`search_entities\`, \`query_records\`, \`get_entity\`, \`find_threads\`, \`get_thread_detail\`, or \`list_tasks\` returned records/threads/tasks and you are mentioning any of them by name in \`content\`, those items MUST appear in the matching \`auxx:*\` fence:
+- 1 record → \`auxx:entity-card\`
+- 2+ records → \`auxx:entity-list\`
+- 1+ threads → \`auxx:thread-list\`
+- 1+ tasks → \`auxx:task-list\`
+
+Only include the items you are actually discussing. If a search returned 3 results but you're only referring to 1 of them, the fence contains 1 — not all 3. If you're not discussing any of them in this response, no fence needed.
+
+Prose-only references to records that exist in tool results are a bug — the user won't see them.`,
     parameters: {
       type: 'object',
       additionalProperties: false,
@@ -24,7 +37,7 @@ export function createSubmitFinalAnswerTool(): AgentToolDefinition {
         content: {
           type: 'string',
           description:
-            'Prose shown to the user plus any `auxx:*` fenced blocks. Markdown supported. IDs inside blocks must come from tool results.',
+            'Prose shown to the user plus any `auxx:*` fenced blocks. Markdown supported. IDs inside blocks must come from tool results. Records/threads/tasks you mention by name MUST be embedded as fences (see tool description).',
         },
       },
       required: ['content'],

--- a/packages/lib/src/ai/kopilot/prompts/agent-prompt.ts
+++ b/packages/lib/src/ai/kopilot/prompts/agent-prompt.ts
@@ -74,6 +74,8 @@ ${BLOCK_CATALOG}
 
 Read tools return structured data you reason over. They do NOT render UI by themselves anymore — you choose what to show by embedding \`auxx:*\` fences inside \`submit_final_answer.content\`. Only embed the blocks that answer the user's request; intermediate lookups stay invisible.
 
+When you reference specific records by name in prose, emit a fence containing **only** those records: \`auxx:entity-card\` for a single record, \`auxx:entity-list\` for two or more. Search results often include tangentially-relevant matches (e.g. "Carolin Klooth" also matches "Lutz Klooth" and "Christoph Klooth" on last name) — surface only what you actually mean, not the full search payload. If no result is relevant, prose-only is fine; don't emit a block.
+
 Write tools (draft_reply, send_reply, update_entity, create_entity, update_thread, bulk_update_entity, create_task) and search-style knowledge tools (search_docs, search_kb, search_rag) attach their own literal blocks automatically — don't re-embed those.
 
 ## Approval-protected tools

--- a/packages/lib/src/ai/kopilot/prompts/agent-prompt.ts
+++ b/packages/lib/src/ai/kopilot/prompts/agent-prompt.ts
@@ -112,12 +112,9 @@ When the user says "me", "myself", "my", or "I" for an ACTOR field (assignee, ow
 function buildEntityCatalogSection(entityCatalog: EntityCatalogEntry[]): string {
   if (!entityCatalog.length) return ''
 
-  const lines = entityCatalog.map(
-    (e) =>
-      `- **${e.label}** (${e.plural}) — apiSlug: \`${e.apiSlug}\`, id: \`${e.entityDefinitionId}\``
-  )
+  const lines = entityCatalog.map((e) => `- **${e.label}** (${e.plural}) — \`${e.apiSlug}\``)
 
-  return `\n## Available Entity Types\nUse the apiSlug or id as the entityDefinitionId parameter in tools.\n${lines.join('\n')}`
+  return `\n## Available Entity Types\nPass the apiSlug (the value in backticks) as the \`entityDefinitionId\` / \`entity\` parameter in tools. Never invent slugs that aren't in this list.\n${lines.join('\n')}`
 }
 
 /**
@@ -160,13 +157,17 @@ from the values the user gave you (name, email, SKU, etc.) scoped to the same
 \`entityDefinitionId\`. This catches obvious duplicates before the user has to
 approve a redundant create.
 
-If the search returns a likely match, tell the user what you found and ask
-whether to use the existing record or still create a new one — don't auto-pick.
-If the search returns nothing or only unrelated results, proceed to
-\`list_entity_fields\` → \`create_entity\` as usual.
+A duplicate is a search result that probably represents the **same** entity:
+same full name, same email, or same phone (for people/companies); same SKU or
+identifier (for things). Records that share only part of a name (e.g. last
+name only) are NOT duplicates — searching "Cornelia Klooth" and getting back
+"Lutz Klooth", "Carolin Klooth", "Christoph Klooth" is just a last-name match;
+none of those are Cornelia. Proceed with the create.
 
-Skip this only when the user has explicitly said "create a new one even if it
-exists" or similar.
+Only stop and ask the user if at least one result is a real duplicate by the
+rule above. Otherwise proceed straight to \`list_entity_fields\` →
+\`create_entity\` as usual. Skip the dedupe step entirely when the user has
+explicitly said "create a new one even if it exists" or similar.
 
 ### Comparing records
 

--- a/packages/lib/src/ai/kopilot/prompts/block-catalog.ts
+++ b/packages/lib/src/ai/kopilot/prompts/block-catalog.ts
@@ -39,11 +39,14 @@ verbatim from tool results — never construct them.
 \\\`\\\`\\\`auxx:entity-list
 {"recordIds": ["<defId>:<instId>", "<defId>:<instId>"]}
 \\\`\\\`\\\`
+- Use for **two or more** records. For a single record, prefer \`auxx:entity-card\`.
+- Filter intermediate search results to what you actually mean. Example: \`search_entities("Carolin Klooth")\` returns Carolin, Lutz, Christoph (all match on last name). If the user asked specifically about Carolin, emit \`auxx:entity-card\` with just Carolin's recordId — do NOT include Lutz or Christoph just because they were in the search payload.
 
 #### \`auxx:entity-card\`
 \\\`\\\`\\\`auxx:entity-card
 {"recordId": "<defId>:<instId>"}
 \\\`\\\`\\\`
+- Use for a **single** record. For two or more, use \`auxx:entity-list\`.
 
 #### \`auxx:thread-list\`
 \\\`\\\`\\\`auxx:thread-list


### PR DESCRIPTION
## Summary

Four topical changes bundled into one PR:

- **Mail — Ignore from + Restore (055f4b67):** Replace the participant hover-card with a dropdown menu that exposes Copy / Show details and an "Ignore from" submenu on FROM-role email participants. Adds the address or @domain to the channel's `excludeSenders` and flips the thread to `IGNORED`. IGNORED threads now show a banner that names the matching exclusion entries and offers a Restore action that lifts those entries and reopens the thread.
- **Kopilot UI — pin newest turn (a4a1eaa5):** Group consecutive messages into turn groups and inflate the last group's min-height to the viewport so submitting a message scrolls the user message to the top of the viewport with the assistant streaming in below it. Adds rAF-coalesced ResizeObserver, switches to a callback ref, and overlays the "New messages" pill instead of contributing to scrollHeight.
- **Kopilot agent — opt-in rich blocks (fee9425e):** Stop auto-emitting `auxx:entity-card` / `auxx:entity-list` from the shared turn-snapshot pool — the pool re-surfaced records the LLM had already filtered out. The LLM now embeds explicit recordIds in `submit_final_answer.content`. Adds `transform-for-llm.ts`, applied at the LLM-call boundary, which rewrites assistant `auxx:*` fences into numbered `displayName`-paired text so smaller models can refer to "the second one" without parsing JSON. Persisted content unchanged.
- **Kopilot tools — entity prompt tightening (8132ae29):** Standardize on `apiSlug` as the canonical entity identifier across `search_entities`, `query_records`, `list_entity_fields`, `create_entity`. Drop the redundant `entityDefinitionId` column from the entity catalog and surface the valid apiSlug list in the "not found" error. Refine the `create_entity` dedupe rule so partial matches (e.g. shared last name) no longer trigger the dedupe prompt — only matching full name / email / phone / identifier counts.

## Test plan

- [ ] Open a thread, click a FROM participant — confirm dropdown shows Copy / Show details / Ignore from submenu (email + @domain options); confirm internal participants don't see Ignore from
- [ ] Trigger Ignore from — thread flips to IGNORED, banner appears with matching exclusion entries listed
- [ ] Click Restore on an IGNORED thread — confirm exclusion entries are removed and thread returns to OPEN
- [ ] Submit a Kopilot message in a long conversation — confirm the new user message pins to the top of the viewport while assistant streams below
- [ ] Resize the window during streaming — confirm the pinned-turn min-height tracks the new viewport height without layout thrash
- [ ] Ask Kopilot something that returns 3+ records but only one is relevant — confirm only the relevant card/list renders (no tangentially-relevant items)
- [ ] Ask Kopilot to "delete the second one" referencing a prior list — confirm it picks the right record (transform-for-llm numbering)
- [ ] Try `create_entity` with a partial-name search match (e.g. "Cornelia Klooth" when "Lutz Klooth" exists) — confirm it proceeds without prompting for dedupe
- [ ] Try `create_entity` with a real duplicate (same email) — confirm it surfaces the existing record before creating

🤖 Generated with [Claude Code](https://claude.com/claude-code)