### PR TITLE
feat(kopilot): page suggestions + list_tags + relative-date filters

### DIFF
--- a/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
+++ b/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
@@ -42,6 +42,7 @@ import {
 import { ContactDrawer } from '~/components/contacts/drawer/contact-drawer'
 import { EmptyState } from '~/components/global/empty-state'
 import { KopilotContext } from '~/components/kopilot/context'
+import { KopilotSuggestion } from '~/components/kopilot/suggestions'
 import {
   MailFilterProvider,
   type SortDirection,
@@ -495,7 +496,14 @@ function MailboxInner({
 
   return (
     <MailFilterProvider value={mailFilterContextValue}>
-      {kopilotEnabled && <KopilotContext page='mail' />}
+      {kopilotEnabled && (
+        <>
+          <KopilotContext page='mail' />
+          <KopilotSuggestion text='What tickets came in today?' icon='mail' autoSubmit />
+          <KopilotSuggestion text='Show high-priority unresolved tickets' icon='list' autoSubmit />
+          <KopilotSuggestion text='Summarize my open tickets' icon='sparkle' autoSubmit />
+        </>
+      )}
       <MainPage>
         <MainPageHeader
           action={

--- a/apps/web/src/components/contacts/drawer/contact-drawer.tsx
+++ b/apps/web/src/components/contacts/drawer/contact-drawer.tsx
@@ -14,6 +14,7 @@ import { BaseEntityDrawer } from '~/components/drawers/base-entity-drawer'
 import { DockToggleButton } from '~/components/global/dock-toggle-button'
 import { Tooltip } from '~/components/global/tooltip'
 import { KopilotContext } from '~/components/kopilot/context'
+import { KopilotSuggestion } from '~/components/kopilot/suggestions'
 import type { EditorPresetValues } from '~/components/mail/email-editor/types'
 import { toRecordId, useRecord } from '~/components/resources'
 import { ManualTriggerButton } from '~/components/workflow/manual-trigger-button'
@@ -109,6 +110,14 @@ export function ContactDrawer({
   return (
     <>
       <KopilotContext activeContactId={contactId} activeContactLabel={contactLabel} />
+      <KopilotSuggestion
+        text='Recent tickets from this contact'
+        icon='history'
+        priority={10}
+        autoSubmit
+      />
+      <KopilotSuggestion text='Summarize this contact' icon='sparkle' autoSubmit />
+      <KopilotSuggestion text='Draft a follow-up email' icon='reply' />
       <BaseEntityDrawer
         recordId={recordId}
         open={open}

--- a/apps/web/src/components/dynamic-table/components/header-cell.tsx
+++ b/apps/web/src/components/dynamic-table/components/header-cell.tsx
@@ -11,6 +11,7 @@ import {
   buildFieldValueKey,
   type FieldId,
   type FieldReference,
+  parseResourceFieldId,
   type ResourceFieldId,
 } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
@@ -41,8 +42,12 @@ import {
   RefreshCw,
   Settings2,
   Sparkles,
+  Trash2,
+  Wand2,
 } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
+import { useCustomFieldMutations } from '~/components/custom-fields/hooks/use-custom-field-mutations'
+import { CustomFieldDialog } from '~/components/custom-fields/ui/custom-field-dialog'
 import { Tooltip } from '~/components/global/tooltip'
 import { SparkleIcon } from '~/components/kopilot/ui/sparkle-icon'
 import { useRunAiBulkGenerate } from '~/components/resources/hooks/run-ai-bulk-generate'
@@ -162,6 +167,7 @@ function HeaderCellOptionsDropdown<TData>({
   aiFieldRef,
   table,
   entityDefinitionId,
+  editableField,
 }: {
   column: Header<TData, unknown>['column']
   columnDef: ExtendedColumnDef<TData>
@@ -187,11 +193,38 @@ function HeaderCellOptionsDropdown<TData>({
   aiFieldRef: FieldReference | null
   table: Table<TData>
   entityDefinitionId: string | undefined
+  editableField: ResourceFieldId | null
 }) {
   const [showLabelDialog, setShowLabelDialog] = useState(false)
   const [showFormattingDialog, setShowFormattingDialog] = useState(false)
+  const [showEditFieldDialog, setShowEditFieldDialog] = useState(false)
   const [confirm, ConfirmDialog] = useConfirm()
   const runAiBulkGenerate = useRunAiBulkGenerate()
+
+  // For path columns the editable field belongs to a different entity than
+  // the table's. Derive the owning entityDefinitionId from the field id itself
+  // so the destroy mutation invalidates the right scope.
+  const editableFieldEntityDefinitionId = useMemo(
+    () => (editableField ? parseResourceFieldId(editableField).entityDefinitionId : undefined),
+    [editableField]
+  )
+  const { destroy: destroyField } = useCustomFieldMutations({
+    entityDefinitionId: editableFieldEntityDefinitionId,
+  })
+
+  const handleDeleteField = useCallback(async () => {
+    if (!editableField) return
+    const ok = await confirm({
+      title: `Delete "${headerContent}"?`,
+      description:
+        'This permanently removes the field and its values from every record. This action cannot be undone.',
+      confirmText: 'Delete field',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!ok) return
+    destroyField.mutate({ resourceFieldId: editableField })
+  }, [editableField, confirm, headerContent, destroyField])
 
   const handleFillMissing = useCallback(() => {
     if (!aiMenuEnabled || !aiField || !aiFieldRef || !entityDefinitionId) return
@@ -377,6 +410,23 @@ function HeaderCellOptionsDropdown<TData>({
             Format column
           </DropdownMenuItem>
         )}
+
+        {editableField && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => setShowEditFieldDialog(true)}>
+              <Wand2 />
+              Edit field
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={handleDeleteField}
+              variant='destructive'
+              disabled={destroyField.isPending}>
+              <Trash2 />
+              Delete field
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
 
       <EditColumnLabelDialog
@@ -398,6 +448,14 @@ function HeaderCellOptionsDropdown<TData>({
           currentFormatting={columnFormatting[column.id]}
           defaultFormatting={columnDef.defaultFormatting ?? terminalDefaultFormatting}
           onSave={(formatting) => setColumnFormatting(column.id, formatting)}
+        />
+      )}
+
+      {editableField && (
+        <CustomFieldDialog
+          open={showEditFieldDialog}
+          onOpenChange={setShowEditFieldDialog}
+          resourceFieldId={editableField}
         />
       )}
 
@@ -489,6 +547,21 @@ export function HeaderCell<TData>({ header, isDragging = false }: HeaderCellProp
   const aiFieldRef: FieldReference | null =
     aiMenuEnabled && !isPathColumn ? (decoded.resourceFieldId as ResourceFieldId) : null
 
+  // ─── EDITABLE CUSTOM FIELD GATE ────────────────────────────────────────────
+  // Show "Edit field" / "Delete field" only when the column maps to a non-system
+  // custom field. For path columns, target the terminal field (which lives on
+  // a different entity definition — the dialog auto-derives that from the
+  // resourceFieldId itself).
+  const editableField = useMemo<ResourceFieldId | null>(() => {
+    if (isPathColumn) {
+      const terminal = pathFields[pathFields.length - 1]
+      if (!terminal || terminal.isSystem) return null
+      return terminal.resourceFieldId
+    }
+    if (!directField || directField.isSystem) return null
+    return directField.resourceFieldId
+  }, [isPathColumn, pathFields, directField])
+
   // ─── ACTIONS (use centralized action hooks) ────────────────────────────────
   const setFilters = useSetFilters(tableId)
   const setColumnLabel = useSetColumnLabel(tableId)
@@ -566,6 +639,7 @@ export function HeaderCell<TData>({ header, isDragging = false }: HeaderCellProp
             aiFieldRef={aiFieldRef}
             table={table}
             entityDefinitionId={entityDefinitionId}
+            editableField={editableField}
           />
         </div>
       )}

--- a/apps/web/src/components/dynamic-table/components/selectable-table-cell.tsx
+++ b/apps/web/src/components/dynamic-table/components/selectable-table-cell.tsx
@@ -74,6 +74,10 @@ function SelectableTableCellInner<TData>({
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
       if (!cellSelectionConfig?.enabled || isSystemColumn) return
+      // While inline-editing this cell, let the input own pointer events:
+      // preventDefault here would block caret placement, mouse selection,
+      // and focus on the textarea/input.
+      if (isEditing) return
       // Ignore non-primary buttons (right-click, middle, etc.)
       if (e.button !== 0) return
       // Ignore events that bubbled here from a React portal (e.g. an open
@@ -104,6 +108,7 @@ function SelectableTableCellInner<TData>({
     [
       cellSelectionConfig?.enabled,
       isSystemColumn,
+      isEditing,
       resolveEndpoint,
       drag,
       setActiveCell,
@@ -168,7 +173,10 @@ function SelectableTableCellInner<TData>({
       ref={cellRef}
       data-col={sanitizeColumnId(columnId)}
       className={cn(
-        'group/cell flex items-center h-full relative outline-none select-none',
+        'group/cell flex items-center h-full relative outline-none',
+        // Suppress text selection on the cell chrome, but allow it inside the
+        // input while inline-editing.
+        !isEditing && 'select-none',
         // .cell-active drives focus ring + content expansion (ExpandableCell, PrimaryCell).
         // .cell-selected kept as alias so existing CSS selectors keep matching the active cell.
         isActive && 'cell-active cell-selected',

--- a/apps/web/src/components/favorites/ui/favorite-item-skeleton.tsx
+++ b/apps/web/src/components/favorites/ui/favorite-item-skeleton.tsx
@@ -1,16 +1,13 @@
 // apps/web/src/components/favorites/ui/favorite-item-skeleton.tsx
 'use client'
 
-import { SidebarMenuSubItem } from '@auxx/ui/components/sidebar'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 
 export function FavoriteItemSkeleton() {
   return (
-    <SidebarMenuSubItem>
-      <div className='flex h-7 w-full items-center px-2'>
-        <Skeleton className='size-4 mr-2 shrink-0 rounded-sm' />
-        <Skeleton className='h-3 w-24' />
-      </div>
-    </SidebarMenuSubItem>
+    <div className='flex h-7 w-full items-center px-2'>
+      <Skeleton className='size-4 mr-2 shrink-0 rounded-sm' />
+      <Skeleton className='h-3 w-24' />
+    </div>
   )
 }

--- a/apps/web/src/components/kb/ui/editor/article-editor.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor.tsx
@@ -6,6 +6,7 @@ import type { JSONContent } from '@tiptap/core'
 import { useCallback, useEffect, useRef } from 'react'
 import { useDebounceCallback } from 'usehooks-ts'
 import { KBArticleEditor } from '~/components/editor/kb-article'
+import { KopilotSuggestion } from '~/components/kopilot/suggestions'
 import { useArticleContent } from '../../hooks/use-article-content'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
 import type { ArticleMeta } from '../../store/article-store'
@@ -60,6 +61,9 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
 
   return (
     <div className='flex min-h-0 flex-1 flex-col'>
+      <KopilotSuggestion text='Outline this article' icon='pencil' priority={10} />
+      <KopilotSuggestion text='Suggest related articles' icon='list' autoSubmit />
+      <KopilotSuggestion text='Improve this article' icon='sparkle' />
       <ArticleEditorHeader article={article} knowledgeBaseId={knowledgeBaseId} />
       <ScrollArea className='flex-1'>
         <div className='flex min-h-min flex-1 flex-col'>

--- a/apps/web/src/components/kb/ui/sidebar/kb-switcher.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/kb-switcher.tsx
@@ -133,7 +133,11 @@ export function KBSwitcherDropdownContent() {
       {canCreateKB && (
         <>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => setShowCreateDialog(true)}>
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault()
+              setShowCreateDialog(true)
+            }}>
             <Plus />
             Add Knowledge Base
           </DropdownMenuItem>

--- a/apps/web/src/components/kopilot/stores/kopilot-store.ts
+++ b/apps/web/src/components/kopilot/stores/kopilot-store.ts
@@ -4,6 +4,7 @@ import { generateId } from '@auxx/utils/generateId'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { ContextSlice } from '../context/types'
+import type { SuggestionSlice } from '../suggestions/types'
 import { summarizeToolResult } from '../ui/blocks/summarize-tool-result'
 
 /**
@@ -180,6 +181,15 @@ interface KopilotState {
   clearContextSlice: (id: string) => void
 
   /**
+   * Page-suggestions — distributed mount-time registration. Each
+   * `<KopilotSuggestion>` writes one slice keyed by its `useId()`. Consumers
+   * read the merged, priority-sorted view via `useKopilotSuggestions`.
+   */
+  suggestionSlices: Record<string, SuggestionSlice>
+  setSuggestionSlice: (id: string, slice: SuggestionSlice) => void
+  clearSuggestionSlice: (id: string) => void
+
+  /**
    * Per-turn chip dismissals. Keyed as `field:value` (e.g. `activeThreadId:abc`).
    * Cleared after each submit so the chip reappears next turn.
    */
@@ -296,6 +306,18 @@ export const useKopilotStore = create<KopilotState>()(
           const next = { ...s.contextSlices }
           delete next[id]
           return { contextSlices: next }
+        }),
+
+      // Page suggestions — distributed slices
+      suggestionSlices: {},
+      setSuggestionSlice: (id, slice) =>
+        set((s) => ({ suggestionSlices: { ...s.suggestionSlices, [id]: slice } })),
+      clearSuggestionSlice: (id) =>
+        set((s) => {
+          if (!(id in s.suggestionSlices)) return s
+          const next = { ...s.suggestionSlices }
+          delete next[id]
+          return { suggestionSlices: next }
         }),
 
       // Per-turn chip dismissals

--- a/apps/web/src/components/kopilot/stores/select-suggestions.ts
+++ b/apps/web/src/components/kopilot/stores/select-suggestions.ts
@@ -1,0 +1,22 @@
+// apps/web/src/components/kopilot/stores/select-suggestions.ts
+
+import { useShallow } from 'zustand/react/shallow'
+import type { SuggestionSlice } from '../suggestions/types'
+import { useKopilotStore } from './kopilot-store'
+
+/**
+ * Sort registered suggestion slices into render order: higher `priority` first,
+ * stable mount-order tiebreak via `Object.values` insertion-order semantics.
+ */
+export function selectMergedSuggestions(
+  slices: Record<string, SuggestionSlice>
+): SuggestionSlice[] {
+  const list = Object.values(slices)
+  // Stable sort by priority desc; mount-order preserved for equal priority.
+  return list.slice().sort((a, b) => b.priority - a.priority)
+}
+
+// `useShallow` is required: this selector builds a fresh array on every call.
+// Zustand v5 (built on `useSyncExternalStore`) requires snapshot stability.
+export const useKopilotSuggestions = () =>
+  useKopilotStore(useShallow((s) => selectMergedSuggestions(s.suggestionSlices)))

--- a/apps/web/src/components/kopilot/suggestions/index.ts
+++ b/apps/web/src/components/kopilot/suggestions/index.ts
@@ -1,0 +1,4 @@
+// apps/web/src/components/kopilot/suggestions/index.ts
+
+export { KopilotSuggestion } from './kopilot-suggestion'
+export type { SuggestionIcon, SuggestionSlice } from './types'

--- a/apps/web/src/components/kopilot/suggestions/kopilot-suggestion.tsx
+++ b/apps/web/src/components/kopilot/suggestions/kopilot-suggestion.tsx
@@ -1,0 +1,45 @@
+// apps/web/src/components/kopilot/suggestions/kopilot-suggestion.tsx
+
+'use client'
+
+import { useEffect, useId } from 'react'
+import { useKopilotStore } from '../stores/kopilot-store'
+import type { SuggestionIcon } from './types'
+
+interface KopilotSuggestionProps {
+  /** Literal text inserted into the composer (or fired) on click. */
+  text: string
+  /** Optional icon for the suggestion row. */
+  icon?: SuggestionIcon
+  /** Sort priority. Higher numbers appear first. Default: 0. */
+  priority?: number
+  /** When true, click fires the turn immediately. When false (default), the
+   * composer is populated and focused for the user to edit/send. */
+  autoSubmit?: boolean
+}
+
+/**
+ * Distributed page-suggestion contributor. Mount one (or many) on a page; each
+ * mount registers a slice while alive and unregisters on unmount.
+ *
+ * Conditional rendering at the call site is the registration condition — wrap
+ * each mount in the data check that proves the suggestion is relevant
+ * (e.g. `{thread.linkedOrderId && <KopilotSuggestion ... />}`).
+ */
+export function KopilotSuggestion({
+  text,
+  icon,
+  priority = 0,
+  autoSubmit = false,
+}: KopilotSuggestionProps): null {
+  const id = useId()
+  const setSlice = useKopilotStore((s) => s.setSuggestionSlice)
+  const clearSlice = useKopilotStore((s) => s.clearSuggestionSlice)
+
+  useEffect(() => {
+    setSlice(id, { id, text, icon, priority, autoSubmit })
+    return () => clearSlice(id)
+  }, [id, text, icon, priority, autoSubmit, setSlice, clearSlice])
+
+  return null
+}

--- a/apps/web/src/components/kopilot/suggestions/types.ts
+++ b/apps/web/src/components/kopilot/suggestions/types.ts
@@ -1,0 +1,25 @@
+// apps/web/src/components/kopilot/suggestions/types.ts
+
+export type SuggestionIcon =
+  | 'mail'
+  | 'user'
+  | 'file'
+  | 'mic'
+  | 'sparkle'
+  | 'reply'
+  | 'list'
+  | 'plus'
+  | 'history'
+  | 'shopping-bag'
+  | 'workflow'
+  | 'pencil'
+  | 'search'
+
+/** What each `<KopilotSuggestion>` mount writes into the store. */
+export interface SuggestionSlice {
+  id: string
+  text: string
+  icon?: SuggestionIcon
+  priority: number
+  autoSubmit: boolean
+}

--- a/apps/web/src/components/kopilot/ui/blocks/task-create-approval-card.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/task-create-approval-card.tsx
@@ -3,7 +3,9 @@
 'use client'
 
 import type { ActorId } from '@auxx/types/actor'
+import type { AbsoluteDate, RelativeDate } from '@auxx/types/task'
 import { cn } from '@auxx/ui/lib/utils'
+import { formatAbsoluteDate, formatRelativeDate } from '@auxx/utils'
 import { Calendar, Flag, ListTodo, User } from 'lucide-react'
 import { ActorBadge } from '~/components/resources/ui/actor-badge'
 import { ItemsListView } from '~/components/ui/items-list-view'
@@ -16,10 +18,22 @@ const PRIORITY_STYLES = {
   low: 'bg-muted text-muted-foreground',
 } as const
 
+function formatDeadline(input: unknown): string | undefined {
+  if (input == null) return undefined
+  if (typeof input === 'string') return input
+  if (typeof input !== 'object') return undefined
+  const obj = input as Partial<AbsoluteDate> & RelativeDate
+  if (obj.type === 'static' && obj.value) {
+    const d = obj.value instanceof Date ? obj.value : new Date(obj.value)
+    return Number.isNaN(d.getTime()) ? undefined : formatAbsoluteDate(d)
+  }
+  return formatRelativeDate(obj as RelativeDate) ?? undefined
+}
+
 export function TaskCreateApprovalCard({ args, status, onApprove, onReject }: ApprovalCardProps) {
   const title = args.title as string
   const description = args.description as string | undefined
-  const deadline = args.deadline as string | undefined
+  const deadline = formatDeadline(args.deadline)
   const priority = args.priority as 'low' | 'medium' | 'high' | undefined
   const assigneeIds = args.assigneeIds as string[] | undefined
   const linkedRecordIds = args.linkedRecordIds as string[] | undefined

--- a/apps/web/src/components/kopilot/ui/kopilot-chat.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-chat.tsx
@@ -108,7 +108,11 @@ export function KopilotChat({
   }, [])
 
   const handleSuggestionClick = useCallback(
-    (text: string) => {
+    (text: string, autoSubmit: boolean) => {
+      if (!autoSubmit) {
+        composerRef.current?.populate(text)
+        return
+      }
       addMessage({
         id: generateId(),
         role: 'user',

--- a/apps/web/src/components/kopilot/ui/kopilot-composer.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-composer.tsx
@@ -45,6 +45,12 @@ interface KopilotComposerProps {
 
 export interface KopilotComposerHandle {
   focus: () => void
+  /**
+   * Replace editor content with `text` (wrapped in a paragraph) and focus the
+   * end. Used by suggestion clicks where `autoSubmit` is false — the user
+   * edits before sending.
+   */
+  populate: (text: string) => void
 }
 
 function isEmptyContent(html: string): boolean {
@@ -194,6 +200,12 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
         if (editor) {
           editor.commands.focus('end')
         }
+      },
+      populate: (text: string) => {
+        if (!editor) return
+        const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        editor.commands.setContent(`<p>${escaped}</p>`)
+        editor.commands.focus('end')
       },
     }),
     [editor]

--- a/apps/web/src/components/kopilot/ui/kopilot-empty-state.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-empty-state.tsx
@@ -3,31 +3,83 @@
 'use client'
 
 import { cn } from '@auxx/ui/lib/utils'
-import { Sparkles } from 'lucide-react'
-import { AnimatePresence, motion } from 'motion/react'
-import { useEffect, useState } from 'react'
+import {
+  FileText,
+  History,
+  List,
+  Mail,
+  Mic,
+  Pencil,
+  Plus,
+  Reply,
+  Search,
+  ShoppingBag,
+  Sparkles,
+  User,
+  Workflow,
+} from 'lucide-react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { useMemo } from 'react'
+import { useKopilotSuggestions } from '../stores/select-suggestions'
+import type { SuggestionIcon, SuggestionSlice } from '../suggestions/types'
 
-const suggestions = [
-  'Summarize my open tickets',
-  'Draft a reply to the latest email',
-  'Find contacts from California',
-  'Show me unresolved orders',
-  'What tickets came in today?',
+const ICONS: Record<SuggestionIcon, typeof Sparkles> = {
+  mail: Mail,
+  user: User,
+  file: FileText,
+  mic: Mic,
+  sparkle: Sparkles,
+  reply: Reply,
+  list: List,
+  plus: Plus,
+  history: History,
+  'shopping-bag': ShoppingBag,
+  workflow: Workflow,
+  pencil: Pencil,
+  search: Search,
+}
+
+const SPRING = { type: 'spring', stiffness: 220, damping: 26 } as const
+
+const FALLBACK: SuggestionSlice[] = [
+  { id: '__fallback_open', text: 'Summarize my open tickets', priority: 0, autoSubmit: true },
+  {
+    id: '__fallback_today',
+    text: 'What tickets came in today?',
+    priority: 0,
+    autoSubmit: true,
+  },
+  {
+    id: '__fallback_unresolved',
+    text: 'Show me unresolved orders',
+    priority: 0,
+    autoSubmit: true,
+  },
+  {
+    id: '__fallback_contacts',
+    text: 'Find contacts from California',
+    priority: 0,
+    autoSubmit: true,
+  },
+  {
+    id: '__fallback_draft',
+    text: 'Draft a reply to the latest email',
+    priority: 0,
+    autoSubmit: true,
+  },
 ]
 
 interface KopilotEmptyStateProps {
-  onSuggestionClick?: (text: string) => void
+  onSuggestionClick?: (text: string, autoSubmit: boolean) => void
 }
 
 export function KopilotEmptyState({ onSuggestionClick }: KopilotEmptyStateProps) {
-  const [currentIndex, setCurrentIndex] = useState(0)
+  const registered = useKopilotSuggestions()
+  const prefersReducedMotion = useReducedMotion()
 
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setCurrentIndex((prev) => (prev + 1) % suggestions.length)
-    }, 2500)
-    return () => clearInterval(timer)
-  }, [])
+  // All-or-nothing: page-registered suggestions take over completely. The
+  // fallback list is only rendered when no surface contributed anything.
+  const visible = useMemo(() => (registered.length > 0 ? registered : FALLBACK), [registered])
 
   return (
     <div className='flex flex-1 flex-col items-center justify-center gap-5 p-6 text-center'>
@@ -62,12 +114,8 @@ export function KopilotEmptyState({ onSuggestionClick }: KopilotEmptyStateProps)
           <div className='animate-scan absolute -inset-x-2 inset-y-0 z-10'>
             <div className='absolute inset-x-0 m-auto h-6 rounded-full bg-white/50 blur-2xl' />
           </div>
-
-          {/* <div className='absolute inset-0 z-20 m-auto flex size-10 items-center justify-center rounded-full bg-purple-500/10'>
-          <Sparkles className='size-5 text-purple-500' />
-        </div> */}
         </div>
-        <div className='space-y-1 '>
+        <div className='space-y-1'>
           <p className='text-sm font-medium'>Kopilot</p>
           <p className='text-xs text-muted-foreground max-w-[200px]'>
             Ask about tickets, contacts, or anything in your inbox.
@@ -75,26 +123,40 @@ export function KopilotEmptyState({ onSuggestionClick }: KopilotEmptyStateProps)
         </div>
       </div>
 
-      {/* Title */}
-
-      {/* Rotating suggestions */}
-      <div className='h-8 w-full max-w-xs'>
-        <AnimatePresence mode='wait'>
-          <motion.button
-            type='button'
-            key={currentIndex}
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -12 }}
-            transition={{ duration: 0.25 }}
-            className={cn(
-              'w-full cursor-pointer rounded-full border px-4 py-1.5 text-xs',
-              'text-muted-foreground hover:border-purple-500/40 hover:text-foreground',
-              'transition-colors'
-            )}
-            onClick={() => onSuggestionClick?.(suggestions[currentIndex]!)}>
-            {suggestions[currentIndex]}
-          </motion.button>
+      {/* Suggestions column */}
+      <div className='flex w-full max-w-xs flex-col gap-1'>
+        <AnimatePresence initial={true}>
+          {visible.map((s, i) => {
+            const Icon = s.icon ? ICONS[s.icon] : Sparkles
+            return (
+              <motion.button
+                type='button'
+                key={s.id}
+                layout
+                initial={
+                  prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 8, filter: 'blur(3px)' }
+                }
+                animate={
+                  prefersReducedMotion ? { opacity: 1 } : { opacity: 1, y: 0, filter: 'blur(0px)' }
+                }
+                exit={
+                  prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 4, filter: 'blur(3px)' }
+                }
+                transition={
+                  prefersReducedMotion ? { duration: 0.12 } : { ...SPRING, delay: i * 0.04 }
+                }
+                onClick={() => onSuggestionClick?.(s.text, s.autoSubmit)}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-lg border bg-background',
+                  'px-3 py-2 text-left text-xs text-muted-foreground',
+                  'hover:border-purple-500/40 hover:text-foreground',
+                  'transition-colors cursor-pointer'
+                )}>
+                <Icon className='size-3.5 shrink-0' />
+                <span className='flex-1 truncate'>{s.text}</span>
+              </motion.button>
+            )
+          })}
         </AnimatePresence>
       </div>
     </div>

--- a/apps/web/src/components/kopilot/ui/kopilot-message-list.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-message-list.tsx
@@ -38,7 +38,7 @@ interface KopilotMessageListProps {
   onEditMessage?: (messageId: string) => void
   onRetryMessage?: (messageId: string) => void
   onFeedback?: (messageId: string, isPositive: boolean) => void
-  onSuggestionClick?: (text: string) => void
+  onSuggestionClick?: (text: string, autoSubmit: boolean) => void
   /** Class applied to inner content for centering/width constraints */
   contentClassName?: string
 }

--- a/apps/web/src/components/mail/thread-display.tsx
+++ b/apps/web/src/components/mail/thread-display.tsx
@@ -8,6 +8,7 @@ import { Mail, Plus, Waypoints } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect } from 'react'
 import { KopilotContext } from '~/components/kopilot/context'
+import { KopilotSuggestion } from '~/components/kopilot/suggestions'
 import { useThread, useThreadReadStatus } from '~/components/threads/hooks'
 import { useActiveThreadId, useHasMultipleSelected } from '~/components/threads/store'
 import type { ChannelProvider } from '~/components/threads/store/thread-store'
@@ -82,6 +83,16 @@ export function ThreadDisplay({ centered, expectedThreadId }: ThreadDisplayProps
   return (
     <div className='flex h-full flex-col flex-1'>
       {thread && <KopilotContext activeThreadId={thread.id} activeThreadLabel={thread.subject} />}
+      {thread && (
+        <>
+          <KopilotSuggestion text='Summarize this thread' icon='sparkle' priority={10} autoSubmit />
+          <KopilotSuggestion text='Draft a reply' icon='reply' priority={5} />
+          <KopilotSuggestion text='Find similar tickets' icon='search' autoSubmit />
+          {thread.ticketId && (
+            <KopilotSuggestion text='Show ticket history' icon='history' autoSubmit />
+          )}
+        </>
+      )}
       <BulkActionToolbar />
       {thread && viewMode !== 'edit' ? (
         isChatThread(thread.integrationProvider) ? (

--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -35,6 +35,7 @@ import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggl
 import { DockToggleButton } from '~/components/global/dock-toggle-button'
 import { Tooltip } from '~/components/global/tooltip'
 import { KopilotContext } from '~/components/kopilot/context'
+import { KopilotSuggestion } from '~/components/kopilot/suggestions'
 import { MergeDialog } from '~/components/merge'
 import { useRecord, useResource } from '~/components/resources'
 import { useFieldValue } from '~/components/resources/hooks/use-field-values'
@@ -244,6 +245,8 @@ export const RecordDrawer = React.memo(function RecordDrawer({
   return (
     <>
       <KopilotContext activeRecordId={recordId} activeRecordLabel={displayName ?? undefined} />
+      <KopilotSuggestion text='Summarize this record' icon='sparkle' priority={10} autoSubmit />
+      <KopilotSuggestion text='Show related records' icon='list' autoSubmit />
       <BaseEntityDrawer
         recordId={recordId}
         open={open}

--- a/packages/lib/src/ai/kopilot/capabilities/mail/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/index.ts
@@ -4,6 +4,7 @@ import type { GetToolDeps, PageCapability } from '../types'
 import { createFindThreadsTool } from './tools/find-threads'
 import { createGetThreadDetailTool } from './tools/get-thread-detail'
 import { createListDraftsTool } from './tools/list-drafts'
+import { createListTagsTool } from './tools/list-tags'
 import { createReplyToThreadTool } from './tools/reply-to-thread'
 import { createStartNewConversationTool } from './tools/start-new-conversation'
 import { createUpdateThreadTool } from './tools/update-thread'
@@ -21,17 +22,19 @@ export function createMailCapabilities(getDeps: GetToolDeps): PageCapability {
       createFindThreadsTool(getDeps),
       createGetThreadDetailTool(getDeps),
       createListDraftsTool(getDeps),
+      createListTagsTool(getDeps),
       createReplyToThreadTool(getDeps),
       createStartNewConversationTool(getDeps),
       createUpdateThreadTool(getDeps),
     ],
     systemPromptAddition:
-      "You have access to the user's connected conversation channels (email, SMS, WhatsApp, Facebook DM, Instagram DM). You can search threads, read messages, draft or send replies, start brand-new conversations on integrations that support it, and manage thread status/tags/assignment.",
+      "You have access to the user's connected conversation channels (email, SMS, WhatsApp, Facebook DM, Instagram DM). You can search threads, read messages, draft or send replies, start brand-new conversations on integrations that support it, and manage thread status/tags/assignment. Tags are referenced by ID — when the user mentions a tag by name, call `list_tags` first to resolve it before passing IDs to `update_thread` or `find_threads`.",
     capabilities: [
       'Search threads and read messages across email and messaging channels',
       'Draft or send replies on existing threads',
       'Start brand-new conversations on integrations that support new outbound',
       'List unsent drafts — in-progress replies and standalone compositions',
+      'List and search workspace tags by name',
       'Manage thread status, tags, and assignment',
     ],
   }

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/find-threads.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/find-threads.ts
@@ -1,7 +1,9 @@
 // packages/lib/src/ai/kopilot/capabilities/mail/tools/find-threads.ts
 
+import { parseRecordId } from '@auxx/types/resource'
 import { generateId } from '@auxx/utils'
 import type { Condition, ConditionGroup } from '../../../../../conditions'
+import { TagService } from '../../../../../tags'
 import { ThreadQueryService } from '../../../../../threads'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import { FindThreadsDigest, takeSample } from '../../../digests'
@@ -172,17 +174,43 @@ export function createFindThreadsTool(getDeps: GetToolDeps): AgentToolDefinition
 
       const threadMetas = await service.getThreadMetaBatch(rawIds, agentDeps.userId)
 
-      const threads = threadMetas.map((t) => ({
-        id: t.id,
-        subject: t.subject,
-        status: t.status,
-        assigneeId: t.assigneeId,
-        lastMessageAt:
-          t.lastMessageAt instanceof Date ? t.lastMessageAt.toISOString() : t.lastMessageAt,
-        messageCount: t.messageCount,
-        isUnread: t.isUnread,
-        tagIds: t.tagIds,
-      }))
+      // Resolve tag names so the agent doesn't have to call list_tags after.
+      // tagIds on ThreadMeta are RecordIds ("entityDefId:instanceId") — parse to
+      // raw instance IDs since update_thread expects those.
+      const tagInfo = new Map<
+        string,
+        { id: string; name: string; color: string; emoji: string | null }
+      >()
+      if (threadMetas.some((t) => t.tagIds.length > 0)) {
+        const tagService = new TagService(agentDeps.organizationId, agentDeps.userId, db)
+        const allTags = await tagService.getAllTags()
+        for (const tag of allTags) {
+          tagInfo.set(tag.id, {
+            id: tag.id,
+            name: tag.title,
+            color: tag.tag_color,
+            emoji: tag.tag_emoji,
+          })
+        }
+      }
+
+      const threads = threadMetas.map((t) => {
+        const instanceIds = t.tagIds.map((rid) => parseRecordId(rid).entityInstanceId)
+        return {
+          id: t.id,
+          subject: t.subject,
+          status: t.status,
+          assigneeId: t.assigneeId,
+          lastMessageAt:
+            t.lastMessageAt instanceof Date ? t.lastMessageAt.toISOString() : t.lastMessageAt,
+          messageCount: t.messageCount,
+          isUnread: t.isUnread,
+          tagIds: instanceIds,
+          tags: instanceIds.map(
+            (id) => tagInfo.get(id) ?? { id, name: id, color: 'gray', emoji: null }
+          ),
+        }
+      })
 
       return {
         success: true,

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/get-thread-detail.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/get-thread-detail.ts
@@ -1,6 +1,8 @@
 // packages/lib/src/ai/kopilot/capabilities/mail/tools/get-thread-detail.ts
 
+import { parseRecordId } from '@auxx/types/resource'
 import { MessageQueryService } from '../../../../../messages'
+import { TagService } from '../../../../../tags'
 import { ThreadQueryService } from '../../../../../threads'
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
@@ -87,6 +89,22 @@ export function createGetThreadDetailTool(getDeps: GetToolDeps): AgentToolDefini
         participants: m.participants,
       }))
 
+      // tagIds on ThreadMeta are RecordIds ("entityDefId:instanceId") — parse to
+      // raw instance IDs since update_thread expects those, and resolve names.
+      const tagInstanceIds = thread.tagIds.map((rid) => parseRecordId(rid).entityInstanceId)
+      let tags: Array<{ id: string; name: string; color: string; emoji: string | null }> = []
+      if (tagInstanceIds.length > 0) {
+        const tagService = new TagService(agentDeps.organizationId, agentDeps.userId, db)
+        const allTags = await tagService.getAllTags()
+        const byId = new Map(allTags.map((t) => [t.id, t]))
+        tags = tagInstanceIds.map((id) => {
+          const tag = byId.get(id)
+          return tag
+            ? { id: tag.id, name: tag.title, color: tag.tag_color, emoji: tag.tag_emoji }
+            : { id, name: id, color: 'gray', emoji: null }
+        })
+      }
+
       return {
         success: true,
         output: {
@@ -101,7 +119,8 @@ export function createGetThreadDetailTool(getDeps: GetToolDeps): AgentToolDefini
                 : thread.lastMessageAt,
             messageCount: thread.messageCount,
             isUnread: thread.isUnread,
-            tagIds: thread.tagIds,
+            tagIds: tagInstanceIds,
+            tags,
             integrationId: thread.integrationId,
           },
           messages,

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/list-tags.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/list-tags.ts
@@ -1,0 +1,74 @@
+// packages/lib/src/ai/kopilot/capabilities/mail/tools/list-tags.ts
+
+import { TagService } from '../../../../../tags'
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import { ListTagsDigest, takeSample } from '../../../digests'
+import type { GetToolDeps } from '../../types'
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 200
+
+export function createListTagsTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'list_tags',
+    idempotent: true,
+    outputDigestSchema: ListTagsDigest,
+    buildDigest: (output) => {
+      const out = (output ?? {}) as {
+        tags?: Array<{ name?: string | null }>
+        count?: number
+      }
+      const tags = Array.isArray(out.tags) ? out.tags : []
+      return {
+        count: typeof out.count === 'number' ? out.count : tags.length,
+        names: takeSample(
+          tags
+            .map((t) => (typeof t.name === 'string' && t.name ? t.name : null))
+            .filter((n): n is string => Boolean(n))
+        ),
+      }
+    },
+    usageNotes: 'Tag IDs from this tool are what update_thread expects in addTagIds/removeTagIds.',
+    description:
+      "List the workspace's tags with their IDs, names, colors, and hierarchy. Use to resolve a tag name to an ID before calling update_thread (addTagIds/removeTagIds) or filtering find_threads by tagIds.",
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Optional case-insensitive filter on tag name',
+        },
+        limit: {
+          type: 'number',
+          description: `Max results (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT})`,
+        },
+      },
+      additionalProperties: false,
+    },
+    execute: async (args, agentDeps) => {
+      const { db } = getDeps()
+      const query = args.query as string | undefined
+      const limit = Math.min((args.limit as number) ?? DEFAULT_LIMIT, MAX_LIMIT)
+
+      const service = new TagService(agentDeps.organizationId, agentDeps.userId, db)
+
+      const all = await service.getAllTags()
+      const lower = query?.toLowerCase()
+      const filtered = lower ? all.filter((t) => t.title.toLowerCase().includes(lower)) : all
+
+      const tags = filtered.slice(0, limit).map((t) => ({
+        id: t.id,
+        name: t.title,
+        color: t.tag_color,
+        emoji: t.tag_emoji,
+        isSystemTag: t.isSystemTag,
+        parentId: t.parentId,
+      }))
+
+      return {
+        success: true,
+        output: { tags, count: tags.length },
+      }
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/digests.ts
+++ b/packages/lib/src/ai/kopilot/digests.ts
@@ -124,6 +124,12 @@ export type ListMembersDigest = z.infer<typeof ListMembersDigest>
 export const ListGroupsDigest = ListMembersDigest
 export type ListGroupsDigest = z.infer<typeof ListGroupsDigest>
 
+export const ListTagsDigest = z.object({
+  count: z.number(),
+  names: z.array(z.string()).max(DIGEST_SAMPLE_MAX),
+})
+export type ListTagsDigest = z.infer<typeof ListTagsDigest>
+
 export const ListFieldChangesDigest = z.object({
   count: z.number(),
   sample: z

--- a/packages/lib/src/favorites/favorites-service.ts
+++ b/packages/lib/src/favorites/favorites-service.ts
@@ -3,7 +3,7 @@
 // fire onCacheEvent after successful DB write so the user cache stays warm.
 
 import { type Database, database as ddb, schema } from '@auxx/database'
-import { generateKeyBetween, getSmartSortPositions } from '@auxx/utils'
+import { generateKeyBetween, getSmartSortPositions, nextKeyAfter } from '@auxx/utils'
 import { and, eq, inArray } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { onCacheEvent } from '../cache/invalidate'
@@ -54,7 +54,7 @@ async function nextSortOrderForParent(
     .sort()
 
   const last = siblings[siblings.length - 1] ?? null
-  return generateKeyBetween(last, null)
+  return nextKeyAfter(last)
 }
 
 async function countNodes(db: Database, memberId: string): Promise<number> {

--- a/packages/lib/src/field-hooks/post/bom-movement-triggers.ts
+++ b/packages/lib/src/field-hooks/post/bom-movement-triggers.ts
@@ -6,6 +6,7 @@ import type { TypedFieldValueInput } from '@auxx/types'
 import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
+import { nextKeyAfter } from '@auxx/utils/fractional-indexing'
 import { and, eq, inArray, sql } from 'drizzle-orm'
 import { getOrgCache, requireCachedEntityDefId } from '../../cache'
 import { createFieldValueContext } from '../../field-values/field-value-helpers'
@@ -164,7 +165,9 @@ export const explodeBomMovement: EntityTriggerHandler = async (event) => {
       })
     }
 
-    // Convert each typed value to a FieldValue insert row
+    // Convert each typed value to a FieldValue insert row.
+    // These are single-value fields (one row per (entityId, fieldId)),
+    // so the sortKey is purely positional — always the canonical first key.
     for (const { fieldId, value } of typedValues) {
       fieldValueRows.push(
         buildFieldValueRow({
@@ -173,6 +176,7 @@ export const explodeBomMovement: EntityTriggerHandler = async (event) => {
           entityDefinitionId: stockMovementDefId,
           fieldId,
           value,
+          sortKey: nextKeyAfter(null),
         })
       )
     }
@@ -484,7 +488,7 @@ async function batchRecalculateQoH(
     const status = deriveStockStatus(qoh, reorderPoint)
     const recordId = toRecordId(partDefId, partId) as RecordId
 
-    // QoH field value row
+    // QoH field value row (single-value field; positional sortKey).
     insertRows.push(
       buildFieldValueRow({
         organizationId,
@@ -492,6 +496,7 @@ async function batchRecalculateQoH(
         entityDefinitionId: partDefId,
         fieldId: qohField.id,
         value: { type: 'number', value: qoh },
+        sortKey: nextKeyAfter(null),
       })
     )
 
@@ -504,6 +509,7 @@ async function batchRecalculateQoH(
           entityDefinitionId: partDefId,
           fieldId: statusField.id,
           value: { type: 'option', optionId: status },
+          sortKey: nextKeyAfter(null),
         })
       )
     }

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -21,7 +21,12 @@ import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
 import { isSystemAttribute } from '@auxx/types/system-attribute'
 import { generateId } from '@auxx/utils'
-import { generateKeyBetween } from '@auxx/utils/fractional-indexing'
+import {
+  generateKeyBetween,
+  isValidOrderKey,
+  nextKeyAfter,
+  nKeysAfter,
+} from '@auxx/utils/fractional-indexing'
 import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import { getCachedFieldMap, getCachedResource } from '../cache'
 import {
@@ -412,15 +417,15 @@ export async function setValueWithType(
   // the input (stage-2 AI commit), merge the `aiStatus='result'` + metadata
   // marker onto each insert row. Absent = manual write → marker stays null,
   // naturally clearing any prior AI marker via this DELETE+INSERT cycle.
+  const sortKeys = nKeysAfter(null, values.length)
   const insertRows = values.map((v, index) => {
-    const sortKey = generateKeyBetween(index === 0 ? null : `a${index - 1}`, null)
     const baseRow = buildFieldValueRow({
       organizationId: ctx.organizationId,
       entityId: entityInstanceId,
       entityDefinitionId,
       fieldId,
       value: v,
-      sortKey,
+      sortKey: sortKeys[index]!,
     })
     return params.aiGeneration ? applyAiMarker(baseRow, params.aiGeneration) : baseRow
   })
@@ -482,22 +487,31 @@ export async function addValue(
     .orderBy(asc(schema.FieldValue.sortKey))
 
   // Calculate sort key based on position
+  // existing[].sortKey may be a legacy/corrupt value; `nextKeyAfter`
+  // degrades to 'a0' rather than throwing. For 'start'/'between' positions
+  // we still need a strict generateKeyBetween call — if the surrounding key
+  // is corrupt, fall back to appending at the end.
   let sortKey: string
   if (existing.length === 0) {
-    sortKey = generateKeyBetween(null, null)
+    sortKey = nextKeyAfter(null)
   } else if (position === 'start') {
-    sortKey = generateKeyBetween(null, existing[0]!.sortKey)
+    const firstKey = existing[0]!.sortKey
+    sortKey = isValidOrderKey(firstKey) ? generateKeyBetween(null, firstKey) : nextKeyAfter(null)
   } else if (position === 'end') {
-    sortKey = generateKeyBetween(existing[existing.length - 1]!.sortKey, null)
+    sortKey = nextKeyAfter(existing[existing.length - 1]!.sortKey)
   } else {
     // Insert after specific value
     const afterIndex = existing.findIndex((e) => e.sortKey === position.after)
     if (afterIndex === -1) {
-      sortKey = generateKeyBetween(existing[existing.length - 1]!.sortKey, null)
+      sortKey = nextKeyAfter(existing[existing.length - 1]!.sortKey)
     } else {
       const afterKey = existing[afterIndex]!.sortKey
       const beforeKey = existing[afterIndex + 1]?.sortKey ?? null
-      sortKey = generateKeyBetween(afterKey, beforeKey)
+      if (isValidOrderKey(afterKey) && (beforeKey == null || isValidOrderKey(beforeKey))) {
+        sortKey = generateKeyBetween(afterKey, beforeKey)
+      } else {
+        sortKey = nextKeyAfter(existing[existing.length - 1]!.sortKey)
+      }
     }
   }
 
@@ -649,12 +663,13 @@ export async function addRelationValues(
     )
     .orderBy(asc(schema.FieldValue.sortKey))
 
-  // Generate sort keys and insert new values
+  // Generate sort keys and insert new values. `nextKeyAfter` tolerates a
+  // corrupt prevKey from the DB (degrades to 'a0') rather than throwing.
   const { entityDefinitionId } = parseRecordId(recordId)
-  let prevKey = existing.length > 0 ? existing[existing.length - 1]!.sortKey : null
+  let prevKey: string | null = existing.length > 0 ? existing[existing.length - 1]!.sortKey : null
 
   const insertRows = newIds.map((relatedId) => {
-    const sortKey = generateKeyBetween(prevKey, null)
+    const sortKey = nextKeyAfter(prevKey)
     prevKey = sortKey
     return {
       organizationId: ctx.organizationId,
@@ -855,7 +870,8 @@ export async function addRelationValuesBulk(
 
   const insertRows = toInsert.map(({ entityId, relatedEntityId }) => {
     const prevKey = nextKeyByEntity.get(entityId) ?? null
-    const sortKey = generateKeyBetween(prevKey, null)
+    // `nextKeyAfter` tolerates a corrupt MAX from the DB by degrading to 'a0'.
+    const sortKey = nextKeyAfter(prevKey)
     nextKeyByEntity.set(entityId, sortKey)
     return {
       organizationId: ctx.organizationId,
@@ -1255,9 +1271,11 @@ export async function addValues(
     }
 
     // Generate sortKeys appended after the current max.
-    let prevKey = existingRows.length > 0 ? existingRows[existingRows.length - 1]!.sortKey : null
+    // `nextKeyAfter` tolerates a corrupt last-row sortKey by degrading to 'a0'.
+    let prevKey: string | null =
+      existingRows.length > 0 ? existingRows[existingRows.length - 1]!.sortKey : null
     const insertRows = survivors.map((v) => {
-      const sortKey = generateKeyBetween(prevKey, null)
+      const sortKey = nextKeyAfter(prevKey)
       prevKey = sortKey
       return buildFieldValueRow({
         organizationId: ctx.organizationId,
@@ -1478,7 +1496,9 @@ export async function addValuesBulk(
         if (k !== null) seen.add(k)
       }
 
-      let prevKey = existing.length > 0 ? existing[existing.length - 1]!.sortKey : null
+      // `nextKeyAfter` tolerates a corrupt last-row sortKey from the DB.
+      let prevKey: string | null =
+        existing.length > 0 ? existing[existing.length - 1]!.sortKey : null
       const localSeen = new Set<string>()
       const insertedTyped: TypedFieldValueInput[] = []
       for (let i = 0; i < typedInputs.length; i++) {
@@ -1488,7 +1508,7 @@ export async function addValuesBulk(
           continue
         }
         localSeen.add(key)
-        const sortKey = generateKeyBetween(prevKey, null)
+        const sortKey = nextKeyAfter(prevKey)
         prevKey = sortKey
         insertRows.push(
           buildFieldValueRow({
@@ -2640,11 +2660,12 @@ async function setMultiValue(
   if (values.length === 0) return []
 
   // Build insert rows with sortKeys - pass recordId
+  const sortKeys = nKeysAfter(null, values.length)
   const insertInputs = values.map((v, index) => ({
     recordId,
     fieldId,
     organizationId: ctx.organizationId,
-    sortKey: generateKeyBetween(index === 0 ? null : `a${index - 1}`, null),
+    sortKey: sortKeys[index]!,
     ...buildInsertData(fieldType, v),
   }))
 
@@ -2781,9 +2802,9 @@ export function buildFieldValueRow(params: {
   entityDefinitionId: string
   fieldId: string
   value: TypedFieldValueInput
-  sortKey?: string
+  sortKey: string
 }): typeof schema.FieldValue.$inferInsert {
-  const { organizationId, entityId, entityDefinitionId, fieldId, value, sortKey = 'a' } = params
+  const { organizationId, entityId, entityDefinitionId, fieldId, value, sortKey } = params
 
   const base = {
     organizationId,

--- a/packages/lib/src/field-values/relationship-sync.ts
+++ b/packages/lib/src/field-values/relationship-sync.ts
@@ -2,7 +2,7 @@
 
 import { type Database, schema } from '@auxx/database'
 import type { RelationshipType } from '@auxx/types/custom-field'
-import { generateKeyBetween } from '@auxx/utils/fractional-indexing'
+import { generateKeyBetween, nextKeyAfter } from '@auxx/utils/fractional-indexing'
 import { and, eq, inArray, sql } from 'drizzle-orm'
 
 // ============================================================================
@@ -509,7 +509,8 @@ async function batchAddToInverse(
 
     const insertValues = toInsert.map(({ targetId, sourceId }) => {
       const prevKey = nextKeyForTarget.get(targetId) ?? keyMap.get(targetId) ?? null
-      const newKey = generateKeyBetween(prevKey, null)
+      // `nextKeyAfter` tolerates a corrupt MAX from the DB by degrading to 'a0'.
+      const newKey = nextKeyAfter(prevKey)
       nextKeyForTarget.set(targetId, newKey)
 
       return {

--- a/packages/lib/src/workflow-engine/query-builder/entity-condition-builder.ts
+++ b/packages/lib/src/workflow-engine/query-builder/entity-condition-builder.ts
@@ -14,6 +14,7 @@ import { getFieldOutputKey, type ResourceField } from '../../resources/registry/
 import { type FieldOptionItem, getFieldOptions } from '../../resources/registry/option-helpers'
 import { BaseType } from '../core/types'
 import { BaseConditionBuilder, type GenericCondition } from './base-condition-builder'
+import { resolveOlderThanCutoff, resolveRelativeDateRange } from './relative-date-range'
 
 const logger = createScopedLogger('entity-condition-builder')
 
@@ -316,6 +317,20 @@ export class EntityConditionBuilder extends BaseConditionBuilder<EntityQueryCont
           return sql`${column} IS NULL`
         case 'not empty':
           return sql`${column} IS NOT NULL`
+        case 'today':
+        case 'yesterday':
+        case 'this_week':
+        case 'this_month':
+        case 'within_days': {
+          const range = resolveRelativeDateRange(operator, rawValue)
+          if (!range) return undefined
+          return sql`${column} >= ${range.start.toISOString()} AND ${column} < ${range.end.toISOString()}`
+        }
+        case 'older_than_days': {
+          const cutoff = resolveOlderThanCutoff(rawValue)
+          if (!cutoff) return undefined
+          return sql`${column} < ${cutoff.toISOString()}`
+        }
         default:
           logger.warn(`Operator '${operator}' not supported for date system fields`)
           return undefined
@@ -669,6 +684,20 @@ export class EntityConditionBuilder extends BaseConditionBuilder<EntityQueryCont
           return rawValue === null || rawValue === undefined
             ? sql`${dateCol} IS NOT NULL`
             : sql`${dateCol}::date != ${String(rawValue)}::date`
+        case 'today':
+        case 'yesterday':
+        case 'this_week':
+        case 'this_month':
+        case 'within_days': {
+          const range = resolveRelativeDateRange(operator, rawValue)
+          if (!range) return undefined
+          return sql`${dateCol} >= ${range.start.toISOString()} AND ${dateCol} < ${range.end.toISOString()}`
+        }
+        case 'older_than_days': {
+          const cutoff = resolveOlderThanCutoff(rawValue)
+          if (!cutoff) return undefined
+          return sql`${dateCol} < ${cutoff.toISOString()}`
+        }
       }
     }
 
@@ -1022,6 +1051,20 @@ export class EntityConditionBuilder extends BaseConditionBuilder<EntityQueryCont
           return sql`${dateCol} < ${String(rawValue)}`
         case 'after':
           return sql`${dateCol} > ${String(rawValue)}`
+        case 'today':
+        case 'yesterday':
+        case 'this_week':
+        case 'this_month':
+        case 'within_days': {
+          const range = resolveRelativeDateRange(operator, rawValue)
+          if (!range) return undefined
+          return sql`${dateCol} >= ${range.start.toISOString()} AND ${dateCol} < ${range.end.toISOString()}`
+        }
+        case 'older_than_days': {
+          const cutoff = resolveOlderThanCutoff(rawValue)
+          if (!cutoff) return undefined
+          return sql`${dateCol} < ${cutoff.toISOString()}`
+        }
       }
     }
 

--- a/packages/lib/src/workflow-engine/query-builder/relative-date-range.test.ts
+++ b/packages/lib/src/workflow-engine/query-builder/relative-date-range.test.ts
@@ -1,0 +1,63 @@
+// packages/lib/src/workflow-engine/query-builder/relative-date-range.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { resolveOlderThanCutoff, resolveRelativeDateRange } from './relative-date-range'
+
+// Wednesday 2026-05-13 14:30:00 local time
+const NOW = new Date(2026, 4, 13, 14, 30, 0, 0)
+
+describe('resolveRelativeDateRange', () => {
+  it('today: covers [start of day, start of next day)', () => {
+    const range = resolveRelativeDateRange('today', null, NOW)
+    expect(range).not.toBeNull()
+    expect(range!.start).toEqual(new Date(2026, 4, 13, 0, 0, 0, 0))
+    expect(range!.end).toEqual(new Date(2026, 4, 14, 0, 0, 0, 0))
+  })
+
+  it('yesterday: covers prior calendar day', () => {
+    const range = resolveRelativeDateRange('yesterday', null, NOW)
+    expect(range!.start).toEqual(new Date(2026, 4, 12, 0, 0, 0, 0))
+    expect(range!.end).toEqual(new Date(2026, 4, 13, 0, 0, 0, 0))
+  })
+
+  it('this_week: starts Sunday, spans 7 days (matches evaluate.ts)', () => {
+    // 2026-05-13 is Wednesday → week starts 2026-05-10 (Sunday)
+    const range = resolveRelativeDateRange('this_week', null, NOW)
+    expect(range!.start).toEqual(new Date(2026, 4, 10, 0, 0, 0, 0))
+    expect(range!.end).toEqual(new Date(2026, 4, 17, 0, 0, 0, 0))
+  })
+
+  it('this_month: spans the calendar month', () => {
+    const range = resolveRelativeDateRange('this_month', null, NOW)
+    expect(range!.start).toEqual(new Date(2026, 4, 1, 0, 0, 0, 0))
+    expect(range!.end).toEqual(new Date(2026, 5, 1, 0, 0, 0, 0))
+  })
+
+  it('within_days: spans [now - days, now + 1ms)', () => {
+    const range = resolveRelativeDateRange('within_days', 7, NOW)
+    expect(range!.start.getTime()).toBe(NOW.getTime() - 7 * 86_400_000)
+    expect(range!.end.getTime()).toBe(NOW.getTime() + 1)
+  })
+
+  it('within_days: returns null for non-numeric value', () => {
+    expect(resolveRelativeDateRange('within_days', 'abc', NOW)).toBeNull()
+    expect(resolveRelativeDateRange('within_days', null, NOW)).toBeNull()
+  })
+
+  it('returns null for non-relative operators', () => {
+    expect(resolveRelativeDateRange('is', null, NOW)).toBeNull()
+    expect(resolveRelativeDateRange('older_than_days', 5, NOW)).toBeNull()
+  })
+})
+
+describe('resolveOlderThanCutoff', () => {
+  it('returns now - days', () => {
+    const cutoff = resolveOlderThanCutoff(7, NOW)
+    expect(cutoff!.getTime()).toBe(NOW.getTime() - 7 * 86_400_000)
+  })
+
+  it('returns null for invalid input', () => {
+    expect(resolveOlderThanCutoff('abc', NOW)).toBeNull()
+    expect(resolveOlderThanCutoff(null, NOW)).toBeNull()
+  })
+})

--- a/packages/lib/src/workflow-engine/query-builder/relative-date-range.ts
+++ b/packages/lib/src/workflow-engine/query-builder/relative-date-range.ts
@@ -1,0 +1,100 @@
+// packages/lib/src/workflow-engine/query-builder/relative-date-range.ts
+
+import type { Operator } from '../../conditions/operator-definitions'
+
+export interface DateRange {
+  /** Inclusive lower bound. */
+  start: Date
+  /** Exclusive upper bound. */
+  end: Date
+}
+
+/**
+ * Resolve a relative-date operator (today, yesterday, this_week, this_month,
+ * within_days) to a concrete `[start, end)` half-open range. Returns `null` for
+ * non-relative operators or when `rawValue` is required but invalid — callers
+ * should fall through to their default branch.
+ *
+ * `older_than_days` is intentionally excluded: it has no upper bound and is
+ * better expressed as a single `column < cutoff` comparison upstream.
+ *
+ * Semantics mirror `evaluate.ts` (server local time, week starts Sunday) so
+ * client-side and server-side filtering agree on the same set of rows. A
+ * timezone-aware variant is a separate follow-up.
+ */
+export function resolveRelativeDateRange(
+  operator: Operator,
+  rawValue: unknown,
+  now: Date = new Date()
+): DateRange | null {
+  switch (operator) {
+    case 'today': {
+      const start = startOfDay(now)
+      return { start, end: addDays(start, 1) }
+    }
+    case 'yesterday': {
+      const start = addDays(startOfDay(now), -1)
+      return { start, end: addDays(start, 1) }
+    }
+    case 'this_week': {
+      const start = startOfWeek(now)
+      return { start, end: addDays(start, 7) }
+    }
+    case 'this_month': {
+      const start = startOfMonth(now)
+      const end = new Date(start)
+      end.setMonth(end.getMonth() + 1)
+      return { start, end }
+    }
+    case 'within_days': {
+      if (rawValue === null || rawValue === undefined) return null
+      const days = Number(rawValue)
+      if (!Number.isFinite(days)) return null
+      // Match evaluate.ts: diffDays >= 0 && diffDays <= days, i.e.
+      // [now - days, now]. Express as half-open [now - days, now + 1ms).
+      const end = new Date(now.getTime() + 1)
+      const start = new Date(now.getTime() - days * MS_PER_DAY)
+      return { start, end }
+    }
+    default:
+      return null
+  }
+}
+
+/**
+ * Cutoff for `older_than_days`: returns the timestamp `days` ago. Caller
+ * compares `column < cutoff`. Returns `null` for invalid input.
+ */
+export function resolveOlderThanCutoff(rawValue: unknown, now: Date = new Date()): Date | null {
+  if (rawValue === null || rawValue === undefined) return null
+  const days = Number(rawValue)
+  if (!Number.isFinite(days)) return null
+  return new Date(now.getTime() - days * MS_PER_DAY)
+}
+
+const MS_PER_DAY = 86_400_000
+
+function startOfDay(d: Date): Date {
+  const out = new Date(d)
+  out.setHours(0, 0, 0, 0)
+  return out
+}
+
+function addDays(d: Date, days: number): Date {
+  const out = new Date(d)
+  out.setDate(out.getDate() + days)
+  return out
+}
+
+function startOfWeek(d: Date): Date {
+  const out = startOfDay(d)
+  out.setDate(out.getDate() - out.getDay())
+  return out
+}
+
+function startOfMonth(d: Date): Date {
+  const out = new Date(d)
+  out.setDate(1)
+  out.setHours(0, 0, 0, 0)
+  return out
+}

--- a/packages/lib/src/workflow-engine/query-builder/system-condition-builder.ts
+++ b/packages/lib/src/workflow-engine/query-builder/system-condition-builder.ts
@@ -29,6 +29,7 @@ import { RESOURCE_FIELD_REGISTRY, RESOURCE_TABLE_MAP } from '../../resources/reg
 import type { TableId } from '../../resources/registry/field-registry'
 import { type FieldOptionItem, getFieldOptions } from '../../resources/registry/option-helpers'
 import { BaseConditionBuilder, type GenericCondition } from './base-condition-builder'
+import { resolveOlderThanCutoff, resolveRelativeDateRange } from './relative-date-range'
 
 const logger = createScopedLogger('system-condition-builder')
 
@@ -276,6 +277,25 @@ export class SystemConditionBuilder extends BaseConditionBuilder<TableId> {
 
       case 'not exists': {
         return this.combineColumnPredicates(columns, (col) => isNull(col), 'and')
+      }
+
+      // ===== RELATIVE DATE =====
+      case 'today':
+      case 'yesterday':
+      case 'this_week':
+      case 'this_month':
+      case 'within_days': {
+        const range = resolveRelativeDateRange(operator, rawValue)
+        if (!range) return undefined
+        return this.combineColumnPredicates(columns, (col) =>
+          and(gte(col, range.start), lt(col, range.end))
+        )
+      }
+
+      case 'older_than_days': {
+        const cutoff = resolveOlderThanCutoff(rawValue)
+        if (!cutoff) return undefined
+        return this.combineColumnPredicates(columns, (col) => lt(col, cutoff), 'and')
       }
 
       default: {

--- a/packages/utils/src/fractional-indexing.ts
+++ b/packages/utils/src/fractional-indexing.ts
@@ -244,6 +244,58 @@ export function generateKeyBetween(
 }
 
 /**
+ * Returns true if `key` is a syntactically valid order key.
+ *
+ * Use this to guard inputs that come from a data store where legacy or
+ * corrupt keys may exist. Internally calls the strict `validateOrderKey`
+ * and converts a thrown error into `false`.
+ */
+export function isValidOrderKey(key: string, digits: string = BASE_62_DIGITS): boolean {
+  if (typeof key !== 'string' || key.length === 0) return false
+  try {
+    validateOrderKey(key, digits)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Generate the next order key after `prevKey`.
+ *
+ * If `prevKey` is null, undefined, or not a valid order key, returns the
+ * canonical first key (`'a0'`). Use this when reading the current MAX
+ * from a column that may contain legacy or corrupt values — the strict
+ * `generateKeyBetween` throws on bad input, which can poison every
+ * subsequent write to that scope.
+ */
+export function nextKeyAfter(
+  prevKey: string | null | undefined,
+  digits: string = BASE_62_DIGITS
+): string {
+  if (prevKey == null || !isValidOrderKey(prevKey, digits)) {
+    return generateKeyBetween(null, null, digits)
+  }
+  return generateKeyBetween(prevKey, null, digits)
+}
+
+/**
+ * Generate `n` strictly increasing order keys after `prevKey`.
+ *
+ * Like `nextKeyAfter` but for batch inserts. Tolerates a corrupt or
+ * missing `prevKey` by starting from the beginning.
+ */
+export function nKeysAfter(
+  prevKey: string | null | undefined,
+  n: number,
+  digits: string = BASE_62_DIGITS
+): string[] {
+  if (n <= 0) return []
+  const start = prevKey != null && isValidOrderKey(prevKey, digits) ? prevKey : null
+  return generateNKeysBetween(start, null, n, digits)
+}
+
+/**
  * Generate n order keys between two keys
  * @param a - Lower bound order key (null for start)
  * @param b - Upper bound order key (null for end)

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -94,6 +94,9 @@ export {
   generateKeyBetween,
   generateNKeysBetween,
   getSmartSortPositions,
+  isValidOrderKey,
+  nextKeyAfter,
+  nKeysAfter,
   type SmartSortItem,
   type SmartSortResult,
 } from './fractional-indexing'


### PR DESCRIPTION
## Summary

- **Kopilot page suggestions** — distributed `<KopilotSuggestion>` contributors register slices in the store; empty-state renders the priority-sorted merged view (icon column + reduced-motion support). `autoSubmit=false` routes through a new `composer.populate()` so the user edits before sending. Mounted on mail-box, thread-display, contact/record drawers, and the KB article editor.
- **Mail tools** — new `list_tags` agent tool; `find_threads` / `get_thread_detail` parse RecordIds to instance IDs and resolve tag names inline so the agent doesn't have to round-trip. System prompt updated to point at `list_tags`.
- **Relative-date filtering** — new `relative-date-range.ts` (with tests) plumbed into entity + system condition builders for `today`, `yesterday`, `this_week`, `this_month`, `within_days`, `older_than_days`.
- **Order-key safety** — `nextKeyAfter` / `nKeysAfter` / `isValidOrderKey` in `@auxx/utils` tolerate corrupt prevKeys by degrading to `'a0'` instead of throwing. Rolled out across field-value mutations, relationship-sync, bom-movement-triggers, and favorites — a single bad row no longer poisons subsequent writes.
- **UI polish** — dynamic-table header edit/delete custom field menu; selectable cells skip pointerdown while inline-editing so the textarea owns the caret; favorites skeleton drops the `SidebarMenuSubItem` wrapper; KB switcher add-KB item uses `onSelect`+`preventDefault`; `TaskCreateApprovalCard` formats relative + absolute deadlines.

## Test plan

- [ ] Visit a mail thread / contact drawer / record drawer / KB article — confirm Kopilot empty-state shows the page-specific suggestions, sorted by priority.
- [ ] Click a non-`autoSubmit` suggestion — composer is populated and focused at end; click an `autoSubmit` one — turn fires immediately.
- [ ] Empty-state with no page contributors — fallback list still renders.
- [ ] Prefers-reduced-motion — suggestions fade without translate/blur.
- [ ] Ask Kopilot to "tag this thread Foo" — verify `list_tags` resolves the ID and `update_thread` succeeds.
- [ ] `find_threads` and `get_thread_detail` return tag objects with `name`, `color`, `emoji` and instance-shaped `tagIds`.
- [ ] Workflow filter on a date field with `today` / `this_week` / `within_days=7` / `older_than_days=30` — rows match the documented half-open ranges (server-local time, week starts Sunday).
- [ ] Vitest: `pnpm -F @auxx/lib test relative-date-range`.
- [ ] Add / reorder field values where DB has a legacy key — no throws; new key is appended cleanly.
- [ ] Dynamic-table header → custom column dropdown shows Edit/Delete; deleting non-system field invalidates the right entityDef scope.
- [ ] Inline-edit a cell — caret placement and mouse selection inside the input work; cell-selection drag still fires when not editing.
- [ ] KB switcher → "Add Knowledge Base" opens dialog without immediately closing.
- [ ] Approval card for `create_task` shows formatted deadline for both `{type:'static', value: Date}` and relative shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)