### PR TITLE
feat(kb): cookie mode persistence + sidebar header cleanup + editor polish

### DIFF
--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
@@ -3,9 +3,11 @@
 import { WEBAPP_URL } from '@auxx/config/urls'
 import { isOrgMember } from '@auxx/lib/cache'
 import { KBLayout } from '@auxx/ui/components/kb'
+import type { KBMode } from '@auxx/ui/components/kb/theme'
 import '@auxx/ui/global.css'
 import type { Metadata } from 'next'
 import { cacheLife, cacheTag } from 'next/cache'
+import { cookies } from 'next/headers'
 import { notFound, redirect } from 'next/navigation'
 import { Suspense } from 'react'
 import { getLocalSession, getLoginUrl } from '~/lib/auth'
@@ -36,9 +38,11 @@ export default async function KBSlugLayout({ params, children }: KBSlugLayoutPro
   const visibility = await getCachedKBVisibility(orgSlug, kbSlug)
   if (!visibility || visibility.publishStatus === 'DRAFT') notFound()
 
+  const mode = await readModeCookie(visibility.id)
+
   if (visibility.visibility === 'PUBLIC') {
     return (
-      <PublicKBLayout orgSlug={orgSlug} kbSlug={kbSlug}>
+      <PublicKBLayout orgSlug={orgSlug} kbSlug={kbSlug} mode={mode}>
         {children}
       </PublicKBLayout>
     )
@@ -52,20 +56,29 @@ export default async function KBSlugLayout({ params, children }: KBSlugLayoutPro
         orgSlug={orgSlug}
         kbSlug={kbSlug}
         kbId={visibility.id}
-        organizationId={visibility.organizationId}>
+        organizationId={visibility.organizationId}
+        mode={mode}>
         {children}
       </InternalKBLayoutGate>
     </Suspense>
   )
 }
 
+async function readModeCookie(kbId: string): Promise<KBMode | undefined> {
+  const cookieStore = await cookies()
+  const value = cookieStore.get(`kb-mode-${kbId}`)?.value
+  return value === 'dark' ? 'dark' : value === 'light' ? 'light' : undefined
+}
+
 async function PublicKBLayout({
   orgSlug,
   kbSlug,
+  mode,
   children,
 }: {
   orgSlug: string
   kbSlug: string
+  mode?: KBMode
   children: React.ReactNode
 }) {
   'use cache'
@@ -79,7 +92,12 @@ async function PublicKBLayout({
   const searchOrigin = `${basePath}/search.json`
 
   return (
-    <KBLayout kb={kb} articles={articles} basePath={basePath} searchOrigin={searchOrigin}>
+    <KBLayout
+      kb={kb}
+      articles={articles}
+      basePath={basePath}
+      searchOrigin={searchOrigin}
+      mode={mode}>
       {children}
     </KBLayout>
   )
@@ -90,12 +108,14 @@ async function InternalKBLayoutGate({
   kbSlug,
   kbId,
   organizationId,
+  mode,
   children,
 }: {
   orgSlug: string
   kbSlug: string
   kbId: string
   organizationId: string
+  mode?: KBMode
   children: React.ReactNode
 }) {
   const session = await getLocalSession()
@@ -116,7 +136,12 @@ async function InternalKBLayoutGate({
   const searchOrigin = `${basePath}/search.json`
 
   return (
-    <KBLayout kb={kb} articles={articles} basePath={basePath} searchOrigin={searchOrigin}>
+    <KBLayout
+      kb={kb}
+      articles={articles}
+      basePath={basePath}
+      searchOrigin={searchOrigin}
+      mode={mode}>
       {children}
     </KBLayout>
   )

--- a/apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/r/[articleId]/route.ts
+++ b/apps/web/src/app/(protected)/preview/kb/[knowledgeBaseId]/r/[articleId]/route.ts
@@ -44,8 +44,9 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<Response
   // Authorize against the *target* article's org. Cross-org leakage would
   // be a problem, but we expect the picker to scope to the active org so
   // this is mostly a sanity check.
-  const activeOrgId = (session.session as { activeOrganizationId?: string }).activeOrganizationId
-  if (activeOrgId && activeOrgId !== row.organizationId) {
+  const userOrgId = (session.user as { defaultOrganizationId?: string | null })
+    .defaultOrganizationId
+  if (userOrgId && userOrgId !== row.organizationId) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 

--- a/apps/web/src/components/editor/kb-article/block-drag-plugin.ts
+++ b/apps/web/src/components/editor/kb-article/block-drag-plugin.ts
@@ -73,7 +73,16 @@ export function blockDragPlugin() {
         event.dataTransfer.clearData()
         event.dataTransfer.setData('text/plain', node.textContent ?? '')
         event.dataTransfer.effectAllowed = 'move'
-        event.dataTransfer.setDragImage(blockEl, 0, 0)
+        // Anchor the drag image at the cursor's actual offset within the block
+        // — passing (0, 0) puts the cursor at the top-left, which visibly
+        // yanks tall blocks (cards grids) down when the grip is grabbed
+        // mid-height.
+        const rect = blockEl.getBoundingClientRect()
+        event.dataTransfer.setDragImage(
+          blockEl,
+          event.clientX - rect.left,
+          event.clientY - rect.top
+        )
 
         document.body.classList.add('is-block-dragging')
         // Block PM's own dragstart so it doesn't also seed view.dragging,

--- a/apps/web/src/components/editor/kb-article/cards-block-view.tsx
+++ b/apps/web/src/components/editor/kb-article/cards-block-view.tsx
@@ -170,7 +170,7 @@ function SortableCard({
             <EntityIcon iconId={card.iconId} variant='bare' size='sm' />
           </span>
         ) : null}
-        <span className={styles.cardTitle}>{card.title || 'Untitled'}</span>
+        {card.title ? <span className={styles.cardTitle}>{card.title}</span> : null}
         {card.description ? (
           <span className={styles.cardDescription}>{renderMarkdownLite(card.description)}</span>
         ) : null}

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
@@ -68,6 +68,7 @@ export function KBArticleEditor({
     (pick: ArticleLinkPick) => {
       if (!pendingLink) return
       const isInternal = pick.href.startsWith('auxx://')
+      const endPos = pendingLink.insertPos + pick.text.length
       pendingLink.editor
         .chain()
         .focus()
@@ -84,6 +85,8 @@ export function KBArticleEditor({
             },
           ],
         })
+        .setTextSelection(endPos)
+        .unsetMark('link')
         .run()
       setPendingLink(null)
     },

--- a/apps/web/src/components/kb/hooks/use-article-mutations.ts
+++ b/apps/web/src/components/kb/hooks/use-article-mutations.ts
@@ -167,6 +167,11 @@ export function useArticleMutations(knowledgeBaseId: string): UseArticleMutation
         const normalized = normalizeServerArticle(server)
         if (showInSidebar) store.confirmUpdate(id, normalized)
         else store.applyArticleMetadataFromServer(id, normalized)
+        // The article-list response carries the *published* revision's
+        // metadata for published articles, so the store can't see draft-only
+        // edits (title/emoji/description). The editor reads those from
+        // getArticleById — invalidate so a remount picks up fresh draft data.
+        utils.kb.getArticleById.invalidate({ id, knowledgeBaseId })
       } catch (error) {
         if (showInSidebar) store.rollbackUpdate(id)
         toastError({
@@ -175,7 +180,7 @@ export function useArticleMutations(knowledgeBaseId: string): UseArticleMutation
         })
       }
     },
-    [knowledgeBaseId, updateDraftMutation]
+    [knowledgeBaseId, updateDraftMutation, utils.kb.getArticleById]
   )
 
   const updateArticleStructure = useCallback<UseArticleMutationsResult['updateArticleStructure']>(

--- a/apps/web/src/components/kb/ui/editor/article-editor-top.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor-top.tsx
@@ -6,6 +6,7 @@ import { EntityIcon } from '@auxx/ui/components/icons'
 import { Smile } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { EditableText } from '~/components/editor/editable-text'
+import { useArticleContent } from '../../hooks/use-article-content'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
 import type { ArticleMeta } from '../../store/article-store'
 
@@ -21,15 +22,17 @@ export function ArticleEditorTop({
   onUpdateMetadata,
 }: ArticleEditorTopProps) {
   const { updateArticleDraft } = useArticleMutations(knowledgeBaseId)
+  // article.emoji on the store mirrors the *published* revision for published
+  // articles. The editor edits the draft, so source the icon from the draft
+  // revision via getArticleById instead — falls back to article.emoji while
+  // the query loads.
+  const { draftEmoji } = useArticleContent(article.id, knowledgeBaseId)
+  const effectiveEmoji = draftEmoji ?? article.emoji
 
-  // The store keeps article.emoji at the *published* revision's value for published
-  // articles, so a freshly picked icon would appear to revert. Mirror what
-  // EditableText does for the title: hold a local override that resets when the
-  // article id changes.
-  const [pickedEmoji, setPickedEmoji] = useState<string | null>(article.emoji)
+  const [pickedEmoji, setPickedEmoji] = useState<string | null>(effectiveEmoji)
   useEffect(() => {
-    setPickedEmoji(article.emoji)
-  }, [article.id, article.emoji])
+    setPickedEmoji(effectiveEmoji)
+  }, [article.id, effectiveEmoji])
 
   const handleEmojiChange = (emoji: string) => {
     setPickedEmoji(emoji)

--- a/apps/web/src/components/kb/ui/preview/kb-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview.tsx
@@ -36,7 +36,8 @@ export function KBPreview({ knowledgeBase, activeSlugPath }: KBPreviewProps) {
 }
 
 function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath?: string[] }) {
-  const { isMobile, effectiveMode, knowledgeBase, previewMode, setPreviewMode } = usePreview()
+  const { isMobile, effectiveMode, knowledgeBase, previewMode, setPreviewMode, setOverride } =
+    usePreview()
   const articles = useArticleList(kbId)
 
   // Article from the editor's slug path; resets the override when the editor switches.
@@ -91,7 +92,8 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
         mode={effectiveMode}
         embedded
         mainScroll
-        onArticleClick={(id) => setOverrideId(id)}>
+        onArticleClick={(id) => setOverrideId(id)}
+        onModeChange={setOverride}>
         {articleId ? (
           <div className='flex min-w-0 flex-1 flex-col'>
             <div className='flex flex-col gap-6 @kb-lg:flex-row @kb-lg:items-start'>

--- a/apps/web/src/components/kb/ui/preview/preview-context.tsx
+++ b/apps/web/src/components/kb/ui/preview/preview-context.tsx
@@ -33,9 +33,11 @@ interface PreviewProviderProps {
   knowledgeBase?: KnowledgeBase
 }
 
+const COOKIE_PREFIX = 'kb-mode-'
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365
+
 export function PreviewProvider({ children, knowledgeBase }: PreviewProviderProps) {
   const [device, setDevice] = React.useState<Device>('desktop')
-  const [override, setOverride] = React.useState<Theme | null>(null)
   const [previewMode, setPreviewMode] = React.useState<PreviewMode>('draft')
   const [isLoading, setIsLoading] = React.useState(!knowledgeBase)
 
@@ -56,12 +58,29 @@ export function PreviewProvider({ children, knowledgeBase }: PreviewProviderProp
   const defaultMode: Theme = merged?.defaultMode === 'dark' ? 'dark' : 'light'
   const kbId = merged?.id
 
-  // Settings are the source of truth — reset the override whenever the active KB
-  // changes or its default mode is edited so the new default propagates.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `kbId` is intentional — switching KBs must clear any author override even if both KBs share the same defaultMode.
+  // Initialize from the live cookie so admins see the same mode they last picked
+  // (preview and live share the `kb-mode-<id>` cookie). Falls back to the KB's
+  // default when no cookie is set.
+  const [override, setOverrideState] = React.useState<Theme | null>(() => readModeCookie(kbId))
+
+  // Re-sync the override when the active KB changes (cookies are scoped per id).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `kbId` is intentional — switching KBs must re-read the cookie under the new id.
   React.useEffect(() => {
-    setOverride(null)
-  }, [defaultMode, kbId])
+    setOverrideState(readModeCookie(kbId))
+  }, [kbId])
+
+  const setOverride = React.useCallback(
+    (next: Theme | null) => {
+      setOverrideState(next)
+      if (!kbId) return
+      if (next === null) {
+        document.cookie = `${COOKIE_PREFIX}${kbId}=; path=/; max-age=0; SameSite=Lax`
+      } else {
+        document.cookie = `${COOKIE_PREFIX}${kbId}=${next}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`
+      }
+    },
+    [kbId]
+  )
 
   const effectiveMode: Theme = override ?? defaultMode
 
@@ -78,10 +97,23 @@ export function PreviewProvider({ children, knowledgeBase }: PreviewProviderProp
       setDevice,
       setPreviewMode,
     }),
-    [merged, isLoading, defaultMode, override, effectiveMode, device, previewMode]
+    [merged, isLoading, defaultMode, override, effectiveMode, device, previewMode, setOverride]
   )
 
   return <PreviewContext.Provider value={value}>{children}</PreviewContext.Provider>
+}
+
+function readModeCookie(kbId: string | undefined): Theme | null {
+  if (!kbId || typeof document === 'undefined') return null
+  const match = document.cookie.match(
+    new RegExp(`(?:^|; )${COOKIE_PREFIX}${escapeRegex(kbId)}=([^;]+)`)
+  )
+  if (!match) return null
+  return match[1] === 'dark' ? 'dark' : match[1] === 'light' ? 'light' : null
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 export function usePreview(): PreviewContextValue {

--- a/packages/ui/src/components/kb/article/card-item.tsx
+++ b/packages/ui/src/components/kb/article/card-item.tsx
@@ -60,7 +60,7 @@ export function CardItem({ card, resolveAuxxHref }: CardItemProps) {
           <EntityIcon iconId={card.iconId} variant='bare' size='sm' />
         </span>
       ) : null}
-      <span className={styles.cardTitle}>{card.title || 'Untitled'}</span>
+      {card.title ? <span className={styles.cardTitle}>{card.title}</span> : null}
       {card.description ? (
         <span className={styles.cardDescription}>
           {renderMarkdownLite(card.description, { resolveAuxxHref: resolver })}

--- a/packages/ui/src/components/kb/layout/kb-header.tsx
+++ b/packages/ui/src/components/kb/layout/kb-header.tsx
@@ -27,6 +27,8 @@ export interface KBHeaderProps {
   searchOrigin?: string
   /** Optional slot rendered before the logo (mobile menu trigger / sidebar toggle). */
   startSlot?: React.ReactNode
+  /** Notified when the in-header mode toggle flips. Used to keep external state in sync. */
+  onModeChange?: (mode: KBMode) => void
 }
 
 export function KBHeader({
@@ -43,6 +45,7 @@ export function KBHeader({
   searchbarPosition = 'center',
   searchOrigin,
   startSlot,
+  onModeChange,
 }: KBHeaderProps) {
   // Treat empty strings as missing — `LogoUploadCell` writes `''` on remove,
   // so `??` would lock the variant slot and hide the opposite-mode fallback.
@@ -81,13 +84,11 @@ export function KBHeader({
         <nav className='flex items-center gap-2 @kb-md:gap-4'>
           {showNav
             ? navigation?.map((link) => (
-                <Link
+                <span
                   key={link.href}
-                  href={link.href}
-                  className='hidden text-sm text-[var(--kb-fg)]/85 no-underline hover:text-[var(--kb-primary)] hover:opacity-100 @kb-md:inline'
-                  prefetch={false}>
+                  className='hidden text-sm text-[var(--kb-fg)]/85 @kb-md:inline'>
                   {link.label}
-                </Link>
+                </span>
               ))
             : null}
           {searchbarPosition === 'center' ? (
@@ -98,7 +99,9 @@ export function KBHeader({
               className='@kb-md:hidden'
             />
           ) : null}
-          {showMode ? <KBModeToggle kbId={kbId} initialMode={mode} /> : null}
+          {showMode ? (
+            <KBModeToggle kbId={kbId} initialMode={mode} onChange={onModeChange} />
+          ) : null}
         </nav>
       </div>
     </header>

--- a/packages/ui/src/components/kb/layout/kb-layout-shell.tsx
+++ b/packages/ui/src/components/kb/layout/kb-layout-shell.tsx
@@ -39,6 +39,8 @@ interface KBLayoutShellProps<T extends KBSidebarArticle> {
   onArticleClick?: (articleId: string) => void
   /** When true, the `<main>` element owns the scroll instead of the document. Used inside admin previews where document scroll is unavailable. */
   mainScroll?: boolean
+  /** Notified when an in-tree mode toggle flips. */
+  onModeChange?: (mode: KBMode) => void
   children: ReactNode
 }
 
@@ -61,6 +63,7 @@ export function KBLayoutShell<T extends KBSidebarArticle>({
   listStyle,
   onArticleClick,
   mainScroll = false,
+  onModeChange,
   children,
 }: KBLayoutShellProps<T>) {
   const [collapsed, setCollapsed] = useState(false)
@@ -159,6 +162,7 @@ export function KBLayoutShell<T extends KBSidebarArticle>({
         navigationEnabled={headerEnabled}
         searchbarPosition={searchbarPosition}
         searchOrigin={searchOrigin}
+        onModeChange={onModeChange}
         startSlot={
           <>
             <KBSidebarMobileTrigger />
@@ -189,6 +193,7 @@ export function KBLayoutShell<T extends KBSidebarArticle>({
           logoDark={logoDark}
           mode={effectiveMode}
           showMode={showMode}
+          onModeChange={onModeChange}
           tabs={tabs}
           activeTabId={activeTabId}
           tabHrefs={tabHrefs}

--- a/packages/ui/src/components/kb/layout/kb-layout.tsx
+++ b/packages/ui/src/components/kb/layout/kb-layout.tsx
@@ -43,6 +43,8 @@ interface KBLayoutProps<T extends KBSidebarArticle> {
   embedded?: boolean
   /** When true, the `<main>` element owns vertical scroll instead of the document. Required in admin previews where document scroll is unavailable. */
   mainScroll?: boolean
+  /** Notified when the in-tree mode toggle flips. Used by apps/web preview to keep its override in sync with cookie writes. */
+  onModeChange?: (mode: KBMode) => void
   children: ReactNode
 }
 
@@ -56,6 +58,7 @@ export function KBLayout<T extends KBSidebarArticle>({
   onArticleClick,
   embedded = false,
   mainScroll = false,
+  onModeChange,
   children,
 }: KBLayoutProps<T>) {
   const headerNav = parseNavigation(kb.headerNavigation)
@@ -94,6 +97,7 @@ export function KBLayout<T extends KBSidebarArticle>({
           footerNav={footerNav}
           listStyle={listStyle}
           onArticleClick={onArticleClick}
+          onModeChange={onModeChange}
           mainScroll={mainScroll}>
           {children}
         </KBLayoutShell>

--- a/packages/ui/src/components/kb/layout/kb-sidebar-tree.tsx
+++ b/packages/ui/src/components/kb/layout/kb-sidebar-tree.tsx
@@ -157,19 +157,16 @@ function TreeBranch<T extends KBSidebarArticle>({
   }
 
   // Headers are uppercase section labels rendered flat at the same depth as
-  // their children. The label itself is a link to the header's slug path —
-  // the public route handler 308-redirects to the first navigable descendant
-  // (or 404s on an empty section).
+  // their children. They are pure visual groupings — not navigable — so the
+  // label is a static span. Children always render (no collapse).
   if (node.articleKind === 'header') {
     return (
       <li className='my-0.5 pb-4'>
-        <Link
-          href={href}
-          className='block px-2 pt-3 pb-1 text-[var(--kb-fg)]/60 text-xs font-semibold uppercase tracking-wide no-underline hover:text-[var(--kb-primary)]'
-          style={lineIndent}
-          prefetch={false}>
+        <span
+          className='block px-2 pt-3 pb-1 text-[var(--kb-fg)]/60 text-xs font-semibold uppercase tracking-wide'
+          style={lineIndent}>
           {node.title}
-        </Link>
+        </span>
         {hasChildren ? (
           <ul className='m-0 list-none p-0'>
             {node.children.map((child) => (
@@ -193,21 +190,10 @@ function TreeBranch<T extends KBSidebarArticle>({
     )
   }
 
-  const isCategory = node.articleKind === 'category'
-
   return (
     <li className={cn(listStyle === 'line' ? 'my-0' : 'my-0.5')}>
       <div className='flex items-center'>
-        {isCategory ? (
-          <button
-            type='button'
-            className={cn(itemClass(listStyle), 'cursor-pointer text-left')}
-            data-active={active}
-            style={lineIndent}
-            onClick={() => onToggle?.(node.id, !open)}>
-            {itemContent}
-          </button>
-        ) : onArticleClick ? (
+        {onArticleClick ? (
           <button
             type='button'
             className={cn(itemClass(listStyle), 'cursor-pointer text-left')}

--- a/packages/ui/src/components/kb/layout/kb-sidebar.tsx
+++ b/packages/ui/src/components/kb/layout/kb-sidebar.tsx
@@ -33,6 +33,8 @@ interface KBSidebarProps<T extends KBSidebarArticle> {
   tabHrefs?: Record<string, string>
   /** Forwarded to `<KBTabSelect>` so the admin preview can intercept tab clicks. */
   onTabSelect?: (tabId: string) => void
+  /** Notified when the mobile-drawer mode toggle flips. Keeps external state in sync. */
+  onModeChange?: (mode: KBMode) => void
 }
 
 export function KBSidebar<T extends KBSidebarArticle>({
@@ -53,6 +55,7 @@ export function KBSidebar<T extends KBSidebarArticle>({
   activeTabId,
   tabHrefs,
   onTabSelect,
+  onModeChange,
 }: KBSidebarProps<T>) {
   const { kbId, collapsed, setCollapsed, mobileOpen, setMobileOpen } = useKBLayoutContext()
 
@@ -181,6 +184,7 @@ export function KBSidebar<T extends KBSidebarArticle>({
             logoDark={logoDark}
             mode={mode}
             showMode={showMode}
+            onModeChange={onModeChange}
             onNavigate={() => setMobileOpen(false)}
           />
           {inner}
@@ -198,6 +202,7 @@ interface KBSidebarMobileHeaderProps {
   logoDark?: string | null
   mode: KBMode
   showMode: boolean
+  onModeChange?: (mode: KBMode) => void
   onNavigate: () => void
 }
 
@@ -209,6 +214,7 @@ function KBSidebarMobileHeader({
   logoDark,
   mode,
   showMode,
+  onModeChange,
   onNavigate,
 }: KBSidebarMobileHeaderProps) {
   const logo = (mode === 'dark' ? logoDark || logoLight : logoLight || logoDark) || null
@@ -226,7 +232,7 @@ function KBSidebarMobileHeader({
         )}
       </Link>
       <div className='flex-1' />
-      {showMode ? <KBModeToggle kbId={kbId} initialMode={mode} /> : null}
+      {showMode ? <KBModeToggle kbId={kbId} initialMode={mode} onChange={onModeChange} /> : null}
     </div>
   )
 }

--- a/packages/ui/src/components/kb/theme/kb-mode-toggle.tsx
+++ b/packages/ui/src/components/kb/theme/kb-mode-toggle.tsx
@@ -7,29 +7,40 @@ import type { KBMode } from './kb-theme-tokens'
 
 interface KBModeToggleProps {
   kbId: string
-  /** Default mode when no localStorage value is set. */
+  /** Server-resolved mode (from cookie or KB default) used for SSR/initial render. */
   initialMode?: KBMode
+  /**
+   * When provided, the toggle also notifies the parent so external state
+   * (e.g. apps/web admin preview) can stay in sync. The toggle still writes
+   * the cookie + updates the DOM imperatively so first paint is instant.
+   */
+  onChange?: (mode: KBMode) => void
   className?: string
 }
 
-const STORAGE_PREFIX = 'kb-mode:'
+const COOKIE_PREFIX = 'kb-mode-'
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365
 
-export function KBModeToggle({ kbId, initialMode = 'light', className }: KBModeToggleProps) {
+export function KBModeToggle({
+  kbId,
+  initialMode = 'light',
+  onChange,
+  className,
+}: KBModeToggleProps) {
   const [mode, setMode] = useState<KBMode>(initialMode)
 
+  // Keep the icon in sync when the parent drives the mode (apps/web preview).
   useEffect(() => {
-    const stored = window.localStorage.getItem(`${STORAGE_PREFIX}${kbId}`) as KBMode | null
-    const next = stored === 'dark' || stored === 'light' ? stored : initialMode
-    setMode(next)
-    applyMode(kbId, next)
-  }, [kbId, initialMode])
+    setMode(initialMode)
+  }, [initialMode])
 
   const toggle = useCallback(() => {
     const next: KBMode = mode === 'dark' ? 'light' : 'dark'
     setMode(next)
     applyMode(kbId, next)
-    window.localStorage.setItem(`${STORAGE_PREFIX}${kbId}`, next)
-  }, [kbId, mode])
+    document.cookie = `${COOKIE_PREFIX}${kbId}=${next}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`
+    onChange?.(next)
+  }, [kbId, mode, onChange])
 
   return (
     <button

--- a/packages/ui/src/components/kb/utils/article-paths.ts
+++ b/packages/ui/src/components/kb/utils/article-paths.ts
@@ -69,10 +69,9 @@ interface ParentLinkArticle extends ArticleSlugFields {
 
 /**
  * Resolves the parent breadcrumb for `KBArticleRenderer`. Returns `undefined`
- * when the article has no parent. Pages and headers are navigable (a header
- * URL redirects to its first descendant on the public site); tabs and
- * categories aren't, so their `href` is `null` and the renderer falls back
- * to plain text.
+ * when the article has no parent. Pages and categories are navigable; tabs
+ * and headers are pure groupings, so their `href` is `null` and the renderer
+ * falls back to plain text.
  */
 export function getArticleParentLink<T extends ParentLinkArticle>(
   article: T | undefined | null,
@@ -82,7 +81,7 @@ export function getArticleParentLink<T extends ParentLinkArticle>(
   if (!article?.parentId) return undefined
   const parent = allArticles.find((a) => a.id === article.parentId)
   if (!parent) return undefined
-  const navigable = parent.articleKind === 'page' || parent.articleKind === 'header'
+  const navigable = parent.articleKind === 'page' || parent.articleKind === 'category'
   return {
     title: parent.title,
     emoji: parent.emoji,

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -9,7 +9,7 @@
 @import 'tw-animate-css';
 @import './random-gradient.css';
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:is(.dark *):not([data-kb-mode='light'] *), &:is([data-kb-mode='dark'] *));
 
 /*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,
@@ -167,7 +167,8 @@
   animation: action-bar-enter-top 200ms ease-out forwards;
 }
 
-:root {
+:root,
+[data-kb-mode='light'] {
   /* --text-sm: 0.5rem; */
   /* --background: 255 255 255;
   --foreground: 10 10 10; */
@@ -365,7 +366,8 @@
   --auxxai-highlight-pink: #faf1f5;
   --auxxai-highlight-gray: #f1f1ef;
 }
-.dark {
+.dark,
+[data-kb-mode='dark'] {
   --background: #23272e; /* oklch(0.145 0 0); */
   --foreground: oklch(0.985 0 0);
   /* --card: oklch(0.145 0 0); */


### PR DESCRIPTION
## Summary
- Switch KB mode from localStorage to a `kb-mode-<id>` cookie so the layout SSRs the correct theme on first paint and the admin preview shares state with the live site (preview reads on init, writes on toggle, listens via `onModeChange` from the in-tree toggle).
- Sidebar headers become pure visual groupings (static span, children always visible); categories take over the navigable-parent role in breadcrumbs. Cards drop the "Untitled" placeholder. Block drag image is anchored at cursor offset so tall blocks (cards grids) don't yank.
- Editor polish: after inserting a link, move selection past the new text and unset the link mark; source article emoji from the draft revision via `getArticleById` and invalidate it after `updateArticleDraft` so the editor sees fresh draft metadata.
- Preview route authorizes against `user.defaultOrganizationId` instead of `session.activeOrganizationId`.
- CSS: dark variant now respects `[data-kb-mode]` scopes so KB content inside admin preview can override the global theme.

## Test plan
- [ ] Toggle mode on the live KB → reload → mode persists (cookie, not localStorage).
- [ ] Toggle mode in admin preview → live site picks up the same mode (and vice versa).
- [ ] First paint on a fresh load uses the cookie's mode (no flash from default).
- [ ] Sidebar headers render as labels (no link), with children visible underneath.
- [ ] Cards with empty title render no placeholder; drag a tall cards block — drag image stays anchored to the cursor.
- [ ] Insert an internal link → cursor lands after the link, typing extends plain text.
- [ ] Pick a new emoji on a published article → editor shows it immediately.
- [ ] Preview route still 403s on cross-org article ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)