### PR TITLE
feat(kb): markdown import/export, preview device frames, mobile TOC drawer

### DIFF
--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/[...articleSlug]/page.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/[...articleSlug]/page.tsx
@@ -6,6 +6,7 @@ import {
   extractKBHeadings,
   findArticleBySlugPath,
   getArticleNeighbours,
+  getArticleParentLink,
   KBArticlePager,
   KBArticleRenderer,
   KBTableOfContents,
@@ -39,10 +40,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { orgSlug, kbSlug, articleSlug } = await params
 
   const visibility = await getCachedKBVisibility(orgSlug, kbSlug)
-  if (!visibility || visibility.publishStatus === 'DRAFT') return { title: 'Not found' }
+  if (!visibility || visibility.publishStatus === 'DRAFT') {
+    return { title: { absolute: 'Not found' } }
+  }
 
   if (visibility.visibility === 'INTERNAL') {
-    return { title: 'Knowledge base', robots: { index: false, follow: false } }
+    return { title: { absolute: 'Knowledge base' }, robots: { index: false, follow: false } }
   }
   return getCachedMetadata(orgSlug, kbSlug, articleSlug)
 }
@@ -57,8 +60,9 @@ async function getCachedMetadata(
   cacheLife('max')
   const { kb, articles } = await getPublicKBPayloadWithContent(orgSlug, kbSlug)
   const article = findArticleBySlugPath(articles, articleSlug)
-  if (!article) return { title: 'Not found' }
+  if (!article) return { title: { absolute: 'Not found' } }
   return {
+    // Bare string -- the parent layout's "%s | KB Name" template fills in the suffix.
     title: article.title,
     description: article.description ?? undefined,
     openGraph: { title: article.title, description: article.description ?? undefined },
@@ -170,18 +174,25 @@ function ArticleBodyContent({
 
   const headings = extractKBHeadings(article.contentJson)
   const { prev, next } = getArticleNeighbours(articles, article.id)
+  const parent = getArticleParentLink(article, articles, basePath)
 
   return (
     <div className='flex min-w-0 flex-1 flex-col'>
-      <div className='w-full max-w-3xl px-6 pt-4'>
-        <KBTableOfContents headings={headings} />
+      <div className='flex flex-col gap-6 @kb-lg:flex-row @kb-lg:items-start'>
+        <aside className='hidden @kb-lg:sticky @kb-lg:top-20 @kb-lg:order-2 @kb-lg:block @kb-lg:w-64 @kb-lg:max-w-none @kb-lg:flex-none @kb-lg:px-4 @kb-lg:pt-8'>
+          <KBTableOfContents headings={headings} />
+        </aside>
+        <div className='min-w-0 flex-1 @kb-lg:order-1'>
+          <KBArticleRenderer
+            doc={article.contentJson}
+            title={article.title}
+            emoji={article.emoji}
+            description={article.description}
+            updatedAt={article.updatedAt}
+            parent={parent}
+          />
+        </div>
       </div>
-      <KBArticleRenderer
-        doc={article.contentJson}
-        title={article.title}
-        description={article.description}
-        updatedAt={article.updatedAt}
-      />
       <div className='mt-auto w-full max-w-3xl px-6'>
         <KBArticlePager articles={articles} prev={prev} next={next} basePath={basePath} />
       </div>

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
@@ -4,6 +4,7 @@ import { WEBAPP_URL } from '@auxx/config/urls'
 import { isOrgMember } from '@auxx/lib/cache'
 import { KBLayout } from '@auxx/ui/components/kb'
 import '@auxx/ui/global.css'
+import type { Metadata } from 'next'
 import { cacheLife, cacheTag } from 'next/cache'
 import { notFound, redirect } from 'next/navigation'
 import { Suspense } from 'react'
@@ -14,6 +15,19 @@ import { loadKBPayload } from '../../../server/kb-data'
 interface KBSlugLayoutProps {
   params: Promise<{ orgSlug: string; kbSlug: string }>
   children: React.ReactNode
+}
+
+export async function generateMetadata({ params }: KBSlugLayoutProps): Promise<Metadata> {
+  const { orgSlug, kbSlug } = await params
+  const visibility = await getCachedKBVisibility(orgSlug, kbSlug)
+  if (!visibility || visibility.publishStatus === 'DRAFT') return {}
+  // Keep internal KB names out of the tab title.
+  if (visibility.visibility === 'INTERNAL') {
+    return { title: { template: '%s | Knowledge base', default: 'Knowledge base' } }
+  }
+  const { kb } = await getPublicKBPayload(orgSlug, kbSlug)
+  if (!kb) return {}
+  return { title: { template: `%s | ${kb.name}`, default: kb.name } }
 }
 
 export default async function KBSlugLayout({ params, children }: KBSlugLayoutProps) {

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
@@ -38,16 +38,20 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { orgSlug, kbSlug } = await params
   const visibility = await getCachedKBVisibility(orgSlug, kbSlug)
-  if (!visibility || visibility.publishStatus === 'DRAFT') return { title: 'Not found' }
+  if (!visibility || visibility.publishStatus === 'DRAFT') {
+    return { title: { absolute: 'Not found' } }
+  }
 
   if (visibility.visibility === 'INTERNAL') {
-    return { title: 'Knowledge base', robots: { index: false, follow: false } }
+    return { title: { absolute: 'Knowledge base' }, robots: { index: false, follow: false } }
   }
 
   const { kb } = await getPublicKBPayloadWithContent(orgSlug, kbSlug)
-  if (!kb) return { title: 'Not found' }
+  if (!kb) return { title: { absolute: 'Not found' } }
   return {
-    title: kb.name,
+    // Use absolute so the parent layout's "%s | KB Name" template doesn't
+    // produce "KB Name | KB Name" on the index page.
+    title: { absolute: kb.name },
     description: kb.description ?? undefined,
     openGraph: { title: kb.name, description: kb.description ?? undefined },
     robots: kb.publishStatus === 'UNLISTED' ? { index: false, follow: false } : undefined,
@@ -137,15 +141,20 @@ function LandingBody({
 
   return (
     <div className='flex min-w-0 flex-1 flex-col'>
-      <div className='w-full max-w-3xl px-6 pt-4'>
-        <KBTableOfContents headings={headings} />
+      <div className='flex flex-col gap-6 @kb-lg:flex-row @kb-lg:items-start'>
+        <aside className='w-full max-w-3xl px-6 pt-4 @kb-lg:sticky @kb-lg:top-20 @kb-lg:order-2 @kb-lg:w-64 @kb-lg:max-w-none @kb-lg:flex-none @kb-lg:px-4 @kb-lg:pt-8'>
+          <KBTableOfContents headings={headings} />
+        </aside>
+        <div className='min-w-0 flex-1 @kb-lg:order-1'>
+          <KBArticleRenderer
+            doc={doc}
+            title={homeArticle?.title ?? kb.name}
+            emoji={homeArticle?.emoji ?? null}
+            description={homeArticle?.description ?? kb.description}
+            updatedAt={homeArticle?.updatedAt ?? null}
+          />
+        </div>
       </div>
-      <KBArticleRenderer
-        doc={doc}
-        title={homeArticle?.title ?? kb.name}
-        description={homeArticle?.description ?? kb.description}
-        updatedAt={homeArticle?.updatedAt ?? null}
-      />
       <div className='mt-auto w-full max-w-3xl px-6'>
         <KBArticlePager articles={articles} prev={prev} next={next} basePath={basePath} />
       </div>

--- a/apps/web/src/components/editor/kb-article/block-node-view.module.css
+++ b/apps/web/src/components/editor/kb-article/block-node-view.module.css
@@ -509,6 +509,8 @@
 
 .blockContainer--callout {
   position: relative;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .blockContentWrapper--callout {
@@ -633,8 +635,7 @@
 
 .embedPrompt {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-direction: column;
   gap: 0.5rem;
   width: 100%;
   padding: 0.75rem;
@@ -643,36 +644,21 @@
   background: var(--color-muted);
 }
 
+.embedPromptRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
 .embedInput {
-  flex: 1 1 240px;
+  flex: 1 1 auto;
   min-width: 0;
-  padding: 0.375rem 0.5rem;
-  border-radius: 0.25rem;
-  border: 1px solid var(--color-border);
-  background: var(--color-background);
-  font-size: 0.8125rem;
-  color: var(--color-foreground);
-}
-
-.embedInput:focus {
-  outline: 2px solid var(--color-primary);
-  outline-offset: -1px;
-}
-
-.embedSubmit {
-  padding: 0.375rem 0.75rem;
-  border-radius: 0.25rem;
-  border: 1px solid transparent;
-  background: var(--color-primary);
-  color: var(--color-primary-foreground, white);
-  font-size: 0.8125rem;
-  cursor: pointer;
 }
 
 .embedError {
-  flex: 1 1 100%;
   font-size: 0.75rem;
-  color: #dc2626;
+  color: var(--color-destructive, #dc2626);
 }
 
 .embedFrame {

--- a/apps/web/src/components/editor/kb-article/block-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/block-node-view.tsx
@@ -1,12 +1,14 @@
 // apps/web/src/components/editor/kb-article/block-node-view.tsx
 'use client'
 
+import { Button } from '@auxx/ui/components/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
+import { Input } from '@auxx/ui/components/input'
 import type { CalloutVariant, EmbedAspect, EmbedProvider } from '@auxx/ui/components/kb/article'
 import { CalloutIcon } from '@auxx/ui/components/kb/article'
 import { parseEmbedUrl } from '@auxx/ui/components/kb/utils'
@@ -154,13 +156,9 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
   const isEmpty = node.content.size === 0
   const isFirstBlock = pos === 0
   const showPlaceholder =
-    isEmpty && !isDivider && !isImage && !isEmbed && (isFocused || isFirstBlock)
+    isEmpty && !isDivider && !isImage && !isEmbed && !isCallout && (isFocused || isFirstBlock)
   const placeholderText =
-    blockType === 'heading'
-      ? `Heading ${level ?? 1}`
-      : isCallout
-        ? 'Callout text'
-        : "Press '/' for commands"
+    blockType === 'heading' ? `Heading ${level ?? 1}` : "Press '/' for commands"
 
   const submitEmbed = (raw: string) => {
     const trimmed = raw.trim()
@@ -326,28 +324,28 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
                 </div>
               ) : (
                 <div className={styles.embedPrompt} contentEditable={false}>
-                  <input
-                    type='url'
-                    className={styles.embedInput}
-                    placeholder='Paste YouTube / Loom / Vimeo URL'
-                    value={embedDraft}
-                    onChange={(e) => {
-                      setEmbedDraft(e.target.value)
-                      if (embedError) setEmbedError(null)
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault()
-                        submitEmbed(embedDraft)
-                      }
-                    }}
-                  />
-                  <button
-                    type='button'
-                    className={styles.embedSubmit}
-                    onClick={() => submitEmbed(embedDraft)}>
-                    Embed
-                  </button>
+                  <div className={styles.embedPromptRow}>
+                    <Input
+                      type='url'
+                      variant='secondary'
+                      className={styles.embedInput}
+                      placeholder='Paste YouTube / Loom / Vimeo URL'
+                      value={embedDraft}
+                      onChange={(e) => {
+                        setEmbedDraft(e.target.value)
+                        if (embedError) setEmbedError(null)
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault()
+                          submitEmbed(embedDraft)
+                        }
+                      }}
+                    />
+                    <Button type='button' onClick={() => submitEmbed(embedDraft)}>
+                      Embed
+                    </Button>
+                  </div>
                   {embedError && <span className={styles.embedError}>{embedError}</span>}
                 </div>
               )}

--- a/apps/web/src/components/editor/kb-article/block-node.ts
+++ b/apps/web/src/components/editor/kb-article/block-node.ts
@@ -187,6 +187,11 @@ export const Block = Node.create({
           const blockType = node.attrs.blockType as string
           const isEmpty = node.content.size === 0
 
+          // Code block: Enter inserts a literal newline; Mod-Enter exits below.
+          if (blockType === 'codeBlock') {
+            return editor.chain().insertContent('\n').run()
+          }
+
           // Divider stays as divider — split and convert the new sibling to text.
           if (blockType === 'divider') {
             return editor
@@ -222,6 +227,21 @@ export const Block = Node.create({
           }
 
           return false
+        }
+        return false
+      },
+      'Mod-Enter': ({ editor }) => {
+        const { $from } = editor.state.selection
+        for (let depth = $from.depth; depth >= 0; depth--) {
+          const node = $from.node(depth)
+          if (node.type.name !== 'block') continue
+          if (node.attrs.blockType !== 'codeBlock') return false
+          const blockEnd = $from.before(depth) + node.nodeSize
+          return editor
+            .chain()
+            .insertContentAt(blockEnd, { type: 'block' })
+            .focus(blockEnd + 1)
+            .run()
         }
         return false
       },

--- a/apps/web/src/components/editor/kb-article/markdown-input-rules.ts
+++ b/apps/web/src/components/editor/kb-article/markdown-input-rules.ts
@@ -1,0 +1,98 @@
+// apps/web/src/components/editor/kb-article/markdown-input-rules.ts
+
+import { Extension, InputRule } from '@tiptap/core'
+import type { Node as PMNode, ResolvedPos } from '@tiptap/pm/model'
+import type { BlockType } from './block-node'
+
+interface BlockSpec {
+  blockType: BlockType
+  level?: number | null
+  checked?: boolean
+}
+
+/**
+ * Markdown-style typing shortcuts for the KB editor. Each rule fires when
+ * the user types its trigger at the start of an empty (or to-be-converted)
+ * `text` block, and switches that block's `blockType` in place.
+ *
+ * Rules only apply when the block is currently a plain `text` block — we
+ * don't auto-convert headings into lists mid-stream. To revert, the user
+ * can hit Backspace immediately after typing (Tiptap default).
+ */
+export const MarkdownInputRules = Extension.create({
+  name: 'markdown-input-rules',
+
+  addInputRules() {
+    return [
+      headingRule(/^#\s$/, 1),
+      headingRule(/^##\s$/, 2),
+      headingRule(/^###\s$/, 3),
+      blockRule(/^[-*]\s$/, { blockType: 'bulletListItem', level: 1 }),
+      blockRule(/^1\.\s$/, { blockType: 'numberedListItem', level: 1 }),
+      blockRule(/^\[\s?\]\s$/, { blockType: 'todoListItem', checked: false, level: 1 }),
+      blockRule(/^\[x\]\s$/i, { blockType: 'todoListItem', checked: true, level: 1 }),
+      blockRule(/^>\s$/, { blockType: 'quote' }),
+      blockRule(/^```$/, { blockType: 'codeBlock' }),
+      dividerRule(),
+    ]
+  },
+})
+
+function headingRule(find: RegExp, level: number): InputRule {
+  return blockRule(find, { blockType: 'heading', level })
+}
+
+function blockRule(find: RegExp, spec: BlockSpec): InputRule {
+  return new InputRule({
+    find,
+    handler: ({ state, range, chain }) => {
+      const $from = state.doc.resolve(range.from)
+      const block = findEnclosingBlock($from)
+      if (!block || block.attrs.blockType !== 'text') return null
+
+      // Only fire at the very start of the block.
+      if ($from.parentOffset !== 0) return null
+
+      const attrs: Record<string, unknown> = {
+        blockType: spec.blockType,
+        level: spec.level ?? null,
+      }
+      if (spec.blockType === 'todoListItem') attrs.checked = spec.checked ?? false
+
+      chain().deleteRange({ from: range.from, to: range.to }).updateAttributes('block', attrs).run()
+      return null
+    },
+  })
+}
+
+/**
+ * `---` on its own line converts the current block to a divider and splits
+ * a fresh text block below for the user to keep typing.
+ */
+function dividerRule(): InputRule {
+  return new InputRule({
+    find: /^---$/,
+    handler: ({ state, range, chain }) => {
+      const $from = state.doc.resolve(range.from)
+      const block = findEnclosingBlock($from)
+      if (!block || block.attrs.blockType !== 'text') return null
+      if ($from.parentOffset !== 0) return null
+
+      chain()
+        .deleteRange({ from: range.from, to: range.to })
+        .updateAttributes('block', { blockType: 'divider', level: null, checked: false })
+        .splitBlock()
+        .updateAttributes('block', { blockType: 'text', level: null, checked: false })
+        .run()
+      return null
+    },
+  })
+}
+
+function findEnclosingBlock($pos: ResolvedPos): PMNode | null {
+  for (let depth = $pos.depth; depth >= 0; depth--) {
+    const node = $pos.node(depth)
+    if (node?.type?.name === 'block') return node
+  }
+  return null
+}

--- a/apps/web/src/components/editor/kb-article/markdown-paste.ts
+++ b/apps/web/src/components/editor/kb-article/markdown-paste.ts
@@ -1,0 +1,99 @@
+// apps/web/src/components/editor/kb-article/markdown-paste.ts
+
+import { type Editor, Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+
+const MARKDOWN_HEURISTIC = [
+  /^#{1,6}\s/m,
+  /^\s*[-*]\s/m,
+  /^\s*\d+\.\s/m,
+  /^>\s/m,
+  /^---\s*$/m,
+  /^```/m,
+  /\*\*[^*\n]+\*\*/,
+  /\[[^\]\n]+\]\([^\s)]+\)/,
+  /^:::\w+/m,
+]
+
+function looksLikeMarkdown(text: string): boolean {
+  if (!text) return false
+  if (text.length < 3) return false
+  return MARKDOWN_HEURISTIC.some((re) => re.test(text))
+}
+
+/**
+ * Intercepts plain-text clipboard payloads that look like markdown and
+ * replaces them with parsed BlockJSON. The converter is loaded via
+ * dynamic import on first use so it stays out of the cold editor bundle.
+ */
+export const MarkdownPaste = Extension.create({
+  name: 'markdown-paste',
+
+  addProseMirrorPlugins() {
+    const editor = this.editor
+    return [
+      new Plugin({
+        key: new PluginKey('markdown-paste'),
+        props: {
+          handlePaste: (view, event) => {
+            const cd = event.clipboardData
+            if (!cd) return false
+
+            const text = cd.getData('text/plain')
+            if (!text || !looksLikeMarkdown(text)) return false
+
+            // Don't transform when pasting into a code block — code paste
+            // should stay verbatim.
+            const $from = view.state.selection.$from
+            for (let depth = $from.depth; depth >= 0; depth--) {
+              const node = $from.node(depth)
+              if (node.type.name === 'block' && node.attrs.blockType === 'codeBlock') {
+                return false
+              }
+            }
+
+            event.preventDefault()
+            void importAndInsert(editor, text)
+            return true
+          },
+        },
+      }),
+    ]
+  },
+})
+
+async function importAndInsert(editor: Editor, text: string): Promise<void> {
+  let parsed: { content: unknown[] } | null = null
+  try {
+    const { mdToBlocks } = await import('@auxx/lib/kb/markdown')
+    parsed = mdToBlocks(text)
+  } catch (error) {
+    console.error('Markdown parse failed; falling back to plain text paste', error)
+    insertPlainText(editor, text)
+    return
+  }
+
+  if (!parsed || !parsed.content?.length) {
+    insertPlainText(editor, text)
+    return
+  }
+
+  try {
+    editor
+      .chain()
+      .focus()
+      .insertContent(parsed.content as never[])
+      .run()
+  } catch (error) {
+    console.error('Markdown insert failed; falling back to plain text paste', error)
+    insertPlainText(editor, text)
+  }
+}
+
+function insertPlainText(editor: Editor, text: string): void {
+  try {
+    editor.chain().focus().insertContent(text).run()
+  } catch (error) {
+    console.error('Plain text fallback paste failed', error)
+  }
+}

--- a/apps/web/src/components/editor/kb-article/use-kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/use-kb-article-editor.tsx
@@ -14,6 +14,8 @@ import { useEffect, useMemo, useRef } from 'react'
 import { Table, TableCell, TableHeader, TableRow } from '../extensions/table'
 import { createPlaceholderNode, PlaceholderBadge, useSlashCommand } from '../inline-picker'
 import { Block } from './block-node'
+import { MarkdownInputRules } from './markdown-input-rules'
+import { MarkdownPaste } from './markdown-paste'
 import { migrateLegacyContent } from './migrate-legacy-content'
 
 const Doc = Node.create({
@@ -92,6 +94,8 @@ export function useKBArticleEditor({ initialContent, onChange }: UseKBArticleEdi
           // Marks stay enabled (bold, italic, strike, code).
         }),
         Block,
+        MarkdownInputRules,
+        MarkdownPaste,
         Table.configure({ resizable: true }),
         TableRow,
         TableHeader,

--- a/apps/web/src/components/kb/ui/editor/article-editor-top.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor-top.tsx
@@ -2,9 +2,10 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
-import { EmojiPicker } from '@auxx/ui/components/emoji-picker'
+import { IconPicker } from '@auxx/ui/components/icon-picker'
+import { EntityIcon } from '@auxx/ui/components/icons'
 import { Cog, Smile } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { EditableText } from '~/components/editor/editable-text'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
 import type { ArticleMeta } from '../../store/article-store'
@@ -26,7 +27,17 @@ export function ArticleEditorTop({
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const { updateArticleDraft } = useArticleMutations(knowledgeBaseId)
 
+  // The store keeps article.emoji at the *published* revision's value for published
+  // articles, so a freshly picked icon would appear to revert. Mirror what
+  // EditableText does for the title: hold a local override that resets when the
+  // article id changes.
+  const [pickedEmoji, setPickedEmoji] = useState<string | null>(article.emoji)
+  useEffect(() => {
+    setPickedEmoji(article.emoji)
+  }, [article.id, article.emoji])
+
   const handleEmojiChange = (emoji: string) => {
+    setPickedEmoji(emoji)
     void updateArticleDraft(article.id, { emoji })
   }
 
@@ -52,15 +63,18 @@ export function ArticleEditorTop({
               <div className='flex h-full flex-1 self-stretch'>
                 <div className='flex h-10 w-auto shrink-0 flex-row items-center justify-end lg:h-12'>
                   <div className='relative flex pl-0 pr-2 lg:absolute lg:pl-4 lg:pr-2'>
-                    <EmojiPicker value={article.emoji ?? undefined} onChange={handleEmojiChange}>
+                    <IconPicker
+                      value={pickedEmoji ? { icon: pickedEmoji, color: 'gray' } : undefined}
+                      onChange={(v) => handleEmojiChange(v.icon)}
+                      hideColors>
                       <Button variant='ghost' size='icon' className='rounded-full'>
-                        {article.emoji ? (
-                          <span className='text-2xl leading-none'>{article.emoji}</span>
+                        {pickedEmoji ? (
+                          <EntityIcon iconId={pickedEmoji} variant='bare' size='xl' />
                         ) : (
                           <Smile size={26} />
                         )}
                       </Button>
-                    </EmojiPicker>
+                    </IconPicker>
                   </div>
                 </div>
                 <div className='relative flex h-full w-full items-center overflow-hidden text-2xl font-semibold lg:text-4xl'>

--- a/apps/web/src/components/kb/ui/editor/article-settings-dialog.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-settings-dialog.tsx
@@ -10,8 +10,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@auxx/ui/components/dialog'
-import { EmojiPicker } from '@auxx/ui/components/emoji-picker'
 import { Field, FieldDescription, FieldLabel } from '@auxx/ui/components/field'
+import { IconPicker } from '@auxx/ui/components/icon-picker'
+import { EntityIcon } from '@auxx/ui/components/icons'
 import { Input } from '@auxx/ui/components/input'
 import {
   InputGroup,
@@ -86,9 +87,14 @@ export function ArticleSettingsDialog({
   const trigger = (
     <button
       type='button'
-      className='flex size-7.5 items-center justify-center rounded-full border bg-background text-lg leading-none hover:bg-muted'
+      className='flex size-7.5 items-center justify-center rounded-full border bg-background hover:bg-muted'
       disabled={isSaving}>
-      {emoji || '📄'}
+      <EntityIcon
+        iconId={emoji ?? 'file-text'}
+        variant='bare'
+        size='sm'
+        className={emoji ? '' : 'text-muted-foreground'}
+      />
     </button>
   )
 
@@ -196,10 +202,14 @@ export function ArticleSettingsDialog({
               <section className='space-y-3'>
                 <div className='grid grid-cols-[30px_1fr] items-end gap-2'>
                   <Field>
-                    <FieldLabel className='sr-only'>Emoji</FieldLabel>
-                    <EmojiPicker value={emoji ?? undefined} onChange={setEmoji} modal={false}>
+                    <FieldLabel className='sr-only'>Icon</FieldLabel>
+                    <IconPicker
+                      value={emoji ? { icon: emoji, color: 'gray' } : undefined}
+                      onChange={(v) => setEmoji(v.icon)}
+                      hideColors
+                      modal={false}>
                       {trigger}
-                    </EmojiPicker>
+                    </IconPicker>
                   </Field>
                   <Field>
                     <FieldLabel>Title</FieldLabel>

--- a/apps/web/src/components/kb/ui/editor/article-status-pill.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-status-pill.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { Badge } from '@auxx/ui/components/badge'
+import { cn } from '@auxx/ui/lib/utils'
 import type { ArticleMeta } from '../../store/article-store'
 
 interface ArticleStatusPillProps {
@@ -23,7 +24,7 @@ export function ArticleStatusPill({ article, className }: ArticleStatusPillProps
   if (article.isPublished) {
     if (article.hasUnpublishedChanges) {
       return (
-        <Badge variant='amber' className={className}>
+        <Badge variant='amber' className={cn(className, 'shrink-0')}>
           Live · unsaved changes
         </Badge>
       )
@@ -47,7 +48,7 @@ export function articleStatusDescription(
   if (article.status === 'ARCHIVED') return 'Hidden from sidebar and the public site.'
   if (article.isPublished) {
     if (article.hasUnpublishedChanges) {
-      return 'Visible publicly. Your draft has unsaved changes that aren’t live yet.'
+      return 'Your draft has unsaved changes that aren’t live yet.'
     }
     if (article.publishedAt) {
       return `Published ${formatRelative(article.publishedAt)}.`

--- a/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
@@ -6,6 +6,7 @@ import {
   extractKBHeadings,
   findArticleBySlugPath,
   getArticleNeighbours,
+  getArticleParentLink,
   KBArticlePager,
   KBArticleRenderer,
   KBLayout,
@@ -44,6 +45,7 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath }: KBFullscreenP
   const { prev, next } = articleId
     ? getArticleNeighbours(articles, articleId)
     : { prev: undefined, next: undefined }
+  const parent = getArticleParentLink(activeArticle, articles, basePath)
 
   return (
     <KBLayout
@@ -53,14 +55,20 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath }: KBFullscreenP
       activeArticleId={activeArticle?.id}>
       {articleId ? (
         <div className='flex min-w-0 flex-1 flex-col'>
-          <div className='w-full max-w-3xl px-6 pt-4'>
-            <KBTableOfContents headings={headings} />
+          <div className='flex flex-col gap-6 @kb-lg:flex-row @kb-lg:items-start'>
+            <aside className='hidden @kb-lg:sticky @kb-lg:top-20 @kb-lg:order-2 @kb-lg:block @kb-lg:w-64 @kb-lg:max-w-none @kb-lg:flex-none @kb-lg:px-4 @kb-lg:pt-8'>
+              <KBTableOfContents headings={headings} />
+            </aside>
+            <div className='min-w-0 flex-1 @kb-lg:order-1'>
+              <KBArticleRenderer
+                doc={docJson}
+                title={activeArticle?.title}
+                emoji={activeArticle?.emoji}
+                description={description ?? activeArticle?.description}
+                parent={parent}
+              />
+            </div>
           </div>
-          <KBArticleRenderer
-            doc={docJson}
-            title={activeArticle?.title}
-            description={description ?? activeArticle?.description}
-          />
           <div className='mt-auto w-full max-w-3xl px-6'>
             <KBArticlePager articles={articles} prev={prev} next={next} basePath={basePath} />
           </div>

--- a/apps/web/src/components/kb/ui/preview/kb-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview.tsx
@@ -5,6 +5,7 @@ import {
   type DocJSON,
   extractKBHeadings,
   getArticleNeighbours,
+  getArticleParentLink,
   KBArticlePager,
   KBArticleRenderer,
   KBLayout,
@@ -13,10 +14,12 @@ import {
 import { useEffect, useState } from 'react'
 import { useArticleContent } from '../../hooks/use-article-content'
 import { useArticleList } from '../../hooks/use-article-list'
+import { useKbPublicUrl } from '../../hooks/use-kb-public-url'
 import type { KnowledgeBase } from '../../store/knowledge-base-store'
 import { KBPreviewTopBar } from './kb-preview-topbar'
 import { mapKBForPreview } from './map-kb-for-preview'
 import { PreviewProvider, usePreview } from './preview-context'
+import { DesktopPreviewFrame, MobilePreviewFrame } from './preview-frames'
 
 interface KBPreviewProps {
   knowledgeBase: KnowledgeBase
@@ -49,48 +52,67 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
   const articleId = activeArticle?.id ?? null
   const { contentJson, description } = useArticleContent(articleId, kbId)
 
+  const publicUrl = useKbPublicUrl(knowledgeBase?.slug)
+
   if (!knowledgeBase) return null
 
-  const widthClass = isMobile ? 'w-[420px]' : 'w-full max-w-7xl'
   const docJson = (contentJson ?? null) as DocJSON | null
   const headings = docJson ? extractKBHeadings(docJson) : []
   const { prev, next } = articleId
     ? getArticleNeighbours(articles, articleId)
     : { prev: undefined, next: undefined }
+  const parent = getArticleParentLink(activeArticle, articles, '#preview')
+
+  const isLive =
+    knowledgeBase.publishStatus === 'PUBLISHED' || knowledgeBase.publishStatus === 'UNLISTED'
+  const browserUrl = isLive && publicUrl ? publicUrl : `(draft) ${knowledgeBase.slug}`
+
+  const layout = (
+    <div style={{ colorScheme: isDark ? 'dark' : 'light' }}>
+      <KBLayout
+        kb={mapKBForPreview(knowledgeBase)}
+        articles={articles}
+        basePath='#preview'
+        activeArticleId={activeArticle?.id}
+        mode={isDark ? 'dark' : 'light'}
+        embedded
+        onArticleClick={(id) => setOverrideId(id)}>
+        {articleId ? (
+          <div className='flex min-w-0 flex-1 flex-col'>
+            <div className='flex flex-col gap-6 @kb-lg:flex-row @kb-lg:items-start'>
+              <aside className='hidden @kb-lg:sticky @kb-lg:top-20 @kb-lg:order-2 @kb-lg:block @kb-lg:w-64 @kb-lg:max-w-none @kb-lg:flex-none @kb-lg:px-4 @kb-lg:pt-8'>
+                <KBTableOfContents headings={headings} />
+              </aside>
+              <div className='min-w-0 flex-1 @kb-lg:order-1'>
+                <KBArticleRenderer
+                  doc={docJson}
+                  title={activeArticle?.title ?? articles.find((a) => a.id === articleId)?.title}
+                  emoji={activeArticle?.emoji ?? articles.find((a) => a.id === articleId)?.emoji}
+                  description={description ?? activeArticle?.description}
+                  parent={parent}
+                />
+              </div>
+            </div>
+            <div className='mt-auto w-full max-w-3xl px-6'>
+              <KBArticlePager articles={articles} prev={prev} next={next} basePath='#preview' />
+            </div>
+          </div>
+        ) : (
+          <div style={{ padding: '2rem', opacity: 0.7 }}>No articles yet.</div>
+        )}
+      </KBLayout>
+    </div>
+  )
 
   return (
     <div className='flex flex-1 flex-col'>
       <KBPreviewTopBar kbId={kbId} activeSlugPath={activeSlugPath} />
       <div className='flex flex-1 items-start justify-center overflow-auto bg-muted p-4'>
-        <div
-          className={`${widthClass} overflow-hidden rounded border border-foreground/10 shadow-sm`}
-          style={{ colorScheme: isDark ? 'dark' : 'light' }}>
-          <KBLayout
-            kb={mapKBForPreview(knowledgeBase)}
-            articles={articles}
-            basePath='#preview'
-            activeArticleId={activeArticle?.id}
-            mode={isDark ? 'dark' : 'light'}
-            onArticleClick={(id) => setOverrideId(id)}>
-            {articleId ? (
-              <div className='flex min-w-0 flex-1 flex-col'>
-                <div className='w-full max-w-3xl px-6 pt-4'>
-                  <KBTableOfContents headings={headings} />
-                </div>
-                <KBArticleRenderer
-                  doc={docJson}
-                  title={activeArticle?.title ?? articles.find((a) => a.id === articleId)?.title}
-                  description={description ?? activeArticle?.description}
-                />
-                <div className='mt-auto w-full max-w-3xl px-6'>
-                  <KBArticlePager articles={articles} prev={prev} next={next} basePath='#preview' />
-                </div>
-              </div>
-            ) : (
-              <div style={{ padding: '2rem', opacity: 0.7 }}>No articles yet.</div>
-            )}
-          </KBLayout>
-        </div>
+        {isMobile ? (
+          <MobilePreviewFrame>{layout}</MobilePreviewFrame>
+        ) : (
+          <DesktopPreviewFrame url={browserUrl}>{layout}</DesktopPreviewFrame>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/components/kb/ui/preview/preview-frames.tsx
+++ b/apps/web/src/components/kb/ui/preview/preview-frames.tsx
@@ -1,0 +1,68 @@
+// apps/web/src/components/kb/ui/preview/preview-frames.tsx
+'use client'
+
+import type { ReactNode } from 'react'
+
+interface MobilePreviewFrameProps {
+  children: ReactNode
+}
+
+export function MobilePreviewFrame({ children }: MobilePreviewFrameProps) {
+  return (
+    <div
+      data-slot='mobile-frame'
+      className='relative aspect-[390/844] w-[390px] rounded-[3rem] border border-foreground/10 bg-white p-[10px] shadow-[0_8px_32px_rgba(15,23,42,0.08)]'>
+      <div
+        data-slot='mobile-screen'
+        className='relative flex h-full w-full flex-col overflow-auto rounded-[2.4rem] bg-background'>
+        {children}
+        <DynamicIsland />
+      </div>
+    </div>
+  )
+}
+
+function DynamicIsland() {
+  return (
+    <div
+      data-slot='dynamic-island'
+      className='pointer-events-none absolute top-2 left-1/2 z-50 flex h-[34px] w-[120px] -translate-x-1/2 items-center justify-center gap-2 rounded-full bg-zinc-900'>
+      <span className='h-[5px] w-9 rounded-full bg-zinc-700' aria-hidden />
+      <span
+        className='relative h-[10px] w-[10px] rounded-full bg-zinc-800 ring-[1.5px] ring-zinc-700'
+        aria-hidden>
+        <span className='absolute inset-[2.5px] rounded-full bg-zinc-950' />
+      </span>
+    </div>
+  )
+}
+
+interface DesktopPreviewFrameProps {
+  url: string
+  children: ReactNode
+}
+
+export function DesktopPreviewFrame({ url, children }: DesktopPreviewFrameProps) {
+  return (
+    <div
+      data-slot='desktop-frame'
+      className='w-full max-w-7xl overflow-hidden rounded-lg border border-foreground/10 bg-background shadow-sm'>
+      <div
+        data-slot='desktop-chrome'
+        className='flex items-center gap-3 border-b border-foreground/10 bg-muted/60 px-3 py-2'>
+        <div className='flex items-center gap-1.5'>
+          <span className='size-3 rounded-full bg-[#ff5f57]' aria-hidden />
+          <span className='size-3 rounded-full bg-[#febc2e]' aria-hidden />
+          <span className='size-3 rounded-full bg-[#28c841]' aria-hidden />
+        </div>
+        <div className='mx-auto w-full max-w-md truncate rounded-md border border-foreground/10 bg-background px-3 py-1 text-center font-mono text-xs text-foreground/70'>
+          {url}
+        </div>
+        <div className='w-12' aria-hidden />
+      </div>
+      <div data-slot='desktop-content' className='relative'>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/kb/ui/sidebar/article-sidebar-item.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/article-sidebar-item.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
+import { EntityIcon, getIcon } from '@auxx/ui/components/icons'
 import { getArticleSlugPaths, getFullSlugPath, isArticleActive } from '@auxx/ui/components/kb/utils'
 import { cn } from '@auxx/ui/lib/utils'
 import { useDroppable } from '@dnd-kit/core'
@@ -20,6 +21,8 @@ import {
   BookCopy,
   ChevronRight,
   Cog,
+  Copy,
+  Download,
   EyeOff,
   Files,
   FileText,
@@ -33,6 +36,7 @@ import {
 } from 'lucide-react'
 import { usePathname, useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
+import { api } from '~/trpc/react'
 import { useArticleList } from '../../hooks/use-article-list'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
 import type { ArticleTreeNode } from '../../store/article-store'
@@ -68,6 +72,36 @@ export function ArticleSidebarItem({
     setHomeArticle,
     duplicateArticle,
   } = useArticleMutations(knowledgeBaseId)
+
+  const utils = api.useUtils()
+  const fetchExport = async () =>
+    utils.kb.exportArticleMarkdown.fetch({ id: article.id, knowledgeBaseId })
+
+  const handleCopyMarkdown = async () => {
+    try {
+      const { markdown } = await fetchExport()
+      await navigator.clipboard.writeText(markdown)
+    } catch (error) {
+      console.error('Failed to copy markdown', error)
+    }
+  }
+
+  const handleDownloadMarkdown = async () => {
+    try {
+      const { markdown, filename } = await fetchExport()
+      const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' })
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = filename
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      URL.revokeObjectURL(url)
+    } catch (error) {
+      console.error('Failed to download markdown', error)
+    }
+  }
 
   const basePath = `/app/kb/${knowledgeBaseId}`
   const slugPaths = useMemo(() => getArticleSlugPaths(articles), [articles])
@@ -105,17 +139,25 @@ export function ArticleSidebarItem({
     return `${basePath}/editor/~/${path}?tab=articles`
   }, [article, articles, slugPaths, basePath])
 
+  const hasCustomIcon = !!article.emoji && !!getIcon(article.emoji)
   const icon = isCategory ? (
     isOpen ? (
       <FolderOpen className='size-4 shrink-0 text-muted-foreground' />
     ) : (
       <FolderClosed className='size-4 shrink-0 text-muted-foreground' />
     )
+  ) : hasCustomIcon ? (
+    <EntityIcon
+      iconId={article.emoji as string}
+      variant='bare'
+      size='sm'
+      className='text-muted-foreground'
+    />
   ) : (
     <FileText className='size-4 shrink-0 text-muted-foreground' />
   )
 
-  const displayName = article.emoji ? `${article.emoji} ${article.title}` : article.title
+  const displayName = article.title
 
   const handleAddSubItem = async () => {
     const created = await createArticle({ parentId: article.id })
@@ -265,6 +307,15 @@ export function ArticleSidebarItem({
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => duplicateArticle(article)}>
                     <BookCopy /> Duplicate
+                  </DropdownMenuItem>
+                </DropdownMenuGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuGroup>
+                  <DropdownMenuItem onClick={handleCopyMarkdown}>
+                    <Copy /> Copy as markdown
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={handleDownloadMarkdown}>
+                    <Download /> Download .md
                   </DropdownMenuItem>
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator />

--- a/apps/web/src/components/kb/ui/sidebar/kb-articles-panel.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/kb-articles-panel.tsx
@@ -8,13 +8,15 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
+import { EntityIcon, getIcon } from '@auxx/ui/components/icons'
 import { getFullSlugPath } from '@auxx/ui/components/kb/utils'
+import { toastError } from '@auxx/ui/components/toast'
 import { closestCorners, DndContext, DragOverlay } from '@dnd-kit/core'
 import { restrictToVerticalAxis, restrictToWindowEdges } from '@dnd-kit/modifiers'
-import { Archive, Loader2, Plus, Settings } from 'lucide-react'
+import { Archive, Loader2, Plus, Settings, Upload } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useArticleList, useIsArticleListLoaded } from '../../hooks/use-article-list'
 import { useArticleMove } from '../../hooks/use-article-move'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
@@ -143,6 +145,41 @@ export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
     }
   }, [articles, basePath, createArticle, router])
 
+  const importInputRef = useRef<HTMLInputElement>(null)
+
+  const handleImportMarkdown = useCallback(
+    async (files: FileList | null) => {
+      if (!files || files.length === 0) return
+      const { mdToBlocks, parseFrontmatter } = await import('@auxx/lib/kb/markdown')
+      const failures: string[] = []
+      for (const file of Array.from(files)) {
+        try {
+          const text = await file.text()
+          const { fields } = parseFrontmatter(text)
+          const doc = mdToBlocks(text)
+          const inferredTitle =
+            fields.title ?? extractFirstHeading(doc) ?? file.name.replace(/\.md$/i, '')
+          await createArticle({
+            title: inferredTitle,
+            slug: fields.slug,
+            description: fields.description,
+            contentJson: doc,
+          })
+        } catch (error) {
+          console.error('Markdown import failed', file.name, error)
+          failures.push(file.name)
+        }
+      }
+      if (failures.length > 0) {
+        toastError({
+          title: `Failed to import ${failures.length} file${failures.length === 1 ? '' : 's'}`,
+          description: failures.join(', '),
+        })
+      }
+    },
+    [createArticle]
+  )
+
   if (!hasLoaded) {
     return (
       <div className='flex items-center justify-center py-8'>
@@ -192,6 +229,9 @@ export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
                 </>
               )}
             </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => importInputRef.current?.click()}>
+              <Upload className='mr-2 h-4 w-4' /> Import .md
+            </DropdownMenuItem>
             <DropdownMenuItem asChild>
               <Link href={`${basePath}/settings`}>
                 <Settings className='mr-2 h-4 w-4' />
@@ -200,6 +240,17 @@ export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+        <input
+          ref={importInputRef}
+          type='file'
+          accept='.md,text/markdown'
+          multiple
+          className='hidden'
+          onChange={(e) => {
+            void handleImportMarkdown(e.target.files)
+            e.target.value = ''
+          }}
+        />
       </div>
 
       <DndContext
@@ -225,13 +276,15 @@ export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
               style={{ maxWidth: '280px' }}>
               <div className='flex items-center space-x-2'>
                 <span className='shrink-0 text-muted-foreground'>
-                  {activeArticle.isCategory ? '📁' : '📄'}
+                  {activeArticle.emoji && getIcon(activeArticle.emoji) ? (
+                    <EntityIcon iconId={activeArticle.emoji} variant='bare' size='sm' />
+                  ) : activeArticle.isCategory ? (
+                    '📁'
+                  ) : (
+                    '📄'
+                  )}
                 </span>
-                <span className='truncate font-medium'>
-                  {activeArticle.emoji
-                    ? `${activeArticle.emoji} ${activeArticle.title}`
-                    : activeArticle.title || 'Untitled'}
-                </span>
+                <span className='truncate font-medium'>{activeArticle.title || 'Untitled'}</span>
               </div>
             </div>
           ) : null}
@@ -269,4 +322,21 @@ export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
       </div>
     </div>
   )
+}
+
+interface MaybeDoc {
+  content?: { attrs?: { blockType?: string }; content?: { type: string; text?: string }[] }[]
+}
+
+function extractFirstHeading(doc: MaybeDoc): string | undefined {
+  for (const block of doc.content ?? []) {
+    if (block?.attrs?.blockType !== 'heading') continue
+    const text = (block.content ?? [])
+      .filter((c) => c.type === 'text')
+      .map((c) => c.text ?? '')
+      .join('')
+      .trim()
+    if (text.length > 0) return text
+  }
+  return undefined
 }

--- a/apps/web/src/server/api/routers/kb.ts
+++ b/apps/web/src/server/api/routers/kb.ts
@@ -4,7 +4,7 @@ import { schema } from '@auxx/database'
 import { ArticleStatus } from '@auxx/database/enums'
 import { onCacheEvent } from '@auxx/lib/cache'
 import { getUserOrganizationId } from '@auxx/lib/email'
-import { KBService } from '@auxx/lib/kb'
+import { articleToMarkdown, KBService } from '@auxx/lib/kb'
 import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
 import { TRPCError } from '@trpc/server'
 import { and, count, eq } from 'drizzle-orm'
@@ -388,6 +388,21 @@ export const knowledgeBaseRouter = createTRPCRouter({
     .input(z.object({ articleId: z.string() }))
     .query(async ({ ctx, input }) => {
       return await getKBService(ctx).getArticleVersions(input.articleId)
+    }),
+
+  exportArticleMarkdown: protectedProcedure
+    .input(z.object({ id: z.string(), knowledgeBaseId: z.string().optional() }))
+    .query(async ({ ctx, input }) => {
+      const article = await getKBService(ctx).getArticleById(input.id, input.knowledgeBaseId)
+      const fallback = (article.slug || article.title || 'article').replace(/[^a-z0-9-_]+/gi, '-')
+      const filename = `${fallback}.md`
+      const markdown = articleToMarkdown({
+        title: article.title,
+        contentJson: article.contentJson,
+      })
+      const header =
+        article.title && article.title.trim().length > 0 ? `# ${article.title}\n\n` : ''
+      return { filename, markdown: header + markdown }
     }),
 
   renameArticleVersion: protectedProcedure

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -382,6 +382,12 @@
       "import": "./dist/kb/index.mjs",
       "default": "./src/kb/index.ts"
     },
+    "./kb/markdown": {
+      "types": "./src/kb/markdown/index.ts",
+      "source": "./src/kb/markdown/index.ts",
+      "import": "./dist/kb/markdown/index.mjs",
+      "default": "./src/kb/markdown/index.ts"
+    },
     "./mail-domains": {
       "types": "./src/mail-domains/index.ts",
       "source": "./src/mail-domains/index.ts",
@@ -825,6 +831,7 @@
     "lucide-react": "catalog:",
     "mailgun.js": "^12.0.1",
     "mammoth": "^1.10.0",
+    "mdast-util-to-string": "^4.0.0",
     "nanoid": "^5.1.5",
     "neverthrow": "^6.2.2",
     "nodemailer": "catalog:",
@@ -837,11 +844,15 @@
     "posthog-node": "catalog:",
     "pusher": "catalog:",
     "pusher-js": "catalog:",
+    "remark-directive": "^3.0.0",
+    "remark-gfm": "^4.0.0",
+    "remark-parse": "^11.0.0",
     "sharp": "catalog:",
     "shiki": "catalog:",
     "stripe": "catalog:",
     "tldts": "^7.0.28",
     "turndown": "catalog:",
+    "unified": "^11.0.5",
     "uuid": "catalog:",
     "xlsx": "^0.18.5",
     "zod": "catalog:",

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-kb.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-kb.ts
@@ -3,7 +3,7 @@
 import { type Database, schema } from '@auxx/database'
 import { and, eq, ilike, or } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/pg-core'
-import { KBService } from '../../../../../kb'
+import { articleToMarkdown, KBService } from '../../../../../kb'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
 
@@ -13,6 +13,14 @@ const MAX_CONTENT_LENGTH = 800
 function truncate(text: string | null | undefined, maxLen: number): string {
   if (!text) return ''
   return text.length > maxLen ? `${text.slice(0, maxLen)}...` : text
+}
+
+function renderArticleBody(contentJson: unknown, fallback: string | null | undefined): string {
+  if (contentJson) {
+    const md = articleToMarkdown({ contentJson })
+    if (md && md.trim().length > 0) return md
+  }
+  return fallback ?? ''
 }
 
 /**
@@ -46,6 +54,7 @@ async function searchArticles(
       description: pub.description,
       excerpt: pub.excerpt,
       content: pub.content,
+      contentJson: pub.contentJson,
       knowledgeBaseId: schema.Article.knowledgeBaseId,
       slug: schema.Article.slug,
       updatedAt: schema.Article.updatedAt,
@@ -109,7 +118,7 @@ export function createSearchKBTool(getDeps: GetToolDeps): AgentToolDefinition {
         id: a.id,
         title: a.title,
         excerpt: a.excerpt || a.description || '',
-        content: truncate(a.content, MAX_CONTENT_LENGTH),
+        content: truncate(renderArticleBody(a.contentJson, a.content), MAX_CONTENT_LENGTH),
         knowledgeBaseId: a.knowledgeBaseId,
       }))
 

--- a/packages/lib/src/kb/index.ts
+++ b/packages/lib/src/kb/index.ts
@@ -17,3 +17,4 @@ export {
   KBService,
   type KBUpdateInput,
 } from './kb-service'
+export { articleToMarkdown } from './markdown/article-to-markdown'

--- a/packages/lib/src/kb/markdown/__tests__/round-trip.test.ts
+++ b/packages/lib/src/kb/markdown/__tests__/round-trip.test.ts
@@ -1,0 +1,242 @@
+// packages/lib/src/kb/markdown/__tests__/round-trip.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { blocksToMd } from '../blocks-to-md'
+import { mdToBlocks, parseFrontmatter } from '../md-to-blocks'
+import type { DocJSON } from '../types'
+
+function block(
+  blockType: string,
+  attrs: Record<string, unknown> = {},
+  content: unknown[] = []
+): unknown {
+  return { type: 'block', attrs: { blockType, ...attrs }, content }
+}
+
+const text = (s: string, marks?: unknown[]) =>
+  marks ? { type: 'text', text: s, marks } : { type: 'text', text: s }
+
+describe('mdToBlocks — basic blocks', () => {
+  it('parses headings (clamps to 3)', () => {
+    const doc = mdToBlocks('# H1\n\n## H2\n\n### H3\n\n#### H4')
+    expect(doc.content.map((b) => b.attrs.blockType)).toEqual([
+      'heading',
+      'heading',
+      'heading',
+      'heading',
+    ])
+    expect(doc.content.map((b) => b.attrs.level)).toEqual([1, 2, 3, 3])
+  })
+
+  it('parses paragraphs as text blocks', () => {
+    const doc = mdToBlocks('Hello world.\n\nSecond para.')
+    expect(doc.content).toHaveLength(2)
+    expect(doc.content[0]).toMatchObject({ attrs: { blockType: 'text' } })
+    expect(doc.content[1]).toMatchObject({ attrs: { blockType: 'text' } })
+  })
+
+  it('parses bullet, numbered, and task lists', () => {
+    const md = '- one\n- two\n\n1. first\n2. second\n\n- [ ] open\n- [x] done'
+    const doc = mdToBlocks(md)
+    const types = doc.content.map((b) => b.attrs.blockType)
+    expect(types).toEqual([
+      'bulletListItem',
+      'bulletListItem',
+      'numberedListItem',
+      'numberedListItem',
+      'todoListItem',
+      'todoListItem',
+    ])
+    expect(doc.content[4]?.attrs.checked).toBe(false)
+    expect(doc.content[5]?.attrs.checked).toBe(true)
+  })
+
+  it('parses nested lists with level attribute', () => {
+    const md = '- one\n  - nested\n  - also nested\n- two'
+    const doc = mdToBlocks(md)
+    expect(doc.content.map((b) => b.attrs.level)).toEqual([1, 2, 2, 1])
+  })
+
+  it('parses code fences with language', () => {
+    const md = '```ts\nconst x = 1\n```'
+    const doc = mdToBlocks(md)
+    expect(doc.content[0]?.attrs.blockType).toBe('codeBlock')
+    expect(doc.content[0]?.attrs.codeLanguage).toBe('ts')
+    expect(doc.content[0]?.content?.[0]).toEqual({ type: 'text', text: 'const x = 1' })
+  })
+
+  it('parses blockquotes and dividers', () => {
+    const doc = mdToBlocks('> quoted\n\n---\n\ntrailing')
+    expect(doc.content.map((b) => b.attrs.blockType)).toEqual(['quote', 'divider', 'text'])
+  })
+})
+
+describe('mdToBlocks — directives', () => {
+  it('parses callout container directives', () => {
+    const doc = mdToBlocks(':::tip\nBe kind.\n:::')
+    expect(doc.content[0]?.attrs.blockType).toBe('callout')
+    expect(doc.content[0]?.attrs.calloutVariant).toBe('tip')
+  })
+
+  it('aliases note → info, warning → warn, danger → error', () => {
+    const doc = mdToBlocks(':::note\nA\n:::\n\n:::warning\nB\n:::\n\n:::danger\nC\n:::')
+    expect(doc.content.map((b) => b.attrs.calloutVariant)).toEqual(['info', 'warn', 'error'])
+  })
+
+  it('parses embed leaf directives', () => {
+    const doc = mdToBlocks(
+      '::embed{url="https://www.youtube.com/watch?v=abcdefg" provider="youtube"}'
+    )
+    expect(doc.content[0]).toMatchObject({
+      attrs: { blockType: 'embed', embedUrl: 'https://www.youtube.com/watch?v=abcdefg' },
+    })
+  })
+
+  it('promotes a bare YouTube URL line to an embed', () => {
+    const doc = mdToBlocks('https://www.youtube.com/watch?v=abcdefg')
+    expect(doc.content[0]?.attrs.blockType).toBe('embed')
+    expect(doc.content[0]?.attrs.embedProvider).toBe('youtube')
+  })
+})
+
+describe('mdToBlocks — inline marks', () => {
+  it('parses bold, italic, strike, code', () => {
+    const doc = mdToBlocks('**bold** *italic* ~~strike~~ `code`')
+    const inline = doc.content[0]?.content ?? []
+    const marksOf = (i: number) => (inline[i] as { marks?: { type: string }[] }).marks?.[0]?.type
+    expect(marksOf(0)).toBe('bold')
+    expect(marksOf(2)).toBe('italic')
+    expect(marksOf(4)).toBe('strike')
+    expect(marksOf(6)).toBe('code')
+  })
+
+  it('parses links with href attr', () => {
+    const doc = mdToBlocks('[click](https://example.com)')
+    const inline = doc.content[0]?.content?.[0] as {
+      type: string
+      marks?: { type: string; attrs?: Record<string, unknown> }[]
+    }
+    expect(inline.marks?.[0]?.type).toBe('link')
+    expect(inline.marks?.[0]?.attrs?.href).toBe('https://example.com')
+  })
+
+  it('parses <u> as underline mark', () => {
+    const doc = mdToBlocks('plain <u>emphasized</u>.')
+    const inline = doc.content[0]?.content ?? []
+    const u = inline.find((n) =>
+      (n as { marks?: { type: string }[] }).marks?.some((m) => m.type === 'underline')
+    )
+    expect(u).toBeTruthy()
+  })
+
+  it('extracts {{placeholder}} syntax', () => {
+    const doc = mdToBlocks('Hi {{first_name}}, welcome.')
+    const inline = doc.content[0]?.content ?? []
+    expect(inline[1]).toEqual({ type: 'placeholder', attrs: { id: 'first_name' } })
+  })
+
+  it('emits code mark exclusively (no bold+code combos that the schema rejects)', () => {
+    // ProseMirror's `code` mark excludes all others. If the converter combined
+    // it with bold/italic, the editor would throw "Invalid collection of marks".
+    const doc = mdToBlocks('**before `inside` after**')
+    const inline = doc.content[0]?.content ?? []
+    for (const node of inline) {
+      const marks = (node as { marks?: { type: string }[] }).marks ?? []
+      const hasCode = marks.some((m) => m.type === 'code')
+      if (hasCode) {
+        expect(marks).toEqual([{ type: 'code' }])
+      }
+    }
+  })
+})
+
+describe('mdToBlocks — frontmatter', () => {
+  it('extracts title/slug/description', () => {
+    const md = '---\ntitle: Hello\nslug: hi\ndescription: "A test"\n---\n\n# Body'
+    const { fields, body } = parseFrontmatter(md)
+    expect(fields).toEqual({ title: 'Hello', slug: 'hi', description: 'A test' })
+    expect(body.startsWith('\n# Body')).toBe(true)
+  })
+
+  it('strips frontmatter when parsing', () => {
+    const md = '---\ntitle: x\n---\n\n# Body'
+    const doc = mdToBlocks(md)
+    expect(doc.content[0]?.attrs.blockType).toBe('heading')
+  })
+})
+
+describe('blocksToMd — basic blocks', () => {
+  const doc: DocJSON = {
+    type: 'doc',
+    content: [
+      block('heading', { level: 1 }, [text('Title')]),
+      block('text', {}, [
+        text('Para with '),
+        text('bold', [{ type: 'bold' }]),
+        text(' and '),
+        text('italic', [{ type: 'italic' }]),
+        text('.'),
+      ]),
+      block('bulletListItem', { level: 1 }, [text('one')]),
+      block('bulletListItem', { level: 2 }, [text('nested')]),
+      block('numberedListItem', { level: 1 }, [text('first')]),
+      block('todoListItem', { level: 1, checked: true }, [text('done')]),
+      block('quote', {}, [text('quoted')]),
+      block('codeBlock', { codeLanguage: 'ts' }, [text('const x = 1')]),
+      block('divider'),
+      block('callout', { calloutVariant: 'tip' }, [text('Pro tip')]),
+      block('embed', {
+        embedUrl: 'https://www.youtube.com/watch?v=abcdefg',
+        embedProvider: 'youtube',
+      }),
+      block('image', { imageUrl: 'https://x.com/y.png', imageWidth: 600, imageAlign: 'left' }),
+    ] as never,
+  }
+
+  it('produces expected markdown shape', () => {
+    const md = blocksToMd(doc)
+    expect(md).toContain('# Title')
+    expect(md).toContain('Para with **bold** and *italic*')
+    expect(md).toContain('- one')
+    expect(md).toContain('  - nested')
+    expect(md).toContain('1. first')
+    expect(md).toContain('- [x] done')
+    expect(md).toContain('> quoted')
+    expect(md).toContain('```ts\nconst x = 1\n```')
+    expect(md).toContain('---')
+    expect(md).toContain(':::tip\nPro tip\n:::')
+    expect(md).toContain('::embed{url="https://www.youtube.com/watch?v=abcdefg"')
+    expect(md).toContain('![](https://x.com/y.png){width=600 align=left}')
+  })
+})
+
+describe('round-trip', () => {
+  it('preserves block types across mdToBlocks(blocksToMd(doc))', () => {
+    const original: DocJSON = {
+      type: 'doc',
+      content: [
+        block('heading', { level: 2 }, [text('Setup')]),
+        block('text', {}, [text('Install '), text('the', [{ type: 'bold' }]), text(' deps.')]),
+        block('bulletListItem', { level: 1 }, [text('one')]),
+        block('bulletListItem', { level: 1 }, [text('two')]),
+        block('codeBlock', { codeLanguage: 'bash' }, [text('pnpm install')]),
+        block('callout', { calloutVariant: 'warn' }, [text('Heads up.')]),
+        block('quote', {}, [text('Cited.')]),
+        block('divider'),
+      ] as never,
+    }
+
+    const md = blocksToMd(original)
+    const reparsed = mdToBlocks(md)
+
+    const types = (d: DocJSON) => d.content.map((b) => b.attrs.blockType)
+    expect(types(reparsed)).toEqual(types(original))
+  })
+
+  it('preserves placeholders across the round-trip', () => {
+    const md = 'Hi {{first_name}}, your order is ready.'
+    const doc = mdToBlocks(md)
+    const out = blocksToMd(doc)
+    expect(out).toContain('{{first_name}}')
+  })
+})

--- a/packages/lib/src/kb/markdown/article-to-markdown.ts
+++ b/packages/lib/src/kb/markdown/article-to-markdown.ts
@@ -1,0 +1,22 @@
+// packages/lib/src/kb/markdown/article-to-markdown.ts
+
+import { type BlocksToMdOptions, blocksToMd } from './blocks-to-md'
+import type { DocJSON } from './types'
+
+interface ArticleLike {
+  title?: string | null
+  contentJson?: unknown
+}
+
+/**
+ * Render a KB article as markdown for AI prompts, exports, or any other
+ * downstream consumer. Pulls `contentJson` off the article and runs it
+ * through the standard serializer.
+ *
+ * Pass `placeholders: (id) => 'value'` when you have resolved values to
+ * inline; otherwise placeholders render as their literal `{{id}}` syntax.
+ */
+export function articleToMarkdown(article: ArticleLike, opts: BlocksToMdOptions = {}): string {
+  if (!article || !article.contentJson) return ''
+  return blocksToMd(article.contentJson as DocJSON, opts)
+}

--- a/packages/lib/src/kb/markdown/blocks-to-md.ts
+++ b/packages/lib/src/kb/markdown/blocks-to-md.ts
@@ -1,0 +1,166 @@
+// packages/lib/src/kb/markdown/blocks-to-md.ts
+//
+// Serializes a KB DocJSON to markdown in the "Auxx MD" dialect.
+// See plans/kb/markdown-support.md for the format spec.
+
+import { escapeLinkUrl, escapeMarkdownText, inlineToMd } from './inline'
+import type {
+  BlockAttrs,
+  BlockJSON,
+  CalloutVariant,
+  DocJSON,
+  EmbedAspect,
+  EmbedProvider,
+  ImageAlign,
+  InlineJSON,
+} from './types'
+import { CALLOUT_VARIANTS } from './types'
+
+export interface BlocksToMdOptions {
+  /** How to render placeholder inline nodes. `'literal'` writes `{{id}}`. */
+  placeholders?: 'literal' | ((id: string) => string)
+}
+
+export function blocksToMd(doc: DocJSON | null | undefined, opts: BlocksToMdOptions = {}): string {
+  if (!doc || doc.type !== 'doc' || !Array.isArray(doc.content)) return ''
+  const placeholders = opts.placeholders ?? 'literal'
+  const ctx = { placeholders }
+
+  const blocks = doc.content
+  const lines: string[] = []
+  let inListRun = false
+
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i]
+    if (!block || block.type !== 'block') continue
+    const next = blocks[i + 1]
+
+    const renderedLines = renderBlock(block, ctx)
+    if (renderedLines.length === 0) continue
+
+    if (lines.length > 0) lines.push('') // blank line between blocks
+
+    for (const line of renderedLines) lines.push(line)
+
+    inListRun = isListItem(block)
+    // List runs don't get inter-item blank lines in CommonMark, but tighter
+    // rendering is fine here since GFM normalizes anyway.
+    if (inListRun && next && isListItem(next) && sameListType(block, next)) {
+      // Drop the blank we just queued — pop and re-emit without separator.
+      // Easier: emit as-is, GFM tolerates it.
+    }
+  }
+
+  return `${lines
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd()}\n`
+}
+
+function isListItem(block: BlockJSON): boolean {
+  const t = block.attrs?.blockType
+  return t === 'bulletListItem' || t === 'numberedListItem' || t === 'todoListItem'
+}
+
+function sameListType(a: BlockJSON, b: BlockJSON): boolean {
+  return a.attrs?.blockType === b.attrs?.blockType
+}
+
+interface RenderCtx {
+  placeholders: 'literal' | ((id: string) => string)
+}
+
+function renderBlock(block: BlockJSON, ctx: RenderCtx): string[] {
+  const attrs = block.attrs ?? ({} as BlockAttrs)
+  const inline = inlineToMd(block.content, ctx)
+
+  switch (attrs.blockType) {
+    case 'heading': {
+      const level = clampLevel(attrs.level, 1, 3)
+      return [`${'#'.repeat(level)} ${inline}`.trimEnd()]
+    }
+    case 'quote': {
+      return inline.split('\n').map((line) => `> ${line}`)
+    }
+    case 'codeBlock': {
+      const lang = typeof attrs.codeLanguage === 'string' ? attrs.codeLanguage : ''
+      const code = blockText(block.content)
+      return ['```' + lang, ...code.split('\n'), '```']
+    }
+    case 'divider':
+      return ['---']
+    case 'image':
+      return [renderImage(attrs)]
+    case 'bulletListItem':
+      return [renderListItem('-', attrs.level ?? 1, inline)]
+    case 'numberedListItem':
+      return [renderListItem('1.', attrs.level ?? 1, inline)]
+    case 'todoListItem': {
+      const box = attrs.checked ? '[x]' : '[ ]'
+      return [renderListItem(`- ${box}`, attrs.level ?? 1, inline)]
+    }
+    case 'callout':
+      return renderCallout(attrs.calloutVariant, inline)
+    case 'embed':
+      return [renderEmbed(attrs)]
+    default:
+      return inline.length > 0 ? [inline] : []
+  }
+}
+
+function clampLevel(value: unknown, min: number, max: number): number {
+  const n = typeof value === 'number' ? value : 1
+  if (!Number.isFinite(n)) return min
+  return Math.min(max, Math.max(min, Math.trunc(n)))
+}
+
+function renderListItem(marker: string, level: number, content: string): string {
+  const indent = '  '.repeat(Math.max(0, clampLevel(level, 1, 5) - 1))
+  return `${indent}${marker} ${content}`
+}
+
+function renderCallout(variant: CalloutVariant | undefined, body: string): string[] {
+  const safe = variant && CALLOUT_VARIANTS.has(variant) ? variant : 'info'
+  const lines = body.length > 0 ? body.split('\n') : ['']
+  return [`:::${safe}`, ...lines, ':::']
+}
+
+function renderImage(attrs: BlockAttrs): string {
+  const url = typeof attrs.imageUrl === 'string' ? attrs.imageUrl : ''
+  const base = `![](${escapeLinkUrl(url)})`
+  const trailerParts: string[] = []
+  if (typeof attrs.imageWidth === 'number' && attrs.imageWidth !== 400) {
+    trailerParts.push(`width=${attrs.imageWidth}`)
+  }
+  if (typeof attrs.imageAlign === 'string' && attrs.imageAlign !== 'center') {
+    trailerParts.push(`align=${attrs.imageAlign}`)
+  }
+  if (trailerParts.length === 0) return base
+  return `${base}{${trailerParts.join(' ')}}`
+}
+
+function renderEmbed(attrs: BlockAttrs): string {
+  const url = typeof attrs.embedUrl === 'string' ? attrs.embedUrl : ''
+  if (!url) return ''
+  const parts = [`url="${escapeAttrValue(url)}"`]
+  if (typeof attrs.embedProvider === 'string') {
+    parts.push(`provider="${attrs.embedProvider}"`)
+  }
+  if (typeof attrs.embedAspect === 'string' && attrs.embedAspect !== '16:9') {
+    parts.push(`aspect="${attrs.embedAspect}"`)
+  }
+  return `::embed{${parts.join(' ')}}`
+}
+
+function escapeAttrValue(value: string): string {
+  return value.replace(/"/g, '&quot;')
+}
+
+function blockText(content: InlineJSON[] | undefined): string {
+  if (!content) return ''
+  return content.map((node) => (typeof node.text === 'string' ? node.text : '')).join('')
+}
+
+// Re-export for the inline.ts module to share the same escape rules.
+export { escapeMarkdownText, escapeLinkUrl }
+export type { ImageAlign, EmbedProvider, EmbedAspect }

--- a/packages/lib/src/kb/markdown/index.ts
+++ b/packages/lib/src/kb/markdown/index.ts
@@ -1,0 +1,17 @@
+// packages/lib/src/kb/markdown/index.ts
+
+export { type BlocksToMdOptions, blocksToMd } from './blocks-to-md'
+export { type FrontmatterFields, mdToBlocks, parseFrontmatter } from './md-to-blocks'
+export type {
+  BlockAttrs,
+  BlockJSON,
+  BlockType,
+  CalloutVariant,
+  DocJSON,
+  EmbedAspect,
+  EmbedProvider,
+  ImageAlign,
+  InlineJSON,
+  InlineMarkType,
+  MarkJSON,
+} from './types'

--- a/packages/lib/src/kb/markdown/inline.ts
+++ b/packages/lib/src/kb/markdown/inline.ts
@@ -1,0 +1,110 @@
+// packages/lib/src/kb/markdown/inline.ts
+//
+// Helpers for serializing inline content (text + marks + placeholders) to
+// markdown. Parsing is handled by the unified pipeline in md-to-blocks.ts.
+
+import type { InlineJSON, MarkJSON } from './types'
+
+const MARK_ORDER: MarkJSON['type'][] = [
+  'link',
+  'highlight',
+  'underline',
+  'bold',
+  'italic',
+  'strike',
+  'code',
+]
+
+interface SerializeOpts {
+  placeholders: 'literal' | ((id: string) => string)
+}
+
+export function inlineToMd(content: InlineJSON[] | undefined, opts: SerializeOpts): string {
+  if (!content || content.length === 0) return ''
+  let out = ''
+  for (const node of content) {
+    if (node.type === 'placeholder') {
+      const id = typeof node.attrs?.id === 'string' ? (node.attrs.id as string) : ''
+      out += renderPlaceholder(id, opts)
+      continue
+    }
+    if (node.type === 'hardBreak') {
+      out += '  \n'
+      continue
+    }
+    out += renderTextNode(node)
+  }
+  return out
+}
+
+function renderPlaceholder(id: string, opts: SerializeOpts): string {
+  if (typeof opts.placeholders === 'function') return opts.placeholders(id)
+  return `{{${id}}}`
+}
+
+function renderTextNode(node: InlineJSON): string {
+  const raw = node.text ?? ''
+  if (raw.length === 0) return ''
+  const marks = orderMarks(node.marks)
+
+  // `code` mark wraps verbatim — escape only the surrounding backticks.
+  if (marks.some((m) => m.type === 'code')) {
+    return wrapCode(raw)
+  }
+
+  let body = escapeMarkdownText(raw)
+  for (const mark of marks) {
+    body = applyMark(body, mark)
+  }
+  return body
+}
+
+function orderMarks(marks: MarkJSON[] | undefined): MarkJSON[] {
+  if (!marks || marks.length === 0) return []
+  return [...marks].sort(
+    (a, b) =>
+      MARK_ORDER.indexOf(a.type as MarkJSON['type']) -
+      MARK_ORDER.indexOf(b.type as MarkJSON['type'])
+  )
+}
+
+function applyMark(body: string, mark: MarkJSON): string {
+  switch (mark.type) {
+    case 'bold':
+      return `**${body}**`
+    case 'italic':
+      return `*${body}*`
+    case 'strike':
+      return `~~${body}~~`
+    case 'underline':
+      return `<u>${body}</u>`
+    case 'highlight':
+      // No native MD equivalent — drops to plain text. Documented as lossy.
+      return body
+    case 'link': {
+      const href = typeof mark.attrs?.href === 'string' ? (mark.attrs.href as string) : ''
+      return `[${body}](${escapeLinkUrl(href)})`
+    }
+    default:
+      return body
+  }
+}
+
+function wrapCode(text: string): string {
+  // Pick a backtick fence longer than any run of backticks inside the text.
+  const longestRun = (text.match(/`+/g) ?? []).reduce((max, r) => Math.max(max, r.length), 0)
+  const fence = '`'.repeat(longestRun + 1)
+  // Pad with a space when the text starts/ends with a backtick.
+  const needsPad = text.startsWith('`') || text.endsWith('`')
+  return needsPad ? `${fence} ${text} ${fence}` : `${fence}${text}${fence}`
+}
+
+const MARKDOWN_SPECIALS = /([\\`*_{}[\]()#+\-.!~<>|])/g
+
+export function escapeMarkdownText(text: string): string {
+  return text.replace(MARKDOWN_SPECIALS, '\\$1')
+}
+
+export function escapeLinkUrl(url: string): string {
+  return url.replace(/[()\s]/g, encodeURIComponent)
+}

--- a/packages/lib/src/kb/markdown/md-to-blocks.ts
+++ b/packages/lib/src/kb/markdown/md-to-blocks.ts
@@ -1,0 +1,606 @@
+// packages/lib/src/kb/markdown/md-to-blocks.ts
+//
+// Parses markdown (Auxx MD dialect — GFM + remark-directive) into the KB
+// editor's BlockJSON shape. See plans/kb/markdown-support.md for the spec.
+
+import remarkDirective from 'remark-directive'
+import remarkGfm from 'remark-gfm'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+import type {
+  BlockAttrs,
+  BlockJSON,
+  BlockType,
+  CalloutVariant,
+  DocJSON,
+  EmbedAspect,
+  EmbedProvider,
+  ImageAlign,
+  InlineJSON,
+  MarkJSON,
+} from './types'
+import { CALLOUT_VARIANTS, EMBED_ASPECTS, EMBED_PROVIDERS, IMAGE_ALIGNS } from './types'
+
+const PLACEHOLDER_RE = /\{\{([a-zA-Z0-9_.-]+)\}\}/g
+const IMAGE_ATTR_TRAILER_RE = /^\{([^{}\n]*)\}/
+const HEADING_MAX_LEVEL = 3
+
+const parser = unified().use(remarkParse).use(remarkGfm).use(remarkDirective)
+
+export function mdToBlocks(markdown: string): DocJSON {
+  const cleaned = stripFrontmatter(markdown ?? '')
+  if (!cleaned.trim()) return emptyDoc()
+
+  const tree = parser.parse(cleaned) as MdastRoot
+  const ctx: ParseCtx = { blocks: [] }
+  for (const child of tree.children ?? []) {
+    walkBlock(child, ctx, 1)
+  }
+  if (ctx.blocks.length === 0) return emptyDoc()
+  return { type: 'doc', content: ctx.blocks }
+}
+
+interface ParseCtx {
+  blocks: BlockJSON[]
+}
+
+function emptyDoc(): DocJSON {
+  return {
+    type: 'doc',
+    content: [{ type: 'block', attrs: { blockType: 'text' }, content: [] }],
+  }
+}
+
+// ─── frontmatter ─────────────────────────────────────────────────────
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/
+
+export interface FrontmatterFields {
+  title?: string
+  slug?: string
+  description?: string
+}
+
+export function parseFrontmatter(markdown: string): {
+  body: string
+  fields: FrontmatterFields
+} {
+  const m = (markdown ?? '').match(FRONTMATTER_RE)
+  if (!m) return { body: markdown ?? '', fields: {} }
+  const body = (markdown ?? '').slice(m[0].length)
+  const fields: FrontmatterFields = {}
+  for (const line of m[1].split(/\r?\n/)) {
+    const kv = line.match(/^([a-zA-Z][\w-]*)\s*:\s*(.*)$/)
+    if (!kv) continue
+    const key = kv[1].toLowerCase()
+    const value = trimYamlValue(kv[2])
+    if (key === 'title') fields.title = value
+    else if (key === 'slug') fields.slug = value
+    else if (key === 'description') fields.description = value
+  }
+  return { body, fields }
+}
+
+function stripFrontmatter(markdown: string): string {
+  return parseFrontmatter(markdown).body
+}
+
+function trimYamlValue(raw: string): string {
+  const trimmed = raw.trim()
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+// ─── block walker ────────────────────────────────────────────────────
+
+interface MdastNode {
+  type: string
+  children?: MdastNode[]
+  value?: string
+  url?: string
+  alt?: string
+  depth?: number
+  ordered?: boolean
+  checked?: boolean | null
+  lang?: string | null
+  name?: string
+  attributes?: Record<string, string | null | undefined>
+}
+
+interface MdastRoot extends MdastNode {
+  children: MdastNode[]
+}
+
+function walkBlock(node: MdastNode, ctx: ParseCtx, level: number): void {
+  switch (node.type) {
+    case 'heading': {
+      const depth = clamp(node.depth ?? 1, 1, HEADING_MAX_LEVEL)
+      pushBlock(ctx, 'heading', inlineFrom(node.children), { level: depth })
+      return
+    }
+    case 'paragraph': {
+      const inline = inlineFrom(node.children)
+      // A paragraph that's only an embed-y URL becomes an embed block.
+      const embed = paragraphAsEmbed(node.children)
+      if (embed) {
+        pushBlock(ctx, 'embed', [], embed)
+        return
+      }
+      // A paragraph that's only an image (or image + attr trailer) becomes
+      // an image block.
+      const image = paragraphAsImage(node.children)
+      if (image) {
+        pushBlock(ctx, 'image', [], image)
+        return
+      }
+      pushBlock(ctx, 'text', inline, {})
+      return
+    }
+    case 'blockquote': {
+      // Render each child block as a quote — for multi-paragraph quotes
+      // we end up with multiple sibling quote blocks (closest match in the
+      // flat schema, mirrors migrate-legacy-content behavior).
+      for (const child of node.children ?? []) {
+        if (child.type === 'paragraph') {
+          pushBlock(ctx, 'quote', inlineFrom(child.children), {})
+        } else {
+          walkBlock(child, ctx, level)
+        }
+      }
+      return
+    }
+    case 'code': {
+      const lang = typeof node.lang === 'string' ? node.lang : 'plaintext'
+      const text = node.value ?? ''
+      pushBlock(ctx, 'codeBlock', [{ type: 'text', text }], { codeLanguage: lang })
+      return
+    }
+    case 'thematicBreak':
+      pushBlock(ctx, 'divider', [], {})
+      return
+    case 'list':
+      walkList(node, ctx, level)
+      return
+    case 'table':
+      walkTable(node, ctx)
+      return
+    case 'containerDirective': {
+      const variant = pickCalloutVariant(node.name)
+      if (variant) {
+        // Concatenate child paragraphs into a single callout block (we
+        // don't model multi-paragraph callouts).
+        const inline: InlineJSON[] = []
+        for (const child of node.children ?? []) {
+          if (child.type === 'paragraph') {
+            if (inline.length > 0) inline.push({ type: 'hardBreak' })
+            inline.push(...inlineFrom(child.children))
+          }
+        }
+        pushBlock(ctx, 'callout', inline, { calloutVariant: variant })
+        return
+      }
+      // Unknown container — flatten its children.
+      for (const child of node.children ?? []) walkBlock(child, ctx, level)
+      return
+    }
+    case 'leafDirective': {
+      if (node.name === 'embed') {
+        const attrs = directiveEmbedAttrs(node.attributes)
+        if (attrs?.embedUrl) {
+          pushBlock(ctx, 'embed', [], attrs)
+          return
+        }
+      }
+      // Fall through: drop unknown leaf directives.
+      return
+    }
+    case 'html': {
+      // Best-effort: surface raw HTML as plain text. We don't run an HTML
+      // parser here; the editor's clipboard-text path is for markdown.
+      const text = (node.value ?? '').replace(/<[^>]+>/g, '').trim()
+      if (text) pushBlock(ctx, 'text', [{ type: 'text', text }], {})
+      return
+    }
+    default:
+      // Unknown block — try to extract inline text.
+      if (node.children?.length) {
+        const inline = inlineFrom(node.children)
+        if (inline.length > 0) pushBlock(ctx, 'text', inline, {})
+      }
+  }
+}
+
+function walkList(node: MdastNode, ctx: ParseCtx, level: number): void {
+  const items = (node.children ?? []).filter((c) => c.type === 'listItem')
+  const ordered = node.ordered === true
+
+  for (const item of items) {
+    const isTask = item.checked === true || item.checked === false
+    const checked = item.checked === true
+    let firstParagraph = true
+
+    for (const child of item.children ?? []) {
+      if (child.type === 'paragraph') {
+        if (firstParagraph) {
+          if (isTask) {
+            pushBlock(ctx, 'todoListItem', inlineFrom(child.children), {
+              checked,
+              level,
+            })
+          } else {
+            const blockType: BlockType = ordered ? 'numberedListItem' : 'bulletListItem'
+            pushBlock(ctx, blockType, inlineFrom(child.children), { level })
+          }
+          firstParagraph = false
+        } else {
+          // Continuation paragraph — flatten as a text block.
+          pushBlock(ctx, 'text', inlineFrom(child.children), {})
+        }
+      } else if (child.type === 'list') {
+        walkList(child, ctx, Math.min(level + 1, 5))
+      } else {
+        walkBlock(child, ctx, level)
+      }
+    }
+  }
+}
+
+function walkTable(node: MdastNode, ctx: ParseCtx): void {
+  // Tables are deferred from the renderer (Tier 1 plan). Capture the
+  // markdown source as a fenced plaintext block so authors don't lose
+  // content silently.
+  const lines = renderTableAsMd(node)
+  if (lines.length === 0) return
+  pushBlock(ctx, 'codeBlock', [{ type: 'text', text: lines.join('\n') }], {
+    codeLanguage: 'plaintext',
+  })
+}
+
+function renderTableAsMd(table: MdastNode): string[] {
+  const rows = (table.children ?? []).filter((c) => c.type === 'tableRow')
+  if (rows.length === 0) return []
+  const renderedRows = rows.map((row) =>
+    (row.children ?? [])
+      .filter((c) => c.type === 'tableCell')
+      .map((cell) => textOnly(cell.children).trim() || ' ')
+  )
+  if (renderedRows.length === 0) return []
+  const widths = renderedRows[0].map((_, i) =>
+    Math.max(...renderedRows.map((r) => (r[i]?.length ?? 0) || 1))
+  )
+  const out: string[] = []
+  out.push('| ' + renderedRows[0].map((c, i) => c.padEnd(widths[i])).join(' | ') + ' |')
+  out.push('| ' + widths.map((w) => '-'.repeat(Math.max(3, w))).join(' | ') + ' |')
+  for (let i = 1; i < renderedRows.length; i++) {
+    out.push('| ' + renderedRows[i].map((c, j) => c.padEnd(widths[j])).join(' | ') + ' |')
+  }
+  return out
+}
+
+// ─── inline walker ───────────────────────────────────────────────────
+
+function inlineFrom(children: MdastNode[] | undefined): InlineJSON[] {
+  if (!children || children.length === 0) return []
+  const out: InlineJSON[] = []
+  // Stateful HTML-tag stack so we can fold <u>...</u> across sibling
+  // mdast nodes (remark-parse emits the open and close tags as separate
+  // `html` nodes around the inner text).
+  const htmlMarks: MarkJSON[] = []
+  for (const child of children) {
+    if (child.type === 'html' && typeof child.value === 'string') {
+      const value = child.value.trim()
+      if (/^<u>$/i.test(value)) {
+        htmlMarks.push({ type: 'underline' })
+        continue
+      }
+      if (/^<\/u>$/i.test(value)) {
+        const idx = htmlMarks.findLastIndex((m) => m.type === 'underline')
+        if (idx >= 0) htmlMarks.splice(idx, 1)
+        continue
+      }
+    }
+    walkInline(child, htmlMarks, out)
+  }
+  return mergeInline(out)
+}
+
+function walkInline(node: MdastNode, marks: MarkJSON[], out: InlineJSON[]): void {
+  switch (node.type) {
+    case 'text': {
+      pushTextSplit(node.value ?? '', marks, out)
+      return
+    }
+    case 'inlineCode': {
+      // The `code` mark is exclusive in the standard PM schema — combining
+      // it with bold/italic/etc. throws "Invalid collection of marks". Emit
+      // code as a solo mark, dropping any inherited formatting.
+      out.push(makeText(node.value ?? '', [{ type: 'code' }]))
+      return
+    }
+    case 'strong': {
+      for (const c of node.children ?? []) walkInline(c, addMark(marks, { type: 'bold' }), out)
+      return
+    }
+    case 'emphasis': {
+      for (const c of node.children ?? []) walkInline(c, addMark(marks, { type: 'italic' }), out)
+      return
+    }
+    case 'delete': {
+      for (const c of node.children ?? []) walkInline(c, addMark(marks, { type: 'strike' }), out)
+      return
+    }
+    case 'link': {
+      const linkMark: MarkJSON = { type: 'link', attrs: { href: node.url ?? '' } }
+      for (const c of node.children ?? []) walkInline(c, addMark(marks, linkMark), out)
+      return
+    }
+    case 'image': {
+      // Inline image inside text — surface as a link to keep the data.
+      const text = (node.alt ?? '').trim() || node.url || ''
+      const linkMark: MarkJSON = { type: 'link', attrs: { href: node.url ?? '' } }
+      out.push(makeText(text, addMark(marks, linkMark)))
+      return
+    }
+    case 'break':
+      out.push({ type: 'hardBreak' })
+      return
+    case 'html': {
+      // Recognize <u>...</u> as an underline mark.
+      const value = node.value ?? ''
+      const m = value.match(/^<u>(.*)<\/u>$/i)
+      if (m) {
+        out.push(makeText(m[1], addMark(marks, { type: 'underline' })))
+        return
+      }
+      // Otherwise drop tags, keep text.
+      const stripped = value.replace(/<[^>]+>/g, '')
+      if (stripped) pushTextSplit(stripped, marks, out)
+      return
+    }
+    case 'textDirective':
+    case 'leafDirective': {
+      // Inline directives — surface as plain text fallback.
+      const inner = textOnly(node.children)
+      if (inner) pushTextSplit(inner, marks, out)
+      return
+    }
+    default: {
+      const inner = textOnly(node.children)
+      if (inner) pushTextSplit(inner, marks, out)
+    }
+  }
+}
+
+function pushTextSplit(text: string, marks: MarkJSON[], out: InlineJSON[]): void {
+  if (!text) return
+  // Split out {{placeholder}} segments.
+  let lastIndex = 0
+  const re = new RegExp(PLACEHOLDER_RE.source, 'g')
+  let match: RegExpExecArray | null = re.exec(text)
+  while (match) {
+    if (match.index > lastIndex) {
+      out.push(makeText(text.slice(lastIndex, match.index), marks))
+    }
+    out.push({ type: 'placeholder', attrs: { id: match[1] } })
+    lastIndex = match.index + match[0].length
+    match = re.exec(text)
+  }
+  if (lastIndex < text.length) {
+    out.push(makeText(text.slice(lastIndex), marks))
+  }
+}
+
+function makeText(text: string, marks: MarkJSON[]): InlineJSON {
+  const node: InlineJSON = { type: 'text', text }
+  const sanitized = sanitizeMarks(marks)
+  if (sanitized.length > 0) node.marks = sanitized
+  return node
+}
+
+/**
+ * Enforce the editor schema's mark exclusivity rules. The `code` mark in
+ * the standard PM schema excludes every other mark — combining it throws
+ * "Invalid collection of marks for node text" in `insertContent`. Strip
+ * other marks when code is present, no matter how they accumulated.
+ */
+function sanitizeMarks(marks: MarkJSON[]): MarkJSON[] {
+  if (marks.length === 0) return marks
+  if (marks.some((m) => m.type === 'code')) return [{ type: 'code' }]
+  return marks.slice()
+}
+
+function addMark(marks: MarkJSON[], mark: MarkJSON): MarkJSON[] {
+  if (marks.some((m) => m.type === mark.type && sameAttrs(m.attrs, mark.attrs))) return marks
+  return [...marks, mark]
+}
+
+function sameAttrs(a: Record<string, unknown> | undefined, b: Record<string, unknown> | undefined) {
+  if (!a && !b) return true
+  if (!a || !b) return false
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)])
+  for (const k of keys) if (a[k] !== b[k]) return false
+  return true
+}
+
+function mergeInline(nodes: InlineJSON[]): InlineJSON[] {
+  const out: InlineJSON[] = []
+  for (const node of nodes) {
+    const last = out[out.length - 1]
+    if (
+      last &&
+      last.type === 'text' &&
+      node.type === 'text' &&
+      sameMarks(last.marks, node.marks) &&
+      typeof last.text === 'string' &&
+      typeof node.text === 'string'
+    ) {
+      last.text += node.text
+      continue
+    }
+    out.push(node)
+  }
+  return out
+}
+
+function sameMarks(a: MarkJSON[] | undefined, b: MarkJSON[] | undefined) {
+  if (!a && !b) return true
+  if (!a || !b) return a?.length === 0 && b == null ? true : (a == null && b?.length === 0) || false
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].type !== b[i].type) return false
+    if (!sameAttrs(a[i].attrs, b[i].attrs)) return false
+  }
+  return true
+}
+
+function textOnly(children: MdastNode[] | undefined): string {
+  if (!children) return ''
+  return children
+    .map((c) => {
+      if (typeof c.value === 'string') return c.value
+      return textOnly(c.children)
+    })
+    .join('')
+}
+
+// ─── special-paragraph helpers ───────────────────────────────────────
+
+function paragraphAsEmbed(children: MdastNode[] | undefined): Partial<BlockAttrs> | null {
+  if (!children || children.length === 0) return null
+  if (children.length !== 1) return null
+  const only = children[0]
+  // Bare URL on its own line (autolink → link node, plain link → also link).
+  if (only.type === 'link' && typeof only.url === 'string') {
+    const provider = sniffProvider(only.url)
+    if (provider) return { embedUrl: only.url, embedProvider: provider }
+  }
+  if (only.type === 'text' && typeof only.value === 'string') {
+    const url = only.value.trim()
+    const provider = sniffProvider(url)
+    if (provider) return { embedUrl: url, embedProvider: provider }
+  }
+  return null
+}
+
+function paragraphAsImage(children: MdastNode[] | undefined): Partial<BlockAttrs> | null {
+  if (!children || children.length === 0) return null
+  const first = children[0]
+  if (first?.type !== 'image') return null
+  if (typeof first.url !== 'string' || first.url.length === 0) return null
+
+  const result: Partial<BlockAttrs> = { imageUrl: first.url }
+  // Look for an attribute trailer in the next text child.
+  const next = children[1]
+  if (next?.type === 'text' && typeof next.value === 'string') {
+    const m = next.value.match(IMAGE_ATTR_TRAILER_RE)
+    if (m) {
+      Object.assign(result, parseImageTrailer(m[1]))
+      const remainder = next.value.slice(m[0].length).trim()
+      if (remainder.length > 0) return null // image + extra text → not just an image
+    }
+  }
+  // Reject if there's any non-trailer content.
+  for (let i = 1; i < children.length; i++) {
+    const c = children[i]
+    if (i === 1 && c.type === 'text' && typeof c.value === 'string') {
+      const stripped = c.value.replace(IMAGE_ATTR_TRAILER_RE, '').trim()
+      if (stripped.length > 0) return null
+      continue
+    }
+    return null
+  }
+  return result
+}
+
+function parseImageTrailer(body: string): Partial<BlockAttrs> {
+  const out: Partial<BlockAttrs> = {}
+  for (const part of body.split(/\s+/)) {
+    const kv = part.match(/^([a-z]+)=(.+)$/i)
+    if (!kv) continue
+    const key = kv[1].toLowerCase()
+    const value = stripQuotes(kv[2])
+    if (key === 'width') {
+      const n = Number.parseInt(value, 10)
+      if (Number.isFinite(n) && n > 0) out.imageWidth = n
+    } else if (key === 'align') {
+      if (IMAGE_ALIGNS.has(value as ImageAlign)) out.imageAlign = value as ImageAlign
+    }
+  }
+  return out
+}
+
+// ─── directive helpers ───────────────────────────────────────────────
+
+function pickCalloutVariant(name: string | undefined): CalloutVariant | null {
+  if (!name) return null
+  const lower = name.toLowerCase()
+  if (CALLOUT_VARIANTS.has(lower as CalloutVariant)) return lower as CalloutVariant
+  // Common GFM-alert aliases.
+  if (lower === 'note' || lower === 'important') return 'info'
+  if (lower === 'warning' || lower === 'caution') return 'warn'
+  if (lower === 'danger') return 'error'
+  return null
+}
+
+function directiveEmbedAttrs(
+  attributes: Record<string, string | null | undefined> | undefined
+): Partial<BlockAttrs> | null {
+  if (!attributes) return null
+  const url = typeof attributes.url === 'string' ? attributes.url : null
+  if (!url) return null
+  const out: Partial<BlockAttrs> = { embedUrl: url }
+  const provider =
+    typeof attributes.provider === 'string' ? attributes.provider.toLowerCase() : sniffProvider(url)
+  if (provider && EMBED_PROVIDERS.has(provider as EmbedProvider)) {
+    out.embedProvider = provider as EmbedProvider
+  }
+  const aspect = typeof attributes.aspect === 'string' ? attributes.aspect : ''
+  if (EMBED_ASPECTS.has(aspect as EmbedAspect)) out.embedAspect = aspect as EmbedAspect
+  return out
+}
+
+function sniffProvider(rawUrl: string): EmbedProvider | null {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl.trim())
+  } catch {
+    return null
+  }
+  const host = parsed.hostname.replace(/^www\./, '').toLowerCase()
+  if (host === 'youtube.com' || host === 'm.youtube.com' || host === 'youtu.be') return 'youtube'
+  if (host === 'loom.com') return 'loom'
+  if (host === 'vimeo.com' || host === 'player.vimeo.com') return 'vimeo'
+  return null
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+function pushBlock(
+  ctx: ParseCtx,
+  blockType: BlockType,
+  content: InlineJSON[],
+  attrs: Partial<BlockAttrs>
+): void {
+  const merged: BlockAttrs = { blockType, ...attrs }
+  ctx.blocks.push({ type: 'block', attrs: merged, content })
+}
+
+function clamp(n: number, min: number, max: number): number {
+  if (!Number.isFinite(n)) return min
+  return Math.min(max, Math.max(min, Math.trunc(n)))
+}
+
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1)
+  }
+  return value
+}

--- a/packages/lib/src/kb/markdown/types.ts
+++ b/packages/lib/src/kb/markdown/types.ts
@@ -1,0 +1,85 @@
+// packages/lib/src/kb/markdown/types.ts
+//
+// Local mirror of the canonical KB block schema declared in
+// packages/ui/src/components/kb/article/types.ts. We can't import that here
+// because @auxx/ui sits above @auxx/lib in the dependency graph. The shapes
+// are kept structurally identical so consumers can pass either type in.
+
+export type BlockType =
+  | 'text'
+  | 'heading'
+  | 'bulletListItem'
+  | 'numberedListItem'
+  | 'todoListItem'
+  | 'quote'
+  | 'image'
+  | 'divider'
+  | 'codeBlock'
+  | 'callout'
+  | 'embed'
+
+export type ImageAlign = 'left' | 'center' | 'right'
+export type CalloutVariant = 'info' | 'warn' | 'error' | 'tip' | 'success'
+export type EmbedProvider = 'youtube' | 'loom' | 'vimeo'
+export type EmbedAspect = '16:9' | '4:3' | '1:1'
+
+export interface BlockAttrs {
+  blockType: BlockType
+  level?: number | null
+  checked?: boolean
+  imageUrl?: string | null
+  imageWidth?: number
+  imageAlign?: ImageAlign
+  calloutVariant?: CalloutVariant
+  codeLanguage?: string
+  codeHighlightedHtml?: string
+  embedUrl?: string
+  embedProvider?: EmbedProvider
+  embedAspect?: EmbedAspect
+}
+
+export type InlineMarkType =
+  | 'bold'
+  | 'italic'
+  | 'underline'
+  | 'strike'
+  | 'code'
+  | 'link'
+  | 'highlight'
+
+export interface MarkJSON {
+  type: InlineMarkType
+  attrs?: Record<string, unknown>
+}
+
+export interface InlineJSON {
+  type: 'text' | 'placeholder' | 'hardBreak'
+  text?: string
+  marks?: MarkJSON[]
+  attrs?: Record<string, unknown>
+}
+
+export interface BlockJSON {
+  type: 'block'
+  attrs: BlockAttrs
+  content?: InlineJSON[]
+}
+
+export interface DocJSON {
+  type: 'doc'
+  content: BlockJSON[]
+}
+
+export const CALLOUT_VARIANTS: ReadonlySet<CalloutVariant> = new Set([
+  'info',
+  'tip',
+  'warn',
+  'error',
+  'success',
+])
+
+export const EMBED_PROVIDERS: ReadonlySet<EmbedProvider> = new Set(['youtube', 'loom', 'vimeo'])
+
+export const EMBED_ASPECTS: ReadonlySet<EmbedAspect> = new Set(['16:9', '4:3', '1:1'])
+
+export const IMAGE_ALIGNS: ReadonlySet<ImageAlign> = new Set(['left', 'center', 'right'])

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -3,7 +3,13 @@
 
 import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
-import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Switch } from '@auxx/ui/components/switch'
 import { cn } from '@auxx/ui/lib/utils'
@@ -317,11 +323,24 @@ function Command({ className, ...props }: React.ComponentProps<typeof CommandPri
   )
 }
 
-function CommandDialog({ children, ...props }: DialogProps & { children?: React.ReactNode }) {
+function CommandDialog({
+  children,
+  title = 'Command palette',
+  description = 'Search and run commands.',
+  ...props
+}: DialogProps & {
+  children?: React.ReactNode
+  title?: string
+  description?: string
+}) {
   return (
     <Dialog {...props}>
-      <DialogContent className='overflow-hidden p-0'>
-        <Command className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5'>
+      <DialogContent className='overflow-hidden p-0' position='tc' innerClassName='p-0'>
+        <DialogHeader className='sr-only'>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <Command className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-8 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5'>
           {children}
         </Command>
       </DialogContent>

--- a/packages/ui/src/components/icon-picker.tsx
+++ b/packages/ui/src/components/icon-picker.tsx
@@ -83,6 +83,8 @@ export interface IconPickerProps {
   children?: React.ReactNode
   /** Set to false when used inside a Dialog to fix scroll issues */
   modal?: boolean
+  /** Hide the color swatch row. The default color is still applied to onChange. */
+  hideColors?: boolean
 }
 
 /** Icon picker component */
@@ -96,6 +98,7 @@ export function IconPicker({
   open,
   children,
   modal = true,
+  hideColors = false,
 }: IconPickerProps) {
   // Use internal state if open is not provided (uncontrolled mode)
   const [internalOpen, setInternalOpen] = useState(false)
@@ -225,18 +228,20 @@ export function IconPicker({
           )}
         </div>
         {/* Color selector bar */}
-        <div className='border-b p-2'>
-          <div className='flex justify-start gap-2'>
-            {ICON_COLORS.map((color) => (
-              <ColorButton
-                key={color.id}
-                color={color}
-                isActive={selectedColor === color.id}
-                onClick={() => handleColorSelect(color.id)}
-              />
-            ))}
+        {hideColors ? null : (
+          <div className='border-b p-2'>
+            <div className='flex justify-start gap-2'>
+              {ICON_COLORS.map((color) => (
+                <ColorButton
+                  key={color.id}
+                  color={color}
+                  isActive={selectedColor === color.id}
+                  onClick={() => handleColorSelect(color.id)}
+                />
+              ))}
+            </div>
           </div>
-        </div>
+        )}
         {/* Icon grid */}
         <div
           className='relative h-64 overflow-y-auto p-2 pb-8'

--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -578,6 +578,7 @@ export const entityIconVariants = cva('flex items-center justify-center shrink-0
       full: 'rounded-full border',
       muted:
         'rounded-lg border bg-muted group-hover:bg-secondary transition-colors overflow-hidden',
+      bare: 'text-current',
     },
     size: {
       xs: 'size-4 [&_svg]:size-2.5!',

--- a/packages/ui/src/components/kb/article/kb-article-pager.tsx
+++ b/packages/ui/src/components/kb/article/kb-article-pager.tsx
@@ -1,5 +1,6 @@
 // packages/ui/src/components/kb/article/kb-article-pager.tsx
 
+import { EntityIcon } from '@auxx/ui/components/icons'
 import { cn } from '@auxx/ui/lib/utils'
 import Link from 'next/link'
 import type { ArticleSlugFields } from '../utils/article-paths'
@@ -64,9 +65,13 @@ function PagerLink<T extends PagerArticle>({
       <span className='block text-xs text-[var(--kb-fg)]/60'>
         {direction === 'prev' ? '← Previous' : 'Next →'}
       </span>
-      <span className='mt-1 block text-base font-medium text-[var(--kb-fg)] group-hover:text-[var(--kb-primary)]'>
-        {article.emoji ? <span className='mr-1.5'>{article.emoji}</span> : null}
-        {article.title}
+      <span
+        className={cn(
+          'mt-1 inline-flex items-center gap-1.5 text-base font-medium text-[var(--kb-fg)] group-hover:text-[var(--kb-primary)]',
+          direction === 'next' && '@kb-md:flex-row-reverse'
+        )}>
+        {article.emoji ? <EntityIcon iconId={article.emoji} variant='bare' size='sm' /> : null}
+        <span>{article.title}</span>
       </span>
     </Link>
   )

--- a/packages/ui/src/components/kb/article/kb-article-renderer.module.css
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.module.css
@@ -7,7 +7,7 @@
   font-size: 16px;
   max-width: 768px;
   margin: 0;
-  padding: 0 1.5rem;
+  padding-left:1.5rem;
 }
 
 .article :global(.kb-link) {
@@ -46,12 +46,65 @@
   margin: 0.5em 0;
 }
 
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 1.5em 0 0;
+  padding-bottom: 2.5em;
+}
+
+.headerMain {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25em;
+  min-width: 0;
+  flex: 1;
+}
+
+.headerDescription {
+  margin: 0.5em 0 0;
+}
+
+.headerUpdatedAt {
+  margin: 0.25em 0 0;
+  font-size: 0.75em;
+  color: var(--kb-fg);
+  opacity: 0.6;
+}
+
 .h1 {
   font-size: 2em;
   font-weight: 700;
   line-height: 1.2;
-  margin: 1.5em 0 0.5em;
+  margin: 0;
   scroll-margin-top: 4rem;
+}
+
+.parentLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  width: fit-content;
+  font-size: 0.875em;
+  color: var(--kb-primary);
+  text-decoration: none;
+}
+
+.parentLink:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.parentText {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  width: fit-content;
+  font-size: 0.875em;
+  color: var(--kb-fg);
+  opacity: 0.65;
 }
 
 .h2 {

--- a/packages/ui/src/components/kb/article/kb-article-renderer.tsx
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.tsx
@@ -1,28 +1,74 @@
 // packages/ui/src/components/kb/article/kb-article-renderer.tsx
 
+import { Button } from '@auxx/ui/components/button'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import Link from 'next/link'
 import { BlockRenderer } from './block-renderer'
-import { extractKBHeadings } from './extract-headings'
+import { extractKBHeadings, type KBHeading } from './extract-headings'
 import styles from './kb-article-renderer.module.css'
+import { KBTableOfContentsDrawer } from './kb-toc-drawer'
 import type { DocJSON } from './types'
 
 interface KBArticleRendererProps {
   doc: DocJSON | null | undefined
   /** Optional title rendered as <h1>; the doc's heading levels start at <h2>. */
   title?: string
+  /** Icon id (from ICON_DATA) rendered inline left of the title. */
+  emoji?: string | null
   description?: string | null
   updatedAt?: Date | string | null
+  /** Parent category/section rendered as a small link above the title. Omit when the article has no parent. */
+  parent?: { title: string; emoji?: string | null; href?: string | null }
 }
 
-export function KBArticleRenderer({ doc, title, description, updatedAt }: KBArticleRendererProps) {
-  const headingIds = doc ? buildHeadingIdMap(doc) : {}
+export function KBArticleRenderer({
+  doc,
+  title,
+  emoji,
+  description,
+  updatedAt,
+  parent,
+}: KBArticleRendererProps) {
+  const headings = doc ? extractKBHeadings(doc) : []
+  const headingIds = doc ? buildHeadingIdMap(doc, headings) : {}
   return (
     <article className={styles.article}>
-      {title ? <h1 className={styles.h1}>{title}</h1> : null}
-      {description ? <p className={styles.text}>{description}</p> : null}
-      {updatedAt ? (
-        <p className='text-xs text-[var(--kb-fg)]/60 -mt-2'>
-          Last updated {formatRelative(updatedAt)}
-        </p>
+      {parent || title || description || updatedAt ? (
+        <header className={styles.header}>
+          <div className={styles.headerMain}>
+            {parent?.href ? (
+              <Link href={parent.href} prefetch={false} className={styles.parentLink}>
+                {parent.emoji ? (
+                  <EntityIcon iconId={parent.emoji} variant='bare' size='xs' />
+                ) : null}
+                {parent.title}
+              </Link>
+            ) : parent ? (
+              <span className={styles.parentText}>
+                {parent.emoji ? (
+                  <EntityIcon iconId={parent.emoji} variant='bare' size='xs' />
+                ) : null}
+                {parent.title}
+              </span>
+            ) : null}
+            {title ? (
+              <h1 className={styles.h1}>
+                <span className='inline-flex flex-row items-center gap-3'>
+                  {emoji ? <EntityIcon iconId={emoji} variant='bare' size='xl' /> : null}
+                  <span>{title}</span>
+                </span>
+              </h1>
+            ) : null}
+            {description ? <p className={styles.headerDescription}>{description}</p> : null}
+            {updatedAt ? (
+              <p className={styles.headerUpdatedAt}>Last updated {formatRelative(updatedAt)}</p>
+            ) : null}
+          </div>
+          <div className='flex items-center gap-2'>
+            <KBTableOfContentsDrawer headings={headings} className='@kb-lg:hidden' />
+            <Button variant='outline'>Copy</Button>
+          </div>
+        </header>
       ) : null}
       {doc?.content?.map((node, idx) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: block order is stable per render
@@ -32,8 +78,7 @@ export function KBArticleRenderer({ doc, title, description, updatedAt }: KBArti
   )
 }
 
-function buildHeadingIdMap(doc: DocJSON): Record<number, string> {
-  const headings = extractKBHeadings(doc)
+function buildHeadingIdMap(doc: DocJSON, headings: KBHeading[]): Record<number, string> {
   // extractKBHeadings preserves order; rebuild a map keyed by block index.
   const map: Record<number, string> = {}
   let cursor = 0

--- a/packages/ui/src/components/kb/article/kb-toc-drawer.tsx
+++ b/packages/ui/src/components/kb/article/kb-toc-drawer.tsx
@@ -1,0 +1,64 @@
+// packages/ui/src/components/kb/article/kb-toc-drawer.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@auxx/ui/components/sheet'
+import { List } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import type { KBHeading } from './extract-headings'
+import { KBTableOfContents } from './kb-toc'
+
+interface KBTableOfContentsDrawerProps {
+  headings: KBHeading[]
+  className?: string
+}
+
+/**
+ * Compact trigger + right-side drawer rendering the article's TOC.
+ * Used on small screens where the inline TOC rail is hidden.
+ *
+ * KB theme vars (`--kb-*`) are scoped to `[data-kb-id="<id>"]` and the Sheet
+ * portals to document.body, escaping that scope. We mirror the kb-id onto a
+ * wrapper inside the SheetContent so the same CSS rule cascades into the
+ * portaled subtree.
+ */
+export function KBTableOfContentsDrawer({ headings, className }: KBTableOfContentsDrawerProps) {
+  const anchorRef = useRef<HTMLSpanElement>(null)
+  const [open, setOpen] = useState(false)
+  const [kbId, setKbId] = useState<string | undefined>()
+
+  useEffect(() => {
+    const id = anchorRef.current?.closest('[data-kb-id]')?.getAttribute('data-kb-id')
+    setKbId(id ?? undefined)
+  }, [])
+
+  if (headings.length === 0) return null
+
+  return (
+    <span ref={anchorRef} className='contents'>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTrigger asChild>
+          <Button variant='outline' size='icon' aria-label='On this page' className={className}>
+            <List />
+          </Button>
+        </SheetTrigger>
+        <SheetContent side='right' className='overflow-y-auto'>
+          <div
+            data-kb-id={kbId}
+            className='flex flex-col gap-4 bg-[var(--kb-page-bg)] text-[var(--kb-fg)]'>
+            <SheetHeader>
+              <SheetTitle className='text-[var(--kb-fg)]'>On this page</SheetTitle>
+            </SheetHeader>
+            <KBTableOfContents headings={headings} hideHeading onLinkClick={() => setOpen(false)} />
+          </div>
+        </SheetContent>
+      </Sheet>
+    </span>
+  )
+}

--- a/packages/ui/src/components/kb/article/kb-toc.tsx
+++ b/packages/ui/src/components/kb/article/kb-toc.tsx
@@ -2,14 +2,19 @@
 'use client'
 
 import { cn } from '@auxx/ui/lib/utils'
+import { Text } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import type { KBHeading } from './extract-headings'
 
 interface KBTableOfContentsProps {
   headings: KBHeading[]
+  /** Hide the inline "On this page" heading (used inside drawers that already provide a title). */
+  hideHeading?: boolean
+  /** Called when a heading link is clicked — used by the drawer to auto-close. */
+  onLinkClick?: () => void
 }
 
-export function KBTableOfContents({ headings }: KBTableOfContentsProps) {
+export function KBTableOfContents({ headings, hideHeading, onLinkClick }: KBTableOfContentsProps) {
   const [active, setActive] = useState<string | null>(headings[0]?.id ?? null)
 
   useEffect(() => {
@@ -33,26 +38,34 @@ export function KBTableOfContents({ headings }: KBTableOfContentsProps) {
   if (headings.length === 0) return null
 
   return (
-    <aside className='mx-auto mb-8 w-full max-w-3xl rounded-[var(--kb-radius)] border border-[var(--kb-border)] bg-[var(--kb-muted)]/40 px-5 py-4 text-sm'>
-      <p className='mb-2 text-xs font-medium uppercase tracking-wider text-[var(--kb-fg)]/60'>
-        On this page
-      </p>
-      <ul className='m-0 list-none space-y-1 p-0'>
-        {headings.map((h) => (
-          <li key={h.id} style={{ paddingLeft: `${(h.depth - 2) * 12}px` }}>
-            <a
-              href={`#${h.id}`}
-              data-active={active === h.id}
-              className={cn(
-                'block py-1 text-[var(--kb-fg)]/70 no-underline transition-colors',
-                'hover:text-[var(--kb-fg)]',
-                'data-[active=true]:font-medium data-[active=true]:text-[var(--kb-primary)]'
-              )}>
-              {h.text}
-            </a>
-          </li>
-        ))}
+    <nav data-slot='kb-toc' aria-label='Table of contents' className='text-sm'>
+      {hideHeading ? null : (
+        <p className='mb-3 flex items-center gap-2 font-medium text-[var(--kb-fg)]'>
+          <Text className='size-4 text-[var(--kb-fg)]/70' aria-hidden />
+          On this page
+        </p>
+      )}
+      <ul className='m-0 flex list-none flex-col border-l border-[var(--kb-border)] p-0'>
+        {headings.map((h) => {
+          const indent = Math.max(0, h.depth - 2) * 12
+          return (
+            <li key={h.id}>
+              <a
+                href={`#${h.id}`}
+                data-active={active === h.id}
+                style={{ paddingLeft: `${indent + 12}px` }}
+                onClick={onLinkClick}
+                className={cn(
+                  '-ml-px block border-l border-transparent py-1.5 pr-2 text-[var(--kb-fg)]/60 no-underline transition-colors',
+                  'hover:text-[var(--kb-fg)]',
+                  'data-[active=true]:border-[var(--kb-primary)] data-[active=true]:text-[var(--kb-primary)]'
+                )}>
+                {h.text}
+              </a>
+            </li>
+          )
+        })}
       </ul>
-    </aside>
+    </nav>
   )
 }

--- a/packages/ui/src/components/kb/layout/kb-layout.tsx
+++ b/packages/ui/src/components/kb/layout/kb-layout.tsx
@@ -1,5 +1,6 @@
 // packages/ui/src/components/kb/layout/kb-layout.tsx
 
+import { cn } from '@auxx/ui/lib/utils'
 import type { ReactNode } from 'react'
 import { KBThemeProvider } from '../theme/kb-theme-provider'
 import type { KBMode, KBThemeInput } from '../theme/kb-theme-tokens'
@@ -38,6 +39,8 @@ interface KBLayoutProps<T extends KBSidebarArticle> {
   mode?: KBMode
   /** Intercept sidebar article clicks (used by admin preview to swap article without navigation). */
   onArticleClick?: (articleId: string) => void
+  /** When true, drops the `min-h-screen` so the layout sizes to its content (used when embedded inside the admin editor preview). */
+  embedded?: boolean
   children: ReactNode
 }
 
@@ -49,6 +52,7 @@ export function KBLayout<T extends KBSidebarArticle>({
   activeArticleId,
   mode,
   onArticleClick,
+  embedded = false,
   children,
 }: KBLayoutProps<T>) {
   const headerNav = parseNavigation(kb.headerNavigation)
@@ -63,7 +67,12 @@ export function KBLayout<T extends KBSidebarArticle>({
 
   return (
     <KBThemeProvider kb={kb} mode={effectiveMode}>
-      <div className='@container relative flex min-h-screen flex-col bg-[var(--kb-page-bg)] font-[var(--kb-font,system-ui)] text-[var(--kb-fg)]'>
+      <div
+        data-slot='kb-layout'
+        className={cn(
+          '@container relative flex flex-col bg-[var(--kb-page-bg)] font-[var(--kb-font,system-ui)] text-[var(--kb-fg)]',
+          embedded ? 'flex-1' : 'min-h-screen'
+        )}>
         <KBLayoutShell
           kbId={kb.id}
           kbName={kb.name}

--- a/packages/ui/src/components/kb/layout/kb-sidebar-tree.tsx
+++ b/packages/ui/src/components/kb/layout/kb-sidebar-tree.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { AnimatedCollapsibleContent, CollapsibleChevron } from '@auxx/ui/components/collapsible'
+import { EntityIcon } from '@auxx/ui/components/icons'
 import { cn } from '@auxx/ui/lib/utils'
 import Link from 'next/link'
 import {
@@ -111,11 +112,7 @@ function TreeBranch<T extends KBSidebarArticle>({
 
   const itemContent = (
     <>
-      {node.emoji ? (
-        <span aria-hidden className='shrink-0'>
-          {node.emoji}
-        </span>
-      ) : null}
+      {node.emoji ? <EntityIcon iconId={node.emoji} variant='bare' size='sm' /> : null}
       <span className='min-w-0 truncate'>{node.title}</span>
       {hasChildren ? (
         <button
@@ -206,10 +203,8 @@ function itemClass(listStyle: KBSidebarListStyle): string {
   return cn(
     'group/item relative flex min-h-9 flex-1 items-center gap-2 px-2 py-1.5 text-sm leading-tight text-[var(--kb-fg)] no-underline transition-colors',
     'hover:bg-[var(--kb-muted)] hover:text-[var(--kb-primary)]',
-    listStyle === 'default' &&
+    (listStyle === 'default' || listStyle === 'pill') &&
       'rounded-[var(--kb-radius)] data-[active=true]:bg-[var(--kb-muted)] data-[active=true]:text-[var(--kb-primary)] data-[active=true]:font-medium',
-    listStyle === 'pill' &&
-      'rounded-full data-[active=true]:bg-[var(--kb-muted)] data-[active=true]:text-[var(--kb-primary)] data-[active=true]:font-medium',
     listStyle === 'line' && [
       'rounded-none hover:bg-transparent',
       'before:pointer-events-none before:absolute before:inset-y-0 before:left-0 before:w-0.5 before:bg-[var(--kb-border)] before:transition-colors',

--- a/packages/ui/src/components/kb/layout/kb-sidebar.tsx
+++ b/packages/ui/src/components/kb/layout/kb-sidebar.tsx
@@ -67,7 +67,12 @@ export function KBSidebar<T extends KBSidebarArticle>({
   const visible = tabs.length >= 2 ? filterToTab(articles, activeTabId) : articles
 
   const inner = (
-    <div className='flex h-full flex-col gap-2 overflow-y-auto px-4 py-6'>
+    <div
+      data-slot='kb-sidebar-inner'
+      className={cn(
+        'flex flex-1 flex-col gap-2 overflow-y-auto',
+        listStyle === 'pill' ? 'm-3 rounded-2xl bg-[var(--kb-muted)]/50 px-3 py-4' : 'px-4 py-6'
+      )}>
       {showSearch ? (
         <div className='mb-1'>
           <KBSearchInput searchOrigin={searchOrigin ?? ''} basePath={basePath} />
@@ -92,17 +97,19 @@ export function KBSidebar<T extends KBSidebarArticle>({
   return (
     <>
       {/* Desktop persistent sidebar */}
-      <div className='relative hidden shrink-0 @kb-md:block'>
+      <div className='relative hidden shrink-0 @kb-md:flex @kb-md:flex-col'>
         <aside
+          data-slot='kb-sidebar'
           data-collapsed={collapsed}
           className={cn(
-            'overflow-hidden border-r border-[var(--kb-border)] bg-[var(--kb-sidebar-bg)]',
+            'flex flex-1 flex-col overflow-hidden',
+            listStyle !== 'pill' && 'border-r border-[var(--kb-border)] bg-[var(--kb-sidebar-bg)]',
             'transition-[width,border-color] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]',
             collapsed ? 'w-0 border-transparent' : 'w-72'
           )}>
           <div
             className={cn(
-              'w-72 transition-[transform,opacity] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]',
+              'flex w-72 flex-1 flex-col transition-[transform,opacity] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]',
               collapsed
                 ? 'pointer-events-none -translate-x-4 opacity-0'
                 : 'translate-x-0 opacity-100'

--- a/packages/ui/src/components/kb/theme/kb-theme-provider.tsx
+++ b/packages/ui/src/components/kb/theme/kb-theme-provider.tsx
@@ -16,9 +16,11 @@ export function KBThemeProvider({ kb, mode, children }: KBThemeProviderProps) {
   const theme = sanitizeTheme(kb.theme)
   return (
     <div
+      data-slot='kb-theme'
       data-kb-id={kb.id}
       data-kb-mode={initialMode}
       data-kb-theme={theme}
+      className='flex flex-1 flex-col'
       style={{ background: 'var(--kb-page-bg)' }}>
       {/* biome-ignore lint/security/noDangerouslySetInnerHtml: values are sanitized via buildKBCss */}
       <style dangerouslySetInnerHTML={{ __html: css }} />

--- a/packages/ui/src/components/kb/utils/article-paths.ts
+++ b/packages/ui/src/components/kb/utils/article-paths.ts
@@ -19,6 +19,32 @@ export function getFullSlugPath<T extends ArticleSlugFields>(article: T, allArti
   return slugs.join('/')
 }
 
+interface ParentLinkArticle extends ArticleSlugFields {
+  title: string
+  emoji?: string | null
+  isCategory?: boolean
+}
+
+/**
+ * Resolves the parent breadcrumb for `KBArticleRenderer`. Returns `undefined`
+ * when the article has no parent. Categories aren't navigable, so their `href`
+ * is `null` and the renderer falls back to plain text.
+ */
+export function getArticleParentLink<T extends ParentLinkArticle>(
+  article: T | undefined | null,
+  allArticles: T[],
+  basePath: string
+): { title: string; emoji?: string | null; href: string | null } | undefined {
+  if (!article?.parentId) return undefined
+  const parent = allArticles.find((a) => a.id === article.parentId)
+  if (!parent) return undefined
+  return {
+    title: parent.title,
+    emoji: parent.emoji,
+    href: parent.isCategory ? null : `${basePath}/${getFullSlugPath(parent, allArticles)}`,
+  }
+}
+
 export function findArticleBySlugPath<T extends ArticleSlugFields>(
   allArticles: T[],
   slugPath: string[]

--- a/packages/ui/src/components/kb/utils/index.ts
+++ b/packages/ui/src/components/kb/utils/index.ts
@@ -4,6 +4,7 @@ export { getArticleNeighbours } from './article-neighbours'
 export {
   type ArticleSlugFields,
   findArticleBySlugPath,
+  getArticleParentLink,
   getArticleSlugPaths,
   getFullSlugPath,
   isArticleActive,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1880,6 +1880,9 @@ importers:
       mammoth:
         specifier: ^1.10.0
         version: 1.11.0
+      mdast-util-to-string:
+        specifier: ^4.0.0
+        version: 4.0.0
       nanoid:
         specifier: ^5.1.5
         version: 5.1.6
@@ -1916,6 +1919,15 @@ importers:
       pusher-js:
         specifier: 'catalog:'
         version: 8.4.0
+      remark-directive:
+        specifier: ^3.0.0
+        version: 3.0.1
+      remark-gfm:
+        specifier: ^4.0.0
+        version: 4.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
       sharp:
         specifier: 'catalog:'
         version: 0.34.3
@@ -1931,6 +1943,9 @@ importers:
       turndown:
         specifier: 'catalog:'
         version: 7.2.2
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       uuid:
         specifier: 'catalog:'
         version: 11.1.0
@@ -11320,6 +11335,9 @@ packages:
   md5@2.3.0:
     resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
+  mdast-util-directive@3.1.0:
+    resolution: {integrity: sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==}
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -11405,6 +11423,9 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-directive@3.0.2:
+    resolution: {integrity: sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -12795,6 +12816,9 @@ packages:
 
   relay-runtime@12.0.0:
     resolution: {integrity: sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==}
+
+  remark-directive@3.0.1:
+    resolution: {integrity: sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -24373,6 +24397,20 @@ snapshots:
       crypt: 0.0.2
       is-buffer: 1.1.6
 
+  mdast-util-directive@3.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-find-and-replace@3.0.2:
     dependencies:
       '@types/mdast': 4.0.4
@@ -24574,6 +24612,16 @@ snapshots:
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
+
+  micromark-extension-directive@3.0.2:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      parse-entities: 4.0.2
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     dependencies:
@@ -26288,6 +26336,15 @@ snapshots:
       invariant: 2.2.4
     transitivePeerDependencies:
       - encoding
+
+  remark-directive@3.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-directive: 3.1.0
+      micromark-extension-directive: 3.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds markdown round-trip (`@auxx/lib/kb/markdown`) using remark + GFM + directives, plus an `exportArticleMarkdown` tRPC query and copy/download actions in the article sidebar
- Editor gains a paste-as-markdown extension and markdown input rules so common syntax types-through naturally
- Public preview gets dedicated mobile and desktop device frames, and a mobile TOC drawer in `@auxx/ui` for narrow screens
- Sidebar now renders the article's custom icon (new `bare` variant on `EntityIcon`) instead of stuffing the emoji into the title

## Test plan
- [ ] Paste a markdown doc into the article editor and confirm it converts to blocks
- [ ] Copy / download an article as markdown from the sidebar dropdown and re-import to verify round-trip
- [ ] Open the public KB preview and toggle mobile vs desktop frame; on mobile, open the TOC drawer
- [ ] Pick a custom icon for an article and confirm it shows in the sidebar tree
- [ ] `pnpm test --filter @auxx/lib` (round-trip suite)