### PR TITLE
feat(kb): internal visibility + custom-domain verification + auth flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,7 @@ SDK_CLIENT_SECRET=
 LOGIN_TOKEN_PRIVATE_KEY=
 LOGIN_TOKEN_PUBLIC_KEY=
 BUILD_SESSION_SECRET=
+KB_SESSION_SECRET=
 
 # ------------------------------------
 # Core App Settings

--- a/apps/build/src/lib/auth.ts
+++ b/apps/build/src/lib/auth.ts
@@ -2,69 +2,26 @@
 // Authentication utilities for developer portal
 
 import { WEBAPP_URL } from '@auxx/config/urls'
-import { configService } from '@auxx/credentials'
+import { createLocalSessionHelpers } from '@auxx/credentials/local-session'
 import { DeveloperAccountMember, database } from '@auxx/database'
 import { getRedisClient } from '@auxx/redis'
 import { and, eq } from 'drizzle-orm'
-import { jwtVerify, SignJWT } from 'jose'
 import { cookies } from 'next/headers'
 
-const SESSION_COOKIE_NAME = 'auxx-build.session'
-const SESSION_DURATION = 60 * 60 // 1 hour in seconds
+const helpers = createLocalSessionHelpers({
+  cookieName: 'auxx-build.session',
+  secretEnv: 'BUILD_SESSION_SECRET',
+  ttlSeconds: 60 * 60, // 1 hour
+  getCookieStore: () => cookies(),
+  getRedis: () => getRedisClient(),
+})
 
-/** Session type */
-export interface Session {
-  userId: string
-  email: string
-}
+export type Session = { userId: string; email: string }
 
-/** Get the session signing secret — fails fast if not configured */
-function getSessionSecret(): Uint8Array {
-  const secret = configService.get<string>('BUILD_SESSION_SECRET')
-  if (!secret) throw new Error('BUILD_SESSION_SECRET not configured')
-  return new TextEncoder().encode(secret)
-}
-
-/** Create a signed local session JWT */
-export async function createLocalSession(user: { userId: string; email: string }): Promise<string> {
-  return new SignJWT({ email: user.email })
-    .setProtectedHeader({ alg: 'HS256' })
-    .setSubject(user.userId)
-    .setIssuedAt()
-    .setExpirationTime(`${SESSION_DURATION}s`)
-    .sign(getSessionSecret())
-}
-
-/** Verify a local session cookie, return user info or null */
-export async function verifyLocalSession(
-  token: string
-): Promise<{ userId: string; email: string } | null> {
-  try {
-    const { payload } = await jwtVerify(token, getSessionSecret())
-
-    if (!payload.sub || !payload.email) return null
-    return { userId: payload.sub, email: payload.email as string }
-  } catch {
-    return null
-  }
-}
-
-/** Consume a login token jti (single-use). Returns true if consumed, false if already used. */
-export async function consumeLoginTokenJti(jti: string): Promise<boolean> {
-  const redis = await getRedisClient()
-  if (!redis) return false
-  // SET NX EX: only set if not exists, expire after 10 minutes
-  const result = await redis.set(`login-token:${jti}`, 'consumed', 'EX', 600, 'NX')
-  return result === 'OK'
-}
-
-/** Get local session from cookie */
-export async function getLocalSession(): Promise<Session | null> {
-  const cookieStore = await cookies()
-  const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME)
-  if (!sessionCookie?.value) return null
-  return verifyLocalSession(sessionCookie.value)
-}
+export const createLocalSession = helpers.createSession
+export const verifyLocalSession = helpers.verifySession
+export const getLocalSession = helpers.getSession
+export const consumeLoginTokenJti = helpers.consumeLoginTokenJti
 
 /**
  * Get login URL with return path

--- a/apps/homepage/package.json
+++ b/apps/homepage/package.json
@@ -36,7 +36,7 @@
     "reading-time": "^1.5.0",
     "recharts": "^2.15.4",
     "remark-gfm": "^4.0.1",
-    "shiki": "^4.0.2",
+    "shiki": "catalog:",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/apps/kb/.env.example
+++ b/apps/kb/.env.example
@@ -1,3 +1,13 @@
 DATABASE_URL="postgresql://postgres:password@localhost:5432/auxx-ai"
 # DB_POOL_MAX=10
 # DB_QUERY_LOGGING=true
+
+REDIS_HOST=
+REDIS_PORT=
+REDIS_PASSWORD=
+
+# Ed25519 SPKI public key — must match LOGIN_TOKEN_PRIVATE_KEY in apps/web for verifying
+# the cross-app login token issued by web before minting auxx-kb.session.
+LOGIN_TOKEN_PUBLIC_KEY=
+# HS256 secret used to sign the local auxx-kb.session cookie. Independent of build.
+KB_SESSION_SECRET=

--- a/apps/kb/package.json
+++ b/apps/kb/package.json
@@ -12,8 +12,10 @@
   "dependencies": {
     "@aws-sdk/s3-presigned-post": "catalog:",
     "@auxx/config": "workspace:*",
+    "@auxx/credentials": "workspace:*",
     "@auxx/database": "workspace:*",
     "@auxx/lib": "workspace:*",
+    "@auxx/redis": "workspace:*",
     "@auxx/ui": "workspace:*",
     "drizzle-orm": "catalog:",
     "lucide-react": "catalog:",

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/[...articleSlug]/page.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/[...articleSlug]/page.tsx
@@ -1,5 +1,7 @@
 // apps/kb/src/app/[orgSlug]/[kbSlug]/[...articleSlug]/page.tsx
 
+import { WEBAPP_URL } from '@auxx/config/urls'
+import { isOrgMember } from '@auxx/lib/cache'
 import {
   extractKBHeadings,
   findArticleBySlugPath,
@@ -10,9 +12,16 @@ import {
 } from '@auxx/ui/components/kb'
 import type { Metadata } from 'next'
 import { cacheLife, cacheTag } from 'next/cache'
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import { Suspense } from 'react'
-import { getKBPayloadWithContent, kbArticleTag, kbTag } from '../../../../server/kb-cache'
+import { getLocalSession, getLoginUrl } from '~/lib/auth'
+import {
+  getCachedKBVisibility,
+  getPublicKBPayloadWithContent,
+  kbArticleTag,
+  kbTag,
+} from '../../../../server/kb-cache'
+import { loadKBPayloadWithContent, type PublicArticleFull } from '../../../../server/kb-data'
 
 interface PageProps {
   params: Promise<{ orgSlug: string; kbSlug: string; articleSlug: string[] }>
@@ -28,6 +37,13 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { orgSlug, kbSlug, articleSlug } = await params
+
+  const visibility = await getCachedKBVisibility(orgSlug, kbSlug)
+  if (!visibility || visibility.publishStatus === 'DRAFT') return { title: 'Not found' }
+
+  if (visibility.visibility === 'INTERNAL') {
+    return { title: 'Knowledge base', robots: { index: false, follow: false } }
+  }
   return getCachedMetadata(orgSlug, kbSlug, articleSlug)
 }
 
@@ -39,7 +55,7 @@ async function getCachedMetadata(
   'use cache'
   cacheTag(kbTag(orgSlug, kbSlug))
   cacheLife('max')
-  const { kb, articles } = await getKBPayloadWithContent(orgSlug, kbSlug)
+  const { kb, articles } = await getPublicKBPayloadWithContent(orgSlug, kbSlug)
   const article = findArticleBySlugPath(articles, articleSlug)
   if (!article) return { title: 'Not found' }
   return {
@@ -51,25 +67,103 @@ async function getCachedMetadata(
 }
 
 export default async function ArticlePage({ params }: PageProps) {
+  const { orgSlug, kbSlug, articleSlug } = await params
+
+  const visibility = await getCachedKBVisibility(orgSlug, kbSlug)
+  if (!visibility || visibility.publishStatus === 'DRAFT') notFound()
+
+  if (visibility.visibility === 'PUBLIC') {
+    return (
+      <Suspense fallback={null}>
+        <PublicArticleBody orgSlug={orgSlug} kbSlug={kbSlug} articleSlug={articleSlug} />
+      </Suspense>
+    )
+  }
+
   return (
     <Suspense fallback={null}>
-      <ArticleBody params={params} />
+      <InternalArticleGate
+        orgSlug={orgSlug}
+        kbSlug={kbSlug}
+        articleSlug={articleSlug}
+        kbId={visibility.id}
+        organizationId={visibility.organizationId}
+      />
     </Suspense>
   )
 }
 
-async function ArticleBody({
-  params,
+async function PublicArticleBody({
+  orgSlug,
+  kbSlug,
+  articleSlug,
 }: {
-  params: Promise<{ orgSlug: string; kbSlug: string; articleSlug: string[] }>
+  orgSlug: string
+  kbSlug: string
+  articleSlug: string[]
 }) {
   'use cache'
-  const { orgSlug, kbSlug, articleSlug } = await params
   const slugPath = articleSlug.join('/')
   cacheTag(kbTag(orgSlug, kbSlug), kbArticleTag(orgSlug, kbSlug, slugPath))
   cacheLife('max')
 
-  const { articles } = await getKBPayloadWithContent(orgSlug, kbSlug)
+  const { articles } = await getPublicKBPayloadWithContent(orgSlug, kbSlug)
+  return (
+    <ArticleBodyContent
+      articles={articles}
+      orgSlug={orgSlug}
+      kbSlug={kbSlug}
+      articleSlug={articleSlug}
+    />
+  )
+}
+
+async function InternalArticleGate({
+  orgSlug,
+  kbSlug,
+  articleSlug,
+  kbId,
+  organizationId,
+}: {
+  orgSlug: string
+  kbSlug: string
+  articleSlug: string[]
+  kbId: string
+  organizationId: string
+}) {
+  const session = await getLocalSession()
+  if (!session) {
+    redirect(getLoginUrl(kbId, `/${orgSlug}/${kbSlug}/${articleSlug.join('/')}`))
+  }
+  const member = await isOrgMember(organizationId, session.userId)
+  if (!member) {
+    redirect(`${WEBAPP_URL}/kb-auth/no-access`)
+  }
+
+  const { articles } = await loadKBPayloadWithContent(orgSlug, kbSlug, {
+    session: { userId: session.userId },
+  })
+  return (
+    <ArticleBodyContent
+      articles={articles}
+      orgSlug={orgSlug}
+      kbSlug={kbSlug}
+      articleSlug={articleSlug}
+    />
+  )
+}
+
+function ArticleBodyContent({
+  articles,
+  orgSlug,
+  kbSlug,
+  articleSlug,
+}: {
+  articles: PublicArticleFull[]
+  orgSlug: string
+  kbSlug: string
+  articleSlug: string[]
+}) {
   const basePath = `/${orgSlug}/${kbSlug}`
   const article = findArticleBySlugPath(articles, articleSlug)
   if (!article || article.isCategory) notFound()
@@ -78,8 +172,8 @@ async function ArticleBody({
   const { prev, next } = getArticleNeighbours(articles, article.id)
 
   return (
-    <div className='min-w-0 flex-1'>
-      <div className='mx-auto max-w-3xl px-6 pt-4'>
+    <div className='flex min-w-0 flex-1 flex-col'>
+      <div className='w-full max-w-3xl px-6 pt-4'>
         <KBTableOfContents headings={headings} />
       </div>
       <KBArticleRenderer
@@ -88,7 +182,7 @@ async function ArticleBody({
         description={article.description}
         updatedAt={article.updatedAt}
       />
-      <div className='mx-auto max-w-3xl px-6'>
+      <div className='mt-auto w-full max-w-3xl px-6'>
         <KBArticlePager articles={articles} prev={prev} next={next} basePath={basePath} />
       </div>
     </div>

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
@@ -1,12 +1,15 @@
-'use cache'
-
 // apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
 
+import { WEBAPP_URL } from '@auxx/config/urls'
+import { isOrgMember } from '@auxx/lib/cache'
 import { KBLayout } from '@auxx/ui/components/kb'
 import '@auxx/ui/global.css'
 import { cacheLife, cacheTag } from 'next/cache'
-import { notFound } from 'next/navigation'
-import { getKBPayload, kbTag } from '../../../server/kb-cache'
+import { notFound, redirect } from 'next/navigation'
+import { Suspense } from 'react'
+import { getLocalSession, getLoginUrl } from '~/lib/auth'
+import { getCachedKBVisibility, getPublicKBPayload, kbTag } from '../../../server/kb-cache'
+import { loadKBPayload } from '../../../server/kb-data'
 
 interface KBSlugLayoutProps {
   params: Promise<{ orgSlug: string; kbSlug: string }>
@@ -15,10 +18,84 @@ interface KBSlugLayoutProps {
 
 export default async function KBSlugLayout({ params, children }: KBSlugLayoutProps) {
   const { orgSlug, kbSlug } = await params
+
+  const visibility = await getCachedKBVisibility(orgSlug, kbSlug)
+  if (!visibility || visibility.publishStatus === 'DRAFT') notFound()
+
+  if (visibility.visibility === 'PUBLIC') {
+    return (
+      <PublicKBLayout orgSlug={orgSlug} kbSlug={kbSlug}>
+        {children}
+      </PublicKBLayout>
+    )
+  }
+
+  // INTERNAL: dynamic — auth gate inside Suspense so the cacheComponents
+  // model is satisfied (uncached cookie/membership reads are streamed).
+  return (
+    <Suspense fallback={null}>
+      <InternalKBLayoutGate
+        orgSlug={orgSlug}
+        kbSlug={kbSlug}
+        kbId={visibility.id}
+        organizationId={visibility.organizationId}>
+        {children}
+      </InternalKBLayoutGate>
+    </Suspense>
+  )
+}
+
+async function PublicKBLayout({
+  orgSlug,
+  kbSlug,
+  children,
+}: {
+  orgSlug: string
+  kbSlug: string
+  children: React.ReactNode
+}) {
+  'use cache'
   cacheTag(kbTag(orgSlug, kbSlug))
   cacheLife('max')
 
-  const { kb, articles } = await getKBPayload(orgSlug, kbSlug)
+  const { kb, articles } = await getPublicKBPayload(orgSlug, kbSlug)
+  if (!kb) notFound()
+
+  const basePath = `/${orgSlug}/${kbSlug}`
+  const searchOrigin = `${basePath}/search.json`
+
+  return (
+    <KBLayout kb={kb} articles={articles} basePath={basePath} searchOrigin={searchOrigin}>
+      {children}
+    </KBLayout>
+  )
+}
+
+async function InternalKBLayoutGate({
+  orgSlug,
+  kbSlug,
+  kbId,
+  organizationId,
+  children,
+}: {
+  orgSlug: string
+  kbSlug: string
+  kbId: string
+  organizationId: string
+  children: React.ReactNode
+}) {
+  const session = await getLocalSession()
+  if (!session) {
+    redirect(getLoginUrl(kbId, `/${orgSlug}/${kbSlug}`))
+  }
+  const member = await isOrgMember(organizationId, session.userId)
+  if (!member) {
+    redirect(`${WEBAPP_URL}/kb-auth/no-access`)
+  }
+
+  const { kb, articles } = await loadKBPayload(orgSlug, kbSlug, {
+    session: { userId: session.userId },
+  })
   if (!kb) notFound()
 
   const basePath = `/${orgSlug}/${kbSlug}`

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
@@ -1,7 +1,7 @@
-'use cache'
-
 // apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
 
+import { WEBAPP_URL } from '@auxx/config/urls'
+import { isOrgMember } from '@auxx/lib/cache'
 import {
   extractKBHeadings,
   getArticleNeighbours,
@@ -11,8 +11,19 @@ import {
 } from '@auxx/ui/components/kb'
 import type { Metadata } from 'next'
 import { cacheLife, cacheTag } from 'next/cache'
-import { notFound } from 'next/navigation'
-import { getKBPayloadWithContent, kbTag } from '../../../server/kb-cache'
+import { notFound, redirect } from 'next/navigation'
+import { Suspense } from 'react'
+import { getLocalSession, getLoginUrl } from '~/lib/auth'
+import {
+  getCachedKBVisibility,
+  getPublicKBPayloadWithContent,
+  kbTag,
+} from '../../../server/kb-cache'
+import {
+  loadKBPayloadWithContent,
+  type PublicArticleFull,
+  type PublicKB,
+} from '../../../server/kb-data'
 
 interface PageProps {
   params: Promise<{ orgSlug: string; kbSlug: string }>
@@ -26,7 +37,14 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { orgSlug, kbSlug } = await params
-  const { kb } = await getKBPayloadWithContent(orgSlug, kbSlug)
+  const visibility = await getCachedKBVisibility(orgSlug, kbSlug)
+  if (!visibility || visibility.publishStatus === 'DRAFT') return { title: 'Not found' }
+
+  if (visibility.visibility === 'INTERNAL') {
+    return { title: 'Knowledge base', robots: { index: false, follow: false } }
+  }
+
+  const { kb } = await getPublicKBPayloadWithContent(orgSlug, kbSlug)
   if (!kb) return { title: 'Not found' }
   return {
     title: kb.name,
@@ -38,12 +56,75 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function KBLandingPage({ params }: PageProps) {
   const { orgSlug, kbSlug } = await params
+
+  const visibility = await getCachedKBVisibility(orgSlug, kbSlug)
+  if (!visibility || visibility.publishStatus === 'DRAFT') notFound()
+
+  if (visibility.visibility === 'PUBLIC') {
+    return <PublicLanding orgSlug={orgSlug} kbSlug={kbSlug} />
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <InternalLandingGate
+        orgSlug={orgSlug}
+        kbSlug={kbSlug}
+        kbId={visibility.id}
+        organizationId={visibility.organizationId}
+      />
+    </Suspense>
+  )
+}
+
+async function PublicLanding({ orgSlug, kbSlug }: { orgSlug: string; kbSlug: string }) {
+  'use cache'
   cacheTag(kbTag(orgSlug, kbSlug))
   cacheLife('max')
 
-  const { kb, articles } = await getKBPayloadWithContent(orgSlug, kbSlug)
+  const { kb, articles } = await getPublicKBPayloadWithContent(orgSlug, kbSlug)
+  if (!kb) notFound()
+  return <LandingBody kb={kb} articles={articles} orgSlug={orgSlug} kbSlug={kbSlug} />
+}
+
+async function InternalLandingGate({
+  orgSlug,
+  kbSlug,
+  kbId,
+  organizationId,
+}: {
+  orgSlug: string
+  kbSlug: string
+  kbId: string
+  organizationId: string
+}) {
+  const session = await getLocalSession()
+  if (!session) {
+    redirect(getLoginUrl(kbId, `/${orgSlug}/${kbSlug}`))
+  }
+  const member = await isOrgMember(organizationId, session.userId)
+  if (!member) {
+    redirect(`${WEBAPP_URL}/kb-auth/no-access`)
+  }
+
+  const { kb, articles } = await loadKBPayloadWithContent(orgSlug, kbSlug, {
+    session: { userId: session.userId },
+  })
   if (!kb) notFound()
 
+  return <LandingBody kb={kb} articles={articles} orgSlug={orgSlug} kbSlug={kbSlug} />
+}
+
+function LandingBody({
+  kb,
+  articles,
+  orgSlug,
+  kbSlug,
+}: {
+  kb: PublicKB
+  articles: PublicArticleFull[]
+  orgSlug: string
+  kbSlug: string
+}) {
   const basePath = `/${orgSlug}/${kbSlug}`
   const homeArticle =
     articles.find((a) => a.isHomePage && a.isPublished && !a.isCategory) ??
@@ -55,8 +136,8 @@ export default async function KBLandingPage({ params }: PageProps) {
     : { prev: undefined, next: undefined }
 
   return (
-    <div className='min-w-0 flex-1'>
-      <div className='mx-auto max-w-3xl px-6 pt-4'>
+    <div className='flex min-w-0 flex-1 flex-col'>
+      <div className='w-full max-w-3xl px-6 pt-4'>
         <KBTableOfContents headings={headings} />
       </div>
       <KBArticleRenderer
@@ -65,7 +146,7 @@ export default async function KBLandingPage({ params }: PageProps) {
         description={homeArticle?.description ?? kb.description}
         updatedAt={homeArticle?.updatedAt ?? null}
       />
-      <div className='mx-auto max-w-3xl px-6'>
+      <div className='mt-auto w-full max-w-3xl px-6'>
         <KBArticlePager articles={articles} prev={prev} next={next} basePath={basePath} />
       </div>
     </div>

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/search.json/route.ts
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/search.json/route.ts
@@ -1,14 +1,17 @@
 // apps/kb/src/app/[orgSlug]/[kbSlug]/search.json/route.ts
 
+import { isOrgMember } from '@auxx/lib/cache'
 import { buildKBSearchIndex, getArticleSlugPaths } from '@auxx/ui/components/kb'
 import { cacheLife, cacheTag } from 'next/cache'
-import { getKBPayloadWithContent, kbTag } from '../../../../server/kb-cache'
+import { getLocalSession } from '~/lib/auth'
+import { getPublicKBPayloadWithContent, kbTag } from '../../../../server/kb-cache'
+import { getKBVisibility, loadKBPayloadWithContent } from '../../../../server/kb-data'
 
-async function getSearchDocs(orgSlug: string, kbSlug: string) {
+async function getPublicSearchDocs(orgSlug: string, kbSlug: string) {
   'use cache'
   cacheTag(kbTag(orgSlug, kbSlug))
   cacheLife('max')
-  const { articles } = await getKBPayloadWithContent(orgSlug, kbSlug)
+  const { articles } = await getPublicKBPayloadWithContent(orgSlug, kbSlug)
   const fullPaths = getArticleSlugPaths(articles)
   return buildKBSearchIndex(articles, fullPaths)
 }
@@ -18,8 +21,35 @@ export async function GET(
   { params }: { params: Promise<{ orgSlug: string; kbSlug: string }> }
 ) {
   const { orgSlug, kbSlug } = await params
-  const docs = await getSearchDocs(orgSlug, kbSlug)
+
+  const visibility = await getKBVisibility(orgSlug, kbSlug)
+  if (!visibility || visibility.publishStatus === 'DRAFT') {
+    return new Response('Not Found', { status: 404 })
+  }
+
+  if (visibility.visibility === 'PUBLIC') {
+    const docs = await getPublicSearchDocs(orgSlug, kbSlug)
+    return Response.json(docs, {
+      headers: { 'cache-control': 'public, s-maxage=31536000, stale-while-revalidate=60' },
+    })
+  }
+
+  // INTERNAL: gate on session + membership, never cache.
+  const session = await getLocalSession()
+  if (!session) {
+    return new Response('Not Found', { status: 404 })
+  }
+  const member = await isOrgMember(visibility.organizationId, session.userId)
+  if (!member) {
+    return new Response('Not Found', { status: 404 })
+  }
+
+  const { articles } = await loadKBPayloadWithContent(orgSlug, kbSlug, {
+    session: { userId: session.userId },
+  })
+  const fullPaths = getArticleSlugPaths(articles)
+  const docs = buildKBSearchIndex(articles, fullPaths)
   return Response.json(docs, {
-    headers: { 'cache-control': 'public, s-maxage=31536000, stale-while-revalidate=60' },
+    headers: { 'cache-control': 'private, no-store' },
   })
 }

--- a/apps/kb/src/app/auth/verify/route.ts
+++ b/apps/kb/src/app/auth/verify/route.ts
@@ -1,0 +1,91 @@
+// apps/kb/src/app/auth/verify/route.ts
+// Verifies an Ed25519 cross-app login token issued by apps/web and mints
+// a local `auxx-kb.session` cookie. The cookie has no `domain` attribute
+// so it correctly scopes to whatever host the request landed on (KB
+// subdomain or a custom domain).
+
+import { WEBAPP_URL } from '@auxx/config/urls'
+import { configService } from '@auxx/credentials'
+import { sanitizeReturnTo, verifyLoginToken } from '@auxx/credentials/login-token'
+import { database, schema } from '@auxx/database'
+import { isOrgMember } from '@auxx/lib/cache'
+import { getDemoEmailDomain } from '@auxx/lib/demo'
+import { eq } from 'drizzle-orm'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import { consumeLoginTokenJti, createLocalSession, KB_SESSION_COOKIE_NAME } from '~/lib/auth'
+
+function getRequestOrigin(request: NextRequest): string {
+  const host = request.headers.get('host')
+  if (!host) return new URL(request.url).origin
+  const proto = request.headers.get('x-forwarded-proto') ?? 'https'
+  return `${proto}://${host}`
+}
+
+export async function GET(request: NextRequest) {
+  const origin = getRequestOrigin(request)
+  const loginToken = request.nextUrl.searchParams.get('loginToken')
+
+  if (!loginToken) {
+    return NextResponse.redirect(`${WEBAPP_URL}/`)
+  }
+
+  // 1. Verify token signature and claims (aud=requestOrigin, exp, iss)
+  const result = await verifyLoginToken(loginToken, origin)
+  if (result.isErr()) {
+    return NextResponse.redirect(`${WEBAPP_URL}/login?callbackApp=kb&returnTo=/`)
+  }
+
+  const { userId, email, returnTo, jti } = result.value
+
+  // 2. Block demo accounts
+  if (email.endsWith(`@${getDemoEmailDomain()}`)) {
+    return NextResponse.redirect(`${WEBAPP_URL}/kb-auth/no-access?reason=demo`)
+  }
+
+  // 3. Single-use jti via Redis SET NX EX
+  const consumed = await consumeLoginTokenJti(jti)
+  if (!consumed) {
+    return NextResponse.redirect(`${WEBAPP_URL}/login?callbackApp=kb&returnTo=/`)
+  }
+
+  // 4. Resolve the KB on this host and re-check membership.
+  // The aud check above already proves the token was minted for this origin,
+  // but we still need to know which KB this host serves to verify membership.
+  const [kbForHost] = await database
+    .select({
+      organizationId: schema.KnowledgeBase.organizationId,
+    })
+    .from(schema.KnowledgeBase)
+    .where(eq(schema.KnowledgeBase.customDomain, new URL(origin).hostname))
+    .limit(1)
+
+  // If a customDomain row matches, gate on its org. Otherwise we're on the
+  // KB_URL host which serves all KBs — defer the membership re-check to the
+  // page-level layout (it has the kbId/orgSlug from URL params).
+  if (kbForHost) {
+    const member = await isOrgMember(kbForHost.organizationId, userId)
+    if (!member) {
+      return NextResponse.redirect(`${WEBAPP_URL}/kb-auth/no-access`)
+    }
+  }
+
+  // 5. Mint local KB session cookie
+  const sessionCookie = await createLocalSession({ userId, email })
+
+  const safeReturnTo = sanitizeReturnTo(returnTo)
+  const response = NextResponse.redirect(new URL(safeReturnTo, origin), { status: 303 })
+
+  const isProduction = configService.get<string>('NODE_ENV') === 'production'
+  response.cookies.set(KB_SESSION_COOKIE_NAME, sessionCookie, {
+    httpOnly: true,
+    secure: isProduction || !!configService.get<string>('DOMAIN'),
+    sameSite: 'lax',
+    maxAge: 24 * 60 * 60,
+    path: '/',
+    // Intentionally no `domain` — defaults to the request host so the cookie
+    // works on customer custom domains as well as the KB subdomain.
+  })
+
+  return response
+}

--- a/apps/kb/src/lib/auth.ts
+++ b/apps/kb/src/lib/auth.ts
@@ -1,0 +1,35 @@
+// apps/kb/src/lib/auth.ts
+// Authentication utilities for the public KB satellite app.
+
+import { WEBAPP_URL } from '@auxx/config/urls'
+import { createLocalSessionHelpers } from '@auxx/credentials/local-session'
+import { getRedisClient } from '@auxx/redis'
+import { cookies } from 'next/headers'
+
+const helpers = createLocalSessionHelpers({
+  cookieName: 'auxx-kb.session',
+  secretEnv: 'KB_SESSION_SECRET',
+  ttlSeconds: 24 * 60 * 60, // 24 hours
+  getCookieStore: () => cookies(),
+  getRedis: () => getRedisClient(),
+})
+
+export type Session = { userId: string; email: string }
+
+export const KB_SESSION_COOKIE_NAME = 'auxx-kb.session'
+
+export const createLocalSession = helpers.createSession
+export const verifyLocalSession = helpers.verifySession
+export const getLocalSession = helpers.getSession
+export const consumeLoginTokenJti = helpers.consumeLoginTokenJti
+
+/**
+ * URL on the issuing web app where users land when they hit an INTERNAL KB
+ * without a local KB session. The web app handles login + token issuance,
+ * then bounces back to the KB's `/auth/verify` route.
+ */
+export function getLoginUrl(kbId: string, returnPath?: string): string {
+  const params = new URLSearchParams({ kbId })
+  if (returnPath) params.set('returnTo', returnPath)
+  return `${WEBAPP_URL}/kb-auth?${params.toString()}`
+}

--- a/apps/kb/src/server/kb-cache.ts
+++ b/apps/kb/src/server/kb-cache.ts
@@ -1,7 +1,7 @@
 // apps/kb/src/server/kb-cache.ts
 
 import { cacheLife, cacheTag } from 'next/cache'
-import { loadKBPayload, loadKBPayloadWithContent } from './kb-data'
+import { getKBVisibility, loadKBPayload, loadKBPayloadWithContent } from './kb-data'
 
 export function kbTag(orgSlug: string, kbSlug: string): string {
   return `kb:${orgSlug}/${kbSlug}`
@@ -11,16 +11,34 @@ export function kbArticleTag(orgSlug: string, kbSlug: string, slugPath: string):
   return `kb-article:${orgSlug}/${kbSlug}/${slugPath}`
 }
 
-export async function getKBPayload(orgSlug: string, kbSlug: string) {
+/**
+ * Cached visibility/lifecycle lookup. Used by both PUBLIC and INTERNAL
+ * paths to decide whether to short-circuit, render a 404, or run the
+ * auth gate. Busted by `kbTag` on any KB update.
+ */
+export async function getCachedKBVisibility(orgSlug: string, kbSlug: string) {
+  'use cache'
+  cacheTag(kbTag(orgSlug, kbSlug))
+  cacheLife('max')
+  return getKBVisibility(orgSlug, kbSlug)
+}
+
+/** Public-only cached payload — never used for INTERNAL KBs. */
+export async function getPublicKBPayload(orgSlug: string, kbSlug: string) {
   'use cache'
   cacheTag(kbTag(orgSlug, kbSlug))
   cacheLife('max')
   return loadKBPayload(orgSlug, kbSlug)
 }
 
-export async function getKBPayloadWithContent(orgSlug: string, kbSlug: string) {
+/** Public-only cached payload with content — never used for INTERNAL KBs. */
+export async function getPublicKBPayloadWithContent(orgSlug: string, kbSlug: string) {
   'use cache'
   cacheTag(kbTag(orgSlug, kbSlug))
   cacheLife('max')
   return loadKBPayloadWithContent(orgSlug, kbSlug)
 }
+
+// Backwards-compatible aliases for the cached public path.
+export const getKBPayload = getPublicKBPayload
+export const getKBPayloadWithContent = getPublicKBPayloadWithContent

--- a/apps/kb/src/server/kb-data.ts
+++ b/apps/kb/src/server/kb-data.ts
@@ -1,6 +1,7 @@
 // apps/kb/src/server/kb-data.ts
 
 import { Article, ArticleRevision, database, KnowledgeBase, Organization } from '@auxx/database'
+import { isOrgMember } from '@auxx/lib/cache'
 import type { DocJSON, KBLayoutKB } from '@auxx/ui/components/kb'
 import { and, eq } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/pg-core'
@@ -32,7 +33,41 @@ export type PublicKB = KBLayoutKB & {
   slug: string
   description: string | null
   publishStatus: 'DRAFT' | 'PUBLISHED' | 'UNLISTED'
+  visibility: 'PUBLIC' | 'INTERNAL'
   defaultMode: string | null
+}
+
+export type AccessDenied = 'unauthenticated' | 'forbidden'
+
+export interface KBVisibilityInfo {
+  id: string
+  organizationId: string
+  visibility: 'PUBLIC' | 'INTERNAL'
+  publishStatus: 'DRAFT' | 'PUBLISHED' | 'UNLISTED'
+}
+
+/**
+ * Lightweight metadata-only lookup for the layout to decide between the
+ * cached public path and the auth-gated internal path before doing full
+ * payload work. Cheaper than `loadKBPayload` and safe to short-cache when
+ * needed by the caller.
+ */
+export async function getKBVisibility(
+  orgSlug: string,
+  kbSlug: string
+): Promise<KBVisibilityInfo | null> {
+  const [row] = await database
+    .select({
+      id: KnowledgeBase.id,
+      organizationId: KnowledgeBase.organizationId,
+      visibility: KnowledgeBase.visibility,
+      publishStatus: KnowledgeBase.publishStatus,
+    })
+    .from(KnowledgeBase)
+    .innerJoin(Organization, eq(Organization.id, KnowledgeBase.organizationId))
+    .where(and(eq(Organization.handle, orgSlug), eq(KnowledgeBase.slug, kbSlug)))
+    .limit(1)
+  return row ?? null
 }
 
 /**
@@ -59,10 +94,12 @@ function filterVisibleSubtree<
 
 export async function loadKBPayload(
   orgSlug: string,
-  kbSlug: string
+  kbSlug: string,
+  opts?: { session?: { userId: string } | null }
 ): Promise<{
   kb: PublicKB | null
   articles: PublicArticleListItem[]
+  accessDenied?: AccessDenied
 }> {
   const rows = await database
     .select({
@@ -79,6 +116,12 @@ export async function loadKBPayload(
 
   const kb = row.kb
   if (kb.publishStatus === 'DRAFT') return { kb: null, articles: [] }
+
+  if (kb.visibility === 'INTERNAL') {
+    if (!opts?.session) return { kb: null, articles: [], accessDenied: 'unauthenticated' }
+    const member = await isOrgMember(kb.organizationId, opts.session.userId)
+    if (!member) return { kb: null, articles: [], accessDenied: 'forbidden' }
+  }
 
   const pub = alias(ArticleRevision, 'pub')
   const rawArticles = await database
@@ -109,6 +152,7 @@ export async function loadKBPayload(
     organizationId: kb.organizationId,
     description: kb.description,
     publishStatus: kb.publishStatus,
+    visibility: kb.visibility,
     defaultMode: kb.defaultMode,
     showMode: kb.showMode,
     primaryColorLight: kb.primaryColorLight,
@@ -141,10 +185,15 @@ export async function loadKBPayload(
 
 export async function loadKBPayloadWithContent(
   orgSlug: string,
-  kbSlug: string
-): Promise<{ kb: PublicKB | null; articles: PublicArticleFull[] }> {
-  const { kb } = await loadKBPayload(orgSlug, kbSlug)
-  if (!kb) return { kb: null, articles: [] }
+  kbSlug: string,
+  opts?: { session?: { userId: string } | null }
+): Promise<{
+  kb: PublicKB | null
+  articles: PublicArticleFull[]
+  accessDenied?: AccessDenied
+}> {
+  const { kb, accessDenied } = await loadKBPayload(orgSlug, kbSlug, opts)
+  if (!kb) return { kb: null, articles: [], accessDenied }
 
   const pub = alias(ArticleRevision, 'pub')
   const rows = await database

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -154,6 +154,7 @@
     "remark-gfm": "^4.0.1",
     "server-only": "catalog:",
     "sharp": "catalog:",
+    "shiki": "catalog:",
     "sonner": "^2.0.7",
     "stripe": "catalog:",
     "superjson": "^2.2.1",

--- a/apps/web/src/app/(auth)/kb-auth/no-access/page.tsx
+++ b/apps/web/src/app/(auth)/kb-auth/no-access/page.tsx
@@ -1,0 +1,87 @@
+// apps/web/src/app/(auth)/kb-auth/no-access/page.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@auxx/ui/components/card'
+import { Lock } from 'lucide-react'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
+import { client } from '~/auth/auth-client'
+import { Logo } from '~/components/global/login/logo'
+
+function NoAccessContent() {
+  const params = useSearchParams()
+  const reason = params.get('reason')
+
+  const { title, description } = (() => {
+    if (reason === 'demo') {
+      return {
+        title: 'Demo accounts cannot access knowledge bases',
+        description:
+          'Demo accounts are restricted from accessing organization knowledge bases. Sign in with a regular account to continue.',
+      }
+    }
+    if (reason === 'missing') {
+      return {
+        title: 'Knowledge base not found',
+        description: "The knowledge base you're trying to access doesn't exist.",
+      }
+    }
+    return {
+      title: 'You do not have access',
+      description:
+        "You're signed in, but you're not a member of the organization that owns this knowledge base. Switch accounts or ask an admin to invite you.",
+    }
+  })()
+
+  return (
+    <Card variant='translucent' className='w-full max-w-md border-transparent px-4 py-3'>
+      <CardHeader className='items-center text-center'>
+        <Lock className='mb-2 size-8 text-muted-foreground' />
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className='flex justify-center'>
+        <Button
+          variant='outline'
+          onClick={() =>
+            client.signOut({
+              fetchOptions: {
+                onSuccess: () => {
+                  window.location.href = '/login'
+                },
+              },
+            })
+          }>
+          Switch account
+        </Button>
+      </CardContent>
+      <CardFooter className='flex justify-center'>
+        <Button variant='link' asChild className='text-white'>
+          <Link href='/'>Back to home</Link>
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}
+
+export default function KbNoAccessPage() {
+  return (
+    <div className='flex min-h-screen w-screen items-center justify-center p-4'>
+      <div className='flex w-full max-w-sm flex-col items-center gap-4'>
+        <Logo />
+        <Suspense fallback={null}>
+          <NoAccessContent />
+        </Suspense>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(auth)/kb-auth/route.ts
+++ b/apps/web/src/app/(auth)/kb-auth/route.ts
@@ -1,0 +1,91 @@
+// apps/web/src/app/(auth)/kb-auth/route.ts
+// Cross-app bounce target for users landing on an INTERNAL KB without a
+// local KB session cookie. Authenticates via better-auth, issues an
+// Ed25519 login token bound to the KB's origin, and redirects to the
+// KB's `/auth/verify` route which mints `auxx-kb.session`.
+
+import { WEBAPP_URL } from '@auxx/config/server'
+import { issueLoginToken, sanitizeReturnTo } from '@auxx/credentials/login-token'
+import { database, schema } from '@auxx/database'
+import { isOrgMember } from '@auxx/lib/cache'
+import { getDemoEmailDomain } from '@auxx/lib/demo'
+import { eq } from 'drizzle-orm'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import { auth } from '~/auth/server'
+import { resolveTrustedAppOrigin } from '~/auth/trusted-apps'
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url)
+  const kbId = url.searchParams.get('kbId')
+  const returnTo = sanitizeReturnTo(url.searchParams.get('returnTo'))
+
+  if (!kbId) {
+    return NextResponse.redirect(new URL('/', WEBAPP_URL))
+  }
+
+  // 1. Look up the KB
+  const [kb] = await database
+    .select({
+      id: schema.KnowledgeBase.id,
+      organizationId: schema.KnowledgeBase.organizationId,
+      visibility: schema.KnowledgeBase.visibility,
+    })
+    .from(schema.KnowledgeBase)
+    .where(eq(schema.KnowledgeBase.id, kbId))
+    .limit(1)
+
+  if (!kb) {
+    return NextResponse.redirect(new URL('/kb-auth/no-access?reason=missing', WEBAPP_URL))
+  }
+
+  // 2. Resolve target origin (handles verified custom domains)
+  const targetOrigin = await resolveTrustedAppOrigin('kb', { kbId })
+  if (!targetOrigin) {
+    return NextResponse.redirect(new URL('/kb-auth/no-access?reason=missing', WEBAPP_URL))
+  }
+
+  // 3. Public KBs don't need a token — bounce straight to the KB.
+  if (kb.visibility === 'PUBLIC') {
+    return NextResponse.redirect(`${targetOrigin}${returnTo}`)
+  }
+
+  // 4. Require better-auth session
+  const session = await auth.api.getSession({ headers: request.headers })
+  if (!session?.user) {
+    const loginParams = new URLSearchParams({
+      callbackApp: 'kb',
+      kbId,
+      returnTo,
+    })
+    return NextResponse.redirect(new URL(`/login?${loginParams.toString()}`, WEBAPP_URL))
+  }
+
+  // 5. Demo accounts blocked
+  if (session.user.email.endsWith(`@${getDemoEmailDomain()}`)) {
+    return NextResponse.redirect(new URL('/kb-auth/no-access?reason=demo', WEBAPP_URL))
+  }
+
+  // 6. Membership check
+  const member = await isOrgMember(kb.organizationId, session.user.id)
+  if (!member) {
+    return NextResponse.redirect(new URL('/kb-auth/no-access', WEBAPP_URL))
+  }
+
+  // 7. Issue login token bound to the KB's origin
+  const result = await issueLoginToken({
+    userId: session.user.id,
+    email: session.user.email,
+    targetOrigin,
+    issuerOrigin: WEBAPP_URL,
+    returnTo,
+  })
+
+  if (result.isErr()) {
+    return NextResponse.redirect(new URL('/kb-auth/no-access?reason=error', WEBAPP_URL))
+  }
+
+  const verifyUrl = new URL('/auth/verify', targetOrigin)
+  verifyUrl.searchParams.set('loginToken', result.value.token)
+  return NextResponse.redirect(verifyUrl)
+}

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -77,16 +77,25 @@ async function Login({ searchParams }: LoginPageProps) {
     // Cross-app flow: user is already logged in, issue token and redirect to satellite
     const callbackApp = q?.callbackApp as string | undefined
     if (callbackApp) {
+      const returnTo = (q?.returnTo as string) || '/'
+      const safePath =
+        typeof returnTo === 'string' &&
+        returnTo.startsWith('/') &&
+        !returnTo.startsWith('//') &&
+        !returnTo.includes('..')
+          ? returnTo
+          : '/'
+
+      // KB needs the kbId to resolve a (possibly custom-domain) origin —
+      // delegate to /kb-auth which knows how to look it up.
+      if (callbackApp === 'kb') {
+        const kbId = (q?.kbId as string) || ''
+        const params = new URLSearchParams({ kbId, returnTo: safePath })
+        redirect(`/kb-auth?${params.toString()}`)
+      }
+
       const targetOrigin = getTrustedAppOrigin(callbackApp)
       if (targetOrigin) {
-        const returnTo = (q?.returnTo as string) || '/'
-        const safePath =
-          typeof returnTo === 'string' &&
-          returnTo.startsWith('/') &&
-          !returnTo.startsWith('//') &&
-          !returnTo.includes('..')
-            ? returnTo
-            : '/'
         const result = await issueLoginToken({
           userId: session.user.id,
           email: session.user.email,

--- a/apps/web/src/app/api/auth/login-token/route.ts
+++ b/apps/web/src/app/api/auth/login-token/route.ts
@@ -1,12 +1,15 @@
 // apps/web/src/app/api/auth/login-token/route.ts
 
 import { WEBAPP_URL } from '@auxx/config/server'
-import { issueLoginToken } from '@auxx/credentials/login-token'
+import { issueLoginToken, sanitizeReturnTo } from '@auxx/credentials/login-token'
+import { database, schema } from '@auxx/database'
+import { isOrgMember } from '@auxx/lib/cache'
 import { getDemoEmailDomain } from '@auxx/lib/demo'
+import { eq } from 'drizzle-orm'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { auth } from '~/auth/server'
-import { getTrustedAppOrigin } from '~/auth/trusted-apps'
+import { resolveTrustedAppOrigin } from '~/auth/trusted-apps'
 
 export async function POST(request: NextRequest) {
   // 1. Verify the user has a valid session
@@ -15,32 +18,75 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  // 2. Parse and validate request body
+  // 2. Parse request body
   const body = await request.json()
-  const { callbackApp, returnTo } = body
+  const { callbackApp, returnTo, kbId } = body as {
+    callbackApp?: unknown
+    returnTo?: unknown
+    kbId?: unknown
+  }
 
   if (!callbackApp || typeof callbackApp !== 'string') {
     return NextResponse.json({ error: 'Missing callbackApp' }, { status: 400 })
   }
 
-  // Block demo users from accessing the developer portal
-  if (callbackApp === 'build' && session.user.email.endsWith(`@${getDemoEmailDomain()}`)) {
-    return NextResponse.json(
-      { error: 'Demo accounts cannot access the developer portal' },
-      { status: 403 }
-    )
+  // 3. Per-app gates
+  const isDemoUser = session.user.email.endsWith(`@${getDemoEmailDomain()}`)
+
+  if (callbackApp === 'build') {
+    if (isDemoUser) {
+      return NextResponse.json(
+        { error: 'Demo accounts cannot access the developer portal' },
+        { status: 403 }
+      )
+    }
+  } else if (callbackApp === 'kb') {
+    if (isDemoUser) {
+      return NextResponse.json(
+        { error: 'Demo accounts cannot access knowledge bases' },
+        { status: 403 }
+      )
+    }
+    if (!kbId || typeof kbId !== 'string') {
+      return NextResponse.json({ error: 'Missing kbId' }, { status: 400 })
+    }
+    const [kb] = await database
+      .select({
+        id: schema.KnowledgeBase.id,
+        organizationId: schema.KnowledgeBase.organizationId,
+        visibility: schema.KnowledgeBase.visibility,
+      })
+      .from(schema.KnowledgeBase)
+      .where(eq(schema.KnowledgeBase.id, kbId))
+      .limit(1)
+
+    if (!kb) {
+      return NextResponse.json({ error: 'Knowledge base not found' }, { status: 404 })
+    }
+    if (kb.visibility !== 'INTERNAL') {
+      return NextResponse.json(
+        { error: 'Login tokens are only issued for internal knowledge bases' },
+        { status: 400 }
+      )
+    }
+    const member = await isOrgMember(kb.organizationId, session.user.id)
+    if (!member) {
+      return NextResponse.json({ error: 'Not a member of this knowledge base' }, { status: 403 })
+    }
   }
 
-  // 3. Resolve app ID to origin
-  const targetOrigin = getTrustedAppOrigin(callbackApp)
+  // 4. Resolve target origin (custom domain for KB)
+  const targetOrigin = await resolveTrustedAppOrigin(callbackApp, {
+    kbId: typeof kbId === 'string' ? kbId : undefined,
+  })
   if (!targetOrigin) {
     return NextResponse.json({ error: 'Unknown app' }, { status: 400 })
   }
 
-  // 4. Validate returnTo is a safe relative path
+  // 5. Validate returnTo is a safe relative path
   const safePath = sanitizeReturnTo(returnTo)
 
-  // 5. Issue login token
+  // 6. Issue login token
   const result = await issueLoginToken({
     userId: session.user.id,
     email: session.user.email,
@@ -57,13 +103,4 @@ export async function POST(request: NextRequest) {
     loginToken: result.value.token,
     redirectUrl: `${targetOrigin}/auth/verify?loginToken=${result.value.token}`,
   })
-}
-
-function sanitizeReturnTo(returnTo: unknown): string {
-  if (typeof returnTo !== 'string') return '/'
-  // Must start with /, no protocol, no //, no ..
-  if (!returnTo.startsWith('/') || returnTo.startsWith('//') || returnTo.includes('..')) {
-    return '/'
-  }
-  return returnTo
 }

--- a/apps/web/src/auth/trusted-apps.ts
+++ b/apps/web/src/auth/trusted-apps.ts
@@ -1,22 +1,61 @@
 // apps/web/src/auth/trusted-apps.ts
 
-import { DEV_PORTAL_URL } from '@auxx/config/server'
+import { DEV_PORTAL_URL, KB_URL } from '@auxx/config/server'
+import { database, schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
 
 /** Known satellite apps that can receive login tokens */
-export type TrustedAppId = 'build'
+export type TrustedAppId = 'build' | 'kb'
 
-/** Registry of satellite app IDs to their origin URLs */
-const TRUSTED_APP_ORIGINS: Record<TrustedAppId, string> = {
-  build: DEV_PORTAL_URL,
-  // Add future satellite apps here
+interface ResolveOpts {
+  /** Required when `appId === 'kb'` to resolve custom-domain origins */
+  kbId?: string
 }
 
-/** Resolve a trusted app ID to its origin URL */
+/**
+ * Resolve a trusted satellite app to its target origin URL.
+ *
+ * For `build`: returns the static `DEV_PORTAL_URL`.
+ * For `kb`: requires `opts.kbId`. Returns the KB's verified custom domain
+ * (`https://${customDomain}`) when `customDomainVerifiedAt != null`, else
+ * falls back to `KB_URL`. Unverified custom domains never become a token
+ * audience — that's the gate against issuing trust to unconfigured DNS.
+ */
+export async function resolveTrustedAppOrigin(
+  appId: string,
+  opts?: ResolveOpts
+): Promise<string | null> {
+  if (appId === 'build') return DEV_PORTAL_URL
+
+  if (appId === 'kb') {
+    if (!opts?.kbId) return KB_URL
+    const [kb] = await database
+      .select({
+        customDomain: schema.KnowledgeBase.customDomain,
+        customDomainVerifiedAt: schema.KnowledgeBase.customDomainVerifiedAt,
+      })
+      .from(schema.KnowledgeBase)
+      .where(eq(schema.KnowledgeBase.id, opts.kbId))
+      .limit(1)
+
+    if (!kb) return null
+    if (kb.customDomain && kb.customDomainVerifiedAt) {
+      return `https://${kb.customDomain}`
+    }
+    return KB_URL
+  }
+
+  return null
+}
+
+/** Synchronous resolver for static apps (no DB lookup). */
 export function getTrustedAppOrigin(appId: string): string | null {
-  return TRUSTED_APP_ORIGINS[appId as TrustedAppId] ?? null
+  if (appId === 'build') return DEV_PORTAL_URL
+  if (appId === 'kb') return KB_URL
+  return null
 }
 
 /** Check if an app ID is registered */
 export function isTrustedApp(appId: string): boolean {
-  return appId in TRUSTED_APP_ORIGINS
+  return appId === 'build' || appId === 'kb'
 }

--- a/apps/web/src/components/editor/kb-article/block-node-view.module.css
+++ b/apps/web/src/components/editor/kb-article/block-node-view.module.css
@@ -504,6 +504,227 @@
 }
 
 /* ============================================
+   Callout
+   ============================================ */
+
+.blockContainer--callout {
+  position: relative;
+}
+
+.blockContentWrapper--callout {
+  align-items: flex-start;
+  border-radius: 0.5rem;
+  border-left: 3px solid var(--callout-accent, var(--color-primary));
+  background: var(--callout-bg, var(--color-muted));
+  padding: 0.625rem 0.875rem;
+  padding-right: 2.5rem;
+  gap: 0.625rem;
+}
+
+.callout--info .blockContentWrapper--callout {
+  --callout-accent: #2563eb;
+  --callout-bg: rgba(37, 99, 235, 0.08);
+}
+
+.callout--tip .blockContentWrapper--callout {
+  --callout-accent: var(--color-primary);
+  --callout-bg: color-mix(in srgb, var(--color-primary) 10%, transparent);
+}
+
+.callout--warn .blockContentWrapper--callout {
+  --callout-accent: #d97706;
+  --callout-bg: rgba(217, 119, 6, 0.1);
+}
+
+.callout--error .blockContentWrapper--callout {
+  --callout-accent: #dc2626;
+  --callout-bg: rgba(220, 38, 38, 0.1);
+}
+
+.callout--success .blockContentWrapper--callout {
+  --callout-accent: #16a34a;
+  --callout-bg: rgba(22, 163, 74, 0.1);
+}
+
+.calloutIcon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--callout-accent, var(--color-primary));
+  margin-top: 0.2rem;
+}
+
+.blockContent--callout {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-foreground);
+}
+
+.calloutVariantPicker {
+  position: absolute;
+  top: 0.375rem;
+  right: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+  padding: 0.25rem 0.375rem;
+  border-radius: 0.25rem;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--callout-accent, var(--color-muted-foreground));
+  cursor: pointer;
+  font-size: 0.75rem;
+  user-select: none;
+}
+
+.calloutVariantPicker:hover,
+.calloutVariantPicker[data-state='open'] {
+  background-color: var(--color-background);
+  border-color: var(--color-border);
+}
+
+/* ============================================
+   Code language picker
+   ============================================ */
+
+.blockContainer--codeBlock {
+  position: relative;
+}
+
+.codeLanguagePicker {
+  position: absolute;
+  top: 0.375rem;
+  right: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-muted-foreground);
+  cursor: pointer;
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+  user-select: none;
+}
+
+.codeLanguagePicker:hover,
+.codeLanguagePicker[data-state='open'] {
+  background-color: var(--color-background);
+  border-color: var(--color-border);
+}
+
+/* ============================================
+   Embed
+   ============================================ */
+
+.blockContainer--embed {
+  position: relative;
+}
+
+.blockContentWrapper--embed {
+  display: block;
+  width: 100%;
+}
+
+.embedPrompt {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px dashed var(--color-border);
+  background: var(--color-muted);
+}
+
+.embedInput {
+  flex: 1 1 240px;
+  min-width: 0;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-background);
+  font-size: 0.8125rem;
+  color: var(--color-foreground);
+}
+
+.embedInput:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -1px;
+}
+
+.embedSubmit {
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.25rem;
+  border: 1px solid transparent;
+  background: var(--color-primary);
+  color: var(--color-primary-foreground, white);
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+.embedError {
+  flex: 1 1 100%;
+  font-size: 0.75rem;
+  color: #dc2626;
+}
+
+.embedFrame {
+  position: relative;
+  width: 100%;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: var(--color-muted);
+  aspect-ratio: 16 / 9;
+}
+
+.embedFrame[data-aspect='4:3'] {
+  aspect-ratio: 4 / 3;
+}
+
+.embedFrame[data-aspect='1:1'] {
+  aspect-ratio: 1 / 1;
+}
+
+.embedFrame iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+
+.embedToolbar {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  gap: 0.25rem;
+}
+
+.embedSmallButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-background);
+  color: var(--color-foreground);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.embedSmallButton:hover {
+  background: var(--color-muted);
+}
+
+/* ============================================
    Reduced motion
    ============================================ */
 

--- a/apps/web/src/components/editor/kb-article/block-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/block-node-view.tsx
@@ -1,10 +1,48 @@
 // apps/web/src/components/editor/kb-article/block-node-view.tsx
 'use client'
 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import type { CalloutVariant, EmbedAspect, EmbedProvider } from '@auxx/ui/components/kb/article'
+import { CalloutIcon } from '@auxx/ui/components/kb/article'
+import { parseEmbedUrl } from '@auxx/ui/components/kb/utils'
 import type { NodeViewProps } from '@tiptap/react'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
-import { Check } from 'lucide-react'
+import { Check, ChevronDown } from 'lucide-react'
+import { useState } from 'react'
 import styles from './block-node-view.module.css'
+
+const CALLOUT_VARIANTS: CalloutVariant[] = ['info', 'tip', 'warn', 'error', 'success']
+
+const CALLOUT_LABELS: Record<CalloutVariant, string> = {
+  info: 'Info',
+  tip: 'Tip',
+  warn: 'Warning',
+  error: 'Error',
+  success: 'Success',
+}
+
+const CODE_LANGUAGES = [
+  { id: 'plaintext', label: 'Plain text' },
+  { id: 'ts', label: 'TypeScript' },
+  { id: 'tsx', label: 'TSX' },
+  { id: 'js', label: 'JavaScript' },
+  { id: 'jsx', label: 'JSX' },
+  { id: 'json', label: 'JSON' },
+  { id: 'bash', label: 'Bash' },
+  { id: 'sh', label: 'Shell' },
+  { id: 'html', label: 'HTML' },
+  { id: 'css', label: 'CSS' },
+  { id: 'py', label: 'Python' },
+  { id: 'go', label: 'Go' },
+  { id: 'sql', label: 'SQL' },
+] as const
+
+const EMBED_ASPECTS: EmbedAspect[] = ['16:9', '4:3', '1:1']
 
 function formatBullet(depth: number): string {
   const bullets = ['•', '◦', '▪']
@@ -53,6 +91,10 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
     imageUrl,
     imageWidth,
     imageAlign,
+    calloutVariant,
+    codeLanguage,
+    embedUrl,
+    embedAspect,
   } = node.attrs as {
     blockType?: string
     level?: number | null
@@ -60,7 +102,15 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
     imageUrl?: string | null
     imageWidth?: number
     imageAlign?: 'left' | 'center' | 'right'
+    calloutVariant?: CalloutVariant
+    codeLanguage?: string
+    embedUrl?: string | null
+    embedProvider?: EmbedProvider
+    embedAspect?: EmbedAspect
   }
+
+  const [embedDraft, setEmbedDraft] = useState('')
+  const [embedError, setEmbedError] = useState<string | null>(null)
 
   const pos = typeof getPos === 'function' ? getPos() : null
   const isListType =
@@ -97,11 +147,36 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
 
   const isDivider = blockType === 'divider'
   const isImage = blockType === 'image' && !!imageUrl
+  const isCallout = blockType === 'callout'
+  const isCodeBlock = blockType === 'codeBlock'
+  const isEmbed = blockType === 'embed'
+  const hasEmbedUrl = isEmbed && !!embedUrl
   const isEmpty = node.content.size === 0
   const isFirstBlock = pos === 0
-  const showPlaceholder = isEmpty && !isDivider && !isImage && (isFocused || isFirstBlock)
+  const showPlaceholder =
+    isEmpty && !isDivider && !isImage && !isEmbed && (isFocused || isFirstBlock)
   const placeholderText =
-    blockType === 'heading' ? `Heading ${level ?? 1}` : "Press '/' for commands"
+    blockType === 'heading'
+      ? `Heading ${level ?? 1}`
+      : isCallout
+        ? 'Callout text'
+        : "Press '/' for commands"
+
+  const submitEmbed = (raw: string) => {
+    const trimmed = raw.trim()
+    if (!trimmed) return
+    const parsed = parseEmbedUrl(trimmed)
+    if (!parsed) {
+      setEmbedError('Only YouTube, Loom, and Vimeo URLs are supported')
+      return
+    }
+    setEmbedError(null)
+    setEmbedDraft('')
+    updateAttributes({ embedUrl: trimmed, embedProvider: parsed.provider })
+  }
+
+  const calloutVariantValue: CalloutVariant = calloutVariant ?? 'info'
+  const parsedEmbed = hasEmbedUrl ? parseEmbedUrl(embedUrl!) : null
 
   const wrapperClasses = [styles.blockWrapper, isFocused ? styles.focused : '']
     .filter(Boolean)
@@ -120,8 +195,11 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
     blockType === 'heading' && level === 1 ? styles['blockContainer--heading1'] : '',
     blockType === 'heading' && level === 2 ? styles['blockContainer--heading2'] : '',
     blockType === 'heading' && level === 3 ? styles['blockContainer--heading3'] : '',
-    blockType === 'codeBlock' ? styles['blockContainer--codeBlock'] : '',
+    isCodeBlock ? styles['blockContainer--codeBlock'] : '',
     blockType === 'quote' ? styles['blockContainer--quote'] : '',
+    isCallout ? styles['blockContainer--callout'] : '',
+    isCallout ? styles[`callout--${calloutVariantValue}`] : '',
+    isEmbed ? styles['blockContainer--embed'] : '',
   ]
     .filter(Boolean)
     .join(' ')
@@ -129,7 +207,9 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
   const contentWrapperClasses = [
     styles.blockContentWrapper,
     isDivider ? styles['blockContentWrapper--divider'] : '',
-    blockType === 'codeBlock' ? styles['blockContentWrapper--codeBlock'] : '',
+    isCodeBlock ? styles['blockContentWrapper--codeBlock'] : '',
+    isCallout ? styles['blockContentWrapper--callout'] : '',
+    isEmbed ? styles['blockContentWrapper--embed'] : '',
   ]
     .filter(Boolean)
     .join(' ')
@@ -140,7 +220,8 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
     blockType === 'heading' && level === 2 ? styles['blockContent--heading2'] : '',
     blockType === 'heading' && level === 3 ? styles['blockContent--heading3'] : '',
     blockType === 'quote' ? styles['blockContent--quote'] : '',
-    blockType === 'codeBlock' ? styles['blockContent--codeBlock'] : '',
+    isCodeBlock ? styles['blockContent--codeBlock'] : '',
+    isCallout ? styles['blockContent--callout'] : '',
   ]
     .filter(Boolean)
     .join(' ')
@@ -188,6 +269,12 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
 
           {blockType === 'quote' && <div className={styles.quoteBar} contentEditable={false} />}
 
+          {isCallout && (
+            <span className={styles.calloutIcon} contentEditable={false}>
+              <CalloutIcon variant={calloutVariantValue} size={16} />
+            </span>
+          )}
+
           {isDivider ? (
             <>
               <div
@@ -199,8 +286,119 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
               />
               <NodeViewContent className={`${styles.blockContent} ${styles.blockContentHidden}`} />
             </>
+          ) : isEmbed ? (
+            <>
+              {hasEmbedUrl && parsedEmbed ? (
+                <div
+                  className={styles.embedFrame}
+                  data-aspect={embedAspect ?? '16:9'}
+                  contentEditable={false}>
+                  <iframe
+                    src={parsedEmbed.embedSrc}
+                    title={`${parsedEmbed.provider} embed`}
+                    allowFullScreen
+                    sandbox='allow-scripts allow-same-origin allow-presentation'
+                  />
+                  <div className={styles.embedToolbar}>
+                    <button
+                      type='button'
+                      className={styles.embedSmallButton}
+                      onClick={() => updateAttributes({ embedUrl: null, embedProvider: null })}>
+                      Edit URL
+                    </button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button type='button' className={styles.embedSmallButton}>
+                          {embedAspect ?? '16:9'} <ChevronDown size={12} />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align='end'>
+                        {EMBED_ASPECTS.map((aspect) => (
+                          <DropdownMenuItem
+                            key={aspect}
+                            onSelect={() => updateAttributes({ embedAspect: aspect })}>
+                            {aspect}
+                          </DropdownMenuItem>
+                        ))}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                </div>
+              ) : (
+                <div className={styles.embedPrompt} contentEditable={false}>
+                  <input
+                    type='url'
+                    className={styles.embedInput}
+                    placeholder='Paste YouTube / Loom / Vimeo URL'
+                    value={embedDraft}
+                    onChange={(e) => {
+                      setEmbedDraft(e.target.value)
+                      if (embedError) setEmbedError(null)
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        submitEmbed(embedDraft)
+                      }
+                    }}
+                  />
+                  <button
+                    type='button'
+                    className={styles.embedSubmit}
+                    onClick={() => submitEmbed(embedDraft)}>
+                    Embed
+                  </button>
+                  {embedError && <span className={styles.embedError}>{embedError}</span>}
+                </div>
+              )}
+              <NodeViewContent className={`${styles.blockContent} ${styles.blockContentHidden}`} />
+            </>
           ) : (
             <NodeViewContent className={contentClasses} />
+          )}
+
+          {isCodeBlock && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button type='button' className={styles.codeLanguagePicker} contentEditable={false}>
+                  {CODE_LANGUAGES.find((l) => l.id === codeLanguage)?.label ?? 'Plain text'}{' '}
+                  <ChevronDown size={12} />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align='end'>
+                {CODE_LANGUAGES.map((lang) => (
+                  <DropdownMenuItem
+                    key={lang.id}
+                    onSelect={() => updateAttributes({ codeLanguage: lang.id })}>
+                    {lang.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+
+          {isCallout && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type='button'
+                  className={styles.calloutVariantPicker}
+                  contentEditable={false}
+                  aria-label='Change callout variant'>
+                  <CalloutIcon variant={calloutVariantValue} size={14} />
+                  <ChevronDown size={12} />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align='end'>
+                {CALLOUT_VARIANTS.map((variant) => (
+                  <DropdownMenuItem
+                    key={variant}
+                    onSelect={() => updateAttributes({ calloutVariant: variant })}>
+                    <CalloutIcon variant={variant} size={14} /> {CALLOUT_LABELS[variant]}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
 
           {isImage && (

--- a/apps/web/src/components/editor/kb-article/block-node.ts
+++ b/apps/web/src/components/editor/kb-article/block-node.ts
@@ -15,6 +15,8 @@ export type BlockType =
   | 'image'
   | 'divider'
   | 'codeBlock'
+  | 'callout'
+  | 'embed'
 
 const LIST_TYPES: BlockType[] = ['bulletListItem', 'numberedListItem', 'todoListItem']
 
@@ -75,6 +77,44 @@ export const Block = Node.create({
         renderHTML: (attrs) =>
           attrs.blockType === 'image' && attrs.imageAlign
             ? { 'data-image-align': attrs.imageAlign }
+            : {},
+      },
+      calloutVariant: {
+        default: 'info',
+        parseHTML: (el) => el.getAttribute('data-callout-variant') || 'info',
+        renderHTML: (attrs) =>
+          attrs.blockType === 'callout' && attrs.calloutVariant
+            ? { 'data-callout-variant': attrs.calloutVariant }
+            : {},
+      },
+      codeLanguage: {
+        default: 'plaintext',
+        parseHTML: (el) => el.getAttribute('data-code-language') || 'plaintext',
+        renderHTML: (attrs) =>
+          attrs.blockType === 'codeBlock' && attrs.codeLanguage
+            ? { 'data-code-language': attrs.codeLanguage }
+            : {},
+      },
+      embedUrl: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-embed-url'),
+        renderHTML: (attrs) =>
+          attrs.blockType === 'embed' && attrs.embedUrl ? { 'data-embed-url': attrs.embedUrl } : {},
+      },
+      embedProvider: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-embed-provider'),
+        renderHTML: (attrs) =>
+          attrs.blockType === 'embed' && attrs.embedProvider
+            ? { 'data-embed-provider': attrs.embedProvider }
+            : {},
+      },
+      embedAspect: {
+        default: '16:9',
+        parseHTML: (el) => el.getAttribute('data-embed-aspect') || '16:9',
+        renderHTML: (attrs) =>
+          attrs.blockType === 'embed' && attrs.embedAspect
+            ? { 'data-embed-aspect': attrs.embedAspect }
             : {},
       },
     }
@@ -149,6 +189,16 @@ export const Block = Node.create({
 
           // Divider stays as divider — split and convert the new sibling to text.
           if (blockType === 'divider') {
+            return editor
+              .chain()
+              .splitBlock()
+              .updateAttributes('block', { blockType: 'text', level: null, checked: false })
+              .run()
+          }
+
+          // Filled embed (URL set): split off a new text block below instead of
+          // converting the embed back to text.
+          if (blockType === 'embed' && node.attrs.embedUrl) {
             return editor
               .chain()
               .splitBlock()

--- a/apps/web/src/components/editor/kb-article/kb-slash-command-picker.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-slash-command-picker.tsx
@@ -37,8 +37,11 @@ interface BlockCommandSpec {
     | 'quote'
     | 'codeBlock'
     | 'divider'
+    | 'callout'
+    | 'embed'
   level?: number | null
   checked?: boolean
+  calloutVariant?: 'info' | 'tip' | 'warn' | 'error' | 'success'
 }
 
 interface CommandItemDef {
@@ -188,19 +191,52 @@ const BASE_COMMANDS: CommandItemDef[] = [
     },
   },
   {
-    id: 'table',
-    title: 'Table',
-    description: 'Insert a table',
-    keywords: ['grid', 'rows', 'columns'],
-    iconId: 'table',
-    custom: (editor, range) => {
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
-        .run()
-    },
+    id: 'callout-info',
+    title: 'Info callout',
+    description: 'Highlight a note with an info tone',
+    keywords: ['callout', 'note', 'aside', 'info', 'admonition'],
+    iconId: 'info',
+    spec: { blockType: 'callout', calloutVariant: 'info' },
+  },
+  {
+    id: 'callout-tip',
+    title: 'Tip callout',
+    description: 'Share a helpful tip',
+    keywords: ['callout', 'tip', 'hint', 'lightbulb', 'idea'],
+    iconId: 'lightbulb',
+    spec: { blockType: 'callout', calloutVariant: 'tip' },
+  },
+  {
+    id: 'callout-warn',
+    title: 'Warning callout',
+    description: 'Warn the reader about something',
+    keywords: ['callout', 'warning', 'caution', 'alert'],
+    iconId: 'alert-triangle',
+    spec: { blockType: 'callout', calloutVariant: 'warn' },
+  },
+  {
+    id: 'callout-error',
+    title: 'Error callout',
+    description: 'Flag an error or breaking note',
+    keywords: ['callout', 'error', 'danger', 'stop', 'critical'],
+    iconId: 'x-circle',
+    spec: { blockType: 'callout', calloutVariant: 'error' },
+  },
+  {
+    id: 'callout-success',
+    title: 'Success callout',
+    description: 'Confirm a successful outcome',
+    keywords: ['callout', 'success', 'done', 'check', 'ok'],
+    iconId: 'check-circle',
+    spec: { blockType: 'callout', calloutVariant: 'success' },
+  },
+  {
+    id: 'embed',
+    title: 'Video / embed',
+    description: 'Embed a YouTube, Loom, or Vimeo video',
+    keywords: ['video', 'youtube', 'loom', 'vimeo', 'embed', 'iframe'],
+    iconId: 'video',
+    spec: { blockType: 'embed' },
   },
 ]
 
@@ -331,6 +367,7 @@ function KBSlashCommandPickerContent({
           level: spec.level ?? null,
         }
         if (spec.blockType === 'todoListItem') attrs.checked = spec.checked ?? false
+        if (spec.blockType === 'callout') attrs.calloutVariant = spec.calloutVariant ?? 'info'
         editor.chain().focus().deleteRange(range).updateAttributes('block', attrs).run()
       })
     },

--- a/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
@@ -52,8 +52,8 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath }: KBFullscreenP
       basePath={basePath}
       activeArticleId={activeArticle?.id}>
       {articleId ? (
-        <div className='min-w-0 flex-1'>
-          <div className='mx-auto max-w-3xl px-6 pt-4'>
+        <div className='flex min-w-0 flex-1 flex-col'>
+          <div className='w-full max-w-3xl px-6 pt-4'>
             <KBTableOfContents headings={headings} />
           </div>
           <KBArticleRenderer
@@ -61,7 +61,7 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath }: KBFullscreenP
             title={activeArticle?.title}
             description={description ?? activeArticle?.description}
           />
-          <div className='mx-auto max-w-3xl px-6'>
+          <div className='mt-auto w-full max-w-3xl px-6'>
             <KBArticlePager articles={articles} prev={prev} next={next} basePath={basePath} />
           </div>
         </div>

--- a/apps/web/src/components/kb/ui/preview/kb-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview.tsx
@@ -73,8 +73,8 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
             mode={isDark ? 'dark' : 'light'}
             onArticleClick={(id) => setOverrideId(id)}>
             {articleId ? (
-              <div className='min-w-0 flex-1'>
-                <div className='mx-auto max-w-3xl px-6 pt-4'>
+              <div className='flex min-w-0 flex-1 flex-col'>
+                <div className='w-full max-w-3xl px-6 pt-4'>
                   <KBTableOfContents headings={headings} />
                 </div>
                 <KBArticleRenderer
@@ -82,7 +82,7 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
                   title={activeArticle?.title ?? articles.find((a) => a.id === articleId)?.title}
                   description={description ?? activeArticle?.description}
                 />
-                <div className='mx-auto max-w-3xl px-6'>
+                <div className='mt-auto w-full max-w-3xl px-6'>
                   <KBArticlePager articles={articles} prev={prev} next={next} basePath='#preview' />
                 </div>
               </div>

--- a/apps/web/src/components/kb/ui/settings/general/general-schema.ts
+++ b/apps/web/src/components/kb/ui/settings/general/general-schema.ts
@@ -10,6 +10,7 @@ export const generalSchema = z.object({
     .regex(/^[a-z0-9-]+$/, 'Slug can only contain lowercase letters, numbers, and hyphens'),
   description: z.string().optional().nullable(),
   customDomain: z.string().optional().nullable(),
+  visibility: z.enum(['PUBLIC', 'INTERNAL']).default('PUBLIC'),
 
   logoDark: z.string().optional().nullable(),
   logoLight: z.string().optional().nullable(),

--- a/apps/web/src/components/kb/ui/settings/general/general-tab.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/general-tab.tsx
@@ -30,6 +30,7 @@ function buildDefaults(kb: KnowledgeBase): GeneralFormValues {
     slug: kb.slug,
     description: kb.description || '',
     customDomain: kb.customDomain || '',
+    visibility: (kb.visibility as GeneralFormValues['visibility']) ?? 'PUBLIC',
     logoDark: kb.logoDark || '',
     logoLight: kb.logoLight || '',
     theme: (lower(kb.theme) as GeneralFormValues['theme']) || 'clean',

--- a/apps/web/src/components/kb/ui/settings/general/identity-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/identity-section.tsx
@@ -15,6 +15,11 @@ interface IdentitySectionProps {
   isPending: boolean
 }
 
+const VISIBILITY_OPTIONS = [
+  { label: 'Public', value: 'PUBLIC' },
+  { label: 'Internal — sign-in required', value: 'INTERNAL' },
+]
+
 export function IdentitySection({ form, isPending }: IdentitySectionProps) {
   return (
     <Section title='Basic' description='Public identity of your knowledge base'>
@@ -100,6 +105,29 @@ export function IdentitySection({ form, isPending }: IdentitySectionProps) {
                 onChange={(v) => field.onChange(v ?? '')}
                 placeholder='docs.example.com'
                 disabled={isPending}
+              />
+            </VarEditorFieldRow>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name='visibility'
+          render={({ field, fieldState }) => (
+            <VarEditorFieldRow
+              title='Visibility'
+              description='Public knowledge bases are accessible to anyone with the link. Internal knowledge bases require visitors to sign in and be a member of your organization.'
+              type={BaseType.ENUM}
+              showIcon
+              validationError={fieldState.error?.message}>
+              <FieldInputAdapter
+                fieldType={FieldType.SINGLE_SELECT}
+                fieldOptions={{ options: VISIBILITY_OPTIONS }}
+                value={field.value ?? 'PUBLIC'}
+                onChange={(v) => field.onChange((v as string[])[0] ?? 'PUBLIC')}
+                placeholder='Public'
+                disabled={isPending}
+                triggerProps={{ className: 'w-full' }}
               />
             </VarEditorFieldRow>
           )}

--- a/apps/web/src/components/kb/ui/sidebar/kb-switcher.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/kb-switcher.tsx
@@ -93,11 +93,13 @@ export function KBSwitcher() {
                 {isLoading ? 'Loading...' : activeKB?.name || 'Knowledge Base'}
               </span>
               <span className='truncate text-xs'>
-                {activeKB?.publishStatus === 'PUBLISHED'
-                  ? 'Public'
+                {activeKB?.publishStatus === 'DRAFT'
+                  ? 'Draft'
                   : activeKB?.publishStatus === 'UNLISTED'
                     ? 'Unlisted'
-                    : 'Private'}
+                    : activeKB?.visibility === 'INTERNAL'
+                      ? 'Internal'
+                      : 'Public'}
               </span>
             </div>
             <ChevronsUpDown className='ml-auto size-4' />

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -26,6 +26,7 @@ const KNOWN_ROUTE_PREFIXES = new Set([
   'demo',
   'demo-expired',
   'forgot-password',
+  'kb-auth',
   'login',
   'reset-password',
   'signup',

--- a/apps/web/src/server/api/routers/kb.ts
+++ b/apps/web/src/server/api/routers/kb.ts
@@ -18,6 +18,7 @@ const kbFieldsSchema = z.object({
   slug: z.string().min(1).optional(),
   description: z.string().optional(),
   publishStatus: z.enum(['DRAFT', 'PUBLISHED', 'UNLISTED']).optional(),
+  visibility: z.enum(['PUBLIC', 'INTERNAL']).optional(),
   customDomain: z.string().optional(),
   logoDark: z.string().optional(),
   logoLight: z.string().optional(),

--- a/infra/secrets.ts
+++ b/infra/secrets.ts
@@ -47,6 +47,10 @@ export const secretsConfig = {
     secret: new sst.Secret('BUILD_SESSION_SECRET'),
     description: 'HMAC secret for apps/build local session cookies',
   },
+  KB_SESSION_SECRET: {
+    secret: new sst.Secret('KB_SESSION_SECRET'),
+    description: 'HMAC secret for apps/kb local session cookies',
+  },
 
   // OAuth - GitHub
   AUTH_GITHUB_ID: {

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -46,6 +46,12 @@
       "import": "./dist/login-token/index.mjs",
       "default": "./src/login-token/index.ts"
     },
+    "./local-session": {
+      "types": "./src/local-session/index.ts",
+      "source": "./src/local-session/index.ts",
+      "import": "./dist/local-session/index.mjs",
+      "default": "./src/local-session/index.ts"
+    },
     "./config": {
       "types": "./src/config/index.ts",
       "source": "./src/config/index.ts",

--- a/packages/credentials/src/local-session/index.ts
+++ b/packages/credentials/src/local-session/index.ts
@@ -1,0 +1,100 @@
+// packages/credentials/src/local-session/index.ts
+// Shared local-session helpers for satellite Next.js apps (build, kb, ...).
+//
+// Each satellite app mints its own short-lived HS256 JWT cookie after a
+// cross-app login token has been verified. The shape is identical across apps
+// — only the cookie name, secret, and TTL differ. This factory captures that
+// shape so we don't fork the logic.
+//
+// Redis (for jti single-use) and the cookie store (next/headers) are injected
+// to avoid `@auxx/credentials` taking a hard dependency on `@auxx/redis`
+// (circular) or `next` (peer-only).
+
+import { jwtVerify, SignJWT } from 'jose'
+import { configService } from '../config'
+
+/** User payload carried in the local session JWT */
+export interface LocalSession {
+  userId: string
+  email: string
+}
+
+/** Minimal cookie-store interface — matches `next/headers`' `cookies()` return value */
+export interface CookieStoreLike {
+  get(name: string): { value: string } | undefined
+}
+
+/** Minimal redis-client interface — matches `ioredis` for SET NX EX */
+export interface RedisLike {
+  set(
+    key: string,
+    value: string,
+    expireMode: 'EX',
+    seconds: number,
+    setMode: 'NX'
+  ): Promise<unknown>
+}
+
+export interface LocalSessionConfig {
+  /** Cookie name for the local session, e.g. `auxx-build.session` */
+  cookieName: string
+  /** Env key for the HS256 signing secret, e.g. `BUILD_SESSION_SECRET` */
+  secretEnv: string
+  /** Session lifetime in seconds */
+  ttlSeconds: number
+  /** Reads the request cookie store (typically `() => cookies()` from `next/headers`) */
+  getCookieStore: () => Promise<CookieStoreLike>
+  /** Returns a redis client for single-use jti tracking. Optional; if omitted, jti consumption no-ops to `false`. */
+  getRedis?: () => Promise<RedisLike | null>
+}
+
+export interface LocalSessionHelpers {
+  createSession(user: LocalSession): Promise<string>
+  verifySession(token: string): Promise<LocalSession | null>
+  getSession(): Promise<LocalSession | null>
+  consumeLoginTokenJti(jti: string): Promise<boolean>
+}
+
+export function createLocalSessionHelpers(config: LocalSessionConfig): LocalSessionHelpers {
+  function getSecret(): Uint8Array {
+    const secret = configService.get<string>(config.secretEnv)
+    if (!secret) throw new Error(`${config.secretEnv} not configured`)
+    return new TextEncoder().encode(secret)
+  }
+
+  async function createSession(user: LocalSession): Promise<string> {
+    return new SignJWT({ email: user.email })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setSubject(user.userId)
+      .setIssuedAt()
+      .setExpirationTime(`${config.ttlSeconds}s`)
+      .sign(getSecret())
+  }
+
+  async function verifySession(token: string): Promise<LocalSession | null> {
+    try {
+      const { payload } = await jwtVerify(token, getSecret())
+      if (!payload.sub || !payload.email) return null
+      return { userId: payload.sub, email: payload.email as string }
+    } catch {
+      return null
+    }
+  }
+
+  async function getSession(): Promise<LocalSession | null> {
+    const store = await config.getCookieStore()
+    const cookie = store.get(config.cookieName)
+    if (!cookie?.value) return null
+    return verifySession(cookie.value)
+  }
+
+  async function consumeLoginTokenJti(jti: string): Promise<boolean> {
+    if (!config.getRedis) return false
+    const redis = await config.getRedis()
+    if (!redis) return false
+    const result = await redis.set(`login-token:${jti}`, 'consumed', 'EX', 600, 'NX')
+    return result === 'OK'
+  }
+
+  return { createSession, verifySession, getSession, consumeLoginTokenJti }
+}

--- a/packages/credentials/src/login-token/index.ts
+++ b/packages/credentials/src/login-token/index.ts
@@ -1,6 +1,7 @@
 // packages/credentials/src/login-token/index.ts
 
 export { issueLoginToken } from './issue-login-token'
+export { sanitizeReturnTo } from './sanitize-return-to'
 export type {
   IssueLoginTokenOptions,
   IssueLoginTokenResult,

--- a/packages/credentials/src/login-token/sanitize-return-to.ts
+++ b/packages/credentials/src/login-token/sanitize-return-to.ts
@@ -1,0 +1,20 @@
+// packages/credentials/src/login-token/sanitize-return-to.ts
+
+/**
+ * Sanitize a `returnTo` value to a safe relative path.
+ *
+ * Rejects anything that:
+ * - isn't a string
+ * - doesn't start with `/`
+ * - starts with `//` (protocol-relative)
+ * - contains `..` (parent traversal)
+ *
+ * Falls back to the provided `fallback` (default `/`).
+ */
+export function sanitizeReturnTo(value: unknown, fallback = '/'): string {
+  if (typeof value !== 'string') return fallback
+  if (!value.startsWith('/') || value.startsWith('//') || value.includes('..')) {
+    return fallback
+  }
+  return value
+}

--- a/packages/credentials/tsdown.config.ts
+++ b/packages/credentials/tsdown.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     'src/service/index.ts',
     'src/types/index.ts',
     'src/login-token/index.ts',
+    'src/local-session/index.ts',
     'src/config/index.ts',
     'src/config/client.ts',
     'src/lambda-auth/index.ts',

--- a/packages/database/drizzle/0139_kb_visibility_and_custom_domain_verification.sql
+++ b/packages/database/drizzle/0139_kb_visibility_and_custom_domain_verification.sql
@@ -1,0 +1,3 @@
+CREATE TYPE "public"."KBVisibility" AS ENUM('PUBLIC', 'INTERNAL');--> statement-breakpoint
+ALTER TABLE "KnowledgeBase" ADD COLUMN "visibility" "KBVisibility" DEFAULT 'PUBLIC' NOT NULL;--> statement-breakpoint
+ALTER TABLE "KnowledgeBase" ADD COLUMN "customDomainVerifiedAt" timestamp (3);

--- a/packages/database/drizzle/meta/0139_snapshot.json
+++ b/packages/database/drizzle/meta/0139_snapshot.json
@@ -1,0 +1,31280 @@
+{
+  "id": "abf2bf06-39cc-4a76-b64f-0d296e8bbf20",
+  "prevId": "90b4346d-b688-4cdc-b456-3e64d90e1b2c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHistoryId": {
+          "name": "lastHistoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_providerId_accountId_key": {
+          "name": "account_providerId_accountId_key",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_User_id_fk": {
+          "name": "account_userId_User_id_fk",
+          "tableFrom": "account",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Address": {
+      "name": "Address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address1": {
+          "name": "address1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address2": {
+          "name": "address2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "countryCode": {
+          "name": "countryCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provinceCode": {
+          "name": "provinceCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orderType": {
+          "name": "orderType",
+          "type": "ORDER_ADDRESS_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Address_customerId_idx": {
+          "name": "Address_customerId_idx",
+          "columns": [
+            {
+              "expression": "customerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Address_orderId_idx": {
+          "name": "Address_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Address_customerId_shopify_customers_id_fk": {
+          "name": "Address_customerId_shopify_customers_id_fk",
+          "tableFrom": "Address",
+          "tableTo": "shopify_customers",
+          "columnsFrom": ["customerId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Address_organizationId_Organization_id_fk": {
+          "name": "Address_organizationId_Organization_id_fk",
+          "tableFrom": "Address",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Address_integrationId_ShopifyIntegration_id_fk": {
+          "name": "Address_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "Address",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AdminActionLog": {
+      "name": "AdminActionLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "adminUserId": {
+          "name": "adminUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionType": {
+          "name": "actionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetType": {
+          "name": "targetType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousState": {
+          "name": "previousState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newState": {
+          "name": "newState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AdminActionLog_organizationId_idx": {
+          "name": "AdminActionLog_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminActionLog_adminUserId_idx": {
+          "name": "AdminActionLog_adminUserId_idx",
+          "columns": [
+            {
+              "expression": "adminUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminActionLog_createdAt_idx": {
+          "name": "AdminActionLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminActionLog_actionType_idx": {
+          "name": "AdminActionLog_actionType_idx",
+          "columns": [
+            {
+              "expression": "actionType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AdminActionLog_adminUserId_User_id_fk": {
+          "name": "AdminActionLog_adminUserId_User_id_fk",
+          "tableFrom": "AdminActionLog",
+          "tableTo": "User",
+          "columnsFrom": ["adminUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "AdminActionLog_organizationId_Organization_id_fk": {
+          "name": "AdminActionLog_organizationId_Organization_id_fk",
+          "tableFrom": "AdminActionLog",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiAgentSession": {
+      "name": "AiAgentSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "domainState": {
+          "name": "domainState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "AiAgentSession_organizationId_userId_type_idx": {
+          "name": "AiAgentSession_organizationId_userId_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiAgentSession_userId_type_updatedAt_idx": {
+          "name": "AiAgentSession_userId_type_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiAgentSession_organizationId_Organization_id_fk": {
+          "name": "AiAgentSession_organizationId_Organization_id_fk",
+          "tableFrom": "AiAgentSession",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiAgentSession_userId_User_id_fk": {
+          "name": "AiAgentSession_userId_User_id_fk",
+          "tableFrom": "AiAgentSession",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiIntegration": {
+      "name": "AiIntegration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiKey": {
+          "name": "apiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "AiIntegrationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryptedCredentials": {
+          "name": "encryptedCredentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loadBalancingEnabled": {
+          "name": "loadBalancingEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm'"
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "quotaLimit": {
+          "name": "quotaLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-1'"
+        },
+        "quotaType": {
+          "name": "quotaType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaUsed": {
+          "name": "quotaUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "AiIntegration_organizationId_idx": {
+          "name": "AiIntegration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_organizationId_isDefault_idx": {
+          "name": "AiIntegration_organizationId_isDefault_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isDefault",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_organizationId_modelType_idx": {
+          "name": "AiIntegration_organizationId_modelType_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_organizationId_providerType_idx": {
+          "name": "AiIntegration_organizationId_providerType_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_provider_organizationId_key": {
+          "name": "AiIntegration_provider_organizationId_key",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiIntegration_organizationId_Organization_id_fk": {
+          "name": "AiIntegration_organizationId_Organization_id_fk",
+          "tableFrom": "AiIntegration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiIntegration_userId_User_id_fk": {
+          "name": "AiIntegration_userId_User_id_fk",
+          "tableFrom": "AiIntegration",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiMessageFeedback": {
+      "name": "AiMessageFeedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isPositive": {
+          "name": "isPositive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "AiMessageFeedback_sessionId_messageId_userId_key": {
+          "name": "AiMessageFeedback_sessionId_messageId_userId_key",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiMessageFeedback_organizationId_idx": {
+          "name": "AiMessageFeedback_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiMessageFeedback_isPositive_idx": {
+          "name": "AiMessageFeedback_isPositive_idx",
+          "columns": [
+            {
+              "expression": "isPositive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiMessageFeedback_sessionId_AiAgentSession_id_fk": {
+          "name": "AiMessageFeedback_sessionId_AiAgentSession_id_fk",
+          "tableFrom": "AiMessageFeedback",
+          "tableTo": "AiAgentSession",
+          "columnsFrom": ["sessionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiMessageFeedback_organizationId_Organization_id_fk": {
+          "name": "AiMessageFeedback_organizationId_Organization_id_fk",
+          "tableFrom": "AiMessageFeedback",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiMessageFeedback_userId_User_id_fk": {
+          "name": "AiMessageFeedback_userId_User_id_fk",
+          "tableFrom": "AiMessageFeedback",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiSuggestion": {
+      "name": "AiSuggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerUserId": {
+          "name": "ownerUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle": {
+          "name": "bundle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionCount": {
+          "name": "actionCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computedForActivityAt": {
+          "name": "computedForActivityAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computedForLatestMessageId": {
+          "name": "computedForLatestMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerSource": {
+          "name": "triggerSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerEventType": {
+          "name": "triggerEventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FRESH'"
+        },
+        "outcomes": {
+          "name": "outcomes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decidedById": {
+          "name": "decidedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decidedAt": {
+          "name": "decidedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AiSuggestion_org_entity_active_key": {
+          "name": "AiSuggestion_org_entity_active_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'FRESH'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiSuggestion_org_status_idx": {
+          "name": "AiSuggestion_org_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiSuggestion_org_entity_createdAt_idx": {
+          "name": "AiSuggestion_org_entity_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiSuggestion_org_entityDef_status_idx": {
+          "name": "AiSuggestion_org_entityDef_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiSuggestion_organizationId_Organization_id_fk": {
+          "name": "AiSuggestion_organizationId_Organization_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_entityInstanceId_EntityInstance_id_fk": {
+          "name": "AiSuggestion_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "AiSuggestion_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_threadId_Thread_id_fk": {
+          "name": "AiSuggestion_threadId_Thread_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_ownerUserId_User_id_fk": {
+          "name": "AiSuggestion_ownerUserId_User_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "User",
+          "columnsFrom": ["ownerUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_decidedById_User_id_fk": {
+          "name": "AiSuggestion_decidedById_User_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "User",
+          "columnsFrom": ["decidedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiUsage": {
+      "name": "AiUsage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputTokens": {
+          "name": "inputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm'"
+        },
+        "outputTokens": {
+          "name": "outputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creditsUsed": {
+          "name": "creditsUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "ProviderType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialSource": {
+          "name": "credentialSource",
+          "type": "CredentialSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "AiUsage_createdAt_idx": {
+          "name": "AiUsage_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiUsage_organizationId_createdAt_idx": {
+          "name": "AiUsage_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiUsage_provider_model_idx": {
+          "name": "AiUsage_provider_model_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiUsage_source_idx": {
+          "name": "AiUsage_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiUsage_organizationId_Organization_id_fk": {
+          "name": "AiUsage_organizationId_Organization_id_fk",
+          "tableFrom": "AiUsage",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiUsage_userId_User_id_fk": {
+          "name": "AiUsage_userId_User_id_fk",
+          "tableFrom": "AiUsage",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApiKey": {
+      "name": "ApiKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashedKey": {
+          "name": "hashedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app'"
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ApiKey_hashedKey_key": {
+          "name": "ApiKey_hashedKey_key",
+          "columns": [
+            {
+              "expression": "hashedKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApiKey_userId_isActive_idx": {
+          "name": "ApiKey_userId_isActive_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApiKey_type_referenceId_idx": {
+          "name": "ApiKey_type_referenceId_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referenceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApiKey_userId_User_id_fk": {
+          "name": "ApiKey_userId_User_id_fk",
+          "tableFrom": "ApiKey",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ApiKey_organizationId_Organization_id_fk": {
+          "name": "ApiKey_organizationId_Organization_id_fk",
+          "tableFrom": "ApiKey",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppBundle": {
+      "name": "AppBundle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundleType": {
+          "name": "bundleType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploadedAt": {
+          "name": "uploadedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppBundle_content_idx": {
+          "name": "AppBundle_content_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundleType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppBundle_appId_idx": {
+          "name": "AppBundle_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppBundle_appId_App_id_fk": {
+          "name": "AppBundle_appId_App_id_fk",
+          "tableFrom": "AppBundle",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppDeployment": {
+      "name": "AppDeployment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deploymentType": {
+          "name": "deploymentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientBundleId": {
+          "name": "clientBundleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverBundleId": {
+          "name": "serverBundleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settingsSchema": {
+          "name": "settingsSchema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetOrganizationId": {
+          "name": "targetOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environmentVariables": {
+          "name": "environmentVariables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "reviewedAt": {
+          "name": "reviewedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewedBy": {
+          "name": "reviewedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectionReason": {
+          "name": "rejectionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "releaseNotes": {
+          "name": "releaseNotes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppDeployment_appId_idx": {
+          "name": "AppDeployment_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppDeployment_type_idx": {
+          "name": "AppDeployment_type_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deploymentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppDeployment_targetOrganizationId_idx": {
+          "name": "AppDeployment_targetOrganizationId_idx",
+          "columns": [
+            {
+              "expression": "targetOrganizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppDeployment_appId_App_id_fk": {
+          "name": "AppDeployment_appId_App_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppDeployment_clientBundleId_AppBundle_id_fk": {
+          "name": "AppDeployment_clientBundleId_AppBundle_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "AppBundle",
+          "columnsFrom": ["clientBundleId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "AppDeployment_serverBundleId_AppBundle_id_fk": {
+          "name": "AppDeployment_serverBundleId_AppBundle_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "AppBundle",
+          "columnsFrom": ["serverBundleId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "AppDeployment_targetOrganizationId_Organization_id_fk": {
+          "name": "AppDeployment_targetOrganizationId_Organization_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "Organization",
+          "columnsFrom": ["targetOrganizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppEventLog": {
+      "name": "AppEventLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appDeploymentId": {
+          "name": "appDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventData": {
+          "name": "eventData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestMethod": {
+          "name": "requestMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestPath": {
+          "name": "requestPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseStatus": {
+          "name": "responseStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppEventLog_appId_idx": {
+          "name": "AppEventLog_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppEventLog_organizationId_idx": {
+          "name": "AppEventLog_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppEventLog_appDeploymentId_idx": {
+          "name": "AppEventLog_appDeploymentId_idx",
+          "columns": [
+            {
+              "expression": "appDeploymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppEventLog_timestamp_idx": {
+          "name": "AppEventLog_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppEventLog_appId_App_id_fk": {
+          "name": "AppEventLog_appId_App_id_fk",
+          "tableFrom": "AppEventLog",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppEventLog_organizationId_Organization_id_fk": {
+          "name": "AppEventLog_organizationId_Organization_id_fk",
+          "tableFrom": "AppEventLog",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppEventLog_appDeploymentId_AppDeployment_id_fk": {
+          "name": "AppEventLog_appDeploymentId_AppDeployment_id_fk",
+          "tableFrom": "AppEventLog",
+          "tableTo": "AppDeployment",
+          "columnsFrom": ["appDeploymentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppInstallation": {
+      "name": "AppInstallation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installationType": {
+          "name": "installationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentDeploymentId": {
+          "name": "currentDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installedAt": {
+          "name": "installedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "uninstalledAt": {
+          "name": "uninstalledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppInstallation_unique_idx": {
+          "name": "AppInstallation_unique_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppInstallation_appId_idx": {
+          "name": "AppInstallation_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppInstallation_organizationId_idx": {
+          "name": "AppInstallation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppInstallation_appId_App_id_fk": {
+          "name": "AppInstallation_appId_App_id_fk",
+          "tableFrom": "AppInstallation",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppInstallation_organizationId_Organization_id_fk": {
+          "name": "AppInstallation_organizationId_Organization_id_fk",
+          "tableFrom": "AppInstallation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppInstallation_currentDeploymentId_AppDeployment_id_fk": {
+          "name": "AppInstallation_currentDeploymentId_AppDeployment_id_fk",
+          "tableFrom": "AppInstallation",
+          "tableTo": "AppDeployment",
+          "columnsFrom": ["currentDeploymentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppMarketplaceImage": {
+      "name": "AppMarketplaceImage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileExtension": {
+          "name": "fileExtension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "savedSortOrder": {
+          "name": "savedSortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploadCompletedAt": {
+          "name": "uploadCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSavedAt": {
+          "name": "lastSavedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppMarketplaceImage_appId_idx": {
+          "name": "AppMarketplaceImage_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppMarketplaceImage_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "AppMarketplaceImage_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "AppMarketplaceImage",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppMarketplaceImage_appId_App_id_fk": {
+          "name": "AppMarketplaceImage_appId_App_id_fk",
+          "tableFrom": "AppMarketplaceImage",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppSetting": {
+      "name": "AppSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appDeploymentId": {
+          "name": "appDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppSetting_appInstallationId_key_key": {
+          "name": "AppSetting_appInstallationId_key_key",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppSetting_appInstallationId_idx": {
+          "name": "AppSetting_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppSetting_appDeploymentId_idx": {
+          "name": "AppSetting_appDeploymentId_idx",
+          "columns": [
+            {
+              "expression": "appDeploymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppSetting_appInstallationId_AppInstallation_id_fk": {
+          "name": "AppSetting_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "AppSetting",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppSetting_appDeploymentId_AppDeployment_id_fk": {
+          "name": "AppSetting_appDeploymentId_AppDeployment_id_fk",
+          "tableFrom": "AppSetting",
+          "tableTo": "AppDeployment",
+          "columnsFrom": ["appDeploymentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppWebhookHandler": {
+      "name": "AppWebhookHandler",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handlerId": {
+          "name": "handlerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalWebhookId": {
+          "name": "externalWebhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerId": {
+          "name": "triggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppWebhookHandler_unique_idx": {
+          "name": "AppWebhookHandler_unique_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handlerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppWebhookHandler_appInstallationId_idx": {
+          "name": "AppWebhookHandler_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppWebhookHandler_appInstallationId_AppInstallation_id_fk": {
+          "name": "AppWebhookHandler_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "AppWebhookHandler",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "AppWebhookHandler_connectionId_WorkflowCredentials_id_fk": {
+          "name": "AppWebhookHandler_connectionId_WorkflowCredentials_id_fk",
+          "tableFrom": "AppWebhookHandler",
+          "tableTo": "WorkflowCredentials",
+          "columnsFrom": ["connectionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.App": {
+      "name": "App",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarId": {
+          "name": "avatarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "websiteUrl": {
+          "name": "websiteUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentationUrl": {
+          "name": "documentationUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contactUrl": {
+          "name": "contactUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supportSiteUrl": {
+          "name": "supportSiteUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termsOfServiceUrl": {
+          "name": "termsOfServiceUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentOverview": {
+          "name": "contentOverview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentHowItWorks": {
+          "name": "contentHowItWorks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentConfigure": {
+          "name": "contentConfigure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "hasOauth": {
+          "name": "hasOauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "oauthApplicationId": {
+          "name": "oauthApplicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauthExternalEntrypointUrl": {
+          "name": "oauthExternalEntrypointUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasBundle": {
+          "name": "hasBundle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "publicationStatus": {
+          "name": "publicationStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpublished'"
+        },
+        "reviewStatus": {
+          "name": "reviewStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autoApprove": {
+          "name": "autoApprove",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "App_slug_idx": {
+          "name": "App_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "App_developerAccountId_idx": {
+          "name": "App_developerAccountId_idx",
+          "columns": [
+            {
+              "expression": "developerAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "App_reviewStatus_idx": {
+          "name": "App_reviewStatus_idx",
+          "columns": [
+            {
+              "expression": "reviewStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "App_autoApprove_idx": {
+          "name": "App_autoApprove_idx",
+          "columns": [
+            {
+              "expression": "autoApprove",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "App_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "App_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "App",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "App_oauthApplicationId_oauthApplication_id_fk": {
+          "name": "App_oauthApplicationId_oauthApplication_id_fk",
+          "tableFrom": "App",
+          "tableTo": "oauthApplication",
+          "columnsFrom": ["oauthApplicationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "App_slug_unique": {
+          "name": "App_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApprovalRequest": {
+      "name": "ApprovalRequest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowRunId": {
+          "name": "workflowRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeName": {
+          "name": "nodeName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ApprovalStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeUsers": {
+          "name": "assigneeUsers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeGroups": {
+          "name": "assigneeGroups",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflowName": {
+          "name": "workflowName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ApprovalRequest_createdById_idx": {
+          "name": "ApprovalRequest_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_organizationId_assigneeGroups_idx": {
+          "name": "ApprovalRequest_organizationId_assigneeGroups_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigneeGroups",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_organizationId_assigneeUsers_idx": {
+          "name": "ApprovalRequest_organizationId_assigneeUsers_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigneeUsers",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_organizationId_idx": {
+          "name": "ApprovalRequest_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_status_expiresAt_idx": {
+          "name": "ApprovalRequest_status_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_workflowRunId_idx": {
+          "name": "ApprovalRequest_workflowRunId_idx",
+          "columns": [
+            {
+              "expression": "workflowRunId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApprovalRequest_organizationId_Organization_id_fk": {
+          "name": "ApprovalRequest_organizationId_Organization_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ApprovalRequest_workflowId_Workflow_id_fk": {
+          "name": "ApprovalRequest_workflowId_Workflow_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ApprovalRequest_workflowRunId_WorkflowRun_id_fk": {
+          "name": "ApprovalRequest_workflowRunId_WorkflowRun_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "WorkflowRun",
+          "columnsFrom": ["workflowRunId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ApprovalRequest_createdById_User_id_fk": {
+          "name": "ApprovalRequest_createdById_User_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApprovalResponse": {
+      "name": "ApprovalResponse",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "approvalRequestId": {
+          "name": "approvalRequestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "ApprovalAction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responseMethod": {
+          "name": "responseMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ApprovalResponse_approvalRequestId_userId_key": {
+          "name": "ApprovalResponse_approvalRequestId_userId_key",
+          "columns": [
+            {
+              "expression": "approvalRequestId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalResponse_userId_idx": {
+          "name": "ApprovalResponse_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApprovalResponse_approvalRequestId_ApprovalRequest_id_fk": {
+          "name": "ApprovalResponse_approvalRequestId_ApprovalRequest_id_fk",
+          "tableFrom": "ApprovalResponse",
+          "tableTo": "ApprovalRequest",
+          "columnsFrom": ["approvalRequestId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ApprovalResponse_userId_User_id_fk": {
+          "name": "ApprovalResponse_userId_User_id_fk",
+          "tableFrom": "ApprovalResponse",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ArticleRevision": {
+      "name": "ArticleRevision",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentJson": {
+          "name": "contentJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editorId": {
+          "name": "editorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ArticleRevision_articleId_idx": {
+          "name": "ArticleRevision_articleId_idx",
+          "columns": [
+            {
+              "expression": "articleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ArticleRevision_articleId_versionNumber_key": {
+          "name": "ArticleRevision_articleId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "articleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"versionNumber\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ArticleRevision_articleId_Article_id_fk": {
+          "name": "ArticleRevision_articleId_Article_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "Article",
+          "columnsFrom": ["articleId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ArticleRevision_organizationId_Organization_id_fk": {
+          "name": "ArticleRevision_organizationId_Organization_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ArticleRevision_editorId_User_id_fk": {
+          "name": "ArticleRevision_editorId_User_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "User",
+          "columnsFrom": ["editorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Article": {
+      "name": "Article",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isCategory": {
+          "name": "isCategory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ArticleStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastReviewedAt": {
+          "name": "lastReviewedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewsCount": {
+          "name": "viewsCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "knowledgeBaseId": {
+          "name": "knowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isPublished": {
+          "name": "isPublished",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isHomePage": {
+          "name": "isHomePage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishedRevisionId": {
+          "name": "publishedRevisionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draftRevisionId": {
+          "name": "draftRevisionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishedById": {
+          "name": "publishedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasUnpublishedChanges": {
+          "name": "hasUnpublishedChanges",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Article_isCategory_idx": {
+          "name": "Article_isCategory_idx",
+          "columns": [
+            {
+              "expression": "isCategory",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_knowledgeBaseId_idx": {
+          "name": "Article_knowledgeBaseId_idx",
+          "columns": [
+            {
+              "expression": "knowledgeBaseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_knowledgeBaseId_slug_key": {
+          "name": "Article_knowledgeBaseId_slug_key",
+          "columns": [
+            {
+              "expression": "knowledgeBaseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_parentId_idx": {
+          "name": "Article_parentId_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Article_authorId_User_id_fk": {
+          "name": "Article_authorId_User_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "User",
+          "columnsFrom": ["authorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Article_knowledgeBaseId_KnowledgeBase_id_fk": {
+          "name": "Article_knowledgeBaseId_KnowledgeBase_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "KnowledgeBase",
+          "columnsFrom": ["knowledgeBaseId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Article_organizationId_Organization_id_fk": {
+          "name": "Article_organizationId_Organization_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Article_parentId_Article_id_fk": {
+          "name": "Article_parentId_Article_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "Article",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Article_publishedRevisionId_ArticleRevision_id_fk": {
+          "name": "Article_publishedRevisionId_ArticleRevision_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "ArticleRevision",
+          "columnsFrom": ["publishedRevisionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Article_draftRevisionId_ArticleRevision_id_fk": {
+          "name": "Article_draftRevisionId_ArticleRevision_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "ArticleRevision",
+          "columnsFrom": ["draftRevisionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Article_publishedById_User_id_fk": {
+          "name": "Article_publishedById_User_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "User",
+          "columnsFrom": ["publishedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Attachment": {
+      "name": "Attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ATTACHMENT'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort": {
+          "name": "sort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileVersionId": {
+          "name": "fileVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assetVersionId": {
+          "name": "assetVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentId": {
+          "name": "contentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Attachment_assetId_idx": {
+          "name": "Attachment_assetId_idx",
+          "columns": [
+            {
+              "expression": "assetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_createdAt_idx": {
+          "name": "Attachment_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_entityType_entityId_idx": {
+          "name": "Attachment_entityType_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_fileId_idx": {
+          "name": "Attachment_fileId_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_id_organizationId_key": {
+          "name": "Attachment_id_organizationId_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_organizationId_entityType_entityId_idx": {
+          "name": "Attachment_organizationId_entityType_entityId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Attachment_organizationId_Organization_id_fk": {
+          "name": "Attachment_organizationId_Organization_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Attachment_fileId_FolderFile_id_fk": {
+          "name": "Attachment_fileId_FolderFile_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "FolderFile",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Attachment_fileVersionId_FileVersion_id_fk": {
+          "name": "Attachment_fileVersionId_FileVersion_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "FileVersion",
+          "columnsFrom": ["fileVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Attachment_assetId_MediaAsset_id_fk": {
+          "name": "Attachment_assetId_MediaAsset_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["assetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Attachment_assetVersionId_MediaAssetVersion_id_fk": {
+          "name": "Attachment_assetVersionId_MediaAssetVersion_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "MediaAssetVersion",
+          "columnsFrom": ["assetVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Attachment_createdById_User_id_fk": {
+          "name": "Attachment_createdById_User_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CalendarEvent": {
+      "name": "CalendarEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "CalendarProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetingUrl": {
+          "name": "meetingUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetingPlatform": {
+          "name": "meetingPlatform",
+          "type": "MeetingPlatform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAllDay": {
+          "name": "isAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "CalendarEventStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirmed'"
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendees": {
+          "name": "attendees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "isExternal": {
+          "name": "isExternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recurringEventId": {
+          "name": "recurringEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rawData": {
+          "name": "rawData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncedAt": {
+          "name": "syncedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "CalendarEvent_org_provider_externalId_key": {
+          "name": "CalendarEvent_org_provider_externalId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CalendarEvent_organizationId_idx": {
+          "name": "CalendarEvent_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CalendarEvent_userId_idx": {
+          "name": "CalendarEvent_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CalendarEvent_startTime_endTime_idx": {
+          "name": "CalendarEvent_startTime_endTime_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CalendarEvent_entityInstanceId_idx": {
+          "name": "CalendarEvent_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CalendarEvent_organizationId_Organization_id_fk": {
+          "name": "CalendarEvent_organizationId_Organization_id_fk",
+          "tableFrom": "CalendarEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CalendarEvent_userId_User_id_fk": {
+          "name": "CalendarEvent_userId_User_id_fk",
+          "tableFrom": "CalendarEvent",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CalendarEvent_entityInstanceId_EntityInstance_id_fk": {
+          "name": "CalendarEvent_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "CalendarEvent",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CallRecording": {
+      "name": "CallRecording",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetingId": {
+          "name": "meetingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "RecordingProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetingPlatform": {
+          "name": "meetingPlatform",
+          "type": "MeetingPlatform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalBotId": {
+          "name": "externalBotId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "RecordingStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "videoAssetId": {
+          "name": "videoAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audioAssetId": {
+          "name": "audioAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videoPreviewAssetId": {
+          "name": "videoPreviewAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videoStoryboardAssetId": {
+          "name": "videoStoryboardAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationSeconds": {
+          "name": "durationSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "botName": {
+          "name": "botName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentMessage": {
+          "name": "consentMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summaryText": {
+          "name": "summaryText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actionItems": {
+          "name": "actionItems",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProcessingStatus": {
+          "name": "aiProcessingStatus",
+          "type": "AiProcessingStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "aiProcessingError": {
+          "name": "aiProcessingError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProcessedAt": {
+          "name": "aiProcessedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "CallRecording_organizationId_idx": {
+          "name": "CallRecording_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_meetingId_idx": {
+          "name": "CallRecording_meetingId_idx",
+          "columns": [
+            {
+              "expression": "meetingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_calendarEventId_idx": {
+          "name": "CallRecording_calendarEventId_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_status_idx": {
+          "name": "CallRecording_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_organizationId_status_idx": {
+          "name": "CallRecording_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_externalBotId_idx": {
+          "name": "CallRecording_externalBotId_idx",
+          "columns": [
+            {
+              "expression": "externalBotId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_createdById_idx": {
+          "name": "CallRecording_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_organizationId_calendarEventId_key": {
+          "name": "CallRecording_organizationId_calendarEventId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendarEventId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CallRecording_organizationId_Organization_id_fk": {
+          "name": "CallRecording_organizationId_Organization_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_meetingId_EntityInstance_id_fk": {
+          "name": "CallRecording_meetingId_EntityInstance_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["meetingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_calendarEventId_CalendarEvent_id_fk": {
+          "name": "CallRecording_calendarEventId_CalendarEvent_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "CalendarEvent",
+          "columnsFrom": ["calendarEventId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_videoAssetId_MediaAsset_id_fk": {
+          "name": "CallRecording_videoAssetId_MediaAsset_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["videoAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_audioAssetId_MediaAsset_id_fk": {
+          "name": "CallRecording_audioAssetId_MediaAsset_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["audioAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_videoPreviewAssetId_MediaAsset_id_fk": {
+          "name": "CallRecording_videoPreviewAssetId_MediaAsset_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["videoPreviewAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_videoStoryboardAssetId_MediaAsset_id_fk": {
+          "name": "CallRecording_videoStoryboardAssetId_MediaAsset_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["videoStoryboardAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_createdById_User_id_fk": {
+          "name": "CallRecording_createdById_User_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatAttachment": {
+      "name": "ChatAttachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ChatAttachment_messageId_idx": {
+          "name": "ChatAttachment_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatAttachment_sessionId_idx": {
+          "name": "ChatAttachment_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatAttachment_sessionId_ChatSession_id_fk": {
+          "name": "ChatAttachment_sessionId_ChatSession_id_fk",
+          "tableFrom": "ChatAttachment",
+          "tableTo": "ChatSession",
+          "columnsFrom": ["sessionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatAttachment_messageId_ChatMessage_id_fk": {
+          "name": "ChatAttachment_messageId_ChatMessage_id_fk",
+          "tableFrom": "ChatAttachment",
+          "tableTo": "ChatMessage",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatMessage": {
+      "name": "ChatMessage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SENT'"
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ChatMessage_agentId_idx": {
+          "name": "ChatMessage_agentId_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatMessage_createdAt_idx": {
+          "name": "ChatMessage_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatMessage_sessionId_idx": {
+          "name": "ChatMessage_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatMessage_threadId_idx": {
+          "name": "ChatMessage_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatMessage_sessionId_ChatSession_id_fk": {
+          "name": "ChatMessage_sessionId_ChatSession_id_fk",
+          "tableFrom": "ChatMessage",
+          "tableTo": "ChatSession",
+          "columnsFrom": ["sessionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatMessage_agentId_User_id_fk": {
+          "name": "ChatMessage_agentId_User_id_fk",
+          "tableFrom": "ChatMessage",
+          "tableTo": "User",
+          "columnsFrom": ["agentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ChatMessage_threadId_Thread_id_fk": {
+          "name": "ChatMessage_threadId_Thread_id_fk",
+          "tableFrom": "ChatMessage",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatSession": {
+      "name": "ChatSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "widgetId": {
+          "name": "widgetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "lastActivityAt": {
+          "name": "lastActivityAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closedById": {
+          "name": "closedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorId": {
+          "name": "visitorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitorName": {
+          "name": "visitorName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorEmail": {
+          "name": "visitorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ChatSession_lastActivityAt_idx": {
+          "name": "ChatSession_lastActivityAt_idx",
+          "columns": [
+            {
+              "expression": "lastActivityAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatSession_organizationId_idx": {
+          "name": "ChatSession_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatSession_status_idx": {
+          "name": "ChatSession_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatSession_visitorId_idx": {
+          "name": "ChatSession_visitorId_idx",
+          "columns": [
+            {
+              "expression": "visitorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatSession_widgetId_idx": {
+          "name": "ChatSession_widgetId_idx",
+          "columns": [
+            {
+              "expression": "widgetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatSession_widgetId_ChatWidget_id_fk": {
+          "name": "ChatSession_widgetId_ChatWidget_id_fk",
+          "tableFrom": "ChatSession",
+          "tableTo": "ChatWidget",
+          "columnsFrom": ["widgetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatSession_organizationId_Organization_id_fk": {
+          "name": "ChatSession_organizationId_Organization_id_fk",
+          "tableFrom": "ChatSession",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatSession_threadId_Thread_id_fk": {
+          "name": "ChatSession_threadId_Thread_id_fk",
+          "tableFrom": "ChatSession",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatSession_closedById_User_id_fk": {
+          "name": "ChatSession_closedById_User_id_fk",
+          "tableFrom": "ChatSession",
+          "tableTo": "User",
+          "columnsFrom": ["closedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatWidget": {
+      "name": "ChatWidget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Chat Support'"
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryColor": {
+          "name": "primaryColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#4F46E5'"
+        },
+        "logoUrl": {
+          "name": "logoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BOTTOM_RIGHT'"
+        },
+        "welcomeMessage": {
+          "name": "welcomeMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autoOpen": {
+          "name": "autoOpen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mobileFullScreen": {
+          "name": "mobileFullScreen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collectUserInfo": {
+          "name": "collectUserInfo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "offlineMessage": {
+          "name": "offlineMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'We''re currently offline. Please leave a message and we''ll get back to you as soon as possible.'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowedDomains": {
+          "name": "allowedDomains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "useAi": {
+          "name": "useAi",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiInstructions": {
+          "name": "aiInstructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ChatWidget_integrationId_key": {
+          "name": "ChatWidget_integrationId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatWidget_organizationId_idx": {
+          "name": "ChatWidget_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatWidget_organizationId_name_key": {
+          "name": "ChatWidget_organizationId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatWidget_integrationId_Integration_id_fk": {
+          "name": "ChatWidget_integrationId_Integration_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatWidget_organizationId_Organization_id_fk": {
+          "name": "ChatWidget_organizationId_Organization_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CommentMention": {
+      "name": "CommentMention",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "CommentMention_commentId_idx": {
+          "name": "CommentMention_commentId_idx",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentMention_commentId_userId_key": {
+          "name": "CommentMention_commentId_userId_key",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentMention_userId_idx": {
+          "name": "CommentMention_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CommentMention_commentId_Comment_id_fk": {
+          "name": "CommentMention_commentId_Comment_id_fk",
+          "tableFrom": "CommentMention",
+          "tableTo": "Comment",
+          "columnsFrom": ["commentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CommentMention_userId_User_id_fk": {
+          "name": "CommentMention_userId_User_id_fk",
+          "tableFrom": "CommentMention",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CommentReaction": {
+      "name": "CommentReaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "CommentReaction_commentId_idx": {
+          "name": "CommentReaction_commentId_idx",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReaction_commentId_userId_type_emoji_key": {
+          "name": "CommentReaction_commentId_userId_type_emoji_key",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReaction_type_idx": {
+          "name": "CommentReaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReaction_userId_idx": {
+          "name": "CommentReaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CommentReaction_commentId_Comment_id_fk": {
+          "name": "CommentReaction_commentId_Comment_id_fk",
+          "tableFrom": "CommentReaction",
+          "tableTo": "Comment",
+          "columnsFrom": ["commentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CommentReaction_userId_User_id_fk": {
+          "name": "CommentReaction_userId_User_id_fk",
+          "tableFrom": "CommentReaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Comment": {
+      "name": "Comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinnedAt": {
+          "name": "pinnedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinnedById": {
+          "name": "pinnedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Comment_createdById_idx": {
+          "name": "Comment_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_deletedAt_idx": {
+          "name": "Comment_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_entityId_entityDefinitionId_idx": {
+          "name": "Comment_entityId_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_isPinned_idx": {
+          "name": "Comment_isPinned_idx",
+          "columns": [
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_organizationId_idx": {
+          "name": "Comment_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_parentId_idx": {
+          "name": "Comment_parentId_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Comment_createdById_User_id_fk": {
+          "name": "Comment_createdById_User_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Comment_organizationId_Organization_id_fk": {
+          "name": "Comment_organizationId_Organization_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Comment_parentId_Comment_id_fk": {
+          "name": "Comment_parentId_Comment_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "Comment",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Comment_pinnedById_User_id_fk": {
+          "name": "Comment_pinnedById_User_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "User",
+          "columnsFrom": ["pinnedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ConnectionDefinition": {
+      "name": "ConnectionDefinition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major": {
+          "name": "major",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionType": {
+          "name": "connectionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global": {
+          "name": "global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "oauth2AuthorizeUrl": {
+          "name": "oauth2AuthorizeUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2AccessTokenUrl": {
+          "name": "oauth2AccessTokenUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2Scopes": {
+          "name": "oauth2Scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "oauth2ClientId": {
+          "name": "oauth2ClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2ClientSecret": {
+          "name": "oauth2ClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2TokenRequestAuthMethod": {
+          "name": "oauth2TokenRequestAuthMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'request-body'"
+        },
+        "oauth2RefreshTokenIntervalSeconds": {
+          "name": "oauth2RefreshTokenIntervalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2Features": {
+          "name": "oauth2Features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ConnectionDefinition_app_version_idx": {
+          "name": "ConnectionDefinition_app_version_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "major",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ConnectionDefinition_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "ConnectionDefinition_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "ConnectionDefinition",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ConnectionDefinition_appId_App_id_fk": {
+          "name": "ConnectionDefinition_appId_App_id_fk",
+          "tableFrom": "ConnectionDefinition",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CustomField": {
+      "name": "CustomField",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "ContactFieldType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a0'"
+        },
+        "displayOptions": {
+          "name": "displayOptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "defaultValue": {
+          "name": "defaultValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contact'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isCustom": {
+          "name": "isCustom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "systemAttribute": {
+          "name": "systemAttribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isUnique": {
+          "name": "isUnique",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isCreatable": {
+          "name": "isCreatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isUpdatable": {
+          "name": "isUpdatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isComputed": {
+          "name": "isComputed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isSortable": {
+          "name": "isSortable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isFilterable": {
+          "name": "isFilterable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "CustomField_modelType_idx": {
+          "name": "CustomField_modelType_idx",
+          "columns": [
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_name_org_model_entity_key": {
+          "name": "CustomField_name_org_model_entity_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_organizationId_idx": {
+          "name": "CustomField_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_entityDefinitionId_idx": {
+          "name": "CustomField_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_organizationId_entityDefinitionId_sortOrder_idx": {
+          "name": "CustomField_organizationId_entityDefinitionId_sortOrder_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortOrder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CustomField_organizationId_Organization_id_fk": {
+          "name": "CustomField_organizationId_Organization_id_fk",
+          "tableFrom": "CustomField",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CustomField_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "CustomField_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "CustomField",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DatasetMetadata": {
+      "name": "DatasetMetadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "DatasetMetadata_datasetId_idx": {
+          "name": "DatasetMetadata_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetMetadata_datasetId_name_key": {
+          "name": "DatasetMetadata_datasetId_name_key",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetMetadata_type_idx": {
+          "name": "DatasetMetadata_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DatasetMetadata_datasetId_Dataset_id_fk": {
+          "name": "DatasetMetadata_datasetId_Dataset_id_fk",
+          "tableFrom": "DatasetMetadata",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DatasetSearchQuery": {
+      "name": "DatasetSearchQuery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queryType": {
+          "name": "queryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hybrid'"
+        },
+        "resultsCount": {
+          "name": "resultsCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vectorSimilarityThreshold": {
+          "name": "vectorSimilarityThreshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.7
+        },
+        "maxResults": {
+          "name": "maxResults",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "DatasetSearchQuery_createdAt_idx": {
+          "name": "DatasetSearchQuery_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchQuery_datasetId_idx": {
+          "name": "DatasetSearchQuery_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchQuery_organizationId_idx": {
+          "name": "DatasetSearchQuery_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchQuery_userId_idx": {
+          "name": "DatasetSearchQuery_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DatasetSearchQuery_datasetId_Dataset_id_fk": {
+          "name": "DatasetSearchQuery_datasetId_Dataset_id_fk",
+          "tableFrom": "DatasetSearchQuery",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DatasetSearchQuery_organizationId_Organization_id_fk": {
+          "name": "DatasetSearchQuery_organizationId_Organization_id_fk",
+          "tableFrom": "DatasetSearchQuery",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DatasetSearchQuery_userId_User_id_fk": {
+          "name": "DatasetSearchQuery_userId_User_id_fk",
+          "tableFrom": "DatasetSearchQuery",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DatasetSearchResult": {
+      "name": "DatasetSearchResult",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queryId": {
+          "name": "queryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segmentId": {
+          "name": "segmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "DatasetSearchResult_queryId_idx": {
+          "name": "DatasetSearchResult_queryId_idx",
+          "columns": [
+            {
+              "expression": "queryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_queryId_segmentId_key": {
+          "name": "DatasetSearchResult_queryId_segmentId_key",
+          "columns": [
+            {
+              "expression": "queryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_rank_idx": {
+          "name": "DatasetSearchResult_rank_idx",
+          "columns": [
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_score_idx": {
+          "name": "DatasetSearchResult_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_segmentId_idx": {
+          "name": "DatasetSearchResult_segmentId_idx",
+          "columns": [
+            {
+              "expression": "segmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DatasetSearchResult_queryId_DatasetSearchQuery_id_fk": {
+          "name": "DatasetSearchResult_queryId_DatasetSearchQuery_id_fk",
+          "tableFrom": "DatasetSearchResult",
+          "tableTo": "DatasetSearchQuery",
+          "columnsFrom": ["queryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DatasetSearchResult_segmentId_DocumentSegment_id_fk": {
+          "name": "DatasetSearchResult_segmentId_DocumentSegment_id_fk",
+          "tableFrom": "DatasetSearchResult",
+          "tableTo": "DocumentSegment",
+          "columnsFrom": ["segmentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Dataset": {
+      "name": "Dataset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "DatasetStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "documentCount": {
+          "name": "documentCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalSize": {
+          "name": "totalSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastIndexedAt": {
+          "name": "lastIndexedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunkSettings": {
+          "name": "chunkSettings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"strategy\":\"FIXED_SIZE\",\"size\":1024,\"overlap\":50,\"delimiter\":\"\\n\\n\",\"preprocessing\":{\"normalizeWhitespace\":true,\"removeUrlsAndEmails\":false}}'::jsonb"
+        },
+        "vectorDbConfig": {
+          "name": "vectorDbConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingModel": {
+          "name": "embeddingModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vectorDimension": {
+          "name": "vectorDimension",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vectorDbType": {
+          "name": "vectorDbType",
+          "type": "VectorDbType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POSTGRESQL'"
+        },
+        "searchConfig": {
+          "name": "searchConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"searchType\":\"hybrid\"}'::jsonb"
+        }
+      },
+      "indexes": {
+        "Dataset_createdById_idx": {
+          "name": "Dataset_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Dataset_organizationId_idx": {
+          "name": "Dataset_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Dataset_organizationId_name_key": {
+          "name": "Dataset_organizationId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Dataset_status_idx": {
+          "name": "Dataset_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dataset_org_status": {
+          "name": "idx_dataset_org_status",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Dataset_organizationId_Organization_id_fk": {
+          "name": "Dataset_organizationId_Organization_id_fk",
+          "tableFrom": "Dataset",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Dataset_createdById_User_id_fk": {
+          "name": "Dataset_createdById_User_id_fk",
+          "tableFrom": "Dataset",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeveloperAccountInvite": {
+      "name": "DeveloperAccountInvite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailAddress": {
+          "name": "emailAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessLevel": {
+          "name": "accessLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "failedToSend": {
+          "name": "failedToSend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeveloperAccountInvite_account_idx": {
+          "name": "DeveloperAccountInvite_account_idx",
+          "columns": [
+            {
+              "expression": "developerAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeveloperAccountInvite_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "DeveloperAccountInvite_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "DeveloperAccountInvite",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeveloperAccountMember": {
+      "name": "DeveloperAccountMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailAddress": {
+          "name": "emailAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessLevel": {
+          "name": "accessLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeveloperAccountMember_unique_idx": {
+          "name": "DeveloperAccountMember_unique_idx",
+          "columns": [
+            {
+              "expression": "developerAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DeveloperAccountMember_userId_idx": {
+          "name": "DeveloperAccountMember_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeveloperAccountMember_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "DeveloperAccountMember_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "DeveloperAccountMember",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DeveloperAccountMember_userId_User_id_fk": {
+          "name": "DeveloperAccountMember_userId_User_id_fk",
+          "tableFrom": "DeveloperAccountMember",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeveloperAccount": {
+      "name": "DeveloperAccount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logoId": {
+          "name": "logoId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoUrl": {
+          "name": "logoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featureFlags": {
+          "name": "featureFlags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"legacy-collection-scopes\":false,\"search-records-api\":false,\"find-create-meetings-api\":false,\"get-list-meetings-api\":true,\"write-call-recordings-api\":false,\"read-call-recordings-api\":true}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeveloperAccount_slug_idx": {
+          "name": "DeveloperAccount_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "DeveloperAccount_slug_unique": {
+          "name": "DeveloperAccount_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DocumentSegment": {
+      "name": "DocumentSegment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startOffset": {
+          "name": "startOffset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endOffset": {
+          "name": "endOffset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenCount": {
+          "name": "tokenCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_512": {
+          "name": "embedding_512",
+          "type": "vector(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_768": {
+          "name": "embedding_768",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_1024": {
+          "name": "embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_1536": {
+          "name": "embedding_1536",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_3072": {
+          "name": "embedding_3072",
+          "type": "vector(3072)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingModel": {
+          "name": "embeddingModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingDimension": {
+          "name": "embeddingDimension",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "indexStatus": {
+          "name": "indexStatus",
+          "type": "IndexStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "searchMetadata": {
+          "name": "searchMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchVector": {
+          "name": "searchVector",
+          "type": "tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "DocumentSegment_documentId_idx": {
+          "name": "DocumentSegment_documentId_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DocumentSegment_organizationId_idx": {
+          "name": "DocumentSegment_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DocumentSegment_position_idx": {
+          "name": "DocumentSegment_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_embedding_512_hnsw": {
+          "name": "idx_embedding_512_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_512",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_512 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_embedding_768_hnsw": {
+          "name": "idx_embedding_768_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_768",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_768 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_embedding_1024_hnsw": {
+          "name": "idx_embedding_1024_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_1024",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_1024 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_embedding_1536_hnsw": {
+          "name": "idx_embedding_1536_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_1536",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_1536 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_document_segment_search_vector": {
+          "name": "idx_document_segment_search_vector",
+          "columns": [
+            {
+              "expression": "searchVector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_document_segment_dataset_filter": {
+          "name": "idx_document_segment_dataset_filter",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((enabled = true) AND (\"indexStatus\" = 'INDEXED'::\"IndexStatus\"))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DocumentSegment_documentId_Document_id_fk": {
+          "name": "DocumentSegment_documentId_Document_id_fk",
+          "tableFrom": "DocumentSegment",
+          "tableTo": "Document",
+          "columnsFrom": ["documentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DocumentSegment_organizationId_Organization_id_fk": {
+          "name": "DocumentSegment_organizationId_Organization_id_fk",
+          "tableFrom": "DocumentSegment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalPath": {
+          "name": "originalPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "DocumentType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "DocumentStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UPLOADED'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingTime": {
+          "name": "processingTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalChunks": {
+          "name": "totalChunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploadedById": {
+          "name": "uploadedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunkSettings": {
+          "name": "chunkSettings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mediaAssetId": {
+          "name": "mediaAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Document_checksum_idx": {
+          "name": "Document_checksum_idx",
+          "columns": [
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_datasetId_checksum_key": {
+          "name": "Document_datasetId_checksum_key",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_datasetId_idx": {
+          "name": "Document_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_enabled_idx": {
+          "name": "Document_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_mediaAssetId_idx": {
+          "name": "Document_mediaAssetId_idx",
+          "columns": [
+            {
+              "expression": "mediaAssetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_organizationId_idx": {
+          "name": "Document_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_status_idx": {
+          "name": "Document_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_type_idx": {
+          "name": "Document_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_uploadedById_idx": {
+          "name": "Document_uploadedById_idx",
+          "columns": [
+            {
+              "expression": "uploadedById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_document_dataset_enabled": {
+          "name": "idx_document_dataset_enabled",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Document_datasetId_Dataset_id_fk": {
+          "name": "Document_datasetId_Dataset_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Document_organizationId_Organization_id_fk": {
+          "name": "Document_organizationId_Organization_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Document_uploadedById_User_id_fk": {
+          "name": "Document_uploadedById_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["uploadedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Document_mediaAssetId_MediaAsset_id_fk": {
+          "name": "Document_mediaAssetId_MediaAsset_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["mediaAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Draft": {
+      "name": "Draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inReplyToMessageId": {
+          "name": "inReplyToMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerThreadId": {
+          "name": "providerThreadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Draft_organizationId_idx": {
+          "name": "Draft_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_createdById_idx": {
+          "name": "Draft_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_threadId_idx": {
+          "name": "Draft_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_integrationId_idx": {
+          "name": "Draft_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_threadId_createdById_key": {
+          "name": "Draft_threadId_createdById_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"threadId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_organizationId_providerId_key": {
+          "name": "Draft_organizationId_providerId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"providerId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_organizationId_createdById_idx": {
+          "name": "Draft_organizationId_createdById_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Draft_organizationId_Organization_id_fk": {
+          "name": "Draft_organizationId_Organization_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Draft_createdById_User_id_fk": {
+          "name": "Draft_createdById_User_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Draft_threadId_Thread_id_fk": {
+          "name": "Draft_threadId_Thread_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Draft_inReplyToMessageId_Message_id_fk": {
+          "name": "Draft_inReplyToMessageId_Message_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Message",
+          "columnsFrom": ["inReplyToMessageId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Draft_integrationId_Integration_id_fk": {
+          "name": "Draft_integrationId_Integration_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailAddress": {
+      "name": "EmailAddress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationType": {
+          "name": "integrationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "EmailAddress_integrationId_address_key": {
+          "name": "EmailAddress_integrationId_address_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailEmbedding": {
+      "name": "EmailEmbedding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text-embedding-3-small'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EmailEmbedding_messageId_idx": {
+          "name": "EmailEmbedding_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EmailEmbedding_messageId_Message_id_fk": {
+          "name": "EmailEmbedding_messageId_Message_id_fk",
+          "tableFrom": "EmailEmbedding",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailTemplate": {
+      "name": "EmailTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "EmailTemplateType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bodyHtml": {
+          "name": "bodyHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bodyPlain": {
+          "name": "bodyPlain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "EmailTemplate_organizationId_type_idx": {
+          "name": "EmailTemplate_organizationId_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EmailTemplate_organizationId_type_isDefault_key": {
+          "name": "EmailTemplate_organizationId_type_isDefault_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isDefault",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EmailTemplate_organizationId_Organization_id_fk": {
+          "name": "EmailTemplate_organizationId_Organization_id_fk",
+          "tableFrom": "EmailTemplate",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.embedding_jobs": {
+      "name": "embedding_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documents": {
+          "name": "documents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunkingOptions": {
+          "name": "chunkingOptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentCount": {
+          "name": "documentCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processedCount": {
+          "name": "processedCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errorCount": {
+          "name": "errorCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "embedding_jobs_collection_idx": {
+          "name": "embedding_jobs_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_jobs_status_idx": {
+          "name": "embedding_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "embedding_jobs_organizationId_Organization_id_fk": {
+          "name": "embedding_jobs_organizationId_Organization_id_fk",
+          "tableFrom": "embedding_jobs",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.embeddings": {
+      "name": "embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "jobId": {
+          "name": "jobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "embeddings_collection_idx": {
+          "name": "embeddings_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embeddings_documentId_idx": {
+          "name": "embeddings_documentId_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embeddings_jobId_idx": {
+          "name": "embeddings_jobId_idx",
+          "columns": [
+            {
+              "expression": "jobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "embeddings_jobId_embedding_jobs_id_fk": {
+          "name": "embeddings_jobId_embedding_jobs_id_fk",
+          "tableFrom": "embeddings",
+          "tableTo": "embedding_jobs",
+          "columnsFrom": ["jobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EndUser": {
+      "name": "EndUser",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "totalRuns": {
+          "name": "totalRuns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EndUser_workflowAppId_idx": {
+          "name": "EndUser_workflowAppId_idx",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_sessionId_idx": {
+          "name": "EndUser_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_userId_idx": {
+          "name": "EndUser_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_workflowAppId_sessionId_idx": {
+          "name": "EndUser_workflowAppId_sessionId_idx",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_workflowAppId_userId_idx": {
+          "name": "EndUser_workflowAppId_userId_idx",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EndUser_workflowAppId_WorkflowApp_id_fk": {
+          "name": "EndUser_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "EndUser",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EndUser_userId_User_id_fk": {
+          "name": "EndUser_userId_User_id_fk",
+          "tableFrom": "EndUser",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EntityDefinition": {
+      "name": "EntityDefinition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiSlug": {
+          "name": "apiSlug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Box'"
+        },
+        "singular": {
+          "name": "singular",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plural": {
+          "name": "plural",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standardType": {
+          "name": "standardType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryDisplayFieldId": {
+          "name": "primaryDisplayFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondaryDisplayFieldId": {
+          "name": "secondaryDisplayFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarFieldId": {
+          "name": "avatarFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isVisible": {
+          "name": "isVisible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "EntityDefinition_apiSlug_organizationId_key": {
+          "name": "EntityDefinition_apiSlug_organizationId_key",
+          "columns": [
+            {
+              "expression": "apiSlug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"EntityDefinition\".\"archivedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_organizationId_idx": {
+          "name": "EntityDefinition_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_entityType_idx": {
+          "name": "EntityDefinition_entityType_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_archivedAt_idx": {
+          "name": "EntityDefinition_archivedAt_idx",
+          "columns": [
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EntityDefinition_organizationId_Organization_id_fk": {
+          "name": "EntityDefinition_organizationId_Organization_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_primaryDisplayFieldId_CustomField_id_fk": {
+          "name": "EntityDefinition_primaryDisplayFieldId_CustomField_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "CustomField",
+          "columnsFrom": ["primaryDisplayFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_secondaryDisplayFieldId_CustomField_id_fk": {
+          "name": "EntityDefinition_secondaryDisplayFieldId_CustomField_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "CustomField",
+          "columnsFrom": ["secondaryDisplayFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_avatarFieldId_CustomField_id_fk": {
+          "name": "EntityDefinition_avatarFieldId_CustomField_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "CustomField",
+          "columnsFrom": ["avatarFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EntityGroupMember": {
+      "name": "EntityGroupMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "groupInstanceId": {
+          "name": "groupInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memberType": {
+          "name": "memberType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memberRefId": {
+          "name": "memberRefId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedById": {
+          "name": "addedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortKey": {
+          "name": "sortKey",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a0'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EntityGroupMember_group_member_key": {
+          "name": "EntityGroupMember_group_member_key",
+          "columns": [
+            {
+              "expression": "groupInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memberType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memberRefId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityGroupMember_group_idx": {
+          "name": "EntityGroupMember_group_idx",
+          "columns": [
+            {
+              "expression": "groupInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityGroupMember_member_idx": {
+          "name": "EntityGroupMember_member_idx",
+          "columns": [
+            {
+              "expression": "memberType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memberRefId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EntityGroupMember_groupInstanceId_EntityInstance_id_fk": {
+          "name": "EntityGroupMember_groupInstanceId_EntityInstance_id_fk",
+          "tableFrom": "EntityGroupMember",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["groupInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityGroupMember_addedById_User_id_fk": {
+          "name": "EntityGroupMember_addedById_User_id_fk",
+          "tableFrom": "EntityGroupMember",
+          "tableTo": "User",
+          "columnsFrom": ["addedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EntityInstance": {
+      "name": "EntityInstance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondaryDisplayValue": {
+          "name": "secondaryDisplayValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchText": {
+          "name": "searchText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActivityAt": {
+          "name": "lastActivityAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSuggestionScanAt": {
+          "name": "lastSuggestionScanAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "EntityInstance_entityDefinitionId_idx": {
+          "name": "EntityInstance_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_organizationId_idx": {
+          "name": "EntityInstance_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_archivedAt_idx": {
+          "name": "EntityInstance_archivedAt_idx",
+          "columns": [
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_orgId_defId_idx": {
+          "name": "EntityInstance_orgId_defId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_displayName_idx": {
+          "name": "EntityInstance_displayName_idx",
+          "columns": [
+            {
+              "expression": "displayName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_organizationId_entityDefinitionId_lastActivityAt_idx": {
+          "name": "EntityInstance_organizationId_entityDefinitionId_lastActivityAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastActivityAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_org_def_scan_idx": {
+          "name": "EntityInstance_org_def_scan_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastActivityAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastSuggestionScanAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"archivedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EntityInstance_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "EntityInstance_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "EntityInstance",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityInstance_organizationId_Organization_id_fk": {
+          "name": "EntityInstance_organizationId_Organization_id_fk",
+          "tableFrom": "EntityInstance",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityInstance_createdById_User_id_fk": {
+          "name": "EntityInstance_createdById_User_id_fk",
+          "tableFrom": "EntityInstance",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Event": {
+      "name": "Event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "Event_organizationId_idx": {
+          "name": "Event_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Event_type_idx": {
+          "name": "Event_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Event_organizationId_Organization_id_fk": {
+          "name": "Event_organizationId_Organization_id_fk",
+          "tableFrom": "Event",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ExternalKnowledgeSource": {
+      "name": "ExternalKnowledgeSource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "syncEnabled": {
+          "name": "syncEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "syncInterval": {
+          "name": "syncInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextSyncAt": {
+          "name": "nextSyncAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ExternalKnowledgeSource_datasetId_idx": {
+          "name": "ExternalKnowledgeSource_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_datasetId_name_key": {
+          "name": "ExternalKnowledgeSource_datasetId_name_key",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_nextSyncAt_idx": {
+          "name": "ExternalKnowledgeSource_nextSyncAt_idx",
+          "columns": [
+            {
+              "expression": "nextSyncAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_organizationId_idx": {
+          "name": "ExternalKnowledgeSource_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_status_idx": {
+          "name": "ExternalKnowledgeSource_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ExternalKnowledgeSource_datasetId_Dataset_id_fk": {
+          "name": "ExternalKnowledgeSource_datasetId_Dataset_id_fk",
+          "tableFrom": "ExternalKnowledgeSource",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ExternalKnowledgeSource_organizationId_Organization_id_fk": {
+          "name": "ExternalKnowledgeSource_organizationId_Organization_id_fk",
+          "tableFrom": "ExternalKnowledgeSource",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ExternalKnowledgeSource_createdById_User_id_fk": {
+          "name": "ExternalKnowledgeSource_createdById_User_id_fk",
+          "tableFrom": "ExternalKnowledgeSource",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Favorite": {
+      "name": "Favorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationMemberId": {
+          "name": "organizationMemberId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeType": {
+          "name": "nodeType",
+          "type": "FavoriteNodeType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetType": {
+          "name": "targetType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetIds": {
+          "name": "targetIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentFolderId": {
+          "name": "parentFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Favorite_member_idx": {
+          "name": "Favorite_member_idx",
+          "columns": [
+            {
+              "expression": "organizationMemberId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Favorite_organizationId_idx": {
+          "name": "Favorite_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Favorite_parentFolderId_idx": {
+          "name": "Favorite_parentFolderId_idx",
+          "columns": [
+            {
+              "expression": "parentFolderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Favorite_organizationId_Organization_id_fk": {
+          "name": "Favorite_organizationId_Organization_id_fk",
+          "tableFrom": "Favorite",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Favorite_organizationMemberId_OrganizationMember_id_fk": {
+          "name": "Favorite_organizationMemberId_OrganizationMember_id_fk",
+          "tableFrom": "Favorite",
+          "tableTo": "OrganizationMember",
+          "columnsFrom": ["organizationMemberId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Favorite_userId_User_id_fk": {
+          "name": "Favorite_userId_User_id_fk",
+          "tableFrom": "Favorite",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Favorite_parentFolderId_Favorite_id_fk": {
+          "name": "Favorite_parentFolderId_Favorite_id_fk",
+          "tableFrom": "Favorite",
+          "tableTo": "Favorite",
+          "columnsFrom": ["parentFolderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FieldValue": {
+      "name": "FieldValue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fieldId": {
+          "name": "fieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valueText": {
+          "name": "valueText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueNumber": {
+          "name": "valueNumber",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueBoolean": {
+          "name": "valueBoolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueDate": {
+          "name": "valueDate",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueJson": {
+          "name": "valueJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optionId": {
+          "name": "optionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedEntityId": {
+          "name": "relatedEntityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedEntityDefinitionId": {
+          "name": "relatedEntityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortKey": {
+          "name": "sortKey",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a'"
+        },
+        "aiStatus": {
+          "name": "aiStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FieldValue_organizationId_idx": {
+          "name": "FieldValue_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityId_idx": {
+          "name": "FieldValue_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityDefinitionId_idx": {
+          "name": "FieldValue_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_fieldId_idx": {
+          "name": "FieldValue_fieldId_idx",
+          "columns": [
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityId_fieldId_idx": {
+          "name": "FieldValue_entityId_fieldId_idx",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityDefinitionId_entityId_idx": {
+          "name": "FieldValue_entityDefinitionId_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_orgId_fieldId_relatedEntityId_idx": {
+          "name": "FieldValue_orgId_fieldId_relatedEntityId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_optionId_idx": {
+          "name": "FieldValue_optionId_idx",
+          "columns": [
+            {
+              "expression": "optionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_relatedEntityId_idx": {
+          "name": "FieldValue_relatedEntityId_idx",
+          "columns": [
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_relatedEntityDefinitionId_idx": {
+          "name": "FieldValue_relatedEntityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "relatedEntityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_actorId_idx": {
+          "name": "FieldValue_actorId_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entity_field_sortKey_key": {
+          "name": "FieldValue_entity_field_sortKey_key",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_text_idx": {
+          "name": "FieldValue_lookup_text_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueText",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"valueText\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_number_idx": {
+          "name": "FieldValue_lookup_number_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"valueNumber\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_option_idx": {
+          "name": "FieldValue_lookup_option_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "optionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"optionId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_related_idx": {
+          "name": "FieldValue_lookup_related_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relatedEntityId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_actor_idx": {
+          "name": "FieldValue_lookup_actor_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"actorId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_date_idx": {
+          "name": "FieldValue_lookup_date_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"valueDate\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FieldValue_organizationId_Organization_id_fk": {
+          "name": "FieldValue_organizationId_Organization_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FieldValue_fieldId_CustomField_id_fk": {
+          "name": "FieldValue_fieldId_CustomField_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "CustomField",
+          "columnsFrom": ["fieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FieldValue_actorId_User_id_fk": {
+          "name": "FieldValue_actorId_User_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "User",
+          "columnsFrom": ["actorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FileAttachment": {
+      "name": "FileAttachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachableId": {
+          "name": "attachableId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachableType": {
+          "name": "attachableType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FileAttachment_attachableId_attachableType_idx": {
+          "name": "FileAttachment_attachableId_attachableType_idx",
+          "columns": [
+            {
+              "expression": "attachableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachableType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FileAttachment_fileId_attachableId_attachableType_key": {
+          "name": "FileAttachment_fileId_attachableId_attachableType_key",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachableType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FileAttachment_fileId_File_id_fk": {
+          "name": "FileAttachment_fileId_File_id_fk",
+          "tableFrom": "FileAttachment",
+          "tableTo": "File",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FileVersion": {
+      "name": "FileVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageLocationId": {
+          "name": "storageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "FileVersion_fileId_createdAt_idx": {
+          "name": "FileVersion_fileId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FileVersion_fileId_versionNumber_key": {
+          "name": "FileVersion_fileId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FileVersion_fileId_FolderFile_id_fk": {
+          "name": "FileVersion_fileId_FolderFile_id_fk",
+          "tableFrom": "FileVersion",
+          "tableTo": "FolderFile",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FileVersion_storageLocationId_StorageLocation_id_fk": {
+          "name": "FileVersion_storageLocationId_StorageLocation_id_fk",
+          "tableFrom": "FileVersion",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["storageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.File": {
+      "name": "File",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashedKey": {
+          "name": "hashedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedById": {
+          "name": "deletedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "knowledgeBaseId": {
+          "name": "knowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmedAt": {
+          "name": "confirmedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "downloadCount": {
+          "name": "downloadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "FileStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "FileVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        }
+      },
+      "indexes": {
+        "File_checksum_organizationId_idx": {
+          "name": "File_checksum_organizationId_idx",
+          "columns": [
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_hashedKey_key": {
+          "name": "File_hashedKey_key",
+          "columns": [
+            {
+              "expression": "hashedKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_organizationId_status_idx": {
+          "name": "File_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_status_expiresAt_idx": {
+          "name": "File_status_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_visibility_hashedKey_idx": {
+          "name": "File_visibility_hashedKey_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hashedKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "File_createdById_User_id_fk": {
+          "name": "File_createdById_User_id_fk",
+          "tableFrom": "File",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "File_organizationId_Organization_id_fk": {
+          "name": "File_organizationId_Organization_id_fk",
+          "tableFrom": "File",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "File_deletedById_User_id_fk": {
+          "name": "File_deletedById_User_id_fk",
+          "tableFrom": "File",
+          "tableTo": "User",
+          "columnsFrom": ["deletedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "File_articleId_Article_id_fk": {
+          "name": "File_articleId_Article_id_fk",
+          "tableFrom": "File",
+          "tableTo": "Article",
+          "columnsFrom": ["articleId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "File_knowledgeBaseId_KnowledgeBase_id_fk": {
+          "name": "File_knowledgeBaseId_KnowledgeBase_id_fk",
+          "tableFrom": "File",
+          "tableTo": "KnowledgeBase",
+          "columnsFrom": ["knowledgeBaseId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FolderFile": {
+      "name": "FolderFile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentVersionId": {
+          "name": "currentVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "StorageProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FolderFile_currentVersionId_key": {
+          "name": "FolderFile_currentVersionId_key",
+          "columns": [
+            {
+              "expression": "currentVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_checksum_idx": {
+          "name": "FolderFile_organizationId_checksum_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_deletedAt_isArchived_idx": {
+          "name": "FolderFile_organizationId_deletedAt_isArchived_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_ext_createdAt_idx": {
+          "name": "FolderFile_organizationId_ext_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ext",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_folderId_idx": {
+          "name": "FolderFile_organizationId_folderId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_folderId_path_idx": {
+          "name": "FolderFile_organizationId_folderId_path_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_mimeType_updatedAt_idx": {
+          "name": "FolderFile_organizationId_mimeType_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mimeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_name_idx": {
+          "name": "FolderFile_organizationId_name_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_path_idx": {
+          "name": "FolderFile_organizationId_path_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_updatedAt_idx": {
+          "name": "FolderFile_organizationId_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_path_name_idx": {
+          "name": "FolderFile_path_name_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FolderFile_organizationId_Organization_id_fk": {
+          "name": "FolderFile_organizationId_Organization_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FolderFile_folderId_Folder_id_fk": {
+          "name": "FolderFile_folderId_Folder_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "Folder",
+          "columnsFrom": ["folderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "FolderFile_currentVersionId_FileVersion_id_fk": {
+          "name": "FolderFile_currentVersionId_FileVersion_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "FileVersion",
+          "columnsFrom": ["currentVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "FolderFile_createdById_User_id_fk": {
+          "name": "FolderFile_createdById_User_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Folder": {
+      "name": "Folder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Folder_organizationId_deletedAt_isArchived_idx": {
+          "name": "Folder_organizationId_deletedAt_isArchived_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_organizationId_depth_path_idx": {
+          "name": "Folder_organizationId_depth_path_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_organizationId_parentId_idx": {
+          "name": "Folder_organizationId_parentId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_organizationId_parentId_name_key": {
+          "name": "Folder_organizationId_parentId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_parentId_name_idx": {
+          "name": "Folder_parentId_name_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Folder_organizationId_Organization_id_fk": {
+          "name": "Folder_organizationId_Organization_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Folder_parentId_Folder_id_fk": {
+          "name": "Folder_parentId_Folder_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "Folder",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Folder_createdById_User_id_fk": {
+          "name": "Folder_createdById_User_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FreeToolLead": {
+      "name": "FreeToolLead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolSlug": {
+          "name": "toolSlug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utmSource": {
+          "name": "utmSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utmMedium": {
+          "name": "utmMedium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utmCampaign": {
+          "name": "utmCampaign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FreeToolLead_toolSlug_idx": {
+          "name": "FreeToolLead_toolSlug_idx",
+          "columns": [
+            {
+              "expression": "toolSlug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FreeToolLead_email_idx": {
+          "name": "FreeToolLead_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FreeToolLead_createdAt_idx": {
+          "name": "FreeToolLead_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FulfillmentTracking": {
+      "name": "FulfillmentTracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillmentId": {
+          "name": "fulfillmentId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "FulfillmentTracking_fulfillmentId_idx": {
+          "name": "FulfillmentTracking_fulfillmentId_idx",
+          "columns": [
+            {
+              "expression": "fulfillmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FulfillmentTracking_number_idx": {
+          "name": "FulfillmentTracking_number_idx",
+          "columns": [
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FulfillmentTracking_number_key": {
+          "name": "FulfillmentTracking_number_key",
+          "columns": [
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FulfillmentTracking_orderId_idx": {
+          "name": "FulfillmentTracking_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FulfillmentTracking_orderId_Order_id_fk": {
+          "name": "FulfillmentTracking_orderId_Order_id_fk",
+          "tableFrom": "FulfillmentTracking",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FulfillmentTracking_fulfillmentId_OrderFulfillment_id_fk": {
+          "name": "FulfillmentTracking_fulfillmentId_OrderFulfillment_id_fk",
+          "tableFrom": "FulfillmentTracking",
+          "tableTo": "OrderFulfillment",
+          "columnsFrom": ["fulfillmentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJobMappableProperty": {
+      "name": "ImportJobMappableProperty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnIndex": {
+          "name": "columnIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibleName": {
+          "name": "visibleName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ImportJobMappableProperty_importJobId_idx": {
+          "name": "ImportJobMappableProperty_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobMappableProperty_jobId_columnIndex_key": {
+          "name": "ImportJobMappableProperty_jobId_columnIndex_key",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "columnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJobMappableProperty_importJobId_ImportJob_id_fk": {
+          "name": "ImportJobMappableProperty_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportJobMappableProperty",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJobProperty": {
+      "name": "ImportJobProperty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importMappingPropertyId": {
+          "name": "importMappingPropertyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uniqueValueCount": {
+          "name": "uniqueValueCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolvedCount": {
+          "name": "resolvedCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errorCount": {
+          "name": "errorCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ImportJobProperty_importJobId_idx": {
+          "name": "ImportJobProperty_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobProperty_jobId_mappingPropertyId_key": {
+          "name": "ImportJobProperty_jobId_mappingPropertyId_key",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "importMappingPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJobProperty_importJobId_ImportJob_id_fk": {
+          "name": "ImportJobProperty_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportJobProperty",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportJobProperty_importMappingPropertyId_ImportMappingProperty_id_fk": {
+          "name": "ImportJobProperty_importMappingPropertyId_ImportMappingProperty_id_fk",
+          "tableFrom": "ImportJobProperty",
+          "tableTo": "ImportMappingProperty",
+          "columnsFrom": ["importMappingPropertyId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJobRawData": {
+      "name": "ImportJobRawData",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnIndex": {
+          "name": "columnIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "valueHash": {
+          "name": "valueHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ImportJobRawData_importJobId_idx": {
+          "name": "ImportJobRawData_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobRawData_importJobId_rowIndex_idx": {
+          "name": "ImportJobRawData_importJobId_rowIndex_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobRawData_importJobId_columnIndex_idx": {
+          "name": "ImportJobRawData_importJobId_columnIndex_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "columnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobRawData_valueHash_idx": {
+          "name": "ImportJobRawData_valueHash_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "columnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJobRawData_importJobId_ImportJob_id_fk": {
+          "name": "ImportJobRawData_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportJobRawData",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJob": {
+      "name": "ImportJob",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importMappingId": {
+          "name": "importMappingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceFileName": {
+          "name": "sourceFileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnCount": {
+          "name": "columnCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowCount": {
+          "name": "rowCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalChunks": {
+          "name": "totalChunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedChunks": {
+          "name": "receivedChunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportJobStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "ingestionFailureReason": {
+          "name": "ingestionFailureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowPlanGeneration": {
+          "name": "allowPlanGeneration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmedAt": {
+          "name": "confirmedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedExecutionAt": {
+          "name": "startedExecutionAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportJob_organizationId_idx": {
+          "name": "ImportJob_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJob_importMappingId_idx": {
+          "name": "ImportJob_importMappingId_idx",
+          "columns": [
+            {
+              "expression": "importMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJob_status_idx": {
+          "name": "ImportJob_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJob_createdById_idx": {
+          "name": "ImportJob_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJob_organizationId_Organization_id_fk": {
+          "name": "ImportJob_organizationId_Organization_id_fk",
+          "tableFrom": "ImportJob",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportJob_importMappingId_ImportMapping_id_fk": {
+          "name": "ImportJob_importMappingId_ImportMapping_id_fk",
+          "tableFrom": "ImportJob",
+          "tableTo": "ImportMapping",
+          "columnsFrom": ["importMappingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportJob_createdById_User_id_fk": {
+          "name": "ImportJob_createdById_User_id_fk",
+          "tableFrom": "ImportJob",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportMappingProperty": {
+      "name": "ImportMappingProperty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importMappingId": {
+          "name": "importMappingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceColumnIndex": {
+          "name": "sourceColumnIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceColumnName": {
+          "name": "sourceColumnName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetType": {
+          "name": "targetType",
+          "type": "ImportMappingTargetType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skip'"
+        },
+        "targetFieldKey": {
+          "name": "targetFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customFieldId": {
+          "name": "customFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolutionType": {
+          "name": "resolutionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text:value'"
+        },
+        "resolutionConfig": {
+          "name": "resolutionConfig",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportMappingProperty_importMappingId_idx": {
+          "name": "ImportMappingProperty_importMappingId_idx",
+          "columns": [
+            {
+              "expression": "importMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportMappingProperty_sourceColumnIndex_idx": {
+          "name": "ImportMappingProperty_sourceColumnIndex_idx",
+          "columns": [
+            {
+              "expression": "importMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceColumnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportMappingProperty_importMappingId_ImportMapping_id_fk": {
+          "name": "ImportMappingProperty_importMappingId_ImportMapping_id_fk",
+          "tableFrom": "ImportMappingProperty",
+          "tableTo": "ImportMapping",
+          "columnsFrom": ["importMappingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportMappingProperty_customFieldId_CustomField_id_fk": {
+          "name": "ImportMappingProperty_customFieldId_CustomField_id_fk",
+          "tableFrom": "ImportMappingProperty",
+          "tableTo": "CustomField",
+          "columnsFrom": ["customFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportMapping": {
+      "name": "ImportMapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv'"
+        },
+        "defaultStrategy": {
+          "name": "defaultStrategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'create'"
+        },
+        "identifierFieldKey": {
+          "name": "identifierFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportMapping_organizationId_idx": {
+          "name": "ImportMapping_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportMapping_entityDefinitionId_idx": {
+          "name": "ImportMapping_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportMapping_organizationId_Organization_id_fk": {
+          "name": "ImportMapping_organizationId_Organization_id_fk",
+          "tableFrom": "ImportMapping",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportMapping_createdById_User_id_fk": {
+          "name": "ImportMapping_createdById_User_id_fk",
+          "tableFrom": "ImportMapping",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportPlanRow": {
+      "name": "ImportPlanRow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importPlanStrategyId": {
+          "name": "importPlanStrategyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "existingRecordId": {
+          "name": "existingRecordId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportPlanRowStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "resultRecordId": {
+          "name": "resultRecordId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executedAt": {
+          "name": "executedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportPlanRow_importPlanStrategyId_idx": {
+          "name": "ImportPlanRow_importPlanStrategyId_idx",
+          "columns": [
+            {
+              "expression": "importPlanStrategyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlanRow_status_idx": {
+          "name": "ImportPlanRow_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlanRow_strategyId_rowIndex_key": {
+          "name": "ImportPlanRow_strategyId_rowIndex_key",
+          "columns": [
+            {
+              "expression": "importPlanStrategyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportPlanRow_importPlanStrategyId_ImportPlanStrategy_id_fk": {
+          "name": "ImportPlanRow_importPlanStrategyId_ImportPlanStrategy_id_fk",
+          "tableFrom": "ImportPlanRow",
+          "tableTo": "ImportPlanStrategy",
+          "columnsFrom": ["importPlanStrategyId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportPlanStrategy": {
+      "name": "ImportPlanStrategy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importPlanId": {
+          "name": "importPlanId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "ImportStrategyType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matchingFieldKey": {
+          "name": "matchingFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matchingCustomFieldId": {
+          "name": "matchingCustomFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportStrategyStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planning_queued'"
+        },
+        "planningProgress": {
+          "name": "planningProgress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planningStartedAt": {
+          "name": "planningStartedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planningCompletedAt": {
+          "name": "planningCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionStartedAt": {
+          "name": "executionStartedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionCompletedAt": {
+          "name": "executionCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportPlanStrategy_importPlanId_idx": {
+          "name": "ImportPlanStrategy_importPlanId_idx",
+          "columns": [
+            {
+              "expression": "importPlanId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlanStrategy_strategy_idx": {
+          "name": "ImportPlanStrategy_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportPlanStrategy_importPlanId_ImportPlan_id_fk": {
+          "name": "ImportPlanStrategy_importPlanId_ImportPlan_id_fk",
+          "tableFrom": "ImportPlanStrategy",
+          "tableTo": "ImportPlan",
+          "columnsFrom": ["importPlanId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportPlanStrategy_matchingCustomFieldId_CustomField_id_fk": {
+          "name": "ImportPlanStrategy_matchingCustomFieldId_CustomField_id_fk",
+          "tableFrom": "ImportPlanStrategy",
+          "tableTo": "CustomField",
+          "columnsFrom": ["matchingCustomFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportPlan": {
+      "name": "ImportPlan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportPlanStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planning'"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportPlan_importJobId_idx": {
+          "name": "ImportPlan_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlan_status_idx": {
+          "name": "ImportPlan_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportPlan_importJobId_ImportJob_id_fk": {
+          "name": "ImportPlan_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportPlan",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportValueResolution": {
+      "name": "ImportValueResolution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importJobPropertyId": {
+          "name": "importJobPropertyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashedValue": {
+          "name": "hashedValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rawValue": {
+          "name": "rawValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cellCount": {
+          "name": "cellCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "resolvedValues": {
+          "name": "resolvedValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportResolutionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "isValid": {
+          "name": "isValid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userOverride": {
+          "name": "userOverride",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overriddenAt": {
+          "name": "overriddenAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportValueResolution_importJobPropertyId_idx": {
+          "name": "ImportValueResolution_importJobPropertyId_idx",
+          "columns": [
+            {
+              "expression": "importJobPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportValueResolution_propertyId_hash_key": {
+          "name": "ImportValueResolution_propertyId_hash_key",
+          "columns": [
+            {
+              "expression": "importJobPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hashedValue",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportValueResolution_status_idx": {
+          "name": "ImportValueResolution_status_idx",
+          "columns": [
+            {
+              "expression": "importJobPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportValueResolution_importJobPropertyId_ImportJobProperty_id_fk": {
+          "name": "ImportValueResolution_importJobPropertyId_ImportJobProperty_id_fk",
+          "tableFrom": "ImportValueResolution",
+          "tableTo": "ImportJobProperty",
+          "columnsFrom": ["importJobPropertyId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.InboxIntegration": {
+      "name": "InboxIntegration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "inboxId": {
+          "name": "inboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "InboxIntegration_inboxId_idx": {
+          "name": "InboxIntegration_inboxId_idx",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "InboxIntegration_inboxId_integrationId_key": {
+          "name": "InboxIntegration_inboxId_integrationId_key",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "InboxIntegration_integrationId_key": {
+          "name": "InboxIntegration_integrationId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "InboxIntegration_inboxId_EntityInstance_id_fk": {
+          "name": "InboxIntegration_inboxId_EntityInstance_id_fk",
+          "tableFrom": "InboxIntegration",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["inboxId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "InboxIntegration_integrationId_Integration_id_fk": {
+          "name": "InboxIntegration_integrationId_Integration_id_fk",
+          "tableFrom": "InboxIntegration",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.InsightTemplate": {
+      "name": "InsightTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aiTitle": {
+          "name": "aiTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "InsightTemplateStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enabled'"
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "InsightTemplate_organizationId_idx": {
+          "name": "InsightTemplate_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "InsightTemplate_organizationId_status_idx": {
+          "name": "InsightTemplate_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "InsightTemplate_organizationId_Organization_id_fk": {
+          "name": "InsightTemplate_organizationId_Organization_id_fk",
+          "tableFrom": "InsightTemplate",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "InsightTemplate_createdById_User_id_fk": {
+          "name": "InsightTemplate_createdById_User_id_fk",
+          "tableFrom": "InsightTemplate",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Integration": {
+      "name": "Integration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "IntegrationProviderType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSuccessfulSync": {
+          "name": "lastSuccessfulSync",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHistoryId": {
+          "name": "lastHistoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authStatus": {
+          "name": "authStatus",
+          "type": "IntegrationAuthStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AUTHENTICATED'"
+        },
+        "requiresReauth": {
+          "name": "requiresReauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastAuthError": {
+          "name": "lastAuthError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAuthErrorAt": {
+          "name": "lastAuthErrorAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncStatus": {
+          "name": "syncStatus",
+          "type": "IntegrationSyncStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOT_SYNCED'"
+        },
+        "syncStage": {
+          "name": "syncStage",
+          "type": "IntegrationSyncStage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDLE'"
+        },
+        "syncStageStartedAt": {
+          "name": "syncStageStartedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "throttleFailureCount": {
+          "name": "throttleFailureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "throttleRetryAfter": {
+          "name": "throttleRetryAfter",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncMode": {
+          "name": "syncMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "pollingIntervalMs": {
+          "name": "pollingIntervalMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 300000
+        },
+        "is_example": {
+          "name": "is_example",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Integration_organizationId_email_key": {
+          "name": "Integration_organizationId_email_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"Integration\".\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_organizationId_idx": {
+          "name": "Integration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_provider_organizationId_idx": {
+          "name": "Integration_provider_organizationId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_credentialId_idx": {
+          "name": "Integration_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credentialId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_syncStatus_idx": {
+          "name": "Integration_syncStatus_idx",
+          "columns": [
+            {
+              "expression": "syncStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Integration_organizationId_Organization_id_fk": {
+          "name": "Integration_organizationId_Organization_id_fk",
+          "tableFrom": "Integration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Integration_credentialId_WorkflowCredentials_id_fk": {
+          "name": "Integration_credentialId_WorkflowCredentials_id_fk",
+          "tableFrom": "Integration",
+          "tableTo": "WorkflowCredentials",
+          "columnsFrom": ["credentialId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.IntegrationTagLabel": {
+      "name": "IntegrationTagLabel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IntegrationTagLabel_integrationId_idx": {
+          "name": "IntegrationTagLabel_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IntegrationTagLabel_integrationId_labelId_key": {
+          "name": "IntegrationTagLabel_integrationId_labelId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "labelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IntegrationTagLabel_integrationId_tagId_key": {
+          "name": "IntegrationTagLabel_integrationId_tagId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IntegrationTagLabel_organizationId_idx": {
+          "name": "IntegrationTagLabel_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "IntegrationTagLabel_tagId_Tag_id_fk": {
+          "name": "IntegrationTagLabel_tagId_Tag_id_fk",
+          "tableFrom": "IntegrationTagLabel",
+          "tableTo": "Tag",
+          "columnsFrom": ["tagId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "IntegrationTagLabel_labelId_Label_id_fk": {
+          "name": "IntegrationTagLabel_labelId_Label_id_fk",
+          "tableFrom": "IntegrationTagLabel",
+          "tableTo": "Label",
+          "columnsFrom": ["labelId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "IntegrationTagLabel_organizationId_Organization_id_fk": {
+          "name": "IntegrationTagLabel_organizationId_Organization_id_fk",
+          "tableFrom": "IntegrationTagLabel",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Invoice": {
+      "name": "Invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoiceNumber": {
+          "name": "invoiceNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "InvoiceStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "invoiceDate": {
+          "name": "invoiceDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paidDate": {
+          "name": "paidDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billingReason": {
+          "name": "billingReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeInvoiceId": {
+          "name": "stripeInvoiceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdfUrl": {
+          "name": "pdfUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Invoice_organizationId_idx": {
+          "name": "Invoice_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Invoice_stripeInvoiceId_key": {
+          "name": "Invoice_stripeInvoiceId_key",
+          "columns": [
+            {
+              "expression": "stripeInvoiceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Invoice_subscriptionId_idx": {
+          "name": "Invoice_subscriptionId_idx",
+          "columns": [
+            {
+              "expression": "subscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Invoice_organizationId_Organization_id_fk": {
+          "name": "Invoice_organizationId_Organization_id_fk",
+          "tableFrom": "Invoice",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Invoice_subscriptionId_PlanSubscription_id_fk": {
+          "name": "Invoice_subscriptionId_PlanSubscription_id_fk",
+          "tableFrom": "Invoice",
+          "tableTo": "PlanSubscription",
+          "columnsFrom": ["subscriptionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KeyValuePair": {
+      "name": "KeyValuePair",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEncrypted": {
+          "name": "isEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedById": {
+          "name": "updatedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "KeyValuePair_key_userId_organizationId_key": {
+          "name": "KeyValuePair_key_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_key_organizationId_null_userId_key": {
+          "name": "KeyValuePair_key_organizationId_null_userId_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"userId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_key_userId_null_organizationId_key": {
+          "name": "KeyValuePair_key_userId_null_organizationId_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organizationId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_key_system_unique": {
+          "name": "KeyValuePair_key_system_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"userId\" IS NULL AND \"organizationId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_type_idx": {
+          "name": "KeyValuePair_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_organizationId_idx": {
+          "name": "KeyValuePair_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_userId_idx": {
+          "name": "KeyValuePair_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "KeyValuePair_organizationId_Organization_id_fk": {
+          "name": "KeyValuePair_organizationId_Organization_id_fk",
+          "tableFrom": "KeyValuePair",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KeyValuePair_userId_User_id_fk": {
+          "name": "KeyValuePair_userId_User_id_fk",
+          "tableFrom": "KeyValuePair",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KeyValuePair_updatedById_User_id_fk": {
+          "name": "KeyValuePair_updatedById_User_id_fk",
+          "tableFrom": "KeyValuePair",
+          "tableTo": "User",
+          "columnsFrom": ["updatedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KnowledgeBase": {
+      "name": "KnowledgeBase",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishStatus": {
+          "name": "publishStatus",
+          "type": "KBPublishStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPublishedAt": {
+          "name": "lastPublishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "KBVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLIC'"
+        },
+        "customDomainVerifiedAt": {
+          "name": "customDomainVerifiedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customDomain": {
+          "name": "customDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoDark": {
+          "name": "logoDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoLight": {
+          "name": "logoLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'clean'"
+        },
+        "showMode": {
+          "name": "showMode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "defaultMode": {
+          "name": "defaultMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'light'"
+        },
+        "primaryColorLight": {
+          "name": "primaryColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryColorDark": {
+          "name": "primaryColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tintColorLight": {
+          "name": "tintColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tintColorDark": {
+          "name": "tintColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "infoColorLight": {
+          "name": "infoColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "infoColorDark": {
+          "name": "infoColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successColorLight": {
+          "name": "successColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successColorDark": {
+          "name": "successColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warningColorLight": {
+          "name": "warningColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warningColorDark": {
+          "name": "warningColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dangerColorLight": {
+          "name": "dangerColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dangerColorDark": {
+          "name": "dangerColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fontFamily": {
+          "name": "fontFamily",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iconsFamily": {
+          "name": "iconsFamily",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'regular'"
+        },
+        "cornerStyle": {
+          "name": "cornerStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'rounded'"
+        },
+        "sidebarListStyle": {
+          "name": "sidebarListStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "searchbarPosition": {
+          "name": "searchbarPosition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'center'"
+        },
+        "headerEnabled": {
+          "name": "headerEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "footerEnabled": {
+          "name": "footerEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "headerNavigation": {
+          "name": "headerNavigation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "footerNavigation": {
+          "name": "footerNavigation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoDarkId": {
+          "name": "logoDarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoLightId": {
+          "name": "logoLightId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "KnowledgeBase_logoDarkId_key": {
+          "name": "KnowledgeBase_logoDarkId_key",
+          "columns": [
+            {
+              "expression": "logoDarkId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeBase_logoLightId_key": {
+          "name": "KnowledgeBase_logoLightId_key",
+          "columns": [
+            {
+              "expression": "logoLightId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeBase_organizationId_idx": {
+          "name": "KnowledgeBase_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeBase_organizationId_slug_key": {
+          "name": "KnowledgeBase_organizationId_slug_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "KnowledgeBase_organizationId_Organization_id_fk": {
+          "name": "KnowledgeBase_organizationId_Organization_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeBase_logoDarkId_MediaAsset_id_fk": {
+          "name": "KnowledgeBase_logoDarkId_MediaAsset_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["logoDarkId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeBase_logoLightId_MediaAsset_id_fk": {
+          "name": "KnowledgeBase_logoLightId_MediaAsset_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["logoLightId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Label": {
+      "name": "Label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationType": {
+          "name": "integrationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isVisible": {
+          "name": "isVisible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "backgroundColor": {
+          "name": "backgroundColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "textColor": {
+          "name": "textColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "LabelType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerCursor": {
+          "name": "providerCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pendingAction": {
+          "name": "pendingAction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isSentBox": {
+          "name": "isSentBox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parentLabelId": {
+          "name": "parentLabelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCheckpoint": {
+          "name": "syncCheckpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Label_labelId_organizationId_integrationId_key": {
+          "name": "Label_labelId_organizationId_integrationId_key",
+          "columns": [
+            {
+              "expression": "labelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Label_name_organizationId_integrationId_idx": {
+          "name": "Label_name_organizationId_integrationId_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Label_integrationId_idx": {
+          "name": "Label_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Label_organizationId_Organization_id_fk": {
+          "name": "Label_organizationId_Organization_id_fk",
+          "tableFrom": "Label",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Label_parentLabelId_Label_id_fk": {
+          "name": "Label_parentLabelId_Label_id_fk",
+          "tableFrom": "Label",
+          "tableTo": "Label",
+          "columnsFrom": ["parentLabelId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LabelsOnThread": {
+      "name": "LabelsOnThread",
+      "schema": "",
+      "columns": {
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "LabelsOnThread_threadId_Thread_id_fk": {
+          "name": "LabelsOnThread_threadId_Thread_id_fk",
+          "tableFrom": "LabelsOnThread",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "LabelsOnThread_labelId_Label_id_fk": {
+          "name": "LabelsOnThread_labelId_Label_id_fk",
+          "tableFrom": "LabelsOnThread",
+          "tableTo": "Label",
+          "columnsFrom": ["labelId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "LabelsOnThread_pkey": {
+          "name": "LabelsOnThread_pkey",
+          "columns": ["threadId", "labelId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LoadBalancingConfig": {
+      "name": "LoadBalancingConfig",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "LoadBalancingConfig_organizationId_provider_model_idx": {
+          "name": "LoadBalancingConfig_organizationId_provider_model_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LoadBalancingConfig_organizationId_provider_model_modelType_key": {
+          "name": "LoadBalancingConfig_organizationId_provider_model_modelType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LoadBalancingConfig_organizationId_Organization_id_fk": {
+          "name": "LoadBalancingConfig_organizationId_Organization_id_fk",
+          "tableFrom": "LoadBalancingConfig",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MailDomain": {
+      "name": "MailDomain",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "DomainType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CUSTOM'"
+        },
+        "routingPrefix": {
+          "name": "routingPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "isVerified": {
+          "name": "isVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verificationToken": {
+          "name": "verificationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookKey": {
+          "name": "webhookKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "MailDomain_organizationId_domain_key": {
+          "name": "MailDomain_organizationId_domain_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MailDomain_organizationId_Organization_id_fk": {
+          "name": "MailDomain_organizationId_Organization_id_fk",
+          "tableFrom": "MailDomain",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MailView": {
+      "name": "MailView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortField": {
+          "name": "sortField",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortDirection": {
+          "name": "sortDirection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'desc'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "MailView_isDefault_idx": {
+          "name": "MailView_isDefault_idx",
+          "columns": [
+            {
+              "expression": "isDefault",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MailView_name_userId_organizationId_key": {
+          "name": "MailView_name_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MailView_organizationId_idx": {
+          "name": "MailView_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MailView_userId_idx": {
+          "name": "MailView_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MailView_organizationId_Organization_id_fk": {
+          "name": "MailView_organizationId_Organization_id_fk",
+          "tableFrom": "MailView",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MailView_userId_User_id_fk": {
+          "name": "MailView_userId_User_id_fk",
+          "tableFrom": "MailView",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MediaAsset": {
+      "name": "MediaAsset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPrivate": {
+          "name": "isPrivate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentVersionId": {
+          "name": "currentVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ORIGINAL'"
+        }
+      },
+      "indexes": {
+        "MediaAsset_currentVersionId_key": {
+          "name": "MediaAsset_currentVersionId_key",
+          "columns": [
+            {
+              "expression": "currentVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_expiresAt_idx": {
+          "name": "MediaAsset_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_id_organizationId_key": {
+          "name": "MediaAsset_id_organizationId_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_kind_isPrivate_idx": {
+          "name": "MediaAsset_kind_isPrivate_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPrivate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_organizationId_expiresAt_idx": {
+          "name": "MediaAsset_organizationId_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_organizationId_kind_idx": {
+          "name": "MediaAsset_organizationId_kind_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_organizationId_purpose_kind_idx": {
+          "name": "MediaAsset_organizationId_purpose_kind_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thumbnail_assets": {
+          "name": "idx_thumbnail_assets",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((kind = 'THUMBNAIL'::text) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MediaAsset_organizationId_Organization_id_fk": {
+          "name": "MediaAsset_organizationId_Organization_id_fk",
+          "tableFrom": "MediaAsset",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MediaAsset_currentVersionId_MediaAssetVersion_id_fk": {
+          "name": "MediaAsset_currentVersionId_MediaAssetVersion_id_fk",
+          "tableFrom": "MediaAsset",
+          "tableTo": "MediaAssetVersion",
+          "columnsFrom": ["currentVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "MediaAsset_createdById_User_id_fk": {
+          "name": "MediaAsset_createdById_User_id_fk",
+          "tableFrom": "MediaAsset",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MediaAssetVersion": {
+      "name": "MediaAssetVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageLocationId": {
+          "name": "storageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivedFromVersionId": {
+          "name": "derivedFromVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preset": {
+          "name": "preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "AssetVersionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        }
+      },
+      "indexes": {
+        "MediaAssetVersion_assetId_createdAt_idx": {
+          "name": "MediaAssetVersion_assetId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "assetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_assetId_versionNumber_key": {
+          "name": "MediaAssetVersion_assetId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "assetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_derivedFromVersionId_preset_key": {
+          "name": "MediaAssetVersion_derivedFromVersionId_preset_key",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_derivedFromVersionId_preset_status_idx": {
+          "name": "MediaAssetVersion_derivedFromVersionId_preset_status_idx",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_status_idx": {
+          "name": "MediaAssetVersion_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thumbnail_cleanup": {
+          "name": "idx_thumbnail_cleanup",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((\"derivedFromVersionId\" IS NOT NULL) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thumbnail_lookup_covering": {
+          "name": "idx_thumbnail_lookup_covering",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((\"derivedFromVersionId\" IS NOT NULL) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_thumbnail": {
+          "name": "idx_unique_thumbnail",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((\"derivedFromVersionId\" IS NOT NULL) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MediaAssetVersion_assetId_MediaAsset_id_fk": {
+          "name": "MediaAssetVersion_assetId_MediaAsset_id_fk",
+          "tableFrom": "MediaAssetVersion",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["assetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MediaAssetVersion_storageLocationId_StorageLocation_id_fk": {
+          "name": "MediaAssetVersion_storageLocationId_StorageLocation_id_fk",
+          "tableFrom": "MediaAssetVersion",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["storageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MediaAssetVersion_derivedFromVersionId_MediaAssetVersion_id_fk": {
+          "name": "MediaAssetVersion_derivedFromVersionId_MediaAssetVersion_id_fk",
+          "tableFrom": "MediaAssetVersion",
+          "tableTo": "MediaAssetVersion",
+          "columnsFrom": ["derivedFromVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MeetingParticipant": {
+      "name": "MeetingParticipant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetingId": {
+          "name": "meetingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailDomain": {
+          "name": "emailDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contactEntityInstanceId": {
+          "name": "contactEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "companyEntityInstanceId": {
+          "name": "companyEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOrganizer": {
+          "name": "isOrganizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rsvpStatus": {
+          "name": "rsvpStatus",
+          "type": "RsvpStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'needs_action'"
+        },
+        "isBot": {
+          "name": "isBot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isExternal": {
+          "name": "isExternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "MeetingParticipant_organizationId_idx": {
+          "name": "MeetingParticipant_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_meetingId_idx": {
+          "name": "MeetingParticipant_meetingId_idx",
+          "columns": [
+            {
+              "expression": "meetingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_calendarEventId_idx": {
+          "name": "MeetingParticipant_calendarEventId_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_email_idx": {
+          "name": "MeetingParticipant_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_emailDomain_idx": {
+          "name": "MeetingParticipant_emailDomain_idx",
+          "columns": [
+            {
+              "expression": "emailDomain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_contactEntityInstanceId_idx": {
+          "name": "MeetingParticipant_contactEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "contactEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_companyEntityInstanceId_idx": {
+          "name": "MeetingParticipant_companyEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "companyEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MeetingParticipant_organizationId_Organization_id_fk": {
+          "name": "MeetingParticipant_organizationId_Organization_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_meetingId_EntityInstance_id_fk": {
+          "name": "MeetingParticipant_meetingId_EntityInstance_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["meetingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_calendarEventId_CalendarEvent_id_fk": {
+          "name": "MeetingParticipant_calendarEventId_CalendarEvent_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "CalendarEvent",
+          "columnsFrom": ["calendarEventId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_userId_User_id_fk": {
+          "name": "MeetingParticipant_userId_User_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_contactEntityInstanceId_EntityInstance_id_fk": {
+          "name": "MeetingParticipant_contactEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["contactEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_companyEntityInstanceId_EntityInstance_id_fk": {
+          "name": "MeetingParticipant_companyEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["companyEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalThreadId": {
+          "name": "externalThreadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isInbound": {
+          "name": "isInbound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isFirstInThread": {
+          "name": "isFirstInThread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "textHtml": {
+          "name": "textHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "textPlain": {
+          "name": "textPlain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internetMessageId": {
+          "name": "internetMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromId": {
+          "name": "fromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replyToId": {
+          "name": "replyToId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isReply": {
+          "name": "isReply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "historyId": {
+          "name": "historyId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedAt": {
+          "name": "receivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureId": {
+          "name": "signatureId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "htmlBodyStorageLocationId": {
+          "name": "htmlBodyStorageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasAttachments": {
+          "name": "hasAttachments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerError": {
+          "name": "providerError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sendStatus": {
+          "name": "sendStatus",
+          "type": "SendStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'SENT'"
+        },
+        "sendToken": {
+          "name": "sendToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Message_createdById_idx": {
+          "name": "Message_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_fromId_idx": {
+          "name": "Message_fromId_idx",
+          "columns": [
+            {
+              "expression": "fromId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_integrationId_externalId_key": {
+          "name": "Message_integrationId_externalId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_integrationId_idx": {
+          "name": "Message_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_organizationId_idx": {
+          "name": "Message_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_organizationId_internetMessageId_key": {
+          "name": "Message_organizationId_internetMessageId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internetMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"internetMessageId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_replyToId_idx": {
+          "name": "Message_replyToId_idx",
+          "columns": [
+            {
+              "expression": "replyToId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_sendToken_key": {
+          "name": "Message_sendToken_key",
+          "columns": [
+            {
+              "expression": "sendToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"sendToken\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_sentAt_idx": {
+          "name": "Message_sentAt_idx",
+          "columns": [
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_threadId_createdById_idx": {
+          "name": "Message_threadId_createdById_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_threadId_idx": {
+          "name": "Message_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retry_queue_idx": {
+          "name": "retry_queue_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sendStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastAttemptAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_messages_idx": {
+          "name": "thread_messages_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Message_threadId_Thread_id_fk": {
+          "name": "Message_threadId_Thread_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Message_integrationId_Integration_id_fk": {
+          "name": "Message_integrationId_Integration_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Message_createdById_User_id_fk": {
+          "name": "Message_createdById_User_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Message_organizationId_Organization_id_fk": {
+          "name": "Message_organizationId_Organization_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Message_fromId_Participant_id_fk": {
+          "name": "Message_fromId_Participant_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Participant",
+          "columnsFrom": ["fromId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "Message_replyToId_Participant_id_fk": {
+          "name": "Message_replyToId_Participant_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Participant",
+          "columnsFrom": ["replyToId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Message_signatureId_EntityInstance_id_fk": {
+          "name": "Message_signatureId_EntityInstance_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["signatureId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Message_htmlBodyStorageLocationId_StorageLocation_id_fk": {
+          "name": "Message_htmlBodyStorageLocationId_StorageLocation_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["htmlBodyStorageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MessageParticipant": {
+      "name": "MessageParticipant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "ParticipantRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participantId": {
+          "name": "participantId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "MessageParticipant_messageId_idx": {
+          "name": "MessageParticipant_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageParticipant_messageId_participantId_role_key": {
+          "name": "MessageParticipant_messageId_participantId_role_key",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "participantId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageParticipant_participantId_idx": {
+          "name": "MessageParticipant_participantId_idx",
+          "columns": [
+            {
+              "expression": "participantId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageParticipant_role_idx": {
+          "name": "MessageParticipant_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_idx": {
+          "name": "contact_history_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "participant_lookup_idx": {
+          "name": "participant_lookup_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MessageParticipant_messageId_Message_id_fk": {
+          "name": "MessageParticipant_messageId_Message_id_fk",
+          "tableFrom": "MessageParticipant",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MessageParticipant_participantId_Participant_id_fk": {
+          "name": "MessageParticipant_participantId_Participant_id_fk",
+          "tableFrom": "MessageParticipant",
+          "tableTo": "Participant",
+          "columnsFrom": ["participantId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ModelConfiguration": {
+      "name": "ModelConfiguration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ModelConfiguration_organizationId_enabled_idx": {
+          "name": "ModelConfiguration_organizationId_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModelConfiguration_organizationId_provider_idx": {
+          "name": "ModelConfiguration_organizationId_provider_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModelConfiguration_organizationId_provider_model_modelType_key": {
+          "name": "ModelConfiguration_organizationId_provider_model_modelType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ModelConfiguration_organizationId_Organization_id_fk": {
+          "name": "ModelConfiguration_organizationId_Organization_id_fk",
+          "tableFrom": "ModelConfiguration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Notification": {
+      "name": "Notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryMethod": {
+          "name": "deliveryMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Notification_entityType_entityId_idx": {
+          "name": "Notification_entityType_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_organizationId_idx": {
+          "name": "Notification_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_userId_createdAt_idx": {
+          "name": "Notification_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_userId_isRead_idx": {
+          "name": "Notification_userId_isRead_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Notification_userId_User_id_fk": {
+          "name": "Notification_userId_User_id_fk",
+          "tableFrom": "Notification",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Notification_actorId_User_id_fk": {
+          "name": "Notification_actorId_User_id_fk",
+          "tableFrom": "Notification",
+          "tableTo": "User",
+          "columnsFrom": ["actorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Notification_organizationId_Organization_id_fk": {
+          "name": "Notification_organizationId_Organization_id_fk",
+          "tableFrom": "Notification",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauthAccessToken_userId_User_id_fk": {
+          "name": "oauthAccessToken_userId_User_id_fk",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthAccessToken_accessToken_unique": {
+          "name": "oauthAccessToken_accessToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["accessToken"]
+        },
+        "oauthAccessToken_refreshToken_unique": {
+          "name": "oauthAccessToken_refreshToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refreshToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthApplication": {
+      "name": "oauthApplication",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectURLs": {
+          "name": "redirectURLs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauthApplication_userId_User_id_fk": {
+          "name": "oauthApplication_userId_User_id_fk",
+          "tableFrom": "oauthApplication",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthApplication_clientId_unique": {
+          "name": "oauthApplication_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["clientId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthConsent": {
+      "name": "oauthConsent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentGiven": {
+          "name": "consentGiven",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauthConsent_userId_User_id_fk": {
+          "name": "oauthConsent_userId_User_id_fk",
+          "tableFrom": "oauthConsent",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OperatingHours": {
+      "name": "OperatingHours",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgetId": {
+          "name": "widgetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dayOfWeek": {
+          "name": "dayOfWeek",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startHour": {
+          "name": "startHour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startMinute": {
+          "name": "startMinute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endHour": {
+          "name": "endHour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endMinute": {
+          "name": "endMinute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        }
+      },
+      "indexes": {
+        "OperatingHours_widgetId_dayOfWeek_key": {
+          "name": "OperatingHours_widgetId_dayOfWeek_key",
+          "columns": [
+            {
+              "expression": "widgetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dayOfWeek",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OperatingHours_widgetId_idx": {
+          "name": "OperatingHours_widgetId_idx",
+          "columns": [
+            {
+              "expression": "widgetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OperatingHours_widgetId_ChatWidget_id_fk": {
+          "name": "OperatingHours_widgetId_ChatWidget_id_fk",
+          "tableFrom": "OperatingHours",
+          "tableTo": "ChatWidget",
+          "columnsFrom": ["widgetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Order": {
+      "name": "Order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelReason": {
+          "name": "cancelReason",
+          "type": "ORDER_CANCEL_REASON",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canNotifyCustomer": {
+          "name": "canNotifyCustomer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confirmationNumber": {
+          "name": "confirmationNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "discountCode": {
+          "name": "discountCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "financialStatus": {
+          "name": "financialStatus",
+          "type": "ORDER_FINANCIAL_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillmentStatus": {
+          "name": "fulfillmentStatus",
+          "type": "ORDER_FULFILLMENT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poNumber": {
+          "name": "poNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returnStatus": {
+          "name": "returnStatus",
+          "type": "ORDER_RETURN_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taxExempt": {
+          "name": "taxExempt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "subtotalPrice": {
+          "name": "subtotalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalDiscounts": {
+          "name": "totalDiscounts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalRefunded": {
+          "name": "totalRefunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalShippingPrice": {
+          "name": "totalShippingPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalTax": {
+          "name": "totalTax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shippingAddressId": {
+          "name": "shippingAddressId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billingAddressId": {
+          "name": "billingAddressId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Order_customerId_idx": {
+          "name": "Order_customerId_idx",
+          "columns": [
+            {
+              "expression": "customerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Order_name_idx": {
+          "name": "Order_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Order_shippingAddressId_Address_id_fk": {
+          "name": "Order_shippingAddressId_Address_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "Address",
+          "columnsFrom": ["shippingAddressId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Order_billingAddressId_Address_id_fk": {
+          "name": "Order_billingAddressId_Address_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "Address",
+          "columnsFrom": ["billingAddressId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Order_customerId_shopify_customers_id_fk": {
+          "name": "Order_customerId_shopify_customers_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "shopify_customers",
+          "columnsFrom": ["customerId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Order_organizationId_Organization_id_fk": {
+          "name": "Order_organizationId_Organization_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Order_integrationId_ShopifyIntegration_id_fk": {
+          "name": "Order_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrderFulfillment": {
+      "name": "OrderFulfillment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "FULFILLMENT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "requiresShipping": {
+          "name": "requiresShipping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrderFulfillment_orderId_idx": {
+          "name": "OrderFulfillment_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrderFulfillment_status_idx": {
+          "name": "OrderFulfillment_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrderFulfillment_orderId_Order_id_fk": {
+          "name": "OrderFulfillment_orderId_Order_id_fk",
+          "tableFrom": "OrderFulfillment",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrderLineItem": {
+      "name": "OrderLineItem",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productId": {
+          "name": "productId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variantId": {
+          "name": "variantId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalTotal": {
+          "name": "originalTotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "originalUnitPrice": {
+          "name": "originalUnitPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrderLineItem_orderId_idx": {
+          "name": "OrderLineItem_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrderLineItem_orderId_Order_id_fk": {
+          "name": "OrderLineItem_orderId_Order_id_fk",
+          "tableFrom": "OrderLineItem",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrderRefund": {
+      "name": "OrderRefund",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalRefundedAmount": {
+          "name": "totalRefundedAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrderRefund_orderId_idx": {
+          "name": "OrderRefund_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrderRefund_orderId_Order_id_fk": {
+          "name": "OrderRefund_orderId_Order_id_fk",
+          "tableFrom": "OrderRefund",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrderReturn": {
+      "name": "OrderReturn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "RETURN_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrderReturn_orderId_idx": {
+          "name": "OrderReturn_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrderReturn_orderId_Order_id_fk": {
+          "name": "OrderReturn_orderId_Order_id_fk",
+          "tableFrom": "OrderReturn",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domains": {
+          "name": "domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "OrganizationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'TEAM'"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "systemUserId": {
+          "name": "systemUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledReason": {
+          "name": "disabledReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledBy": {
+          "name": "disabledBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedOnboarding": {
+          "name": "completedOnboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "demo_expires_at": {
+          "name": "demo_expires_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Organization_handle_idx": {
+          "name": "Organization_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_handle_key": {
+          "name": "Organization_handle_key",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_systemUserId_key": {
+          "name": "Organization_systemUserId_key",
+          "columns": [
+            {
+              "expression": "systemUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Organization_createdById_User_id_fk": {
+          "name": "Organization_createdById_User_id_fk",
+          "tableFrom": "Organization",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "Organization_systemUserId_User_id_fk": {
+          "name": "Organization_systemUserId_User_id_fk",
+          "tableFrom": "Organization",
+          "tableTo": "User",
+          "columnsFrom": ["systemUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationAiQuota": {
+      "name": "OrganizationAiQuota",
+      "schema": "",
+      "columns": {
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quotaType": {
+          "name": "quotaType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quotaLimit": {
+          "name": "quotaLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quotaUsed": {
+          "name": "quotaUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "quotaPeriodStart": {
+          "name": "quotaPeriodStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "quotaPeriodEnd": {
+          "name": "quotaPeriodEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "OrganizationAiQuota_organizationId_Organization_id_fk": {
+          "name": "OrganizationAiQuota_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationAiQuota",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationInvitation": {
+      "name": "OrganizationInvitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "OrganizationRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "InvitationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitedById": {
+          "name": "invitedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptedById": {
+          "name": "acceptedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "OrganizationInvitation_email_idx": {
+          "name": "OrganizationInvitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationInvitation_organizationId_idx": {
+          "name": "OrganizationInvitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationInvitation_status_idx": {
+          "name": "OrganizationInvitation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationInvitation_token_key": {
+          "name": "OrganizationInvitation_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationInvitation_organizationId_Organization_id_fk": {
+          "name": "OrganizationInvitation_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationInvitation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationInvitation_invitedById_User_id_fk": {
+          "name": "OrganizationInvitation_invitedById_User_id_fk",
+          "tableFrom": "OrganizationInvitation",
+          "tableTo": "User",
+          "columnsFrom": ["invitedById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationInvitation_acceptedById_User_id_fk": {
+          "name": "OrganizationInvitation_acceptedById_User_id_fk",
+          "tableFrom": "OrganizationInvitation",
+          "tableTo": "User",
+          "columnsFrom": ["acceptedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationMember": {
+      "name": "OrganizationMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "OrganizationMemberStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "role": {
+          "name": "role",
+          "type": "OrganizationRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        }
+      },
+      "indexes": {
+        "OrganizationMember_organizationId_idx": {
+          "name": "OrganizationMember_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_userId_idx": {
+          "name": "OrganizationMember_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_userId_organizationId_key": {
+          "name": "OrganizationMember_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationMember_userId_User_id_fk": {
+          "name": "OrganizationMember_userId_User_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationMember_organizationId_Organization_id_fk": {
+          "name": "OrganizationMember_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationSetting": {
+      "name": "OrganizationSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowUserOverride": {
+          "name": "allowUserOverride",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "SettingScope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GENERAL'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrganizationSetting_key_idx": {
+          "name": "OrganizationSetting_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationSetting_organizationId_idx": {
+          "name": "OrganizationSetting_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationSetting_organizationId_key_key": {
+          "name": "OrganizationSetting_organizationId_key_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationSetting_scope_idx": {
+          "name": "OrganizationSetting_scope_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationSetting_organizationId_Organization_id_fk": {
+          "name": "OrganizationSetting_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationSetting",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Participant": {
+      "name": "Participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifierType": {
+          "name": "identifierType",
+          "type": "IdentifierType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isSpammer": {
+          "name": "isSpammer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isInternal": {
+          "name": "isInternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstInteractionDate": {
+          "name": "firstInteractionDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstInteractionType": {
+          "name": "firstInteractionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasReceivedMessage": {
+          "name": "hasReceivedMessage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSentMessageAt": {
+          "name": "lastSentMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Participant_entityInstanceId_idx": {
+          "name": "Participant_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_identifierType_idx": {
+          "name": "Participant_identifierType_idx",
+          "columns": [
+            {
+              "expression": "identifierType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_identifier_idx": {
+          "name": "Participant_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_organizationId_identifier_identifierType_key": {
+          "name": "Participant_organizationId_identifier_identifierType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifierType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_organizationId_idx": {
+          "name": "Participant_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Participant_entityInstanceId_EntityInstance_id_fk": {
+          "name": "Participant_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "Participant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Participant_organizationId_Organization_id_fk": {
+          "name": "Participant_organizationId_Organization_id_fk",
+          "tableFrom": "Participant",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Passkey": {
+      "name": "Passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Passkey_userId_User_id_fk": {
+          "name": "Passkey_userId_User_id_fk",
+          "tableFrom": "Passkey",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PasswordResetToken": {
+      "name": "PasswordResetToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "PasswordResetToken_token_key": {
+          "name": "PasswordResetToken_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PasswordResetToken_userId_idx": {
+          "name": "PasswordResetToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PasswordResetToken_userId_User_id_fk": {
+          "name": "PasswordResetToken_userId_User_id_fk",
+          "tableFrom": "PasswordResetToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Plan": {
+      "name": "Plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "monthlyPrice": {
+          "name": "monthlyPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annualPrice": {
+          "name": "annualPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isCustomPricing": {
+          "name": "isCustomPricing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trialDays": {
+          "name": "trialDays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "hasTrial": {
+          "name": "hasTrial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "minSeats": {
+          "name": "minSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "maxSeats": {
+          "name": "maxSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "isLegacy": {
+          "name": "isLegacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selfServed": {
+          "name": "selfServed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isMostPopular": {
+          "name": "isMostPopular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isFree": {
+          "name": "isFree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featureLimits": {
+          "name": "featureLimits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "trialFeatureLimits": {
+          "name": "trialFeatureLimits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeProductId": {
+          "name": "stripeProductId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripePriceIdMonthly": {
+          "name": "stripePriceIdMonthly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripePriceIdAnnual": {
+          "name": "stripePriceIdAnnual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchyLevel": {
+          "name": "hierarchyLevel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PlanSubscription": {
+      "name": "PlanSubscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planId": {
+          "name": "planId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incomplete'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "billingCycle": {
+          "name": "billingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MONTHLY'"
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "creditsBalance": {
+          "name": "creditsBalance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "trialStart": {
+          "name": "trialStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trialEnd": {
+          "name": "trialEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasTrialEnded": {
+          "name": "hasTrialEnded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trialConversionStatus": {
+          "name": "trialConversionStatus",
+          "type": "TrialConversionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEligibleForTrial": {
+          "name": "isEligibleForTrial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trialEligibilityReason": {
+          "name": "trialEligibilityReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPlanId": {
+          "name": "scheduledPlanId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPlan": {
+          "name": "scheduledPlan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledBillingCycle": {
+          "name": "scheduledBillingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledSeats": {
+          "name": "scheduledSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledChangeAt": {
+          "name": "scheduledChangeAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeletionNotificationSent": {
+          "name": "lastDeletionNotificationSent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeletionNotificationDate": {
+          "name": "lastDeletionNotificationDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletionScheduledDate": {
+          "name": "deletionScheduledDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletionReason": {
+          "name": "deletionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customFeatureLimits": {
+          "name": "customFeatureLimits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customPricingMonthly": {
+          "name": "customPricingMonthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customPricingAnnual": {
+          "name": "customPricingAnnual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customPricingNotes": {
+          "name": "customPricingNotes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "PlanSubscription_organizationId_key": {
+          "name": "PlanSubscription_organizationId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PlanSubscription_organizationId_Organization_id_fk": {
+          "name": "PlanSubscription_organizationId_Organization_id_fk",
+          "tableFrom": "PlanSubscription",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PlanSubscription_planId_Plan_id_fk": {
+          "name": "PlanSubscription_planId_Plan_id_fk",
+          "tableFrom": "PlanSubscription",
+          "tableTo": "Plan",
+          "columnsFrom": ["planId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PlanSubscription_scheduledPlanId_Plan_id_fk": {
+          "name": "PlanSubscription_scheduledPlanId_Plan_id_fk",
+          "tableFrom": "PlanSubscription",
+          "tableTo": "Plan",
+          "columnsFrom": ["scheduledPlanId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PlanSubscriptionHistory": {
+      "name": "PlanSubscriptionHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changeType": {
+          "name": "changeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromPlan": {
+          "name": "fromPlan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toPlan": {
+          "name": "toPlan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromBillingCycle": {
+          "name": "fromBillingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toBillingCycle": {
+          "name": "toBillingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromSeats": {
+          "name": "fromSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toSeats": {
+          "name": "toSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immediate": {
+          "name": "immediate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledFor": {
+          "name": "scheduledFor",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appliedAt": {
+          "name": "appliedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prorationAmount": {
+          "name": "prorationAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PollingTriggerState": {
+      "name": "PollingTriggerState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerId": {
+          "name": "triggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "lastPollAt": {
+          "name": "lastPollAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPollStatus": {
+          "name": "lastPollStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPollError": {
+          "name": "lastPollError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutiveErrors": {
+          "name": "consecutiveErrors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "PollingTriggerState_workflowAppId_triggerId_key": {
+          "name": "PollingTriggerState_workflowAppId_triggerId_key",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PollingTriggerState_organizationId_idx": {
+          "name": "PollingTriggerState_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PollingTriggerState_organizationId_Organization_id_fk": {
+          "name": "PollingTriggerState_organizationId_Organization_id_fk",
+          "tableFrom": "PollingTriggerState",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PollingTriggerState_workflowAppId_WorkflowApp_id_fk": {
+          "name": "PollingTriggerState_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "PollingTriggerState",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Product": {
+      "name": "Product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descriptionHtml": {
+          "name": "descriptionHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasOnlyDefaultVariant": {
+          "name": "hasOnlyDefaultVariant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productType": {
+          "name": "productType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "PRODUDT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracksInventory": {
+          "name": "tracksInventory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalInventory": {
+          "name": "totalInventory",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Product_handle_key": {
+          "name": "Product_handle_key",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Product_integrationId_ShopifyIntegration_id_fk": {
+          "name": "Product_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "Product",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Product_organizationId_Organization_id_fk": {
+          "name": "Product_organizationId_Organization_id_fk",
+          "tableFrom": "Product",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProductMedia": {
+      "name": "ProductMedia",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mediaContentType": {
+          "name": "mediaContentType",
+          "type": "MEDIA_CONTENT_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IMAGE'"
+        },
+        "previewId": {
+          "name": "previewId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previewAlt": {
+          "name": "previewAlt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewHeight": {
+          "name": "previewHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewWidth": {
+          "name": "previewWidth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewUrl": {
+          "name": "previewUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variantIds": {
+          "name": "variantIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProductMedia_productId_idx": {
+          "name": "ProductMedia_productId_idx",
+          "columns": [
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProductMedia_productId_Product_id_fk": {
+          "name": "ProductMedia_productId_Product_id_fk",
+          "tableFrom": "ProductMedia",
+          "tableTo": "Product",
+          "columnsFrom": ["productId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProductOption": {
+      "name": "ProductOption",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "values": {
+          "name": "values",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProductOption_productId_idx": {
+          "name": "ProductOption_productId_idx",
+          "columns": [
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProductOption_productId_Product_id_fk": {
+          "name": "ProductOption_productId_Product_id_fk",
+          "tableFrom": "ProductOption",
+          "tableTo": "Product",
+          "columnsFrom": ["productId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProductVariant": {
+      "name": "ProductVariant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "availableForSale": {
+          "name": "availableForSale",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compareAtPrice": {
+          "name": "compareAtPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selectedOptions": {
+          "name": "selectedOptions",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageId": {
+          "name": "imageId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventoryItemId": {
+          "name": "inventoryItemId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventoryManagement": {
+          "name": "inventoryManagement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventoryPolicy": {
+          "name": "inventoryPolicy",
+          "type": "INVENTORY_POLICY",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONTINUE'"
+        },
+        "inventoryQuantity": {
+          "name": "inventoryQuantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weightUnit": {
+          "name": "weightUnit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProductVariant_productId_idx": {
+          "name": "ProductVariant_productId_idx",
+          "columns": [
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProductVariant_productId_Product_id_fk": {
+          "name": "ProductVariant_productId_Product_id_fk",
+          "tableFrom": "ProductVariant",
+          "tableTo": "Product",
+          "columnsFrom": ["productId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ProductVariant_organizationId_Organization_id_fk": {
+          "name": "ProductVariant_organizationId_Organization_id_fk",
+          "tableFrom": "ProductVariant",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ProductVariant_integrationId_ShopifyIntegration_id_fk": {
+          "name": "ProductVariant_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "ProductVariant",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PromptHistory": {
+      "name": "PromptHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "PromptHistory_userId_User_id_fk": {
+          "name": "PromptHistory_userId_User_id_fk",
+          "tableFrom": "PromptHistory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PromptTemplate": {
+      "name": "PromptTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "PromptTemplate_organizationId_idx": {
+          "name": "PromptTemplate_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PromptTemplate_categories_idx": {
+          "name": "PromptTemplate_categories_idx",
+          "columns": [
+            {
+              "expression": "categories",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PromptTemplate_organizationId_Organization_id_fk": {
+          "name": "PromptTemplate_organizationId_Organization_id_fk",
+          "tableFrom": "PromptTemplate",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PromptTemplate_createdById_User_id_fk": {
+          "name": "PromptTemplate_createdById_User_id_fk",
+          "tableFrom": "PromptTemplate",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProviderConfiguration": {
+      "name": "ProviderConfiguration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "quotaType": {
+          "name": "quotaType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaLimit": {
+          "name": "quotaLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-1'"
+        },
+        "quotaPeriodEnd": {
+          "name": "quotaPeriodEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaPeriodStart": {
+          "name": "quotaPeriodStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaUsed": {
+          "name": "quotaUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ProviderConfiguration_organizationId_provider_idx": {
+          "name": "ProviderConfiguration_organizationId_provider_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ProviderConfiguration_org_provider_type_key": {
+          "name": "ProviderConfiguration_org_provider_type_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProviderConfiguration_organizationId_Organization_id_fk": {
+          "name": "ProviderConfiguration_organizationId_Organization_id_fk",
+          "tableFrom": "ProviderConfiguration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProviderPreference": {
+      "name": "ProviderPreference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferredType": {
+          "name": "preferredType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProviderPreference_organizationId_provider_idx": {
+          "name": "ProviderPreference_organizationId_provider_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ProviderPreference_organizationId_provider_key": {
+          "name": "ProviderPreference_organizationId_provider_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProviderPreference_organizationId_Organization_id_fk": {
+          "name": "ProviderPreference_organizationId_Organization_id_fk",
+          "tableFrom": "ProviderPreference",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecordingChapter": {
+      "name": "RecordingChapter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startMs": {
+          "name": "startMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endMs": {
+          "name": "endMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "RecordingChapter_callRecordingId_sortOrder_idx": {
+          "name": "RecordingChapter_callRecordingId_sortOrder_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortOrder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecordingChapter_organizationId_Organization_id_fk": {
+          "name": "RecordingChapter_organizationId_Organization_id_fk",
+          "tableFrom": "RecordingChapter",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingChapter_callRecordingId_CallRecording_id_fk": {
+          "name": "RecordingChapter_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "RecordingChapter",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecordingInsight": {
+      "name": "RecordingInsight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "insightTemplateId": {
+          "name": "insightTemplateId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "InsightStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "RecordingInsight_callRecordingId_idx": {
+          "name": "RecordingInsight_callRecordingId_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordingInsight_insightTemplateId_idx": {
+          "name": "RecordingInsight_insightTemplateId_idx",
+          "columns": [
+            {
+              "expression": "insightTemplateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordingInsight_organizationId_idx": {
+          "name": "RecordingInsight_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecordingInsight_organizationId_Organization_id_fk": {
+          "name": "RecordingInsight_organizationId_Organization_id_fk",
+          "tableFrom": "RecordingInsight",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingInsight_callRecordingId_CallRecording_id_fk": {
+          "name": "RecordingInsight_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "RecordingInsight",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingInsight_insightTemplateId_InsightTemplate_id_fk": {
+          "name": "RecordingInsight_insightTemplateId_InsightTemplate_id_fk",
+          "tableFrom": "RecordingInsight",
+          "tableTo": "InsightTemplate",
+          "columnsFrom": ["insightTemplateId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecordingShareLink": {
+      "name": "RecordingShareLink",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeVideo": {
+          "name": "includeVideo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeTranscript": {
+          "name": "includeTranscript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeInsights": {
+          "name": "includeInsights",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "RecordingShareLink_publicId_key": {
+          "name": "RecordingShareLink_publicId_key",
+          "columns": [
+            {
+              "expression": "publicId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordingShareLink_callRecordingId_idx": {
+          "name": "RecordingShareLink_callRecordingId_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecordingShareLink_organizationId_Organization_id_fk": {
+          "name": "RecordingShareLink_organizationId_Organization_id_fk",
+          "tableFrom": "RecordingShareLink",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingShareLink_callRecordingId_CallRecording_id_fk": {
+          "name": "RecordingShareLink_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "RecordingShareLink",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingShareLink_createdById_User_id_fk": {
+          "name": "RecordingShareLink_createdById_User_id_fk",
+          "tableFrom": "RecordingShareLink",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ResourceAccess": {
+      "name": "ResourceAccess",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granteeType": {
+          "name": "granteeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granteeId": {
+          "name": "granteeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantedById": {
+          "name": "grantedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ResourceAccess_entity_grantee_key": {
+          "name": "ResourceAccess_entity_grantee_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granteeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granteeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_entityDef_idx": {
+          "name": "ResourceAccess_entityDef_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_instance_idx": {
+          "name": "ResourceAccess_instance_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_grantee_idx": {
+          "name": "ResourceAccess_grantee_idx",
+          "columns": [
+            {
+              "expression": "granteeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granteeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_org_idx": {
+          "name": "ResourceAccess_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ResourceAccess_organizationId_Organization_id_fk": {
+          "name": "ResourceAccess_organizationId_Organization_id_fk",
+          "tableFrom": "ResourceAccess",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ResourceAccess_grantedById_User_id_fk": {
+          "name": "ResourceAccess_grantedById_User_id_fk",
+          "tableFrom": "ResourceAccess",
+          "tableTo": "User",
+          "columnsFrom": ["grantedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ScheduledMessage": {
+      "name": "ScheduledMessage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draftId": {
+          "name": "draftId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledAt": {
+          "name": "scheduledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ScheduledMessageStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "jobId": {
+          "name": "jobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sendPayload": {
+          "name": "sendPayload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "ScheduledMessageSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER_SCHEDULED'"
+        },
+        "approvedById": {
+          "name": "approvedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledById": {
+          "name": "cancelledById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiSuggestionId": {
+          "name": "aiSuggestionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ScheduledMessage_orgId_status_scheduledAt_idx": {
+          "name": "ScheduledMessage_orgId_status_scheduledAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduledAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ScheduledMessage_draftId_idx": {
+          "name": "ScheduledMessage_draftId_idx",
+          "columns": [
+            {
+              "expression": "draftId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ScheduledMessage_orgId_source_approvedById_status_idx": {
+          "name": "ScheduledMessage_orgId_source_approvedById_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "approvedById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ScheduledMessage_organizationId_Organization_id_fk": {
+          "name": "ScheduledMessage_organizationId_Organization_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_draftId_Draft_id_fk": {
+          "name": "ScheduledMessage_draftId_Draft_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "Draft",
+          "columnsFrom": ["draftId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_integrationId_Integration_id_fk": {
+          "name": "ScheduledMessage_integrationId_Integration_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_threadId_Thread_id_fk": {
+          "name": "ScheduledMessage_threadId_Thread_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_createdById_User_id_fk": {
+          "name": "ScheduledMessage_createdById_User_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_approvedById_User_id_fk": {
+          "name": "ScheduledMessage_approvedById_User_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "User",
+          "columnsFrom": ["approvedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_cancelledById_User_id_fk": {
+          "name": "ScheduledMessage_cancelledById_User_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "User",
+          "columnsFrom": ["cancelledById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_aiSuggestionId_AiSuggestion_id_fk": {
+          "name": "ScheduledMessage_aiSuggestionId_AiSuggestion_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "AiSuggestion",
+          "columnsFrom": ["aiSuggestionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SearchHistory": {
+      "name": "SearchHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "searchedAt": {
+          "name": "searchedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SearchHistory_userId_organizationId_searchedAt_idx": {
+          "name": "SearchHistory_userId_organizationId_searchedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "searchedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SearchHistory_userId_User_id_fk": {
+          "name": "SearchHistory_userId_User_id_fk",
+          "tableFrom": "SearchHistory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SearchHistory_organizationId_Organization_id_fk": {
+          "name": "SearchHistory_organizationId_Organization_id_fk",
+          "tableFrom": "SearchHistory",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonatedBy": {
+          "name": "impersonatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_User_id_fk": {
+          "name": "session_userId_User_id_fk",
+          "tableFrom": "session",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ShopifyAuthState": {
+      "name": "ShopifyAuthState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shopDomain": {
+          "name": "shopDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ShopifyAuthState_state_idx": {
+          "name": "ShopifyAuthState_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ShopifyAuthState_userId_idx": {
+          "name": "ShopifyAuthState_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ShopifyAuthState_userId_User_id_fk": {
+          "name": "ShopifyAuthState_userId_User_id_fk",
+          "tableFrom": "ShopifyAuthState",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ShopifyAuthState_organizationId_Organization_id_fk": {
+          "name": "ShopifyAuthState_organizationId_Organization_id_fk",
+          "tableFrom": "ShopifyAuthState",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopify_customers": {
+      "name": "shopify_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "numberOfOrders": {
+          "name": "numberOfOrders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amountSpent": {
+          "name": "amountSpent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifiedEmail": {
+          "name": "verifiedEmail",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multipassIdentifier": {
+          "name": "multipassIdentifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taxExempt": {
+          "name": "taxExempt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defaultAddressId": {
+          "name": "defaultAddressId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastOrderId": {
+          "name": "lastOrderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastOrderName": {
+          "name": "lastOrderName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shopify_customers_entityInstanceId_idx": {
+          "name": "shopify_customers_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopify_customers_defaultAddressId_key": {
+          "name": "shopify_customers_defaultAddressId_key",
+          "columns": [
+            {
+              "expression": "defaultAddressId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopify_customers_email_idx": {
+          "name": "shopify_customers_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopify_customers_lastOrderId_key": {
+          "name": "shopify_customers_lastOrderId_key",
+          "columns": [
+            {
+              "expression": "lastOrderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopify_customers_phone_idx": {
+          "name": "shopify_customers_phone_idx",
+          "columns": [
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopify_customers_defaultAddressId_Address_id_fk": {
+          "name": "shopify_customers_defaultAddressId_Address_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "Address",
+          "columnsFrom": ["defaultAddressId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "shopify_customers_lastOrderId_Order_id_fk": {
+          "name": "shopify_customers_lastOrderId_Order_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "Order",
+          "columnsFrom": ["lastOrderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "shopify_customers_organizationId_Organization_id_fk": {
+          "name": "shopify_customers_organizationId_Organization_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "shopify_customers_integrationId_ShopifyIntegration_id_fk": {
+          "name": "shopify_customers_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "shopify_customers_entityInstanceId_EntityInstance_id_fk": {
+          "name": "shopify_customers_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ShopifyIntegration": {
+      "name": "ShopifyIntegration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shopDomain": {
+          "name": "shopDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ShopifyIntegration_organizationId_idx": {
+          "name": "ShopifyIntegration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ShopifyIntegration_organizationId_shopDomain_key": {
+          "name": "ShopifyIntegration_organizationId_shopDomain_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shopDomain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ShopifyIntegration_shopDomain_idx": {
+          "name": "ShopifyIntegration_shopDomain_idx",
+          "columns": [
+            {
+              "expression": "shopDomain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ShopifyIntegration_organizationId_Organization_id_fk": {
+          "name": "ShopifyIntegration_organizationId_Organization_id_fk",
+          "tableFrom": "ShopifyIntegration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ShopifyIntegration_createdById_User_id_fk": {
+          "name": "ShopifyIntegration_createdById_User_id_fk",
+          "tableFrom": "ShopifyIntegration",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SignatureIntegrationShare": {
+      "name": "SignatureIntegrationShare",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SignatureIntegrationShare_integrationId_idx": {
+          "name": "SignatureIntegrationShare_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SignatureIntegrationShare_entityInstanceId_idx": {
+          "name": "SignatureIntegrationShare_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SignatureIntegrationShare_entityInstanceId_integrationId_key": {
+          "name": "SignatureIntegrationShare_entityInstanceId_integrationId_key",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SignatureIntegrationShare_entityInstanceId_EntityInstance_id_fk": {
+          "name": "SignatureIntegrationShare_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "SignatureIntegrationShare",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SignatureIntegrationShare_integrationId_Integration_id_fk": {
+          "name": "SignatureIntegrationShare_integrationId_Integration_id_fk",
+          "tableFrom": "SignatureIntegrationShare",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Snippet": {
+      "name": "Snippet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHtml": {
+          "name": "contentHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDeleted": {
+          "name": "isDeleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharingType": {
+          "name": "sharingType",
+          "type": "SnippetSharingType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "isFavorite": {
+          "name": "isFavorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usageCount": {
+          "name": "usageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "Snippet_createdById_idx": {
+          "name": "Snippet_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Snippet_folderId_idx": {
+          "name": "Snippet_folderId_idx",
+          "columns": [
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Snippet_organizationId_idx": {
+          "name": "Snippet_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Snippet_sharingType_idx": {
+          "name": "Snippet_sharingType_idx",
+          "columns": [
+            {
+              "expression": "sharingType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Snippet_folderId_SnippetFolder_id_fk": {
+          "name": "Snippet_folderId_SnippetFolder_id_fk",
+          "tableFrom": "Snippet",
+          "tableTo": "SnippetFolder",
+          "columnsFrom": ["folderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Snippet_organizationId_Organization_id_fk": {
+          "name": "Snippet_organizationId_Organization_id_fk",
+          "tableFrom": "Snippet",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Snippet_createdById_User_id_fk": {
+          "name": "Snippet_createdById_User_id_fk",
+          "tableFrom": "Snippet",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SnippetFolder": {
+      "name": "SnippetFolder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "SnippetFolder_createdById_idx": {
+          "name": "SnippetFolder_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SnippetFolder_organizationId_idx": {
+          "name": "SnippetFolder_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SnippetFolder_organizationId_parentId_name_key": {
+          "name": "SnippetFolder_organizationId_parentId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SnippetFolder_parentId_SnippetFolder_id_fk": {
+          "name": "SnippetFolder_parentId_SnippetFolder_id_fk",
+          "tableFrom": "SnippetFolder",
+          "tableTo": "SnippetFolder",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "SnippetFolder_organizationId_Organization_id_fk": {
+          "name": "SnippetFolder_organizationId_Organization_id_fk",
+          "tableFrom": "SnippetFolder",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SnippetFolder_createdById_User_id_fk": {
+          "name": "SnippetFolder_createdById_User_id_fk",
+          "tableFrom": "SnippetFolder",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.StorageLocation": {
+      "name": "StorageLocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "StorageProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalUrl": {
+          "name": "externalUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalRev": {
+          "name": "externalRev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "StorageLocation_credentialId_idx": {
+          "name": "StorageLocation_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credentialId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StorageLocation_provider_externalId_idx": {
+          "name": "StorageLocation_provider_externalId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StorageLocation_organizationId_idx": {
+          "name": "StorageLocation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StorageLocation_deletedAt_idx": {
+          "name": "StorageLocation_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"StorageLocation\".\"deletedAt\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "StorageLocation_organizationId_Organization_id_fk": {
+          "name": "StorageLocation_organizationId_Organization_id_fk",
+          "tableFrom": "StorageLocation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "StorageLocation_credentialId_WorkflowCredentials_id_fk": {
+          "name": "StorageLocation_credentialId_WorkflowCredentials_id_fk",
+          "tableFrom": "StorageLocation",
+          "tableTo": "WorkflowCredentials",
+          "columnsFrom": ["credentialId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Subscription": {
+      "name": "Subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Subscription_provider_integrationId_topic_key": {
+          "name": "Subscription_provider_integrationId_topic_key",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Subscription_organizationId_Organization_id_fk": {
+          "name": "Subscription_organizationId_Organization_id_fk",
+          "tableFrom": "Subscription",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Subscription_integrationId_ShopifyIntegration_id_fk": {
+          "name": "Subscription_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "Subscription",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SuggestionDismissal": {
+      "name": "SuggestionDismissal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissedAtActivity": {
+          "name": "dismissedAtActivity",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snoozeUntil": {
+          "name": "snoozeUntil",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SuggestionDismissal_org_user_entity_key": {
+          "name": "SuggestionDismissal_org_user_entity_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SuggestionDismissal_org_user_idx": {
+          "name": "SuggestionDismissal_org_user_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SuggestionDismissal_organizationId_Organization_id_fk": {
+          "name": "SuggestionDismissal_organizationId_Organization_id_fk",
+          "tableFrom": "SuggestionDismissal",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SuggestionDismissal_userId_User_id_fk": {
+          "name": "SuggestionDismissal_userId_User_id_fk",
+          "tableFrom": "SuggestionDismissal",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SuggestionDismissal_entityInstanceId_EntityInstance_id_fk": {
+          "name": "SuggestionDismissal_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "SuggestionDismissal",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SyncJob": {
+      "name": "SyncJob",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "SYNC_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalRecords": {
+          "name": "totalRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processedRecords": {
+          "name": "processedRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failedRecords": {
+          "name": "failedRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "integrationCategory": {
+          "name": "integrationCategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'message'"
+        },
+        "integrationSyncJobIds": {
+          "name": "integrationSyncJobIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"RAY\"}'"
+        }
+      },
+      "indexes": {
+        "SyncJob_organizationId_integrationCategory_integrationId_idx": {
+          "name": "SyncJob_organizationId_integrationCategory_integrationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationCategory",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SyncJob_organizationId_integrationCategory_status_idx": {
+          "name": "SyncJob_organizationId_integrationCategory_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationCategory",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SyncJob_organizationId_type_status_idx": {
+          "name": "SyncJob_organizationId_type_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SyncJob_organizationId_Organization_id_fk": {
+          "name": "SyncJob_organizationId_Organization_id_fk",
+          "tableFrom": "SyncJob",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SystemModelDefault": {
+      "name": "SystemModelDefault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "SystemModelDefault_organizationId_modelType_key": {
+          "name": "SystemModelDefault_organizationId_modelType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SystemModelDefault_organizationId_idx": {
+          "name": "SystemModelDefault_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SystemModelDefault_organizationId_Organization_id_fk": {
+          "name": "SystemModelDefault_organizationId_Organization_id_fk",
+          "tableFrom": "SystemModelDefault",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TableView": {
+      "name": "TableView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tableId": {
+          "name": "tableId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextType": {
+          "name": "contextType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'table'"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TableView_tableId_organizationId_idx": {
+          "name": "TableView_tableId_organizationId_idx",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TableView_tableId_organizationId_contextType_isDefault_key": {
+          "name": "TableView_tableId_organizationId_contextType_isDefault_key",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"TableView\".\"isDefault\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TableView_tableId_userId_idx": {
+          "name": "TableView_tableId_userId_idx",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TableView_tableId_userId_name_contextType_key": {
+          "name": "TableView_tableId_userId_name_contextType_key",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TableView_userId_User_id_fk": {
+          "name": "TableView_userId_User_id_fk",
+          "tableFrom": "TableView",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TableView_organizationId_Organization_id_fk": {
+          "name": "TableView_organizationId_Organization_id_fk",
+          "tableFrom": "TableView",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Tag": {
+      "name": "Tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isSystemTag": {
+          "name": "isSystemTag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Tag_organizationId_idx": {
+          "name": "Tag_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Tag_parentId_idx": {
+          "name": "Tag_parentId_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Tag_title_organizationId_parentId_key": {
+          "name": "Tag_title_organizationId_parentId_key",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Tag_parentId_Tag_id_fk": {
+          "name": "Tag_parentId_Tag_id_fk",
+          "tableFrom": "Tag",
+          "tableTo": "Tag",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Tag_organizationId_Organization_id_fk": {
+          "name": "Tag_organizationId_Organization_id_fk",
+          "tableFrom": "Tag",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Task": {
+      "name": "Task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedById": {
+          "name": "completedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firedAt": {
+          "name": "firedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchText": {
+          "name": "searchText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedUserCount": {
+          "name": "assignedUserCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "referenceCount": {
+          "name": "referenceCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Task_organizationId_idx": {
+          "name": "Task_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_archivedAt_deadline_idx": {
+          "name": "Task_organizationId_archivedAt_deadline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_createdById_idx": {
+          "name": "Task_organizationId_createdById_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_deadline_idx": {
+          "name": "Task_organizationId_deadline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_createdAt_idx": {
+          "name": "Task_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_completedAt_idx": {
+          "name": "Task_organizationId_completedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_firedAt_deadline_idx": {
+          "name": "Task_organizationId_firedAt_deadline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"completedAt\" IS NULL AND \"archivedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Task_organizationId_Organization_id_fk": {
+          "name": "Task_organizationId_Organization_id_fk",
+          "tableFrom": "Task",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Task_createdById_User_id_fk": {
+          "name": "Task_createdById_User_id_fk",
+          "tableFrom": "Task",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Task_completedById_User_id_fk": {
+          "name": "Task_completedById_User_id_fk",
+          "tableFrom": "Task",
+          "tableTo": "User",
+          "columnsFrom": ["completedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TaskAssignment": {
+      "name": "TaskAssignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedToUserId": {
+          "name": "assignedToUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedAt": {
+          "name": "assignedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "assignedById": {
+          "name": "assignedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unassignedAt": {
+          "name": "unassignedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TaskAssignment_organizationId_idx": {
+          "name": "TaskAssignment_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_taskId_idx": {
+          "name": "TaskAssignment_taskId_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_assignedToUserId_idx": {
+          "name": "TaskAssignment_assignedToUserId_idx",
+          "columns": [
+            {
+              "expression": "assignedToUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_organizationId_assignedToUserId_unassignedAt_idx": {
+          "name": "TaskAssignment_organizationId_assignedToUserId_unassignedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedToUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "unassignedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_taskId_assignedAt_idx": {
+          "name": "TaskAssignment_taskId_assignedAt_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_unassignedAt_idx": {
+          "name": "TaskAssignment_unassignedAt_idx",
+          "columns": [
+            {
+              "expression": "unassignedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_taskId_assignedToUserId_key": {
+          "name": "TaskAssignment_taskId_assignedToUserId_key",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedToUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TaskAssignment_organizationId_Organization_id_fk": {
+          "name": "TaskAssignment_organizationId_Organization_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskAssignment_taskId_Task_id_fk": {
+          "name": "TaskAssignment_taskId_Task_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "Task",
+          "columnsFrom": ["taskId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskAssignment_assignedToUserId_User_id_fk": {
+          "name": "TaskAssignment_assignedToUserId_User_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "User",
+          "columnsFrom": ["assignedToUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskAssignment_assignedById_User_id_fk": {
+          "name": "TaskAssignment_assignedById_User_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "User",
+          "columnsFrom": ["assignedById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TaskReference": {
+      "name": "TaskReference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referencedEntityInstanceId": {
+          "name": "referencedEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referencedEntityDefinitionId": {
+          "name": "referencedEntityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TaskReference_organizationId_idx": {
+          "name": "TaskReference_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_taskId_idx": {
+          "name": "TaskReference_taskId_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_referencedEntityInstanceId_idx": {
+          "name": "TaskReference_referencedEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "referencedEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_referencedEntityDefinitionId_idx": {
+          "name": "TaskReference_referencedEntityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "referencedEntityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_organizationId_referencedEntityInstanceId_deletedAt_idx": {
+          "name": "TaskReference_organizationId_referencedEntityInstanceId_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referencedEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_deletedAt_idx": {
+          "name": "TaskReference_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_taskId_referencedEntityInstanceId_key": {
+          "name": "TaskReference_taskId_referencedEntityInstanceId_key",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referencedEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TaskReference_organizationId_Organization_id_fk": {
+          "name": "TaskReference_organizationId_Organization_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_taskId_Task_id_fk": {
+          "name": "TaskReference_taskId_Task_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "Task",
+          "columnsFrom": ["taskId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_referencedEntityInstanceId_EntityInstance_id_fk": {
+          "name": "TaskReference_referencedEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["referencedEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_referencedEntityDefinitionId_EntityDefinition_id_fk": {
+          "name": "TaskReference_referencedEntityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["referencedEntityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_createdById_User_id_fk": {
+          "name": "TaskReference_createdById_User_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Thread": {
+      "name": "Thread",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ThreadStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "messageCount": {
+          "name": "messageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participantCount": {
+          "name": "participantCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "firstMessageAt": {
+          "name": "firstMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latestMessageId": {
+          "name": "latestMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latestCommentId": {
+          "name": "latestCommentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inboxId": {
+          "name": "inboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryEntityInstanceId": {
+          "name": "primaryEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryEntityDefinitionId": {
+          "name": "primaryEntityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repliedAt": {
+          "name": "repliedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitingSince": {
+          "name": "waitingSince",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Thread_integrationId_externalId_key": {
+          "name": "Thread_integrationId_externalId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_integrationId_idx": {
+          "name": "Thread_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_lastMessageAt_idx": {
+          "name": "Thread_lastMessageAt_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_assigneeId_status_idx": {
+          "name": "Thread_organizationId_assigneeId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigneeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_createdAt_idx": {
+          "name": "Thread_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_idx": {
+          "name": "Thread_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_status_idx": {
+          "name": "Thread_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_status_idx": {
+          "name": "Thread_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_pagination_idx": {
+          "name": "thread_pagination_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_inboxId_idx": {
+          "name": "Thread_inboxId_idx",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_primaryEntityInstanceId_idx": {
+          "name": "Thread_organizationId_primaryEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "primaryEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_primaryEntityDefinitionId_lastMessageAt_idx": {
+          "name": "Thread_organizationId_primaryEntityDefinitionId_lastMessageAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "primaryEntityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Thread_organizationId_Organization_id_fk": {
+          "name": "Thread_organizationId_Organization_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Thread_integrationId_Integration_id_fk": {
+          "name": "Thread_integrationId_Integration_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Thread_assigneeId_User_id_fk": {
+          "name": "Thread_assigneeId_User_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "User",
+          "columnsFrom": ["assigneeId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_latestMessageId_Message_id_fk": {
+          "name": "Thread_latestMessageId_Message_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Message",
+          "columnsFrom": ["latestMessageId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_latestCommentId_Comment_id_fk": {
+          "name": "Thread_latestCommentId_Comment_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Comment",
+          "columnsFrom": ["latestCommentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_inboxId_EntityInstance_id_fk": {
+          "name": "Thread_inboxId_EntityInstance_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["inboxId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_primaryEntityInstanceId_EntityInstance_id_fk": {
+          "name": "Thread_primaryEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["primaryEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_primaryEntityDefinitionId_EntityDefinition_id_fk": {
+          "name": "Thread_primaryEntityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["primaryEntityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ThreadEntityLink": {
+      "name": "ThreadEntityLink",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unlinkedAt": {
+          "name": "unlinkedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ThreadEntityLink_organizationId_idx": {
+          "name": "ThreadEntityLink_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_threadId_idx": {
+          "name": "ThreadEntityLink_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_entityInstanceId_idx": {
+          "name": "ThreadEntityLink_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_entityDefinitionId_idx": {
+          "name": "ThreadEntityLink_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_unlinkedAt_idx": {
+          "name": "ThreadEntityLink_unlinkedAt_idx",
+          "columns": [
+            {
+              "expression": "unlinkedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_threadId_entityInstanceId_active_key": {
+          "name": "ThreadEntityLink_threadId_entityInstanceId_active_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"unlinkedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ThreadEntityLink_organizationId_Organization_id_fk": {
+          "name": "ThreadEntityLink_organizationId_Organization_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadEntityLink_threadId_Thread_id_fk": {
+          "name": "ThreadEntityLink_threadId_Thread_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadEntityLink_entityInstanceId_EntityInstance_id_fk": {
+          "name": "ThreadEntityLink_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadEntityLink_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "ThreadEntityLink_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadEntityLink_createdById_User_id_fk": {
+          "name": "ThreadEntityLink_createdById_User_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ThreadParticipant": {
+      "name": "ThreadParticipant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isInternal": {
+          "name": "isInternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "messageCount": {
+          "name": "messageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "firstMessageAt": {
+          "name": "firstMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ThreadParticipant_threadId_email_key": {
+          "name": "ThreadParticipant_threadId_email_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ThreadParticipant_threadId_Thread_id_fk": {
+          "name": "ThreadParticipant_threadId_Thread_id_fk",
+          "tableFrom": "ThreadParticipant",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ThreadReadStatus": {
+      "name": "ThreadReadStatus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSeenMessageId": {
+          "name": "lastSeenMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ThreadReadStatus_isRead_idx": {
+          "name": "ThreadReadStatus_isRead_idx",
+          "columns": [
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_organizationId_idx": {
+          "name": "ThreadReadStatus_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_organizationId_userId_idx": {
+          "name": "ThreadReadStatus_organizationId_userId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_threadId_idx": {
+          "name": "ThreadReadStatus_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_threadId_userId_key": {
+          "name": "ThreadReadStatus_threadId_userId_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_userId_idx": {
+          "name": "ThreadReadStatus_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_userId_isRead_idx": {
+          "name": "ThreadReadStatus_userId_isRead_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ThreadReadStatus_threadId_Thread_id_fk": {
+          "name": "ThreadReadStatus_threadId_Thread_id_fk",
+          "tableFrom": "ThreadReadStatus",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadReadStatus_userId_User_id_fk": {
+          "name": "ThreadReadStatus_userId_User_id_fk",
+          "tableFrom": "ThreadReadStatus",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadReadStatus_organizationId_Organization_id_fk": {
+          "name": "ThreadReadStatus_organizationId_Organization_id_fk",
+          "tableFrom": "ThreadReadStatus",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TicketSequence": {
+      "name": "TicketSequence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentNumber": {
+          "name": "currentNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paddingLength": {
+          "name": "paddingLength",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4
+        },
+        "usePrefix": {
+          "name": "usePrefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "useDateInPrefix": {
+          "name": "useDateInPrefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dateFormat": {
+          "name": "dateFormat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'YYMM'"
+        },
+        "separator": {
+          "name": "separator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-'"
+        },
+        "suffix": {
+          "name": "suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "useSuffix": {
+          "name": "useSuffix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TicketSequence_organizationId_key": {
+          "name": "TicketSequence_organizationId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TicketSequence_organizationId_Organization_id_fk": {
+          "name": "TicketSequence_organizationId_Organization_id_fk",
+          "tableFrom": "TicketSequence",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TimelineEvent": {
+      "name": "TimelineEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relatedEntityType": {
+          "name": "relatedEntityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedEntityId": {
+          "name": "relatedEntityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorType": {
+          "name": "actorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventData": {
+          "name": "eventData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isGrouped": {
+          "name": "isGrouped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "groupedEventIds": {
+          "name": "groupedEventIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TimelineEvent_entity_idx": {
+          "name": "TimelineEvent_entity_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_actor_idx": {
+          "name": "TimelineEvent_actor_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actorType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_type_idx": {
+          "name": "TimelineEvent_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_related_entity_idx": {
+          "name": "TimelineEvent_related_entity_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_org_timeline_idx": {
+          "name": "TimelineEvent_org_timeline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TimelineEvent_organizationId_Organization_id_fk": {
+          "name": "TimelineEvent_organizationId_Organization_id_fk",
+          "tableFrom": "TimelineEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Transcript": {
+      "name": "Transcript",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcriptionProvider": {
+          "name": "transcriptionProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TranscriptType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "TranscriptStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "externalJobId": {
+          "name": "externalJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fullText": {
+          "name": "fullText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wordCount": {
+          "name": "wordCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Transcript_organizationId_idx": {
+          "name": "Transcript_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transcript_callRecordingId_idx": {
+          "name": "Transcript_callRecordingId_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transcript_status_idx": {
+          "name": "Transcript_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Transcript_organizationId_Organization_id_fk": {
+          "name": "Transcript_organizationId_Organization_id_fk",
+          "tableFrom": "Transcript",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Transcript_callRecordingId_CallRecording_id_fk": {
+          "name": "Transcript_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "Transcript",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TranscriptSpeaker": {
+      "name": "TranscriptSpeaker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcriptId": {
+          "name": "transcriptId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isHost": {
+          "name": "isHost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participantId": {
+          "name": "participantId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manualParticipantId": {
+          "name": "manualParticipantId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "TranscriptSpeaker_transcriptId_idx": {
+          "name": "TranscriptSpeaker_transcriptId_idx",
+          "columns": [
+            {
+              "expression": "transcriptId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TranscriptSpeaker_callRecordingId_idx": {
+          "name": "TranscriptSpeaker_callRecordingId_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TranscriptSpeaker_organizationId_Organization_id_fk": {
+          "name": "TranscriptSpeaker_organizationId_Organization_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptSpeaker_transcriptId_Transcript_id_fk": {
+          "name": "TranscriptSpeaker_transcriptId_Transcript_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "Transcript",
+          "columnsFrom": ["transcriptId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptSpeaker_callRecordingId_CallRecording_id_fk": {
+          "name": "TranscriptSpeaker_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptSpeaker_participantId_MeetingParticipant_id_fk": {
+          "name": "TranscriptSpeaker_participantId_MeetingParticipant_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "MeetingParticipant",
+          "columnsFrom": ["participantId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "TranscriptSpeaker_manualParticipantId_MeetingParticipant_id_fk": {
+          "name": "TranscriptSpeaker_manualParticipantId_MeetingParticipant_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "MeetingParticipant",
+          "columnsFrom": ["manualParticipantId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TranscriptUtterance": {
+      "name": "TranscriptUtterance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcriptId": {
+          "name": "transcriptId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speakerId": {
+          "name": "speakerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startMs": {
+          "name": "startMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endMs": {
+          "name": "endMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "words": {
+          "name": "words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "TranscriptUtterance_transcriptId_sortOrder_idx": {
+          "name": "TranscriptUtterance_transcriptId_sortOrder_idx",
+          "columns": [
+            {
+              "expression": "transcriptId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortOrder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TranscriptUtterance_speakerId_idx": {
+          "name": "TranscriptUtterance_speakerId_idx",
+          "columns": [
+            {
+              "expression": "speakerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TranscriptUtterance_organizationId_Organization_id_fk": {
+          "name": "TranscriptUtterance_organizationId_Organization_id_fk",
+          "tableFrom": "TranscriptUtterance",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptUtterance_transcriptId_Transcript_id_fk": {
+          "name": "TranscriptUtterance_transcriptId_Transcript_id_fk",
+          "tableFrom": "TranscriptUtterance",
+          "tableTo": "Transcript",
+          "columnsFrom": ["transcriptId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptUtterance_speakerId_TranscriptSpeaker_id_fk": {
+          "name": "TranscriptUtterance_speakerId_TranscriptSpeaker_id_fk",
+          "tableFrom": "TranscriptUtterance",
+          "tableTo": "TranscriptSpeaker",
+          "columnsFrom": ["speakerId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TwoFactor": {
+      "name": "TwoFactor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backupCodes": {
+          "name": "backupCodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TwoFactor_userId_key": {
+          "name": "TwoFactor_userId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TwoFactor_userId_User_id_fk": {
+          "name": "TwoFactor_userId_User_id_fk",
+          "tableFrom": "TwoFactor",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UploadSession": {
+      "name": "UploadSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "StorageProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S3'"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expectedSize": {
+          "name": "expectedSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UploadSession_organizationId_createdById_idx": {
+          "name": "UploadSession_organizationId_createdById_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UploadSession_provider_externalId_idx": {
+          "name": "UploadSession_provider_externalId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UploadSession_organizationId_Organization_id_fk": {
+          "name": "UploadSession_organizationId_Organization_id_fk",
+          "tableFrom": "UploadSession",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UsageEvent": {
+      "name": "UsageEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodKey": {
+          "name": "periodKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UsageEvent_org_metric_period_idx": {
+          "name": "UsageEvent_org_metric_period_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "periodKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UsageEvent_organizationId_Organization_id_fk": {
+          "name": "UsageEvent_organizationId_Organization_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "UsageEvent_userId_User_id_fk": {
+          "name": "UsageEvent_userId_User_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastLoginAt": {
+          "name": "lastLoginAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferredTimezone": {
+          "name": "preferredTimezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedOnboarding": {
+          "name": "completedOnboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "twoFactorEnabled": {
+          "name": "twoFactorEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "hashedPassword": {
+          "name": "hashedPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchEmailsExpirationDate": {
+          "name": "watchEmailsExpirationDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isSuperAdmin": {
+          "name": "isSuperAdmin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "defaultOrganizationId": {
+          "name": "defaultOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "webhookSecret": {
+          "name": "webhookSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "phoneNumber": {
+          "name": "phoneNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phoneNumberVerified": {
+          "name": "phoneNumberVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatarAssetId": {
+          "name": "avatarAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userType": {
+          "name": "userType",
+          "type": "UserType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bannedReason": {
+          "name": "bannedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannedAt": {
+          "name": "bannedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forcePasswordChange": {
+          "name": "forcePasswordChange",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "User_avatarAssetId_key": {
+          "name": "User_avatarAssetId_key",
+          "columns": [
+            {
+              "expression": "avatarAssetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_email_key": {
+          "name": "User_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "User_avatarAssetId_MediaAsset_id_fk": {
+          "name": "User_avatarAssetId_MediaAsset_id_fk",
+          "tableFrom": "User",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["avatarAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserInboxUnreadCount": {
+      "name": "UserInboxUnreadCount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inboxId": {
+          "name": "inboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastUpdatedAt": {
+          "name": "lastUpdatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UserInboxUnreadCount_inboxId_idx": {
+          "name": "UserInboxUnreadCount_inboxId_idx",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_organizationId_idx": {
+          "name": "UserInboxUnreadCount_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_organizationId_inboxId_userId_key": {
+          "name": "UserInboxUnreadCount_organizationId_inboxId_userId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_organizationId_userId_idx": {
+          "name": "UserInboxUnreadCount_organizationId_userId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_userId_idx": {
+          "name": "UserInboxUnreadCount_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserInboxUnreadCount_inboxId_EntityInstance_id_fk": {
+          "name": "UserInboxUnreadCount_inboxId_EntityInstance_id_fk",
+          "tableFrom": "UserInboxUnreadCount",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["inboxId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "UserInboxUnreadCount_userId_User_id_fk": {
+          "name": "UserInboxUnreadCount_userId_User_id_fk",
+          "tableFrom": "UserInboxUnreadCount",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "UserInboxUnreadCount_organizationId_Organization_id_fk": {
+          "name": "UserInboxUnreadCount_organizationId_Organization_id_fk",
+          "tableFrom": "UserInboxUnreadCount",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserSetting": {
+      "name": "UserSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationSettingId": {
+          "name": "organizationSettingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UserSetting_organizationSettingId_idx": {
+          "name": "UserSetting_organizationSettingId_idx",
+          "columns": [
+            {
+              "expression": "organizationSettingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSetting_userId_idx": {
+          "name": "UserSetting_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSetting_userId_organizationSettingId_key": {
+          "name": "UserSetting_userId_organizationSettingId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationSettingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserSetting_userId_User_id_fk": {
+          "name": "UserSetting_userId_User_id_fk",
+          "tableFrom": "UserSetting",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "UserSetting_organizationSettingId_OrganizationSetting_id_fk": {
+          "name": "UserSetting_organizationSettingId_OrganizationSetting_id_fk",
+          "tableFrom": "UserSetting",
+          "tableTo": "OrganizationSetting",
+          "columnsFrom": ["organizationSettingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.VerificationToken": {
+      "name": "VerificationToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "VerificationToken_token_key": {
+          "name": "VerificationToken_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "VerificationToken_userId_idx": {
+          "name": "VerificationToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "VerificationToken_userId_User_id_fk": {
+          "name": "VerificationToken_userId_User_id_fk",
+          "tableFrom": "VerificationToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Webhook": {
+      "name": "Webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "eventTypes": {
+          "name": "eventTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastTriggeredAt": {
+          "name": "lastTriggeredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Webhook_organizationId_idx": {
+          "name": "Webhook_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Webhook_organizationId_Organization_id_fk": {
+          "name": "Webhook_organizationId_Organization_id_fk",
+          "tableFrom": "Webhook",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WebhookDelivery": {
+      "name": "WebhookDelivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookId": {
+          "name": "webhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responseStatus": {
+          "name": "responseStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responseBody": {
+          "name": "responseBody",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attemptCount": {
+          "name": "attemptCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "nextRetryAt": {
+          "name": "nextRetryAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "WebhookDelivery_webhookId_idx": {
+          "name": "WebhookDelivery_webhookId_idx",
+          "columns": [
+            {
+              "expression": "webhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WebhookDelivery_webhookId_Webhook_id_fk": {
+          "name": "WebhookDelivery_webhookId_Webhook_id_fk",
+          "tableFrom": "WebhookDelivery",
+          "tableTo": "Webhook",
+          "columnsFrom": ["webhookId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WebhookEvent": {
+      "name": "WebhookEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retryCount": {
+          "name": "retryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "SYNC_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WebhookEvent_integrationId_idx": {
+          "name": "WebhookEvent_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WebhookEvent_organizationId_idx": {
+          "name": "WebhookEvent_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WebhookEvent_subscriptionId_Subscription_id_fk": {
+          "name": "WebhookEvent_subscriptionId_Subscription_id_fk",
+          "tableFrom": "WebhookEvent",
+          "tableTo": "Subscription",
+          "columnsFrom": ["subscriptionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WebhookEvent_integrationId_ShopifyIntegration_id_fk": {
+          "name": "WebhookEvent_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "WebhookEvent",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WebhookEvent_organizationId_Organization_id_fk": {
+          "name": "WebhookEvent_organizationId_Organization_id_fk",
+          "tableFrom": "WebhookEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Workflow": {
+      "name": "Workflow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAppId": {
+          "name": "triggerAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerTriggerId": {
+          "name": "triggerTriggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerInstallationId": {
+          "name": "triggerInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerConnectionId": {
+          "name": "triggerConnectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Workflow_organizationId_enabled_idx": {
+          "name": "Workflow_organizationId_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Workflow_orgId_triggerType_entityDefId_idx": {
+          "name": "Workflow_orgId_triggerType_entityDefId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Workflow_orgId_appTrigger_idx": {
+          "name": "Workflow_orgId_appTrigger_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerTriggerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Workflow_organizationId_Organization_id_fk": {
+          "name": "Workflow_organizationId_Organization_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Workflow_createdById_User_id_fk": {
+          "name": "Workflow_createdById_User_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Workflow_workflowAppId_WorkflowApp_id_fk": {
+          "name": "Workflow_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowApp": {
+      "name": "WorkflowApp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isUniversal": {
+          "name": "isUniversal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draftWorkflowId": {
+          "name": "draftWorkflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shareToken": {
+          "name": "shareToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webEnabled": {
+          "name": "webEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "apiEnabled": {
+          "name": "apiEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessMode": {
+          "name": "accessMode",
+          "type": "WorkflowShareAccessMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rateLimit": {
+          "name": "rateLimit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalRuns": {
+          "name": "totalRuns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowApp_draftWorkflowId_key": {
+          "name": "WorkflowApp_draftWorkflowId_key",
+          "columns": [
+            {
+              "expression": "draftWorkflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_organizationId_enabled_idx": {
+          "name": "WorkflowApp_organizationId_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_organizationId_isPublic_idx": {
+          "name": "WorkflowApp_organizationId_isPublic_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_workflowId_key": {
+          "name": "WorkflowApp_workflowId_key",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_shareToken_key": {
+          "name": "WorkflowApp_shareToken_key",
+          "columns": [
+            {
+              "expression": "shareToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_webEnabled_idx": {
+          "name": "WorkflowApp_webEnabled_idx",
+          "columns": [
+            {
+              "expression": "webEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_apiEnabled_idx": {
+          "name": "WorkflowApp_apiEnabled_idx",
+          "columns": [
+            {
+              "expression": "apiEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowApp_organizationId_Organization_id_fk": {
+          "name": "WorkflowApp_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowApp_createdById_User_id_fk": {
+          "name": "WorkflowApp_createdById_User_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "WorkflowApp_workflowId_Workflow_id_fk": {
+          "name": "WorkflowApp_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "WorkflowApp_draftWorkflowId_Workflow_id_fk": {
+          "name": "WorkflowApp_draftWorkflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "Workflow",
+          "columnsFrom": ["draftWorkflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "WorkflowApp_shareToken_unique": {
+          "name": "WorkflowApp_shareToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["shareToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowCredentials": {
+      "name": "WorkflowCredentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryptedData": {
+          "name": "encryptedData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastTokenRefreshAt": {
+          "name": "lastTokenRefreshAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRefreshFailureAt": {
+          "name": "lastRefreshFailureAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutiveRefreshFailures": {
+          "name": "consecutiveRefreshFailures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "WorkflowCredentials_createdById_idx": {
+          "name": "WorkflowCredentials_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_organizationId_idx": {
+          "name": "WorkflowCredentials_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_organizationId_type_idx": {
+          "name": "WorkflowCredentials_organizationId_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_appId_organizationId_idx": {
+          "name": "WorkflowCredentials_appId_organizationId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_userId_appId_idx": {
+          "name": "WorkflowCredentials_userId_appId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_appInstallationId_idx": {
+          "name": "WorkflowCredentials_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_expiresAt_idx": {
+          "name": "WorkflowCredentials_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_lastTokenRefreshAt_idx": {
+          "name": "WorkflowCredentials_lastTokenRefreshAt_idx",
+          "columns": [
+            {
+              "expression": "lastTokenRefreshAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowCredentials_organizationId_Organization_id_fk": {
+          "name": "WorkflowCredentials_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowCredentials_createdById_User_id_fk": {
+          "name": "WorkflowCredentials_createdById_User_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowCredentials_userId_User_id_fk": {
+          "name": "WorkflowCredentials_userId_User_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowCredentials_appId_App_id_fk": {
+          "name": "WorkflowCredentials_appId_App_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowCredentials_appInstallationId_AppInstallation_id_fk": {
+          "name": "WorkflowCredentials_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowFile": {
+      "name": "WorkflowFile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploadedAt": {
+          "name": "uploadedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "uploadSource": {
+          "name": "uploadSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "originalUrl": {
+          "name": "originalUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowFile_expiresAt_idx": {
+          "name": "WorkflowFile_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowFile_nodeId_idx": {
+          "name": "WorkflowFile_nodeId_idx",
+          "columns": [
+            {
+              "expression": "nodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowFile_workflowId_fileId_key": {
+          "name": "WorkflowFile_workflowId_fileId_key",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowFile_workflowId_idx": {
+          "name": "WorkflowFile_workflowId_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowFile_workflowId_Workflow_id_fk": {
+          "name": "WorkflowFile_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowFile",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowFile_fileId_File_id_fk": {
+          "name": "WorkflowFile_fileId_File_id_fk",
+          "tableFrom": "WorkflowFile",
+          "tableTo": "File",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowJoinState": {
+      "name": "WorkflowJoinState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joinNodeId": {
+          "name": "joinNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forkNodeId": {
+          "name": "forkNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expectedInputs": {
+          "name": "expectedInputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedInputs": {
+          "name": "completedInputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branchResults": {
+          "name": "branchResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "WorkflowJoinState_executionId_idx": {
+          "name": "WorkflowJoinState_executionId_idx",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowJoinState_executionId_joinNodeId_key": {
+          "name": "WorkflowJoinState_executionId_joinNodeId_key",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "joinNodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowJoinState_workflowId_idx": {
+          "name": "WorkflowJoinState_workflowId_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowJoinState_workflowId_Workflow_id_fk": {
+          "name": "WorkflowJoinState_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowJoinState",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowNodeExecution": {
+      "name": "WorkflowNodeExecution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggeredFrom": {
+          "name": "triggeredFrom",
+          "type": "NodeTriggerSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowRunId": {
+          "name": "workflowRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "predecessorNodeId": {
+          "name": "predecessorNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeType": {
+          "name": "nodeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processData": {
+          "name": "processData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "NodeExecutionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsedTime": {
+          "name": "elapsedTime",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionMetadata": {
+          "name": "executionMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowNodeExecution_nodeId_idx": {
+          "name": "WorkflowNodeExecution_nodeId_idx",
+          "columns": [
+            {
+              "expression": "nodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowNodeExecution_status_idx": {
+          "name": "WorkflowNodeExecution_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowNodeExecution_workflowRunId_idx": {
+          "name": "WorkflowNodeExecution_workflowRunId_idx",
+          "columns": [
+            {
+              "expression": "workflowRunId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowNodeExecution_organizationId_Organization_id_fk": {
+          "name": "WorkflowNodeExecution_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_workflowAppId_WorkflowApp_id_fk": {
+          "name": "WorkflowNodeExecution_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_workflowId_Workflow_id_fk": {
+          "name": "WorkflowNodeExecution_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_workflowRunId_WorkflowRun_id_fk": {
+          "name": "WorkflowNodeExecution_workflowRunId_WorkflowRun_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "WorkflowRun",
+          "columnsFrom": ["workflowRunId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_createdById_User_id_fk": {
+          "name": "WorkflowNodeExecution_createdById_User_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowRun": {
+      "name": "WorkflowRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequenceNumber": {
+          "name": "sequenceNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggeredFrom": {
+          "name": "triggeredFrom",
+          "type": "WorkflowTriggerSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsedTime": {
+          "name": "elapsedTime",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalSteps": {
+          "name": "totalSteps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pausedAt": {
+          "name": "pausedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pausedNodeId": {
+          "name": "pausedNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumeAt": {
+          "name": "resumeAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serializedState": {
+          "name": "serializedState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endUserId": {
+          "name": "endUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowRun_createdAt_idx": {
+          "name": "WorkflowRun_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_organizationId_workflowAppId_idx": {
+          "name": "WorkflowRun_organizationId_workflowAppId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_resumeAt_idx": {
+          "name": "WorkflowRun_resumeAt_idx",
+          "columns": [
+            {
+              "expression": "resumeAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_status_idx": {
+          "name": "WorkflowRun_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_workflowId_idx": {
+          "name": "WorkflowRun_workflowId_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowRun_organizationId_Organization_id_fk": {
+          "name": "WorkflowRun_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_workflowAppId_WorkflowApp_id_fk": {
+          "name": "WorkflowRun_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_workflowId_Workflow_id_fk": {
+          "name": "WorkflowRun_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_createdBy_User_id_fk": {
+          "name": "WorkflowRun_createdBy_User_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "User",
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_endUserId_EndUser_id_fk": {
+          "name": "WorkflowRun_endUserId_EndUser_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "EndUser",
+          "columnsFrom": ["endUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowTemplate": {
+      "name": "WorkflowTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "imgUrl": {
+          "name": "imgUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerConfig": {
+          "name": "triggerConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envVars": {
+          "name": "envVars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiredApps": {
+          "name": "requiredApps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "requiredEntities": {
+          "name": "requiredEntities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "WorkflowTemplate_status_idx": {
+          "name": "WorkflowTemplate_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowTemplate_popularity_idx": {
+          "name": "WorkflowTemplate_popularity_idx",
+          "columns": [
+            {
+              "expression": "popularity",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowTemplate_name_idx": {
+          "name": "WorkflowTemplate_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowTemplate_categories_idx": {
+          "name": "WorkflowTemplate_categories_idx",
+          "columns": [
+            {
+              "expression": "categories",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ActionType": {
+      "name": "ActionType",
+      "schema": "public",
+      "values": [
+        "ARCHIVE",
+        "LABEL",
+        "REPLY",
+        "FORWARD",
+        "MARK_SPAM",
+        "DRAFT_EMAIL",
+        "SEND_MESSAGE",
+        "APPLY_TAG",
+        "REMOVE_TAG",
+        "APPLY_LABEL",
+        "REMOVE_LABEL",
+        "MARK_TRASH",
+        "ASSIGN_THREAD",
+        "ARCHIVE_THREAD",
+        "UNARCHIVE_THREAD",
+        "MOVE_TO_TRASH",
+        "REACT_TO_MESSAGE",
+        "SHARE_MESSAGE",
+        "SEND_SMS",
+        "MAKE_CALL",
+        "ESCALATE",
+        "ASSIGN",
+        "NOTIFY",
+        "CREATE_TICKET",
+        "SHOPIFY_ORDER_LOOKUP",
+        "SHOPIFY_GENERATE_RESPONSE"
+      ]
+    },
+    "public.AiIntegrationStatus": {
+      "name": "AiIntegrationStatus",
+      "schema": "public",
+      "values": ["PENDING", "VALID", "INVALID"]
+    },
+    "public.AiProcessingStatus": {
+      "name": "AiProcessingStatus",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed"]
+    },
+    "public.ApprovalAction": {
+      "name": "ApprovalAction",
+      "schema": "public",
+      "values": ["approve", "deny"]
+    },
+    "public.ApprovalStatus": {
+      "name": "ApprovalStatus",
+      "schema": "public",
+      "values": ["pending", "approved", "denied", "timeout"]
+    },
+    "public.ArticleStatus": {
+      "name": "ArticleStatus",
+      "schema": "public",
+      "values": ["DRAFT", "PUBLISHED", "ARCHIVED"]
+    },
+    "public.AssetVersionStatus": {
+      "name": "AssetVersionStatus",
+      "schema": "public",
+      "values": ["PENDING", "PROCESSING", "READY", "FAILED"]
+    },
+    "public.BillingCycle": {
+      "name": "BillingCycle",
+      "schema": "public",
+      "values": ["MONTHLY", "ANNUAL"]
+    },
+    "public.CalendarEventStatus": {
+      "name": "CalendarEventStatus",
+      "schema": "public",
+      "values": ["confirmed", "tentative", "cancelled"]
+    },
+    "public.CalendarProvider": {
+      "name": "CalendarProvider",
+      "schema": "public",
+      "values": ["google", "outlook"]
+    },
+    "public.ChunkingStrategy": {
+      "name": "ChunkingStrategy",
+      "schema": "public",
+      "values": ["FIXED_SIZE", "SEMANTIC", "SENTENCE", "PARAGRAPH", "DOCUMENT"]
+    },
+    "public.ContactFieldType": {
+      "name": "ContactFieldType",
+      "schema": "public",
+      "values": [
+        "PHONE",
+        "EMAIL",
+        "ADDRESS",
+        "URL",
+        "TAGS",
+        "DATE",
+        "DATETIME",
+        "TIME",
+        "CHECKBOX",
+        "TEXT",
+        "NUMBER",
+        "CURRENCY",
+        "MULTI_SELECT",
+        "SINGLE_SELECT",
+        "RICH_TEXT",
+        "PHONE_INTL",
+        "ADDRESS_STRUCT",
+        "FILE",
+        "NAME",
+        "RELATIONSHIP",
+        "CALC",
+        "ACTOR",
+        "JSON"
+      ]
+    },
+    "public.CredentialSource": {
+      "name": "CredentialSource",
+      "schema": "public",
+      "values": ["SYSTEM", "CUSTOM", "MODEL_SPECIFIC", "LOAD_BALANCED"]
+    },
+    "public.CustomerSourceType": {
+      "name": "CustomerSourceType",
+      "schema": "public",
+      "values": ["EMAIL", "TICKET_SYSTEM", "SHOPIFY", "MANUAL", "OTHER", "FACEBOOK_PSID"]
+    },
+    "public.CustomerStatus": {
+      "name": "CustomerStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE", "SPAM", "MERGED"]
+    },
+    "public.DatasetStatus": {
+      "name": "DatasetStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE", "PROCESSING", "ERROR"]
+    },
+    "public.DeliveryStatus": {
+      "name": "DeliveryStatus",
+      "schema": "public",
+      "values": ["DELIVERED", "BOUNCED", "DELAYED", "DEFERRED", "REJECTED"]
+    },
+    "public.DocumentStatus": {
+      "name": "DocumentStatus",
+      "schema": "public",
+      "values": ["UPLOADED", "PROCESSING", "INDEXED", "FAILED", "ARCHIVED", "WAITING"]
+    },
+    "public.DocumentType": {
+      "name": "DocumentType",
+      "schema": "public",
+      "values": ["PDF", "DOCX", "TXT", "HTML", "MARKDOWN", "CSV", "JSON", "XML"]
+    },
+    "public.DomainType": {
+      "name": "DomainType",
+      "schema": "public",
+      "values": ["CUSTOM", "PROVIDER"]
+    },
+    "public.EmailLabel": {
+      "name": "EmailLabel",
+      "schema": "public",
+      "values": ["inbox", "sent", "draft"]
+    },
+    "public.EmailProvider": {
+      "name": "EmailProvider",
+      "schema": "public",
+      "values": ["GMAIL", "OUTLOOK", "IMAP"]
+    },
+    "public.EmailTemplateType": {
+      "name": "EmailTemplateType",
+      "schema": "public",
+      "values": [
+        "TICKET_CREATED",
+        "TICKET_REPLIED",
+        "TICKET_CLOSED",
+        "TICKET_REOPENED",
+        "TICKET_ASSIGNED",
+        "TICKET_STATUS_CHANGED",
+        "CUSTOM"
+      ]
+    },
+    "public.ExtractionRuleType": {
+      "name": "ExtractionRuleType",
+      "schema": "public",
+      "values": ["REGEX", "MARKER", "POSITION", "AI_ASSISTED", "VISUAL_SELECTION"]
+    },
+    "public.FavoriteNodeType": {
+      "name": "FavoriteNodeType",
+      "schema": "public",
+      "values": ["ITEM", "FOLDER"]
+    },
+    "public.FileStatus": {
+      "name": "FileStatus",
+      "schema": "public",
+      "values": ["PENDING", "CONFIRMED", "ARCHIVED", "DELETED", "FAILED"]
+    },
+    "public.FileVisibility": {
+      "name": "FileVisibility",
+      "schema": "public",
+      "values": ["PUBLIC", "PRIVATE", "INTERNAL"]
+    },
+    "public.FULFILLMENT_STATUS": {
+      "name": "FULFILLMENT_STATUS",
+      "schema": "public",
+      "values": ["CANCELLED", "ERROR", "FAILURE", "SUCCESS", "OPEN", "PENDING"]
+    },
+    "public.IdentifierType": {
+      "name": "IdentifierType",
+      "schema": "public",
+      "values": ["EMAIL", "PHONE", "FACEBOOK_PSID", "INSTAGRAM_IGSID"]
+    },
+    "public.ImportJobStatus": {
+      "name": "ImportJobStatus",
+      "schema": "public",
+      "values": [
+        "uploading",
+        "ingesting",
+        "waiting",
+        "planning",
+        "ready",
+        "executing",
+        "completed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.ImportMappingTargetType": {
+      "name": "ImportMappingTargetType",
+      "schema": "public",
+      "values": ["particle", "relation", "skip"]
+    },
+    "public.ImportPlanRowStatus": {
+      "name": "ImportPlanRowStatus",
+      "schema": "public",
+      "values": ["planned", "executing", "completed", "failed"]
+    },
+    "public.ImportPlanStatus": {
+      "name": "ImportPlanStatus",
+      "schema": "public",
+      "values": ["planning", "planned", "executing", "completed"]
+    },
+    "public.ImportResolutionStatus": {
+      "name": "ImportResolutionStatus",
+      "schema": "public",
+      "values": ["pending", "valid", "error", "warning", "create"]
+    },
+    "public.ImportStrategyStatus": {
+      "name": "ImportStrategyStatus",
+      "schema": "public",
+      "values": ["planning_queued", "planning", "planned", "executing", "completed"]
+    },
+    "public.ImportStrategyType": {
+      "name": "ImportStrategyType",
+      "schema": "public",
+      "values": ["create", "update", "skip"]
+    },
+    "public.InboxStatus": {
+      "name": "InboxStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "ARCHIVED", "PAUSED"]
+    },
+    "public.IndexStatus": {
+      "name": "IndexStatus",
+      "schema": "public",
+      "values": ["PENDING", "INDEXED", "ERROR"]
+    },
+    "public.InsightStatus": {
+      "name": "InsightStatus",
+      "schema": "public",
+      "values": ["processing", "completed", "failed"]
+    },
+    "public.InsightTemplateStatus": {
+      "name": "InsightTemplateStatus",
+      "schema": "public",
+      "values": ["enabled", "disabled", "archived"]
+    },
+    "public.IntegrationAuthStatus": {
+      "name": "IntegrationAuthStatus",
+      "schema": "public",
+      "values": [
+        "AUTHENTICATED",
+        "UNAUTHENTICATED",
+        "ERROR",
+        "INVALID_GRANT",
+        "EXPIRED_TOKEN",
+        "REVOKED_ACCESS",
+        "INSUFFICIENT_SCOPE",
+        "RATE_LIMITED",
+        "PROVIDER_ERROR",
+        "NETWORK_ERROR",
+        "UNKNOWN_ERROR"
+      ]
+    },
+    "public.IntegrationProviderType": {
+      "name": "IntegrationProviderType",
+      "schema": "public",
+      "values": [
+        "google",
+        "outlook",
+        "facebook",
+        "instagram",
+        "openphone",
+        "mailgun",
+        "sms",
+        "whatsapp",
+        "chat",
+        "email",
+        "shopify",
+        "imap"
+      ]
+    },
+    "public.IntegrationSyncStage": {
+      "name": "IntegrationSyncStage",
+      "schema": "public",
+      "values": [
+        "IDLE",
+        "MESSAGE_LIST_FETCH_PENDING",
+        "MESSAGE_LIST_FETCH",
+        "MESSAGES_IMPORT_PENDING",
+        "MESSAGES_IMPORT",
+        "FAILED"
+      ]
+    },
+    "public.IntegrationSyncStatus": {
+      "name": "IntegrationSyncStatus",
+      "schema": "public",
+      "values": ["NOT_SYNCED", "SYNCING", "ACTIVE", "FAILED"]
+    },
+    "public.INVENTORY_POLICY": {
+      "name": "INVENTORY_POLICY",
+      "schema": "public",
+      "values": ["CONTINUE", "DENY"]
+    },
+    "public.InvitationStatus": {
+      "name": "InvitationStatus",
+      "schema": "public",
+      "values": ["PENDING", "ACCEPTED", "EXPIRED", "CANCELLED"]
+    },
+    "public.InvoiceStatus": {
+      "name": "InvoiceStatus",
+      "schema": "public",
+      "values": ["PENDING", "PAID", "VOID", "UNCOLLECTIBLE", "DRAFT"]
+    },
+    "public.JobStatus": {
+      "name": "JobStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "PROCESSING",
+        "COMPLETED_SUCCESS",
+        "COMPLETED_PARTIAL",
+        "COMPLETED_FAILURE",
+        "FAILED",
+        "RETRYING"
+      ]
+    },
+    "public.KBPublishStatus": {
+      "name": "KBPublishStatus",
+      "schema": "public",
+      "values": ["DRAFT", "PUBLISHED", "UNLISTED"]
+    },
+    "public.KBVisibility": {
+      "name": "KBVisibility",
+      "schema": "public",
+      "values": ["PUBLIC", "INTERNAL"]
+    },
+    "public.LabelType": {
+      "name": "LabelType",
+      "schema": "public",
+      "values": ["system", "user"]
+    },
+    "public.MEDIA_CONTENT_TYPE": {
+      "name": "MEDIA_CONTENT_TYPE",
+      "schema": "public",
+      "values": ["EXTERNAL_VIDEO", "IMAGE", "MODEL_3D", "VIDEO"]
+    },
+    "public.MeetingMessageMethod": {
+      "name": "MeetingMessageMethod",
+      "schema": "public",
+      "values": ["request", "reply", "cancel", "counter", "other"]
+    },
+    "public.MeetingPlatform": {
+      "name": "MeetingPlatform",
+      "schema": "public",
+      "values": ["google_meet", "teams", "zoom", "unknown"]
+    },
+    "public.MessageType": {
+      "name": "MessageType",
+      "schema": "public",
+      "values": ["EMAIL", "FACEBOOK", "SMS", "WHATSAPP", "INSTAGRAM", "OPENPHONE", "CHAT"]
+    },
+    "public.ModelType": {
+      "name": "ModelType",
+      "schema": "public",
+      "values": ["LLM", "TEXT_EMBEDDING", "RERANK", "TTS", "SPEECH2TEXT", "MODERATION", "VISION"]
+    },
+    "public.NodeExecutionStatus": {
+      "name": "NodeExecutionStatus",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        "exception",
+        "skipped",
+        "stopped",
+        "waiting"
+      ]
+    },
+    "public.NodeTriggerSource": {
+      "name": "NodeTriggerSource",
+      "schema": "public",
+      "values": ["SINGLE_STEP", "WORKFLOW_RUN"]
+    },
+    "public.NotificationType": {
+      "name": "NotificationType",
+      "schema": "public",
+      "values": [
+        "COMMENT_MENTION",
+        "COMMENT_REPLY",
+        "COMMENT_REACTION",
+        "TICKET_ASSIGNED",
+        "TICKET_UPDATED",
+        "TICKET_MENTIONED",
+        "THREAD_ACTIVITY",
+        "SYSTEM_MESSAGE",
+        "WORKFLOW_APPROVAL_REQUIRED",
+        "WORKFLOW_APPROVAL_REMINDER",
+        "WORKFLOW_APPROVAL_COMPLETED",
+        "TASK_DEADLINE"
+      ]
+    },
+    "public.ORDER_ADDRESS_TYPE": {
+      "name": "ORDER_ADDRESS_TYPE",
+      "schema": "public",
+      "values": ["SHIPPING", "BILLING"]
+    },
+    "public.ORDER_CANCEL_REASON": {
+      "name": "ORDER_CANCEL_REASON",
+      "schema": "public",
+      "values": ["CUSTOMER", "DECLINED", "FRAUD", "INVENTORY", "OTHER", "STAFF"]
+    },
+    "public.ORDER_FINANCIAL_STATUS": {
+      "name": "ORDER_FINANCIAL_STATUS",
+      "schema": "public",
+      "values": [
+        "AUTHORIZED",
+        "EXPIRED",
+        "PAID",
+        "PARTIALLY_PAID",
+        "PARTIALLY_REFUNDED",
+        "PENDING",
+        "REFUNDED",
+        "VOIDED"
+      ]
+    },
+    "public.ORDER_FULFILLMENT_STATUS": {
+      "name": "ORDER_FULFILLMENT_STATUS",
+      "schema": "public",
+      "values": [
+        "FULFILLED",
+        "IN_PROGRESS",
+        "ON_HOLD",
+        "OPEN",
+        "PARTIALLY_FULFILLED",
+        "PENDING_FULFILLMENT",
+        "REQUEST_DECLINED",
+        "RESTOCKED",
+        "SCHEDULED",
+        "UNFULFILLED"
+      ]
+    },
+    "public.ORDER_RETURN_STATUS": {
+      "name": "ORDER_RETURN_STATUS",
+      "schema": "public",
+      "values": [
+        "INSPECTION_COMPLETED",
+        "IN_PROGRESS",
+        "NO_RETURN",
+        "RETURNED",
+        "RETURN_FAILED",
+        "RETURN_REQUESTED"
+      ]
+    },
+    "public.OrganizationMemberStatus": {
+      "name": "OrganizationMemberStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE"]
+    },
+    "public.OrganizationRole": {
+      "name": "OrganizationRole",
+      "schema": "public",
+      "values": ["OWNER", "ADMIN", "USER"]
+    },
+    "public.OrganizationType": {
+      "name": "OrganizationType",
+      "schema": "public",
+      "values": ["INDIVIDUAL", "TEAM"]
+    },
+    "public.ParticipantRole": {
+      "name": "ParticipantRole",
+      "schema": "public",
+      "values": ["FROM", "TO", "CC", "BCC", "REPLY_TO"]
+    },
+    "public.PRODUDT_STATUS": {
+      "name": "PRODUDT_STATUS",
+      "schema": "public",
+      "values": ["ACTIVE", "ARCHIVED", "DRAFT"]
+    },
+    "public.ProposedActionStatus": {
+      "name": "ProposedActionStatus",
+      "schema": "public",
+      "values": ["PENDING", "APPROVED", "REJECTED", "EXECUTED", "FAILED"]
+    },
+    "public.ProviderQuotaType": {
+      "name": "ProviderQuotaType",
+      "schema": "public",
+      "values": ["PAID", "FREE", "TRIAL"]
+    },
+    "public.ProviderType": {
+      "name": "ProviderType",
+      "schema": "public",
+      "values": ["SYSTEM", "CUSTOM"]
+    },
+    "public.RecipientRole": {
+      "name": "RecipientRole",
+      "schema": "public",
+      "values": ["FROM", "TO", "CC", "BCC"]
+    },
+    "public.RecordingProvider": {
+      "name": "RecordingProvider",
+      "schema": "public",
+      "values": ["recall", "babl", "self_hosted"]
+    },
+    "public.RecordingStatus": {
+      "name": "RecordingStatus",
+      "schema": "public",
+      "values": [
+        "created",
+        "joining",
+        "waiting",
+        "admitted",
+        "recording",
+        "processing",
+        "completed",
+        "failed",
+        "kicked",
+        "denied",
+        "timeout",
+        "cancelled"
+      ]
+    },
+    "public.ResponseStatus": {
+      "name": "ResponseStatus",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "PENDING_APPROVAL",
+        "APPROVED",
+        "SCHEDULED",
+        "SENDING",
+        "SENT",
+        "FAILED",
+        "CANCELLED"
+      ]
+    },
+    "public.ResponseType": {
+      "name": "ResponseType",
+      "schema": "public",
+      "values": ["MANUAL", "TEMPLATE", "AI_GENERATED", "RULE_BASED", "HYBRID"]
+    },
+    "public.RETURN_STATUS": {
+      "name": "RETURN_STATUS",
+      "schema": "public",
+      "values": ["CANCELLED", "CLOSED", "DECLINED", "OPEN", "REQUESTED"]
+    },
+    "public.RsvpStatus": {
+      "name": "RsvpStatus",
+      "schema": "public",
+      "values": ["accepted", "declined", "tentative", "needs_action"]
+    },
+    "public.RuleGroupOperator": {
+      "name": "RuleGroupOperator",
+      "schema": "public",
+      "values": ["AND", "OR", "NOT", "XOR", "THRESHOLD"]
+    },
+    "public.RuleType": {
+      "name": "RuleType",
+      "schema": "public",
+      "values": ["STATIC", "CATEGORY", "AI", "SPAM_HANDLER", "RULE_GROUP", "SHOPIFY_AUTOMATION"]
+    },
+    "public.ScheduledMessageSource": {
+      "name": "ScheduledMessageSource",
+      "schema": "public",
+      "values": ["USER_SCHEDULED", "AI_SUGGESTED", "AUTO_REPLY"]
+    },
+    "public.ScheduledMessageStatus": {
+      "name": "ScheduledMessageStatus",
+      "schema": "public",
+      "values": ["PENDING", "PROCESSING", "SENT", "FAILED", "CANCELLED"]
+    },
+    "public.SendStatus": {
+      "name": "SendStatus",
+      "schema": "public",
+      "values": ["PENDING", "SENT", "FAILED"]
+    },
+    "public.SenderType": {
+      "name": "SenderType",
+      "schema": "public",
+      "values": [
+        "INTERNAL_STAFF",
+        "INTERNAL_SYSTEM",
+        "PARTNER",
+        "CUSTOMER",
+        "VENDOR",
+        "UNKNOWN_EXTERNAL"
+      ]
+    },
+    "public.Sensitivity": {
+      "name": "Sensitivity",
+      "schema": "public",
+      "values": ["normal", "private", "personal", "confidential"]
+    },
+    "public.SettingScope": {
+      "name": "SettingScope",
+      "schema": "public",
+      "values": [
+        "APPEARANCE",
+        "NOTIFICATION",
+        "DASHBOARD",
+        "COMMUNICATION",
+        "SECURITY",
+        "INTEGRATION",
+        "GENERAL",
+        "SIDEBAR",
+        "RECORDING"
+      ]
+    },
+    "public.SignatureSharingType": {
+      "name": "SignatureSharingType",
+      "schema": "public",
+      "values": ["PRIVATE", "ORGANIZATION_WIDE", "SPECIFIC_INTEGRATIONS"]
+    },
+    "public.SnippetPermission": {
+      "name": "SnippetPermission",
+      "schema": "public",
+      "values": ["VIEW", "EDIT"]
+    },
+    "public.SnippetSharingType": {
+      "name": "SnippetSharingType",
+      "schema": "public",
+      "values": ["PRIVATE", "ORGANIZATION", "GROUPS", "MEMBERS"]
+    },
+    "public.StaticRuleType": {
+      "name": "StaticRuleType",
+      "schema": "public",
+      "values": [
+        "SENDER_DOMAIN",
+        "SENDER_ADDRESS",
+        "RECIPIENT_PATTERN",
+        "SUBJECT_MATCH",
+        "BODY_KEYWORD",
+        "HEADER_CHECK",
+        "ATTACHMENT_TYPE",
+        "COMBINED",
+        "INTERNAL_EXTERNAL",
+        "THREAD_BASED"
+      ]
+    },
+    "public.StorageProvider": {
+      "name": "StorageProvider",
+      "schema": "public",
+      "values": ["S3", "GOOGLE_DRIVE", "DROPBOX", "ONEDRIVE", "BOX", "GENERIC_URL"]
+    },
+    "public.SYNC_STATUS": {
+      "name": "SYNC_STATUS",
+      "schema": "public",
+      "values": ["PENDING", "IN_PROGRESS", "COMPLETED", "FAILED"]
+    },
+    "public.ThreadStatus": {
+      "name": "ThreadStatus",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "ARCHIVED",
+        "ACTIVE",
+        "RESOLVED",
+        "PENDING",
+        "CLOSED",
+        "SPAM",
+        "TRASH",
+        "IGNORED"
+      ]
+    },
+    "public.ThreadType": {
+      "name": "ThreadType",
+      "schema": "public",
+      "values": ["EMAIL", "CHAT"]
+    },
+    "public.TicketPriority": {
+      "name": "TicketPriority",
+      "schema": "public",
+      "values": ["LOW", "MEDIUM", "HIGH", "URGENT"]
+    },
+    "public.TicketStatus": {
+      "name": "TicketStatus",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "IN_PROGRESS",
+        "WAITING_FOR_CUSTOMER",
+        "WAITING_FOR_THIRD_PARTY",
+        "RESOLVED",
+        "CLOSED",
+        "CANCELLED",
+        "MERGED"
+      ]
+    },
+    "public.TicketType": {
+      "name": "TicketType",
+      "schema": "public",
+      "values": [
+        "GENERAL",
+        "MISSING_ITEM",
+        "RETURN",
+        "REFUND",
+        "PRODUCT_ISSUE",
+        "SHIPPING_ISSUE",
+        "BILLING",
+        "TECHNICAL",
+        "OTHER"
+      ]
+    },
+    "public.TranscriptStatus": {
+      "name": "TranscriptStatus",
+      "schema": "public",
+      "values": ["processing", "completed", "failed"]
+    },
+    "public.TranscriptType": {
+      "name": "TranscriptType",
+      "schema": "public",
+      "values": ["realtime", "async"]
+    },
+    "public.TrialConversionStatus": {
+      "name": "TrialConversionStatus",
+      "schema": "public",
+      "values": [
+        "TRIAL_ACTIVE",
+        "CONVERTED_TO_PAID",
+        "EXPIRED_WITHOUT_CONVERSION",
+        "CANCELED_DURING_TRIAL",
+        "MANUAL_CONVERSION"
+      ]
+    },
+    "public.UserType": {
+      "name": "UserType",
+      "schema": "public",
+      "values": ["USER", "SYSTEM"]
+    },
+    "public.VectorDbType": {
+      "name": "VectorDbType",
+      "schema": "public",
+      "values": ["POSTGRESQL", "CHROMA", "QDRANT", "WEAVIATE", "PINECONE", "MILVUS"]
+    },
+    "public.WorkflowRunStatus": {
+      "name": "WorkflowRunStatus",
+      "schema": "public",
+      "values": ["RUNNING", "SUCCEEDED", "FAILED", "STOPPED", "WAITING"]
+    },
+    "public.WorkflowShareAccessMode": {
+      "name": "WorkflowShareAccessMode",
+      "schema": "public",
+      "values": ["public", "organization"]
+    },
+    "public.WorkflowTriggerSource": {
+      "name": "WorkflowTriggerSource",
+      "schema": "public",
+      "values": ["DEBUGGING", "APP_RUN", "SINGLE_STEP", "PUBLIC_SHARE", "API_KEY", "WEBHOOK"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -974,6 +974,13 @@
       "when": 1777494568536,
       "tag": "0138_kb_drop_legacy_article_content",
       "breakpoints": true
+    },
+    {
+      "idx": 139,
+      "version": "7",
+      "when": 1777500228956,
+      "tag": "0139_kb_visibility_and_custom_domain_verification",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/db/schema/_shared.ts
+++ b/packages/database/src/db/schema/_shared.ts
@@ -37,6 +37,7 @@ export const approvalAction = pgEnum('ApprovalAction', ['approve', 'deny'])
 export const approvalStatus = pgEnum('ApprovalStatus', ['pending', 'approved', 'denied', 'timeout'])
 export const articleStatus = pgEnum('ArticleStatus', ['DRAFT', 'PUBLISHED', 'ARCHIVED'])
 export const kbPublishStatus = pgEnum('KBPublishStatus', ['DRAFT', 'PUBLISHED', 'UNLISTED'])
+export const kbVisibility = pgEnum('KBVisibility', ['PUBLIC', 'INTERNAL'])
 export const assetVersionStatus = pgEnum('AssetVersionStatus', [
   'PENDING',
   'PROCESSING',

--- a/packages/database/src/db/schema/knowledge-base.ts
+++ b/packages/database/src/db/schema/knowledge-base.ts
@@ -8,6 +8,7 @@ import {
   index,
   jsonb,
   kbPublishStatus,
+  kbVisibility,
   pgTable,
   text,
   timestamp,
@@ -31,6 +32,8 @@ export const KnowledgeBase = pgTable(
     publishStatus: kbPublishStatus().default('DRAFT').notNull(),
     publishedAt: timestamp({ precision: 3 }),
     lastPublishedAt: timestamp({ precision: 3 }),
+    visibility: kbVisibility().default('PUBLIC').notNull(),
+    customDomainVerifiedAt: timestamp({ precision: 3 }),
     createdAt: timestamp({ precision: 3 }).defaultNow().notNull(),
     updatedAt: timestamp({ precision: 3 }).notNull(),
     organizationId: text()

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -838,6 +838,7 @@
     "pusher": "catalog:",
     "pusher-js": "catalog:",
     "sharp": "catalog:",
+    "shiki": "catalog:",
     "stripe": "catalog:",
     "tldts": "^7.0.28",
     "turndown": "catalog:",

--- a/packages/lib/src/cache/index.ts
+++ b/packages/lib/src/cache/index.ts
@@ -58,6 +58,7 @@ export {
   getCachedResource,
   getCachedResourceFields,
   getCachedResources,
+  isOrgMember,
   requireCachedEntityDefId,
 } from './org-cache-helpers'
 export type {

--- a/packages/lib/src/cache/org-cache-helpers.ts
+++ b/packages/lib/src/cache/org-cache-helpers.ts
@@ -146,6 +146,14 @@ export async function getCachedMembersByUserIds(
   return members.filter((m) => idSet.has(m.userId))
 }
 
+/**
+ * Check whether a user is a member of an organization (cached).
+ */
+export async function isOrgMember(orgId: string, userId: string): Promise<boolean> {
+  const members = await getOrgCache().get(orgId, 'members')
+  return members.some((m) => m.userId === userId)
+}
+
 // ── Group cache helpers ──
 
 /**

--- a/packages/lib/src/kb/highlight-code.ts
+++ b/packages/lib/src/kb/highlight-code.ts
@@ -1,0 +1,107 @@
+// @auxx/lib/kb/highlight-code.ts
+import { createHighlighter, type Highlighter } from 'shiki'
+
+export const SHIKI_LANGUAGES = [
+  'ts',
+  'tsx',
+  'js',
+  'jsx',
+  'json',
+  'bash',
+  'sh',
+  'html',
+  'css',
+  'py',
+  'go',
+  'sql',
+] as const
+
+export type ShikiLanguage = (typeof SHIKI_LANGUAGES)[number]
+
+const LANGUAGE_SET = new Set<string>(SHIKI_LANGUAGES)
+
+const SHIKI_THEME = 'github-light'
+
+let highlighterPromise: Promise<Highlighter> | null = null
+
+function getHighlighterCached(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: [SHIKI_THEME],
+      langs: [...SHIKI_LANGUAGES],
+    })
+  }
+  return highlighterPromise
+}
+
+interface BlockNode {
+  type?: string
+  attrs?: Record<string, unknown> | null
+  content?: InlineNode[]
+}
+
+interface InlineNode {
+  type?: string
+  text?: string
+}
+
+interface DocLike {
+  type?: string
+  content?: BlockNode[]
+}
+
+function nodeText(content: InlineNode[] | undefined): string {
+  if (!content) return ''
+  return content.map((n) => (typeof n.text === 'string' ? n.text : '')).join('')
+}
+
+function pickLanguage(raw: unknown): ShikiLanguage | 'plaintext' {
+  if (typeof raw !== 'string') return 'plaintext'
+  return LANGUAGE_SET.has(raw) ? (raw as ShikiLanguage) : 'plaintext'
+}
+
+/**
+ * Walk a KB article doc, rebuild every codeBlock's `codeHighlightedHtml` with
+ * Shiki output. Mutates a shallow copy and returns it. Non-code blocks are
+ * passed through unchanged.
+ *
+ * Returns the input untouched if the doc has no codeBlock children — avoids
+ * loading the highlighter for articles that don't need it.
+ */
+export async function enrichDocWithHighlighting<T extends DocLike>(doc: T): Promise<T> {
+  if (!doc || typeof doc !== 'object') return doc
+  const blocks = Array.isArray(doc.content) ? doc.content : null
+  if (!blocks) return doc
+
+  const codeIndices: number[] = []
+  blocks.forEach((node, idx) => {
+    if (node?.attrs?.blockType === 'codeBlock') codeIndices.push(idx)
+  })
+  if (codeIndices.length === 0) return doc
+
+  const highlighter = await getHighlighterCached()
+  const nextBlocks = blocks.slice()
+
+  for (const idx of codeIndices) {
+    const block = nextBlocks[idx]
+    if (!block) continue
+    const code = nodeText(block.content)
+    const language = pickLanguage(block.attrs?.codeLanguage)
+    let html: string
+    try {
+      html = highlighter.codeToHtml(code, { lang: language, theme: SHIKI_THEME })
+    } catch {
+      html = highlighter.codeToHtml(code, { lang: 'plaintext', theme: SHIKI_THEME })
+    }
+    nextBlocks[idx] = {
+      ...block,
+      attrs: {
+        ...(block.attrs ?? {}),
+        codeLanguage: language,
+        codeHighlightedHtml: html,
+      },
+    }
+  }
+
+  return { ...doc, content: nextBlocks }
+}

--- a/packages/lib/src/kb/index.ts
+++ b/packages/lib/src/kb/index.ts
@@ -1,4 +1,10 @@
 // export * from './kb-service'
+
+export {
+  enrichDocWithHighlighting,
+  SHIKI_LANGUAGES,
+  type ShikiLanguage,
+} from './highlight-code'
 export {
   type ArticleBaseFields,
   type ArticleBatchUpdateItem,

--- a/packages/lib/src/kb/kb-service.ts
+++ b/packages/lib/src/kb/kb-service.ts
@@ -5,6 +5,7 @@ import type { ArticleStatus as ArticleStatusType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { and, asc, desc, eq, gt, gte, isNull, ne, or, sql } from 'drizzle-orm'
+import { enrichDocWithHighlighting } from './highlight-code'
 
 // Local model types inferred from Drizzle schema
 type KnowledgeBase = typeof schema.KnowledgeBase.$inferSelect
@@ -55,6 +56,7 @@ export interface KBFields {
   slug?: string
   description?: string
   publishStatus?: KBPublishStatus
+  visibility?: 'PUBLIC' | 'INTERNAL'
   customDomain?: string
   logoDark?: string
   logoLight?: string
@@ -514,8 +516,14 @@ export class KBService {
       if (fields.excerpt !== undefined) draftUpdate.excerpt = fields.excerpt
       if (fields.emoji !== undefined) draftUpdate.emoji = fields.emoji
       if (fields.content !== undefined) draftUpdate.content = fields.content
-      if (fields.contentJson !== undefined)
-        draftUpdate.contentJson = fields.contentJson as ArticleRevision['contentJson']
+      if (fields.contentJson !== undefined) {
+        const enriched = fields.contentJson
+          ? await enrichDocWithHighlighting(
+              fields.contentJson as Parameters<typeof enrichDocWithHighlighting>[0]
+            )
+          : fields.contentJson
+        draftUpdate.contentJson = enriched as ArticleRevision['contentJson']
+      }
 
       const updated = await this.db.transaction(async (tx) => {
         await tx

--- a/packages/ui/src/components/kb/article/block-renderer.tsx
+++ b/packages/ui/src/components/kb/article/block-renderer.tsx
@@ -1,9 +1,12 @@
 // packages/ui/src/components/kb/article/block-renderer.tsx
 
+import { parseEmbedUrl } from '../utils/embed'
 import { walkInlineToText } from '../utils/inline-text'
+import { CalloutIcon } from './callout-icon'
+import { ImageZoomable } from './image-zoomable'
 import { InlineRenderer } from './inline-renderer'
 import styles from './kb-article-renderer.module.css'
-import type { BlockJSON, DocJSON } from './types'
+import type { BlockJSON, CalloutVariant, DocJSON } from './types'
 
 interface BlockRendererProps {
   node: BlockJSON
@@ -84,12 +87,64 @@ export function BlockRenderer({ node, idx, doc, headingIds }: BlockRendererProps
     case 'quote':
       return <blockquote className={styles.quote}>{inline}</blockquote>
 
-    case 'codeBlock':
+    case 'callout': {
+      const variant: CalloutVariant = node.attrs?.calloutVariant ?? 'info'
       return (
-        <pre className={styles.code}>
+        <aside role='note' data-variant={variant} className={styles.callout}>
+          <span className={styles.calloutIcon} aria-hidden='true'>
+            <CalloutIcon variant={variant} />
+          </span>
+          <div className={styles.calloutBody}>{inline}</div>
+        </aside>
+      )
+    }
+
+    case 'codeBlock': {
+      const language = node.attrs?.codeLanguage
+      const html = node.attrs?.codeHighlightedHtml
+      if (html) {
+        return (
+          <pre
+            className={styles.code}
+            data-language={language ?? 'plaintext'}
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: Shiki output is server-generated and trusted
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        )
+      }
+      return (
+        <pre className={styles.code} data-language={language ?? 'plaintext'}>
           <code>{walkInlineToText(node.content)}</code>
         </pre>
       )
+    }
+
+    case 'embed': {
+      const url = node.attrs?.embedUrl
+      if (!url) return null
+      const parsed = parseEmbedUrl(url)
+      const aspect = node.attrs?.embedAspect ?? '16:9'
+      if (!parsed) {
+        return (
+          <p className={styles.text}>
+            <a href={url} target='_blank' rel='noopener noreferrer' className='kb-link'>
+              {url}
+            </a>
+          </p>
+        )
+      }
+      return (
+        <div className={styles.embedAspect} data-aspect={aspect}>
+          <iframe
+            src={parsed.embedSrc}
+            allowFullScreen
+            sandbox='allow-scripts allow-same-origin allow-presentation'
+            title={`${parsed.provider} embed`}
+            loading='lazy'
+          />
+        </div>
+      )
+    }
 
     case 'divider':
       return <hr className={styles.divider} />
@@ -101,8 +156,7 @@ export function BlockRenderer({ node, idx, doc, headingIds }: BlockRendererProps
       const width = node.attrs?.imageWidth ?? 400
       return (
         <div className={`${styles.imageWrapper} ${styles[`imageAlign_${align}`] ?? ''}`}>
-          {/** biome-ignore lint/performance/noImgElement: Next/Image not used cross-package; consumers can override */}
-          <img src={url} width={width} alt='' />
+          <ImageZoomable src={url} width={width} />
         </div>
       )
     }

--- a/packages/ui/src/components/kb/article/callout-icon.tsx
+++ b/packages/ui/src/components/kb/article/callout-icon.tsx
@@ -1,0 +1,102 @@
+// packages/ui/src/components/kb/article/callout-icon.tsx
+
+import type { CalloutVariant } from './types'
+
+interface CalloutIconProps {
+  variant: CalloutVariant
+  size?: number
+}
+
+export function CalloutIcon({ variant, size = 18 }: CalloutIconProps) {
+  switch (variant) {
+    case 'tip':
+      return (
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          width={size}
+          height={size}
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='2'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          aria-hidden='true'>
+          <path d='M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5' />
+          <path d='M9 18h6' />
+          <path d='M10 22h4' />
+        </svg>
+      )
+    case 'warn':
+      return (
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          width={size}
+          height={size}
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='2'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          aria-hidden='true'>
+          <path d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3' />
+          <path d='M12 9v4' />
+          <path d='M12 17h.01' />
+        </svg>
+      )
+    case 'error':
+      return (
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          width={size}
+          height={size}
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='2'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          aria-hidden='true'>
+          <circle cx='12' cy='12' r='10' />
+          <path d='m15 9-6 6' />
+          <path d='m9 9 6 6' />
+        </svg>
+      )
+    case 'success':
+      return (
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          width={size}
+          height={size}
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='2'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          aria-hidden='true'>
+          <path d='M21.801 10A10 10 0 1 1 17 3.335' />
+          <path d='m9 11 3 3L22 4' />
+        </svg>
+      )
+    default:
+      return (
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          width={size}
+          height={size}
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='2'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          aria-hidden='true'>
+          <circle cx='12' cy='12' r='10' />
+          <path d='M12 16v-4' />
+          <path d='M12 8h.01' />
+        </svg>
+      )
+  }
+}

--- a/packages/ui/src/components/kb/article/image-zoomable.tsx
+++ b/packages/ui/src/components/kb/article/image-zoomable.tsx
@@ -1,0 +1,55 @@
+// packages/ui/src/components/kb/article/image-zoomable.tsx
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import styles from './kb-article-renderer.module.css'
+
+interface ImageZoomableProps {
+  src: string
+  width?: number
+  alt?: string
+}
+
+export function ImageZoomable({ src, width, alt = '' }: ImageZoomableProps) {
+  const [open, setOpen] = useState(false)
+
+  const close = useCallback(() => setOpen(false), [])
+
+  useEffect(() => {
+    if (!open) return
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = previous
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [open, close])
+
+  return (
+    <>
+      <button
+        type='button'
+        className={styles.imageZoomTrigger}
+        onClick={() => setOpen(true)}
+        aria-label='Open image in fullscreen'>
+        {/** biome-ignore lint/performance/noImgElement: Next/Image not used cross-package; consumers can override */}
+        <img src={src} width={width} alt={alt} />
+      </button>
+      {open && (
+        <div
+          className={styles.imageZoomOverlay}
+          role='dialog'
+          aria-modal='true'
+          aria-label='Image preview'
+          onClick={close}>
+          {/** biome-ignore lint/performance/noImgElement: Next/Image not used cross-package; consumers can override */}
+          <img src={src} alt={alt} className={styles.imageZoomFull} />
+        </div>
+      )}
+    </>
+  )
+}

--- a/packages/ui/src/components/kb/article/index.ts
+++ b/packages/ui/src/components/kb/article/index.ts
@@ -1,7 +1,9 @@
 // packages/ui/src/components/kb/article/index.ts
 
 export { BlockRenderer } from './block-renderer'
+export { CalloutIcon } from './callout-icon'
 export { extractKBHeadings, type KBHeading } from './extract-headings'
+export { ImageZoomable } from './image-zoomable'
 export { InlineRenderer } from './inline-renderer'
 export { KBArticlePager } from './kb-article-pager'
 export { KBArticleRenderer } from './kb-article-renderer'
@@ -10,7 +12,10 @@ export type {
   BlockAttrs,
   BlockJSON,
   BlockType,
+  CalloutVariant,
   DocJSON,
+  EmbedAspect,
+  EmbedProvider,
   ImageAlign,
   InlineJSON,
   InlineMarkType,

--- a/packages/ui/src/components/kb/article/kb-article-renderer.module.css
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.module.css
@@ -6,7 +6,7 @@
   line-height: 1.6;
   font-size: 16px;
   max-width: 768px;
-  margin: 0 auto;
+  margin: 0;
   padding: 0 1.5rem;
 }
 
@@ -88,10 +88,34 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.9em;
   line-height: 1.5;
+  position: relative;
 }
 
 .code code {
   font-family: inherit;
+}
+
+/* Shiki highlighter wraps the highlighted code in a <pre>/<code>; we keep the
+   provided inline styles but neutralize Shiki's outer background so our token
+   wins for both light and dark themes. */
+.code :global(.shiki) {
+  background: transparent !important;
+  padding: 0;
+  margin: 0;
+}
+
+.code[data-language]:not([data-language='plaintext'])::before {
+  content: attr(data-language);
+  position: absolute;
+  top: 0.5em;
+  right: 0.75em;
+  font-size: 0.7em;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--kb-fg);
+  opacity: 0.4;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  pointer-events: none;
 }
 
 .divider {
@@ -180,4 +204,146 @@
   max-width: 100%;
   height: auto;
   border-radius: var(--kb-radius);
+}
+
+/* ============================================
+   Callout
+   ============================================ */
+
+.callout {
+  display: flex;
+  gap: 0.75em;
+  align-items: flex-start;
+  margin: 1em 0;
+  padding: 0.875em 1em;
+  border-radius: var(--kb-radius);
+  border-left: 3px solid var(--callout-accent, var(--kb-primary));
+  background: var(--callout-bg, var(--kb-tint));
+  color: var(--kb-fg);
+}
+
+.callout[data-variant='info'] {
+  --callout-accent: var(--kb-info, var(--kb-primary));
+  --callout-bg: color-mix(in srgb, var(--kb-info, var(--kb-primary)) 10%, transparent);
+}
+
+.callout[data-variant='tip'] {
+  --callout-accent: var(--kb-primary);
+  --callout-bg: var(--kb-tint);
+}
+
+.callout[data-variant='warn'] {
+  --callout-accent: var(--kb-warning, #d97706);
+  --callout-bg: color-mix(in srgb, var(--kb-warning, #d97706) 12%, transparent);
+}
+
+.callout[data-variant='error'] {
+  --callout-accent: var(--kb-danger, #dc2626);
+  --callout-bg: color-mix(in srgb, var(--kb-danger, #dc2626) 12%, transparent);
+}
+
+.callout[data-variant='success'] {
+  --callout-accent: var(--kb-success, #16a34a);
+  --callout-bg: color-mix(in srgb, var(--kb-success, #16a34a) 12%, transparent);
+}
+
+.calloutIcon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--callout-accent, var(--kb-primary));
+  margin-top: 0.15em;
+}
+
+.calloutBody {
+  flex: 1 1 0%;
+  min-width: 0;
+}
+
+.calloutBody > p:first-child {
+  margin-top: 0;
+}
+
+.calloutBody > p:last-child {
+  margin-bottom: 0;
+}
+
+/* ============================================
+   Embed (YouTube / Loom / Vimeo)
+   ============================================ */
+
+.embedAspect {
+  margin: 1em 0;
+  width: 100%;
+  border-radius: var(--kb-radius);
+  overflow: hidden;
+  background: var(--kb-muted);
+  aspect-ratio: 16 / 9;
+}
+
+.embedAspect[data-aspect='4:3'] {
+  aspect-ratio: 4 / 3;
+}
+
+.embedAspect[data-aspect='1:1'] {
+  aspect-ratio: 1 / 1;
+}
+
+.embedAspect iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+
+/* ============================================
+   Image zoom
+   ============================================ */
+
+.imageZoomTrigger {
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  border: 0;
+  cursor: zoom-in;
+  max-width: 100%;
+  border-radius: var(--kb-radius);
+}
+
+.imageZoomTrigger img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--kb-radius);
+  display: block;
+}
+
+.imageZoomOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  cursor: zoom-out;
+  animation: kb-image-zoom-fade 0.15s ease-out;
+}
+
+.imageZoomFull {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  border-radius: var(--kb-radius);
+}
+
+@keyframes kb-image-zoom-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }

--- a/packages/ui/src/components/kb/article/types.ts
+++ b/packages/ui/src/components/kb/article/types.ts
@@ -10,8 +10,13 @@ export type BlockType =
   | 'image'
   | 'divider'
   | 'codeBlock'
+  | 'callout'
+  | 'embed'
 
 export type ImageAlign = 'left' | 'center' | 'right'
+export type CalloutVariant = 'info' | 'warn' | 'error' | 'tip' | 'success'
+export type EmbedProvider = 'youtube' | 'loom' | 'vimeo'
+export type EmbedAspect = '16:9' | '4:3' | '1:1'
 
 export interface BlockAttrs {
   blockType: BlockType
@@ -20,6 +25,12 @@ export interface BlockAttrs {
   imageUrl?: string | null
   imageWidth?: number
   imageAlign?: ImageAlign
+  calloutVariant?: CalloutVariant
+  codeLanguage?: string
+  codeHighlightedHtml?: string
+  embedUrl?: string
+  embedProvider?: EmbedProvider
+  embedAspect?: EmbedAspect
 }
 
 export interface BlockJSON {

--- a/packages/ui/src/components/kb/layout/kb-layout-shell.tsx
+++ b/packages/ui/src/components/kb/layout/kb-layout-shell.tsx
@@ -1,10 +1,12 @@
 // packages/ui/src/components/kb/layout/kb-layout-shell.tsx
 'use client'
 
+import { useSelectedLayoutSegments } from 'next/navigation'
 import type { ReactNode } from 'react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { KBSearchDialog } from '../search/kb-search-dialog'
 import type { KBMode } from '../theme/kb-theme-tokens'
+import { findArticleBySlugPath } from '../utils'
 import { KBFooter } from './kb-footer'
 import { KBHeader, type KBNavLink } from './kb-header'
 import { KBLayoutContextProvider } from './kb-layout-context'
@@ -58,6 +60,13 @@ export function KBLayoutShell<T extends KBSidebarArticle>({
   const [collapsed, setCollapsed] = useState(false)
   const [mobileOpen, setMobileOpen] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
+
+  const segments = useSelectedLayoutSegments()
+  const derivedActiveId = useMemo(() => {
+    if (segments.length === 0) return undefined
+    return findArticleBySlugPath(articles, segments)?.id
+  }, [articles, segments])
+  const effectiveActiveId = activeArticleId ?? derivedActiveId
 
   useEffect(() => {
     setCollapsed(readCollapsedFromStorage())
@@ -117,13 +126,13 @@ export function KBLayoutShell<T extends KBSidebarArticle>({
         <KBSidebar
           articles={articles}
           basePath={basePath}
-          activeArticleId={activeArticleId}
+          activeArticleId={effectiveActiveId}
           searchOrigin={searchOrigin}
           showSearch={searchbarPosition === 'corner'}
           listStyle={listStyle}
           onArticleClick={onArticleClick}
         />
-        <main className='min-w-0 flex-1 px-4 py-8 @kb-md:px-8'>{children}</main>
+        <main className='flex min-w-0 flex-1 flex-col px-4 py-8 @kb-md:px-8'>{children}</main>
       </div>
       <KBFooter title={kbName} navigation={footerNav} navigationEnabled={footerEnabled} />
       {searchOrigin ? (

--- a/packages/ui/src/components/kb/layout/kb-sidebar.tsx
+++ b/packages/ui/src/components/kb/layout/kb-sidebar.tsx
@@ -92,13 +92,24 @@ export function KBSidebar<T extends KBSidebarArticle>({
   return (
     <>
       {/* Desktop persistent sidebar */}
-      <aside
-        data-collapsed={collapsed}
-        className={cn(
-          'relative hidden shrink-0 overflow-visible border-r border-[var(--kb-border)] bg-[var(--kb-sidebar-bg)] transition-[width] duration-200 ease-out @kb-md:block',
-          collapsed ? 'w-0 border-r-0' : 'w-72'
-        )}>
-        <div className='w-72 overflow-hidden'>{inner}</div>
+      <div className='relative hidden shrink-0 @kb-md:block'>
+        <aside
+          data-collapsed={collapsed}
+          className={cn(
+            'overflow-hidden border-r border-[var(--kb-border)] bg-[var(--kb-sidebar-bg)]',
+            'transition-[width,border-color] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]',
+            collapsed ? 'w-0 border-transparent' : 'w-72'
+          )}>
+          <div
+            className={cn(
+              'w-72 transition-[transform,opacity] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]',
+              collapsed
+                ? 'pointer-events-none -translate-x-4 opacity-0'
+                : 'translate-x-0 opacity-100'
+            )}>
+            {inner}
+          </div>
+        </aside>
         {listStyle === 'default' && !collapsed ? (
           <button
             type='button'
@@ -106,11 +117,11 @@ export function KBSidebar<T extends KBSidebarArticle>({
             title='Toggle sidebar'
             tabIndex={-1}
             onClick={() => setCollapsed((v) => !v)}
-            className='group absolute inset-y-0 -right-2 z-20 hidden w-4 cursor-ew-resize border-0 bg-transparent p-0 @kb-md:flex'>
+            className='group absolute inset-y-0 -right-2 z-20 flex w-4 cursor-ew-resize border-0 bg-transparent p-0'>
             <span className='pointer-events-none mx-auto h-full w-[2px] bg-transparent transition-colors group-hover:bg-[var(--kb-border)]' />
           </button>
         ) : null}
-      </aside>
+      </div>
 
       {/* Mobile in-place drawer (constrained to KB layout root, not document.body) */}
       <div

--- a/packages/ui/src/components/kb/utils/embed.ts
+++ b/packages/ui/src/components/kb/utils/embed.ts
@@ -1,0 +1,63 @@
+// packages/ui/src/components/kb/utils/embed.ts
+
+export type EmbedProvider = 'youtube' | 'loom' | 'vimeo'
+
+export interface ParsedEmbed {
+  provider: EmbedProvider
+  embedSrc: string
+}
+
+/**
+ * Map a user-pasted URL to a sandboxed iframe `src` for one of the
+ * supported providers. Returns `null` for anything else — no raw user
+ * iframes are accepted.
+ */
+export function parseEmbedUrl(url: string): ParsedEmbed | null {
+  if (!url) return null
+  let parsed: URL
+  try {
+    parsed = new URL(url.trim())
+  } catch {
+    return null
+  }
+
+  const host = parsed.hostname.replace(/^www\./, '').toLowerCase()
+
+  if (host === 'youtube.com' || host === 'm.youtube.com') {
+    const id = parsed.searchParams.get('v')
+    if (id && /^[\w-]{6,}$/.test(id)) {
+      return { provider: 'youtube', embedSrc: `https://www.youtube.com/embed/${id}` }
+    }
+    const shortsMatch = parsed.pathname.match(/^\/shorts\/([\w-]{6,})/)
+    if (shortsMatch?.[1]) {
+      return { provider: 'youtube', embedSrc: `https://www.youtube.com/embed/${shortsMatch[1]}` }
+    }
+    return null
+  }
+
+  if (host === 'youtu.be') {
+    const id = parsed.pathname.replace(/^\//, '')
+    if (id && /^[\w-]{6,}$/.test(id)) {
+      return { provider: 'youtube', embedSrc: `https://www.youtube.com/embed/${id}` }
+    }
+    return null
+  }
+
+  if (host === 'loom.com') {
+    const match = parsed.pathname.match(/^\/(share|embed)\/([\w-]{8,})/)
+    if (match?.[2]) {
+      return { provider: 'loom', embedSrc: `https://www.loom.com/embed/${match[2]}` }
+    }
+    return null
+  }
+
+  if (host === 'vimeo.com' || host === 'player.vimeo.com') {
+    const match = parsed.pathname.match(/(\d{6,})/)
+    if (match?.[1]) {
+      return { provider: 'vimeo', embedSrc: `https://player.vimeo.com/video/${match[1]}` }
+    }
+    return null
+  }
+
+  return null
+}

--- a/packages/ui/src/components/kb/utils/index.ts
+++ b/packages/ui/src/components/kb/utils/index.ts
@@ -18,4 +18,5 @@ export {
   flattenArticleTree,
   flattenArticleTreePreservingChildren,
 } from './article-tree'
+export { type EmbedProvider, type ParsedEmbed, parseEmbedUrl } from './embed'
 export { extractHeadings, extractPlainText, walkInlineToText } from './inline-text'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ catalogs:
     sharp:
       specifier: 0.34.3
       version: 0.34.3
+    shiki:
+      specifier: ^4.0.2
+      version: 4.0.2
     stripe:
       specifier: ^19.0.0
       version: 19.3.0
@@ -697,7 +700,7 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       shiki:
-        specifier: ^4.0.2
+        specifier: 'catalog:'
         version: 4.0.2
       tailwind-merge:
         specifier: ^3.3.1
@@ -736,12 +739,18 @@ importers:
       '@auxx/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@auxx/credentials':
+        specifier: workspace:*
+        version: link:../../packages/credentials
       '@auxx/database':
         specifier: workspace:*
         version: link:../../packages/database
       '@auxx/lib':
         specifier: workspace:*
         version: link:../../packages/lib
+      '@auxx/redis':
+        specifier: workspace:*
+        version: link:../../packages/redis
       '@auxx/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -1213,6 +1222,9 @@ importers:
       sharp:
         specifier: 'catalog:'
         version: 0.34.3
+      shiki:
+        specifier: 'catalog:'
+        version: 4.0.2
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1907,6 +1919,9 @@ importers:
       sharp:
         specifier: 'catalog:'
         version: 0.34.3
+      shiki:
+        specifier: 'catalog:'
+        version: 4.0.2
       stripe:
         specifier: 'catalog:'
         version: 19.3.0(@types/node@22.19.13)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,6 +67,7 @@ catalog:
   rimraf: ^5.0.10
   server-only: ^0.0.1
   sharp: 0.34.3
+  shiki: ^4.0.2
   stripe: ^19.0.0
   tailwindcss: ^4.1.7
   ts-node: ^10.9.2


### PR DESCRIPTION
## Summary
- **KB visibility (PUBLIC / INTERNAL)** — new `KBVisibility` enum + `visibility` column on `KnowledgeBase`. Internal KBs require a signed-in member of the owning org.
- **Custom-domain verification** — adds `customDomainVerifiedAt`. Login tokens are only minted for a custom domain once it is verified; otherwise we fall back to `KB_URL`.
- **Satellite auth flow** — `apps/web` mints a scoped login token (`/api/auth/login-token` now accepts `kbId` for `callbackApp: 'kb'`), `apps/kb` consumes it at `/auth/verify`, with a `kb-auth` entry route + `no-access` page on web for unauthenticated/non-member visitors. New `KB_SESSION_SECRET` for HMAC of local kb session cookies.
- **Settings UI** — visibility selector in the KB general settings identity section.
- **Editor / renderer polish** — callouts, zoomable images, code highlighting (`packages/lib/src/kb/highlight-code.ts`), and embeds.

## Test plan
- [ ] Apply migration `0139_kb_visibility_and_custom_domain_verification` cleanly
- [ ] Toggle a KB to INTERNAL → unauthenticated visit redirects through `/kb-auth` → web mints token → kb verifies → access granted
- [ ] Non-member of the org hitting an INTERNAL KB lands on `/kb-auth/no-access`
- [ ] Demo accounts blocked from KB login-token issuance
- [ ] Public KB still loads without auth
- [ ] Custom domain origin only used when `customDomainVerifiedAt` is set; otherwise `KB_URL`
- [ ] Editor: callouts, code highlighting, zoomable images, embeds render correctly in preview + published article

🤖 Generated with [Claude Code](https://claude.com/claude-code)