### PR TITLE
feat(kb): link context menu + kb-switcher delete + kopilot scroll fix

### DIFF
--- a/apps/web/src/components/editor/kb-article/article-link-popover.tsx
+++ b/apps/web/src/components/editor/kb-article/article-link-popover.tsx
@@ -1,17 +1,30 @@
 // apps/web/src/components/editor/kb-article/article-link-popover.tsx
 'use client'
 
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@auxx/ui/components/input-group'
 import { Popover, PopoverAnchor, PopoverContentDialogAware } from '@auxx/ui/components/popover'
 import { buildAuxxArticleUrl } from '@auxx/utils'
-import { useMemo, useRef } from 'react'
+import { Link as LinkIcon } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useArticleList } from '~/components/kb/hooks/use-article-list'
 import { ArticlePicker } from '~/components/kb/ui/articles/article-picker'
 
 export interface ArticleLinkPick {
-  /** Insertable href (auxx://kb/article/{id}). */
+  /** Insertable href — `auxx://kb/article/{id}` or a raw URL. */
   href: string
-  /** Visible link text — the article title. */
+  /** Visible link text — the article title or, for raw URLs, the URL itself. */
   text: string
+}
+
+export interface ArticleLinkEditMode {
+  kind: 'edit'
+  initialHref: string
+  initialText: string
 }
 
 interface ArticleLinkPopoverProps {
@@ -27,6 +40,11 @@ interface ArticleLinkPopoverProps {
    */
   children?: React.ReactNode
   anchorRect?: DOMRect | null
+  /**
+   * When set, renders a URL editor row above the picker (prefilled with the
+   * existing link's href). Used by the right-click → Edit flow.
+   */
+  mode?: ArticleLinkEditMode
 }
 
 export function ArticleLinkPopover({
@@ -36,6 +54,7 @@ export function ArticleLinkPopover({
   onPick,
   children,
   anchorRect,
+  mode,
 }: ArticleLinkPopoverProps) {
   const articles = useArticleList(knowledgeBaseId)
 
@@ -51,6 +70,24 @@ export function ArticleLinkPopover({
     return <PopoverAnchor virtualRef={virtualRef} />
   }, [children])
 
+  const isEdit = mode?.kind === 'edit'
+  const [urlDraft, setUrlDraft] = useState(mode?.initialHref ?? '')
+
+  // Reset the draft each time the popover opens in edit mode.
+  useEffect(() => {
+    if (open && isEdit) setUrlDraft(mode?.initialHref ?? '')
+  }, [open, isEdit, mode?.initialHref])
+
+  const submitUrl = () => {
+    const trimmed = urlDraft.trim()
+    if (!trimmed) return
+    onPick({
+      href: trimmed,
+      text: mode?.initialText?.trim() || trimmed,
+    })
+    onOpenChange(false)
+  }
+
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       {anchorEl}
@@ -59,8 +96,9 @@ export function ArticleLinkPopover({
         sideOffset={8}
         className='p-0'
         onOpenAutoFocus={(e) => {
-          // Let the cmdk input inside ArticlePicker handle its own focus.
-          e.preventDefault()
+          // Let the cmdk input inside ArticlePicker handle its own focus,
+          // unless we're in edit mode where the URL input is primary.
+          if (!isEdit) e.preventDefault()
         }}
         onFocusOutside={(e) => {
           // cmdk re-renders the CommandList on drill-down, which briefly
@@ -70,19 +108,57 @@ export function ArticleLinkPopover({
           // clicks outside should close the picker.
           e.preventDefault()
         }}>
+        {isEdit ? (
+          <div className='border-foreground/10 border-b p-2'>
+            <InputGroup>
+              <InputGroupAddon align='inline-start'>
+                <LinkIcon />
+              </InputGroupAddon>
+              <InputGroupInput
+                autoFocus
+                value={urlDraft}
+                onChange={(e) => setUrlDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    submitUrl()
+                  }
+                }}
+                placeholder='auxx://kb/article/… or https://…'
+              />
+              <InputGroupAddon align='inline-end'>
+                <InputGroupButton
+                  size='xs'
+                  onClick={submitUrl}
+                  disabled={!urlDraft.trim() || urlDraft.trim() === mode?.initialHref}>
+                  Save
+                </InputGroupButton>
+              </InputGroupAddon>
+            </InputGroup>
+            <p className='text-muted-foreground mt-2 px-1 text-xs'>
+              Or pick a different article below.
+            </p>
+          </div>
+        ) : null}
         <ArticlePicker
           knowledgeBaseId={knowledgeBaseId}
           allowedKinds={['page', 'link']}
           drillableKinds={['tab', 'category', 'header']}
-          rootLabel='Link to article'
+          rootLabel={isEdit ? 'Pick article' : 'Link to article'}
           searchPlaceholder='Search articles…'
           flattenSearch
           onPick={(articleId) => {
             const found = articles.find((a) => a.id === articleId)
-            onPick({
-              href: buildAuxxArticleUrl(articleId),
-              text: found?.title || 'article',
-            })
+            const href = buildAuxxArticleUrl(articleId)
+            // In edit mode, keep the existing visible text unless it matches
+            // the previous href (i.e. the user never gave it a custom label).
+            const prevHrefIsLabel =
+              isEdit && mode?.initialText && mode.initialText === mode.initialHref
+            const text =
+              isEdit && mode?.initialText && !prevHrefIsLabel
+                ? mode.initialText
+                : found?.title || 'article'
+            onPick({ href, text })
             onOpenChange(false)
           }}
           onClose={() => onOpenChange(false)}

--- a/apps/web/src/components/editor/kb-article/block-node-view.module.css
+++ b/apps/web/src/components/editor/kb-article/block-node-view.module.css
@@ -240,7 +240,7 @@
 }
 
 .blockContainer--heading1:first-child {
-  margin-top: 0;
+  /* margin-top: 0; */
 }
 
 .blockContent--heading1 {
@@ -257,7 +257,7 @@
 }
 
 .blockContainer--heading2:first-child {
-  margin-top: 0;
+  /* margin-top: 0; */
 }
 
 .blockContent--heading2 {
@@ -274,7 +274,7 @@
 }
 
 .blockContainer--heading3:first-child {
-  margin-top: 0;
+  /* margin-top: 0; */
 }
 
 .blockContent--heading3 {

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
@@ -2,15 +2,21 @@
 'use client'
 
 import type { JSONContent } from '@tiptap/core'
+import { getMarkRange } from '@tiptap/core'
 import type { Editor } from '@tiptap/react'
 import { EditorContent } from '@tiptap/react'
 import type { CSSProperties } from 'react'
 import { useCallback, useState } from 'react'
 import { InlinePickerPopover } from '../inline-picker'
-import { type ArticleLinkPick, ArticleLinkPopover } from './article-link-popover'
+import {
+  type ArticleLinkEditMode,
+  type ArticleLinkPick,
+  ArticleLinkPopover,
+} from './article-link-popover'
 import { KBEditorContextProvider } from './editor-context'
 import styles from './kb-article-editor.module.css'
 import { KBSlashCommandPicker } from './kb-slash-command-picker'
+import { LinkContextMenu, type LinkContextMenuTarget } from './link-context-menu'
 import { useKBArticleEditor } from './use-kb-article-editor'
 
 interface KBArticleEditorProps {
@@ -20,10 +26,17 @@ interface KBArticleEditorProps {
   knowledgeBaseId?: string
 }
 
-interface PendingLink {
-  editor: Editor
-  insertPos: number
+interface LinkPopoverState {
   rect: DOMRect
+  /** When set, replaces this range; otherwise inserts at the cursor. */
+  range?: { from: number; to: number }
+  /** Prefill values when editing an existing link. */
+  edit?: ArticleLinkEditMode
+}
+
+interface LinkMenuState extends LinkContextMenuTarget {
+  range: { from: number; to: number }
+  text: string
 }
 
 export function KBArticleEditor({
@@ -35,7 +48,8 @@ export function KBArticleEditor({
     initialContent,
     onChange,
   })
-  const [pendingLink, setPendingLink] = useState<PendingLink | null>(null)
+  const [linkPopover, setLinkPopover] = useState<LinkPopoverState | null>(null)
+  const [linkMenu, setLinkMenu] = useState<LinkMenuState | null>(null)
 
   // Clicks on chrome around the contenteditable (padding, empty area below
   // the last block) should still focus the editor at end — matches the
@@ -53,6 +67,29 @@ export function KBArticleEditor({
     editor.commands.focus('end')
   }
 
+  const handleContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!editor || editor.isDestroyed) return
+    const target = e.target as HTMLElement
+    if (!target.closest('.ProseMirror')) return
+    const linkType = editor.schema.marks.link
+    if (!linkType) return
+    const pos = editor.view.posAtCoords({ left: e.clientX, top: e.clientY })?.pos
+    if (pos == null) return
+    const $pos = editor.state.doc.resolve(pos)
+    const range = getMarkRange($pos, linkType)
+    if (!range) return // native context menu fires
+    const mark = $pos.marks().find((m) => m.type === linkType)
+    const href = typeof mark?.attrs.href === 'string' ? mark.attrs.href : ''
+    if (!href) return
+    e.preventDefault()
+    setLinkMenu({
+      range,
+      href,
+      rect: new DOMRect(e.clientX, e.clientY, 1, 1),
+      text: editor.state.doc.textBetween(range.from, range.to, ' '),
+    })
+  }
+
   const handleLinkArticle = useCallback((editorInstance: Editor, insertPos: number) => {
     const coords = editorInstance.view.coordsAtPos(insertPos)
     const rect = new DOMRect(
@@ -61,43 +98,67 @@ export function KBArticleEditor({
       Math.max(1, coords.right - coords.left),
       Math.max(1, coords.bottom - coords.top)
     )
-    setPendingLink({ editor: editorInstance, insertPos, rect })
+    setLinkPopover({ rect })
   }, [])
 
   const handlePick = useCallback(
     (pick: ArticleLinkPick) => {
-      if (!pendingLink) return
+      if (!editor || !linkPopover) return
       const isInternal = pick.href.startsWith('auxx://')
-      const endPos = pendingLink.insertPos + pick.text.length
-      pendingLink.editor
-        .chain()
-        .focus()
-        .insertContentAt(pendingLink.insertPos, {
-          type: 'text',
-          text: pick.text,
-          marks: [
-            {
-              type: 'link',
-              attrs: {
-                href: pick.href,
-                target: isInternal ? null : '_blank',
-              },
-            },
-          ],
+      const mark = {
+        type: 'link',
+        attrs: { href: pick.href, target: isInternal ? null : '_blank' },
+      }
+      const node = { type: 'text', text: pick.text, marks: [mark] }
+      const chain = editor.chain().focus()
+      if (linkPopover.range) {
+        chain.insertContentAt(linkPopover.range, node)
+      } else {
+        chain.insertContent(node)
+      }
+      // Strip the stored link mark so the next typed character isn't linked.
+      chain
+        .command(({ tr }) => {
+          tr.removeStoredMark(editor.schema.marks.link)
+          return true
         })
-        .setTextSelection(endPos)
-        .unsetMark('link')
         .run()
-      setPendingLink(null)
+      setLinkPopover(null)
     },
-    [pendingLink]
+    [editor, linkPopover]
   )
+
+  const buildInternalEditorHref = useCallback(
+    (articleId: string) => {
+      if (!knowledgeBaseId) return null
+      return `/app/kb/${knowledgeBaseId}/editor/${articleId}`
+    },
+    [knowledgeBaseId]
+  )
+
+  const handleEditLink = () => {
+    if (!linkMenu) return
+    setLinkPopover({
+      rect: linkMenu.rect,
+      range: linkMenu.range,
+      edit: { kind: 'edit', initialHref: linkMenu.href, initialText: linkMenu.text },
+    })
+    setLinkMenu(null)
+  }
+
+  const handleRemoveLink = () => {
+    if (!editor || !linkMenu) return
+    const { from, to } = linkMenu.range
+    editor.chain().focus().setTextSelection({ from, to }).unsetMark('link').run()
+    setLinkMenu(null)
+  }
 
   return (
     <KBEditorContextProvider knowledgeBaseId={knowledgeBaseId}>
       <div
         className={styles.editorWrapper}
         onMouseDown={handleWrapperMouseDown}
+        onContextMenu={handleContextMenu}
         style={{ '--gutter-min-width': `calc(${gutterCharWidth}ch + 1rem)` } as CSSProperties}>
         <div className={styles.editorContainer}>
           <EditorContent editor={editor} className={styles.editorContent} />
@@ -114,13 +175,23 @@ export function KBArticleEditor({
           />
         </InlinePickerPopover>
         <ArticleLinkPopover
-          open={pendingLink !== null}
+          open={linkPopover !== null}
           onOpenChange={(open) => {
-            if (!open) setPendingLink(null)
+            if (!open) setLinkPopover(null)
           }}
           knowledgeBaseId={knowledgeBaseId}
-          anchorRect={pendingLink?.rect ?? null}
+          anchorRect={linkPopover?.rect ?? null}
           onPick={handlePick}
+          mode={linkPopover?.edit}
+        />
+        <LinkContextMenu
+          target={linkMenu}
+          onOpenChange={(open) => {
+            if (!open) setLinkMenu(null)
+          }}
+          onEdit={handleEditLink}
+          onRemove={handleRemoveLink}
+          buildInternalEditorHref={buildInternalEditorHref}
         />
       </div>
     </KBEditorContextProvider>

--- a/apps/web/src/components/editor/kb-article/link-context-menu.tsx
+++ b/apps/web/src/components/editor/kb-article/link-context-menu.tsx
@@ -1,0 +1,119 @@
+// apps/web/src/components/editor/kb-article/link-context-menu.tsx
+'use client'
+
+import {
+  menuContentStyles,
+  menuItemStyles,
+  menuSeparatorStyles,
+  menuVariants,
+} from '@auxx/ui/components/menu-styles'
+import { Popover, PopoverAnchor, PopoverContent } from '@auxx/ui/components/popover'
+import { cn } from '@auxx/ui/lib/utils'
+import { isAuxxUrl, parseAuxxArticleUrl } from '@auxx/utils'
+import { Copy, ExternalLink, Pencil, Trash2 } from 'lucide-react'
+import { useMemo, useRef } from 'react'
+
+export interface LinkContextMenuTarget {
+  rect: DOMRect
+  href: string
+}
+
+interface Props {
+  target: LinkContextMenuTarget | null
+  onOpenChange: (open: boolean) => void
+  onEdit: () => void
+  onRemove: () => void
+  /**
+   * Resolve an internal article id to an admin-editor href. Returns `null`
+   * when no kb context is available — in that case the "Open" item is hidden
+   * and Copy falls back to the raw `auxx://` reference.
+   */
+  buildInternalEditorHref: (articleId: string) => string | null
+}
+
+export function LinkContextMenu({
+  target,
+  onOpenChange,
+  onEdit,
+  onRemove,
+  buildInternalEditorHref,
+}: Props) {
+  // Cache the last valid rect so the close animation doesn't snap to (0,0)
+  // when `target` clears. Floating UI re-measures during close — without
+  // this, it reads a fresh DOMRect (origin) and the menu visibly flies to
+  // the top-left corner mid-animation. Mirrors `inline-picker-popover.tsx`.
+  const lastRectRef = useRef<DOMRect>(new DOMRect())
+  if (target?.rect) lastRectRef.current = target.rect
+  const virtualRef = useRef<{ getBoundingClientRect: () => DOMRect }>({
+    getBoundingClientRect: () => lastRectRef.current,
+  })
+
+  const href = target?.href ?? ''
+  const internalRef = useMemo(() => parseAuxxArticleUrl(href), [href])
+  const isInternal = isAuxxUrl(href)
+
+  const internalEditorHref =
+    isInternal && internalRef ? buildInternalEditorHref(internalRef.articleId) : null
+  const openHref = isInternal ? internalEditorHref : href || null
+  const copyValue = isInternal ? (internalEditorHref ?? href) : href
+
+  const handleCopy = () => {
+    if (copyValue) void navigator.clipboard.writeText(copyValue)
+    onOpenChange(false)
+  }
+
+  const open = target !== null
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverAnchor virtualRef={virtualRef} />
+      <PopoverContent
+        align='start'
+        sideOffset={4}
+        className={cn(...menuContentStyles, 'w-44')}
+        onOpenAutoFocus={(e) => e.preventDefault()}>
+        <button
+          type='button'
+          className={cn(menuVariants({}), menuItemStyles, 'w-full')}
+          onClick={() => {
+            onEdit()
+            onOpenChange(false)
+          }}>
+          <Pencil />
+          Edit link
+        </button>
+        {openHref ? (
+          <a
+            href={openHref}
+            target='_blank'
+            rel='noopener noreferrer'
+            className={cn(menuVariants({}), menuItemStyles, 'w-full')}
+            onClick={() => onOpenChange(false)}>
+            <ExternalLink />
+            {isInternal ? 'Open article' : 'Open link'}
+          </a>
+        ) : null}
+        {copyValue ? (
+          <button
+            type='button'
+            className={cn(menuVariants({}), menuItemStyles, 'w-full')}
+            onClick={handleCopy}>
+            <Copy />
+            Copy {isInternal ? 'article URL' : 'URL'}
+          </button>
+        ) : null}
+        <div className={cn(menuSeparatorStyles)} />
+        <button
+          type='button'
+          className={cn(menuVariants({ variant: 'destructive' }), menuItemStyles, 'w-full')}
+          onClick={() => {
+            onRemove()
+            onOpenChange(false)
+          }}>
+          <Trash2 />
+          Remove link
+        </button>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/kb/ui/sidebar/kb-switcher.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/kb-switcher.tsx
@@ -7,13 +7,12 @@ import { Avatar, AvatarFallback } from '@auxx/ui/components/avatar'
 import {
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
   DropdownMenuSeparator,
 } from '@auxx/ui/components/dropdown-menu'
-import { Book, Plus } from 'lucide-react'
+import { Book, Check, Plus, Trash2 } from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useMemo, useState } from 'react'
+import { useConfirm } from '~/hooks/use-confirm'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { useActiveKnowledgeBaseId } from '../../hooks/use-knowledge-base'
 import { useKnowledgeBaseMutations } from '../../hooks/use-knowledge-base-mutations'
@@ -46,7 +45,8 @@ export function KBSwitcherDropdownContent() {
 
   const { knowledgeBases, isLoading } = useKnowledgeBases()
   const activeKBId = useActiveKnowledgeBaseId()
-  const { createKnowledgeBase, isCreating } = useKnowledgeBaseMutations()
+  const { createKnowledgeBase, isCreating, deleteKnowledgeBase } = useKnowledgeBaseMutations()
+  const [confirm, ConfirmDialog] = useConfirm()
 
   const { getLimit } = useFeatureFlags()
   const kbLimit = getLimit(FeatureKey.knowledgeBases)
@@ -79,6 +79,22 @@ export function KBSwitcherDropdownContent() {
     }
   }
 
+  const handleDelete = async (id: string, name: string) => {
+    const ok = await confirm({
+      title: 'Delete knowledge base?',
+      description: `"${name}" and all of its docs will be permanently deleted. This action cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!ok) return
+    const success = await deleteKnowledgeBase(id)
+    if (success && id === activeKBId) {
+      const next = knowledgeBases.find((k) => k.id !== id)
+      router.push(next ? `/app/kb/${next.id}/editor` : '/app/kb')
+    }
+  }
+
   return (
     <>
       <KnowledgeBaseDialog
@@ -88,6 +104,7 @@ export function KBSwitcherDropdownContent() {
         isSubmitting={isCreating}
         mode='create'
       />
+      <ConfirmDialog />
 
       <DropdownMenuLabel className='p-0 font-normal'>
         <div className='flex items-center gap-2 px-1 py-1.5 text-left text-sm'>
@@ -111,25 +128,49 @@ export function KBSwitcherDropdownContent() {
         </div>
       </DropdownMenuLabel>
       <DropdownMenuSeparator />
-      <DropdownMenuRadioGroup value={activeKBId ?? ''} onValueChange={handleClickKnowledgeBase}>
-        {isLoading ? (
-          <DropdownMenuItem disabled>Loading...</DropdownMenuItem>
-        ) : knowledgeBases.length > 0 ? (
-          knowledgeBases.map((kb) => {
-            const merged = mergeDraftOverLive(kb as Record<string, unknown>) as typeof kb
-            return (
-              <DropdownMenuRadioItem value={kb.id} key={kb.id} className='gap-2 p-2'>
-                <div className='flex size-6 items-center justify-center rounded-sm border'>
-                  <Book className='size-4 shrink-0' />
+      {isLoading ? (
+        <DropdownMenuItem disabled>Loading...</DropdownMenuItem>
+      ) : knowledgeBases.length > 0 ? (
+        knowledgeBases.map((kb) => {
+          const merged = mergeDraftOverLive(kb as Record<string, unknown>) as typeof kb
+          const isActive = kb.id === activeKBId
+          return (
+            <DropdownMenuItem
+              key={kb.id}
+              onSelect={() => handleClickKnowledgeBase(kb.id)}
+              className='group/kb-item h-7 cursor-pointer'>
+              <div className='flex items-center justify-between w-full'>
+                <div className='flex items-center gap-2 min-w-0'>
+                  <div className='flex size-5 shrink-0 items-center justify-center rounded-sm border'>
+                    <Book className='size-3 shrink-0' />
+                  </div>
+                  <span className='truncate'>{merged.name}</span>
                 </div>
-                {merged.name}
-              </DropdownMenuRadioItem>
-            )
-          })
-        ) : (
-          <DropdownMenuItem disabled>No knowledge bases found</DropdownMenuItem>
-        )}
-      </DropdownMenuRadioGroup>
+                <div className='flex items-center gap-1 shrink-0'>
+                  <button
+                    type='button'
+                    aria-label={`Delete ${merged.name}`}
+                    className='hidden group-hover/kb-item:flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-bad-100 hover:text-bad-500'
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      handleDelete(kb.id, merged.name ?? 'this knowledge base')
+                    }}>
+                    <Trash2 className='size-3' />
+                  </button>
+                  {isActive && (
+                    <div className='rounded-full size-4 bg-info flex items-center justify-center border border-blue-800'>
+                      <Check className='size-2.5! text-white' strokeWidth={4} />
+                    </div>
+                  )}
+                </div>
+              </div>
+            </DropdownMenuItem>
+          )
+        })
+      ) : (
+        <DropdownMenuItem disabled>No knowledge bases found</DropdownMenuItem>
+      )}
       {canCreateKB && (
         <>
           <DropdownMenuSeparator />

--- a/apps/web/src/components/kopilot/ui/kopilot-message-list.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-message-list.tsx
@@ -106,6 +106,11 @@ export function KopilotMessageList({
   const [inflateLast, setInflateLast] = useState(() => messages.length <= 1)
   const [pinTick, setPinTick] = useState(0)
   const pinBehaviorRef = useRef<ScrollBehavior>('smooth')
+  // True while a smooth pin scroll is in flight — used to suppress the
+  // streaming follow-effect's instant `scrollTop =` assignment, which would
+  // otherwise interrupt the smooth animation when stream chunks arrive.
+  const pinningRef = useRef(false)
+  const pinReleaseTimeoutRef = useRef<number | null>(null)
   // Sentinel placed after the last meaningful child of the last turn group.
   // Used to compute "at bottom" relative to the actual content end, not the
   // bottom of the inflated empty space.
@@ -198,6 +203,9 @@ export function KopilotMessageList({
   // biome-ignore lint/correctness/useExhaustiveDependencies: trigger-only deps
   useEffect(() => {
     if (!viewportEl) return
+    // Skip while a smooth pin scroll is animating — assigning scrollTop here
+    // would interrupt the animation mid-flight on every stream chunk.
+    if (pinningRef.current) return
     if (isAtBottom.current) {
       viewportEl.scrollTop = viewportEl.scrollHeight
     }
@@ -227,6 +235,16 @@ export function KopilotMessageList({
 
   const pinNewestTurn = useCallback((behavior: ScrollBehavior = 'smooth') => {
     pinBehaviorRef.current = behavior
+    pinningRef.current = true
+    if (pinReleaseTimeoutRef.current !== null) {
+      window.clearTimeout(pinReleaseTimeoutRef.current)
+    }
+    // Smooth scrolls typically settle well under 800ms; release the guard
+    // afterwards so subsequent stream chunks can resume bottom-following.
+    pinReleaseTimeoutRef.current = window.setTimeout(() => {
+      pinningRef.current = false
+      pinReleaseTimeoutRef.current = null
+    }, 800)
     setInflateLast(true)
     setPinTick((t) => t + 1)
   }, [])
@@ -263,6 +281,14 @@ export function KopilotMessageList({
     pinNewestTurn,
     scrollToBottom,
   ])
+
+  useEffect(() => {
+    return () => {
+      if (pinReleaseTimeoutRef.current !== null) {
+        window.clearTimeout(pinReleaseTimeoutRef.current)
+      }
+    }
+  }, [])
 
   const handleApproval = useCallback(
     (

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,6 +19,7 @@
     "./components/kb/search/build-index": "./src/components/kb/search/build-search-index.ts",
     "./components/kb/theme": "./src/components/kb/theme/index.ts",
     "./components/kb/utils": "./src/components/kb/utils/index.ts",
+    "./components/menu-styles": "./src/components/menu-styles.ts",
     "./components/*": "./src/components/*.tsx",
     "./components/icons/*": "./src/components/icons/*.tsx",
     "./hooks/*": "./src/hooks/*.ts",


### PR DESCRIPTION
## Summary
- **kb-article editor:** right-click on a link opens an Edit/Open/Copy/Remove context menu; edit mode prefills the URL input and still lets users repick an article from the picker below
- **kb-switcher:** replaced the radio dropdown with custom rows that expose a hover-only delete button (with confirm) and a checkmark for the active KB; auto-routes to another KB after deleting the active one
- **kopilot scroll:** guard the streaming follow-effect during smooth pin scrolls so incoming stream chunks don't interrupt the animation mid-flight
- **ui:** export `@auxx/ui/components/menu-styles` so app-level menu components can reuse the popover menu styling

## Test plan
- [ ] Right-click an `auxx://` article link → menu shows Edit / Open article / Copy article URL / Remove
- [ ] Right-click an external link → menu shows Edit / Open link / Copy URL / Remove
- [ ] Edit a link, change the URL, hit Save → href updates, visible text is preserved when previously customized
- [ ] Edit a link, pick a different article → href + (default) text update
- [ ] Remove link → mark cleared, text remains
- [ ] KB switcher: hover a KB row → delete button appears; click → confirm dialog → deletes; if active KB deleted, redirects to next KB or `/app/kb`
- [ ] Kopilot streaming: send a long reply, watch a smooth pin scroll complete without jumping to bottom mid-animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)