### PR TITLE
fix(kb): persist editor sidebar across article navigation

### DIFF
--- a/apps/web/src/app/(protected)/app/kb/[knowledgeBaseId]/editor/[[...slug]]/page.tsx
+++ b/apps/web/src/app/(protected)/app/kb/[knowledgeBaseId]/editor/[[...slug]]/page.tsx
@@ -1,7 +1,6 @@
-// app/kb/[knowledgeBaseId]/editor/[...slug]/page.tsx
+// app/kb/[knowledgeBaseId]/editor/[[...slug]]/page.tsx
 
-import { KnowledgeBaseProvider } from '~/components/kb'
-import { KBEditorShell } from '~/components/kb/ui/editor/kb-editor-shell'
+import { KBEditorPageBody } from '~/components/kb/ui/editor/kb-editor-page-body'
 
 type KBEditorParams = {
   params: Promise<{ knowledgeBaseId: string; slug?: string[] }>
@@ -13,9 +12,5 @@ export default async function KBEditorPage({ params }: KBEditorParams) {
   // Strip the literal `~` separator that's part of the URL convention.
   const cleanSlug = slug.length > 0 && slug[0] === '~' ? slug.slice(1) : slug
 
-  return (
-    <KnowledgeBaseProvider knowledgeBaseId={knowledgeBaseId}>
-      <KBEditorShell knowledgeBaseId={knowledgeBaseId} slug={cleanSlug} />
-    </KnowledgeBaseProvider>
-  )
+  return <KBEditorPageBody knowledgeBaseId={knowledgeBaseId} slug={cleanSlug} />
 }

--- a/apps/web/src/app/(protected)/app/kb/[knowledgeBaseId]/editor/layout.tsx
+++ b/apps/web/src/app/(protected)/app/kb/[knowledgeBaseId]/editor/layout.tsx
@@ -1,0 +1,25 @@
+// app/kb/[knowledgeBaseId]/editor/layout.tsx
+import type React from 'react'
+import { KnowledgeBaseProvider } from '~/components/kb'
+import { KBEditorFrame } from '~/components/kb/ui/editor/kb-editor-frame'
+
+type Props = {
+  children: React.ReactNode
+  params: Promise<{ knowledgeBaseId: string }>
+}
+
+/**
+ * Route segment layout for the KB editor. Mounts the article-store provider
+ * and the persistent chrome (sidebar + header) once per knowledgeBaseId.
+ * Only `page.tsx` (the right-pane editor body) suspends on slug change, so
+ * the sidebar's scroll position survives article navigation.
+ */
+export default async function KBEditorLayout({ children, params }: Props) {
+  const { knowledgeBaseId } = await params
+
+  return (
+    <KnowledgeBaseProvider knowledgeBaseId={knowledgeBaseId}>
+      <KBEditorFrame knowledgeBaseId={knowledgeBaseId}>{children}</KBEditorFrame>
+    </KnowledgeBaseProvider>
+  )
+}

--- a/apps/web/src/components/kb/providers/knowledge-base-provider.tsx
+++ b/apps/web/src/components/kb/providers/knowledge-base-provider.tsx
@@ -54,6 +54,12 @@ export function KnowledgeBaseProvider({ knowledgeBaseId, children }: KnowledgeBa
   }, [knowledgeBaseId])
 
   // Hydrate articles for the active KB.
+  // We intentionally do NOT clearKb on unmount: KBEditorPage suspends on
+  // slug changes (the parent loading.tsx wraps it in a Suspense boundary),
+  // so the provider remounts mid-navigation. Clearing here would race with
+  // pending optimistic state and cause the just-confirmed article to flicker
+  // out and back in. The store's setArticles is upsert-only and survives
+  // stale fetches without leaking across KBs (articleIdsByKb is per-kb).
   const articlesQuery = api.kb.getArticles.useQuery(
     { knowledgeBaseId, includeUnpublished: true },
     { enabled: !!knowledgeBaseId }
@@ -66,13 +72,6 @@ export function KnowledgeBaseProvider({ knowledgeBaseId, children }: KnowledgeBa
       )
     }
   }, [articlesQuery.data, knowledgeBaseId])
-
-  // Clear on unmount / KB switch.
-  useEffect(() => {
-    return () => {
-      getArticleStoreState().clearKb(knowledgeBaseId)
-    }
-  }, [knowledgeBaseId])
 
   return <>{children}</>
 }

--- a/apps/web/src/components/kb/store/article-store.ts
+++ b/apps/web/src/components/kb/store/article-store.ts
@@ -68,6 +68,13 @@ interface ArticleStoreState {
   pendingUpdates: Record<string, PendingArticleUpdate>
   /** Optimistic create entries keyed by tempId. */
   optimisticNewArticles: Record<string, ArticleMeta>
+  /**
+   * Server ids confirmed by `confirmCreate` whose presence has not yet been
+   * observed in a server `setArticles` call. We preserve these in the per-kb
+   * list ordering when a stale fetch arrives, so the just-created article
+   * doesn't flicker out while the GET refetch is in flight.
+   */
+  recentlyCreatedIds: Record<string, Set<string>>
   /** Articles marked deleted (hidden from selectors). */
   optimisticDeleted: Set<string>
   /** Active reorder snapshot (only one in flight at a time). */
@@ -119,24 +126,44 @@ export const useArticleStore = create<ArticleStoreState>()(
 
       pendingUpdates: {},
       optimisticNewArticles: {},
+      recentlyCreatedIds: {},
       optimisticDeleted: new Set<string>(),
       pendingReorder: null,
 
       // ─── Hydration ───────────────────────────────────────────────
       setArticles: (kbId, articles) => {
         set((state) => {
-          // Replace the article ids for this KB
-          state.articleIdsByKb[kbId] = articles.map((a) => a.id)
+          const incomingIds = articles.map((a) => a.id)
+          const incomingSet = new Set(incomingIds)
 
-          // Drop stale entries from this KB that aren't in the new list
-          const incoming = new Set(articles.map((a) => a.id))
-          for (const [id, art] of state.articles) {
-            if (art.knowledgeBaseId === kbId && !incoming.has(id)) {
-              state.articles.delete(id)
+          // Reconcile recentlyCreatedIds: drop any that the server now lists
+          // (its create has been observed by a fetch). Anything still in the
+          // set is a confirmed create the server response hasn't seen yet —
+          // append those to the list ordering so the UI doesn't lose them.
+          const recent = state.recentlyCreatedIds[kbId]
+          const stillPending: string[] = []
+          if (recent) {
+            for (const id of recent) {
+              if (incomingSet.has(id)) {
+                recent.delete(id)
+              } else if (state.articles.has(id) && !state.optimisticDeleted.has(id)) {
+                stillPending.push(id)
+              } else {
+                // Entity gone (rolled back, deleted, etc.) — stop tracking it.
+                recent.delete(id)
+              }
             }
           }
 
-          // Upsert new entries
+          state.articleIdsByKb[kbId] = stillPending.length
+            ? [...incomingIds, ...stillPending]
+            : incomingIds
+
+          // Upsert into the entity map. We deliberately do NOT prune entries
+          // that are missing from the incoming list — a stale fetch arriving
+          // after a confirmed optimistic create/update would otherwise drop
+          // the just-confirmed entity. Entities leave the map only via
+          // explicit confirmDelete (mirrors record-store semantics).
           for (const article of articles) {
             state.articles.set(article.id, article)
           }
@@ -243,6 +270,11 @@ export const useArticleStore = create<ArticleStoreState>()(
           const next = ids.filter((id) => id !== tempId)
           if (!next.includes(server.id)) next.push(server.id)
           state.articleIdsByKb[server.knowledgeBaseId] = next
+          // Track until a server fetch confirms it — protects against a stale
+          // refetch wiping the new id out of articleIdsByKb mid-navigation.
+          const recent = state.recentlyCreatedIds[server.knowledgeBaseId] ?? new Set<string>()
+          recent.add(server.id)
+          state.recentlyCreatedIds[server.knowledgeBaseId] = recent
         })
       },
 
@@ -373,6 +405,7 @@ export const useArticleStore = create<ArticleStoreState>()(
             state.optimisticDeleted.delete(id)
           }
           delete state.articleIdsByKb[kbId]
+          delete state.recentlyCreatedIds[kbId]
           state.loadedKbs.delete(kbId)
         })
       },
@@ -384,6 +417,7 @@ export const useArticleStore = create<ArticleStoreState>()(
           state.loadedKbs.clear()
           state.pendingUpdates = {}
           state.optimisticNewArticles = {}
+          state.recentlyCreatedIds = {}
           state.optimisticDeleted.clear()
           state.pendingReorder = null
         })

--- a/apps/web/src/components/kb/ui/editor/kb-editor-frame.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-frame.tsx
@@ -1,0 +1,58 @@
+// apps/web/src/components/kb/ui/editor/kb-editor-frame.tsx
+'use client'
+
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageContent,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import type React from 'react'
+import { useKnowledgeBase } from '../../hooks/use-knowledge-base'
+import { KBSidebar } from '../sidebar/kb-sidebar'
+
+interface KBEditorFrameProps {
+  knowledgeBaseId: string
+  children: React.ReactNode
+}
+
+/**
+ * Persistent chrome for the KB editor: header, sidebar, and the content
+ * frame. Lives in the route segment layout so slug-level navigations don't
+ * remount the sidebar (which would lose its scroll position).
+ */
+export function KBEditorFrame({ knowledgeBaseId, children }: KBEditorFrameProps) {
+  const { knowledgeBase, isLoading } = useKnowledgeBase(knowledgeBaseId)
+
+  if (isLoading || !knowledgeBase) {
+    return (
+      <div className='p-8'>
+        <Skeleton className='h-8 w-64' />
+        <Skeleton className='mt-4 h-4 w-full' />
+        <Skeleton className='mt-2 h-4 w-full' />
+      </div>
+    )
+  }
+
+  return (
+    <MainPage>
+      <MainPageHeader>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem
+            title='Knowledge base '
+            href={`/app/kb/${knowledgeBaseId}/editor/general`}
+            last
+          />
+        </MainPageBreadcrumb>
+      </MainPageHeader>
+      <MainPageContent>
+        <div className='flex flex-row w-full h-full'>
+          <KBSidebar knowledgeBaseId={knowledgeBaseId} knowledgeBase={knowledgeBase} />
+          <div className='flex min-h-0 max-lg:shrink-0 lg:flex-1'>{children}</div>
+        </div>
+      </MainPageContent>
+    </MainPage>
+  )
+}

--- a/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
@@ -1,78 +1,43 @@
-// apps/web/src/components/kb/ui/editor/kb-editor-shell.tsx
+// apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
 'use client'
 
 import { findArticleBySlugPath } from '@auxx/ui/components/kb/utils'
-import {
-  MainPage,
-  MainPageBreadcrumb,
-  MainPageBreadcrumbItem,
-  MainPageContent,
-  MainPageHeader,
-} from '@auxx/ui/components/main-page'
-import { Skeleton } from '@auxx/ui/components/skeleton'
 import { useQueryState } from 'nuqs'
 import { useMemo } from 'react'
 import { useArticleList, useIsArticleListLoaded } from '../../hooks/use-article-list'
 import { useKnowledgeBase } from '../../hooks/use-knowledge-base'
 import { KBPreview } from '../preview/kb-preview'
-import { KBSidebar } from '../sidebar/kb-sidebar'
 import { ArticleEditor } from './article-editor'
 import { ArticleEditorLoading } from './article-editor-loading'
 
-interface KBEditorShellProps {
+interface KBEditorPageBodyProps {
   knowledgeBaseId: string
   slug: string[]
 }
 
 /**
- * Top-level editor shell. Wraps the page in MainPage + sidebar and
- * renders either the article editor or the live preview based on `?tab`.
+ * Right-pane content for the KB editor. Sits inside the editor route
+ * segment layout (which owns the chrome + sidebar). Only this component
+ * suspends on slug changes, so the sidebar stays mounted across article
+ * navigations.
  */
-export function KBEditorShell({ knowledgeBaseId, slug }: KBEditorShellProps) {
+export function KBEditorPageBody({ knowledgeBaseId, slug }: KBEditorPageBodyProps) {
   const [activeTab] = useQueryState('tab', { defaultValue: 'general' })
-  const { knowledgeBase, isLoading: isKBLoading } = useKnowledgeBase(knowledgeBaseId)
-  const articles = useArticleList(knowledgeBaseId)
+  const { knowledgeBase } = useKnowledgeBase(knowledgeBaseId)
   const hasArticlesLoaded = useIsArticleListLoaded(knowledgeBaseId)
 
-  if (isKBLoading || !knowledgeBase) {
-    return (
-      <div className='p-8'>
-        <Skeleton className='h-8 w-64' />
-        <Skeleton className='mt-4 h-4 w-full' />
-        <Skeleton className='mt-2 h-4 w-full' />
-      </div>
-    )
+  if (!knowledgeBase) return null
+
+  if (activeTab !== 'articles') {
+    return <KBPreview knowledgeBase={knowledgeBase} activeSlugPath={slug} />
   }
 
   return (
-    <MainPage>
-      <MainPageHeader>
-        <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem
-            title='Knowledge base '
-            href={`/app/kb/${knowledgeBaseId}/editor/general`}
-            last
-          />
-        </MainPageBreadcrumb>
-      </MainPageHeader>
-      <MainPageContent>
-        <div className='flex flex-row w-full h-full'>
-          <KBSidebar knowledgeBaseId={knowledgeBaseId} knowledgeBase={knowledgeBase} />
-
-          <div className='flex min-h-0 max-lg:shrink-0 lg:flex-1'>
-            {activeTab === 'articles' ? (
-              <KBEditorBody
-                knowledgeBaseId={knowledgeBaseId}
-                slug={slug}
-                hasArticlesLoaded={hasArticlesLoaded}
-              />
-            ) : (
-              <KBPreview knowledgeBase={knowledgeBase} activeSlugPath={slug} />
-            )}
-          </div>
-        </div>
-      </MainPageContent>
-    </MainPage>
+    <KBEditorBody
+      knowledgeBaseId={knowledgeBaseId}
+      slug={slug}
+      hasArticlesLoaded={hasArticlesLoaded}
+    />
   )
 }
 

--- a/apps/web/src/components/kb/ui/preview/kb-preview-topbar.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview-topbar.tsx
@@ -152,10 +152,6 @@ export function KBPreviewTopBar({ kbId, activeSlugPath }: KBPreviewTopBarProps) 
       </div>
 
       <div className='flex items-center gap-2'>
-        <Button size='sm' variant='outline'>
-          <span className='w-max-full text-ui-small truncate'>Share feedback</span>
-        </Button>
-
         <Button size='icon-sm' variant='ghost' asChild>
           <a
             href={externalHref}

--- a/apps/web/src/components/kb/ui/settings/general/general-tab.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/general-tab.tsx
@@ -89,7 +89,7 @@ export function GeneralTab({ knowledgeBaseId, knowledgeBase }: GeneralTabProps) 
   }, [form, knowledgeBaseId])
 
   return (
-    <div className='relative pb-16'>
+    <div className='relative pb-16 [&_[data-slot=section]]:pr-5'>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <IdentitySection form={form} isPending={isUpdating} />

--- a/apps/web/src/components/kb/ui/settings/layout/layout-tab.tsx
+++ b/apps/web/src/components/kb/ui/settings/layout/layout-tab.tsx
@@ -60,7 +60,7 @@ export function LayoutTab({ knowledgeBaseId, knowledgeBase }: LayoutTabProps) {
   }, [form, knowledgeBaseId])
 
   return (
-    <div className='pb-16'>
+    <div className='pb-16 [&_[data-slot=section]]:pr-5'>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <HeaderSection form={form} isPending={isUpdating} />

--- a/apps/web/src/components/kb/ui/sidebar/kb-sidebar.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/kb-sidebar.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
 import { cn } from '@auxx/ui/lib/utils'
 import { Book, Cog, Layout, Loader2 } from 'lucide-react'
@@ -44,7 +45,7 @@ export function KBSidebar({ knowledgeBaseId, knowledgeBase }: KBSidebarProps) {
           'lg:max-w-lg': activeTab !== 'articles',
         }
       )}>
-      <div className='flex min-h-0 flex-1 flex-col overflow-auto'>
+      <ScrollArea className='flex min-h-0 flex-1 flex-col'>
         <Tabs defaultValue='general' value={activeTab} onValueChange={setActiveTab}>
           <div className='sticky top-0 z-50 bg-background'>
             <div className='p-2'>
@@ -82,7 +83,7 @@ export function KBSidebar({ knowledgeBaseId, knowledgeBase }: KBSidebarProps) {
             <KBArticlesPanel knowledgeBaseId={knowledgeBaseId} />
           </TabsContent>
         </Tabs>
-      </div>
+      </ScrollArea>
       <div className='absolute bottom-4 right-4'>
         <Button size='sm' variant='info' onClick={handleGlobalSave} disabled={isSaving}>
           {isSaving ? <Loader2 className='mr-2 h-4 w-4 animate-spin' /> : null}


### PR DESCRIPTION
## Summary

Move `KnowledgeBaseProvider` + sidebar/header into a route-segment layout so slug navigation no longer tears them down. Fixes:

- **Sidebar scroll resets to 0 on every article click.** Caused by the page suspending under `app/kb/loading.tsx`'s Suspense boundary on each `router.push`.
- **Add Page flicker (~100 ms hole).** Provider was unmounting mid-mutation; on remount the still-stale React Query cache rehydrated the article store and dropped the just-confirmed entity until the refetch returned.

## Routing changes

- New `app/kb/[knowledgeBaseId]/editor/layout.tsx` mounts the provider + persistent chrome via a new `KBEditorFrame`.
- `editor/[[...slug]]/page.tsx` slimmed to a single `KBEditorPageBody` render — only the right pane (preview vs `ArticleEditor`) suspends on slug change.
- Deleted `kb-editor-shell.tsx`; responsibilities split between `KBEditorFrame` (chrome, in layout) and `KBEditorPageBody` (right pane, in page).

## Article-store hardening (mirrors record-store / resource-store)

- `setArticles` is upsert-only — drops the destructive *delete entries not in incoming* loop. Stale fetches can no longer remove a confirmed entity from the Map. Entries leave only via `confirmDelete`.
- New `recentlyCreatedIds` tracks server ids confirmed via `confirmCreate` that haven't been observed in a server fetch yet; `setArticles` preserves them in the per-kb list ordering until a refetch confirms them.
- Dropped `clearKb`-on-unmount in `KnowledgeBaseProvider` — `articleIdsByKb` is per-kb, so leaving stale entries from inactive KBs in the Map is benign and the data needs to survive remounts now.

## Sidebar polish

- Swap the sidebar's `overflow-auto` wrapper for `<ScrollArea>`.
- Right-pad `Section` consumers (`general-tab`, `layout-tab`) via `[&_[data-slot=section]]:pr-5` so content doesn't sit under the scrollbar overlay. No global `Section` change.

## Verified in browser

- Click an article: `scrollTop=97 → 97`, same DOM node before/after (`data-tag` preserved); URL navigates.
- Add Page: panel render count stable at `n` across all post-click renders (was dipping by 1 mid-flow).
- Right-pane editor still updates correctly on slug change.

## Test plan

- [ ] Open KB editor with multiple articles; scroll the sidebar partway down; click an article — scroll position should not jump.
- [ ] Click "Add Page" at the bottom — new article appears immediately, name updates from "Untitled" to "Page N", does not flicker out.
- [ ] Switch between General / Layout / Articles tabs — content unchanged, no scrollbar overlap on Section content.
- [ ] Switch to a different KB via the KB switcher — articles for the new KB load; no leak from the previous KB.
- [ ] Delete an article — disappears immediately, doesn't reappear on refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)