### PR TITLE
feat(records): record hover card preview on badges

### DIFF
--- a/apps/web/src/components/dynamic-table/utils/cell-renderers.tsx
+++ b/apps/web/src/components/dynamic-table/utils/cell-renderers.tsx
@@ -57,7 +57,7 @@ function RelationshipCellContent({ value }: { value: unknown }) {
     <ItemsCellView
       items={items}
       isLoading={false} // RecordBadge handles individual loading states
-      renderItem={(item) => <RecordBadge recordId={item.recordId} link />}
+      renderItem={(item) => <RecordBadge recordId={item.recordId} link hoverCard />}
       maxDisplay={3}
     />
   )

--- a/apps/web/src/components/resources/ui/index.ts
+++ b/apps/web/src/components/resources/ui/index.ts
@@ -2,6 +2,12 @@
 
 export { ActorBadge, actorBadgeVariants } from './actor-badge'
 export { AvatarUploadIcon } from './avatar-upload-icon'
-export { RecordBadge, recordBadgeVariants } from './record-badge'
+export {
+  RecordBadge,
+  type RecordBadgeHoverCardConfig,
+  recordBadgeVariants,
+} from './record-badge'
+export { RecordHoverCard } from './record-hover-card'
+export { RecordHoverCardField } from './record-hover-card-field'
 export { RecordIcon } from './record-icon'
 export { TicketBadge } from './ticket-badge'

--- a/apps/web/src/components/resources/ui/record-badge.tsx
+++ b/apps/web/src/components/resources/ui/record-badge.tsx
@@ -5,6 +5,7 @@
 import type { RecordId } from '@auxx/lib/resources/client'
 // Utility imports
 import { getDefinitionId } from '@auxx/lib/resources/client'
+import type { FieldReference } from '@auxx/types/field'
 // UI component imports
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
@@ -15,7 +16,20 @@ import Link from 'next/link'
 // Hook imports
 import { useRecord, useResource } from '~/components/resources'
 import { type GetRecordLinkOptions, useRecordLink } from '../utils/get-record-link'
+import { RecordHoverCard } from './record-hover-card'
 import { RecordIcon } from './record-icon'
+
+/** Configuration for `RecordBadge`'s optional hover-card preview. */
+export interface RecordBadgeHoverCardConfig {
+  fields?: FieldReference[]
+  onOpenInDrawer?: (recordId: RecordId) => void
+  /** Preferred side to render the hover card. Radix flips on collision. */
+  side?: 'top' | 'right' | 'bottom' | 'left'
+  /** Alignment along the chosen side. */
+  align?: 'start' | 'center' | 'end'
+  /** Pixel offset from the trigger along the side axis. */
+  sideOffset?: number
+}
 
 /**
  * Variants for the RecordBadge component
@@ -63,6 +77,8 @@ interface RecordBadgeProps extends VariantProps<typeof recordBadgeVariants> {
   className?: string
   /** Link configuration - if true uses default link, if object uses those options */
   link?: boolean | GetRecordLinkOptions
+  /** When set, wraps the badge in a `RecordHoverCard` for the same recordId. */
+  hoverCard?: boolean | RecordBadgeHoverCardConfig
 }
 
 /**
@@ -102,6 +118,7 @@ export function RecordBadge({
   variant,
   size,
   link,
+  hoverCard,
   ...props
 }: RecordBadgeProps) {
   // Fetch record data (displayName, avatarUrl)
@@ -133,7 +150,7 @@ export function RecordBadge({
   // Choose the component type based on link prop
   const Comp = link && href ? Link : 'div'
 
-  return (
+  const badge = (
     <Comp
       data-slot='record-badge'
       aria-busy={isLoading}
@@ -162,4 +179,21 @@ export function RecordBadge({
       )}
     </Comp>
   )
+
+  if (hoverCard && recordId) {
+    const hoverConfig = typeof hoverCard === 'object' ? hoverCard : undefined
+    return (
+      <RecordHoverCard
+        recordId={recordId}
+        fields={hoverConfig?.fields}
+        onOpenInDrawer={hoverConfig?.onOpenInDrawer}
+        side={hoverConfig?.side}
+        align={hoverConfig?.align}
+        sideOffset={hoverConfig?.sideOffset}>
+        {badge}
+      </RecordHoverCard>
+    )
+  }
+
+  return badge
 }

--- a/apps/web/src/components/resources/ui/record-hover-card-field.tsx
+++ b/apps/web/src/components/resources/ui/record-hover-card-field.tsx
@@ -1,0 +1,87 @@
+// apps/web/src/components/resources/ui/record-hover-card-field.tsx
+'use client'
+
+import type { FieldType } from '@auxx/database/types'
+import { fieldTypeOptions } from '@auxx/lib/custom-fields/types'
+import type { RecordId } from '@auxx/lib/resources/client'
+import {
+  type FieldPath,
+  type FieldReference,
+  isFieldPath,
+  type ResourceFieldId,
+} from '@auxx/types/field'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { cn } from '@auxx/ui/lib/utils'
+import { memo, useMemo } from 'react'
+import { type CellConfig, renderCellValue } from '~/components/dynamic-table'
+import { useField } from '~/components/resources/hooks/use-field'
+import { useFieldValue } from '~/components/resources/hooks/use-field-values'
+import { ItemsCellView } from '~/components/ui/items-list-view'
+
+/** Field types that already handle array values internally */
+const MULTI_VALUE_FIELD_TYPES = new Set(['TAGS', 'MULTI_SELECT', 'RELATIONSHIP', 'ITEMS'])
+
+interface RecordHoverCardFieldProps {
+  recordId: RecordId
+  fieldRef: FieldReference
+  className?: string
+}
+
+/**
+ * Read-only field row for `RecordHoverCard`. Pulls value + metadata from the
+ * shared resource store. Returns `null` when the value is empty so empty
+ * fields don't clutter the preview.
+ */
+export const RecordHoverCardField = memo(function RecordHoverCardField({
+  recordId,
+  fieldRef,
+  className,
+}: RecordHoverCardFieldProps) {
+  const targetResourceFieldId = useMemo(() => {
+    if (isFieldPath(fieldRef)) {
+      const path = fieldRef as FieldPath
+      return path[path.length - 1] as ResourceFieldId
+    }
+    return fieldRef as ResourceFieldId
+  }, [fieldRef])
+
+  const { value, isLoading } = useFieldValue(recordId, fieldRef, { autoFetch: true })
+  const field = useField(targetResourceFieldId)
+
+  if (isLoading && value === undefined) {
+    return <Skeleton className='h-4 w-24' />
+  }
+
+  const isEmpty = value === null || value === undefined
+  if (isEmpty) return null
+
+  const fieldType = field?.fieldType
+  const iconId = fieldType
+    ? (fieldTypeOptions[fieldType as FieldType]?.iconId ?? 'circle')
+    : 'circle'
+  const type = fieldType ?? 'TEXT'
+  const config: CellConfig = { options: field?.options }
+
+  const isArrayValue = Array.isArray(value)
+  const fieldHandlesArrays = MULTI_VALUE_FIELD_TYPES.has(type)
+
+  return (
+    <div className={cn('flex items-center gap-2 text-xs', className)}>
+      <div className='flex w-24 shrink-0 items-center gap-1.5 text-muted-foreground'>
+        <EntityIcon iconId={iconId} variant='default' size='xs' />
+        <span className='truncate'>{field?.label ?? ''}</span>
+      </div>
+      <div className='min-w-0 flex-1 truncate'>
+        {isArrayValue && !fieldHandlesArrays && value.length > 0 ? (
+          <ItemsCellView
+            items={value.map((v: unknown, i: number) => ({ id: String(i), value: v }))}
+            renderItem={(item) => renderCellValue(item.value, type, undefined, config)}
+          />
+        ) : (
+          renderCellValue(value, type, undefined, config)
+        )}
+      </div>
+    </div>
+  )
+})

--- a/apps/web/src/components/resources/ui/record-hover-card.tsx
+++ b/apps/web/src/components/resources/ui/record-hover-card.tsx
@@ -1,0 +1,238 @@
+// apps/web/src/components/resources/ui/record-hover-card.tsx
+'use client'
+
+import {
+  getDefinitionId,
+  getHoverCardFieldKeys,
+  parseRecordId,
+  type RecordId,
+} from '@auxx/lib/resources/client'
+import type { FieldReference, ResourceFieldId } from '@auxx/types/field'
+import { Button } from '@auxx/ui/components/button'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@auxx/ui/components/hover-card'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { cn } from '@auxx/ui/lib/utils'
+import { Maximize2, PanelRight, Star } from 'lucide-react'
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { useFavoriteToggle } from '~/components/favorites/hooks/use-favorite-toggle'
+import { useRecord } from '~/components/resources/hooks/use-record'
+import { useResource } from '~/components/resources/hooks/use-resource'
+import { useResourceStore } from '~/components/resources/store/resource-store'
+import { useRecordLink } from '~/components/resources/utils/get-record-link'
+import { RecordHoverCardField } from './record-hover-card-field'
+import { RecordIcon } from './record-icon'
+
+interface RecordHoverCardProps {
+  /** RecordId in format "entityDefinitionId:entityInstanceId". When null/undefined, the trigger renders without hover behaviour. */
+  recordId?: RecordId | null
+  /** Field references to render in the body. Falls back to per-resource defaults from `HOVER_CARD_FIELDS`. Pass `[]` to force header-only. */
+  fields?: FieldReference[]
+  /** Trigger element. Wrapped in `HoverCardTrigger asChild`. */
+  children: React.ReactNode
+  /** Hover open delay in ms. */
+  openDelay?: number
+  /** Hover close delay in ms. */
+  closeDelay?: number
+  side?: 'top' | 'right' | 'bottom' | 'left'
+  align?: 'start' | 'center' | 'end'
+  /** Pixel offset from the trigger along the side axis. */
+  sideOffset?: number
+  className?: string
+  /** When provided, shows a "View in drawer" footer button that calls this. */
+  onOpenInDrawer?: (recordId: RecordId) => void
+}
+
+/**
+ * Reusable hover-card preview for any record. Shows a large icon/avatar,
+ * primary + secondary display names, a favorite-toggle star, optional fields,
+ * and footer buttons for opening in drawer / full page.
+ *
+ * Reuses the existing `useRecord` / `useResource` / `useFieldValue` stores;
+ * does not issue new tRPC requests when the record is already cached.
+ */
+export function RecordHoverCard({
+  recordId,
+  fields,
+  children,
+  openDelay = 300,
+  closeDelay = 100,
+  side,
+  align = 'start',
+  sideOffset,
+  className,
+  onOpenInDrawer,
+}: RecordHoverCardProps) {
+  if (!recordId) return <>{children}</>
+
+  return (
+    <HoverCard openDelay={openDelay} closeDelay={closeDelay}>
+      {/* Wrap in a stable inline-flex span so the trigger's pointer listeners
+          attach to a host element we own — avoids asChild merging into a
+          re-rendering Link/anchor inside a virtualized cell, which can drop
+          pointerenter events. */}
+      <HoverCardTrigger asChild>
+        <span data-slot='record-hover-trigger' className='inline-flex max-w-full'>
+          {children}
+        </span>
+      </HoverCardTrigger>
+      <HoverCardContent
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+        collisionPadding={8}
+        className={cn('w-80 p-3', className)}
+        onClick={(e) => e.stopPropagation()}>
+        <RecordHoverCardBody recordId={recordId} fields={fields} onOpenInDrawer={onOpenInDrawer} />
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
+interface BodyProps {
+  recordId: RecordId
+  fields?: FieldReference[]
+  onOpenInDrawer?: (recordId: RecordId) => void
+}
+
+function RecordHoverCardBody({ recordId, fields, onOpenInDrawer }: BodyProps) {
+  const entityDefinitionId = getDefinitionId(recordId)
+  const { record, isLoading: isLoadingRecord, isNotFound } = useRecord({ recordId })
+  const { resource, isLoading: isLoadingResource } = useResource(entityDefinitionId)
+  const href = useRecordLink(recordId)
+  const systemAttributeMap = useResourceStore((s) => s.systemAttributeMap)
+
+  // Secondary display lives on RecordMeta.secondaryInfo (populated by the batch
+  // fetcher from EntityInstance.secondaryDisplayValue). Same path TicketBadge uses.
+  const secondaryDisplay =
+    typeof record?.secondaryInfo === 'string' && record.secondaryInfo.length > 0
+      ? record.secondaryInfo
+      : null
+
+  // Resolve fields: caller override > registry default (system attributes) > [].
+  // The registry stores stable system-attribute names (e.g. 'ticket_status');
+  // resolve them to real ResourceFieldIds via the resource store map — same
+  // primitive `useSystemValues` uses.
+  const resolvedFields = useMemo<FieldReference[]>(() => {
+    if (fields !== undefined) return fields
+    if (!resource?.entityType) return []
+    const attrs = getHoverCardFieldKeys(resource.entityType)
+    if (attrs.length === 0) return []
+    const refs: ResourceFieldId[] = []
+    for (const attr of attrs) {
+      const ref = systemAttributeMap[attr]
+      if (ref) refs.push(ref)
+    }
+    return refs
+  }, [fields, resource?.entityType, systemAttributeMap])
+
+  if (isNotFound) {
+    return <div className='py-4 text-center text-sm text-muted-foreground'>Record not found</div>
+  }
+
+  const isLoading = (isLoadingRecord || isLoadingResource) && !record
+  if (isLoading) {
+    return (
+      <div className='flex items-start gap-3'>
+        <Skeleton className='size-12 rounded-full' />
+        <div className='flex-1 space-y-2 pt-1'>
+          <Skeleton className='h-4 w-32' />
+          <Skeleton className='h-3 w-24' />
+        </div>
+      </div>
+    )
+  }
+
+  const displayName = (record?.displayName as string | undefined) ?? 'Untitled'
+
+  const hasFooter = !!onOpenInDrawer || !!href
+  const showDivider = resolvedFields.length > 0 || hasFooter
+
+  return (
+    <>
+      {/* Header */}
+      <div className='flex items-start gap-3'>
+        <RecordIcon
+          avatarUrl={record?.avatarUrl as string | undefined}
+          iconId={resource?.icon || 'circle'}
+          color={resource?.color || 'gray'}
+          size='xl'
+          inverse
+        />
+        <div className='min-w-0 flex-1'>
+          <div className='flex items-center gap-1.5'>
+            <h4 className=' truncate text-sm font-semibold leading-snug'>{displayName}</h4>
+            <FavoriteStarButton recordId={recordId} />
+          </div>
+          {secondaryDisplay && (
+            <p className='truncate text-xs text-muted-foreground'>{secondaryDisplay}</p>
+          )}
+        </div>
+      </div>
+
+      {/* Fields */}
+      {resolvedFields.length > 0 && (
+        <div className='mt-3 space-y-1 border-t pt-2'>
+          {resolvedFields.map((ref) => (
+            <RecordHoverCardField key={String(ref)} recordId={recordId} fieldRef={ref} />
+          ))}
+        </div>
+      )}
+
+      {/* Footer */}
+      {hasFooter && (
+        <div
+          className={cn(
+            'mt-3 flex items-center justify-end gap-1 pt-2',
+            // Only render the divider once — fields section already has its own.
+            !resolvedFields.length && showDivider && 'border-t'
+          )}>
+          {onOpenInDrawer && (
+            <Button
+              variant='ghost'
+              size='icon-xs'
+              title='Open in drawer'
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                onOpenInDrawer(recordId)
+              }}>
+              <PanelRight />
+            </Button>
+          )}
+          {href && (
+            <Button asChild variant='ghost' size='icon-xs' title='Open full page'>
+              <Link href={href} onClick={(e) => e.stopPropagation()}>
+                <Maximize2 />
+              </Link>
+            </Button>
+          )}
+        </div>
+      )}
+    </>
+  )
+}
+
+function FavoriteStarButton({ recordId }: { recordId: RecordId }) {
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+  const { toggle, isFavorited, isPending } = useFavoriteToggle('ENTITY_INSTANCE', {
+    entityDefinitionId,
+    entityInstanceId,
+  })
+
+  return (
+    <Button
+      variant='ghost'
+      size='icon-xs'
+      className='shrink-0'
+      loading={isPending}
+      title={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        toggle()
+      }}>
+      <Star className={cn(isFavorited && 'fill-yellow-400 text-yellow-400')} />
+    </Button>
+  )
+}

--- a/packages/lib/src/resources/client.ts
+++ b/packages/lib/src/resources/client.ts
@@ -94,6 +94,8 @@ export {
   setResourceVariables,
   sortFieldsForDisplay,
 } from './registry/field-utils'
+// Hover-card field defaults
+export { getHoverCardFieldKeys, HOVER_CARD_FIELDS } from './registry/hover-card-fields'
 export type {
   CustomResource,
   CustomResourceId,

--- a/packages/lib/src/resources/registry/hover-card-fields.ts
+++ b/packages/lib/src/resources/registry/hover-card-fields.ts
@@ -1,0 +1,27 @@
+// packages/lib/src/resources/registry/hover-card-fields.ts
+
+import type { TableId } from './field-registry'
+
+/**
+ * Default fields to render in `RecordHoverCard` for each system resource.
+ *
+ * Values are **system attribute names** (e.g. `'ticket_status'`,
+ * `'assigned_to_id'`) — the same identifiers `useSystemValues` accepts. The
+ * client resolves these to `ResourceFieldId`s via the resource store's
+ * `systemAttributeMap`. Resources omitted render header-only.
+ *
+ * Caller-supplied `fields` always overrides this default.
+ */
+export const HOVER_CARD_FIELDS: Partial<Record<TableId, string[]>> = {
+  ticket: ['ticket_status', 'ticket_priority', 'assigned_to_id', 'due_date'],
+  contact: ['phone', 'contact_company', 'customer_groups', 'contact_status'],
+  company: ['company_website', 'company_industry', 'company_size', 'company_primary_contact'],
+}
+
+/**
+ * Get the default hover-card system attribute names for a resource.
+ * Returns an empty array for resources without defaults.
+ */
+export function getHoverCardFieldKeys(tableId: string): string[] {
+  return HOVER_CARD_FIELDS[tableId as TableId] ?? []
+}

--- a/packages/ui/src/components/hover-card.tsx
+++ b/packages/ui/src/components/hover-card.tsx
@@ -8,6 +8,8 @@ const HoverCard = HoverCardPrimitive.Root
 
 const HoverCardTrigger = HoverCardPrimitive.Trigger
 
+const HoverCardPortal = HoverCardPrimitive.Portal
+
 function HoverCardContent({
   className,
   align = 'center',
@@ -15,16 +17,18 @@ function HoverCardContent({
   ...props
 }: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
   return (
-    <HoverCardPrimitive.Content
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        'z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className
-      )}
-      {...props}
-    />
+    <HoverCardPrimitive.Portal>
+      <HoverCardPrimitive.Content
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-64 rounded-2xl border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
   )
 }
 
-export { HoverCard, HoverCardTrigger, HoverCardContent }
+export { HoverCard, HoverCardTrigger, HoverCardContent, HoverCardPortal }


### PR DESCRIPTION
## Summary
- New `RecordHoverCard` + `RecordHoverCardField` that preview any record (icon, name, secondary info, configurable fields, favorite toggle, drawer / full-page links) on hover, reusing the existing `useRecord`/`useResource`/field-value stores so cached records don't trigger new tRPC fetches.
- `RecordBadge` gains a `hoverCard` prop (boolean or config); table relationship cells in `cell-renderers.tsx` opt in by default.
- Default per-resource field sets in `HOVER_CARD_FIELDS` (ticket / contact / company), resolved via the resource store's `systemAttributeMap`. Callers can override via the `fields` prop.
- `HoverCardContent` now renders through `HoverCardPortal` so the popover escapes virtualized table cells; corner radius bumped to `rounded-2xl`.

## Test plan
- [ ] Hover a record badge inside a relationship cell on the tickets/contacts/companies tables — popup appears, shows icon + name + default fields.
- [ ] Verify popup escapes virtualized rows (scroll the table while hovered).
- [ ] Toggle favorite from the popup star — state persists.
- [ ] Open-in-drawer / full-page footer buttons work and don't propagate to the row click.
- [ ] Pass an explicit `fields={[]}` — header-only render.
- [ ] Pass custom `fields` — overrides defaults.