### PR TITLE
feat(kopilot): shift+n new-session hotkey + extract createEmptyTurnSnapshots

### DIFF
--- a/apps/web/src/components/kopilot/ui/kopilot-panel.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-panel.tsx
@@ -4,6 +4,8 @@
 
 import { Button } from '@auxx/ui/components/button'
 import { DrawerHeader } from '@auxx/ui/components/drawer'
+import { Kbd, KbdGroup } from '@auxx/ui/components/kbd'
+import { useHotkey } from '@tanstack/react-hotkeys'
 import { Expand, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback } from 'react'
@@ -26,6 +28,8 @@ export function KopilotPanel({ page }: KopilotPanelProps) {
     startNewSession()
   }, [startNewSession])
 
+  useHotkey('Shift+N', () => handleNewSession())
+
   const handleExpand = useCallback(() => {
     const path = activeSessionId ? `/app/kopilot/${activeSessionId}` : '/app/kopilot/new'
     setPanelOpen(false)
@@ -38,8 +42,12 @@ export function KopilotPanel({ page }: KopilotPanelProps) {
         title={<KopilotSessionPicker />}
         actions={
           <div className='flex items-center gap-0.5'>
-            <Button variant='ghost' size='icon' className='size-7' onClick={handleNewSession}>
+            <Button variant='ghost' size='sm' onClick={handleNewSession}>
               <Plus className='size-3.5' />
+              <KbdGroup variant='ghost'>
+                <Kbd>⇧</Kbd>
+                <Kbd>N</Kbd>
+              </KbdGroup>
             </Button>
             <Button variant='ghost' size='icon' className='size-7' onClick={handleExpand}>
               <Expand className='size-3.5' />

--- a/packages/lib/src/ai/agent-framework/engine.ts
+++ b/packages/lib/src/ai/agent-framework/engine.ts
@@ -4,16 +4,17 @@ import { createScopedLogger } from '@auxx/logger'
 import { generateId } from '@auxx/utils/generateId'
 import { manageContext } from './context-manager'
 import { agentQueryLoop } from './query-loop'
-import type {
-  AgentDefinition,
-  AgentEngineConfig,
-  AgentEvent,
-  AgentState,
-  ResumeOptions,
-  Route,
-  SessionMessage,
-  TurnBudget,
-  TurnUsageSummary,
+import {
+  type AgentDefinition,
+  type AgentEngineConfig,
+  type AgentEvent,
+  type AgentState,
+  createEmptyTurnSnapshots,
+  type ResumeOptions,
+  type Route,
+  type SessionMessage,
+  type TurnBudget,
+  type TurnUsageSummary,
 } from './types'
 import { buildToolDigest } from './utils'
 
@@ -90,7 +91,7 @@ export class AgentEngine {
       waitingForApproval: false,
       pendingToolCall: undefined,
       approvalsThisTurn: 0,
-      turnSnapshots: { records: {}, threads: {}, tasks: {} },
+      turnSnapshots: createEmptyTurnSnapshots(),
       capturedActions: [],
     }
 

--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -267,6 +267,10 @@ export interface TurnSnapshots {
   docs: Record<string, DocSnapshot>
 }
 
+export function createEmptyTurnSnapshots(): TurnSnapshots {
+  return { records: {}, threads: {}, tasks: {}, drafts: {}, docs: {} }
+}
+
 /**
  * A snapshot value referenced by an inline `auxx://` link in an assistant
  * message. Persisted on the assistant `SessionMessage` so reload renders the

--- a/packages/lib/src/ai/kopilot/blocks/snapshot-walker.ts
+++ b/packages/lib/src/ai/kopilot/blocks/snapshot-walker.ts
@@ -1,12 +1,15 @@
 // packages/lib/src/ai/kopilot/blocks/snapshot-walker.ts
 
-import type {
-  DraftSnapshot,
-  EntitySnapshot,
-  TaskSnapshot,
-  ThreadSnapshot,
-  TurnSnapshots,
+import {
+  createEmptyTurnSnapshots,
+  type DraftSnapshot,
+  type EntitySnapshot,
+  type TaskSnapshot,
+  type ThreadSnapshot,
+  type TurnSnapshots,
 } from '../../agent-framework/types'
+
+export { createEmptyTurnSnapshots }
 
 /**
  * Generic snapshot walker. Recurses into every tool result and harvests
@@ -31,10 +34,6 @@ import type {
 
 const WALKER_MAX_DEPTH = 3
 const CONTAINER_KEYS = ['items', 'threads', 'thread', 'tasks', 'drafts', 'results'] as const
-
-export function createEmptyTurnSnapshots(): TurnSnapshots {
-  return { records: {}, threads: {}, tasks: {}, drafts: {}, docs: {} }
-}
 
 export function runSnapshotWalker(output: unknown, target: TurnSnapshots): void {
   walk(output, target, 0)


### PR DESCRIPTION
## Summary
- Bind `Shift+N` to start a new kopilot session and surface the shortcut on the panel's `+` button via `Kbd`.
- Move `createEmptyTurnSnapshots()` from `snapshot-walker` into `agent-framework/types`, and use it in the engine. Fixes a partial inline literal that was missing the `drafts` and `docs` snapshot buckets.
- `snapshot-walker` re-exports the helper so its public import path is preserved.

## Test plan
- [ ] Open the kopilot panel, press `Shift+N` — a new session should start (same as clicking `+`).
- [ ] Confirm the `+` button shows the `⇧ N` chord.
- [ ] Run a kopilot turn that touches drafts/docs tools and verify snapshots persist on the assistant message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)