### PR TITLE
feat(kb): cards block + auxx:// internal link scheme + preview version picker

### DIFF
--- a/apps/kb/src/app/r/[articleId]/route.ts
+++ b/apps/kb/src/app/r/[articleId]/route.ts
@@ -1,0 +1,88 @@
+// apps/kb/src/app/r/[articleId]/route.ts
+//
+// Stable-id redirect handler for internal `auxx://kb/article/{id}` links.
+// The renderer emits `<a href="/r/{id}">` so links survive renames; this
+// route resolves the id to the canonical `/orgSlug/kbSlug/slug-path` URL
+// at click time and 308-redirects.
+
+import { Article, database, KnowledgeBase, Organization } from '@auxx/database'
+import { isOrgMember } from '@auxx/lib/cache'
+import { and, eq } from 'drizzle-orm'
+import { redirect } from 'next/navigation'
+import { type NextRequest, NextResponse } from 'next/server'
+import { getLocalSession, getLoginUrl } from '~/lib/auth'
+
+interface RouteContext {
+  params: Promise<{ articleId: string }>
+}
+
+export async function GET(_req: NextRequest, ctx: RouteContext): Promise<Response> {
+  const { articleId } = await ctx.params
+  if (!articleId) return NextResponse.json({ error: 'Missing article id' }, { status: 400 })
+
+  const [row] = await database
+    .select({
+      id: Article.id,
+      slug: Article.slug,
+      parentId: Article.parentId,
+      isPublished: Article.isPublished,
+      knowledgeBaseId: Article.knowledgeBaseId,
+      organizationId: Article.organizationId,
+      kbSlug: KnowledgeBase.slug,
+      kbVisibility: KnowledgeBase.visibility,
+      kbPublishStatus: KnowledgeBase.publishStatus,
+      orgSlug: Organization.handle,
+    })
+    .from(Article)
+    .innerJoin(KnowledgeBase, eq(KnowledgeBase.id, Article.knowledgeBaseId))
+    .innerJoin(Organization, eq(Organization.id, KnowledgeBase.organizationId))
+    .where(eq(Article.id, articleId))
+    .limit(1)
+
+  if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  if (row.kbPublishStatus === 'DRAFT' || !row.isPublished) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  if (row.kbVisibility === 'INTERNAL') {
+    const session = await getLocalSession()
+    if (!session) {
+      const slugPath = await buildSlugPath(row.id, row.knowledgeBaseId)
+      redirect(getLoginUrl(row.knowledgeBaseId, `/${row.orgSlug}/${row.kbSlug}/${slugPath}`))
+    }
+    const member = await isOrgMember(row.organizationId, session.userId)
+    if (!member) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const slugPath = await buildSlugPath(row.id, row.knowledgeBaseId)
+  return NextResponse.redirect(new URL(`/${row.orgSlug}/${row.kbSlug}/${slugPath}`, _req.url), 308)
+}
+
+/**
+ * Walk parent chain to assemble the article's full slug path. Tiny lookup
+ * (depth ~3-5) — fine to do per redirect.
+ */
+async function buildSlugPath(articleId: string, knowledgeBaseId: string): Promise<string> {
+  const rows = await database
+    .select({
+      id: Article.id,
+      slug: Article.slug,
+      parentId: Article.parentId,
+    })
+    .from(Article)
+    .where(and(eq(Article.knowledgeBaseId, knowledgeBaseId), eq(Article.isPublished, true)))
+
+  const byId = new Map(rows.map((r) => [r.id, r]))
+  const parts: string[] = []
+  const seen = new Set<string>()
+  let cursor: string | null = articleId
+  while (cursor) {
+    if (seen.has(cursor)) break
+    seen.add(cursor)
+    const row = byId.get(cursor)
+    if (!row) break
+    parts.unshift(row.slug)
+    cursor = row.parentId
+  }
+  return parts.join('/')
+}

--- a/apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/[[...articleSlug]]/page.tsx
+++ b/apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/[[...articleSlug]]/page.tsx
@@ -1,18 +1,31 @@
 // apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/[[...articleSlug]]/page.tsx
 
 import { KnowledgeBaseProvider } from '~/components/kb'
+import type { PreviewMode } from '~/components/kb/hooks/use-article-content'
 import { KBFullscreenPreview } from '~/components/kb/ui/preview/kb-fullscreen-preview'
 
 interface PageProps {
   params: Promise<{ knowledgeBaseId: string; articleSlug?: string[] }>
+  searchParams: Promise<{ v?: string | string[] }>
 }
 
-export default async function KBFullscreenPreviewPage({ params }: PageProps) {
+function parsePreviewMode(raw: string | string[] | undefined): PreviewMode {
+  if (!raw || Array.isArray(raw)) return 'draft'
+  if (raw === 'draft') return 'draft'
+  if (raw === 'live' || raw === 'published') return 'live'
+  const n = Number.parseInt(raw, 10)
+  if (Number.isFinite(n) && n > 0) return { versionNumber: n }
+  return 'draft'
+}
+
+export default async function KBFullscreenPreviewPage({ params, searchParams }: PageProps) {
   const { knowledgeBaseId, articleSlug = [] } = await params
+  const { v } = await searchParams
+  const mode = parsePreviewMode(v)
 
   return (
     <KnowledgeBaseProvider knowledgeBaseId={knowledgeBaseId}>
-      <KBFullscreenPreview knowledgeBaseId={knowledgeBaseId} slugPath={articleSlug} />
+      <KBFullscreenPreview knowledgeBaseId={knowledgeBaseId} slugPath={articleSlug} mode={mode} />
     </KnowledgeBaseProvider>
   )
 }

--- a/apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/r/[articleId]/route.ts
+++ b/apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/r/[articleId]/route.ts
@@ -1,0 +1,82 @@
+// apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/r/[articleId]/route.ts
+//
+// Stable-id redirect handler for `auxx://kb/article/{id}` links rendered
+// inside the admin preview. Resolves the article id to its current slug
+// path and 308-redirects to `/preview/kb/{targetKbId}/{slugPath}` — the
+// target's *actual* KB id, so cross-KB internal links navigate correctly.
+
+import { Article, database, KnowledgeBase } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import { headers } from 'next/headers'
+import { type NextRequest, NextResponse } from 'next/server'
+import { auth } from '~/auth/server'
+
+interface RouteContext {
+  params: Promise<{ knowledgeBaseId: string; articleId: string }>
+}
+
+export async function GET(req: NextRequest, ctx: RouteContext): Promise<Response> {
+  const { articleId } = await ctx.params
+  if (!articleId) {
+    return NextResponse.json({ error: 'Missing article id' }, { status: 400 })
+  }
+
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session?.user) {
+    return NextResponse.redirect(
+      new URL(`/login?callbackUrl=${encodeURIComponent(req.nextUrl.pathname)}`, req.url)
+    )
+  }
+
+  const [row] = await database
+    .select({
+      id: Article.id,
+      knowledgeBaseId: Article.knowledgeBaseId,
+      organizationId: Article.organizationId,
+    })
+    .from(Article)
+    .innerJoin(KnowledgeBase, eq(KnowledgeBase.id, Article.knowledgeBaseId))
+    .where(eq(Article.id, articleId))
+    .limit(1)
+
+  if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  // Authorize against the *target* article's org. Cross-org leakage would
+  // be a problem, but we expect the picker to scope to the active org so
+  // this is mostly a sanity check.
+  const activeOrgId = (session.session as { activeOrganizationId?: string }).activeOrganizationId
+  if (activeOrgId && activeOrgId !== row.organizationId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const slugPath = await buildSlugPath(row.id, row.knowledgeBaseId)
+  return NextResponse.redirect(
+    new URL(`/preview/kb/${row.knowledgeBaseId}/${slugPath}`, req.url),
+    308
+  )
+}
+
+async function buildSlugPath(articleId: string, knowledgeBaseId: string): Promise<string> {
+  const rows = await database
+    .select({
+      id: Article.id,
+      slug: Article.slug,
+      parentId: Article.parentId,
+    })
+    .from(Article)
+    .where(eq(Article.knowledgeBaseId, knowledgeBaseId))
+
+  const byId = new Map(rows.map((r) => [r.id, r]))
+  const parts: string[] = []
+  const seen = new Set<string>()
+  let cursor: string | null = articleId
+  while (cursor) {
+    if (seen.has(cursor)) break
+    seen.add(cursor)
+    const row = byId.get(cursor)
+    if (!row) break
+    parts.unshift(row.slug)
+    cursor = row.parentId
+  }
+  return parts.join('/')
+}

--- a/apps/web/src/components/editor/kb-article/article-link-popover.tsx
+++ b/apps/web/src/components/editor/kb-article/article-link-popover.tsx
@@ -1,0 +1,93 @@
+// apps/web/src/components/editor/kb-article/article-link-popover.tsx
+'use client'
+
+import { Popover, PopoverAnchor, PopoverContentDialogAware } from '@auxx/ui/components/popover'
+import { buildAuxxArticleUrl } from '@auxx/utils'
+import { useMemo, useRef } from 'react'
+import { useArticleList } from '~/components/kb/hooks/use-article-list'
+import { ArticlePicker } from '~/components/kb/ui/articles/article-picker'
+
+export interface ArticleLinkPick {
+  /** Insertable href (auxx://kb/article/{id}). */
+  href: string
+  /** Visible link text — the article title. */
+  text: string
+}
+
+interface ArticleLinkPopoverProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Optional initial KB to scope to — if absent, picker shows the org's KB list. */
+  knowledgeBaseId?: string
+  onPick: (pick: ArticleLinkPick) => void
+  /**
+   * Anchor element the popover positions against. Provide either `children`
+   * (rendered as the trigger via PopoverAnchor) or `anchorRect` for a virtual
+   * anchor (e.g. cursor position inside an editor).
+   */
+  children?: React.ReactNode
+  anchorRect?: DOMRect | null
+}
+
+export function ArticleLinkPopover({
+  open,
+  onOpenChange,
+  knowledgeBaseId,
+  onPick,
+  children,
+  anchorRect,
+}: ArticleLinkPopoverProps) {
+  const articles = useArticleList(knowledgeBaseId)
+
+  const virtualRef = useRef<{ getBoundingClientRect: () => DOMRect }>({
+    getBoundingClientRect: () => anchorRect ?? new DOMRect(),
+  })
+  // Keep the virtual anchor's rect in sync with the latest prop without
+  // recreating the ref (Radix reads getBoundingClientRect lazily).
+  virtualRef.current.getBoundingClientRect = () => anchorRect ?? new DOMRect()
+
+  const anchorEl = useMemo(() => {
+    if (children) return <PopoverAnchor asChild>{children}</PopoverAnchor>
+    return <PopoverAnchor virtualRef={virtualRef} />
+  }, [children])
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      {anchorEl}
+      <PopoverContentDialogAware
+        align='start'
+        sideOffset={8}
+        className='p-0'
+        onOpenAutoFocus={(e) => {
+          // Let the cmdk input inside ArticlePicker handle its own focus.
+          e.preventDefault()
+        }}
+        onFocusOutside={(e) => {
+          // cmdk re-renders the CommandList on drill-down, which briefly
+          // unmounts the focused element. Browser focus shifts to a sibling
+          // input outside the popover, which Radix would otherwise treat as
+          // a dismissal. Ignore focus-driven dismissals — only real pointer
+          // clicks outside should close the picker.
+          e.preventDefault()
+        }}>
+        <ArticlePicker
+          knowledgeBaseId={knowledgeBaseId}
+          allowedKinds={['page', 'link']}
+          drillableKinds={['tab', 'category', 'header']}
+          rootLabel='Link to article'
+          searchPlaceholder='Search articles…'
+          flattenSearch
+          onPick={(articleId) => {
+            const found = articles.find((a) => a.id === articleId)
+            onPick({
+              href: buildAuxxArticleUrl(articleId),
+              text: found?.title || 'article',
+            })
+            onOpenChange(false)
+          }}
+          onClose={() => onOpenChange(false)}
+        />
+      </PopoverContentDialogAware>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/editor/kb-article/block-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/block-node-view.tsx
@@ -9,7 +9,12 @@ import {
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import { Input } from '@auxx/ui/components/input'
-import type { CalloutVariant, EmbedAspect, EmbedProvider } from '@auxx/ui/components/kb/article'
+import type {
+  CalloutVariant,
+  CardData,
+  EmbedAspect,
+  EmbedProvider,
+} from '@auxx/ui/components/kb/article'
 import { CalloutIcon } from '@auxx/ui/components/kb/article'
 import { parseEmbedUrl } from '@auxx/ui/components/kb/utils'
 import type { NodeViewProps } from '@tiptap/react'
@@ -17,6 +22,7 @@ import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import { Check, ChevronDown } from 'lucide-react'
 import { useState } from 'react'
 import styles from './block-node-view.module.css'
+import { CardsBlockView } from './cards-block-view'
 
 const CALLOUT_VARIANTS: CalloutVariant[] = ['info', 'tip', 'warn', 'error', 'success']
 
@@ -113,6 +119,8 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
 
   const [embedDraft, setEmbedDraft] = useState('')
   const [embedError, setEmbedError] = useState<string | null>(null)
+  const cards = (node.attrs as { cards?: CardData[] }).cards ?? []
+  const isCards = blockType === 'cards'
 
   const pos = typeof getPos === 'function' ? getPos() : null
   const isListType =
@@ -156,7 +164,13 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
   const isEmpty = node.content.size === 0
   const isFirstBlock = pos === 0
   const showPlaceholder =
-    isEmpty && !isDivider && !isImage && !isEmbed && !isCallout && (isFocused || isFirstBlock)
+    isEmpty &&
+    !isDivider &&
+    !isImage &&
+    !isEmbed &&
+    !isCallout &&
+    !isCards &&
+    (isFocused || isFirstBlock)
   const placeholderText =
     blockType === 'heading' ? `Heading ${level ?? 1}` : "Press '/' for commands"
 
@@ -281,6 +295,19 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
                 aria-hidden='true'
                 contentEditable={false}
                 onClick={selectThisBlock}
+              />
+              <NodeViewContent className={`${styles.blockContent} ${styles.blockContentHidden}`} />
+            </>
+          ) : isCards ? (
+            <>
+              <CardsBlockView
+                cards={cards}
+                onChange={(next) => updateAttributes({ cards: next })}
+                onDeleteBlock={() => {
+                  if (typeof pos === 'number') {
+                    editor.chain().setNodeSelection(pos).deleteSelection().run()
+                  }
+                }}
               />
               <NodeViewContent className={`${styles.blockContent} ${styles.blockContentHidden}`} />
             </>

--- a/apps/web/src/components/editor/kb-article/block-node.ts
+++ b/apps/web/src/components/editor/kb-article/block-node.ts
@@ -17,6 +17,7 @@ export type BlockType =
   | 'codeBlock'
   | 'callout'
   | 'embed'
+  | 'cards'
 
 const LIST_TYPES: BlockType[] = ['bulletListItem', 'numberedListItem', 'todoListItem']
 
@@ -115,6 +116,23 @@ export const Block = Node.create({
         renderHTML: (attrs) =>
           attrs.blockType === 'embed' && attrs.embedAspect
             ? { 'data-embed-aspect': attrs.embedAspect }
+            : {},
+      },
+      cards: {
+        default: null,
+        parseHTML: (el) => {
+          const raw = el.getAttribute('data-cards')
+          if (!raw) return null
+          try {
+            const parsed = JSON.parse(raw)
+            return Array.isArray(parsed) ? parsed : null
+          } catch {
+            return null
+          }
+        },
+        renderHTML: (attrs) =>
+          attrs.blockType === 'cards' && Array.isArray(attrs.cards)
+            ? { 'data-cards': JSON.stringify(attrs.cards) }
             : {},
       },
     }

--- a/apps/web/src/components/editor/kb-article/card-edit-popover.tsx
+++ b/apps/web/src/components/editor/kb-article/card-edit-popover.tsx
@@ -1,0 +1,167 @@
+// apps/web/src/components/editor/kb-article/card-edit-popover.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Field, FieldLabel } from '@auxx/ui/components/field'
+import { IconPicker } from '@auxx/ui/components/icon-picker'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@auxx/ui/components/input-group'
+import type { CardData } from '@auxx/ui/components/kb/article'
+import { Popover, PopoverAnchor, PopoverContent } from '@auxx/ui/components/popover'
+import { Textarea } from '@auxx/ui/components/textarea'
+import { Link as LinkIcon, Trash2 } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { type ArticleLinkPick, ArticleLinkPopover } from './article-link-popover'
+
+interface CardEditPopoverProps {
+  card: CardData
+  knowledgeBaseId?: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onChange: (patch: Partial<CardData>) => void
+  /** The element the popover anchors to — typically the card itself. */
+  children: React.ReactNode
+}
+
+export function CardEditPopover({
+  card,
+  knowledgeBaseId,
+  open,
+  onOpenChange,
+  onChange,
+  children,
+}: CardEditPopoverProps) {
+  const [title, setTitle] = useState(card.title)
+  const [description, setDescription] = useState(card.description ?? '')
+  const [href, setHref] = useState(card.href ?? '')
+  const [iconId, setIconId] = useState(card.iconId ?? null)
+  const [linkPickerOpen, setLinkPickerOpen] = useState(false)
+  const linkPickerOpenRef = useRef(false)
+
+  useEffect(() => {
+    linkPickerOpenRef.current = linkPickerOpen
+  }, [linkPickerOpen])
+
+  useEffect(() => {
+    if (open) {
+      setTitle(card.title)
+      setDescription(card.description ?? '')
+      setHref(card.href ?? '')
+      setIconId(card.iconId ?? null)
+    }
+  }, [open, card])
+
+  const persistAndClose = () => {
+    onChange({
+      title: title.trim(),
+      description: description.trim() || undefined,
+      href: href.trim() || undefined,
+      iconId: iconId ?? undefined,
+    })
+    onOpenChange(false)
+  }
+
+  const handleLinkPick = (pick: ArticleLinkPick) => {
+    setHref(pick.href)
+    setLinkPickerOpen(false)
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) persistAndClose()
+        else onOpenChange(true)
+      }}>
+      <PopoverAnchor asChild>{children}</PopoverAnchor>
+      <PopoverContent
+        align='start'
+        sideOffset={8}
+        className='w-96 space-y-4 p-4'
+        onInteractOutside={(e) => {
+          if (linkPickerOpenRef.current) e.preventDefault()
+        }}
+        onEscapeKeyDown={(e) => {
+          if (linkPickerOpenRef.current) e.preventDefault()
+        }}
+        onOpenAutoFocus={(e) => {
+          e.preventDefault()
+        }}>
+        <Field>
+          <InputGroup>
+            <InputGroupAddon align='inline-start' className='ml-1'>
+              <IconPicker
+                value={{ icon: iconId ?? 'square', color: 'gray' }}
+                onChange={(v) => setIconId(v.icon)}
+                hideColors
+                modal={false}
+                className='size-6'
+              />
+            </InputGroupAddon>
+            <InputGroupInput
+              autoFocus
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder='Card title'
+            />
+          </InputGroup>
+        </Field>
+
+        <Field>
+          <Textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder='*bold*, _italic_, `code`, [label](url)…'
+            rows={3}
+          />
+        </Field>
+
+        <Field>
+          <InputGroup>
+            <InputGroupAddon align='inline-start'>
+              <LinkIcon />
+            </InputGroupAddon>
+            <InputGroupInput
+              value={href}
+              onChange={(e) => setHref(e.target.value)}
+              placeholder='auxx://kb/article/… or https://…'
+            />
+            <InputGroupAddon align='inline-end' className='gap-1'>
+              <ArticleLinkPopover
+                open={linkPickerOpen}
+                onOpenChange={setLinkPickerOpen}
+                knowledgeBaseId={knowledgeBaseId}
+                onPick={handleLinkPick}>
+                <InputGroupButton size='xs' onClick={() => setLinkPickerOpen(true)}>
+                  Pick article
+                </InputGroupButton>
+              </ArticleLinkPopover>
+              {href ? (
+                <InputGroupButton
+                  size='icon-xs'
+                  aria-label='Clear link'
+                  onClick={() => setHref('')}
+                  className='hover:bg-destructive/10 hover:text-destructive'>
+                  <Trash2 />
+                </InputGroupButton>
+              ) : null}
+            </InputGroupAddon>
+          </InputGroup>
+        </Field>
+
+        <div className='flex justify-end gap-2 pt-1'>
+          <Button type='button' variant='ghost' size='sm' onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type='button' variant='outline' size='sm' onClick={persistAndClose}>
+            Save
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/editor/kb-article/cards-block-view.module.css
+++ b/apps/web/src/components/editor/kb-article/cards-block-view.module.css
@@ -1,0 +1,87 @@
+/* apps/web/src/components/editor/kb-article/cards-block-view.module.css */
+
+.cardsBlock {
+  width: 100%;
+  margin: 0.5rem 0;
+}
+
+.cardsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--background);
+  cursor: pointer;
+  user-select: none;
+}
+
+.card:hover {
+  border-color: var(--primary);
+}
+
+.cardClose {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  border: none;
+  cursor: pointer;
+}
+
+.card:hover .cardClose {
+  display: inline-flex;
+}
+
+.cardIcon {
+  color: var(--primary);
+  display: inline-flex;
+  align-items: center;
+}
+
+.cardTitle {
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.cardDescription {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--muted-foreground);
+}
+
+.addCard {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.875rem 1rem;
+  min-height: 80px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.addCard:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}

--- a/apps/web/src/components/editor/kb-article/cards-block-view.tsx
+++ b/apps/web/src/components/editor/kb-article/cards-block-view.tsx
@@ -1,0 +1,180 @@
+// apps/web/src/components/editor/kb-article/cards-block-view.tsx
+'use client'
+
+import { EntityIcon } from '@auxx/ui/components/icons'
+import type { CardData } from '@auxx/ui/components/kb/article'
+import { renderMarkdownLite } from '@auxx/ui/components/kb/utils'
+import { generateId } from '@auxx/utils'
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  rectSortingStrategy,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { Plus, X } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { CardEditPopover } from './card-edit-popover'
+import styles from './cards-block-view.module.css'
+import { useKBEditorContext } from './editor-context'
+
+interface CardsBlockViewProps {
+  cards: CardData[]
+  onChange: (next: CardData[]) => void
+  onDeleteBlock: () => void
+}
+
+export function CardsBlockView({ cards, onChange, onDeleteBlock }: CardsBlockViewProps) {
+  const { knowledgeBaseId } = useKBEditorContext()
+  const [editingId, setEditingId] = useState<string | null>(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+      const oldIndex = cards.findIndex((c) => c.id === active.id)
+      const newIndex = cards.findIndex((c) => c.id === over.id)
+      if (oldIndex < 0 || newIndex < 0) return
+      const next = [...cards]
+      const [moved] = next.splice(oldIndex, 1)
+      next.splice(newIndex, 0, moved)
+      onChange(next)
+    },
+    [cards, onChange]
+  )
+
+  const handleAdd = () => {
+    onChange([...cards, { id: generateId(), title: 'New card' }])
+  }
+
+  const handleDelete = (cardId: string) => {
+    const next = cards.filter((c) => c.id !== cardId)
+    if (next.length === 0) {
+      onDeleteBlock()
+      return
+    }
+    onChange(next)
+  }
+
+  const handleUpdate = (cardId: string, patch: Partial<CardData>) => {
+    onChange(cards.map((c) => (c.id === cardId ? { ...c, ...patch } : c)))
+  }
+
+  return (
+    <div className={styles.cardsBlock} contentEditable={false}>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={cards.map((c) => c.id)} strategy={rectSortingStrategy}>
+          <div className={styles.cardsGrid} role='list'>
+            {cards.map((card) => (
+              <SortableCard
+                key={card.id}
+                card={card}
+                knowledgeBaseId={knowledgeBaseId}
+                isEditing={editingId === card.id}
+                onOpenChange={(open) => setEditingId(open ? card.id : null)}
+                onChange={(patch) => handleUpdate(card.id, patch)}
+                onDelete={() => handleDelete(card.id)}
+              />
+            ))}
+            <button type='button' className={styles.addCard} onClick={handleAdd}>
+              <Plus size={16} aria-hidden='true' />
+              <span>Add card</span>
+            </button>
+          </div>
+        </SortableContext>
+      </DndContext>
+    </div>
+  )
+}
+
+interface SortableCardProps {
+  card: CardData
+  knowledgeBaseId?: string
+  isEditing: boolean
+  onOpenChange: (open: boolean) => void
+  onChange: (patch: Partial<CardData>) => void
+  onDelete: () => void
+}
+
+function SortableCard({
+  card,
+  knowledgeBaseId,
+  isEditing,
+  onOpenChange,
+  onChange,
+  onDelete,
+}: SortableCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: card.id,
+  })
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 1 : 0,
+  }
+
+  return (
+    <CardEditPopover
+      card={card}
+      knowledgeBaseId={knowledgeBaseId}
+      open={isEditing}
+      onOpenChange={onOpenChange}
+      onChange={onChange}>
+      <div
+        ref={setNodeRef}
+        style={style}
+        className={styles.card}
+        data-interactive={card.href ? 'true' : 'false'}
+        data-editing={isEditing ? 'true' : undefined}
+        role='listitem'
+        {...attributes}
+        {...listeners}
+        onClick={(e) => {
+          if (e.defaultPrevented) return
+          onOpenChange(true)
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Backspace' && !card.title) {
+            e.preventDefault()
+            onDelete()
+          }
+        }}>
+        <button
+          type='button'
+          className={styles.cardClose}
+          aria-label='Remove card'
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            onDelete()
+          }}>
+          <X size={12} />
+        </button>
+        {card.iconId ? (
+          <span className={styles.cardIcon}>
+            <EntityIcon iconId={card.iconId} variant='bare' size='sm' />
+          </span>
+        ) : null}
+        <span className={styles.cardTitle}>{card.title || 'Untitled'}</span>
+        {card.description ? (
+          <span className={styles.cardDescription}>{renderMarkdownLite(card.description)}</span>
+        ) : null}
+      </div>
+    </CardEditPopover>
+  )
+}

--- a/apps/web/src/components/editor/kb-article/editor-context.tsx
+++ b/apps/web/src/components/editor/kb-article/editor-context.tsx
@@ -1,0 +1,26 @@
+// apps/web/src/components/editor/kb-article/editor-context.tsx
+'use client'
+
+import { createContext, type ReactNode, useContext, useMemo } from 'react'
+
+interface KBEditorContextValue {
+  /** Knowledge base id for any nested pickers (article-link, cards). */
+  knowledgeBaseId?: string
+}
+
+const Ctx = createContext<KBEditorContextValue>({})
+
+export function KBEditorContextProvider({
+  knowledgeBaseId,
+  children,
+}: {
+  knowledgeBaseId?: string
+  children: ReactNode
+}) {
+  const value = useMemo(() => ({ knowledgeBaseId }), [knowledgeBaseId])
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>
+}
+
+export function useKBEditorContext(): KBEditorContextValue {
+  return useContext(Ctx)
+}

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.module.css
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.module.css
@@ -132,3 +132,27 @@
 :global(body.is-block-dragging) .editorContent :global(.ProseMirror) {
   cursor: grabbing;
 }
+
+/* ============================================
+   Internal vs external link styling — internal
+   `auxx://kb/...` links render with a small
+   leading book-open glyph; external links keep
+   the standard look.
+   ============================================ */
+
+.editorContent :global(.ProseMirror) :global(a[href^='auxx://kb/article/'])::before {
+  content: '';
+  display: inline-block;
+  vertical-align: -0.1em;
+  width: 0.85em;
+  height: 0.85em;
+  margin-right: 0.25em;
+  background-color: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z'/><path d='M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z'/></svg>");
+  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z'/><path d='M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z'/></svg>");
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  opacity: 0.7;
+}

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
@@ -2,9 +2,13 @@
 'use client'
 
 import type { JSONContent } from '@tiptap/core'
+import type { Editor } from '@tiptap/react'
 import { EditorContent } from '@tiptap/react'
 import type { CSSProperties } from 'react'
+import { useCallback, useState } from 'react'
 import { InlinePickerPopover } from '../inline-picker'
+import { type ArticleLinkPick, ArticleLinkPopover } from './article-link-popover'
+import { KBEditorContextProvider } from './editor-context'
 import styles from './kb-article-editor.module.css'
 import { KBSlashCommandPicker } from './kb-slash-command-picker'
 import { useKBArticleEditor } from './use-kb-article-editor'
@@ -12,44 +16,110 @@ import { useKBArticleEditor } from './use-kb-article-editor'
 interface KBArticleEditorProps {
   initialContent: JSONContent | null
   onChange: (content: { json: JSONContent; html: string }) => void
+  /** Knowledge base id — scopes the article-link picker to a single KB by default. */
+  knowledgeBaseId?: string
 }
 
-export function KBArticleEditor({ initialContent, onChange }: KBArticleEditorProps) {
+interface PendingLink {
+  editor: Editor
+  insertPos: number
+  rect: DOMRect
+}
+
+export function KBArticleEditor({
+  initialContent,
+  onChange,
+  knowledgeBaseId,
+}: KBArticleEditorProps) {
   const { editor, gutterCharWidth, slashCommand } = useKBArticleEditor({
     initialContent,
     onChange,
   })
+  const [pendingLink, setPendingLink] = useState<PendingLink | null>(null)
 
   // Clicks on chrome around the contenteditable (padding, empty area below
   // the last block) should still focus the editor at end — matches the
   // behavior people expect from doc editors.
-  const handleWrapperMouseDown = (e: React.MouseEvent) => {
+  const handleWrapperMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!editor || editor.isDestroyed) return
     const target = e.target as HTMLElement
+    // React synthetic events bubble through the React tree, including from
+    // portaled descendants (popovers, dialogs). Ignore events whose target
+    // isn't actually a DOM descendant of this wrapper.
+    if (!e.currentTarget.contains(target)) return
     if (target.closest('.ProseMirror')) return
     if (target.closest('[data-block-drag-handle]')) return
     e.preventDefault()
     editor.commands.focus('end')
   }
 
+  const handleLinkArticle = useCallback((editorInstance: Editor, insertPos: number) => {
+    const coords = editorInstance.view.coordsAtPos(insertPos)
+    const rect = new DOMRect(
+      coords.left,
+      coords.top,
+      Math.max(1, coords.right - coords.left),
+      Math.max(1, coords.bottom - coords.top)
+    )
+    setPendingLink({ editor: editorInstance, insertPos, rect })
+  }, [])
+
+  const handlePick = useCallback(
+    (pick: ArticleLinkPick) => {
+      if (!pendingLink) return
+      const isInternal = pick.href.startsWith('auxx://')
+      pendingLink.editor
+        .chain()
+        .focus()
+        .insertContentAt(pendingLink.insertPos, {
+          type: 'text',
+          text: pick.text,
+          marks: [
+            {
+              type: 'link',
+              attrs: {
+                href: pick.href,
+                target: isInternal ? null : '_blank',
+              },
+            },
+          ],
+        })
+        .run()
+      setPendingLink(null)
+    },
+    [pendingLink]
+  )
+
   return (
-    <div
-      className={styles.editorWrapper}
-      onMouseDown={handleWrapperMouseDown}
-      style={{ '--gutter-min-width': `calc(${gutterCharWidth}ch + 1rem)` } as CSSProperties}>
-      <div className={styles.editorContainer}>
-        <EditorContent editor={editor} className={styles.editorContent} />
-      </div>
-      <InlinePickerPopover
-        state={slashCommand.suggestionState}
-        onClose={slashCommand.closePicker}
-        width={288}>
-        <KBSlashCommandPicker
-          query={slashCommand.suggestionState.query}
-          onExecute={slashCommand.executeCommand}
+    <KBEditorContextProvider knowledgeBaseId={knowledgeBaseId}>
+      <div
+        className={styles.editorWrapper}
+        onMouseDown={handleWrapperMouseDown}
+        style={{ '--gutter-min-width': `calc(${gutterCharWidth}ch + 1rem)` } as CSSProperties}>
+        <div className={styles.editorContainer}>
+          <EditorContent editor={editor} className={styles.editorContent} />
+        </div>
+        <InlinePickerPopover
+          state={slashCommand.suggestionState}
           onClose={slashCommand.closePicker}
+          width={288}>
+          <KBSlashCommandPicker
+            query={slashCommand.suggestionState.query}
+            onExecute={slashCommand.executeCommand}
+            onClose={slashCommand.closePicker}
+            onLinkArticle={handleLinkArticle}
+          />
+        </InlinePickerPopover>
+        <ArticleLinkPopover
+          open={pendingLink !== null}
+          onOpenChange={(open) => {
+            if (!open) setPendingLink(null)
+          }}
+          knowledgeBaseId={knowledgeBaseId}
+          anchorRect={pendingLink?.rect ?? null}
+          onPick={handlePick}
         />
-      </InlinePickerPopover>
-    </div>
+      </div>
+    </KBEditorContextProvider>
   )
 }

--- a/apps/web/src/components/editor/kb-article/kb-slash-command-picker.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-slash-command-picker.tsx
@@ -13,6 +13,7 @@ import {
   useCommandNavigation,
 } from '@auxx/ui/components/command'
 import { EntityIcon } from '@auxx/ui/components/icons'
+import { generateId } from '@auxx/utils'
 import type { Editor } from '@tiptap/react'
 import { ChevronRight } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -25,6 +26,9 @@ interface KBSlashCommandPickerProps {
   query: string
   onExecute: (command: (editor: Editor, range: Range) => void) => void
   onClose: () => void
+  /** Open the article-link dialog. The picker deletes the slash range first
+   * and passes the resulting cursor position to the host. */
+  onLinkArticle?: (editor: Editor, insertPos: number) => void
 }
 
 interface BlockCommandSpec {
@@ -71,6 +75,13 @@ const BASE_COMMANDS: CommandItemDef[] = [
     keywords: ['variable', 'token', 'dynamic', 'merge', 'field'],
     iconId: 'braces',
     drillDown: true,
+  },
+  {
+    id: 'article-link',
+    title: 'Link to article',
+    description: 'Insert a link to another KB article',
+    keywords: ['link', 'article', 'reference', 'href', 'url'],
+    iconId: 'link',
   },
   {
     id: 'text',
@@ -238,6 +249,31 @@ const BASE_COMMANDS: CommandItemDef[] = [
     iconId: 'video',
     spec: { blockType: 'embed' },
   },
+  {
+    id: 'cards',
+    title: 'Card grid',
+    description: 'Linked navigation cards',
+    keywords: ['cards', 'card', 'grid', 'links', 'nav'],
+    iconId: 'grid',
+    custom: (editor, range) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .updateAttributes('block', {
+          blockType: 'cards',
+          level: null,
+          checked: false,
+          cards: [
+            { id: generateId(), title: 'Card 1' },
+            { id: generateId(), title: 'Card 2' },
+          ],
+        })
+        .splitBlock()
+        .updateAttributes('block', { blockType: 'text', level: null, checked: false })
+        .run()
+    },
+  },
 ]
 
 interface SlashCommandNavItem {
@@ -289,6 +325,7 @@ function KBSlashCommandPickerContent({
   query,
   onExecute,
   onClose,
+  onLinkArticle,
   searchQuery,
   setSearchQuery,
   onEnterPlaceholderMode,
@@ -351,13 +388,16 @@ function KBSlashCommandPickerContent({
 
   const filteredCommands = useMemo(() => {
     if (isInSnippets) return []
-    return BASE_COMMANDS.filter(
+    const base = onLinkArticle
+      ? BASE_COMMANDS
+      : BASE_COMMANDS.filter((c) => c.id !== 'article-link')
+    return base.filter(
       (item) =>
         item.title.toLowerCase().includes(q) ||
         item.description.toLowerCase().includes(q) ||
         item.keywords.some((kw) => kw.includes(q))
     )
-  }, [isInSnippets, q])
+  }, [isInSnippets, q, onLinkArticle])
 
   const runBlockSpec = useCallback(
     (spec: BlockCommandSpec) => {
@@ -383,6 +423,13 @@ function KBSlashCommandPickerContent({
       }
       if (itemId === 'placeholder') {
         onEnterPlaceholderMode()
+        return
+      }
+      if (itemId === 'article-link' && onLinkArticle) {
+        onExecute((editor, range) => {
+          editor.chain().focus().deleteRange(range).run()
+          onLinkArticle(editor, range.from)
+        })
         return
       }
 

--- a/apps/web/src/components/kb/hooks/use-article-content.ts
+++ b/apps/web/src/components/kb/hooks/use-article-content.ts
@@ -4,6 +4,15 @@
 import type { JSONContent } from '@tiptap/core'
 import { api } from '~/trpc/react'
 
+/**
+ * Which slice of an article the preview should render.
+ * - `'draft'`: the in-progress draft revision (default).
+ * - `'live'`: the currently published revision; falls back to draft when
+ *   the article has no published revision.
+ * - `{ versionNumber }`: a historical immutable snapshot.
+ */
+export type PreviewMode = 'draft' | 'live' | { versionNumber: number }
+
 interface UseArticleContentResult {
   /** Draft revision content (what the editor writes to). */
   draftContent: string | null
@@ -18,6 +27,17 @@ interface UseArticleContentResult {
   publishedContentJson: JSONContent | null
   hasPublishedVersion: boolean
   hasUnpublishedChanges: boolean
+  /** What the preview should render for the resolved mode. */
+  previewTitle: string | null
+  previewDescription: string | null
+  previewExcerpt: string | null
+  previewEmoji: string | null
+  previewContent: string | null
+  previewContentJson: JSONContent | null
+  /** Resolved version number when mode is `'live'` or historical; null otherwise. */
+  previewVersionNumber: number | null
+  /** True when mode === 'live' but the article has no published revision. */
+  fellBackToDraft: boolean
   isLoading: boolean
 }
 
@@ -25,31 +45,107 @@ interface UseArticleContentResult {
  * Fetch an article's heavy content (HTML + JSON) directly from the server.
  * Content is intentionally not stored in the article store — only metadata is.
  *
- * Returns both the draft (what the editor mutates) and the published revision
- * (used to power "discard draft" preview comparisons in the settings dialog).
+ * Returns the draft (what the editor mutates), the published revision (used
+ * to power "discard draft" preview comparisons in the settings dialog), and
+ * a resolved preview slice for the requested `mode`. Historical versions
+ * are fetched as a separate cache cell keyed by `versionNumber` and treated
+ * as immutable (`staleTime: Infinity`).
  */
 export function useArticleContent(
   id: string | null | undefined,
-  knowledgeBaseId: string | null | undefined
+  knowledgeBaseId: string | null | undefined,
+  mode: PreviewMode = 'draft'
 ): UseArticleContentResult {
-  const query = api.kb.getArticleById.useQuery(
+  const isHistorical = typeof mode === 'object' && mode !== null
+  const requestedVersion = isHistorical ? mode.versionNumber : undefined
+
+  const baseQuery = api.kb.getArticleById.useQuery(
     { id: id ?? '', knowledgeBaseId: knowledgeBaseId ?? undefined },
     { enabled: !!id && !!knowledgeBaseId }
   )
 
+  const versionQuery = api.kb.getArticleById.useQuery(
+    {
+      id: id ?? '',
+      knowledgeBaseId: knowledgeBaseId ?? undefined,
+      versionNumber: requestedVersion,
+    },
+    {
+      enabled: !!id && !!knowledgeBaseId && isHistorical,
+      staleTime: Number.POSITIVE_INFINITY,
+    }
+  )
+
+  const data = baseQuery.data
+  const draftContent = data?.content ?? null
+  const draftContentJson = (data?.contentJson as JSONContent | null | undefined) ?? null
+  const draftTitle = data?.title ?? null
+  const draftDescription = data?.description ?? null
+  const draftExcerpt = data?.excerpt ?? null
+  const draftEmoji = data?.emoji ?? null
+  const publishedTitle = data?.publishedTitle ?? null
+  const publishedContent = data?.publishedContent ?? null
+  const publishedContentJson =
+    (data?.publishedContentJson as JSONContent | null | undefined) ?? null
+  const hasPublishedVersion = !!data?.hasPublishedVersion
+
+  let previewTitle: string | null = draftTitle
+  let previewDescription: string | null = draftDescription
+  let previewExcerpt: string | null = draftExcerpt
+  let previewEmoji: string | null = draftEmoji
+  let previewContent: string | null = draftContent
+  let previewContentJson: JSONContent | null = draftContentJson
+  let previewVersionNumber: number | null = null
+  let fellBackToDraft = false
+
+  if (mode === 'live') {
+    if (hasPublishedVersion) {
+      previewTitle = publishedTitle
+      // The base query only returns published content + title — fall back to
+      // draft fields for description/excerpt/emoji since they're not in the
+      // editor view's published payload. Acceptable: the body is what
+      // changes between versions; metadata diffs are rare.
+      previewContent = publishedContent
+      previewContentJson = publishedContentJson
+      // versionNumber for the live revision isn't returned by the base query
+      // either; the picker pulls it from getArticleVersions when needed.
+    } else {
+      fellBackToDraft = true
+    }
+  } else if (isHistorical) {
+    const v = versionQuery.data
+    if (v) {
+      previewTitle = v.selectedTitle ?? draftTitle
+      previewDescription = v.selectedDescription ?? draftDescription
+      previewExcerpt = v.selectedExcerpt ?? draftExcerpt
+      previewEmoji = v.selectedEmoji ?? draftEmoji
+      previewContent = v.selectedContent ?? draftContent
+      previewContentJson =
+        (v.selectedContentJson as JSONContent | null | undefined) ?? draftContentJson
+      previewVersionNumber = v.selectedVersionNumber ?? requestedVersion ?? null
+    }
+  }
+
   return {
-    draftContent: query.data?.content ?? null,
-    draftContentJson: (query.data?.contentJson as JSONContent | null | undefined) ?? null,
-    draftTitle: query.data?.title ?? null,
-    draftDescription: query.data?.description ?? null,
-    draftExcerpt: query.data?.excerpt ?? null,
-    draftEmoji: query.data?.emoji ?? null,
-    publishedTitle: query.data?.publishedTitle ?? null,
-    publishedContent: query.data?.publishedContent ?? null,
-    publishedContentJson:
-      (query.data?.publishedContentJson as JSONContent | null | undefined) ?? null,
-    hasPublishedVersion: !!query.data?.hasPublishedVersion,
-    hasUnpublishedChanges: !!query.data?.hasUnpublishedChanges,
-    isLoading: query.isLoading,
+    draftContent,
+    draftContentJson,
+    draftTitle,
+    draftDescription,
+    draftExcerpt,
+    draftEmoji,
+    publishedTitle,
+    publishedContent,
+    publishedContentJson,
+    hasPublishedVersion,
+    hasUnpublishedChanges: !!data?.hasUnpublishedChanges,
+    previewTitle,
+    previewDescription,
+    previewExcerpt,
+    previewEmoji,
+    previewContent,
+    previewContentJson,
+    previewVersionNumber,
+    fellBackToDraft,
+    isLoading: baseQuery.isLoading || (isHistorical && versionQuery.isLoading),
   }
 }

--- a/apps/web/src/components/kb/ui/articles/article-move-picker.tsx
+++ b/apps/web/src/components/kb/ui/articles/article-move-picker.tsx
@@ -1,26 +1,9 @@
 // apps/web/src/components/kb/ui/articles/article-move-picker.tsx
 'use client'
 
-import {
-  Command,
-  CommandBreadcrumb,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandNavigation,
-  useCommandNavigation,
-} from '@auxx/ui/components/command'
-import { ChevronRight, CornerDownRight } from 'lucide-react'
-import { type KeyboardEvent, useCallback, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useArticleList } from '../../hooks/use-article-list'
-
-interface MoveNavItem {
-  id: string
-  label: string
-  type: 'tab'
-}
+import { ArticlePicker } from './article-picker'
 
 interface ArticleMovePickerProps {
   knowledgeBaseId: string
@@ -33,15 +16,7 @@ interface ArticleMovePickerProps {
   onClose: () => void
 }
 
-export function ArticleMovePicker(props: ArticleMovePickerProps) {
-  return (
-    <CommandNavigation<MoveNavItem>>
-      <ArticleMovePickerContent {...props} />
-    </CommandNavigation>
-  )
-}
-
-function ArticleMovePickerContent({
+export function ArticleMovePicker({
   knowledgeBaseId,
   articleId,
   currentParentId,
@@ -49,8 +24,6 @@ function ArticleMovePickerContent({
   onClose,
 }: ArticleMovePickerProps) {
   const articles = useArticleList(knowledgeBaseId)
-  const [search, setSearch] = useState('')
-  const { push, pop, isAtRoot, current } = useCommandNavigation<MoveNavItem>()
 
   // Self + descendants are never valid destinations.
   const forbiddenIds = useMemo(() => {
@@ -68,105 +41,17 @@ function ArticleMovePickerContent({
     return banned
   }, [articles, articleId])
 
-  const tabs = useMemo(
-    () =>
-      articles
-        .filter((a) => a.articleKind === 'tab' && !forbiddenIds.has(a.id))
-        .sort((a, b) => (a.sortOrder < b.sortOrder ? -1 : a.sortOrder > b.sortOrder ? 1 : 0)),
-    [articles, forbiddenIds]
-  )
-
-  const insideTab = current?.type === 'tab' ? current : null
-
-  const subItems = useMemo(() => {
-    if (!insideTab) return []
-    return articles
-      .filter(
-        (a) =>
-          a.parentId === insideTab.id && a.articleKind === 'category' && !forbiddenIds.has(a.id)
-      )
-      .sort((a, b) => (a.sortOrder < b.sortOrder ? -1 : a.sortOrder > b.sortOrder ? 1 : 0))
-  }, [articles, forbiddenIds, insideTab])
-
-  const q = search.toLowerCase()
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLDivElement>) => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        e.stopPropagation()
-        onClose()
-        return
-      }
-      if ((e.key === 'Backspace' || e.key === 'ArrowLeft') && !search) {
-        if (!isAtRoot) {
-          e.preventDefault()
-          pop()
-          return
-        }
-        if (e.key === 'Backspace') {
-          e.preventDefault()
-          onClose()
-        }
-      }
-    },
-    [isAtRoot, onClose, pop, search]
-  )
-
   return (
-    <Command className='w-72 overflow-hidden' shouldFilter={false} onKeyDown={handleKeyDown}>
-      <CommandBreadcrumb rootLabel='Move to' />
-      <CommandInput
-        placeholder={insideTab ? `Search inside ${insideTab.label}…` : 'Search tabs…'}
-        value={search}
-        onValueChange={setSearch}
-      />
-      <CommandList>
-        <CommandEmpty>No matches.</CommandEmpty>
-
-        {isAtRoot && (
-          <CommandGroup heading='Tabs'>
-            {tabs
-              .filter((t) => !q || t.title.toLowerCase().includes(q))
-              .map((t) => (
-                <CommandItem
-                  key={t.id}
-                  value={t.title}
-                  onSelect={() => {
-                    push({ id: t.id, label: t.title || 'Untitled', type: 'tab' })
-                    setSearch('')
-                  }}
-                  className='flex items-center justify-between'>
-                  <span>{t.title || 'Untitled'}</span>
-                  <ChevronRight className='size-4 opacity-50' />
-                </CommandItem>
-              ))}
-          </CommandGroup>
-        )}
-
-        {insideTab && (
-          <CommandGroup heading={insideTab.label}>
-            <CommandItem
-              value={`top-${insideTab.id}`}
-              onSelect={() => onPick(insideTab.id)}
-              data-current={currentParentId === insideTab.id || undefined}>
-              <CornerDownRight className='mr-2 size-4 opacity-50' />
-              <span>Top of {insideTab.label}</span>
-            </CommandItem>
-            {subItems
-              .filter((c) => !q || c.title.toLowerCase().includes(q))
-              .map((c) => (
-                <CommandItem
-                  key={c.id}
-                  value={c.title}
-                  onSelect={() => onPick(c.id)}
-                  data-current={currentParentId === c.id || undefined}>
-                  <span>{c.title || 'Untitled'}</span>
-                </CommandItem>
-              ))}
-          </CommandGroup>
-        )}
-      </CommandList>
-    </Command>
+    <ArticlePicker
+      knowledgeBaseId={knowledgeBaseId}
+      allowedKinds={['tab', 'category']}
+      drillableKinds={['tab']}
+      forbiddenIds={forbiddenIds}
+      showTopOfTab
+      currentParentId={currentParentId}
+      rootLabel='Move to'
+      onPick={onPick}
+      onClose={onClose}
+    />
   )
 }

--- a/apps/web/src/components/kb/ui/articles/article-picker.tsx
+++ b/apps/web/src/components/kb/ui/articles/article-picker.tsx
@@ -1,0 +1,272 @@
+// apps/web/src/components/kb/ui/articles/article-picker.tsx
+'use client'
+
+import type { ArticleKind } from '@auxx/database/types'
+import {
+  Command,
+  CommandBreadcrumb,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandNavigation,
+  useCommandNavigation,
+} from '@auxx/ui/components/command'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { ChevronRight, CornerDownRight } from 'lucide-react'
+import { type KeyboardEvent, useCallback, useMemo, useState } from 'react'
+import { useArticleList } from '../../hooks/use-article-list'
+import { useKnowledgeBases } from '../../hooks/use-knowledge-bases'
+
+interface NavItem {
+  /** When `kind` is omitted, this entry is a KB root (cross-KB picker). */
+  id: string
+  label: string
+  kind?: 'kb' | 'tab' | 'category'
+}
+
+export interface ArticlePickerProps {
+  /**
+   * KB to browse. If omitted, the picker shows a top-level KB list and
+   * pushes a KB onto the navigation stack on select.
+   */
+  knowledgeBaseId?: string
+  /** Article kinds the user is allowed to pick. */
+  allowedKinds: ArticleKind[]
+  /** Article kinds shown as drillable parents. */
+  drillableKinds?: ArticleKind[]
+  /** Article ids that are *not* valid choices. */
+  forbiddenIds?: Set<string>
+  /** Show a synthetic "Top of {tab}" entry inside a tab. */
+  showTopOfTab?: boolean
+  /** Highlight the article's current parent (move-picker shape). */
+  currentParentId?: string | null
+  /** Heading shown above the list (mirrors the breadcrumb root). */
+  rootLabel?: string
+  /** Placeholder for the search input. */
+  searchPlaceholder?: string
+  /**
+   * When true, typing in the search input searches across all pickable
+   * articles in the KB regardless of the current navigation level. Hierarchy
+   * navigation still works when the search is empty.
+   */
+  flattenSearch?: boolean
+  onPick: (articleId: string) => void
+  onClose: () => void
+}
+
+const DEFAULT_DRILLABLE: ArticleKind[] = ['tab', 'category']
+
+export function ArticlePicker(props: ArticlePickerProps) {
+  return (
+    <CommandNavigation<NavItem>>
+      <ArticlePickerContent {...props} />
+    </CommandNavigation>
+  )
+}
+
+function ArticlePickerContent({
+  knowledgeBaseId,
+  allowedKinds,
+  drillableKinds = DEFAULT_DRILLABLE,
+  forbiddenIds,
+  showTopOfTab,
+  currentParentId,
+  rootLabel = 'Pick an article',
+  searchPlaceholder,
+  flattenSearch,
+  onPick,
+  onClose,
+}: ArticlePickerProps) {
+  const { push, pop, isAtRoot, current, stack } = useCommandNavigation<NavItem>()
+  const [search, setSearch] = useState('')
+  const q = search.toLowerCase()
+
+  // Cross-KB scope: when no `knowledgeBaseId` is provided, the root is a KB
+  // list and we drill into a KB on select. Inside a KB, behave like the
+  // single-KB form.
+  const { knowledgeBases } = useKnowledgeBases()
+  const activeKbId =
+    knowledgeBaseId ??
+    (stack[0]?.kind === 'kb' ? stack[0].id : isAtRoot ? null : (current?.id ?? null))
+
+  const articles = useArticleList(activeKbId)
+
+  const allowedSet = useMemo(() => new Set(allowedKinds), [allowedKinds])
+  const drillableSet = useMemo(() => new Set(drillableKinds), [drillableKinds])
+
+  const isPickable = useCallback(
+    (kind: ArticleKind, id: string) => {
+      if (!allowedSet.has(kind)) return false
+      if (forbiddenIds?.has(id)) return false
+      return true
+    },
+    [allowedSet, forbiddenIds]
+  )
+
+  const isDrillable = useCallback((kind: ArticleKind) => drillableSet.has(kind), [drillableSet])
+
+  // Crossing-KB: stack[0] is the KB itself when knowledgeBaseId not set.
+  const insideKb = activeKbId != null
+  const inTabOrCat =
+    current && (current.kind === 'tab' || current.kind === 'category') ? current : null
+  const parentId = inTabOrCat?.id ?? null
+
+  const visibleArticles = useMemo(() => {
+    if (!insideKb) return []
+    if (flattenSearch && q) {
+      // Global search across the whole KB — only pickable articles, ignoring
+      // the current navigation level. Drillable parents are excluded since
+      // "drill into a tab" doesn't make sense in flat search results.
+      return articles
+        .filter((a) => isPickable(a.articleKind, a.id))
+        .filter((a) => a.title.toLowerCase().includes(q))
+        .sort((a, b) => (a.sortOrder < b.sortOrder ? -1 : a.sortOrder > b.sortOrder ? 1 : 0))
+    }
+    return articles
+      .filter((a) => {
+        if (parentId == null) {
+          // Root of the KB — show top-level entries (no parent).
+          return a.parentId == null
+        }
+        return a.parentId === parentId
+      })
+      .filter((a) => isPickable(a.articleKind, a.id) || isDrillable(a.articleKind))
+      .filter((a) => !q || a.title.toLowerCase().includes(q))
+      .sort((a, b) => (a.sortOrder < b.sortOrder ? -1 : a.sortOrder > b.sortOrder ? 1 : 0))
+  }, [articles, insideKb, parentId, isPickable, isDrillable, q, flattenSearch])
+
+  const visibleKbs = useMemo(() => {
+    if (knowledgeBaseId || activeKbId) return []
+    return knowledgeBases.filter((kb) => !q || (kb.name ?? '').toLowerCase().includes(q))
+  }, [knowledgeBaseId, activeKbId, knowledgeBases, q])
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        onClose()
+        return
+      }
+      if ((e.key === 'Backspace' || e.key === 'ArrowLeft') && !search) {
+        if (!isAtRoot) {
+          e.preventDefault()
+          pop()
+          return
+        }
+        if (e.key === 'Backspace') {
+          e.preventDefault()
+          onClose()
+        }
+      }
+    },
+    [isAtRoot, onClose, pop, search]
+  )
+
+  const placeholder =
+    searchPlaceholder ??
+    (current?.kind === 'tab' || current?.kind === 'category'
+      ? `Search inside ${current.label}…`
+      : insideKb
+        ? 'Search articles…'
+        : 'Search knowledge bases…')
+
+  return (
+    <Command className='w-72 overflow-hidden' shouldFilter={false} onKeyDown={handleKeyDown}>
+      <CommandBreadcrumb rootLabel={rootLabel} />
+      <CommandInput placeholder={placeholder} value={search} onValueChange={setSearch} />
+      <CommandList>
+        <CommandEmpty>No matches.</CommandEmpty>
+
+        {!insideKb && visibleKbs.length > 0 && (
+          <CommandGroup heading='Knowledge bases'>
+            {visibleKbs.map((kb) => (
+              <CommandItem
+                key={kb.id}
+                value={kb.name}
+                onSelect={() => {
+                  push({ id: kb.id, label: kb.name || 'Untitled', kind: 'kb' })
+                  setSearch('')
+                }}
+                className='flex items-center justify-between'>
+                <div className='flex items-center gap-2'>
+                  <EntityIcon iconId='book-open' size='xs' className='text-muted-foreground' />
+                  <span>{kb.name || 'Untitled'}</span>
+                </div>
+                <ChevronRight className='size-4 opacity-50' />
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {insideKb && (
+          <CommandGroup
+            heading={
+              current?.kind === 'tab' || current?.kind === 'category' ? current.label : 'Articles'
+            }>
+            {showTopOfTab && inTabOrCat?.kind === 'tab' && (
+              <CommandItem
+                value={`top-${inTabOrCat.id}`}
+                onSelect={() => onPick(inTabOrCat.id)}
+                data-current={currentParentId === inTabOrCat.id || undefined}>
+                <CornerDownRight className='mr-2 size-4 opacity-50' />
+                <span>Top of {inTabOrCat.label}</span>
+              </CommandItem>
+            )}
+            {visibleArticles.map((a) => {
+              const drill = isDrillable(a.articleKind)
+              const pick = isPickable(a.articleKind, a.id)
+              const onSelect = () => {
+                if (drill) {
+                  push({
+                    id: a.id,
+                    label: a.title || 'Untitled',
+                    kind: a.articleKind === 'tab' ? 'tab' : 'category',
+                  })
+                  setSearch('')
+                  return
+                }
+                if (pick) onPick(a.id)
+              }
+              return (
+                <CommandItem
+                  key={a.id}
+                  value={a.title || a.id}
+                  onSelect={onSelect}
+                  data-current={currentParentId === a.id || undefined}
+                  className='flex items-center justify-between'>
+                  <div className='flex items-center gap-2'>
+                    <EntityIcon
+                      iconId={a.emoji ?? articleKindIcon(a.articleKind)}
+                      size='xs'
+                      className='text-muted-foreground'
+                    />
+                    <span>{a.title || 'Untitled'}</span>
+                  </div>
+                  {drill ? <ChevronRight className='size-4 opacity-50' /> : null}
+                </CommandItem>
+              )
+            })}
+          </CommandGroup>
+        )}
+      </CommandList>
+    </Command>
+  )
+}
+
+function articleKindIcon(kind: ArticleKind): string {
+  switch (kind) {
+    case 'tab':
+      return 'folder'
+    case 'category':
+      return 'folder-open'
+    case 'header':
+      return 'heading'
+    case 'link':
+      return 'link'
+    default:
+      return 'file-text'
+  }
+}

--- a/apps/web/src/components/kb/ui/editor/article-editor.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor.tsx
@@ -75,6 +75,7 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
                   <KBArticleEditor
                     initialContent={draftContentJson ?? emptyContent}
                     onChange={debouncedPersist}
+                    knowledgeBaseId={knowledgeBaseId}
                   />
                 )}
               </div>

--- a/apps/web/src/components/kb/ui/editor/article-versions-dialog.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-versions-dialog.tsx
@@ -10,11 +10,14 @@ import {
   DialogTitle,
 } from '@auxx/ui/components/dialog'
 import { Input } from '@auxx/ui/components/input'
+import { getFullSlugPath } from '@auxx/ui/components/kb'
+import { getKbPreviewHref } from '@auxx/ui/components/kb/utils'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
-import { Check, Loader2, Pencil, Undo2, X } from 'lucide-react'
+import { Check, ExternalLink, Loader2, Pencil, Undo2, X } from 'lucide-react'
 import { useState } from 'react'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
+import { useArticleList } from '../../hooks/use-article-list'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
 
 interface ArticleVersionsDialogProps {
@@ -53,6 +56,12 @@ export function ArticleVersionsDialog({
     { id: articleId, knowledgeBaseId },
     { enabled: open }
   )
+
+  const articles = useArticleList(knowledgeBaseId)
+  const slugPath = (() => {
+    const a = articles.find((x) => x.id === articleId)
+    return a ? getFullSlugPath(a, articles) : ''
+  })()
 
   const renameMutation = api.kb.renameArticleVersion.useMutation()
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -194,6 +203,18 @@ export function ArticleVersionsDialog({
                         <span className='flex-1 text-xs text-muted-foreground'>
                           {v.editor?.name ?? 'System'}
                         </span>
+                        {v.versionNumber !== null && slugPath ? (
+                          <Button size='sm' variant='ghost' asChild>
+                            <a
+                              href={getKbPreviewHref(knowledgeBaseId, slugPath, {
+                                versionNumber: v.versionNumber,
+                              })}
+                              target='_blank'
+                              rel='noopener'>
+                              <ExternalLink /> View
+                            </a>
+                          </Button>
+                        ) : null}
                         {!isCurrent && (
                           <Button
                             size='sm'

--- a/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { Banner } from '@auxx/ui/components/banner'
+import { Button } from '@auxx/ui/components/button'
 import {
   type DocJSON,
   extractKBHeadings,
@@ -15,33 +16,40 @@ import {
   KBLayout,
   KBTableOfContents,
 } from '@auxx/ui/components/kb'
-import { ExternalLink, Eye } from 'lucide-react'
+import { ExternalLink, Eye, Undo2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 import { type CSSProperties, useCallback, useState } from 'react'
-import { useArticleContent } from '../../hooks/use-article-content'
+import { api } from '~/trpc/react'
+import { type PreviewMode, useArticleContent } from '../../hooks/use-article-content'
 import { useArticleList } from '../../hooks/use-article-list'
+import { useArticleMutations } from '../../hooks/use-article-mutations'
 import { useBodyClass } from '../../hooks/use-body-class'
 import { useKbPublicUrl } from '../../hooks/use-kb-public-url'
 import { useKnowledgeBase } from '../../hooks/use-knowledge-base'
 import { ArticleMarkdownCopy } from './article-markdown-copy'
 import { mapKBForPreview } from './map-kb-for-preview'
+import { PreviewVersionPicker } from './preview-version-picker'
 
 interface KBFullscreenPreviewProps {
   knowledgeBaseId: string
   /** Slug path from the URL catch-all, e.g. `["docs", "intro"]`. */
   slugPath: string[]
+  /** Resolved from the `?v=` query param by the server route. */
+  mode: PreviewMode
 }
 
 /**
- * Standalone fullscreen render of a KB, served at `/preview/kb/<id>[/<slug>...]`.
- * Renders the author's current draft so unsaved changes show up before publish.
- * Admin-only via the surrounding (protected) layout. Real `<Link>` navigation
- * between articles.
+ * Standalone fullscreen render of a KB, served at `/preview/kb/<id>[/<slug>...][?v=…]`.
+ * Renders draft, the live published revision, or any historical snapshot
+ * depending on `mode`. Admin-only via the surrounding (protected) layout.
  */
-export function KBFullscreenPreview({ knowledgeBaseId, slugPath }: KBFullscreenPreviewProps) {
+export function KBFullscreenPreview({ knowledgeBaseId, slugPath, mode }: KBFullscreenPreviewProps) {
   // The global body has `overflow-hidden` so app routes manage their own scroll.
   // The fullscreen preview wants document-level scroll to match the public KB site
   // (header scrolls away naturally with content).
   useBodyClass({ remove: 'overflow-hidden' })
+
+  const router = useRouter()
 
   // Measure the banner so the KB layout's sticky elements (header, tabs, sidebar)
   // can offset themselves below it via the `--kb-top-offset` CSS variable.
@@ -73,12 +81,51 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath }: KBFullscreenP
     resolvedArticle ??
     articles.find((a) => a.articleKind === 'page' || a.articleKind === 'category')
   const articleId = activeArticle?.id ?? null
-  const { draftContentJson, draftDescription } = useArticleContent(articleId, knowledgeBaseId)
+  const {
+    previewContentJson,
+    previewDescription,
+    previewTitle,
+    previewEmoji,
+    hasPublishedVersion,
+    fellBackToDraft,
+  } = useArticleContent(articleId, knowledgeBaseId, mode)
+
+  // Versions list — used to label the live banner with vN and to map a
+  // historical versionNumber to a revision id for "Restore as draft".
+  const versionsQuery = api.kb.getArticleVersions.useQuery(
+    { articleId: articleId ?? '' },
+    { enabled: !!articleId && (mode === 'live' || (typeof mode === 'object' && mode !== null)) }
+  )
+  const versions = versionsQuery.data ?? []
+  const liveVersionNumber = versions[0]?.versionNumber ?? null
+  const historicalVersion =
+    typeof mode === 'object' && mode !== null
+      ? versions.find((v) => v.versionNumber === mode.versionNumber)
+      : undefined
+
+  const { restoreArticleVersion } = useArticleMutations(knowledgeBaseId)
+
+  const handleModeChange = useCallback(
+    (next: PreviewMode) => {
+      const path = slugPath.length > 0 ? `/${slugPath.map(encodeURIComponent).join('/')}` : ''
+      const token = next === 'draft' ? null : next === 'live' ? 'live' : String(next.versionNumber)
+      const query = token ? `?v=${token}` : ''
+      router.replace(`/preview/kb/${knowledgeBaseId}${path}${query}`)
+    },
+    [knowledgeBaseId, router, slugPath]
+  )
+
+  const handleSwitchToDraft = useCallback(() => handleModeChange('draft'), [handleModeChange])
+  const handleRestoreFromBanner = useCallback(async () => {
+    if (!historicalVersion) return
+    await restoreArticleVersion(historicalVersion.id)
+    handleModeChange('draft')
+  }, [historicalVersion, restoreArticleVersion, handleModeChange])
 
   if (!knowledgeBase) return null
 
   const basePath = `/preview/kb/${knowledgeBaseId}`
-  const docJson = (draftContentJson ?? null) as DocJSON | null
+  const docJson = (previewContentJson ?? null) as DocJSON | null
   const headings = docJson ? extractKBHeadings(docJson) : []
   const { prev, next } = articleId
     ? getArticleNeighbours(articles, articleId)
@@ -90,29 +137,104 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath }: KBFullscreenP
   const isLive =
     knowledgeBase.publishStatus === 'PUBLISHED' || knowledgeBase.publishStatus === 'UNLISTED'
   const slugSegment = slugPath.length > 0 ? `/${slugPath.map(encodeURIComponent).join('/')}` : ''
-  const liveHref = isLive && publicUrl ? `${publicUrl}${slugSegment}` : null
+  const liveSiteHref = isLive && publicUrl ? `${publicUrl}${slugSegment}` : null
+
+  const isHistoricalMode = typeof mode === 'object' && mode !== null
+  const bannerVariant = isHistoricalMode || mode === 'live' ? 'warning' : 'default'
+
+  let bannerTitle: string
+  let bannerBody: string
+  let bannerAction: React.ReactNode
+
+  if (mode === 'draft') {
+    bannerTitle = 'Preview mode'
+    bannerBody = 'Viewing draft (includes unpublished changes)'
+    bannerAction = (
+      <>
+        {articleId ? (
+          <PreviewVersionPicker
+            articleId={articleId}
+            mode={mode}
+            hasPublishedVersion={hasPublishedVersion}
+            onModeChange={handleModeChange}
+          />
+        ) : null}
+        {liveSiteHref ? (
+          <a
+            href={liveSiteHref}
+            target='_blank'
+            rel='noopener'
+            className='inline-flex items-center gap-1 font-medium text-info hover:underline'>
+            View live site <ExternalLink className='size-3.5' />
+          </a>
+        ) : (
+          <span className='text-muted-foreground'>Not published yet</span>
+        )}
+      </>
+    )
+  } else if (mode === 'live') {
+    if (fellBackToDraft) {
+      bannerTitle = 'No published version yet'
+      bannerBody = 'Showing draft until this article is published.'
+    } else {
+      bannerTitle = liveVersionNumber
+        ? `Viewing the live version (v${liveVersionNumber})`
+        : 'Viewing the live version'
+      bannerBody = ''
+    }
+    bannerAction = (
+      <>
+        {articleId ? (
+          <PreviewVersionPicker
+            articleId={articleId}
+            mode={mode}
+            hasPublishedVersion={hasPublishedVersion}
+            onModeChange={handleModeChange}
+          />
+        ) : null}
+        <Button variant='outline' size='xs' onClick={handleSwitchToDraft}>
+          Switch to draft
+        </Button>
+      </>
+    )
+  } else {
+    const v = mode.versionNumber
+    const labelSuffix = historicalVersion?.label ? ` — “${historicalVersion.label}”` : ''
+    const editorName = historicalVersion?.editor?.name ?? null
+    const meta = historicalVersion?.createdAt
+      ? new Date(historicalVersion.createdAt).toLocaleDateString()
+      : null
+    bannerTitle = `Viewing v${v}${labelSuffix}`
+    bannerBody = [meta ? `published ${meta}` : null, editorName ? `by ${editorName}` : null]
+      .filter(Boolean)
+      .join(' ')
+    bannerAction = (
+      <>
+        {articleId ? (
+          <PreviewVersionPicker
+            articleId={articleId}
+            mode={mode}
+            hasPublishedVersion={hasPublishedVersion}
+            onModeChange={handleModeChange}
+          />
+        ) : null}
+        <Button variant='outline' size='xs' onClick={handleSwitchToDraft}>
+          Switch to draft
+        </Button>
+        {historicalVersion ? (
+          <Button variant='outline' size='xs' onClick={handleRestoreFromBanner}>
+            <Undo2 /> Restore as draft
+          </Button>
+        ) : null}
+      </>
+    )
+  }
 
   return (
     <div style={{ '--kb-top-offset': `${bannerHeight}px` } as CSSProperties}>
       <div ref={setBannerRef} className='sticky top-0 z-30'>
-        <Banner
-          variant='default'
-          icon={<Eye />}
-          title='Preview mode'
-          action={
-            liveHref ? (
-              <a
-                href={liveHref}
-                target='_blank'
-                rel='noopener'
-                className='inline-flex items-center gap-1 font-medium text-info hover:underline'>
-                View live site <ExternalLink className='size-3.5' />
-              </a>
-            ) : (
-              <span className='text-muted-foreground'>Not published yet</span>
-            )
-          }>
-          Viewing draft (includes unpublished changes)
+        <Banner variant={bannerVariant} icon={<Eye />} title={bannerTitle} action={bannerAction}>
+          {bannerBody}
         </Banner>
       </div>
       <KBLayout
@@ -129,14 +251,15 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath }: KBFullscreenP
               <div className='min-w-0 flex-1 @kb-lg:order-1'>
                 <KBArticleRenderer
                   doc={docJson}
-                  title={activeArticle?.title}
-                  emoji={activeArticle?.emoji}
-                  description={draftDescription ?? activeArticle?.description}
+                  title={previewTitle ?? activeArticle?.title}
+                  emoji={previewEmoji ?? activeArticle?.emoji}
+                  description={previewDescription ?? activeArticle?.description}
                   parent={parent}
+                  resolveAuxxHref={(id) => `/preview/kb/${knowledgeBaseId}/r/${id}`}
                   copyMenu={
                     <ArticleMarkdownCopy
                       doc={docJson}
-                      title={activeArticle?.title}
+                      title={previewTitle ?? activeArticle?.title}
                       markdownHref={markdownHref}
                     />
                   }

--- a/apps/web/src/components/kb/ui/preview/kb-preview-topbar.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview-topbar.tsx
@@ -24,12 +24,16 @@ import {
 } from 'lucide-react'
 import { useKbPublicUrl } from '~/components/kb/hooks/use-kb-public-url'
 import { api } from '~/trpc/react'
+import { useArticleContent } from '../../hooks/use-article-content'
 import { type Device, type Theme, usePreview } from './preview-context'
+import { PreviewVersionPicker } from './preview-version-picker'
 
 interface KBPreviewTopBarProps {
   kbId: string
   /** Slug path of the article currently being edited; used to deep-link the new tab. */
   activeSlugPath?: string[]
+  /** Resolved article id (from the editor's slug or override) — needed by the version picker. */
+  articleId?: string | null
 }
 
 /**
@@ -37,18 +41,28 @@ interface KBPreviewTopBarProps {
  * toggles on the right. Publish lifecycle controls live in the editor header
  * (`KBPublishCluster`).
  */
-export function KBPreviewTopBar({ kbId, activeSlugPath }: KBPreviewTopBarProps) {
-  const { effectiveMode, defaultMode, override, isMobile, knowledgeBase, setOverride, setDevice } =
-    usePreview()
+export function KBPreviewTopBar({ kbId, activeSlugPath, articleId }: KBPreviewTopBarProps) {
+  const {
+    effectiveMode,
+    defaultMode,
+    override,
+    isMobile,
+    knowledgeBase,
+    previewMode,
+    setOverride,
+    setDevice,
+    setPreviewMode,
+  } = usePreview()
 
   const { data: kb } = api.kb.byId.useQuery({ id: kbId })
 
-  const previewHref = getKbPreviewHref(kbId, activeSlugPath)
+  const previewHref = getKbPreviewHref(kbId, activeSlugPath, previewMode)
   const slugSegment =
     activeSlugPath && activeSlugPath.length > 0
       ? `/${activeSlugPath.map(encodeURIComponent).join('/')}`
       : ''
   const publicUrl = useKbPublicUrl(kb?.slug)
+  const { hasPublishedVersion } = useArticleContent(articleId ?? null, kbId)
 
   const isPublished = kb?.publishStatus === 'PUBLISHED'
   const isUnlisted = kb?.publishStatus === 'UNLISTED'
@@ -70,44 +84,58 @@ export function KBPreviewTopBar({ kbId, activeSlugPath }: KBPreviewTopBarProps) 
 
   return (
     <div className='flex items-center justify-between gap-2 border-b bg-background px-3 py-1'>
-      {isLive && liveHref ? (
-        <DropdownMenu>
-          <ButtonGroup>
-            <Button variant='outline' size='xs' className='border-r-0' asChild>
-              <a
-                href={previewHref}
-                target='_blank'
-                rel='noopener'
-                aria-label='Open preview in new tab'>
-                <Eye /> Preview
-              </a>
-            </Button>
-            <ButtonGroupSeparator />
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant='outline'
-                size='xs'
-                className='px-1.5'
-                aria-label='More preview options'>
-                <ChevronDown />
+      <div className='flex items-center gap-2'>
+        {isLive && liveHref ? (
+          <DropdownMenu>
+            <ButtonGroup>
+              <Button variant='outline' size='xs' className='border-r-0' asChild>
+                <a
+                  href={previewHref}
+                  target='_blank'
+                  rel='noopener'
+                  aria-label='Open preview in new tab'>
+                  <Eye /> Preview
+                </a>
               </Button>
-            </DropdownMenuTrigger>
-          </ButtonGroup>
-          <DropdownMenuContent align='start'>
-            <DropdownMenuItem asChild>
-              <a href={liveHref} target='_blank' rel='noopener'>
-                <ExternalLink /> Open live site
-              </a>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      ) : (
-        <Button variant='outline' size='xs' asChild>
-          <a href={previewHref} target='_blank' rel='noopener' aria-label='Open preview in new tab'>
-            <Eye /> Preview
-          </a>
-        </Button>
-      )}
+              <ButtonGroupSeparator />
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant='outline'
+                  size='xs'
+                  className='px-1.5'
+                  aria-label='More preview options'>
+                  <ChevronDown />
+                </Button>
+              </DropdownMenuTrigger>
+            </ButtonGroup>
+            <DropdownMenuContent align='start'>
+              <DropdownMenuItem asChild>
+                <a href={liveHref} target='_blank' rel='noopener'>
+                  <ExternalLink /> Open live site
+                </a>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          <Button variant='outline' size='xs' asChild>
+            <a
+              href={previewHref}
+              target='_blank'
+              rel='noopener'
+              aria-label='Open preview in new tab'>
+              <Eye /> Preview
+            </a>
+          </Button>
+        )}
+        {articleId ? (
+          <PreviewVersionPicker
+            articleId={articleId}
+            mode={previewMode}
+            hasPublishedVersion={hasPublishedVersion}
+            onModeChange={setPreviewMode}
+          />
+        ) : null}
+      </div>
 
       <div className='flex items-center gap-2'>
         {showsHiddenModeHint && (

--- a/apps/web/src/components/kb/ui/preview/kb-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview.tsx
@@ -36,7 +36,7 @@ export function KBPreview({ knowledgeBase, activeSlugPath }: KBPreviewProps) {
 }
 
 function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath?: string[] }) {
-  const { isMobile, effectiveMode, knowledgeBase } = usePreview()
+  const { isMobile, effectiveMode, knowledgeBase, previewMode, setPreviewMode } = usePreview()
   const articles = useArticleList(kbId)
 
   // Article from the editor's slug path; resets the override when the editor switches.
@@ -50,13 +50,24 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
     ? articles.find((a) => a.id === overrideId)
     : (editorArticle ?? articles[0])
   const articleId = activeArticle?.id ?? null
-  const { draftContentJson, draftDescription } = useArticleContent(articleId, kbId)
+
+  // Reset the picker to draft whenever the active article changes — covers both
+  // editor URL changes and sidebar-click overrides. Otherwise stale "Live" state
+  // would leak onto a sibling article that may not even be published.
+  useEffect(() => {
+    setPreviewMode('draft')
+  }, [articleId, setPreviewMode])
+  const { previewContentJson, previewDescription, previewTitle, previewEmoji } = useArticleContent(
+    articleId,
+    kbId,
+    previewMode
+  )
 
   const publicUrl = useKbPublicUrl(knowledgeBase?.slug)
 
   if (!knowledgeBase) return null
 
-  const docJson = (draftContentJson ?? null) as DocJSON | null
+  const docJson = (previewContentJson ?? null) as DocJSON | null
   const headings = docJson ? extractKBHeadings(docJson) : []
   const { prev, next } = articleId
     ? getArticleNeighbours(articles, articleId)
@@ -90,10 +101,19 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
               <div className='min-w-0 flex-1 @kb-lg:order-1'>
                 <KBArticleRenderer
                   doc={docJson}
-                  title={activeArticle?.title ?? articles.find((a) => a.id === articleId)?.title}
-                  emoji={activeArticle?.emoji ?? articles.find((a) => a.id === articleId)?.emoji}
-                  description={draftDescription ?? activeArticle?.description}
+                  title={
+                    previewTitle ??
+                    activeArticle?.title ??
+                    articles.find((a) => a.id === articleId)?.title
+                  }
+                  emoji={
+                    previewEmoji ??
+                    activeArticle?.emoji ??
+                    articles.find((a) => a.id === articleId)?.emoji
+                  }
+                  description={previewDescription ?? activeArticle?.description}
                   parent={parent}
+                  resolveAuxxHref={(id) => `/preview/kb/${kbId}/r/${id}`}
                 />
               </div>
             </div>
@@ -110,7 +130,7 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
 
   return (
     <div className='flex min-h-0 flex-1 flex-col'>
-      <KBPreviewTopBar kbId={kbId} activeSlugPath={activeSlugPath} />
+      <KBPreviewTopBar kbId={kbId} activeSlugPath={activeSlugPath} articleId={articleId} />
       <div className='flex min-h-0 flex-1 justify-center bg-muted p-4'>
         {isMobile ? (
           <MobilePreviewFrame>{layout}</MobilePreviewFrame>

--- a/apps/web/src/components/kb/ui/preview/preview-context.tsx
+++ b/apps/web/src/components/kb/ui/preview/preview-context.tsx
@@ -3,6 +3,7 @@
 
 import { mergeDraftOverLive } from '@auxx/lib/kb/client'
 import React from 'react'
+import type { PreviewMode } from '../../hooks/use-article-content'
 import type { KnowledgeBase } from '../../store/knowledge-base-store'
 
 export type Theme = 'light' | 'dark'
@@ -18,8 +19,11 @@ interface PreviewContextValue {
   /** Mode the preview is currently rendering: `override ?? defaultMode`. */
   effectiveMode: Theme
   isMobile: boolean
+  /** Which slice of the article body the in-editor preview pane renders. */
+  previewMode: PreviewMode
   setOverride: (t: Theme | null) => void
   setDevice: (d: Device) => void
+  setPreviewMode: (m: PreviewMode) => void
 }
 
 const PreviewContext = React.createContext<PreviewContextValue | undefined>(undefined)
@@ -32,6 +36,7 @@ interface PreviewProviderProps {
 export function PreviewProvider({ children, knowledgeBase }: PreviewProviderProps) {
   const [device, setDevice] = React.useState<Device>('desktop')
   const [override, setOverride] = React.useState<Theme | null>(null)
+  const [previewMode, setPreviewMode] = React.useState<PreviewMode>('draft')
   const [isLoading, setIsLoading] = React.useState(!knowledgeBase)
 
   React.useEffect(() => {
@@ -68,10 +73,12 @@ export function PreviewProvider({ children, knowledgeBase }: PreviewProviderProp
       override,
       effectiveMode,
       isMobile: device === 'mobile',
+      previewMode,
       setOverride,
       setDevice,
+      setPreviewMode,
     }),
-    [merged, isLoading, defaultMode, override, effectiveMode, device]
+    [merged, isLoading, defaultMode, override, effectiveMode, device, previewMode]
   )
 
   return <PreviewContext.Provider value={value}>{children}</PreviewContext.Provider>

--- a/apps/web/src/components/kb/ui/preview/preview-version-picker.tsx
+++ b/apps/web/src/components/kb/ui/preview/preview-version-picker.tsx
@@ -1,0 +1,157 @@
+// apps/web/src/components/kb/ui/preview/preview-version-picker.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
+import { Check, ChevronDown, GitBranch, Loader2 } from 'lucide-react'
+import { useState } from 'react'
+import { api } from '~/trpc/react'
+import type { PreviewMode } from '../../hooks/use-article-content'
+
+interface PreviewVersionPickerProps {
+  articleId: string
+  mode: PreviewMode
+  hasPublishedVersion: boolean
+  onModeChange: (mode: PreviewMode) => void
+  /**
+   * When true, a placeholder picker (disabled, "Draft" label) is rendered.
+   * Lets parents keep layout stable while waiting for an article id.
+   */
+  disabled?: boolean
+}
+
+function modeLabel(mode: PreviewMode, activeVersionLabel: string | null): string {
+  if (mode === 'draft') return 'Draft'
+  if (mode === 'live') return 'Live'
+  return activeVersionLabel
+    ? `v${mode.versionNumber} — ${activeVersionLabel}`
+    : `v${mode.versionNumber}`
+}
+
+function relativeTime(date: Date | string): string {
+  const ts = typeof date === 'string' ? new Date(date) : date
+  const diff = Date.now() - ts.getTime()
+  const sec = Math.round(diff / 1000)
+  const min = Math.round(sec / 60)
+  const hr = Math.round(min / 60)
+  const day = Math.round(hr / 24)
+  if (sec < 60) return 'just now'
+  if (min < 60) return `${min}m ago`
+  if (hr < 24) return `${hr}h ago`
+  if (day < 7) return `${day}d ago`
+  return ts.toLocaleDateString()
+}
+
+function isHistorical(mode: PreviewMode): mode is { versionNumber: number } {
+  return typeof mode === 'object' && mode !== null
+}
+
+/**
+ * Compact dropdown for switching the preview body between draft, the live
+ * (currently published) revision, and any historical immutable snapshot.
+ * Versions are loaded lazily on first open via `kb.getArticleVersions`.
+ */
+export function PreviewVersionPicker({
+  articleId,
+  mode,
+  hasPublishedVersion,
+  onModeChange,
+  disabled,
+}: PreviewVersionPickerProps) {
+  const [open, setOpen] = useState(false)
+  const versionsQuery = api.kb.getArticleVersions.useQuery(
+    { articleId },
+    { enabled: open && !disabled, staleTime: 30_000 }
+  )
+  const versions = versionsQuery.data ?? []
+
+  const activeVersion = isHistorical(mode)
+    ? versions.find((v) => v.versionNumber === mode.versionNumber)
+    : undefined
+  const triggerLabel = modeLabel(mode, activeVersion?.label ?? null)
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild disabled={disabled}>
+        <Button variant='outline' size='xs' className='gap-1' aria-label='Switch preview version'>
+          <GitBranch />
+          <span className='max-w-[160px] truncate'>{triggerLabel}</span>
+          <ChevronDown />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align='start' className='min-w-[260px]'>
+        <DropdownMenuLabel className='text-xs text-muted-foreground'>
+          Preview content
+        </DropdownMenuLabel>
+        <DropdownMenuItem onSelect={() => onModeChange('draft')}>
+          <Check className={mode === 'draft' ? 'opacity-100' : 'opacity-0'} />
+          <span>Draft</span>
+          <span className='ml-auto text-xs text-muted-foreground'>in progress</span>
+        </DropdownMenuItem>
+        {hasPublishedVersion ? (
+          <DropdownMenuItem onSelect={() => onModeChange('live')}>
+            <Check className={mode === 'live' ? 'opacity-100' : 'opacity-0'} />
+            <span>Live</span>
+            <span className='ml-auto text-xs text-muted-foreground'>currently published</span>
+          </DropdownMenuItem>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div>
+                <DropdownMenuItem disabled>
+                  <Check className='opacity-0' />
+                  <span>Live</span>
+                  <span className='ml-auto text-xs text-muted-foreground'>not published</span>
+                </DropdownMenuItem>
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>This article has no published version yet.</TooltipContent>
+          </Tooltip>
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className='text-xs text-muted-foreground'>
+          Version history
+        </DropdownMenuLabel>
+        {versionsQuery.isLoading ? (
+          <div className='flex items-center justify-center py-4'>
+            <Loader2 className='size-4 animate-spin text-muted-foreground' />
+          </div>
+        ) : versions.length === 0 ? (
+          <div className='px-2 py-3 text-xs text-muted-foreground'>No published versions yet.</div>
+        ) : (
+          versions.map((v) => {
+            const isActive = isHistorical(mode) && mode.versionNumber === v.versionNumber
+            return (
+              <DropdownMenuItem
+                key={v.id}
+                onSelect={() => {
+                  if (v.versionNumber !== null) {
+                    onModeChange({ versionNumber: v.versionNumber })
+                  }
+                }}>
+                <Check className={isActive ? 'opacity-100' : 'opacity-0'} />
+                <div className='flex min-w-0 flex-1 flex-col'>
+                  <span className='truncate text-sm'>
+                    v{v.versionNumber}
+                    {v.label ? ` — ${v.label}` : ''}
+                  </span>
+                </div>
+                <span className='ml-2 shrink-0 text-xs text-muted-foreground'>
+                  {relativeTime(v.createdAt)}
+                </span>
+              </DropdownMenuItem>
+            )
+          })
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/src/server/api/routers/kb.ts
+++ b/apps/web/src/server/api/routers/kb.ts
@@ -226,9 +226,19 @@ export const knowledgeBaseRouter = createTRPCRouter({
     }),
 
   getArticleById: protectedProcedure
-    .input(z.object({ id: z.string(), knowledgeBaseId: z.string().optional() }))
+    .input(
+      z.object({
+        id: z.string(),
+        knowledgeBaseId: z.string().optional(),
+        versionNumber: z.number().int().positive().optional(),
+      })
+    )
     .query(async ({ ctx, input }) => {
-      return await getKBService(ctx).getArticleById(input.id, input.knowledgeBaseId)
+      return await getKBService(ctx).getArticleById(
+        input.id,
+        input.knowledgeBaseId,
+        input.versionNumber
+      )
     }),
 
   getArticleBySlug: protectedProcedure

--- a/packages/lib/src/kb/kb-service.ts
+++ b/packages/lib/src/kb/kb-service.ts
@@ -53,6 +53,14 @@ export interface ArticleEditorView extends ArticleListItem {
   publishedTitle: string | null
   publishedContent: string | null
   publishedContentJson: unknown
+  // Populated only when getArticleById is called with a versionNumber.
+  selectedVersionNumber: number | null
+  selectedTitle: string | null
+  selectedDescription: string | null
+  selectedExcerpt: string | null
+  selectedEmoji: string | null
+  selectedContent: string | null
+  selectedContentJson: unknown
 }
 
 // ─── KB / Article input shapes ───────────────────────────────────────────
@@ -427,9 +435,15 @@ export class KBService {
 
   /**
    * Editor view: returns the article with its draft revision content + a hint
-   * of the published revision content for "discard draft" previews.
+   * of the published revision content for "discard draft" previews. Pass
+   * `versionNumber` to additionally include the content of an immutable
+   * historical revision in the `selected*` fields.
    */
-  async getArticleById(id: string, knowledgeBaseId?: string): Promise<ArticleEditorView> {
+  async getArticleById(
+    id: string,
+    knowledgeBaseId?: string,
+    versionNumber?: number
+  ): Promise<ArticleEditorView> {
     try {
       const article = await this.db.query.Article.findFirst({
         where: and(
@@ -440,7 +454,21 @@ export class KBService {
         with: { publishedRevision: true, draftRevision: true },
       })
       if (!article) throw this.createNotFoundError(`Article with ID '${id}' not found`)
-      return this.flattenForEditor(article)
+      let selected: ArticleRevision | null = null
+      if (versionNumber !== undefined) {
+        const revision = await this.db.query.ArticleRevision.findFirst({
+          where: and(
+            eq(schema.ArticleRevision.articleId, id),
+            eq(schema.ArticleRevision.organizationId, this.organizationId),
+            eq(schema.ArticleRevision.versionNumber, versionNumber)
+          ),
+        })
+        if (!revision) {
+          throw this.createNotFoundError(`Version ${versionNumber} not found for article '${id}'`)
+        }
+        selected = revision
+      }
+      return this.flattenForEditor(article, selected)
     } catch (error) {
       return this.handleError(error, 'Error fetching article', { articleId: id })
     }
@@ -1402,7 +1430,7 @@ export class KBService {
     }
   }
 
-  private flattenForEditor(a: any): ArticleEditorView {
+  private flattenForEditor(a: any, selected: ArticleRevision | null = null): ArticleEditorView {
     const draft = a.draftRevision
     const pub = a.publishedRevision
     if (!draft) {
@@ -1435,6 +1463,13 @@ export class KBService {
       publishedTitle: pub?.title ?? null,
       publishedContent: pub?.content ?? null,
       publishedContentJson: pub?.contentJson ?? null,
+      selectedVersionNumber: selected?.versionNumber ?? null,
+      selectedTitle: selected?.title ?? null,
+      selectedDescription: selected?.description ?? null,
+      selectedExcerpt: selected?.excerpt ?? null,
+      selectedEmoji: selected?.emoji ?? null,
+      selectedContent: selected?.content ?? null,
+      selectedContentJson: selected?.contentJson ?? null,
     }
   }
 

--- a/packages/lib/src/kb/markdown/__tests__/cards.test.ts
+++ b/packages/lib/src/kb/markdown/__tests__/cards.test.ts
@@ -1,0 +1,98 @@
+// packages/lib/src/kb/markdown/__tests__/cards.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { blocksToMd } from '../blocks-to-md'
+import { mdToBlocks } from '../md-to-blocks'
+import type { DocJSON } from '../types'
+
+describe('cards markdown serialization', () => {
+  it('renders a cards block to :::cards / ::card directives', () => {
+    const doc: DocJSON = {
+      type: 'doc',
+      content: [
+        {
+          type: 'block',
+          attrs: {
+            blockType: 'cards',
+            cards: [
+              {
+                id: 'c1',
+                title: 'Getting Started',
+                href: '/getting-started',
+                iconId: 'rocket',
+                description: 'Set up your account in minutes',
+              },
+              {
+                id: 'c2',
+                title: 'API Reference',
+                href: 'auxx://kb/article/abc123',
+                iconId: 'code',
+              },
+            ],
+          },
+          content: [],
+        },
+      ],
+    }
+    const md = blocksToMd(doc)
+    expect(md).toContain(':::cards')
+    expect(md).toContain('::card{title="Getting Started"')
+    expect(md).toContain('href="/getting-started"')
+    expect(md).toContain('href="auxx://kb/article/abc123"')
+    expect(md).toContain('icon="rocket"')
+    expect(md).toContain('Set up your account in minutes')
+    expect(md.trim().endsWith(':::')).toBe(true)
+  })
+
+  it('parses :::cards directive back into a cards block', () => {
+    const md = `:::cards
+::card{title="Docs" href="/docs" icon="file-text" description="Read the docs"}
+::card{title="Reference" href="auxx://kb/article/xyz"}
+:::
+`
+    const doc = mdToBlocks(md)
+    const block = doc.content[0]
+    expect(block?.attrs.blockType).toBe('cards')
+    const cards = block?.attrs.cards ?? []
+    expect(cards).toHaveLength(2)
+    expect(cards[0]).toMatchObject({
+      title: 'Docs',
+      href: '/docs',
+      iconId: 'file-text',
+      description: 'Read the docs',
+    })
+    expect(cards[1]).toMatchObject({
+      title: 'Reference',
+      href: 'auxx://kb/article/xyz',
+    })
+  })
+
+  it('round-trips the structure (auxx:// hrefs and icons survive)', () => {
+    const original: DocJSON = {
+      type: 'doc',
+      content: [
+        {
+          type: 'block',
+          attrs: {
+            blockType: 'cards',
+            cards: [
+              {
+                id: 'c1',
+                title: 'Foo',
+                href: 'auxx://kb/article/abc',
+                iconId: 'rocket',
+              },
+            ],
+          },
+          content: [],
+        },
+      ],
+    }
+    const md = blocksToMd(original)
+    const reparsed = mdToBlocks(md)
+    const card = reparsed.content[0]?.attrs.cards?.[0]
+    expect(card?.title).toBe('Foo')
+    expect(card?.href).toBe('auxx://kb/article/abc')
+    expect(card?.iconId).toBe('rocket')
+  })
+})

--- a/packages/lib/src/kb/markdown/blocks-to-md.ts
+++ b/packages/lib/src/kb/markdown/blocks-to-md.ts
@@ -8,6 +8,7 @@ import type {
   BlockAttrs,
   BlockJSON,
   CalloutVariant,
+  CardData,
   DocJSON,
   EmbedAspect,
   EmbedProvider,
@@ -103,9 +104,30 @@ function renderBlock(block: BlockJSON, ctx: RenderCtx): string[] {
       return renderCallout(attrs.calloutVariant, inline)
     case 'embed':
       return [renderEmbed(attrs)]
+    case 'cards':
+      return renderCards(attrs.cards)
     default:
       return inline.length > 0 ? [inline] : []
   }
+}
+
+function renderCards(cards: CardData[] | undefined): string[] {
+  if (!Array.isArray(cards) || cards.length === 0) return []
+  const out: string[] = [':::cards']
+  for (const card of cards) {
+    const parts: string[] = [`title="${escapeAttrValue(card.title ?? '')}"`]
+    if (card.href) parts.push(`href="${escapeAttrValue(card.href)}"`)
+    if (card.iconId) parts.push(`icon="${escapeAttrValue(card.iconId)}"`)
+    if (card.description) {
+      // Description is markdown-lite; we keep it on the attribute line so
+      // each card stays a single leaf directive (`::card{...}`). Newlines
+      // inside the description are preserved as `\n` literals.
+      parts.push(`description="${escapeAttrValue(card.description)}"`)
+    }
+    out.push(`::card{${parts.join(' ')}}`)
+  }
+  out.push(':::')
+  return out
 }
 
 function clampLevel(value: unknown, min: number, max: number): number {

--- a/packages/lib/src/kb/markdown/md-to-blocks.ts
+++ b/packages/lib/src/kb/markdown/md-to-blocks.ts
@@ -3,6 +3,7 @@
 // Parses markdown (Auxx MD dialect — GFM + remark-directive) into the KB
 // editor's BlockJSON shape. See plans/kb/markdown-support.md for the spec.
 
+import { generateId } from '@auxx/utils'
 import remarkDirective from 'remark-directive'
 import remarkGfm from 'remark-gfm'
 import remarkParse from 'remark-parse'
@@ -12,6 +13,7 @@ import type {
   BlockJSON,
   BlockType,
   CalloutVariant,
+  CardData,
   DocJSON,
   EmbedAspect,
   EmbedProvider,
@@ -182,6 +184,11 @@ function walkBlock(node: MdastNode, ctx: ParseCtx, level: number): void {
           }
         }
         pushBlock(ctx, 'callout', inline, { calloutVariant: variant })
+        return
+      }
+      if (node.name === 'cards') {
+        const cards = parseCardsContainer(node)
+        if (cards.length > 0) pushBlock(ctx, 'cards', [], { cards })
         return
       }
       // Unknown container — flatten its children.
@@ -535,6 +542,42 @@ function parseImageTrailer(body: string): Partial<BlockAttrs> {
 }
 
 // ─── directive helpers ───────────────────────────────────────────────
+
+function parseCardsContainer(container: MdastNode): CardData[] {
+  const out: CardData[] = []
+  // Each child can come through as a leafDirective (single-line `::card{...}`)
+  // or — if remark-directive wrapped the line into a paragraph — a paragraph
+  // whose only child is a textDirective. Walk both.
+  const walk = (nodes: MdastNode[] | undefined) => {
+    if (!nodes) return
+    for (const child of nodes) {
+      if (
+        (child.type === 'leafDirective' || child.type === 'containerDirective') &&
+        child.name === 'card'
+      ) {
+        out.push(buildCardFromDirective(child))
+        continue
+      }
+      if (child.type === 'paragraph' && Array.isArray(child.children)) {
+        walk(child.children)
+      }
+    }
+  }
+  walk(container.children)
+  return out
+}
+
+function buildCardFromDirective(node: MdastNode): CardData {
+  const attrs = node.attributes ?? {}
+  return {
+    id: generateId(),
+    title: typeof attrs.title === 'string' ? attrs.title : '',
+    href: typeof attrs.href === 'string' && attrs.href ? attrs.href : undefined,
+    iconId: typeof attrs.icon === 'string' && attrs.icon ? attrs.icon : undefined,
+    description:
+      typeof attrs.description === 'string' && attrs.description ? attrs.description : undefined,
+  }
+}
 
 function pickCalloutVariant(name: string | undefined): CalloutVariant | null {
   if (!name) return null

--- a/packages/lib/src/kb/markdown/types.ts
+++ b/packages/lib/src/kb/markdown/types.ts
@@ -17,11 +17,20 @@ export type BlockType =
   | 'codeBlock'
   | 'callout'
   | 'embed'
+  | 'cards'
 
 export type ImageAlign = 'left' | 'center' | 'right'
 export type CalloutVariant = 'info' | 'warn' | 'error' | 'tip' | 'success'
 export type EmbedProvider = 'youtube' | 'loom' | 'vimeo'
 export type EmbedAspect = '16:9' | '4:3' | '1:1'
+
+export interface CardData {
+  id: string
+  title: string
+  description?: string
+  href?: string
+  iconId?: string
+}
 
 export interface BlockAttrs {
   blockType: BlockType
@@ -36,6 +45,7 @@ export interface BlockAttrs {
   embedUrl?: string
   embedProvider?: EmbedProvider
   embedAspect?: EmbedAspect
+  cards?: CardData[]
 }
 
 export type InlineMarkType =

--- a/packages/ui/src/components/kb/article/block-renderer.tsx
+++ b/packages/ui/src/components/kb/article/block-renderer.tsx
@@ -3,20 +3,22 @@
 import { parseEmbedUrl } from '../utils/embed'
 import { walkInlineToText } from '../utils/inline-text'
 import { CalloutIcon } from './callout-icon'
+import { CardItem } from './card-item'
 import { ImageZoomable } from './image-zoomable'
 import { InlineRenderer } from './inline-renderer'
 import styles from './kb-article-renderer.module.css'
-import type { BlockJSON, CalloutVariant, DocJSON } from './types'
+import type { BlockJSON, CalloutVariant, CardData, DocJSON, ResolveAuxxHref } from './types'
 
 interface BlockRendererProps {
   node: BlockJSON
   idx: number
   doc: DocJSON
   headingIds?: Record<number, string>
+  resolveAuxxHref?: ResolveAuxxHref
 }
 
-export function BlockRenderer({ node, idx, doc, headingIds }: BlockRendererProps) {
-  const inline = <InlineRenderer content={node.content} />
+export function BlockRenderer({ node, idx, doc, headingIds, resolveAuxxHref }: BlockRendererProps) {
+  const inline = <InlineRenderer content={node.content} resolveAuxxHref={resolveAuxxHref} />
   const blockType = node.attrs?.blockType ?? 'text'
 
   switch (blockType) {
@@ -142,6 +144,18 @@ export function BlockRenderer({ node, idx, doc, headingIds }: BlockRendererProps
             title={`${parsed.provider} embed`}
             loading='lazy'
           />
+        </div>
+      )
+    }
+
+    case 'cards': {
+      const cards = (node.attrs?.cards ?? []) as CardData[]
+      if (cards.length === 0) return null
+      return (
+        <div className={styles.cardsGrid} role='list'>
+          {cards.map((c) => (
+            <CardItem key={c.id} card={c} resolveAuxxHref={resolveAuxxHref} />
+          ))}
         </div>
       )
     }

--- a/packages/ui/src/components/kb/article/card-item.tsx
+++ b/packages/ui/src/components/kb/article/card-item.tsx
@@ -1,0 +1,91 @@
+// packages/ui/src/components/kb/article/card-item.tsx
+//
+// Server component. Renders a single card inside a `cards` block. The `href`
+// is one of:
+//   - `auxx://kb/article/{id}` — emitted as the consumer-controlled redirect
+//     route (default `/r/{id}`); the server resolves the slug on click.
+//   - http(s)/mailto raw URL — used verbatim, opens in a new tab.
+//   - empty / unsupported — non-interactive card surface.
+
+import { EntityIcon } from '@auxx/ui/components/icons'
+import type { ReactNode } from 'react'
+import { renderMarkdownLite } from '../utils/markdown-lite'
+import styles from './kb-article-renderer.module.css'
+import type { CardData, ResolveAuxxHref } from './types'
+
+const AUXX_KB_PREFIX = 'auxx://kb/article/'
+
+interface CardItemProps {
+  card: CardData
+  resolveAuxxHref?: ResolveAuxxHref
+}
+
+interface ResolvedHref {
+  href: string
+  external: boolean
+}
+
+const defaultResolveAuxxHref: ResolveAuxxHref = (id) => `/r/${id}`
+
+function resolveHref(
+  raw: string | undefined,
+  resolveAuxxHref: ResolveAuxxHref
+): ResolvedHref | null {
+  const trimmed = raw?.trim()
+  if (!trimmed) return null
+  if (trimmed.startsWith(AUXX_KB_PREFIX)) {
+    const articleId = trimmed.slice(AUXX_KB_PREFIX.length)
+    if (!articleId) return null
+    return { href: resolveAuxxHref(articleId), external: false }
+  }
+  if (
+    trimmed.startsWith('http://') ||
+    trimmed.startsWith('https://') ||
+    trimmed.startsWith('mailto:') ||
+    trimmed.startsWith('/')
+  ) {
+    return { href: trimmed, external: !trimmed.startsWith('/') }
+  }
+  return null
+}
+
+export function CardItem({ card, resolveAuxxHref }: CardItemProps) {
+  const resolver = resolveAuxxHref ?? defaultResolveAuxxHref
+  const resolved = resolveHref(card.href, resolver)
+
+  const body: ReactNode = (
+    <>
+      {card.iconId ? (
+        <span className={styles.cardIcon} aria-hidden='true'>
+          <EntityIcon iconId={card.iconId} variant='bare' size='sm' />
+        </span>
+      ) : null}
+      <span className={styles.cardTitle}>{card.title || 'Untitled'}</span>
+      {card.description ? (
+        <span className={styles.cardDescription}>
+          {renderMarkdownLite(card.description, { resolveAuxxHref: resolver })}
+        </span>
+      ) : null}
+    </>
+  )
+
+  if (!resolved) {
+    return (
+      <div className={styles.kbCard} data-interactive='false' role='listitem'>
+        {body}
+      </div>
+    )
+  }
+
+  return (
+    <a
+      className={styles.kbCard}
+      data-interactive='true'
+      role='listitem'
+      href={resolved.href}
+      target={resolved.external ? '_blank' : undefined}
+      rel={resolved.external ? 'noopener noreferrer' : undefined}>
+      {body}
+    </a>
+  )
+}

--- a/packages/ui/src/components/kb/article/index.ts
+++ b/packages/ui/src/components/kb/article/index.ts
@@ -14,6 +14,7 @@ export type {
   BlockJSON,
   BlockType,
   CalloutVariant,
+  CardData,
   DocJSON,
   EmbedAspect,
   EmbedProvider,
@@ -21,4 +22,5 @@ export type {
   InlineJSON,
   InlineMarkType,
   MarkJSON,
+  ResolveAuxxHref,
 } from './types'

--- a/packages/ui/src/components/kb/article/inline-renderer.tsx
+++ b/packages/ui/src/components/kb/article/inline-renderer.tsx
@@ -1,26 +1,37 @@
 // packages/ui/src/components/kb/article/inline-renderer.tsx
 
 import type { Fragment, ReactNode } from 'react'
-import type { InlineJSON, MarkJSON } from './types'
+import type { InlineJSON, MarkJSON, ResolveAuxxHref } from './types'
 
 interface InlineRendererProps {
   content: InlineJSON[] | undefined
+  resolveAuxxHref?: ResolveAuxxHref
 }
 
-export function InlineRenderer({ content }: InlineRendererProps) {
+const AUXX_KB_PREFIX = 'auxx://kb/article/'
+
+const defaultResolveAuxxHref: ResolveAuxxHref = (id) => `/r/${id}`
+
+export function InlineRenderer({ content, resolveAuxxHref }: InlineRendererProps) {
   if (!content || content.length === 0) return null
+  const resolver = resolveAuxxHref ?? defaultResolveAuxxHref
   return (
     <>
       {content.map((node, idx) => (
         // Tiptap inline nodes share neither id nor stable key; idx is the only option.
         // biome-ignore lint/suspicious/noArrayIndexKey: inline order is stable per render
-        <InlineNode key={idx} node={node} />
+        <InlineNode key={idx} node={node} resolveAuxxHref={resolver} />
       ))}
     </>
   )
 }
 
-function InlineNode({ node }: { node: InlineJSON }) {
+interface InlineNodeProps {
+  node: InlineJSON
+  resolveAuxxHref: ResolveAuxxHref
+}
+
+function InlineNode({ node, resolveAuxxHref }: InlineNodeProps) {
   if (node.type === 'placeholder') {
     const label = (node.attrs?.label as string | undefined) ?? ''
     return (
@@ -34,18 +45,18 @@ function InlineNode({ node }: { node: InlineJSON }) {
   const text = node.text ?? ''
   if (!text) return null
 
-  return applyMarks(text, node.marks ?? [])
+  return applyMarks(text, node.marks ?? [], resolveAuxxHref)
 }
 
-function applyMarks(text: string, marks: MarkJSON[]): ReactNode {
+function applyMarks(text: string, marks: MarkJSON[], resolveAuxxHref: ResolveAuxxHref): ReactNode {
   let node: ReactNode = text
   for (const mark of marks) {
-    node = wrapMark(node, mark)
+    node = wrapMark(node, mark, resolveAuxxHref)
   }
   return node
 }
 
-function wrapMark(node: ReactNode, mark: MarkJSON): ReactNode {
+function wrapMark(node: ReactNode, mark: MarkJSON, resolveAuxxHref: ResolveAuxxHref): ReactNode {
   switch (mark.type) {
     case 'bold':
       return <strong>{node}</strong>
@@ -60,11 +71,22 @@ function wrapMark(node: ReactNode, mark: MarkJSON): ReactNode {
     case 'highlight':
       return <mark className='kb-mark'>{node}</mark>
     case 'link': {
-      const href = (mark.attrs?.href as string | undefined) ?? '#'
-      const target = (mark.attrs?.target as string | undefined) ?? undefined
+      const rawHref = (mark.attrs?.href as string | undefined) ?? '#'
+      // Internal auxx:// link — the consumer's redirect handler resolves
+      // the article id to the canonical URL on click.
+      if (rawHref.startsWith(AUXX_KB_PREFIX)) {
+        const articleId = rawHref.slice(AUXX_KB_PREFIX.length)
+        return (
+          <a className='kb-link' href={resolveAuxxHref(articleId)}>
+            {node}
+          </a>
+        )
+      }
+      const explicitTarget = mark.attrs?.target as string | undefined
+      const target = explicitTarget ?? '_blank'
       const rel = target === '_blank' ? 'noopener noreferrer' : undefined
       return (
-        <a className='kb-link' href={href} target={target} rel={rel}>
+        <a className='kb-link' href={rawHref} target={target} rel={rel}>
           {node}
         </a>
       )

--- a/packages/ui/src/components/kb/article/kb-article-renderer.module.css
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.module.css
@@ -400,3 +400,57 @@
     opacity: 1;
   }
 }
+
+/* ============================================
+   Cards block
+   ============================================ */
+
+.cardsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.75rem;
+  margin: 1.25rem 0;
+}
+
+.kbCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid var(--kb-border);
+  border-radius: var(--kb-radius);
+  background: var(--kb-bg, transparent);
+  color: var(--kb-fg);
+  text-decoration: none;
+  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+}
+
+.kbCard[data-interactive='true']:hover {
+  transform: translateY(-1px);
+  border-color: var(--kb-primary);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--kb-fg) 8%, transparent);
+}
+
+.kbCard[data-interactive='false'] {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.cardIcon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--kb-primary);
+}
+
+.cardTitle {
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.cardDescription {
+  display: block;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  opacity: 0.85;
+}

--- a/packages/ui/src/components/kb/article/kb-article-renderer.tsx
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.tsx
@@ -7,7 +7,7 @@ import { BlockRenderer } from './block-renderer'
 import { extractKBHeadings, type KBHeading } from './extract-headings'
 import styles from './kb-article-renderer.module.css'
 import { KBTableOfContentsDrawer } from './kb-toc-drawer'
-import type { DocJSON } from './types'
+import type { DocJSON, ResolveAuxxHref } from './types'
 
 interface KBArticleRendererProps {
   doc: DocJSON | null | undefined
@@ -25,6 +25,10 @@ interface KBArticleRendererProps {
    * (`@auxx/lib/kb/markdown`) lives outside the UI package's dep tier.
    */
   copyMenu?: ReactNode
+  /** Override how `auxx://kb/article/{id}` link/card hrefs are emitted.
+   * Defaults to `/r/{id}` — public KB hosts a redirect handler at that
+   * path. Preview/embed contexts override to nest under their URL prefix. */
+  resolveAuxxHref?: ResolveAuxxHref
 }
 
 export function KBArticleRenderer({
@@ -35,6 +39,7 @@ export function KBArticleRenderer({
   updatedAt,
   parent,
   copyMenu,
+  resolveAuxxHref,
 }: KBArticleRendererProps) {
   const headings = doc ? extractKBHeadings(doc) : []
   const headingIds = doc ? buildHeadingIdMap(doc, headings) : {}
@@ -78,8 +83,15 @@ export function KBArticleRenderer({
         </header>
       ) : null}
       {doc?.content?.map((node, idx) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: block order is stable per render
-        <BlockRenderer key={idx} node={node} idx={idx} doc={doc} headingIds={headingIds} />
+        <BlockRenderer
+          // biome-ignore lint/suspicious/noArrayIndexKey: block order is stable per render
+          key={idx}
+          node={node}
+          idx={idx}
+          doc={doc}
+          headingIds={headingIds}
+          resolveAuxxHref={resolveAuxxHref}
+        />
       ))}
     </article>
   )

--- a/packages/ui/src/components/kb/article/types.ts
+++ b/packages/ui/src/components/kb/article/types.ts
@@ -12,11 +12,24 @@ export type BlockType =
   | 'codeBlock'
   | 'callout'
   | 'embed'
+  | 'cards'
 
 export type ImageAlign = 'left' | 'center' | 'right'
 export type CalloutVariant = 'info' | 'warn' | 'error' | 'tip' | 'success'
 export type EmbedProvider = 'youtube' | 'loom' | 'vimeo'
 export type EmbedAspect = '16:9' | '4:3' | '1:1'
+
+export interface CardData {
+  /** Stable id used for drag-reorder + React keys (`@auxx/utils` `generateId`). */
+  id: string
+  title: string
+  /** Markdown-lite (`*bold*`, `_italic_`, `` `code` ``, `[label](url)`). */
+  description?: string
+  /** Either an `auxx://kb/article/{id}` ref or a raw URL. Empty = non-interactive. */
+  href?: string
+  /** EntityIcon registry id. */
+  iconId?: string
+}
 
 export interface BlockAttrs {
   blockType: BlockType
@@ -31,6 +44,7 @@ export interface BlockAttrs {
   embedUrl?: string
   embedProvider?: EmbedProvider
   embedAspect?: EmbedAspect
+  cards?: CardData[]
 }
 
 export interface BlockJSON {
@@ -64,3 +78,11 @@ export interface DocJSON {
   type: 'doc'
   content: BlockJSON[]
 }
+
+/**
+ * Map an `auxx://kb/article/{id}` reference to the href the renderer should
+ * emit. Defaults to `/r/{id}` so the public KB app can host a redirect
+ * route at that path; preview/embed contexts override this to nest under
+ * their own URL prefix.
+ */
+export type ResolveAuxxHref = (articleId: string) => string

--- a/packages/ui/src/components/kb/utils/article-paths.ts
+++ b/packages/ui/src/components/kb/utils/article-paths.ts
@@ -174,12 +174,34 @@ export function getArticleSlugPaths<T extends ArticleSlugFields>(
 }
 
 /**
+ * Which slice of the article the preview route should render. Mirrors
+ * the `PreviewMode` union from `apps/web` but kept inline here so the UI
+ * package doesn't take a dependency on a hook in the web app.
+ */
+export type PreviewModeArg = 'draft' | 'live' | { versionNumber: number } | undefined
+
+function previewModeToToken(mode: PreviewModeArg): string | null {
+  if (!mode || mode === 'draft') return null
+  if (mode === 'live') return 'live'
+  return String(mode.versionNumber)
+}
+
+/**
  * URL for the in-app fullscreen preview route
  * (`/preview/kb/{kbId}/{...articleSlug}`). Pass the slug path either as an
- * array of segments or as a slash-joined string.
+ * array of segments or as a slash-joined string. Pass `mode` to deep-link
+ * to a specific revision (live or historical) via the `?v=` query param;
+ * sidebar links between articles deliberately omit the mode so navigation
+ * resets to draft.
  */
-export function getKbPreviewHref(kbId: string, slugPath: string[] | string = []): string {
+export function getKbPreviewHref(
+  kbId: string,
+  slugPath: string[] | string = [],
+  mode?: PreviewModeArg
+): string {
   const segments = typeof slugPath === 'string' ? (slugPath ? slugPath.split('/') : []) : slugPath
   const segment = segments.length > 0 ? `/${segments.map(encodeURIComponent).join('/')}` : ''
-  return `/preview/kb/${kbId}${segment}`
+  const token = previewModeToToken(mode)
+  const query = token ? `?v=${token}` : ''
+  return `/preview/kb/${kbId}${segment}${query}`
 }

--- a/packages/ui/src/components/kb/utils/index.ts
+++ b/packages/ui/src/components/kb/utils/index.ts
@@ -22,3 +22,4 @@ export {
 } from './article-tree'
 export { type EmbedProvider, type ParsedEmbed, parseEmbedUrl } from './embed'
 export { extractHeadings, extractPlainText, walkInlineToText } from './inline-text'
+export { renderMarkdownLite } from './markdown-lite'

--- a/packages/ui/src/components/kb/utils/markdown-lite.tsx
+++ b/packages/ui/src/components/kb/utils/markdown-lite.tsx
@@ -1,0 +1,94 @@
+// packages/ui/src/components/kb/utils/markdown-lite.tsx
+//
+// Tiny dependency-free renderer for the inline markdown subset used inside
+// `cards` block descriptions: `*bold*`, `_italic_`, `` `code` ``, and
+// `[label](url)`. Anything that doesn't tokenize falls through as plain text.
+
+import type { ReactNode } from 'react'
+
+interface RenderOpts {
+  /** Map an `auxx://kb/article/{id}` URL inside the description to the href
+   * the renderer should emit. Defaults to `/r/{id}`. */
+  resolveAuxxHref?: (articleId: string) => string
+}
+
+const AUXX_KB_PREFIX = 'auxx://kb/article/'
+
+const defaultResolveAuxxHref = (id: string) => `/r/${id}`
+
+export function renderMarkdownLite(source: string | undefined, opts: RenderOpts = {}): ReactNode {
+  if (!source) return null
+  const resolver = opts.resolveAuxxHref ?? defaultResolveAuxxHref
+  const tokens = tokenize(source)
+  return tokens.map((tok, i) => {
+    switch (tok.kind) {
+      case 'text':
+        // biome-ignore lint/suspicious/noArrayIndexKey: token order is stable per render
+        return <span key={i}>{tok.value}</span>
+      case 'bold':
+        // biome-ignore lint/suspicious/noArrayIndexKey: token order is stable per render
+        return <strong key={i}>{tok.value}</strong>
+      case 'italic':
+        // biome-ignore lint/suspicious/noArrayIndexKey: token order is stable per render
+        return <em key={i}>{tok.value}</em>
+      case 'code':
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: token order is stable per render
+          <code key={i} className='kb-inline-code'>
+            {tok.value}
+          </code>
+        )
+      case 'link': {
+        const href = tok.url.startsWith(AUXX_KB_PREFIX)
+          ? resolver(tok.url.slice(AUXX_KB_PREFIX.length))
+          : tok.url
+        const isExternal = !href.startsWith('/')
+        return (
+          <a
+            // biome-ignore lint/suspicious/noArrayIndexKey: token order is stable per render
+            key={i}
+            href={href}
+            className='kb-link'
+            target={isExternal ? '_blank' : undefined}
+            rel={isExternal ? 'noopener noreferrer' : undefined}>
+            {tok.label}
+          </a>
+        )
+      }
+    }
+  })
+}
+
+type Token =
+  | { kind: 'text'; value: string }
+  | { kind: 'bold'; value: string }
+  | { kind: 'italic'; value: string }
+  | { kind: 'code'; value: string }
+  | { kind: 'link'; label: string; url: string }
+
+const RE = /(`[^`]+`)|(\[[^\]]+\]\([^)\s]+\))|(\*[^*]+\*)|(_[^_]+_)/g
+
+function tokenize(input: string): Token[] {
+  const out: Token[] = []
+  let last = 0
+  for (const m of input.matchAll(RE)) {
+    const idx = m.index ?? 0
+    if (idx > last) out.push({ kind: 'text', value: input.slice(last, idx) })
+    const raw = m[0]
+    if (raw.startsWith('`')) {
+      out.push({ kind: 'code', value: raw.slice(1, -1) })
+    } else if (raw.startsWith('[')) {
+      const close = raw.indexOf('](')
+      const label = raw.slice(1, close)
+      const url = raw.slice(close + 2, -1)
+      out.push({ kind: 'link', label, url })
+    } else if (raw.startsWith('*')) {
+      out.push({ kind: 'bold', value: raw.slice(1, -1) })
+    } else {
+      out.push({ kind: 'italic', value: raw.slice(1, -1) })
+    }
+    last = idx + raw.length
+  }
+  if (last < input.length) out.push({ kind: 'text', value: input.slice(last) })
+  return out
+}

--- a/packages/utils/src/__tests__/url.test.ts
+++ b/packages/utils/src/__tests__/url.test.ts
@@ -1,0 +1,46 @@
+// packages/utils/src/__tests__/url.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { buildAuxxArticleUrl, isAuxxUrl, parseAuxxArticleUrl } from '../url'
+
+describe('buildAuxxArticleUrl', () => {
+  it('builds the canonical URI', () => {
+    expect(buildAuxxArticleUrl('abc123')).toBe('auxx://kb/article/abc123')
+  })
+})
+
+describe('parseAuxxArticleUrl', () => {
+  it('round-trips a built URL', () => {
+    const ref = parseAuxxArticleUrl(buildAuxxArticleUrl('abc123'))
+    expect(ref).toEqual({ kind: 'kb-article', articleId: 'abc123' })
+  })
+
+  it('returns null for non-matching prefix', () => {
+    expect(parseAuxxArticleUrl('https://example.com')).toBeNull()
+    expect(parseAuxxArticleUrl('auxx://record/abc')).toBeNull()
+    expect(parseAuxxArticleUrl('auxx://kb/folder/abc')).toBeNull()
+  })
+
+  it('returns null for empty id', () => {
+    expect(parseAuxxArticleUrl('auxx://kb/article/')).toBeNull()
+  })
+
+  it('returns null for non-string input', () => {
+    expect(parseAuxxArticleUrl(null)).toBeNull()
+    expect(parseAuxxArticleUrl(undefined)).toBeNull()
+  })
+})
+
+describe('isAuxxUrl', () => {
+  it('matches any auxx-prefixed URL', () => {
+    expect(isAuxxUrl('auxx://kb/article/abc')).toBe(true)
+    expect(isAuxxUrl('auxx://record/123')).toBe(true)
+  })
+
+  it('rejects external URLs', () => {
+    expect(isAuxxUrl('https://example.com')).toBe(false)
+    expect(isAuxxUrl('mailto:a@b.com')).toBe(false)
+    expect(isAuxxUrl('')).toBe(false)
+    expect(isAuxxUrl(null)).toBe(false)
+  })
+})

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -160,8 +160,12 @@ export {
 export * from './timezone'
 // URL utilities
 export {
+  type AuxxArticleRef,
+  buildAuxxArticleUrl,
   deriveTitleFromUrl,
   formatUrlForDisplay,
+  isAuxxUrl,
   isLikelyUrlInput,
   normalizeUrl,
+  parseAuxxArticleUrl,
 } from './url'

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -67,3 +67,32 @@ export function deriveTitleFromUrl(url: string): string {
     return url
   }
 }
+
+// ─── auxx:// internal URI scheme ─────────────────────────────────────
+//
+// Internal references inside the product use opaque `auxx://...` URIs that
+// resolve to the current slug at render time. This keeps links stable when
+// the targeted entity is renamed.
+
+const AUXX_KB_ARTICLE_PREFIX = 'auxx://kb/article/'
+
+export interface AuxxArticleRef {
+  kind: 'kb-article'
+  articleId: string
+}
+
+export function buildAuxxArticleUrl(articleId: string): string {
+  return `${AUXX_KB_ARTICLE_PREFIX}${articleId}`
+}
+
+export function isAuxxUrl(url: string | null | undefined): boolean {
+  return typeof url === 'string' && url.startsWith('auxx://')
+}
+
+export function parseAuxxArticleUrl(url: string | null | undefined): AuxxArticleRef | null {
+  if (typeof url !== 'string') return null
+  if (!url.startsWith(AUXX_KB_ARTICLE_PREFIX)) return null
+  const articleId = url.slice(AUXX_KB_ARTICLE_PREFIX.length)
+  if (!articleId) return null
+  return { kind: 'kb-article', articleId }
+}


### PR DESCRIPTION
## Summary
- **Cards block** — new editor block for grids of titled link cards. Slash-command insertion, inline edit popover (title/description/icon/href), markdown round-trip via remark-directive (`:::cards` / `::card{title= description= href= icon=}`), shared renderer in `@auxx/ui` for editor + public/preview surfaces.
- **`auxx://` internal URI scheme** — stable cross-article links that survive renames. Helpers in `@auxx/utils/url` plus tests. The renderer rewrites `auxx://kb/article/{id}` to `/r/{id}` on click; new redirect routes in `apps/kb` and `apps/web` (preview) resolve the id to the current slug path and 308 to the canonical URL.
- **`<ArticlePicker>`** — extracted from the move picker, reused by the new article-link popover.
- **Preview version picker** — admins can scrub through historical article versions inside the preview UI; topbar/context/fullscreen and `kb` router/service threaded through.

## Test plan
- [ ] In the editor: `/cards` inserts a cards block, edit popover updates title/desc/icon/href, descriptions render markdown-lite (bold, italic, code, links).
- [ ] Save → reload → cards block round-trips through markdown unchanged.
- [ ] Insert an article-link via the popover — it stores `auxx://kb/article/{id}` and renders as the article title.
- [ ] Click the link in published view → 308 redirects via `/r/{id}` to current `/orgSlug/kbSlug/slug-path`.
- [ ] Rename the target article's slug → existing link still resolves to the new path.
- [ ] In the admin preview, the version picker switches the rendered content to the selected historical version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)