### PR TITLE
fix(kopilot): never persist half-pair assistant tool_calls

### DIFF
--- a/apps/web/src/components/kopilot/hooks/use-kopilot-sessions.ts
+++ b/apps/web/src/components/kopilot/hooks/use-kopilot-sessions.ts
@@ -152,9 +152,11 @@ export function useLoadSession() {
       // stays contiguous — each visible message's parent is the previous visible message.
       const visibleMessages = messages.filter((m) => !isExecutorAssistant(m))
 
-      // Reconstruct approval card from persisted domainState when session is
-      // still waiting for user approval (the approval message is frontend-only
-      // and not stored in engine messages).
+      // Reconstruct the pending-approval state from persisted domainState. The
+      // engine no longer stores the assistant-with-tool_calls message in
+      // messages[] while paused (kept on _pendingToolCall.assistantMessage so
+      // the persisted array is always provider-valid), so we re-emit the
+      // assistant bubble here, followed by the approval card.
       const domainState = (data as any).domainState as Record<string, unknown> | undefined
       if (domainState?._waitingForApproval && domainState?._pendingToolCall) {
         const ptc = domainState._pendingToolCall as {
@@ -162,7 +164,32 @@ export function useLoadSession() {
           toolName: string
           agentName: string
           args: Record<string, unknown>
+          assistantMessage?: {
+            content?: string
+            toolCalls?: unknown[]
+            reasoning_content?: string
+            timestamp?: number
+            metadata?: Record<string, unknown>
+          }
         }
+
+        if (ptc.assistantMessage) {
+          const am = ptc.assistantMessage
+          const assistantBubble: KopilotMessage = {
+            id: generateId(),
+            role: 'assistant',
+            content: am.content ?? '',
+            timestamp: am.timestamp ?? Date.now(),
+            parentId:
+              visibleMessages.length > 0 ? visibleMessages[visibleMessages.length - 1]!.id : null,
+            metadata: am.metadata,
+            toolCalls: am.toolCalls as KopilotMessage['toolCalls'],
+          }
+          if (!isExecutorAssistant(assistantBubble)) {
+            visibleMessages.push(assistantBubble)
+          }
+        }
+
         visibleMessages.push({
           id: generateId(),
           role: 'system',

--- a/apps/web/src/components/kopilot/ui/kopilot-message-list.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-message-list.tsx
@@ -107,6 +107,10 @@ export function KopilotMessageList({
   const [inflateLast, setInflateLast] = useState(() => messages.length <= 1)
   const [pinTick, setPinTick] = useState(0)
   const pinBehaviorRef = useRef<ScrollBehavior>('smooth')
+  // Sentinel placed after the last meaningful child of the last turn group.
+  // Used to compute "at bottom" relative to the actual content end, not the
+  // bottom of the inflated empty space.
+  const contentEndRef = useRef<HTMLDivElement | null>(null)
   const lastUserIdRef = useRef<string | null>(null)
   const prevLenRef = useRef(0)
   const sessionMountedRef = useRef(false)
@@ -127,6 +131,31 @@ export function KopilotMessageList({
 
   const groups = useMemo(() => groupTurns(visibleMessages), [visibleMessages])
   const showEmptyState = messages.length === 0 && !isStreaming
+
+  /**
+   * Distance from the viewport bottom to the sentinel placed at the end of
+   * meaningful content. Positive = sentinel is below the viewport (more
+   * content to scroll down to). Negative or near-zero = caught up.
+   * Returns null when sentinel/viewport refs aren't ready yet.
+   */
+  const measureContentEndDistance = useCallback((): number | null => {
+    const sentinel = contentEndRef.current
+    if (!sentinel || !viewportEl) return null
+    const sentinelRect = sentinel.getBoundingClientRect()
+    const viewportRect = viewportEl.getBoundingClientRect()
+    return sentinelRect.bottom - viewportRect.bottom
+  }, [viewportEl])
+
+  const updateBottomState = useCallback(() => {
+    const distance = measureContentEndDistance()
+    if (distance === null) {
+      isAtBottom.current = true
+      setShowScrollDown(false)
+      return
+    }
+    isAtBottom.current = distance <= 20
+    setShowScrollDown(distance > 20)
+  }, [measureContentEndDistance])
 
   // Track scroll position + observe viewport size; keyed on the actual node.
   useEffect(() => {
@@ -151,9 +180,7 @@ export function KopilotMessageList({
     ro.observe(viewportEl)
 
     const onScroll = () => {
-      const distance = viewportEl.scrollHeight - viewportEl.scrollTop - viewportEl.clientHeight
-      isAtBottom.current = distance < 20
-      setShowScrollDown(distance >= 20)
+      updateBottomState()
     }
     viewportEl.addEventListener('scroll', onScroll, { passive: true })
 
@@ -165,7 +192,7 @@ export function KopilotMessageList({
       ro.disconnect()
       viewportEl.removeEventListener('scroll', onScroll)
     }
-  }, [viewportEl])
+  }, [viewportEl, updateBottomState])
 
   // Follow the stream: stay pinned to bottom while content grows, if user was at bottom.
   // messages/streamingContent are trigger-only deps — we don't read them inside.
@@ -175,9 +202,8 @@ export function KopilotMessageList({
     if (isAtBottom.current) {
       viewportEl.scrollTop = viewportEl.scrollHeight
     }
-    const distance = viewportEl.scrollHeight - viewportEl.scrollTop - viewportEl.clientHeight
-    setShowScrollDown(distance >= 20)
-  }, [messages, streamingContent, viewportEl])
+    updateBottomState()
+  }, [messages, streamingContent, viewportEl, updateBottomState])
 
   // Deflate when switching sessions (not on initial mount). activeSessionId
   // is intentionally a trigger-only dep — we don't read it inside the effect.
@@ -371,6 +397,7 @@ export function KopilotMessageList({
                 {isLast && isStreaming && streamingContent && (
                   <AssistantMessage streamingContent={streamingContent} />
                 )}
+                {isLast && <div ref={contentEndRef} aria-hidden className='h-0 w-0' />}
               </div>
             )
           })}
@@ -391,6 +418,7 @@ export function KopilotMessageList({
                 </div>
               )}
               {streamingContent && <AssistantMessage streamingContent={streamingContent} />}
+              <div ref={contentEndRef} aria-hidden className='h-0 w-0' />
             </div>
           )}
         </div>

--- a/packages/lib/src/ai/agent-framework/__tests__/engine-pending.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/engine-pending.test.ts
@@ -1,0 +1,242 @@
+// packages/lib/src/ai/agent-framework/__tests__/engine-pending.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { ToolCall, UsageMetrics } from '../../clients/base/types'
+import { AgentEngine } from '../engine'
+import type {
+  AgentDefinition,
+  AgentDomainConfig,
+  AgentEngineConfig,
+  AgentEvent,
+  AgentToolDefinition,
+  LLMCallParams,
+  LLMStreamEvent,
+} from '../types'
+
+const ZERO_USAGE: UsageMetrics = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
+
+interface ScriptedTurn {
+  content: string
+  toolCalls: ToolCall[]
+}
+
+function buildEngine(opts: {
+  turns: ScriptedTurn[]
+  approvalToolName?: string
+  toolExecute?: AgentToolDefinition['execute']
+}) {
+  let turnIdx = 0
+
+  const callModel = async function* (_params: LLMCallParams): AsyncGenerator<LLMStreamEvent> {
+    const turn = opts.turns[turnIdx++] ?? { content: '', toolCalls: [] }
+    yield {
+      type: 'done',
+      content: turn.content,
+      toolCalls: turn.toolCalls,
+      usage: ZERO_USAGE,
+    }
+  }
+
+  const tools: AgentToolDefinition[] = []
+  if (opts.approvalToolName) {
+    tools.push({
+      name: opts.approvalToolName,
+      description: 'approval-gated tool',
+      parameters: { type: 'object', properties: {}, required: [] },
+      requiresApproval: true,
+      execute: opts.toolExecute ?? (async () => ({ success: true, output: { ok: true } })),
+    })
+  }
+
+  const agent: AgentDefinition = {
+    name: 'agent',
+    tools,
+    buildMessages: async () => [],
+    processResult: async (_c, _tc, state) => state,
+    maxIterations: 5,
+  }
+
+  const domainConfig: AgentDomainConfig = {
+    type: 'kopilot',
+    agents: { agent },
+    routes: [{ name: 'default', agents: ['agent'] }],
+    createInitialState: () => ({}),
+    defaultModel: 'test-model',
+    defaultProvider: 'test-provider',
+  }
+
+  const config: AgentEngineConfig = {
+    organizationId: 'org-1',
+    userId: 'user-1',
+    sessionId: 'sess-1',
+    domainConfig,
+    callModel,
+  }
+
+  return new AgentEngine(config)
+}
+
+async function drain(gen: AsyncGenerator<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = []
+  for await (const event of gen) events.push(event)
+  return events
+}
+
+const makeApprovalToolCall = (id: string, name: string, args = {}): ToolCall => ({
+  id,
+  type: 'function',
+  function: { name, arguments: JSON.stringify(args) },
+})
+
+describe('AgentEngine — pending approval persistence invariants', () => {
+  it('approval pause does NOT push the assistant-with-tool_calls into state.messages', async () => {
+    const tc = makeApprovalToolCall('call_1', 'risky_tool')
+    const engine = buildEngine({
+      approvalToolName: 'risky_tool',
+      turns: [{ content: 'I will call risky_tool', toolCalls: [tc] }],
+    })
+
+    await drain(engine.submitMessage('do it'))
+
+    const state = engine.getState()
+    expect(state.waitingForApproval).toBe(true)
+    expect(state.pendingToolCall?.toolCallId).toBe('call_1')
+    // The assistant message lives on pendingToolCall, NOT in state.messages.
+    expect(state.pendingToolCall?.assistantMessage.toolCalls?.[0]?.id).toBe('call_1')
+    const assistantInMessages = state.messages.find(
+      (m) => m.role === 'assistant' && m.toolCalls?.length
+    )
+    expect(assistantInMessages).toBeUndefined()
+  })
+
+  it('approval pause rewrites toolCalls to [approvalTool] only on the stashed assistant', async () => {
+    const auto = makeApprovalToolCall('call_auto', 'some_other_tool')
+    const approval = makeApprovalToolCall('call_appr', 'risky_tool')
+    const engine = buildEngine({
+      approvalToolName: 'risky_tool',
+      turns: [{ content: 'mixed', toolCalls: [auto, approval] }],
+    })
+
+    await drain(engine.submitMessage('do it'))
+
+    const stashed = engine.getState().pendingToolCall?.assistantMessage
+    expect(stashed?.toolCalls).toHaveLength(1)
+    expect(stashed?.toolCalls?.[0]?.id).toBe('call_appr')
+    expect(stashed?.toolCalls?.[0]?.function.name).toBe('risky_tool')
+  })
+
+  it('resume({ action: "reject" }) appends [assistantMessage, toolResultMsg] in order', async () => {
+    const tc = makeApprovalToolCall('call_1', 'risky_tool')
+    const engine = buildEngine({
+      approvalToolName: 'risky_tool',
+      turns: [
+        { content: 'about to call', toolCalls: [tc] },
+        // After reject the engine re-enters the agent loop; emit a no-tool exit.
+        { content: 'understood', toolCalls: [] },
+      ],
+    })
+
+    await drain(engine.submitMessage('do it'))
+    const messagesBefore = engine.getState().messages.length
+
+    await drain(engine.resume({ action: 'reject' }))
+
+    const state = engine.getState()
+    const newSlice = state.messages.slice(messagesBefore)
+    // First two newly-appended items must be the paired assistant + tool result.
+    expect(newSlice[0]?.role).toBe('assistant')
+    expect(newSlice[0]?.toolCalls?.[0]?.id).toBe('call_1')
+    expect(newSlice[1]?.role).toBe('tool')
+    expect(newSlice[1]?.toolCallId).toBe('call_1')
+    expect(JSON.parse(newSlice[1]?.content ?? '{}')).toMatchObject({ rejected: true })
+    expect(state.waitingForApproval).toBe(false)
+    expect(state.pendingToolCall).toBeUndefined()
+  })
+
+  it('resume({ action: "approve" }) success appends [assistantMessage, toolResultMsg] in order', async () => {
+    const tc = makeApprovalToolCall('call_1', 'risky_tool')
+    const engine = buildEngine({
+      approvalToolName: 'risky_tool',
+      toolExecute: async () => ({ success: true, output: { ran: true } }),
+      turns: [
+        { content: 'about to call', toolCalls: [tc] },
+        { content: 'done', toolCalls: [] },
+      ],
+    })
+
+    await drain(engine.submitMessage('do it'))
+    const messagesBefore = engine.getState().messages.length
+
+    await drain(engine.resume({ action: 'approve' }))
+
+    const state = engine.getState()
+    const newSlice = state.messages.slice(messagesBefore)
+    expect(newSlice[0]?.role).toBe('assistant')
+    expect(newSlice[0]?.toolCalls?.[0]?.id).toBe('call_1')
+    expect(newSlice[1]?.role).toBe('tool')
+    expect(newSlice[1]?.toolCallId).toBe('call_1')
+    expect(JSON.parse(newSlice[1]?.content ?? '{}')).toMatchObject({ ran: true })
+    expect(state.pendingToolCall).toBeUndefined()
+  })
+
+  it('resume({ action: "approve" }) when tool throws still appends [assistantMessage, errorToolMsg]', async () => {
+    const tc = makeApprovalToolCall('call_1', 'risky_tool')
+    const engine = buildEngine({
+      approvalToolName: 'risky_tool',
+      toolExecute: async () => {
+        throw new Error('boom')
+      },
+      turns: [
+        { content: 'about to call', toolCalls: [tc] },
+        { content: 'recovered', toolCalls: [] },
+      ],
+    })
+
+    await drain(engine.submitMessage('do it'))
+    const messagesBefore = engine.getState().messages.length
+
+    await drain(engine.resume({ action: 'approve' }))
+
+    const state = engine.getState()
+    const newSlice = state.messages.slice(messagesBefore)
+    expect(newSlice[0]?.role).toBe('assistant')
+    expect(newSlice[0]?.toolCalls?.[0]?.id).toBe('call_1')
+    expect(newSlice[1]?.role).toBe('tool')
+    expect(newSlice[1]?.toolCallId).toBe('call_1')
+    expect(JSON.parse(newSlice[1]?.content ?? '{}')).toMatchObject({ error: 'boom' })
+    expect(state.pendingToolCall).toBeUndefined()
+  })
+
+  it('submitMessage while pending clears pendingToolCall and only appends the new user message', async () => {
+    const tc = makeApprovalToolCall('call_1', 'risky_tool')
+    const engine = buildEngine({
+      approvalToolName: 'risky_tool',
+      turns: [
+        { content: 'first', toolCalls: [tc] },
+        // Second turn (after edit): no tool calls — exit cleanly.
+        { content: 'reply to edit', toolCalls: [] },
+      ],
+    })
+
+    await drain(engine.submitMessage('original'))
+    expect(engine.getState().pendingToolCall).toBeDefined()
+    const messagesBefore = engine.getState().messages.length
+
+    await drain(engine.submitMessage('edited'))
+
+    const state = engine.getState()
+    expect(state.pendingToolCall).toBeUndefined()
+    expect(state.waitingForApproval).toBe(false)
+
+    // The abandoned assistant-with-tool_calls must NOT have leaked into messages
+    // — it lived only on the (now-cleared) pendingToolCall.
+    const orphan = state.messages.find(
+      (m) => m.role === 'assistant' && m.toolCalls?.some((c) => c.id === 'call_1')
+    )
+    expect(orphan).toBeUndefined()
+
+    // The freshly-appended message at the boundary is the new user message.
+    expect(state.messages[messagesBefore]?.role).toBe('user')
+    expect(state.messages[messagesBefore]?.content).toBe('edited')
+  })
+})

--- a/packages/lib/src/ai/agent-framework/__tests__/query-loop-validation.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/query-loop-validation.test.ts
@@ -1,0 +1,124 @@
+// packages/lib/src/ai/agent-framework/__tests__/query-loop-validation.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { ToolCall, UsageMetrics } from '../../clients/base/types'
+import { AgentEngine } from '../engine'
+import type {
+  AgentDefinition,
+  AgentDomainConfig,
+  AgentEngineConfig,
+  AgentEvent,
+  LLMCallParams,
+  LLMStreamEvent,
+} from '../types'
+
+const ZERO_USAGE: UsageMetrics = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
+
+const makeToolCall = (id: string, name: string, args: Record<string, unknown> = {}): ToolCall => ({
+  id,
+  type: 'function',
+  function: { name, arguments: JSON.stringify(args) },
+})
+
+async function drain(gen: AsyncGenerator<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = []
+  for await (const event of gen) events.push(event)
+  return events
+}
+
+describe('query-loop validation-error branch — sibling tool_call orphan regression', () => {
+  it('persists assistant with toolCalls=[approvalTool] only when missing-params + sibling auto-tool', async () => {
+    // Model emits both an auto-tool and an approval-tool with missing required args
+    // in the same response. The validation-error branch synthesizes a tool result
+    // for the approval tool only — without the rewrite, the auto-tool's
+    // tool_call_id would be left dangling in state.messages.
+    const auto = makeToolCall('call_auto', 'auto_tool', { x: 1 })
+    const approval = makeToolCall('call_appr', 'risky_tool', {}) // missing required `target`
+
+    let turnIdx = 0
+    const turns = [
+      // Iteration 1: emit both calls — triggers validation error on approval tool.
+      { content: 'mixed', toolCalls: [auto, approval] as ToolCall[] },
+      // Iteration 2: agent retries with valid args — return no tool calls to exit.
+      { content: 'fixed', toolCalls: [] as ToolCall[] },
+    ]
+    const callModel = async function* (_params: LLMCallParams): AsyncGenerator<LLMStreamEvent> {
+      const turn = turns[turnIdx++] ?? { content: '', toolCalls: [] }
+      yield { type: 'done', content: turn.content, toolCalls: turn.toolCalls, usage: ZERO_USAGE }
+    }
+
+    const agent: AgentDefinition = {
+      name: 'agent',
+      tools: [
+        {
+          name: 'auto_tool',
+          description: 'auto',
+          parameters: { type: 'object', properties: { x: { type: 'number' } }, required: ['x'] },
+          execute: async () => ({ success: true, output: { ok: true } }),
+        },
+        {
+          name: 'risky_tool',
+          description: 'approval',
+          parameters: {
+            type: 'object',
+            properties: { target: { type: 'string' } },
+            required: ['target'], // approval tool emitted without this → validation error
+          },
+          requiresApproval: true,
+          execute: async () => ({ success: true, output: { ran: true } }),
+        },
+      ],
+      buildMessages: async () => [],
+      processResult: async (_c, _tc, state) => state,
+      maxIterations: 3,
+    }
+
+    const domainConfig: AgentDomainConfig = {
+      type: 'kopilot',
+      agents: { agent },
+      routes: [{ name: 'default', agents: ['agent'] }],
+      createInitialState: () => ({}),
+      defaultModel: 'm',
+      defaultProvider: 'p',
+    }
+
+    const config: AgentEngineConfig = {
+      organizationId: 'org-1',
+      userId: 'user-1',
+      sessionId: 'sess-1',
+      domainConfig,
+      callModel,
+    }
+
+    const engine = new AgentEngine(config)
+    await drain(engine.submitMessage('go'))
+
+    const state = engine.getState()
+
+    // The persisted assistant message from the validation-error branch must
+    // carry toolCalls=[approvalTool] only — the sibling auto-tool was dropped.
+    const persistedAssistant = state.messages.find(
+      (m) => m.role === 'assistant' && m.toolCalls && m.toolCalls.length > 0
+    )
+    expect(persistedAssistant).toBeDefined()
+    expect(persistedAssistant?.toolCalls).toHaveLength(1)
+    expect(persistedAssistant?.toolCalls?.[0]?.id).toBe('call_appr')
+    expect(persistedAssistant?.toolCalls?.[0]?.function.name).toBe('risky_tool')
+
+    // The synthetic tool result must match the only persisted tool_call.
+    const toolMsg = state.messages.find((m) => m.role === 'tool' && m.toolCallId === 'call_appr')
+    expect(toolMsg).toBeDefined()
+    const parsed = JSON.parse(toolMsg?.content ?? '{}')
+    expect(parsed.error).toMatch(/Missing required parameters: target/)
+
+    // Critically: NO tool message exists for the dropped sibling tool_call_id,
+    // and NO assistant message references call_auto. Together these mean the
+    // next LLM call will not see a dangling tool_call_id.
+    const orphanRefs = state.messages.filter(
+      (m) =>
+        (m.role === 'tool' && m.toolCallId === 'call_auto') ||
+        (m.role === 'assistant' && m.toolCalls?.some((c) => c.id === 'call_auto'))
+    )
+    expect(orphanRefs).toHaveLength(0)
+  })
+})

--- a/packages/lib/src/ai/agent-framework/engine.ts
+++ b/packages/lib/src/ai/agent-framework/engine.ts
@@ -81,10 +81,14 @@ export class AgentEngine {
       content: userMessage,
       timestamp: Date.now(),
     }
+    // A fresh user message means the user is abandoning whatever was paused.
+    // Drop pendingToolCall (and its assistantMessage) — that branch never
+    // landed in state.messages, so there's nothing else to clean up.
     this.state = {
       ...this.state,
       messages: [...this.state.messages, userMsg],
       waitingForApproval: false,
+      pendingToolCall: undefined,
       approvalsThisTurn: 0,
       turnSnapshots: { records: {}, threads: {}, tasks: {} },
     }
@@ -321,6 +325,7 @@ export class AgentEngine {
         pendingToolCall: undefined,
         messages: [
           ...this.state.messages,
+          pending.assistantMessage,
           {
             role: 'tool' as const,
             content: JSON.stringify(rejectionResult),
@@ -385,6 +390,7 @@ export class AgentEngine {
           approvalsThisTurn: (this.state.approvalsThisTurn ?? 0) + 1,
           messages: [
             ...postHookState.messages,
+            pending.assistantMessage,
             {
               role: 'tool' as const,
               content: toolResultContent,
@@ -414,6 +420,7 @@ export class AgentEngine {
           pendingToolCall: undefined,
           messages: [
             ...this.state.messages,
+            pending.assistantMessage,
             {
               role: 'tool' as const,
               content: JSON.stringify({ error: errorMessage, output: null }),

--- a/packages/lib/src/ai/agent-framework/query-loop.ts
+++ b/packages/lib/src/ai/agent-framework/query-loop.ts
@@ -261,7 +261,9 @@ export async function* agentQueryLoop(
           missingParams,
         })
         // Persist the assistant message + synthetic error tool result so the LLM
-        // can retry with complete args on the next iteration.
+        // can retry with complete args on the next iteration. toolCalls is
+        // rewritten to [approvalTool] so sibling auto-tool calls in the same
+        // response can't dangle (we only synthesize a result for approvalTool).
         const errorContent = JSON.stringify({
           error: `Missing required parameters: ${missingParams.join(', ')}. Please provide all required parameters.`,
           output: null,
@@ -273,7 +275,7 @@ export async function* agentQueryLoop(
             {
               role: 'assistant' as const,
               content,
-              toolCalls,
+              toolCalls: [approvalTool],
               reasoning_content: reasoningContent || undefined,
               timestamp: Date.now(),
               metadata: {
@@ -299,23 +301,22 @@ export async function* agentQueryLoop(
         tool: approvalTool.function.name,
       })
 
-      // Persist the assistant message carrying the tool_call so session restore
-      // has the correct conversation shape. No fake tool result — state.pendingToolCall
-      // is the single source of truth for pending approvals.
+      // Hold the assistant message on pendingToolCall instead of pushing it
+      // into state.messages. The engine re-appends it atomically with the
+      // tool result on resume, so state.messages is always provider-valid.
+      // toolCalls is rewritten to [approvalTool] because the loop never
+      // executes sibling auto-tool calls in the same response — including
+      // them would create dangling tool_call_ids on resume.
       const assistantMessage = {
         role: 'assistant' as const,
         content,
-        toolCalls,
+        toolCalls: [approvalTool],
         reasoning_content: reasoningContent || undefined,
         timestamp: Date.now(),
         metadata: {
           agent: agent.name,
           modelId: `${callParams.provider}:${callParams.model}`,
         },
-      }
-      currentState = {
-        ...currentState,
-        messages: [...currentState.messages, assistantMessage],
       }
 
       yield {
@@ -335,6 +336,7 @@ export async function* agentQueryLoop(
           toolName: approvalTool.function.name,
           agentName: agent.name,
           args: approvalArgs,
+          assistantMessage,
         },
       }
       break

--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -182,6 +182,13 @@ export interface PendingToolCall {
   toolName: string
   agentName: string
   args: Record<string, unknown>
+  /**
+   * The assistant message that emitted this tool_call. Held here (NOT in
+   * state.messages) until the approval resolves, so the persisted messages
+   * array can never contain a dangling assistant tool_call. On resume, the
+   * engine appends this together with the tool result as one atomic pair.
+   */
+  assistantMessage: SessionMessage
 }
 
 /** Runtime state passed through the agent pipeline */

--- a/packages/lib/src/ai/kopilot/agents/agent.ts
+++ b/packages/lib/src/ai/kopilot/agents/agent.ts
@@ -104,24 +104,7 @@ export function createKopilotAgent(
           return msg
         })
 
-      // Drop orphan tool messages: every tool message must follow an assistant
-      // message with a matching tool_calls entry (OpenAI requirement).
-      const validToolCallIds = new Set<string>()
-      const conversationMessages: Message[] = []
-      for (const msg of rawMessages) {
-        if (msg.role === 'assistant' && msg.tool_calls?.length) {
-          for (const tc of msg.tool_calls) validToolCallIds.add(tc.id)
-        }
-        if (msg.role === 'tool') {
-          if (!msg.tool_call_id || !validToolCallIds.has(msg.tool_call_id)) {
-            logger.debug('Dropping orphan tool message', { toolCallId: msg.tool_call_id })
-            continue
-          }
-        }
-        conversationMessages.push(msg)
-      }
-
-      return [{ role: 'system', content: systemPrompt }, ...conversationMessages]
+      return [{ role: 'system', content: systemPrompt }, ...rawMessages]
     },
 
     tools: agentTools,


### PR DESCRIPTION
## Summary

- Approval pauses no longer write a half-pair (assistant with `tool_calls`, no matching tool result) into `state.messages`. The assistant message lives on `pendingToolCall.assistantMessage` until the pause resolves; `engine.runResume` re-appends it atomically with the tool result. `state.messages` is provider-valid by construction — no defensive filtering, no on-load repair.
- Fixes the OpenAI `400 An assistant message with 'tool_calls' must be followed by tool messages...` error triggered by refresh+deny races and editing a user message while an approval was pending. Also kills a sibling-tool-call orphan in the missing-params validation branch.
- Bundles a parallel scroll-pin fix in `kopilot-message-list` (sentinel-based "at bottom" measurement against actual content end, not the inflated empty space at the end of a turn).

### Approach

`packages/lib/src/ai/agent-framework/`:
- `types.ts` — `PendingToolCall` gains required `assistantMessage: SessionMessage`.
- `query-loop.ts` — On approval pause, stash the assistant on `pendingToolCall.assistantMessage` instead of pushing to `state.messages`. Rewrite `toolCalls = [approvalTool]` so siblings can't dangle. Same rewrite applied in the missing-required-params branch.
- `engine.ts` — Prepend `pending.assistantMessage` at all 3 `runResume` append sites (reject / approve-success / approve-error). Clear `pendingToolCall` in `submitMessage` so a fresh user message during a paused approval doesn't leak the abandoned half-pair.

`packages/lib/src/ai/kopilot/agents/agent.ts` — Drop the silent orphan-tool-message filter; the engine invariant makes it unreachable.

`apps/web/src/components/kopilot/hooks/use-kopilot-sessions.ts` — On session restore, render `_pendingToolCall.assistantMessage` as the assistant bubble before the approval card (it no longer lives in `messages[]`).

### Tests

7 new unit tests in `packages/lib/src/ai/agent-framework/__tests__/`:
- approval pause does NOT push assistant-with-tool_calls into `state.messages`
- approval pause rewrites `toolCalls = [approvalTool]` only on the stashed assistant
- `resume({ reject })` appends `[assistantMessage, toolResultMsg]` in order
- `resume({ approve })` success appends pair in order
- `resume({ approve })` when tool throws still appends `[assistantMessage, errorToolMsg]`
- `submitMessage` while pending clears `pendingToolCall` and only appends new user message
- validation-error branch with `[auto_tool, approval_tool_missing_args]` persists `toolCalls = [approvalTool]` only — no orphan for the auto-tool sibling

## Test plan

- [x] `pnpm vitest run src/ai/agent-framework/__tests__/` — 7/7 pass
- [x] Lint clean on all touched files
- [x] Manual: trigger approval, refresh browser, click Deny → turn completes, rejection lands
- [x] Manual: trigger approval, edit prior user message instead of approving → next turn succeeds, no 400
- [ ] Smoke: run a normal Kopilot turn end-to-end after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)