### PR TITLE
feat(kb): tabs + accordion container blocks with markdown roundtrip

### DIFF
--- a/apps/web/src/components/editor/kb-article/accordion-context.tsx
+++ b/apps/web/src/components/editor/kb-article/accordion-context.tsx
@@ -1,0 +1,26 @@
+// apps/web/src/components/editor/kb-article/accordion-context.tsx
+'use client'
+
+import { createContext, useContext } from 'react'
+
+export interface AccordionPanelContext {
+  containerPos: number | null
+  isCollapsed: (panelId: string) => boolean
+  toggleCollapsed: (panelId: string) => void
+}
+
+const Ctx = createContext<AccordionPanelContext | null>(null)
+
+export function AccordionPanelProvider({
+  value,
+  children,
+}: {
+  value: AccordionPanelContext
+  children: React.ReactNode
+}) {
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>
+}
+
+export function useAccordionPanelContext(): AccordionPanelContext | null {
+  return useContext(Ctx)
+}

--- a/apps/web/src/components/editor/kb-article/accordion-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/accordion-node-view.tsx
@@ -1,0 +1,93 @@
+// apps/web/src/components/editor/kb-article/accordion-node-view.tsx
+'use client'
+
+import type { NodeViewProps } from '@tiptap/react'
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import { Plus } from 'lucide-react'
+import { useCallback, useMemo } from 'react'
+import blockStyles from './block-node-view.module.css'
+import { addPanel, collectPanels } from './container-helpers'
+import styles from './container-node-view.module.css'
+
+/**
+ * Per-item drag-reorder is handled inside `panel-node-view.tsx` using
+ * native HTML5 drag (see `panel-drag-state.ts`). dnd-kit can't bridge
+ * across Tiptap's per-node-view React roots, so this parent view holds
+ * no SortableContext.
+ */
+export function AccordionNodeView({ node, editor, getPos, updateAttributes }: NodeViewProps) {
+  const panels = useMemo(() => collectPanels(node), [node])
+  const allowMultiple = (node.attrs as { allowMultiple?: boolean }).allowMultiple !== false
+
+  // Resolve `getPos()` lazily inside handlers — capturing it at render
+  // time goes stale because Tiptap doesn't re-render this NodeView when
+  // doc edits happen elsewhere (e.g. typing in another accordion shifts
+  // this one's position but doesn't trigger a re-render here).
+  const resolveContainerPos = useCallback((): number | null => {
+    if (typeof getPos !== 'function') return null
+    const p = getPos()
+    return typeof p === 'number' ? p : null
+  }, [getPos])
+
+  const containerPosForRender = typeof getPos === 'function' ? getPos() : null
+  const lineNumber =
+    typeof containerPosForRender === 'number'
+      ? editor.state.doc.resolve(containerPosForRender).index(0) + 1
+      : null
+
+  const selectThisContainer = (event: React.MouseEvent) => {
+    const cp = resolveContainerPos()
+    if (cp == null) return
+    event.preventDefault()
+    event.stopPropagation()
+    editor.commands.setNodeSelection(cp)
+  }
+
+  const handleAdd = useCallback(() => {
+    const cp = resolveContainerPos()
+    if (cp == null) return
+    const nextNumber = panels.length + 1
+    addPanel(editor, cp, `Question ${nextNumber}`)
+  }, [editor, resolveContainerPos, panels.length])
+
+  return (
+    <NodeViewWrapper as='div' className={blockStyles.blockWrapper} data-accordion=''>
+      <div className={blockStyles.blockContainer}>
+        <div
+          className={blockStyles.lineGutter}
+          contentEditable={false}
+          draggable={true}
+          data-block-drag-handle='true'
+          onClick={selectThisContainer}>
+          <div className={`${blockStyles.lineNumber} text-xs tabular-nums`}>{lineNumber ?? ''}</div>
+        </div>
+
+        <div
+          className={`${blockStyles.blockContentWrapper} ${styles.containerContent} ${styles.accordionContainerContent}`}>
+          <div className={styles.accordionToolbar} contentEditable={false}>
+            <button
+              type='button'
+              className={styles.accordionToolbarToggle}
+              aria-pressed={allowMultiple}
+              onClick={() => updateAttributes({ allowMultiple: !allowMultiple })}>
+              {allowMultiple ? 'Multiple open' : 'One open'}
+            </button>
+          </div>
+
+          <div className={styles.accordionBodyCard}>
+            <div className={styles.accordionContainer}>
+              <NodeViewContent />
+            </div>
+          </div>
+
+          <div className={styles.accordionFooter} contentEditable={false}>
+            <button type='button' className={styles.addAccordionItemButton} onClick={handleAdd}>
+              <Plus size={14} />
+              <span>Add item</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </NodeViewWrapper>
+  )
+}

--- a/apps/web/src/components/editor/kb-article/accordion-node.ts
+++ b/apps/web/src/components/editor/kb-article/accordion-node.ts
@@ -1,0 +1,36 @@
+// apps/web/src/components/editor/kb-article/accordion-node.ts
+
+import { mergeAttributes, Node } from '@tiptap/core'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+import { AccordionNodeView } from './accordion-node-view'
+
+export const Accordion = Node.create({
+  name: 'accordion',
+  group: 'containerBlock',
+  content: 'panel+',
+  defining: true,
+
+  addAttributes() {
+    return {
+      allowMultiple: {
+        default: true,
+        parseHTML: (el) => el.getAttribute('data-allow-multiple') !== 'false',
+        renderHTML: (attrs) => ({
+          'data-allow-multiple': attrs.allowMultiple === false ? 'false' : 'true',
+        }),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-accordion]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-accordion': '' }, HTMLAttributes), 0]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(AccordionNodeView)
+  },
+})

--- a/apps/web/src/components/editor/kb-article/block-drag-plugin.ts
+++ b/apps/web/src/components/editor/kb-article/block-drag-plugin.ts
@@ -7,6 +7,14 @@ import type { EditorView } from '@tiptap/pm/view'
 
 const PLUGIN_KEY = new PluginKey('blockDrag')
 
+/**
+ * Top-level draggable nodes. Containers (`tabs`, `accordion`) and `block`
+ * sit directly under the doc; the article-level drag handle grabs the
+ * outermost match. New container/format nodes (e.g. `table`) join with
+ * one entry.
+ */
+const DRAGGABLE_NODE_TYPES = new Set<string>(['block', 'tabs', 'accordion'])
+
 interface DraggingState {
   sourcePos: number
   nodeSize: number
@@ -17,18 +25,31 @@ function getBlockEl(target: EventTarget | null): HTMLElement | null {
   if (!(target instanceof HTMLElement)) return null
   const gutter = target.closest<HTMLElement>('[data-block-drag-handle]')
   if (!gutter) return null
-  return gutter.closest<HTMLElement>('[data-block]')
+  // Article-level drag handles live on `[data-block]`. In-container
+  // (panel) drag handles use a different attribute and are handled by
+  // their own dnd-kit instance — bail out so we don't grab the panel
+  // through this plugin.
+  if (gutter.getAttribute('data-block-drag-handle') === 'panel') return null
+  // Match either a flat block or a container element. Containers render
+  // their own outer wrapper with `data-tabs` / `data-accordion`.
+  return gutter.closest<HTMLElement>('[data-block], [data-tabs], [data-accordion]')
 }
 
 function blockPos(view: EditorView, blockEl: HTMLElement): number | null {
   const pos = view.posAtDOM(blockEl, 0)
   if (pos == null || pos < 0) return null
   const $pos = view.state.doc.resolve(pos)
+  // Walk up to the OUTERMOST draggable so clicking the gutter next to a
+  // tabs/accordion container grabs the whole container, not the active
+  // panel's first paragraph.
+  let outermost: { pos: number } | null = null
   for (let depth = $pos.depth; depth >= 0; depth--) {
     const node = $pos.node(depth)
-    if (node.type.name === 'block') return $pos.before(depth)
+    if (DRAGGABLE_NODE_TYPES.has(node.type.name)) {
+      outermost = { pos: $pos.before(depth) }
+    }
   }
-  return null
+  return outermost ? outermost.pos : null
 }
 
 export function blockDragPlugin() {
@@ -73,16 +94,33 @@ export function blockDragPlugin() {
         event.dataTransfer.clearData()
         event.dataTransfer.setData('text/plain', node.textContent ?? '')
         event.dataTransfer.effectAllowed = 'move'
-        // Anchor the drag image at the cursor's actual offset within the block
-        // — passing (0, 0) puts the cursor at the top-left, which visibly
-        // yanks tall blocks (cards grids) down when the grip is grabbed
-        // mid-height.
-        const rect = blockEl.getBoundingClientRect()
-        event.dataTransfer.setDragImage(
-          blockEl,
-          event.clientX - rect.left,
-          event.clientY - rect.top
-        )
+
+        // Use a cloned offscreen copy as the drag image. The browser
+        // snapshots the element passed to setDragImage *before* the drop
+        // begins, but using the live wrapper directly causes two problems
+        // for wide containers (tabs/accordion):
+        //   1. Anchoring the cursor at its grab offset within a 700px+ wide
+        //      element makes the preview extend far to one side.
+        //   2. The browser sometimes captures a stale layout if the
+        //      wrapper has just been re-rendered.
+        // A narrower offscreen clone removed on the next tick avoids both.
+        const clone = blockEl.cloneNode(true) as HTMLElement
+        clone.style.position = 'absolute'
+        clone.style.top = '-10000px'
+        clone.style.left = '-10000px'
+        clone.style.width = `${Math.min(blockEl.offsetWidth, 480)}px`
+        clone.style.maxWidth = '480px'
+        clone.style.maxHeight = '160px'
+        clone.style.overflow = 'hidden'
+        clone.style.opacity = '0.92'
+        clone.style.background = 'var(--color-background, white)'
+        clone.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)'
+        clone.style.borderRadius = '6px'
+        clone.style.pointerEvents = 'none'
+        document.body.appendChild(clone)
+        event.dataTransfer.setDragImage(clone, 16, 16)
+        // Defer removal until after the browser snapshots.
+        setTimeout(() => clone.remove(), 0)
 
         document.body.classList.add('is-block-dragging')
         // Block PM's own dragstart so it doesn't also seed view.dragging,

--- a/apps/web/src/components/editor/kb-article/block-node-view.module.css
+++ b/apps/web/src/components/editor/kb-article/block-node-view.module.css
@@ -53,6 +53,17 @@
   background-color: transparent;
 }
 
+/* Inner blocks rendered inside a tabs/accordion panel suppress their own
+   gutter — the container's outer gutter handles drag for the whole block,
+   and hiding the inner one lets panel content fill the available width. */
+[data-panel] .lineGutter {
+  display: none;
+}
+
+[data-panel] .blockContainer {
+  margin-left: 0;
+}
+
 /* ============================================
    Line number — subtle, appears on hover/focus
    ============================================ */
@@ -139,6 +150,13 @@
 
 .blockContentWrapper--codeBlock {
   width: 100%;
+  flex-direction: column;
+  align-items: stretch;
+  background: color-mix(in srgb, var(--color-foreground) 3%, transparent);
+  border: 1px solid var(--color-border);
+  border-radius: 0.625rem;
+  padding: 0.125rem;
+  gap: 0;
 }
 
 /* ============================================
@@ -431,7 +449,7 @@
 
 .blockContent--codeBlock {
   width: 100%;
-  background-color: var(--color-muted);
+  background-color: var(--color-background);
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
   padding: 0.75rem 1rem;
@@ -587,24 +605,27 @@
 }
 
 /* ============================================
-   Code language picker
+   Code language picker — sits in a top header strip outside the
+   nested code card, mirroring the tabs/accordion top bar.
    ============================================ */
 
-.blockContainer--codeBlock {
-  position: relative;
+.codeBlockHeader {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0.25rem 0.125rem;
+  background: transparent;
 }
 
 .codeLanguagePicker {
-  position: absolute;
-  top: 0.375rem;
-  right: 0.5rem;
   display: inline-flex;
   align-items: center;
-  gap: 0.125rem;
-  padding: 0.125rem 0.375rem;
-  border-radius: 0.25rem;
+  gap: 0.25rem;
+  margin-left: auto;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  border: 1px dashed transparent;
   background: transparent;
-  border: 1px solid transparent;
   color: var(--color-muted-foreground);
   cursor: pointer;
   font-size: 0.6875rem;
@@ -612,12 +633,13 @@
   letter-spacing: 0.04em;
   font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
   user-select: none;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
 }
 
 .codeLanguagePicker:hover,
 .codeLanguagePicker[data-state='open'] {
-  background-color: var(--color-background);
   border-color: var(--color-border);
+  color: var(--color-foreground);
 }
 
 /* ============================================

--- a/apps/web/src/components/editor/kb-article/block-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/block-node-view.tsx
@@ -378,28 +378,31 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
               )}
               <NodeViewContent className={`${styles.blockContent} ${styles.blockContentHidden}`} />
             </>
+          ) : isCodeBlock ? (
+            <>
+              <div className={styles.codeBlockHeader} contentEditable={false}>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button type='button' className={styles.codeLanguagePicker}>
+                      {CODE_LANGUAGES.find((l) => l.id === codeLanguage)?.label ?? 'Plain text'}{' '}
+                      <ChevronDown size={12} />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align='end'>
+                    {CODE_LANGUAGES.map((lang) => (
+                      <DropdownMenuItem
+                        key={lang.id}
+                        onSelect={() => updateAttributes({ codeLanguage: lang.id })}>
+                        {lang.label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+              <NodeViewContent className={contentClasses} />
+            </>
           ) : (
             <NodeViewContent className={contentClasses} />
-          )}
-
-          {isCodeBlock && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button type='button' className={styles.codeLanguagePicker} contentEditable={false}>
-                  {CODE_LANGUAGES.find((l) => l.id === codeLanguage)?.label ?? 'Plain text'}{' '}
-                  <ChevronDown size={12} />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align='end'>
-                {CODE_LANGUAGES.map((lang) => (
-                  <DropdownMenuItem
-                    key={lang.id}
-                    onSelect={() => updateAttributes({ codeLanguage: lang.id })}>
-                    {lang.label}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
           )}
 
           {isCallout && (

--- a/apps/web/src/components/editor/kb-article/container-helpers.ts
+++ b/apps/web/src/components/editor/kb-article/container-helpers.ts
@@ -1,0 +1,198 @@
+// apps/web/src/components/editor/kb-article/container-helpers.ts
+//
+// PM transaction helpers for `tabs` / `accordion` containers.
+// Reorder, add, and remove `panel` children of a container node.
+
+import { generateId } from '@auxx/utils'
+import type { Node as PMNode } from '@tiptap/pm/model'
+import type { Editor } from '@tiptap/react'
+
+export interface PanelLite {
+  id: string
+  label: string
+  iconId?: string
+}
+
+export function collectPanels(container: PMNode): PanelLite[] {
+  const out: PanelLite[] = []
+  container.forEach((child) => {
+    if (child.type.name !== 'panel') return
+    const attrs = child.attrs as { id?: string; label?: string; iconId?: string }
+    out.push({
+      id: attrs.id ?? '',
+      label: attrs.label ?? '',
+      iconId: attrs.iconId,
+    })
+  })
+  return out
+}
+
+function makeEmptyPanel(editor: Editor, label: string, id: string): PMNode {
+  const panelType = editor.schema.nodes.panel
+  const blockType = editor.schema.nodes.block
+  if (!panelType || !blockType) {
+    throw new Error('Editor schema is missing `panel` or `block` node types.')
+  }
+  const emptyBlock = blockType.create({ blockType: 'text' })
+  return panelType.create({ id, label }, emptyBlock)
+}
+
+export function addPanel(editor: Editor, containerPos: number, label: string): string | null {
+  const container = editor.state.doc.nodeAt(containerPos)
+  if (!container) return null
+  const id = generateId()
+  const panel = makeEmptyPanel(editor, label, id)
+  // Insert at the end of the container (just before its closing token).
+  // No `scrollIntoView()` — that scrolls the doc to the new node, which
+  // jumps the page when the accordion is far above the current viewport.
+  const insertPos = containerPos + container.nodeSize - 1
+  editor.view.dispatch(editor.state.tr.insert(insertPos, panel))
+  return id
+}
+
+export function removePanel(editor: Editor, containerPos: number, panelId: string): void {
+  const container = editor.state.doc.nodeAt(containerPos)
+  if (!container) return
+  // If this is the last panel, remove the whole container.
+  if (container.childCount <= 1) {
+    editor.view.dispatch(editor.state.tr.delete(containerPos, containerPos + container.nodeSize))
+    return
+  }
+  const panel = findPanelByIdInContainer(container, panelId)
+  if (!panel) return
+  // Position of the panel inside the doc = containerPos + 1 (open token) + offset
+  let offset = 1
+  let found = false
+  container.forEach((child) => {
+    if (found) return
+    if (child === panel.node) {
+      found = true
+      return
+    }
+    offset += child.nodeSize
+  })
+  if (!found) return
+  const from = containerPos + offset
+  editor.view.dispatch(editor.state.tr.delete(from, from + panel.node.nodeSize))
+}
+
+export function reorderPanels(
+  editor: Editor,
+  containerPos: number,
+  fromIndex: number,
+  toIndex: number
+): void {
+  if (fromIndex === toIndex) return
+  const container = editor.state.doc.nodeAt(containerPos)
+  if (!container) return
+
+  const children: PMNode[] = []
+  container.forEach((child) => children.push(child))
+  if (fromIndex < 0 || fromIndex >= children.length) return
+  if (toIndex < 0 || toIndex >= children.length) return
+
+  const [moved] = children.splice(fromIndex, 1)
+  children.splice(toIndex, 0, moved)
+
+  // Rebuild the container with the same attrs and reordered children.
+  const newContainer = container.type.create(container.attrs, children, container.marks)
+  editor.view.dispatch(
+    editor.state.tr.replaceWith(containerPos, containerPos + container.nodeSize, newContainer)
+  )
+}
+
+export function setPanelAttr(
+  editor: Editor,
+  containerPos: number,
+  panelId: string,
+  attrPatch: Record<string, unknown>
+): void {
+  const container = editor.state.doc.nodeAt(containerPos)
+  if (!container) return
+  const panel = findPanelByIdInContainer(container, panelId)
+  if (!panel) return
+  // Resolve the panel's absolute position in the doc.
+  let offset = 1
+  let found = false
+  container.forEach((child) => {
+    if (found) return
+    if (child === panel.node) {
+      found = true
+      return
+    }
+    offset += child.nodeSize
+  })
+  if (!found) return
+  const panelPos = containerPos + offset
+  const tr = editor.state.tr
+  for (const [k, v] of Object.entries(attrPatch)) {
+    tr.setNodeAttribute(panelPos, k, v)
+  }
+  editor.view.dispatch(tr)
+}
+
+interface FoundPanel {
+  node: PMNode
+  index: number
+}
+
+function findPanelByIdInContainer(container: PMNode, panelId: string): FoundPanel | null {
+  let result: FoundPanel | null = null
+  let index = 0
+  container.forEach((child) => {
+    if (result) {
+      index++
+      return
+    }
+    if (child.type.name === 'panel' && (child.attrs as { id?: string }).id === panelId) {
+      result = { node: child, index }
+    }
+    index++
+  })
+  return result
+}
+
+export function getPanelIndex(editor: Editor, containerPos: number, panelId: string): number {
+  const container = editor.state.doc.nodeAt(containerPos)
+  if (!container) return -1
+  let idx = -1
+  let i = 0
+  container.forEach((child) => {
+    if (idx >= 0) return
+    if (child.type.name === 'panel' && (child.attrs as { id?: string }).id === panelId) {
+      idx = i
+    }
+    i++
+  })
+  return idx
+}
+
+export function focusFirstBlockInPanel(
+  editor: Editor,
+  containerPos: number,
+  panelId: string
+): void {
+  const container = editor.state.doc.nodeAt(containerPos)
+  if (!container) return
+  const panel = findPanelByIdInContainer(container, panelId)
+  if (!panel) return
+  let offset = 1
+  let found = false
+  container.forEach((child) => {
+    if (found) return
+    if (child === panel.node) {
+      found = true
+      return
+    }
+    offset += child.nodeSize
+  })
+  if (!found) return
+  // Position 1 inside the panel = inside its first block. Add 1 to enter the
+  // panel, then 1 to enter the first block.
+  const focusPos = containerPos + offset + 2
+  try {
+    editor.commands.focus(focusPos)
+  } catch {
+    /* no-op — best effort */
+  }
+}

--- a/apps/web/src/components/editor/kb-article/container-node-view.module.css
+++ b/apps/web/src/components/editor/kb-article/container-node-view.module.css
@@ -1,0 +1,424 @@
+/* apps/web/src/components/editor/kb-article/container-node-view.module.css
+   Editor-time chrome for `tabs` / `accordion` containers and their
+   shared `panel` child. The outer wrapper reuses
+   `block-node-view.module.css` (.blockWrapper / .blockContainer /
+   .lineGutter / .blockContentWrapper) so containers align with the
+   rest of the article. This file styles only the inner chrome. */
+
+/* Inner content area — composed with .blockContentWrapper on the SAME
+   element, so we must override its `align-items: flex-start` (which would
+   otherwise shrink column children to content width). */
+.containerContent {
+  width: 100%;
+  flex: 1 1 0%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-background);
+  overflow: visible;
+}
+
+/* ============================================
+   Tabs
+   ============================================ */
+
+/* Tabs-specific outer frame: subtle tint + 2px padding so the body nests
+   inside as a separate rounded card, matching the public renderer.
+   `.blockContentWrapper` (composed on the same element) sets `gap: 0.25rem`
+   between children — collapse it so the tab strip sits flush above the body. */
+.tabsContainerContent {
+  background: color-mix(in srgb, var(--color-foreground) 3%, transparent);
+  padding: 0.125rem;
+  gap: 0;
+}
+
+.tabsHeader {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.125rem;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  background: transparent;
+}
+
+.tabButton {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin: 0.25rem 0;
+  padding: 0.125rem 0.375rem;
+  border: none;
+  background: transparent;
+  color: var(--color-muted-foreground);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.5;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  border-radius: 0.5rem;
+  transition: color 0.12s, background 0.12s, opacity 0.12s;
+}
+
+.tabButton:hover {
+  background: color-mix(in srgb, var(--color-foreground) 7%, transparent);
+  color: var(--color-foreground);
+}
+
+.tabButton[data-active='true'] {
+  color: var(--color-foreground);
+}
+
+.tabButton[data-active='true']::after {
+  content: '';
+  position: absolute;
+  left: 0.375rem;
+  right: 0.375rem;
+  bottom: -0.25rem;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--color-primary);
+}
+
+.tabButton[data-dragging='true'] {
+  opacity: 0.5;
+}
+
+.tabButtonLabel {
+  pointer-events: none;
+  min-width: 1ch;
+}
+
+.tabButtonClose {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border: none;
+  background: transparent;
+  color: var(--color-muted-foreground);
+  opacity: 0.5;
+  border-radius: 999px;
+  cursor: pointer;
+  padding: 0;
+  transition: opacity 0.12s, background 0.12s, color 0.12s;
+}
+
+.tabButtonClose:hover {
+  opacity: 1;
+  background: var(--color-muted);
+  color: var(--color-foreground);
+}
+
+.addTabButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px dashed transparent;
+  background: transparent;
+  color: var(--color-muted-foreground);
+  font-size: 0.75rem;
+  cursor: pointer;
+  border-radius: 0.375rem;
+  margin-left: auto;
+}
+
+.addTabButton:hover {
+  border-color: var(--color-border);
+  color: var(--color-foreground);
+}
+
+.tabsBody {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-background);
+  padding: 0.5rem 0.75rem;
+}
+
+/* Each panel inside the tabs body is wrapped by ReactNodeViewRenderer in
+   a `.react-renderer.node-panel` div — make those block-level + full
+   width so the active panel body fills the tab container. */
+.tabsBody :global(.react-renderer.node-panel) {
+  display: block;
+  width: 100%;
+}
+
+/* ============================================
+   Accordion
+   ============================================ */
+
+/* Mirrors `.tabsContainerContent` — subtle outer frame + 2px padding so
+   the items render as a nested rounded card. `.blockContentWrapper`
+   (composed on the same element) sets `gap: 0.25rem`; collapse it so the
+   toolbar sits flush above the body. */
+.accordionContainerContent {
+  background: color-mix(in srgb, var(--color-foreground) 3%, transparent);
+  padding: 0.125rem;
+  gap: 0;
+}
+
+.accordionToolbar {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.125rem;
+  font-size: 0.75rem;
+  color: var(--color-muted-foreground);
+  background: transparent;
+}
+
+.accordionToolbarToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  border: 1px dashed transparent;
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: var(--color-muted-foreground);
+  margin-left: auto;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
+}
+
+.accordionToolbarToggle:hover {
+  border-color: var(--color-border);
+  color: var(--color-foreground);
+}
+
+.accordionToolbarToggle[aria-pressed='true'] {
+  color: var(--color-foreground);
+}
+
+.accordionContainer {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.accordionItem {
+  width: 100%;
+  position: relative;
+}
+
+/* Suppress ProseMirror's drop / gap cursors while a panel drag is in
+   progress — otherwise the user sees both PM's black insertion line
+   AND our blue panel-edge indicator at the same time. */
+:global(body.is-panel-dragging .ProseMirror-dropcursor),
+:global(body.is-panel-dragging .ProseMirror-gapcursor),
+:global(body.is-panel-dragging .prosemirror-dropcursor-block),
+:global(body.is-panel-dragging .prosemirror-dropcursor-inline) {
+  display: none !important;
+}
+
+/* Belt & suspenders for any other drop/gap cursor class names. */
+:global(body.is-panel-dragging [class*='dropcursor']),
+:global(body.is-panel-dragging [class*='gapcursor']) {
+  display: none !important;
+}
+
+.accordionItem[data-drop-edge='top']::before,
+.accordionItem[data-drop-edge='bottom']::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--color-primary, #2563eb);
+  z-index: 3;
+  pointer-events: none;
+}
+
+.accordionItem[data-drop-edge='top']::before {
+  top: -1px;
+}
+
+.accordionItem[data-drop-edge='bottom']::after {
+  bottom: -1px;
+}
+
+/* ReactNodeViewRenderer wraps each panel in a `<div class="react-renderer
+   node-panel">` so OUR `.accordionItem` divs are NOT direct siblings of
+   each other. Style the wrapper directly to guarantee block-level + full
+   width, and add separators between consecutive panel wrappers. */
+.accordionContainer :global(.react-renderer.node-panel) {
+  display: block;
+  width: 100%;
+}
+
+.accordionContainer
+  :global(.react-renderer.node-panel)
+  + :global(.react-renderer.node-panel) {
+  border-top: 1px solid var(--color-border);
+}
+
+.accordionHeader {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.accordionHeader:hover {
+  background: var(--color-muted);
+}
+
+/* Per-item drag handle — positioned in the gutter to the LEFT of the
+   accordion's bordered box so it doesn't take horizontal space inside
+   the header. Absolute positioning keeps it visually attached to its
+   item row at the height of the header. */
+.accordionDragHandle {
+  position: absolute;
+  left: -1.5rem;
+  top: 0.625rem;
+  width: 1rem;
+  height: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-muted-foreground);
+  cursor: grab;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 2;
+}
+
+.accordionItem:hover .accordionDragHandle {
+  opacity: 0.7;
+}
+
+.accordionDragHandle:active {
+  cursor: grabbing;
+}
+
+.accordionChevron {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.125rem;
+  height: 1.125rem;
+  color: var(--color-muted-foreground);
+  transition: transform 0.15s;
+}
+
+.accordionItem[data-expanded='false'] .accordionChevron {
+  transform: rotate(-90deg);
+}
+
+.accordionLabel {
+  flex: 1 1 auto;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-foreground);
+  outline: none;
+  min-width: 1ch;
+  border-radius: 2px;
+}
+
+.accordionLabel:focus {
+  background: var(--color-muted);
+}
+
+.accordionItemClose {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: none;
+  background: transparent;
+  color: var(--color-muted-foreground);
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.accordionItem:hover .accordionItemClose {
+  display: inline-flex;
+}
+
+.accordionItemClose:hover {
+  background: var(--color-muted);
+  color: var(--color-foreground);
+}
+
+.accordionBody {
+  width: 100%;
+  /* Left padding aligns body content under the title text in the header
+     (header padding-left 0.75rem + drag handle 1rem + gap 0.5rem +
+     chevron 1.125rem + gap 0.5rem ≈ 3.875rem). */
+  padding: 0rem 0.75rem 0 2rem;
+}
+
+.accordionItem[data-expanded='false'] .accordionBody {
+  display: none;
+}
+
+/* Outer card that wraps the accordion items + Add button — mirrors
+   `.tabsBody` so accordion and tabs share the same nested-card look. */
+.accordionBodyCard {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-background);
+  /* overflow: hidden; */
+}
+
+/* Bottom strip — sits in the subtle frame area below the body card. The
+   "Add item" button is full-width and centered to match the original
+   visual weight, while the surrounding strip stays in the outer frame
+   (not inside the white nested card). */
+.accordionFooter {
+  width: 100%;
+  display: flex;
+  background: transparent;
+}
+
+.addAccordionItemButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  width: 100%;
+  padding: 0.4rem 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px dashed transparent;
+  background: transparent;
+  color: var(--color-muted-foreground);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
+}
+
+.addAccordionItemButton:hover {
+  border-color: var(--color-border);
+  color: var(--color-foreground);
+}
+
+/* ============================================
+   Panel — body container rendered by PanelNodeView
+   ============================================ */
+
+.panelBody {
+  display: block;
+}
+
+.panelContent {
+  display: block;
+}

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
@@ -172,6 +172,7 @@ export function KBArticleEditor({
             onExecute={slashCommand.executeCommand}
             onClose={slashCommand.closePicker}
             onLinkArticle={handleLinkArticle}
+            editor={editor}
           />
         </InlinePickerPopover>
         <ArticleLinkPopover

--- a/apps/web/src/components/editor/kb-article/kb-slash-command-picker.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-slash-command-picker.tsx
@@ -29,6 +29,9 @@ interface KBSlashCommandPickerProps {
   /** Open the article-link dialog. The picker deletes the slash range first
    * and passes the resulting cursor position to the host. */
   onLinkArticle?: (editor: Editor, insertPos: number) => void
+  /** Live editor instance — used to filter container blocks (`tabs`,
+   * `accordion`) out of the menu when the cursor is inside a panel. */
+  editor?: Editor | null
 }
 
 interface BlockCommandSpec {
@@ -274,7 +277,63 @@ const BASE_COMMANDS: CommandItemDef[] = [
         .run()
     },
   },
+  {
+    id: 'tabs',
+    title: 'Tabs',
+    description: 'Tabbed content with multiple panels',
+    keywords: ['tabs', 'tab', 'switcher', 'panels'],
+    iconId: 'columns',
+    custom: (editor, range) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent({
+          type: 'tabs',
+          attrs: { activeTab: null },
+          content: [makeEmptyPanelJSON('Tab 1'), makeEmptyPanelJSON('Tab 2')],
+        })
+        .run()
+    },
+  },
+  {
+    id: 'accordion',
+    title: 'Accordion',
+    description: 'Collapsible Q&A or FAQ items',
+    keywords: ['accordion', 'faq', 'collapse', 'toggle', 'questions'],
+    iconId: 'chevrons-up-down',
+    custom: (editor, range) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent({
+          type: 'accordion',
+          attrs: { allowMultiple: true },
+          content: [makeEmptyPanelJSON('Question 1'), makeEmptyPanelJSON('Question 2')],
+        })
+        .run()
+    },
+  },
 ]
+
+function makeEmptyPanelJSON(label: string) {
+  return {
+    type: 'panel' as const,
+    attrs: { id: generateId(), label },
+    content: [{ type: 'block' as const, attrs: { blockType: 'text' as const }, content: [] }],
+  }
+}
+
+const PANEL_RESTRICTED_COMMAND_IDS = new Set(['tabs', 'accordion'])
+
+function selectionIsInsidePanel(editor: Editor): boolean {
+  const { $from } = editor.state.selection
+  for (let depth = $from.depth; depth >= 0; depth--) {
+    if ($from.node(depth).type.name === 'panel') return true
+  }
+  return false
+}
 
 interface SlashCommandNavItem {
   id: string
@@ -326,6 +385,7 @@ function KBSlashCommandPickerContent({
   onExecute,
   onClose,
   onLinkArticle,
+  editor,
   searchQuery,
   setSearchQuery,
   onEnterPlaceholderMode,
@@ -388,16 +448,20 @@ function KBSlashCommandPickerContent({
 
   const filteredCommands = useMemo(() => {
     if (isInSnippets) return []
-    const base = onLinkArticle
-      ? BASE_COMMANDS
-      : BASE_COMMANDS.filter((c) => c.id !== 'article-link')
+    let base = onLinkArticle ? BASE_COMMANDS : BASE_COMMANDS.filter((c) => c.id !== 'article-link')
+    // Q1b: containers (tabs/accordion) cannot be nested inside a panel.
+    // ProseMirror's schema enforces this structurally; filtering here
+    // just keeps the menu clean.
+    if (editor && selectionIsInsidePanel(editor)) {
+      base = base.filter((c) => !PANEL_RESTRICTED_COMMAND_IDS.has(c.id))
+    }
     return base.filter(
       (item) =>
         item.title.toLowerCase().includes(q) ||
         item.description.toLowerCase().includes(q) ||
         item.keywords.some((kw) => kw.includes(q))
     )
-  }, [isInSnippets, q, onLinkArticle])
+  }, [isInSnippets, q, onLinkArticle, editor])
 
   const runBlockSpec = useCallback(
     (spec: BlockCommandSpec) => {

--- a/apps/web/src/components/editor/kb-article/panel-drag-state.ts
+++ b/apps/web/src/components/editor/kb-article/panel-drag-state.ts
@@ -1,0 +1,227 @@
+// apps/web/src/components/editor/kb-article/panel-drag-state.ts
+//
+// Coordinates native HTML5 drag-and-drop for accordion panels. dnd-kit
+// can't be used because Tiptap renders each child node-view (panel) in
+// an independent React root, so a `SortableContext` in the parent
+// would never reach the `useSortable()` calls in the children.
+//
+// Strategy:
+//   - the source panel's drag handle starts a native drag and calls
+//     `startPanelDrag()`, which attaches *document-level* dragover/drop
+//     listeners and adds `body.is-panel-dragging` (used by CSS to hide
+//     ProseMirror's drop cursor extension).
+//   - the document listeners use **Y-only collision** against each item
+//     in the source accordion's DOM, so the user can drag straight up /
+//     down from a handle that visually sits outside the accordion's
+//     bordered box.
+//   - the drop state (`{ panelId, edge }`) is exposed to subscribers so
+//     each panel-node-view can render a blue insertion indicator.
+
+import type { Editor } from '@tiptap/react'
+import { getPanelIndex, reorderPanels } from './container-helpers'
+
+interface PanelDragState {
+  panelId: string
+  containerPos: number
+  fromIndex: number
+  editor: Editor
+  accordionEl: HTMLElement
+}
+
+export interface PanelDropState {
+  panelId: string
+  edge: 'top' | 'bottom'
+}
+
+let drag: PanelDragState | null = null
+let drop: PanelDropState | null = null
+let cleanup: (() => void) | null = null
+const listeners = new Set<() => void>()
+
+function notify(): void {
+  for (const fn of listeners) fn()
+}
+
+export function getPanelDrag(): PanelDragState | null {
+  return drag
+}
+
+export function getPanelDrop(): PanelDropState | null {
+  return drop
+}
+
+export function subscribePanelDrag(fn: () => void): () => void {
+  listeners.add(fn)
+  return () => {
+    listeners.delete(fn)
+  }
+}
+
+export function startPanelDrag(state: PanelDragState): void {
+  drag = state
+  drop = null
+  if (typeof document !== 'undefined') {
+    document.body.classList.add('is-panel-dragging')
+  }
+  attachListeners()
+  notify()
+}
+
+export function endPanelDrag(): void {
+  drag = null
+  drop = null
+  if (typeof document !== 'undefined') {
+    document.body.classList.remove('is-panel-dragging')
+  }
+  detachListeners()
+  notify()
+}
+
+function setDrop(next: PanelDropState | null): void {
+  if (next?.panelId === drop?.panelId && next?.edge === drop?.edge && !!next === !!drop) {
+    return
+  }
+  drop = next
+  notify()
+}
+
+interface ItemEntry {
+  id: string
+  rect: DOMRect
+}
+
+function collectItems(accordionEl: HTMLElement): ItemEntry[] {
+  // Direct children only (don't pick up items from a nested accordion if
+  // someone ever allows that).
+  const items = accordionEl.querySelectorAll<HTMLElement>('[data-accordion-item][data-panel-id]')
+  const out: ItemEntry[] = []
+  for (const el of items) {
+    const id = el.getAttribute('data-panel-id')
+    if (!id) continue
+    out.push({ id, rect: el.getBoundingClientRect() })
+  }
+  return out
+}
+
+function attachListeners(): void {
+  detachListeners()
+
+  const onDragOver = (e: DragEvent) => {
+    if (!drag) return
+    // preventDefault is required for `drop` to fire. We accept drops
+    // anywhere on the page during a panel drag — out-of-accordion drops
+    // are no-ops in onDrop.
+    e.preventDefault()
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'
+
+    const items = collectItems(drag.accordionEl)
+    if (items.length === 0) {
+      setDrop(null)
+      return
+    }
+
+    const y = e.clientY
+    let hover: ItemEntry | null = null
+
+    // Y-only collision against each item.
+    for (const item of items) {
+      if (y >= item.rect.top && y <= item.rect.bottom) {
+        hover = item
+        break
+      }
+    }
+
+    // Above the first / below the last — clamp to the nearest end so
+    // dragging past the edges still shows a sensible indicator.
+    if (!hover) {
+      const first = items[0]
+      const last = items[items.length - 1]
+      if (y < first.rect.top) hover = first
+      else if (y > last.rect.bottom) hover = last
+    }
+
+    if (!hover || hover.id === drag.panelId) {
+      setDrop(null)
+      return
+    }
+
+    const isAfter = y > hover.rect.top + hover.rect.height / 2
+    setDrop({ panelId: hover.id, edge: isAfter ? 'bottom' : 'top' })
+  }
+
+  const onDrop = (e: DragEvent) => {
+    if (!drag) return
+    e.preventDefault()
+    e.stopPropagation()
+
+    const currentDrag = drag
+    const currentDrop = drop
+
+    if (!currentDrop) {
+      console.log('[panel-drag] drop with no target — bail')
+      endPanelDrag()
+      return
+    }
+
+    const overIndex = getPanelIndex(
+      currentDrag.editor,
+      currentDrag.containerPos,
+      currentDrop.panelId
+    )
+    if (overIndex < 0) {
+      console.log('[panel-drag] drop bailed: target panel not found in container', {
+        targetId: currentDrop.panelId,
+        containerPos: currentDrag.containerPos,
+      })
+      endPanelDrag()
+      return
+    }
+
+    let toIndex: number
+    if (currentDrag.fromIndex < overIndex) {
+      // Source removed before target → target shifts down by 1.
+      toIndex = currentDrop.edge === 'bottom' ? overIndex : overIndex - 1
+    } else {
+      // Source after target → target index unchanged.
+      toIndex = currentDrop.edge === 'bottom' ? overIndex + 1 : overIndex
+    }
+
+    console.log('[panel-drag] drop reorder', {
+      from: currentDrag.fromIndex,
+      overIndex,
+      edge: currentDrop.edge,
+      toIndex,
+    })
+
+    if (toIndex !== currentDrag.fromIndex) {
+      reorderPanels(currentDrag.editor, currentDrag.containerPos, currentDrag.fromIndex, toIndex)
+    }
+    endPanelDrag()
+  }
+
+  const onDragEnd = () => {
+    if (drag) {
+      console.log('[panel-drag] dragend cleanup')
+      endPanelDrag()
+    }
+  }
+
+  // Capture phase so we run before any per-element handlers and before
+  // ProseMirror's own drop handling.
+  document.addEventListener('dragover', onDragOver, true)
+  document.addEventListener('drop', onDrop, true)
+  document.addEventListener('dragend', onDragEnd, true)
+
+  cleanup = () => {
+    document.removeEventListener('dragover', onDragOver, true)
+    document.removeEventListener('drop', onDrop, true)
+    document.removeEventListener('dragend', onDragEnd, true)
+  }
+}
+
+function detachListeners(): void {
+  if (cleanup) {
+    cleanup()
+    cleanup = null
+  }
+}

--- a/apps/web/src/components/editor/kb-article/panel-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/panel-node-view.tsx
@@ -1,0 +1,236 @@
+// apps/web/src/components/editor/kb-article/panel-node-view.tsx
+'use client'
+
+import type { NodeViewProps } from '@tiptap/react'
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import { ChevronDown, GripVertical, X } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { getPanelIndex, removePanel as removePanelOp, setPanelAttr } from './container-helpers'
+import styles from './container-node-view.module.css'
+import {
+  endPanelDrag,
+  getPanelDrag,
+  getPanelDrop,
+  startPanelDrag,
+  subscribePanelDrag,
+} from './panel-drag-state'
+
+/**
+ * Tiptap renders each child node-view in an independent React root, so
+ * React Context from a parent NodeView (TabsNodeView / AccordionNodeView)
+ * does NOT reach this component. We detect the parent's type by walking
+ * the PM doc with `getPos()` instead.
+ *
+ * - inside `tabs`: just the body. The active tab is shown / others are
+ *   hidden via TabsNodeView's display-toggle effect.
+ * - inside `accordion`: a header row (drag handle, chevron, label, X) +
+ *   collapsible body. Drag-reorder is coordinated by document-level
+ *   listeners in `panel-drag-state.ts`; this view just starts the drag
+ *   and renders the drop-edge indicator from subscribed state.
+ */
+export function PanelNodeView({ node, editor, getPos }: NodeViewProps) {
+  const id = (node.attrs as { id?: string }).id ?? ''
+  const label = (node.attrs as { label?: string }).label ?? ''
+
+  const parentTypeName = useMemo(() => {
+    if (typeof getPos !== 'function') return null
+    try {
+      const pos = getPos()
+      if (typeof pos !== 'number') return null
+      const $pos = editor.state.doc.resolve(pos)
+      return $pos.parent.type.name
+    } catch {
+      return null
+    }
+  }, [editor, getPos, node])
+
+  if (parentTypeName === 'accordion') {
+    return <AccordionPanelView panelId={id} label={label} editor={editor} getPos={getPos} />
+  }
+
+  return (
+    <NodeViewWrapper as='div' className={styles.panelBody} data-panel='' data-panel-id={id}>
+      <NodeViewContent className={styles.panelContent} />
+    </NodeViewWrapper>
+  )
+}
+
+interface AccordionPanelViewProps {
+  panelId: string
+  label: string
+  editor: NodeViewProps['editor']
+  getPos: NodeViewProps['getPos']
+}
+
+function AccordionPanelView({ panelId, label, editor, getPos }: AccordionPanelViewProps) {
+  const [isCollapsed, setIsCollapsed] = useState(false)
+  const [, forceTick] = useState(0)
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+  const headerRef = useRef<HTMLDivElement | null>(null)
+
+  // Re-render this item when drag/drop state changes so the dropEdge
+  // indicator + isSourceOfDrag opacity update in lockstep with the
+  // module-level state.
+  useEffect(() => subscribePanelDrag(() => forceTick((t) => t + 1)), [])
+
+  const containerPos = useCallback((): number | null => {
+    if (typeof getPos !== 'function') return null
+    try {
+      const pos = getPos()
+      if (typeof pos !== 'number') return null
+      const $pos = editor.state.doc.resolve(pos)
+      return $pos.before($pos.depth)
+    } catch {
+      return null
+    }
+  }, [editor, getPos])
+
+  const onRename = useCallback(
+    (next: string) => {
+      const cp = containerPos()
+      if (cp == null) return
+      setPanelAttr(editor, cp, panelId, { label: next })
+    },
+    [editor, panelId, containerPos]
+  )
+
+  const onDelete = useCallback(() => {
+    const cp = containerPos()
+    if (cp == null) return
+    removePanelOp(editor, cp, panelId)
+  }, [editor, panelId, containerPos])
+
+  const handleDragStart = useCallback(
+    (e: React.DragEvent<HTMLSpanElement>) => {
+      const cp = containerPos()
+      if (cp == null) {
+        console.log('[panel-drag] dragstart bailed: no containerPos', { panelId })
+        return
+      }
+      const fromIndex = getPanelIndex(editor, cp, panelId)
+      if (fromIndex < 0) {
+        console.log('[panel-drag] dragstart bailed: no fromIndex', { panelId, cp })
+        return
+      }
+      const accordionEl = wrapperRef.current?.closest<HTMLElement>('[data-accordion]')
+      if (!accordionEl) {
+        console.log('[panel-drag] dragstart bailed: no accordion ancestor', { panelId })
+        return
+      }
+      console.log('[panel-drag] dragstart', { panelId, containerPos: cp, fromIndex })
+      startPanelDrag({ panelId, containerPos: cp, fromIndex, editor, accordionEl })
+      if (e.dataTransfer) {
+        e.dataTransfer.effectAllowed = 'move'
+        // Firefox cancels drags with empty dataTransfer.
+        e.dataTransfer.setData('text/plain', panelId)
+        // Drag image: a clone of the header only (no body content), so
+        // the preview is a tidy row regardless of how much content the
+        // expanded item is rendering. Cloned offscreen and removed on
+        // the next tick — same pattern as block-drag-plugin.
+        const header = headerRef.current
+        if (header) {
+          const clone = header.cloneNode(true) as HTMLElement
+          clone.style.position = 'absolute'
+          clone.style.top = '-10000px'
+          clone.style.left = '-10000px'
+          clone.style.width = `${Math.min(header.offsetWidth, 480)}px`
+          clone.style.maxWidth = '480px'
+          clone.style.background = 'var(--color-background, white)'
+          clone.style.border = '1px solid var(--color-border, #e5e7eb)'
+          clone.style.borderRadius = '6px'
+          clone.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)'
+          clone.style.opacity = '0.95'
+          clone.style.pointerEvents = 'none'
+          document.body.appendChild(clone)
+          e.dataTransfer.setDragImage(clone, 16, 16)
+          setTimeout(() => clone.remove(), 0)
+        }
+      }
+      // Don't let block-drag-plugin's view.dom-level dragstart see this.
+      e.stopPropagation()
+    },
+    [editor, panelId, containerPos]
+  )
+
+  const handleDragEnd = useCallback(() => {
+    // dragend also fires on document via panel-drag-state. This is the
+    // belt-and-suspenders cleanup if the document listener missed it
+    // (e.g. drag escapes to another window).
+    if (getPanelDrag()?.panelId === panelId) {
+      endPanelDrag()
+    }
+  }, [panelId])
+
+  // Read the current drop indicator from module state.
+  const dropState = getPanelDrop()
+  const dragState = getPanelDrag()
+  const dropEdge = dropState?.panelId === panelId ? dropState.edge : null
+  const isSourceOfDrag = dragState?.panelId === panelId
+
+  return (
+    <NodeViewWrapper
+      as='div'
+      ref={wrapperRef}
+      className={styles.accordionItem}
+      style={{ opacity: isSourceOfDrag ? 0.5 : 1 }}
+      data-panel=''
+      data-accordion-item=''
+      data-panel-id={panelId}
+      data-expanded={isCollapsed ? 'false' : 'true'}
+      data-drop-edge={dropEdge ?? undefined}>
+      <div
+        ref={headerRef}
+        className={styles.accordionHeader}
+        contentEditable={false}
+        onClick={() => setIsCollapsed((v) => !v)}>
+        <span
+          className={styles.accordionDragHandle}
+          aria-label='Drag item'
+          draggable
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}>
+          <GripVertical size={14} />
+        </span>
+        <span className={styles.accordionChevron} aria-hidden='true'>
+          <ChevronDown size={16} />
+        </span>
+        <span
+          className={styles.accordionLabel}
+          contentEditable
+          suppressContentEditableWarning
+          spellCheck={false}
+          onMouseDown={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              ;(e.currentTarget as HTMLElement).blur()
+            }
+          }}
+          onBlur={(e) => {
+            const next = (e.currentTarget.textContent ?? '').trim()
+            if (next !== label) onRename(next)
+          }}>
+          {label || 'Untitled'}
+        </span>
+        <button
+          type='button'
+          className={styles.accordionItemClose}
+          aria-label='Remove item'
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            onDelete()
+          }}>
+          <X size={12} />
+        </button>
+      </div>
+      <div className={styles.accordionBody}>
+        <NodeViewContent className={styles.panelContent} />
+      </div>
+    </NodeViewWrapper>
+  )
+}

--- a/apps/web/src/components/editor/kb-article/panel-node.ts
+++ b/apps/web/src/components/editor/kb-article/panel-node.ts
@@ -1,0 +1,70 @@
+// apps/web/src/components/editor/kb-article/panel-node.ts
+
+import { mergeAttributes, Node } from '@tiptap/core'
+import { TextSelection } from '@tiptap/pm/state'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+import { PanelNodeView } from './panel-node-view'
+
+export const Panel = Node.create({
+  name: 'panel',
+  group: 'panel',
+  content: 'block+',
+  defining: true,
+  isolating: true,
+
+  addKeyboardShortcuts() {
+    return {
+      // Mod-A inside a panel selects only the panel's body (Cmd+A would
+      // otherwise select the entire doc, including sibling tabs and the
+      // surrounding article content).
+      'Mod-a': ({ editor }) => {
+        const { $from } = editor.state.selection
+        for (let depth = $from.depth; depth >= 0; depth--) {
+          const node = $from.node(depth)
+          if (node.type.name !== 'panel') continue
+          const panelStart = $from.before(depth) + 1
+          const panelEnd = panelStart + node.content.size
+          editor.view.dispatch(
+            editor.state.tr.setSelection(
+              TextSelection.create(editor.state.doc, panelStart, panelEnd)
+            )
+          )
+          return true
+        }
+        return false
+      },
+    }
+  },
+
+  addAttributes() {
+    return {
+      id: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-panel-id'),
+        renderHTML: (attrs) => (attrs.id ? { 'data-panel-id': attrs.id } : {}),
+      },
+      label: {
+        default: '',
+        parseHTML: (el) => el.getAttribute('data-panel-label') ?? '',
+        renderHTML: (attrs) => ({ 'data-panel-label': attrs.label ?? '' }),
+      },
+      iconId: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-panel-icon'),
+        renderHTML: (attrs) => (attrs.iconId ? { 'data-panel-icon': attrs.iconId } : {}),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-panel]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-panel': '' }, HTMLAttributes), 0]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(PanelNodeView)
+  },
+})

--- a/apps/web/src/components/editor/kb-article/tab-edit-popover.tsx
+++ b/apps/web/src/components/editor/kb-article/tab-edit-popover.tsx
@@ -1,0 +1,103 @@
+// apps/web/src/components/editor/kb-article/tab-edit-popover.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Field } from '@auxx/ui/components/field'
+import { InputGroup, InputGroupInput } from '@auxx/ui/components/input-group'
+import { Popover, PopoverAnchor, PopoverContent } from '@auxx/ui/components/popover'
+import { useEffect, useState } from 'react'
+
+interface TabEditPopoverProps {
+  initialLabel: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onChange: (label: string) => void
+  onDelete?: () => void
+  /** The element the popover anchors to — typically the tab button. */
+  children: React.ReactNode
+}
+
+export function TabEditPopover({
+  initialLabel,
+  open,
+  onOpenChange,
+  onChange,
+  onDelete,
+  children,
+}: TabEditPopoverProps) {
+  const [label, setLabel] = useState(initialLabel)
+
+  useEffect(() => {
+    if (open) setLabel(initialLabel)
+  }, [open, initialLabel])
+
+  const persistAndClose = () => {
+    const next = label.trim()
+    if (next !== initialLabel) onChange(next)
+    onOpenChange(false)
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) persistAndClose()
+        else onOpenChange(true)
+      }}>
+      <PopoverAnchor asChild>{children}</PopoverAnchor>
+      <PopoverContent
+        align='start'
+        sideOffset={8}
+        className='w-72 space-y-3 p-3'
+        onOpenAutoFocus={(e) => {
+          // Prevent shifting focus to the popover root; we autofocus the input directly.
+          e.preventDefault()
+          requestAnimationFrame(() => {
+            const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>(
+              'input[data-tab-label-input]'
+            )
+            input?.focus()
+            input?.select()
+          })
+        }}>
+        <Field>
+          <InputGroup>
+            <InputGroupInput
+              data-tab-label-input
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  persistAndClose()
+                }
+              }}
+              placeholder='Tab title'
+            />
+          </InputGroup>
+        </Field>
+
+        <div className='flex justify-between gap-2 pt-1'>
+          {onDelete ? (
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              onClick={() => {
+                onOpenChange(false)
+                onDelete()
+              }}
+              className='text-destructive hover:text-destructive'>
+              Delete tab
+            </Button>
+          ) : (
+            <span />
+          )}
+          <Button type='button' variant='outline' size='sm' onClick={persistAndClose}>
+            Save
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/editor/kb-article/tabs-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/tabs-node-view.tsx
@@ -1,0 +1,268 @@
+// apps/web/src/components/editor/kb-article/tabs-node-view.tsx
+'use client'
+
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import { restrictToHorizontalAxis } from '@dnd-kit/modifiers'
+import {
+  horizontalListSortingStrategy,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import type { NodeViewProps } from '@tiptap/react'
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import { Plus, X } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import blockStyles from './block-node-view.module.css'
+import {
+  addPanel,
+  collectPanels,
+  focusFirstBlockInPanel,
+  type PanelLite,
+  removePanel,
+  reorderPanels,
+  setPanelAttr,
+} from './container-helpers'
+import styles from './container-node-view.module.css'
+import { TabEditPopover } from './tab-edit-popover'
+
+export function TabsNodeView({ node, editor, getPos }: NodeViewProps) {
+  const panels = useMemo(() => collectPanels(node), [node])
+  // Stable id key — change only when the panel set changes, not on every body
+  // edit. SortableContext re-registers items when its `items` prop reference
+  // changes; passing a derived stable array avoids re-registering on every
+  // keystroke.
+  const panelIdsKey = panels.map((p) => p.id).join('|')
+  // biome-ignore lint/correctness/useExhaustiveDependencies: panelIdsKey encodes the relevant change
+  const panelIds = useMemo(() => panels.map((p) => p.id), [panelIdsKey])
+
+  const [activeId, setActiveId] = useState<string>(() => panels[0]?.id ?? '')
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const bodyRef = useRef<HTMLDivElement>(null)
+
+  // Fall back to first panel if active was deleted.
+  useEffect(() => {
+    if (panels.length === 0) return
+    if (!panels.find((p) => p.id === activeId)) {
+      setActiveId(panels[0].id)
+    }
+  }, [panels, activeId])
+
+  // Toggle panel body visibility. Runs only when active changes or the panel
+  // SET changes — not on every keystroke inside the body.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: panelIdsKey covers the panel-set change
+  useEffect(() => {
+    const body = bodyRef.current
+    if (!body) return
+    const items = body.querySelectorAll<HTMLElement>('[data-panel][data-panel-id]')
+    items.forEach((el) => {
+      el.style.display = el.getAttribute('data-panel-id') === activeId ? '' : 'none'
+    })
+  }, [activeId, panelIdsKey])
+
+  const containerPos = typeof getPos === 'function' ? getPos() : null
+
+  // Line-number gutter — same logic as BlockNodeView so containers align
+  // visually with the rest of the article.
+  const lineNumber =
+    typeof containerPos === 'number' ? editor.state.doc.resolve(containerPos).index(0) + 1 : null
+
+  const selectThisContainer = (event: React.MouseEvent) => {
+    if (typeof containerPos !== 'number') return
+    event.preventDefault()
+    event.stopPropagation()
+    editor.commands.setNodeSelection(containerPos)
+  }
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over || active.id === over.id || containerPos == null) return
+      const fromIndex = panels.findIndex((p) => p.id === active.id)
+      const toIndex = panels.findIndex((p) => p.id === over.id)
+      if (fromIndex < 0 || toIndex < 0) return
+      reorderPanels(editor, containerPos, fromIndex, toIndex)
+    },
+    [panels, editor, containerPos]
+  )
+
+  const handleAdd = useCallback(() => {
+    if (containerPos == null) return
+    const nextNumber = panels.length + 1
+    const newId = addPanel(editor, containerPos, `Tab ${nextNumber}`)
+    if (newId) {
+      setActiveId(newId)
+      focusFirstBlockInPanel(editor, containerPos, newId)
+    }
+  }, [editor, containerPos, panels.length])
+
+  const handleDelete = useCallback(
+    (panelId: string) => {
+      if (containerPos == null) return
+      removePanel(editor, containerPos, panelId)
+    },
+    [editor, containerPos]
+  )
+
+  const handleRename = useCallback(
+    (panelId: string, label: string) => {
+      if (containerPos == null) return
+      setPanelAttr(editor, containerPos, panelId, { label })
+    },
+    [editor, containerPos]
+  )
+
+  const handleSelect = useCallback(
+    (panelId: string) => {
+      setActiveId(panelId)
+      if (containerPos != null) focusFirstBlockInPanel(editor, containerPos, panelId)
+    },
+    [editor, containerPos]
+  )
+
+  return (
+    <NodeViewWrapper as='div' className={blockStyles.blockWrapper} data-tabs=''>
+      <div className={blockStyles.blockContainer}>
+        <div
+          className={blockStyles.lineGutter}
+          contentEditable={false}
+          draggable={true}
+          data-block-drag-handle='true'
+          onClick={selectThisContainer}>
+          <div className={`${blockStyles.lineNumber} text-xs tabular-nums`}>{lineNumber ?? ''}</div>
+        </div>
+
+        <div
+          className={`${blockStyles.blockContentWrapper} ${styles.containerContent} ${styles.tabsContainerContent}`}>
+          <div className={styles.tabsHeader} contentEditable={false} role='tablist'>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              modifiers={[restrictToHorizontalAxis]}
+              onDragEnd={handleDragEnd}>
+              <SortableContext items={panelIds} strategy={horizontalListSortingStrategy}>
+                {panels.map((panel) => (
+                  <SortableTabHeader
+                    key={panel.id}
+                    panel={panel}
+                    isActive={panel.id === activeId}
+                    isEditing={editingId === panel.id}
+                    onSelect={() => handleSelect(panel.id)}
+                    onDelete={() => handleDelete(panel.id)}
+                    onRename={(label) => handleRename(panel.id, label)}
+                    onEditOpenChange={(open) => setEditingId(open ? panel.id : null)}
+                  />
+                ))}
+              </SortableContext>
+            </DndContext>
+            <button
+              type='button'
+              className={styles.addTabButton}
+              onClick={handleAdd}
+              aria-label='Add tab'>
+              <Plus size={14} />
+              <span>Add tab</span>
+            </button>
+          </div>
+
+          <div ref={bodyRef} className={styles.tabsBody}>
+            <NodeViewContent />
+          </div>
+        </div>
+      </div>
+    </NodeViewWrapper>
+  )
+}
+
+interface SortableTabHeaderProps {
+  panel: PanelLite
+  isActive: boolean
+  isEditing: boolean
+  onSelect: () => void
+  onDelete: () => void
+  onRename: (label: string) => void
+  onEditOpenChange: (open: boolean) => void
+}
+
+function SortableTabHeader({
+  panel,
+  isActive,
+  isEditing,
+  onSelect,
+  onDelete,
+  onRename,
+  onEditOpenChange,
+}: SortableTabHeaderProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: panel.id,
+  })
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <TabEditPopover
+      initialLabel={panel.label}
+      open={isEditing}
+      onOpenChange={onEditOpenChange}
+      onChange={onRename}
+      onDelete={onDelete}>
+      <div
+        ref={setNodeRef}
+        style={style}
+        className={styles.tabButton}
+        role='tab'
+        aria-selected={isActive}
+        data-dragging={isDragging || undefined}
+        data-active={isActive || undefined}
+        {...attributes}
+        {...listeners}
+        onClick={(e) => {
+          if (e.defaultPrevented) return
+          // Click an already-active tab to open the edit popover; otherwise switch.
+          if (isActive) {
+            onEditOpenChange(true)
+            return
+          }
+          onSelect()
+        }}
+        onDoubleClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          onEditOpenChange(true)
+        }}>
+        <span className={styles.tabButtonLabel}>{panel.label || 'Untitled'}</span>
+        <button
+          type='button'
+          aria-label='Remove tab'
+          tabIndex={-1}
+          className={styles.tabButtonClose}
+          onMouseDown={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            onDelete()
+          }}>
+          <X size={11} />
+        </button>
+      </div>
+    </TabEditPopover>
+  )
+}

--- a/apps/web/src/components/editor/kb-article/tabs-node.ts
+++ b/apps/web/src/components/editor/kb-article/tabs-node.ts
@@ -1,0 +1,34 @@
+// apps/web/src/components/editor/kb-article/tabs-node.ts
+
+import { mergeAttributes, Node } from '@tiptap/core'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+import { TabsNodeView } from './tabs-node-view'
+
+export const Tabs = Node.create({
+  name: 'tabs',
+  group: 'containerBlock',
+  content: 'panel+',
+  defining: true,
+
+  addAttributes() {
+    return {
+      activeTab: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-active-tab'),
+        renderHTML: (attrs) => (attrs.activeTab ? { 'data-active-tab': attrs.activeTab } : {}),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-tabs]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-tabs': '' }, HTMLAttributes), 0]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(TabsNodeView)
+  },
+})

--- a/apps/web/src/components/editor/kb-article/use-kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/use-kb-article-editor.tsx
@@ -13,15 +13,18 @@ import StarterKit from '@tiptap/starter-kit'
 import { useEffect, useMemo, useRef } from 'react'
 import { Table, TableCell, TableHeader, TableRow } from '../extensions/table'
 import { createPlaceholderNode, PlaceholderBadge, useSlashCommand } from '../inline-picker'
+import { Accordion } from './accordion-node'
 import { Block } from './block-node'
 import { MarkdownInputRules } from './markdown-input-rules'
 import { MarkdownPaste } from './markdown-paste'
 import { migrateLegacyContent } from './migrate-legacy-content'
+import { Panel } from './panel-node'
+import { Tabs } from './tabs-node'
 
 const Doc = Node.create({
   name: 'doc',
   topNode: true,
-  content: 'block+',
+  content: '(block | containerBlock)+',
 })
 
 const FocusClasses = Extension.create({
@@ -94,6 +97,9 @@ export function useKBArticleEditor({ initialContent, onChange }: UseKBArticleEdi
           // Marks stay enabled (bold, italic, strike, code).
         }),
         Block,
+        Panel,
+        Tabs,
+        Accordion,
         MarkdownInputRules,
         MarkdownPaste,
         Table.configure({ resizable: true }),

--- a/packages/lib/src/kb/markdown/__tests__/accordion-roundtrip.test.ts
+++ b/packages/lib/src/kb/markdown/__tests__/accordion-roundtrip.test.ts
@@ -1,0 +1,107 @@
+// packages/lib/src/kb/markdown/__tests__/accordion-roundtrip.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { blocksToMd } from '../blocks-to-md'
+import { mdToBlocks } from '../md-to-blocks'
+import type { AccordionJSON, DocJSON } from '../types'
+
+function makeAccordionDoc(allowMultiple = true): DocJSON {
+  return {
+    type: 'doc',
+    content: [
+      {
+        type: 'accordion',
+        attrs: { allowMultiple },
+        content: [
+          {
+            type: 'panel',
+            attrs: { id: 'q1', label: 'What is auxx.ai?' },
+            content: [
+              {
+                type: 'block',
+                attrs: { blockType: 'text' },
+                content: [{ type: 'text', text: 'A CRM helpdesk.' }],
+              },
+            ],
+          },
+          {
+            type: 'panel',
+            attrs: { id: 'q2', label: 'How do I get started?' },
+            content: [
+              {
+                type: 'block',
+                attrs: { blockType: 'heading', level: 1 },
+                content: [{ type: 'text', text: 'Sign up' }],
+              },
+              {
+                type: 'block',
+                attrs: { blockType: 'text' },
+                content: [{ type: 'text', text: 'Then connect your inbox.' }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe('accordion markdown serialization', () => {
+  it('renders an accordion with default allowMultiple omitted from header', () => {
+    const md = blocksToMd(makeAccordionDoc(true))
+    expect(md).toContain('::::accordion')
+    // No `multiple=` token when default (true).
+    expect(md).not.toContain('multiple=')
+    expect(md).toContain(':::item{label="What is auxx.ai?"}')
+  })
+
+  it('emits multiple=false when allowMultiple is false', () => {
+    const md = blocksToMd(makeAccordionDoc(false))
+    expect(md).toContain('::::accordion{multiple=false}')
+  })
+
+  it('round-trips allowMultiple=false', () => {
+    const md = blocksToMd(makeAccordionDoc(false))
+    const reparsed = mdToBlocks(md)
+    const accordion = reparsed.content[0] as AccordionJSON
+    expect(accordion.type).toBe('accordion')
+    expect(accordion.attrs.allowMultiple).toBe(false)
+    expect(accordion.content).toHaveLength(2)
+    expect(accordion.content[0].attrs.label).toBe('What is auxx.ai?')
+    expect(accordion.content[1].content[0].attrs.blockType).toBe('heading')
+  })
+})
+
+describe('details HTML import alias (Q6d)', () => {
+  it('converts a single <details>/<summary> into an accordion', () => {
+    const md = '<details><summary>Why?</summary>Because.</details>\n'
+    const doc = mdToBlocks(md)
+    const node = doc.content[0] as AccordionJSON
+    expect(node.type).toBe('accordion')
+    expect(node.attrs.allowMultiple).toBe(true)
+    expect(node.content).toHaveLength(1)
+    expect(node.content[0].attrs.label).toBe('Why?')
+  })
+
+  it('merges consecutive <details> blocks into one accordion', () => {
+    const md = `<details><summary>Q1</summary>A1</details>
+
+<details><summary>Q2</summary>A2</details>
+`
+    const doc = mdToBlocks(md)
+    expect(doc.content).toHaveLength(1)
+    const node = doc.content[0] as AccordionJSON
+    expect(node.type).toBe('accordion')
+    expect(node.content).toHaveLength(2)
+    expect(node.content[0].attrs.label).toBe('Q1')
+    expect(node.content[1].attrs.label).toBe('Q2')
+  })
+
+  it('serializer never re-emits <details> — converted accordion uses :::accordion', () => {
+    const md = '<details><summary>Q</summary>A</details>\n'
+    const doc = mdToBlocks(md)
+    const out = blocksToMd(doc)
+    expect(out).toContain('::::accordion')
+    expect(out).not.toContain('<details>')
+  })
+})

--- a/packages/lib/src/kb/markdown/__tests__/tabs-roundtrip.test.ts
+++ b/packages/lib/src/kb/markdown/__tests__/tabs-roundtrip.test.ts
@@ -1,0 +1,97 @@
+// packages/lib/src/kb/markdown/__tests__/tabs-roundtrip.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { blocksToMd } from '../blocks-to-md'
+import { mdToBlocks } from '../md-to-blocks'
+import type { DocJSON, TabsJSON } from '../types'
+
+function makeTabsDoc(): DocJSON {
+  return {
+    type: 'doc',
+    content: [
+      {
+        type: 'tabs',
+        attrs: { activeTab: null },
+        content: [
+          {
+            type: 'panel',
+            attrs: { id: 'p1', label: 'JavaScript', iconId: 'javascript' },
+            content: [
+              {
+                type: 'block',
+                attrs: { blockType: 'text' },
+                content: [{ type: 'text', text: 'JS body.' }],
+              },
+              {
+                type: 'block',
+                attrs: { blockType: 'codeBlock', codeLanguage: 'js' },
+                content: [{ type: 'text', text: "console.log('hi')" }],
+              },
+            ],
+          },
+          {
+            type: 'panel',
+            attrs: { id: 'p2', label: 'TypeScript' },
+            content: [
+              {
+                type: 'block',
+                attrs: { blockType: 'text' },
+                content: [{ type: 'text', text: 'TS body.' }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe('tabs markdown serialization', () => {
+  it('renders a tabs block with per-panel content', () => {
+    const md = blocksToMd(makeTabsDoc())
+    expect(md).toContain('::::tabs')
+    expect(md).toContain(':::tab{label="JavaScript" icon="javascript"}')
+    expect(md).toContain(':::tab{label="TypeScript"}')
+    expect(md).toContain("console.log('hi')")
+    expect(md).toContain('TS body')
+    expect(md.trim().endsWith('::::')).toBe(true)
+  })
+
+  it('round-trips structure with mixed block types per panel', () => {
+    const original = makeTabsDoc()
+    const md = blocksToMd(original)
+    const reparsed = mdToBlocks(md)
+    const tabs = reparsed.content[0] as TabsJSON
+    expect(tabs.type).toBe('tabs')
+    expect(tabs.content).toHaveLength(2)
+    expect(tabs.content[0].attrs.label).toBe('JavaScript')
+    expect(tabs.content[0].attrs.iconId).toBe('javascript')
+    expect(tabs.content[1].attrs.label).toBe('TypeScript')
+
+    // First panel: text + codeBlock
+    const firstPanelBlocks = tabs.content[0].content
+    expect(firstPanelBlocks).toHaveLength(2)
+    expect(firstPanelBlocks[0].attrs.blockType).toBe('text')
+    expect(firstPanelBlocks[1].attrs.blockType).toBe('codeBlock')
+    expect(firstPanelBlocks[1].attrs.codeLanguage).toBe('js')
+  })
+
+  it('regenerates panel ids on import (Q6c)', () => {
+    const original = makeTabsDoc()
+    const md = blocksToMd(original)
+    const reparsed = mdToBlocks(md)
+    const tabs = reparsed.content[0] as TabsJSON
+    expect(tabs.content[0].attrs.id).not.toBe('p1')
+    expect(tabs.content[1].attrs.id).not.toBe('p2')
+    expect(tabs.content[0].attrs.id).toBeTruthy()
+    expect(tabs.content[1].attrs.id).toBeTruthy()
+  })
+
+  it('renders nothing for an empty tabs container', () => {
+    const md = blocksToMd({
+      type: 'doc',
+      content: [{ type: 'tabs', attrs: { activeTab: null }, content: [] }],
+    })
+    expect(md.trim()).toBe('')
+  })
+})

--- a/packages/lib/src/kb/markdown/blocks-to-md.ts
+++ b/packages/lib/src/kb/markdown/blocks-to-md.ts
@@ -5,6 +5,8 @@
 
 import { escapeLinkUrl, escapeMarkdownText, inlineToMd } from './inline'
 import type {
+  AccordionJSON,
+  ArticleNodeJSON,
   BlockAttrs,
   BlockJSON,
   CalloutVariant,
@@ -14,6 +16,8 @@ import type {
   EmbedProvider,
   ImageAlign,
   InlineJSON,
+  PanelJSON,
+  TabsJSON,
 } from './types'
 import { CALLOUT_VARIANTS } from './types'
 
@@ -27,30 +31,7 @@ export function blocksToMd(doc: DocJSON | null | undefined, opts: BlocksToMdOpti
   const placeholders = opts.placeholders ?? 'literal'
   const ctx = { placeholders }
 
-  const blocks = doc.content
-  const lines: string[] = []
-  let inListRun = false
-
-  for (let i = 0; i < blocks.length; i++) {
-    const block = blocks[i]
-    if (!block || block.type !== 'block') continue
-    const next = blocks[i + 1]
-
-    const renderedLines = renderBlock(block, ctx)
-    if (renderedLines.length === 0) continue
-
-    if (lines.length > 0) lines.push('') // blank line between blocks
-
-    for (const line of renderedLines) lines.push(line)
-
-    inListRun = isListItem(block)
-    // List runs don't get inter-item blank lines in CommonMark, but tighter
-    // rendering is fine here since GFM normalizes anyway.
-    if (inListRun && next && isListItem(next) && sameListType(block, next)) {
-      // Drop the blank we just queued — pop and re-emit without separator.
-      // Easier: emit as-is, GFM tolerates it.
-    }
-  }
+  const lines = renderNodes(doc.content, ctx)
 
   return `${lines
     .join('\n')
@@ -58,13 +39,29 @@ export function blocksToMd(doc: DocJSON | null | undefined, opts: BlocksToMdOpti
     .trimEnd()}\n`
 }
 
-function isListItem(block: BlockJSON): boolean {
-  const t = block.attrs?.blockType
-  return t === 'bulletListItem' || t === 'numberedListItem' || t === 'todoListItem'
+function renderNodes(nodes: ArticleNodeJSON[], ctx: RenderCtx): string[] {
+  const lines: string[] = []
+  for (const node of nodes) {
+    if (!node) continue
+    const renderedLines = renderArticleNode(node, ctx)
+    if (renderedLines.length === 0) continue
+    if (lines.length > 0) lines.push('')
+    for (const line of renderedLines) lines.push(line)
+  }
+  return lines
 }
 
-function sameListType(a: BlockJSON, b: BlockJSON): boolean {
-  return a.attrs?.blockType === b.attrs?.blockType
+function renderArticleNode(node: ArticleNodeJSON, ctx: RenderCtx): string[] {
+  switch (node.type) {
+    case 'tabs':
+      return renderTabs(node, ctx)
+    case 'accordion':
+      return renderAccordion(node, ctx)
+    case 'block':
+      return renderBlock(node, ctx)
+    default:
+      return []
+  }
 }
 
 interface RenderCtx {
@@ -109,6 +106,43 @@ function renderBlock(block: BlockJSON, ctx: RenderCtx): string[] {
     default:
       return inline.length > 0 ? [inline] : []
   }
+}
+
+function renderTabs(node: TabsJSON, ctx: RenderCtx): string[] {
+  if (!Array.isArray(node.content) || node.content.length === 0) return []
+  // remark-directive nests containers by COLON COUNT — outer must have
+  // strictly more colons than inner. Use 4 outside / 3 inside so panel
+  // bodies can themselves contain `:::callout` blocks unchanged.
+  const out: string[] = ['::::tabs']
+  for (const panel of node.content) {
+    out.push(...renderPanel(panel, 'tab', ctx))
+  }
+  out.push('::::')
+  return out
+}
+
+function renderAccordion(node: AccordionJSON, ctx: RenderCtx): string[] {
+  if (!Array.isArray(node.content) || node.content.length === 0) return []
+  const headerParts: string[] = []
+  if (node.attrs?.allowMultiple === false) headerParts.push('multiple=false')
+  const header =
+    headerParts.length > 0 ? `::::accordion{${headerParts.join(' ')}}` : '::::accordion'
+  const out: string[] = [header]
+  for (const panel of node.content) {
+    out.push(...renderPanel(panel, 'item', ctx))
+  }
+  out.push('::::')
+  return out
+}
+
+function renderPanel(panel: PanelJSON, leafName: 'tab' | 'item', ctx: RenderCtx): string[] {
+  const attrParts: string[] = [`label="${escapeAttrValue(panel.attrs.label ?? '')}"`]
+  if (panel.attrs.iconId) attrParts.push(`icon="${escapeAttrValue(panel.attrs.iconId)}"`)
+  const out: string[] = [`:::${leafName}{${attrParts.join(' ')}}`]
+  const bodyLines = renderNodes(panel.content ?? [], ctx)
+  for (const line of bodyLines) out.push(line)
+  out.push(':::')
+  return out
 }
 
 function renderCards(cards: CardData[] | undefined): string[] {

--- a/packages/lib/src/kb/markdown/md-to-blocks.ts
+++ b/packages/lib/src/kb/markdown/md-to-blocks.ts
@@ -9,6 +9,8 @@ import remarkGfm from 'remark-gfm'
 import remarkParse from 'remark-parse'
 import { unified } from 'unified'
 import type {
+  AccordionJSON,
+  ArticleNodeJSON,
   BlockAttrs,
   BlockJSON,
   BlockType,
@@ -20,6 +22,8 @@ import type {
   ImageAlign,
   InlineJSON,
   MarkJSON,
+  PanelJSON,
+  TabsJSON,
 } from './types'
 import { CALLOUT_VARIANTS, EMBED_ASPECTS, EMBED_PROVIDERS, IMAGE_ALIGNS } from './types'
 
@@ -34,16 +38,39 @@ export function mdToBlocks(markdown: string): DocJSON {
   if (!cleaned.trim()) return emptyDoc()
 
   const tree = parser.parse(cleaned) as MdastRoot
-  const ctx: ParseCtx = { blocks: [] }
+  const ctx: ParseCtx = { nodes: [] }
+  // Buffer for consecutive `<details>` HTML siblings so we can merge them
+  // into a single accordion block (Q6d).
+  let detailsBuffer: PanelJSON[] | null = null
+  const flushDetails = () => {
+    if (!detailsBuffer || detailsBuffer.length === 0) return
+    const accordion: AccordionJSON = {
+      type: 'accordion',
+      attrs: { allowMultiple: true },
+      content: detailsBuffer,
+    }
+    ctx.nodes.push(accordion)
+    detailsBuffer = null
+  }
   for (const child of tree.children ?? []) {
+    if (child.type === 'html' && typeof child.value === 'string') {
+      const panel = tryParseDetailsHtml(child.value)
+      if (panel) {
+        if (!detailsBuffer) detailsBuffer = []
+        detailsBuffer.push(panel)
+        continue
+      }
+    }
+    flushDetails()
     walkBlock(child, ctx, 1)
   }
-  if (ctx.blocks.length === 0) return emptyDoc()
-  return { type: 'doc', content: ctx.blocks }
+  flushDetails()
+  if (ctx.nodes.length === 0) return emptyDoc()
+  return { type: 'doc', content: ctx.nodes }
 }
 
 interface ParseCtx {
-  blocks: BlockJSON[]
+  nodes: ArticleNodeJSON[]
 }
 
 function emptyDoc(): DocJSON {
@@ -189,6 +216,16 @@ function walkBlock(node: MdastNode, ctx: ParseCtx, level: number): void {
       if (node.name === 'cards') {
         const cards = parseCardsContainer(node)
         if (cards.length > 0) pushBlock(ctx, 'cards', [], { cards })
+        return
+      }
+      if (node.name === 'tabs') {
+        const tabs = parseTabsContainer(node)
+        if (tabs) ctx.nodes.push(tabs)
+        return
+      }
+      if (node.name === 'accordion') {
+        const accordion = parseAccordionContainer(node)
+        if (accordion) ctx.nodes.push(accordion)
         return
       }
       // Unknown container — flatten its children.
@@ -630,7 +667,7 @@ function pushBlock(
   attrs: Partial<BlockAttrs>
 ): void {
   const merged: BlockAttrs = { blockType, ...attrs }
-  ctx.blocks.push({ type: 'block', attrs: merged, content })
+  ctx.nodes.push({ type: 'block', attrs: merged, content })
 }
 
 function clamp(n: number, min: number, max: number): number {
@@ -646,4 +683,88 @@ function stripQuotes(value: string): string {
     return value.slice(1, -1)
   }
   return value
+}
+
+// ─── tabs / accordion containers ─────────────────────────────────────
+
+function parseTabsContainer(node: MdastNode): TabsJSON | null {
+  const panels = parsePanelChildren(node, 'tab')
+  if (panels.length === 0) return null
+  return { type: 'tabs', attrs: { activeTab: null }, content: panels }
+}
+
+function parseAccordionContainer(node: MdastNode): AccordionJSON | null {
+  const panels = parsePanelChildren(node, 'item')
+  if (panels.length === 0) return null
+  const attrs = node.attributes ?? {}
+  const allowMultiple =
+    typeof attrs.multiple === 'string' ? attrs.multiple.toLowerCase() !== 'false' : true
+  return { type: 'accordion', attrs: { allowMultiple }, content: panels }
+}
+
+function parsePanelChildren(container: MdastNode, leafName: 'tab' | 'item'): PanelJSON[] {
+  const out: PanelJSON[] = []
+  for (const child of container.children ?? []) {
+    if (
+      (child.type === 'containerDirective' || child.type === 'leafDirective') &&
+      child.name === leafName
+    ) {
+      out.push(buildPanelFromDirective(child))
+    }
+  }
+  return out
+}
+
+function buildPanelFromDirective(node: MdastNode): PanelJSON {
+  const attrs = node.attributes ?? {}
+  const label = typeof attrs.label === 'string' ? attrs.label : ''
+  const iconId = typeof attrs.icon === 'string' && attrs.icon ? attrs.icon : undefined
+  // Re-walk the panel body using a fresh ctx; only flat blocks are valid
+  // here (Q1c — containers can't nest in panels). Any container nodes
+  // emitted by walkBlock would violate the schema; we drop them.
+  const subCtx: ParseCtx = { nodes: [] }
+  for (const child of node.children ?? []) {
+    walkBlock(child, subCtx, 1)
+  }
+  const content: BlockJSON[] = subCtx.nodes.filter((n): n is BlockJSON => n.type === 'block')
+  if (content.length === 0) {
+    content.push({ type: 'block', attrs: { blockType: 'text' }, content: [] })
+  }
+  return {
+    type: 'panel',
+    attrs: { id: generateId(), label, iconId },
+    content,
+  }
+}
+
+// ─── <details> import alias (Q6d) ────────────────────────────────────
+
+const DETAILS_OPEN_RE = /<details(?:\s[^>]*)?>/i
+const DETAILS_CLOSE_RE = /<\/details>/i
+const SUMMARY_RE = /<summary(?:\s[^>]*)?>([\s\S]*?)<\/summary>/i
+
+function tryParseDetailsHtml(raw: string): PanelJSON | null {
+  const value = (raw ?? '').trim()
+  if (!DETAILS_OPEN_RE.test(value)) return null
+  if (!DETAILS_CLOSE_RE.test(value)) return null
+  // Strip outer <details>...</details>.
+  const inner = value.replace(DETAILS_OPEN_RE, '').replace(DETAILS_CLOSE_RE, '').trim()
+  const summaryMatch = inner.match(SUMMARY_RE)
+  const label = summaryMatch ? summaryMatch[1].replace(/<[^>]+>/g, '').trim() : 'Details'
+  const body = inner.replace(SUMMARY_RE, '').trim()
+  // Re-parse the body as markdown so embedded markdown lists / paragraphs
+  // produce real blocks.
+  let panelContent: BlockJSON[] = []
+  if (body) {
+    const sub = mdToBlocks(body)
+    panelContent = sub.content.filter((n): n is BlockJSON => n.type === 'block')
+  }
+  if (panelContent.length === 0) {
+    panelContent = [{ type: 'block', attrs: { blockType: 'text' }, content: [] }]
+  }
+  return {
+    type: 'panel',
+    attrs: { id: generateId(), label },
+    content: panelContent,
+  }
 }

--- a/packages/lib/src/kb/markdown/types.ts
+++ b/packages/lib/src/kb/markdown/types.ts
@@ -75,9 +75,35 @@ export interface BlockJSON {
   content?: InlineJSON[]
 }
 
+export interface PanelJSON {
+  type: 'panel'
+  attrs: {
+    id: string
+    label: string
+    iconId?: string
+  }
+  content: BlockJSON[]
+}
+
+export interface TabsJSON {
+  type: 'tabs'
+  attrs: { activeTab?: string | null }
+  content: PanelJSON[]
+}
+
+export interface AccordionJSON {
+  type: 'accordion'
+  attrs: { allowMultiple: boolean }
+  content: PanelJSON[]
+}
+
+export type ContainerBlockJSON = TabsJSON | AccordionJSON
+
+export type ArticleNodeJSON = BlockJSON | ContainerBlockJSON
+
 export interface DocJSON {
   type: 'doc'
-  content: BlockJSON[]
+  content: ArticleNodeJSON[]
 }
 
 export const CALLOUT_VARIANTS: ReadonlySet<CalloutVariant> = new Set([

--- a/packages/ui/src/components/kb/article/accordion-block.tsx
+++ b/packages/ui/src/components/kb/article/accordion-block.tsx
@@ -1,0 +1,75 @@
+// packages/ui/src/components/kb/article/accordion-block.tsx
+'use client'
+
+import { ChevronDown } from 'lucide-react'
+import { type ReactNode, useCallback, useId, useState } from 'react'
+import styles from './kb-article-renderer.module.css'
+
+export interface AccordionBlockItem {
+  id: string
+  label: string
+  body: ReactNode
+}
+
+interface AccordionBlockProps {
+  items: AccordionBlockItem[]
+  allowMultiple: boolean
+}
+
+export function AccordionBlock({ items, allowMultiple }: AccordionBlockProps) {
+  const baseId = useId()
+  // Collapsed by default (Q5e). Track the expanded set; empty initially.
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
+
+  const toggle = useCallback(
+    (id: string) => {
+      setExpanded((prev) => {
+        const next = new Set(prev)
+        if (next.has(id)) {
+          next.delete(id)
+          return next
+        }
+        if (!allowMultiple) next.clear()
+        next.add(id)
+        return next
+      })
+    },
+    [allowMultiple]
+  )
+
+  if (items.length === 0) return null
+
+  return (
+    <div className={styles.accordionContainer}>
+      {items.map((item) => {
+        const isOpen = expanded.has(item.id)
+        const headerId = `${baseId}-h-${item.id}`
+        const panelId = `${baseId}-p-${item.id}`
+        return (
+          <div key={item.id} className={styles.accordionItem}>
+            <button
+              type='button'
+              id={headerId}
+              aria-expanded={isOpen}
+              aria-controls={panelId}
+              className={styles.accordionHeader}
+              onClick={() => toggle(item.id)}>
+              <span className={styles.accordionChevron} aria-hidden='true' data-open={isOpen}>
+                <ChevronDown size={16} />
+              </span>
+              <span className={styles.accordionLabel}>{item.label || 'Untitled'}</span>
+            </button>
+            <div
+              role='region'
+              id={panelId}
+              aria-labelledby={headerId}
+              className={styles.accordionPanel}
+              hidden={!isOpen}>
+              {item.body}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/ui/src/components/kb/article/block-renderer.tsx
+++ b/packages/ui/src/components/kb/article/block-renderer.tsx
@@ -205,12 +205,13 @@ function fallbackAnchorId(node: BlockJSON, idx: number): string {
 
 function computeNumber(doc: DocJSON, idx: number): number {
   const target = doc.content[idx]
-  if (!target) return 1
+  if (!target || target.type !== 'block') return 1
   const targetLevel = target.attrs?.level ?? 1
   let count = 1
   for (let i = idx - 1; i >= 0; i--) {
     const sibling = doc.content[i]
     if (!sibling) break
+    if (sibling.type !== 'block') break
     if (sibling.attrs?.blockType !== 'numberedListItem') break
     if ((sibling.attrs?.level ?? 1) !== targetLevel) break
     count++

--- a/packages/ui/src/components/kb/article/extract-headings.ts
+++ b/packages/ui/src/components/kb/article/extract-headings.ts
@@ -19,6 +19,7 @@ export function extractKBHeadings(doc: DocJSON | null | undefined): KBHeading[] 
   const out: KBHeading[] = []
   const seen = new Map<string, number>()
   doc.content.forEach((node, idx) => {
+    if (node.type !== 'block') return
     if (node.attrs?.blockType !== 'heading') return
     const level = node.attrs?.level ?? 1
     if (level !== 1 && level !== 2) return

--- a/packages/ui/src/components/kb/article/index.ts
+++ b/packages/ui/src/components/kb/article/index.ts
@@ -10,11 +10,14 @@ export { KBArticlePager } from './kb-article-pager'
 export { KBArticleRenderer } from './kb-article-renderer'
 export { KBTableOfContents } from './kb-toc'
 export type {
+  AccordionJSON,
+  ArticleNodeJSON,
   BlockAttrs,
   BlockJSON,
   BlockType,
   CalloutVariant,
   CardData,
+  ContainerBlockJSON,
   DocJSON,
   EmbedAspect,
   EmbedProvider,
@@ -22,5 +25,7 @@ export type {
   InlineJSON,
   InlineMarkType,
   MarkJSON,
+  PanelJSON,
   ResolveAuxxHref,
+  TabsJSON,
 } from './types'

--- a/packages/ui/src/components/kb/article/kb-article-renderer.module.css
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.module.css
@@ -454,3 +454,160 @@
   line-height: 1.5;
   opacity: 0.85;
 }
+
+/* ============================================
+   Tabs block (public renderer)
+   ============================================ */
+
+.tabsContainer {
+  margin: 1.25rem 0;
+  border: 1px solid var(--kb-border);
+  border-radius: 0.625rem;
+  background: color-mix(in srgb, var(--kb-fg) 3%, transparent);
+  padding: 0.125rem;
+}
+
+.tabsHeader {
+  display: flex;
+  flex-direction: row;
+  gap: 0.25rem;
+  padding: 0.125rem 0.625rem;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.tabButton {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin: 0.25rem 0;
+  padding: 0.125rem 0.375rem;
+  border: none;
+  background: transparent;
+  color: var(--kb-fg);
+  opacity: 0.6;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.5;
+  cursor: pointer;
+  white-space: nowrap;
+  border-radius: 0.5rem;
+  font-family: inherit;
+  transition: color 120ms ease, opacity 120ms ease, background 120ms ease;
+}
+
+.tabButton:hover {
+  opacity: 1;
+  background: color-mix(in srgb, var(--kb-fg) 7%, transparent);
+}
+
+.tabButton[aria-selected='true'] {
+  opacity: 1;
+}
+
+.tabButton[aria-selected='true']::after {
+  content: '';
+  position: absolute;
+  left: 0.375rem;
+  right: 0.375rem;
+  bottom: -0.25rem;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--kb-primary);
+}
+
+.tabsBody {
+  border: 1px solid var(--kb-border);
+  border-radius: 0.5rem;
+  background: var(--kb-bg, #fff);
+  overflow: hidden;
+}
+
+.tabPanel {
+  padding: 0.875rem 1rem;
+}
+
+.tabPanel[hidden] {
+  display: none;
+}
+
+/* ============================================
+   Accordion block (public renderer)
+   ============================================ */
+
+.accordionContainer {
+  margin: 1.25rem 0;
+  border: 1px solid var(--kb-border);
+  border-radius: var(--kb-radius);
+  overflow: hidden;
+}
+
+.accordionItem + .accordionItem {
+  border-top: 1px solid var(--kb-border);
+}
+
+.accordionHeader {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.625rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: var(--kb-fg);
+  font-family: inherit;
+  font-size: 0.9375rem;
+  font-weight: 500;
+}
+
+.accordionHeader:hover {
+  background: color-mix(in srgb, var(--kb-fg) 4%, transparent);
+}
+
+.accordionChevron {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--kb-fg);
+  opacity: 0.7;
+  transition: transform 150ms ease;
+}
+
+.accordionChevron[data-open='false'] {
+  transform: rotate(-90deg);
+}
+
+.accordionLabel {
+  flex: 1 1 auto;
+  text-align: left;
+}
+
+.accordionPanel {
+  padding: 0.25rem 1rem 0.875rem 2.625rem;
+}
+
+.accordionPanel[hidden] {
+  display: none;
+}
+
+@media print {
+  /* Tabs: show every panel stacked, hide the strip. */
+  .tabsHeader {
+    display: none;
+  }
+  .tabPanel[hidden] {
+    display: block !important;
+  }
+  /* Accordion: expand every item. */
+  .accordionPanel[hidden] {
+    display: block !important;
+  }
+  .accordionChevron {
+    display: none;
+  }
+}

--- a/packages/ui/src/components/kb/article/kb-article-renderer.tsx
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.tsx
@@ -3,11 +3,21 @@
 import { EntityIcon } from '@auxx/ui/components/icons'
 import Link from 'next/link'
 import type { ReactNode } from 'react'
+import { AccordionBlock } from './accordion-block'
 import { BlockRenderer } from './block-renderer'
 import { extractKBHeadings, type KBHeading } from './extract-headings'
 import styles from './kb-article-renderer.module.css'
 import { KBTableOfContentsDrawer } from './kb-toc-drawer'
-import type { DocJSON, ResolveAuxxHref } from './types'
+import { TabsBlock } from './tabs-block'
+import type {
+  AccordionJSON,
+  ArticleNodeJSON,
+  BlockJSON,
+  DocJSON,
+  PanelJSON,
+  ResolveAuxxHref,
+  TabsJSON,
+} from './types'
 
 interface KBArticleRendererProps {
   doc: DocJSON | null | undefined
@@ -82,26 +92,106 @@ export function KBArticleRenderer({
           </div>
         </header>
       ) : null}
-      {doc?.content?.map((node, idx) => (
-        <BlockRenderer
-          // biome-ignore lint/suspicious/noArrayIndexKey: block order is stable per render
-          key={idx}
-          node={node}
-          idx={idx}
-          doc={doc}
-          headingIds={headingIds}
-          resolveAuxxHref={resolveAuxxHref}
-        />
-      ))}
+      {doc?.content?.map((node, idx) => {
+        switch (node.type) {
+          case 'tabs':
+            return (
+              <ServerTabsBlock
+                // biome-ignore lint/suspicious/noArrayIndexKey: block order is stable per render
+                key={idx}
+                node={node}
+                resolveAuxxHref={resolveAuxxHref}
+              />
+            )
+          case 'accordion':
+            return (
+              <ServerAccordionBlock
+                // biome-ignore lint/suspicious/noArrayIndexKey: block order is stable per render
+                key={idx}
+                node={node}
+                resolveAuxxHref={resolveAuxxHref}
+              />
+            )
+          case 'block':
+            return (
+              <BlockRenderer
+                // biome-ignore lint/suspicious/noArrayIndexKey: block order is stable per render
+                key={idx}
+                node={node}
+                idx={idx}
+                doc={doc}
+                headingIds={headingIds}
+                resolveAuxxHref={resolveAuxxHref}
+              />
+            )
+          default:
+            return null
+        }
+      })}
     </article>
   )
 }
 
+function renderPanelBody(
+  panel: PanelJSON,
+  resolveAuxxHref: ResolveAuxxHref | undefined
+): ReactNode {
+  // Panel bodies are flat block content; reuse BlockRenderer with a synthetic
+  // sub-doc so heading-id maps stay scoped. We intentionally don't pass a
+  // headingIds map — TOC headings are top-level only.
+  const subDoc: DocJSON = { type: 'doc', content: panel.content }
+  return panel.content.map((block: BlockJSON, i) => (
+    <BlockRenderer
+      // biome-ignore lint/suspicious/noArrayIndexKey: panel content order is stable per render
+      key={i}
+      node={block}
+      idx={i}
+      doc={subDoc}
+      resolveAuxxHref={resolveAuxxHref}
+    />
+  ))
+}
+
+function ServerTabsBlock({
+  node,
+  resolveAuxxHref,
+}: {
+  node: TabsJSON
+  resolveAuxxHref?: ResolveAuxxHref
+}) {
+  if (!Array.isArray(node.content) || node.content.length === 0) return null
+  const panels = node.content.map((panel) => ({
+    id: panel.attrs.id,
+    label: panel.attrs.label,
+    iconId: panel.attrs.iconId,
+    body: renderPanelBody(panel, resolveAuxxHref),
+  }))
+  return <TabsBlock panels={panels} />
+}
+
+function ServerAccordionBlock({
+  node,
+  resolveAuxxHref,
+}: {
+  node: AccordionJSON
+  resolveAuxxHref?: ResolveAuxxHref
+}) {
+  if (!Array.isArray(node.content) || node.content.length === 0) return null
+  const items = node.content.map((panel) => ({
+    id: panel.attrs.id,
+    label: panel.attrs.label,
+    body: renderPanelBody(panel, resolveAuxxHref),
+  }))
+  return <AccordionBlock items={items} allowMultiple={node.attrs.allowMultiple !== false} />
+}
+
 function buildHeadingIdMap(doc: DocJSON, headings: KBHeading[]): Record<number, string> {
   // extractKBHeadings preserves order; rebuild a map keyed by block index.
+  // Container nodes (tabs/accordion) don't contribute headings to the TOC.
   const map: Record<number, string> = {}
   let cursor = 0
   doc.content.forEach((node, idx) => {
+    if (node.type !== 'block') return
     if (node.attrs?.blockType !== 'heading') return
     const level = node.attrs?.level ?? 1
     if (level !== 1 && level !== 2) return

--- a/packages/ui/src/components/kb/article/tabs-block.tsx
+++ b/packages/ui/src/components/kb/article/tabs-block.tsx
@@ -1,0 +1,91 @@
+// packages/ui/src/components/kb/article/tabs-block.tsx
+'use client'
+
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { type KeyboardEvent, type ReactNode, useCallback, useId, useState } from 'react'
+import styles from './kb-article-renderer.module.css'
+
+export interface TabsBlockPanel {
+  id: string
+  label: string
+  iconId?: string
+  body: ReactNode
+}
+
+interface TabsBlockProps {
+  panels: TabsBlockPanel[]
+}
+
+export function TabsBlock({ panels }: TabsBlockProps) {
+  const baseId = useId()
+  const [activeId, setActiveId] = useState<string>(panels[0]?.id ?? '')
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (panels.length === 0) return
+      const index = panels.findIndex((p) => p.id === activeId)
+      if (index < 0) return
+      let next: number | null = null
+      if (event.key === 'ArrowRight') next = (index + 1) % panels.length
+      else if (event.key === 'ArrowLeft') next = (index - 1 + panels.length) % panels.length
+      else if (event.key === 'Home') next = 0
+      else if (event.key === 'End') next = panels.length - 1
+      if (next == null) return
+      event.preventDefault()
+      setActiveId(panels[next].id)
+      const target = event.currentTarget.querySelector<HTMLButtonElement>(
+        `[data-tab-id="${panels[next].id}"]`
+      )
+      target?.focus()
+    },
+    [panels, activeId]
+  )
+
+  if (panels.length === 0) return null
+
+  return (
+    <div className={styles.tabsContainer}>
+      <div
+        className={styles.tabsHeader}
+        role='tablist'
+        aria-orientation='horizontal'
+        onKeyDown={handleKeyDown}>
+        {panels.map((panel) => {
+          const isActive = panel.id === activeId
+          return (
+            <button
+              key={panel.id}
+              type='button'
+              role='tab'
+              data-tab-id={panel.id}
+              id={`${baseId}-tab-${panel.id}`}
+              aria-selected={isActive}
+              aria-controls={`${baseId}-panel-${panel.id}`}
+              tabIndex={isActive ? 0 : -1}
+              className={styles.tabButton}
+              onClick={() => setActiveId(panel.id)}>
+              {panel.iconId ? <EntityIcon iconId={panel.iconId} variant='bare' size='xs' /> : null}
+              <span>{panel.label || 'Untitled'}</span>
+            </button>
+          )
+        })}
+      </div>
+      <div className={styles.tabsBody}>
+        {panels.map((panel) => {
+          const isActive = panel.id === activeId
+          return (
+            <div
+              key={panel.id}
+              role='tabpanel'
+              id={`${baseId}-panel-${panel.id}`}
+              aria-labelledby={`${baseId}-tab-${panel.id}`}
+              className={styles.tabPanel}
+              hidden={!isActive}>
+              {panel.body}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/src/components/kb/article/types.ts
+++ b/packages/ui/src/components/kb/article/types.ts
@@ -53,6 +53,43 @@ export interface BlockJSON {
   content?: InlineJSON[]
 }
 
+export interface PanelJSON {
+  type: 'panel'
+  attrs: {
+    /** Stable id for drag-reorder + React keys (`@auxx/utils` `generateId`). */
+    id: string
+    label: string
+    iconId?: string
+  }
+  content: BlockJSON[]
+}
+
+export interface TabsJSON {
+  type: 'tabs'
+  attrs: {
+    /** Editor-only state; not persisted to markdown. First panel is active when omitted. */
+    activeTab?: string | null
+  }
+  content: PanelJSON[]
+}
+
+export interface AccordionJSON {
+  type: 'accordion'
+  attrs: {
+    allowMultiple: boolean
+  }
+  content: PanelJSON[]
+}
+
+export type ContainerBlockJSON = TabsJSON | AccordionJSON
+
+/**
+ * Top-level node in a KB article: either a flat `block` or a container
+ * (`tabs`/`accordion`). Future container/format additions (table, steps)
+ * extend this union without reshaping renderer/markdown/walker dispatch.
+ */
+export type ArticleNodeJSON = BlockJSON | ContainerBlockJSON
+
 export type InlineMarkType =
   | 'bold'
   | 'italic'
@@ -76,7 +113,7 @@ export interface InlineJSON {
 
 export interface DocJSON {
   type: 'doc'
-  content: BlockJSON[]
+  content: ArticleNodeJSON[]
 }
 
 /**

--- a/packages/ui/src/components/kb/utils/inline-text.ts
+++ b/packages/ui/src/components/kb/utils/inline-text.ts
@@ -17,24 +17,39 @@ export function walkInlineToText(nodes: InlineJSON[] | undefined): string {
   return out
 }
 
-/** Plain-text dump of every block in the doc. Used for search snippets. */
+/** Plain-text dump of every block in the doc, including container panels.
+ * Used for search snippets — recursing into tabs/accordion bodies keeps
+ * panel content searchable. */
 export function extractPlainText(doc: DocJSON | null | undefined): string {
   if (!doc || !doc.content) return ''
   const parts: string[] = []
-  for (const block of doc.content) {
-    const text = walkInlineToText(block.content)
-    if (text) parts.push(text)
+  for (const node of doc.content) {
+    if (node.type === 'block') {
+      const text = walkInlineToText(node.content)
+      if (text) parts.push(text)
+    } else if (node.type === 'tabs' || node.type === 'accordion') {
+      for (const panel of node.content) {
+        if (panel.attrs.label) parts.push(panel.attrs.label)
+        for (const block of panel.content) {
+          const text = walkInlineToText(block.content)
+          if (text) parts.push(text)
+        }
+      }
+    }
   }
   return parts.join(' ').replace(/\s+/g, ' ').trim()
 }
 
-/** Pull every heading's text out for search facet weighting. */
+/** Pull every heading's text out for search facet weighting. Container
+ * blocks (tabs/accordion) don't contribute headings; their panel labels
+ * are searchable via extractPlainText instead. */
 export function extractHeadings(doc: DocJSON | null | undefined): string[] {
   if (!doc || !doc.content) return []
   const out: string[] = []
-  for (const block of doc.content) {
-    if (isHeadingBlock(block)) {
-      const text = walkInlineToText(block.content)
+  for (const node of doc.content) {
+    if (node.type !== 'block') continue
+    if (isHeadingBlock(node)) {
+      const text = walkInlineToText(node.content)
       if (text) out.push(text)
     }
   }


### PR DESCRIPTION
## Summary
- Add tabs and accordion container nodes to the KB article editor (with panel children, tab-edit popover, drag plumbing, and slash-command entries)
- Extend the KB article renderer with matching tabs/accordion blocks and shared container styling
- Round-trip these container blocks through markdown via `md-to-blocks` / `blocks-to-md`, with new tests covering both shapes

## Test plan
- [ ] `pnpm test` covers the new accordion + tabs markdown roundtrip tests
- [ ] In the KB editor: insert a tabs block, add/rename/reorder tabs, drag content in/out, save, reload — content round-trips
- [ ] In the KB editor: insert an accordion, toggle allow-multiple, expand/collapse panels, save, reload
- [ ] In the public KB renderer: tabs render with active-tab state, accordion expands/collapses, headings inside containers still extract correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)