### PR TITLE
fix(kb): make apps/kb build under Next 16 cacheComponents

### DIFF
--- a/apps/kb/package.json
+++ b/apps/kb/package.json
@@ -15,9 +15,11 @@
     "@auxx/database": "workspace:*",
     "@auxx/lib": "workspace:*",
     "@auxx/ui": "workspace:*",
+    "drizzle-orm": "catalog:",
     "lucide-react": "catalog:",
     "minisearch": "catalog:",
     "next": "catalog:",
+    "pg": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "sharp": "catalog:"

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/[...articleSlug]/page.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/[...articleSlug]/page.tsx
@@ -4,14 +4,34 @@ import { findArticleBySlugPath, KBArticleRenderer } from '@auxx/ui/components/kb
 import type { Metadata } from 'next'
 import { cacheLife, cacheTag } from 'next/cache'
 import { notFound } from 'next/navigation'
+import { Suspense } from 'react'
 import { getKBPayloadWithContent, kbArticleTag, kbTag } from '../../../../server/kb-cache'
 
 interface PageProps {
   params: Promise<{ orgSlug: string; kbSlug: string; articleSlug: string[] }>
 }
 
+// Articles are entirely tenant-specific, so we have no real paths to prerender
+// at build time. cacheComponents requires at least one stub. The placeholder
+// renders a 404 page (no real article matches "__build__"), and all real
+// requests render at runtime and are cached by 'use cache' + cacheTag.
+export async function generateStaticParams() {
+  return [{ orgSlug: '__build__', kbSlug: '__build__', articleSlug: ['__build__'] }]
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { orgSlug, kbSlug, articleSlug } = await params
+  return getCachedMetadata(orgSlug, kbSlug, articleSlug)
+}
+
+async function getCachedMetadata(
+  orgSlug: string,
+  kbSlug: string,
+  articleSlug: string[]
+): Promise<Metadata> {
+  'use cache'
+  cacheTag(kbTag(orgSlug, kbSlug))
+  cacheLife('max')
   const { articles } = await getKBPayloadWithContent(orgSlug, kbSlug)
   const article = findArticleBySlugPath(articles, articleSlug)
   if (!article) return { title: 'Not found' }
@@ -23,6 +43,18 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function ArticlePage({ params }: PageProps) {
+  return (
+    <Suspense fallback={null}>
+      <ArticleBody params={params} />
+    </Suspense>
+  )
+}
+
+async function ArticleBody({
+  params,
+}: {
+  params: Promise<{ orgSlug: string; kbSlug: string; articleSlug: string[] }>
+}) {
   'use cache'
   const { orgSlug, kbSlug, articleSlug } = await params
   const slugPath = articleSlug.join('/')

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
@@ -1,9 +1,12 @@
+'use cache'
+
 // apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
 
 import { KBLayout } from '@auxx/ui/components/kb'
 import '@auxx/ui/global.css'
+import { cacheLife, cacheTag } from 'next/cache'
 import { notFound } from 'next/navigation'
-import { getKBPayload } from '../../../server/kb-cache'
+import { getKBPayload, kbTag } from '../../../server/kb-cache'
 
 interface KBSlugLayoutProps {
   params: Promise<{ orgSlug: string; kbSlug: string }>
@@ -12,11 +15,14 @@ interface KBSlugLayoutProps {
 
 export default async function KBSlugLayout({ params, children }: KBSlugLayoutProps) {
   const { orgSlug, kbSlug } = await params
+  cacheTag(kbTag(orgSlug, kbSlug))
+  cacheLife('max')
+
   const { kb, articles } = await getKBPayload(orgSlug, kbSlug)
   if (!kb) notFound()
 
   const basePath = `/${orgSlug}/${kbSlug}`
-  const searchOrigin = `${basePath}/_search.json`
+  const searchOrigin = `${basePath}/search.json`
 
   return (
     <KBLayout kb={kb} articles={articles} basePath={basePath} searchOrigin={searchOrigin}>

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
@@ -1,3 +1,5 @@
+'use cache'
+
 // apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
 
 import { KBArticleRenderer } from '@auxx/ui/components/kb'
@@ -8,6 +10,12 @@ import { getKBPayloadWithContent, kbTag } from '../../../server/kb-cache'
 
 interface PageProps {
   params: Promise<{ orgSlug: string; kbSlug: string }>
+}
+
+// KBs are entirely tenant-specific. Provide a stub so cacheComponents can
+// validate the route shape; real requests render at runtime and are cached.
+export async function generateStaticParams() {
+  return [{ orgSlug: '__build__', kbSlug: '__build__' }]
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -22,7 +30,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function KBLandingPage({ params }: PageProps) {
-  'use cache'
   const { orgSlug, kbSlug } = await params
   cacheTag(kbTag(orgSlug, kbSlug))
   cacheLife('max')

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/search.json/route.ts
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/search.json/route.ts
@@ -1,4 +1,4 @@
-// apps/kb/src/app/[orgSlug]/[kbSlug]/_search.json/route.ts
+// apps/kb/src/app/[orgSlug]/[kbSlug]/search.json/route.ts
 
 import { buildKBSearchIndex, getArticleSlugPaths } from '@auxx/ui/components/kb'
 import { cacheLife, cacheTag } from 'next/cache'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -748,6 +748,9 @@ importers:
       '@aws-sdk/s3-presigned-post':
         specifier: 'catalog:'
         version: 3.999.0
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.44.5(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.19.0)(postgres@3.4.8)
       lucide-react:
         specifier: 'catalog:'
         version: 0.575.0(react@19.2.3)
@@ -757,6 +760,9 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.0.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      pg:
+        specifier: 'catalog:'
+        version: 8.19.0
       react:
         specifier: 'catalog:'
         version: 19.2.3


### PR DESCRIPTION
## Summary

Fixes the `pnpm build` for `apps/kb` (the public KB site shipped in #517). The Next 16 + `cacheComponents: true` build caught a few issues that the rendering plan didn't anticipate.

- **Missing deps:** `kb-data.ts` imports `drizzle-orm` directly. Added `drizzle-orm` and `pg` to `apps/kb/package.json` (catalog).
- **`'use cache'` placement:** Next 16 with `cacheComponents` only respects the directive at module top, not at function top. Moved it for `[orgSlug]/[kbSlug]/layout.tsx` and `[orgSlug]/[kbSlug]/page.tsx`.
- **`generateStaticParams` stubs:** With `cacheComponents`, dynamic routes can't return empty arrays — Next refuses to build. Tenant slugs are entirely runtime, so I added `__build__` placeholders that satisfy build-time validation. Real requests render at runtime and cache via `'use cache'` + `cacheTag`.
- **`_search.json` → `search.json`:** App Router excludes any folder starting with `_` from routing, so the search index endpoint was unreachable. Renamed the directory and updated the `searchOrigin` URL in the layout.
- **Article catchall now wraps the data fetch in `<Suspense>`** with an inner cached `ArticleBody` — required to make `cacheComponents` happy on the catchall + `'use cache'` shape.

Build now produces clean route table:
- `/[orgSlug]/[kbSlug]` (PPR, 15m revalidate)
- `/[orgSlug]/[kbSlug]/[...articleSlug]` (PPR, 30d revalidate)
- `/[orgSlug]/[kbSlug]/search.json` (dynamic route handler)
- `/api/revalidate` (dynamic)

## Test plan

- [x] \`pnpm --filter @auxx/kb build\` exits 0
- [ ] Hit \`/<orgSlug>/<kbSlug>/\` for a published KB and verify it renders
- [ ] Hit \`/<orgSlug>/<kbSlug>/<articleSlug>\` and verify article renders
- [ ] Hit \`/<orgSlug>/<kbSlug>/search.json\` and verify it returns the index
- [ ] POST \`/api/revalidate\` with the bearer secret and verify cache busts on next page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)