### PR TITLE
feat(kb): admin preview tab clicks + logo empty-string fix

### DIFF
--- a/packages/ui/src/components/kb/layout/kb-header.tsx
+++ b/packages/ui/src/components/kb/layout/kb-header.tsx
@@ -44,7 +44,9 @@ export function KBHeader({
   searchOrigin,
   startSlot,
 }: KBHeaderProps) {
-  const logo = mode === 'dark' ? (logoDark ?? logoLight) : (logoLight ?? logoDark)
+  // Treat empty strings as missing — `LogoUploadCell` writes `''` on remove,
+  // so `??` would lock the variant slot and hide the opposite-mode fallback.
+  const logo = (mode === 'dark' ? logoDark || logoLight : logoLight || logoDark) || null
   const showNav = navigationEnabled && navigation && navigation.length > 0
   return (
     <header

--- a/packages/ui/src/components/kb/layout/kb-layout-shell.tsx
+++ b/packages/ui/src/components/kb/layout/kb-layout-shell.tsx
@@ -88,15 +88,29 @@ export function KBLayoutShell<T extends KBSidebarArticle>({
   // KBSidebarTree, so the tab itself isn't rendered as a duplicate root node.
 
   // Click-target for each tab pill: the deepest first navigable descendant.
-  const tabHrefs = useMemo(() => {
-    const map: Record<string, string> = {}
+  // `tabHrefs` powers public-site `<Link>` navigation; `tabFirstArticleIds` is
+  // used by the admin preview to switch articles without touching the URL.
+  const { tabHrefs, tabFirstArticleIds } = useMemo(() => {
+    const hrefs: Record<string, string> = {}
+    const firstIds: Record<string, string | null> = {}
     for (const tab of tabs) {
       const first = findFirstNavigableUnder(tab.id, articles)
       const slug = first ? getFullSlugPath(first, articles) : ''
-      map[tab.id] = slug ? `${basePath}/${slug}` : basePath || '/'
+      hrefs[tab.id] = slug ? `${basePath}/${slug}` : basePath || '/'
+      firstIds[tab.id] = first?.id ?? null
     }
-    return map
+    return { tabHrefs: hrefs, tabFirstArticleIds: firstIds }
   }, [tabs, articles, basePath])
+
+  // Inline preview hands `onArticleClick` to swap articles in place. Tabs go
+  // through this same channel so clicking a tab pill / dropdown lands on the
+  // tab's first navigable descendant without an actual route change.
+  const onTabSelect = onArticleClick
+    ? (tabId: string) => {
+        const firstId = tabFirstArticleIds[tabId]
+        if (firstId) onArticleClick(firstId)
+      }
+    : undefined
 
   useEffect(() => {
     setCollapsed(readCollapsedFromStorage())
@@ -152,7 +166,12 @@ export function KBLayoutShell<T extends KBSidebarArticle>({
           </>
         }
       />
-      <KBTopTabs tabs={tabs} activeTabId={activeTabId} tabHrefs={tabHrefs} />
+      <KBTopTabs
+        tabs={tabs}
+        activeTabId={activeTabId}
+        tabHrefs={tabHrefs}
+        onTabSelect={onTabSelect}
+      />
       <div
         className={cn('mx-auto flex w-full max-w-7xl flex-1', mainScroll && 'min-h-0')}
         style={tabs.length >= 2 ? ({ '--kb-tabs-h': '2.625rem' } as CSSProperties) : undefined}>
@@ -173,6 +192,7 @@ export function KBLayoutShell<T extends KBSidebarArticle>({
           tabs={tabs}
           activeTabId={activeTabId}
           tabHrefs={tabHrefs}
+          onTabSelect={onTabSelect}
         />
         <main
           className={cn(

--- a/packages/ui/src/components/kb/layout/kb-sidebar.tsx
+++ b/packages/ui/src/components/kb/layout/kb-sidebar.tsx
@@ -31,6 +31,8 @@ interface KBSidebarProps<T extends KBSidebarArticle> {
   tabs?: T[]
   activeTabId?: string | null
   tabHrefs?: Record<string, string>
+  /** Forwarded to `<KBTabSelect>` so the admin preview can intercept tab clicks. */
+  onTabSelect?: (tabId: string) => void
 }
 
 export function KBSidebar<T extends KBSidebarArticle>({
@@ -50,6 +52,7 @@ export function KBSidebar<T extends KBSidebarArticle>({
   tabs,
   activeTabId,
   tabHrefs,
+  onTabSelect,
 }: KBSidebarProps<T>) {
   const { kbId, collapsed, setCollapsed, mobileOpen, setMobileOpen } = useKBLayoutContext()
 
@@ -97,6 +100,7 @@ export function KBSidebar<T extends KBSidebarArticle>({
             tabs={tabs}
             activeTabId={activeTabId ?? null}
             tabHrefs={tabHrefs}
+            onTabSelect={onTabSelect}
             onNavigate={() => setMobileOpen(false)}
           />
         </div>
@@ -207,7 +211,7 @@ function KBSidebarMobileHeader({
   showMode,
   onNavigate,
 }: KBSidebarMobileHeaderProps) {
-  const logo = mode === 'dark' ? (logoDark ?? logoLight) : (logoLight ?? logoDark)
+  const logo = (mode === 'dark' ? logoDark || logoLight : logoLight || logoDark) || null
   const label = title ?? 'Home'
   return (
     <div className='flex items-center gap-2 border-b border-[var(--kb-border)] px-4 py-3'>

--- a/packages/ui/src/components/kb/layout/kb-tab-select.tsx
+++ b/packages/ui/src/components/kb/layout/kb-tab-select.tsx
@@ -16,6 +16,11 @@ interface KBTabSelectProps<T extends KBSidebarArticle> {
   activeTabId: string | null
   /** `tabId → href` map for the first navigable child of each tab. */
   tabHrefs: Record<string, string>
+  /**
+   * When set, the dropdown calls this with the tab id instead of navigating.
+   * The admin preview uses this to swap the active article in place.
+   */
+  onTabSelect?: (tabId: string) => void
   /** Called after navigation kicks off — used to close the mobile drawer. */
   onNavigate?: () => void
 }
@@ -29,12 +34,18 @@ export function KBTabSelect<T extends KBSidebarArticle>({
   tabs,
   activeTabId,
   tabHrefs,
+  onTabSelect,
   onNavigate,
 }: KBTabSelectProps<T>) {
   const router = useRouter()
   if (tabs.length < 2) return null
 
   const handleChange = (tabId: string) => {
+    if (onTabSelect) {
+      onTabSelect(tabId)
+      onNavigate?.()
+      return
+    }
     const href = tabHrefs[tabId]
     if (!href) return
     router.push(href)

--- a/packages/ui/src/components/kb/layout/kb-top-tabs.tsx
+++ b/packages/ui/src/components/kb/layout/kb-top-tabs.tsx
@@ -11,6 +11,12 @@ interface KBTopTabsProps<T extends KBSidebarArticle> {
   activeTabId: string | null
   /** `tabId → href` map for the first navigable child of each tab. */
   tabHrefs: Record<string, string>
+  /**
+   * When set, renders each tab as a button that calls this with the tab id
+   * instead of navigating. The admin preview uses this to swap articles in
+   * place; the public site leaves it undefined so `<Link>` navigation runs.
+   */
+  onTabSelect?: (tabId: string) => void
 }
 
 /**
@@ -21,8 +27,14 @@ export function KBTopTabs<T extends KBSidebarArticle>({
   tabs,
   activeTabId,
   tabHrefs,
+  onTabSelect,
 }: KBTopTabsProps<T>) {
   if (tabs.length < 2) return null
+  const tabClass = cn(
+    'inline-flex shrink-0 items-center gap-1.5 border-b-2 border-transparent bg-transparent px-3 py-2.5 text-sm text-[var(--kb-fg)]/85 no-underline transition-colors',
+    'cursor-pointer hover:text-[var(--kb-primary)]',
+    'data-[active=true]:border-[var(--kb-primary)] data-[active=true]:font-medium data-[active=true]:text-[var(--kb-primary)]'
+  )
   return (
     <div
       className={cn(
@@ -34,17 +46,26 @@ export function KBTopTabs<T extends KBSidebarArticle>({
         {tabs.map((tab) => {
           const href = tabHrefs[tab.id] ?? '#'
           const active = activeTabId === tab.id
+          if (onTabSelect) {
+            return (
+              <button
+                key={tab.id}
+                type='button'
+                data-active={active}
+                onClick={() => onTabSelect(tab.id)}
+                className={tabClass}>
+                {tab.emoji ? <span aria-hidden>{tab.emoji}</span> : null}
+                <span>{tab.title}</span>
+              </button>
+            )
+          }
           return (
             <Link
               key={tab.id}
               href={href}
               prefetch={false}
               data-active={active}
-              className={cn(
-                'inline-flex shrink-0 items-center gap-1.5 border-b-2 border-transparent px-3 py-2.5 text-sm text-[var(--kb-fg)]/85 no-underline transition-colors',
-                'hover:text-[var(--kb-primary)]',
-                'data-[active=true]:border-[var(--kb-primary)] data-[active=true]:font-medium data-[active=true]:text-[var(--kb-primary)]'
-              )}>
+              className={tabClass}>
               {tab.emoji ? <span aria-hidden>{tab.emoji}</span> : null}
               <span>{tab.title}</span>
             </Link>


### PR DESCRIPTION
## Summary
- Threads an `onTabSelect` callback through `KBLayoutShell` → `KBTopTabs` / `KBSidebar` / `KBTabSelect` so the admin preview can swap articles in place when a tab is clicked instead of performing a real route change. Public site leaves the callback undefined and keeps `<Link>` navigation.
- Treats empty strings from `LogoUploadCell` (which writes `''` on remove) as missing in `KBHeader` and `KBSidebarMobileHeader`, so the opposite-mode fallback logo isn't suppressed.

## Test plan
- [ ] Click a tab in the KB admin preview — active article swaps without changing the URL
- [ ] Click a tab on the public KB site — still navigates via `<Link>` to the first navigable descendant
- [ ] In KB settings, remove a light/dark logo — opposite-mode logo now appears in both desktop header and mobile sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)