### PR TITLE
feat(kb): preview mode override + shared banner

### DIFF
--- a/apps/web/src/components/kb/hooks/use-body-class.ts
+++ b/apps/web/src/components/kb/hooks/use-body-class.ts
@@ -1,0 +1,23 @@
+// apps/web/src/components/kb/hooks/use-body-class.ts
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Temporarily mutate `document.body.classList` for the lifetime of a component.
+ * Use to opt a single route out of global body classes set in `app/layout.tsx`
+ * (e.g. dropping `overflow-hidden` for a page that wants natural document scroll).
+ */
+export function useBodyClass({ add, remove }: { add?: string; remove?: string }) {
+  useEffect(() => {
+    const cls = document.body.classList
+    const toAdd = (add ?? '').split(' ').filter((c) => c && !cls.contains(c))
+    const toRemove = (remove ?? '').split(' ').filter((c) => c && cls.contains(c))
+    for (const c of toAdd) cls.add(c)
+    for (const c of toRemove) cls.remove(c)
+    return () => {
+      for (const c of toAdd) cls.remove(c)
+      for (const c of toRemove) cls.add(c)
+    }
+  }, [add, remove])
+}

--- a/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
 'use client'
 
+import { Banner } from '@auxx/ui/components/banner'
 import {
   type DocJSON,
   extractKBHeadings,
@@ -13,8 +14,12 @@ import {
   KBLayout,
   KBTableOfContents,
 } from '@auxx/ui/components/kb'
+import { ExternalLink, Eye } from 'lucide-react'
+import { type CSSProperties, useCallback, useState } from 'react'
 import { useArticleContent } from '../../hooks/use-article-content'
 import { useArticleList } from '../../hooks/use-article-list'
+import { useBodyClass } from '../../hooks/use-body-class'
+import { useKbPublicUrl } from '../../hooks/use-kb-public-url'
 import { useKnowledgeBase } from '../../hooks/use-knowledge-base'
 import { mapKBForPreview } from './map-kb-for-preview'
 
@@ -31,8 +36,27 @@ interface KBFullscreenPreviewProps {
  * between articles.
  */
 export function KBFullscreenPreview({ knowledgeBaseId, slugPath }: KBFullscreenPreviewProps) {
+  // The global body has `overflow-hidden` so app routes manage their own scroll.
+  // The fullscreen preview wants document-level scroll to match the public KB site
+  // (header scrolls away naturally with content).
+  useBodyClass({ remove: 'overflow-hidden' })
+
+  // Measure the banner so the KB layout's sticky elements (header, tabs, sidebar)
+  // can offset themselves below it via the `--kb-top-offset` CSS variable.
+  // Callback ref runs after the banner mounts (which can be a later render than
+  // this component's first render, since we early-return null while the KB loads).
+  const [bannerHeight, setBannerHeight] = useState(0)
+  const setBannerRef = useCallback((el: HTMLDivElement | null) => {
+    if (!el) return
+    setBannerHeight(el.offsetHeight)
+    const ro = new ResizeObserver(() => setBannerHeight(el.offsetHeight))
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
   const { knowledgeBase } = useKnowledgeBase(knowledgeBaseId)
   const articles = useArticleList(knowledgeBaseId)
+  const publicUrl = useKbPublicUrl(knowledgeBase?.slug)
 
   const matchedArticle = slugPath.length > 0 ? findArticleBySlugPath(articles, slugPath) : undefined
   // Tabs and headers are pure containers — resolve to their first navigable
@@ -59,8 +83,34 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath }: KBFullscreenP
     : { prev: undefined, next: undefined }
   const parent = getArticleParentLink(activeArticle, articles, basePath)
 
+  const isLive =
+    knowledgeBase.publishStatus === 'PUBLISHED' || knowledgeBase.publishStatus === 'UNLISTED'
+  const slugSegment = slugPath.length > 0 ? `/${slugPath.map(encodeURIComponent).join('/')}` : ''
+  const liveHref = isLive && publicUrl ? `${publicUrl}${slugSegment}` : null
+
   return (
-    <div className='h-dvh overflow-y-auto'>
+    <div style={{ '--kb-top-offset': `${bannerHeight}px` } as CSSProperties}>
+      <div ref={setBannerRef} className='sticky top-0 z-30'>
+        <Banner
+          variant='default'
+          icon={<Eye />}
+          title='Preview mode'
+          action={
+            liveHref ? (
+              <a
+                href={liveHref}
+                target='_blank'
+                rel='noopener'
+                className='inline-flex items-center gap-1 font-medium text-info hover:underline'>
+                View live site <ExternalLink className='size-3.5' />
+              </a>
+            ) : (
+              <span className='text-muted-foreground'>Not published yet</span>
+            )
+          }>
+          Viewing draft (includes unpublished changes)
+        </Banner>
+      </div>
       <KBLayout
         kb={mapKBForPreview(knowledgeBase)}
         articles={articles}
@@ -69,7 +119,7 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath }: KBFullscreenP
         {articleId ? (
           <div className='flex min-w-0 flex-1 flex-col'>
             <div className='flex flex-col gap-6 @kb-lg:flex-row @kb-lg:items-start'>
-              <aside className='hidden @kb-lg:sticky @kb-lg:top-20 @kb-lg:order-2 @kb-lg:block @kb-lg:max-h-[calc(100dvh-5rem)] @kb-lg:w-64 @kb-lg:max-w-none @kb-lg:flex-none @kb-lg:overflow-y-auto @kb-lg:px-4 @kb-lg:pt-8'>
+              <aside className='hidden @kb-lg:sticky @kb-lg:top-[calc(var(--kb-top-offset,0px)+5rem)] @kb-lg:order-2 @kb-lg:block @kb-lg:max-h-[calc(100dvh-var(--kb-top-offset,0px)-5rem)] @kb-lg:w-64 @kb-lg:max-w-none @kb-lg:flex-none @kb-lg:overflow-y-auto @kb-lg:px-4 @kb-lg:pt-8'>
                 <KBTableOfContents headings={headings} />
               </aside>
               <div className='min-w-0 flex-1 @kb-lg:order-1'>

--- a/apps/web/src/components/kb/ui/preview/kb-preview-topbar.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview-topbar.tsx
@@ -2,9 +2,26 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
+import { ButtonGroup, ButtonGroupSeparator } from '@auxx/ui/components/button-group'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import { getKbPreviewHref } from '@auxx/ui/components/kb/utils'
 import { ToggleGroup, ToggleGroupItem } from '@auxx/ui/components/toggle-group'
-import { ExternalLink, Monitor, Moon, Smartphone, Sun } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
+import {
+  ChevronDown,
+  ExternalLink,
+  Eye,
+  Monitor,
+  Moon,
+  RotateCcw,
+  Smartphone,
+  Sun,
+} from 'lucide-react'
 import { useKbPublicUrl } from '~/components/kb/hooks/use-kb-public-url'
 import { api } from '~/trpc/react'
 import { type Device, type Theme, usePreview } from './preview-context'
@@ -16,12 +33,13 @@ interface KBPreviewTopBarProps {
 }
 
 /**
- * Preview-pane controls only — open-in-new-tab, light/dark toggle, and
- * desktop/mobile device toggle. Publish lifecycle controls live in the
- * editor header (`KBPublishCluster`).
+ * Preview-pane controls — preview/live entry on the left, theme + device
+ * toggles on the right. Publish lifecycle controls live in the editor header
+ * (`KBPublishCluster`).
  */
 export function KBPreviewTopBar({ kbId, activeSlugPath }: KBPreviewTopBarProps) {
-  const { isDark, isMobile, setTheme, setDevice } = usePreview()
+  const { effectiveMode, defaultMode, override, isMobile, knowledgeBase, setOverride, setDevice } =
+    usePreview()
 
   const { data: kb } = api.kb.byId.useQuery({ id: kbId })
 
@@ -34,14 +52,15 @@ export function KBPreviewTopBar({ kbId, activeSlugPath }: KBPreviewTopBarProps) 
 
   const isPublished = kb?.publishStatus === 'PUBLISHED'
   const isUnlisted = kb?.publishStatus === 'UNLISTED'
-  const isLive = isPublished || isUnlisted
-  const externalHref = isLive && publicUrl ? `${publicUrl}${slugSegment}` : previewHref
-  const externalLabel =
-    isLive && publicUrl ? 'Open public site in new tab' : 'Open preview in new tab'
+  const isLive = (isPublished || isUnlisted) && Boolean(publicUrl)
+  const liveHref = publicUrl ? `${publicUrl}${slugSegment}` : null
+
+  const showMode = knowledgeBase?.showMode !== false
+  const showsHiddenModeHint = !showMode && override !== null && override !== defaultMode
 
   const handleThemeChange = (value?: string) => {
     if (!value) return
-    setTheme(value as Theme)
+    setOverride(value as Theme)
   }
 
   const handleDeviceChange = (value?: string) => {
@@ -50,45 +69,96 @@ export function KBPreviewTopBar({ kbId, activeSlugPath }: KBPreviewTopBarProps) 
   }
 
   return (
-    <div className='flex items-center justify-end gap-2 border-b bg-background px-3 py-1'>
-      <Button size='icon-sm' variant='ghost' asChild>
-        <a
-          href={externalHref}
-          target='_blank'
-          rel='noopener'
-          aria-label={externalLabel}
-          title={externalLabel}>
-          <ExternalLink />
-        </a>
-      </Button>
+    <div className='flex items-center justify-between gap-2 border-b bg-background px-3 py-1'>
+      {isLive && liveHref ? (
+        <DropdownMenu>
+          <ButtonGroup>
+            <Button variant='outline' size='xs' className='border-r-0' asChild>
+              <a
+                href={previewHref}
+                target='_blank'
+                rel='noopener'
+                aria-label='Open preview in new tab'>
+                <Eye /> Preview
+              </a>
+            </Button>
+            <ButtonGroupSeparator />
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant='outline'
+                size='xs'
+                className='px-1.5'
+                aria-label='More preview options'>
+                <ChevronDown />
+              </Button>
+            </DropdownMenuTrigger>
+          </ButtonGroup>
+          <DropdownMenuContent align='start'>
+            <DropdownMenuItem asChild>
+              <a href={liveHref} target='_blank' rel='noopener'>
+                <ExternalLink /> Open live site
+              </a>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        <Button variant='outline' size='xs' asChild>
+          <a href={previewHref} target='_blank' rel='noopener' aria-label='Open preview in new tab'>
+            <Eye /> Preview
+          </a>
+        </Button>
+      )}
 
-      <ToggleGroup
-        size='sm'
-        type='single'
-        value={isDark ? 'dark' : 'light'}
-        onValueChange={handleThemeChange}
-        aria-label='Theme'>
-        <ToggleGroupItem value='light' aria-label='Light mode'>
-          <Sun />
-        </ToggleGroupItem>
-        <ToggleGroupItem value='dark' aria-label='Dark mode'>
-          <Moon />
-        </ToggleGroupItem>
-      </ToggleGroup>
+      <div className='flex items-center gap-2'>
+        {showsHiddenModeHint && (
+          <span className='text-xs text-muted-foreground'>
+            Visitors only see {defaultMode} mode
+          </span>
+        )}
 
-      <ToggleGroup
-        size='sm'
-        type='single'
-        value={isMobile ? 'mobile' : 'desktop'}
-        onValueChange={handleDeviceChange}
-        aria-label='Screen size'>
-        <ToggleGroupItem value='desktop' aria-label='Desktop mode'>
-          <Monitor />
-        </ToggleGroupItem>
-        <ToggleGroupItem value='mobile' aria-label='Mobile mode'>
-          <Smartphone />
-        </ToggleGroupItem>
-      </ToggleGroup>
+        <ToggleGroup
+          size='sm'
+          type='single'
+          value={effectiveMode}
+          onValueChange={handleThemeChange}
+          aria-label='Theme'>
+          <ToggleGroupItem value='light' aria-label='Light mode'>
+            <Sun />
+          </ToggleGroupItem>
+          <ToggleGroupItem value='dark' aria-label='Dark mode'>
+            <Moon />
+          </ToggleGroupItem>
+        </ToggleGroup>
+
+        {override !== null && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size='icon-sm'
+                variant='ghost'
+                onClick={() => setOverride(null)}
+                aria-label='Reset to default mode'>
+                <RotateCcw />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Reset to default ({defaultMode})</TooltipContent>
+          </Tooltip>
+        )}
+
+        <ToggleGroup
+          size='sm'
+          type='single'
+          value={isMobile ? 'mobile' : 'desktop'}
+          onValueChange={handleDeviceChange}
+          aria-label='Screen size'>
+          <ToggleGroupItem value='desktop' aria-label='Desktop mode'>
+            <Monitor />
+          </ToggleGroupItem>
+          <ToggleGroupItem value='mobile' aria-label='Mobile mode'>
+            <Smartphone />
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/kb/ui/preview/kb-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview.tsx
@@ -36,7 +36,7 @@ export function KBPreview({ knowledgeBase, activeSlugPath }: KBPreviewProps) {
 }
 
 function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath?: string[] }) {
-  const { isMobile, isDark, knowledgeBase } = usePreview()
+  const { isMobile, effectiveMode, knowledgeBase } = usePreview()
   const articles = useArticleList(kbId)
 
   // Article from the editor's slug path; resets the override when the editor switches.
@@ -71,13 +71,13 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
     <div
       data-slot='kb-preview-color-scheme'
       className='flex min-h-0 flex-1 flex-col'
-      style={{ colorScheme: isDark ? 'dark' : 'light' }}>
+      style={{ colorScheme: effectiveMode }}>
       <KBLayout
         kb={mapKBForPreview(knowledgeBase)}
         articles={articles}
         basePath='#preview'
         activeArticleId={activeArticle?.id}
-        mode={isDark ? 'dark' : 'light'}
+        mode={effectiveMode}
         embedded
         mainScroll
         onArticleClick={(id) => setOverrideId(id)}>

--- a/apps/web/src/components/kb/ui/preview/map-kb-for-preview.ts
+++ b/apps/web/src/components/kb/ui/preview/map-kb-for-preview.ts
@@ -1,36 +1,42 @@
 // apps/web/src/components/kb/ui/preview/map-kb-for-preview.ts
 
+import { mergeDraftOverLive } from '@auxx/lib/kb/client'
 import type { KnowledgeBase } from '../../store/knowledge-base-store'
 
-/** Project a store KnowledgeBase into the shape KBLayout expects. */
+/**
+ * Project a store KnowledgeBase into the shape KBLayout expects. Always merges
+ * `draftSettings` over the live columns so admin previews reflect unpublished
+ * edits — the public site reads from live columns directly and isn't affected.
+ */
 export function mapKBForPreview(kb: KnowledgeBase) {
+  const merged = mergeDraftOverLive(kb as Record<string, unknown>) as KnowledgeBase
   return {
-    id: kb.id,
-    name: kb.name,
-    defaultMode: kb.defaultMode,
-    showMode: kb.showMode,
-    primaryColorLight: kb.primaryColorLight,
-    primaryColorDark: kb.primaryColorDark,
-    tintColorLight: kb.tintColorLight,
-    tintColorDark: kb.tintColorDark,
-    infoColorLight: kb.infoColorLight,
-    infoColorDark: kb.infoColorDark,
-    successColorLight: kb.successColorLight,
-    successColorDark: kb.successColorDark,
-    warningColorLight: kb.warningColorLight,
-    warningColorDark: kb.warningColorDark,
-    dangerColorLight: kb.dangerColorLight,
-    dangerColorDark: kb.dangerColorDark,
-    fontFamily: kb.fontFamily,
-    cornerStyle: kb.cornerStyle,
-    logoLight: kb.logoLight,
-    logoDark: kb.logoDark,
-    searchbarPosition: kb.searchbarPosition,
-    headerNavigation: kb.headerNavigation,
-    footerNavigation: kb.footerNavigation,
-    theme: kb.theme,
-    sidebarListStyle: kb.sidebarListStyle,
-    headerEnabled: kb.headerEnabled,
-    footerEnabled: kb.footerEnabled,
+    id: merged.id,
+    name: merged.name,
+    defaultMode: merged.defaultMode,
+    showMode: merged.showMode,
+    primaryColorLight: merged.primaryColorLight,
+    primaryColorDark: merged.primaryColorDark,
+    tintColorLight: merged.tintColorLight,
+    tintColorDark: merged.tintColorDark,
+    infoColorLight: merged.infoColorLight,
+    infoColorDark: merged.infoColorDark,
+    successColorLight: merged.successColorLight,
+    successColorDark: merged.successColorDark,
+    warningColorLight: merged.warningColorLight,
+    warningColorDark: merged.warningColorDark,
+    dangerColorLight: merged.dangerColorLight,
+    dangerColorDark: merged.dangerColorDark,
+    fontFamily: merged.fontFamily,
+    cornerStyle: merged.cornerStyle,
+    logoLight: merged.logoLight,
+    logoDark: merged.logoDark,
+    searchbarPosition: merged.searchbarPosition,
+    headerNavigation: merged.headerNavigation,
+    footerNavigation: merged.footerNavigation,
+    theme: merged.theme,
+    sidebarListStyle: merged.sidebarListStyle,
+    headerEnabled: merged.headerEnabled,
+    footerEnabled: merged.footerEnabled,
   }
 }

--- a/apps/web/src/components/kb/ui/preview/preview-context.tsx
+++ b/apps/web/src/components/kb/ui/preview/preview-context.tsx
@@ -11,20 +11,18 @@ export type Device = 'desktop' | 'mobile'
 interface PreviewContextValue {
   knowledgeBase?: KnowledgeBase
   isLoading: boolean
-  isDark: boolean
+  /** What a fresh visitor sees on first load (from `kb.defaultMode`). */
+  defaultMode: Theme
+  /** Author's transient override; null when following `defaultMode`. */
+  override: Theme | null
+  /** Mode the preview is currently rendering: `override ?? defaultMode`. */
+  effectiveMode: Theme
   isMobile: boolean
-  setTheme: (t: Theme) => void
+  setOverride: (t: Theme | null) => void
   setDevice: (d: Device) => void
 }
 
 const PreviewContext = React.createContext<PreviewContextValue | undefined>(undefined)
-
-function getInitialTheme(): Theme {
-  if (typeof window === 'undefined') return 'light'
-  const stored = localStorage.getItem('kb-theme') as Theme | null
-  if (stored) return stored
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-}
 
 interface PreviewProviderProps {
   children: React.ReactNode
@@ -32,8 +30,8 @@ interface PreviewProviderProps {
 }
 
 export function PreviewProvider({ children, knowledgeBase }: PreviewProviderProps) {
-  const [theme, setTheme] = React.useState<Theme>(getInitialTheme)
   const [device, setDevice] = React.useState<Device>('desktop')
+  const [override, setOverride] = React.useState<Theme | null>(null)
   const [isLoading, setIsLoading] = React.useState(!knowledgeBase)
 
   React.useEffect(() => {
@@ -50,16 +48,30 @@ export function PreviewProvider({ children, knowledgeBase }: PreviewProviderProp
     [knowledgeBase]
   )
 
+  const defaultMode: Theme = merged?.defaultMode === 'dark' ? 'dark' : 'light'
+  const kbId = merged?.id
+
+  // Settings are the source of truth — reset the override whenever the active KB
+  // changes or its default mode is edited so the new default propagates.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `kbId` is intentional — switching KBs must clear any author override even if both KBs share the same defaultMode.
+  React.useEffect(() => {
+    setOverride(null)
+  }, [defaultMode, kbId])
+
+  const effectiveMode: Theme = override ?? defaultMode
+
   const value = React.useMemo<PreviewContextValue>(
     () => ({
       knowledgeBase: merged,
       isLoading,
-      isDark: theme === 'dark',
+      defaultMode,
+      override,
+      effectiveMode,
       isMobile: device === 'mobile',
-      setTheme,
+      setOverride,
       setDevice,
     }),
-    [merged, isLoading, theme, device]
+    [merged, isLoading, defaultMode, override, effectiveMode, device]
   )
 
   return <PreviewContext.Provider value={value}>{children}</PreviewContext.Provider>

--- a/packages/ui/src/components/banner.tsx
+++ b/packages/ui/src/components/banner.tsx
@@ -1,0 +1,87 @@
+// packages/ui/src/components/banner.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { cn } from '@auxx/ui/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { X } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+const bannerVariants = cva('relative flex items-center gap-3 px-3 py-1.5 text-sm', {
+  variants: {
+    variant: {
+      default: 'bg-primary-150 text-foreground',
+      info: 'bg-blue-50 dark:bg-blue-600/10 text-foreground',
+      warning: 'bg-amber-50 dark:bg-amber-950/30 text-foreground',
+    },
+  },
+  defaultVariants: { variant: 'default' },
+})
+
+const iconVariants = cva('shrink-0 [&>svg]:size-4', {
+  variants: {
+    variant: {
+      default: 'text-foreground/70',
+      info: 'text-info',
+      warning: 'text-amber-600 dark:text-amber-400',
+    },
+  },
+  defaultVariants: { variant: 'default' },
+})
+
+interface BannerProps extends VariantProps<typeof bannerVariants> {
+  /** Optional leading icon (typically a lucide-react icon node). */
+  icon?: ReactNode
+  /** Bold lead label. Rendered before `children`. */
+  title?: ReactNode
+  /** Body text / inline links. */
+  children?: ReactNode
+  /** Right-aligned slot (button, link, badge…). */
+  action?: ReactNode
+  /** When set, renders an absolutely-positioned X close button at the right edge. */
+  onClose?: () => void
+  className?: string
+}
+
+/**
+ * Slim full-width strip used for app-level notices (preview mode, demo countdown, plan overage).
+ * Variant controls colors only; layout is fixed (icon + content + right-aligned action + optional dismiss).
+ * A subtle gradient + border at the bottom edge gives the banner a "floating above content" feel.
+ */
+export function Banner({
+  variant = 'default',
+  icon,
+  title,
+  children,
+  action,
+  onClose,
+  className,
+}: BannerProps) {
+  return (
+    <div className='relative z-10'>
+      <div role='note' className={cn(bannerVariants({ variant }), onClose && 'pr-10', className)}>
+        {icon ? <span className={iconVariants({ variant })}>{icon}</span> : null}
+        <div className='flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-0.5'>
+          {title ? <span className='font-medium'>{title}</span> : null}
+          {children ? <span className='text-muted-foreground'>{children}</span> : null}
+        </div>
+        {action ? <div className='ml-auto flex items-center gap-2'>{action}</div> : null}
+        {onClose ? (
+          <Button
+            type='button'
+            variant='ghost'
+            size='icon-sm'
+            onClick={onClose}
+            className='absolute right-1 top-1/2 -translate-y-1/2 text-foreground/70 hover:opacity-70'
+            aria-label='Dismiss'>
+            <X />
+          </Button>
+        ) : null}
+      </div>
+      <div className='pointer-events-none absolute bottom-0 inset-x-0 z-20 h-2 shrink-0 border-b border-black/20 bg-gradient-to-t from-black/10 to-transparent transition-opacity duration-300' />
+    </div>
+  )
+}
+
+export { bannerVariants }
+export type { BannerProps }

--- a/packages/ui/src/components/kb/layout/kb-header.tsx
+++ b/packages/ui/src/components/kb/layout/kb-header.tsx
@@ -49,7 +49,7 @@ export function KBHeader({
   return (
     <header
       className={cn(
-        'sticky top-0 z-30 border-b border-[var(--kb-border)] bg-[var(--kb-surface-bg)] px-4 py-3 backdrop-blur',
+        'sticky top-[var(--kb-top-offset,0px)] z-30 border-b border-[var(--kb-border)] bg-[var(--kb-surface-bg)] px-4 py-3 backdrop-blur',
         'data-[kb-theme=bold]:border-b-2 data-[kb-theme=bold]:border-[var(--kb-fg)]'
       )}>
       <div className='mx-auto flex w-full max-w-7xl items-center gap-4'>

--- a/packages/ui/src/components/kb/layout/kb-layout-shell.tsx
+++ b/packages/ui/src/components/kb/layout/kb-layout-shell.tsx
@@ -3,7 +3,7 @@
 
 import { cn } from '@auxx/ui/lib/utils'
 import { useSelectedLayoutSegments } from 'next/navigation'
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { KBSearchDialog } from '../search/kb-search-dialog'
 import type { KBMode } from '../theme/kb-theme-tokens'
@@ -153,7 +153,9 @@ export function KBLayoutShell<T extends KBSidebarArticle>({
         }
       />
       <KBTopTabs tabs={tabs} activeTabId={activeTabId} tabHrefs={tabHrefs} />
-      <div className={cn('mx-auto flex w-full max-w-7xl flex-1', mainScroll && 'min-h-0')}>
+      <div
+        className={cn('mx-auto flex w-full max-w-7xl flex-1', mainScroll && 'min-h-0')}
+        style={tabs.length >= 2 ? ({ '--kb-tabs-h': '2.625rem' } as CSSProperties) : undefined}>
         <KBSidebar
           articles={articles}
           basePath={basePath}

--- a/packages/ui/src/components/kb/layout/kb-sidebar.tsx
+++ b/packages/ui/src/components/kb/layout/kb-sidebar.tsx
@@ -118,7 +118,7 @@ export function KBSidebar<T extends KBSidebarArticle>({
   return (
     <>
       {/* Desktop persistent sidebar */}
-      <div className='relative hidden shrink-0 @kb-md:sticky @kb-md:top-[var(--kb-header-h,3.5rem)] @kb-md:flex @kb-md:h-[calc(100dvh_-_var(--kb-header-h,3.5rem))] @kb-md:max-h-full @kb-md:flex-col @kb-md:self-start'>
+      <div className='relative hidden shrink-0 @kb-md:sticky @kb-md:top-[calc(var(--kb-top-offset,0px)+var(--kb-header-h,3.5rem)+var(--kb-tabs-h,0px))] @kb-md:flex @kb-md:h-[calc(100dvh_-_var(--kb-top-offset,0px)_-_var(--kb-header-h,3.5rem)_-_var(--kb-tabs-h,0px))] @kb-md:max-h-full @kb-md:flex-col @kb-md:self-start'>
         <aside
           data-slot='kb-sidebar'
           data-collapsed={collapsed}

--- a/packages/ui/src/components/kb/layout/kb-top-tabs.tsx
+++ b/packages/ui/src/components/kb/layout/kb-top-tabs.tsx
@@ -26,7 +26,7 @@ export function KBTopTabs<T extends KBSidebarArticle>({
   return (
     <div
       className={cn(
-        'sticky top-[var(--kb-header-h,3.5rem)] z-20 hidden border-b border-[var(--kb-border)] @kb-md:block',
+        'sticky top-[calc(var(--kb-top-offset,0px)+var(--kb-header-h,3.5rem))] z-20 hidden border-b border-[var(--kb-border)] @kb-md:block',
         'bg-[var(--kb-surface-bg)] backdrop-blur',
         'data-[kb-theme=bold]:border-b-2 data-[kb-theme=bold]:border-[var(--kb-fg)]'
       )}>


### PR DESCRIPTION
## Summary
- Preview pane theme is now a transient author override (defaults to `kb.defaultMode`) that resets whenever the active KB or its defaultMode changes — settings stay the source of truth instead of localStorage drift
- Topbar redesign: preview/live entry as a `ButtonGroup` with a dropdown for the live URL, plus a "Visitors only see {defaultMode} mode" hint when the override diverges and the KB has its mode toggle hidden
- New shared `Banner` UI primitive (`@auxx/ui/components/banner`) used by the fullscreen preview; variant-driven colors with optional icon, action slot, and dismiss
- New `useBodyClass` hook so a single route can opt out of global body classes (e.g. drop `overflow-hidden` for natural document scroll)

## Test plan
- [ ] Switch active KB while a theme override is set — override resets to the new KB's defaultMode
- [ ] Edit `defaultMode` on a KB — preview reflects new default without a reload override stuck
- [ ] KB with `showMode: false` and override ≠ default shows the "visitors only see X mode" hint
- [ ] Published KB: dropdown shows "Open live site" linking to the public URL; unpublished KB: only "Open preview"
- [ ] Fullscreen preview banner renders with correct variant + dismiss behavior
- [ ] Route using `useBodyClass({ remove: 'overflow-hidden' })` scrolls naturally; class is restored on unmount

🤖 Generated with [Claude Code](https://claude.com/claude-code)