### PR TITLE
feat(homepage): platform/ai/kopilot + data-model pages

### DIFF
--- a/apps/homepage/next.config.mjs
+++ b/apps/homepage/next.config.mjs
@@ -22,6 +22,15 @@ const nextConfig = {
       { protocol: 'http', hostname: 'localhost' },
     ],
   },
+  async redirects() {
+    return [
+      {
+        source: '/platform/knowledge-base',
+        destination: '/platform/data-model#knowledge-base',
+        permanent: true,
+      },
+    ]
+  },
   async headers() {
     return [
       {

--- a/apps/homepage/src/app/globals.css
+++ b/apps/homepage/src/app/globals.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
+@import './platform/ai/_mocks/mock.css';
 
 @source "../../../../packages/ui/src/components/random-gradient.tsx";
 
@@ -104,6 +105,7 @@
   --animate-scale-out: scale-out 0.2s ease-in;
   --animate-fade-in: fade-in 0.2s ease-out;
   --animate-fade-out: fade-out 0.2s ease-in;
+  --animate-dot-blink: dot-blink 1.4s infinite both;
 
   @keyframes accordion-down {
     from {
@@ -262,6 +264,17 @@
     }
     to {
       opacity: 0;
+    }
+  }
+
+  @keyframes dot-blink {
+    0%,
+    80%,
+    100% {
+      opacity: 0;
+    }
+    40% {
+      opacity: 1;
     }
   }
 }

--- a/apps/homepage/src/app/platform/ai/_mocks/index.ts
+++ b/apps/homepage/src/app/platform/ai/_mocks/index.ts
@@ -1,0 +1,8 @@
+// apps/homepage/src/app/platform/ai/_mocks/index.ts
+
+export { MockAppSidebar, type SidebarKey } from './mock-app-sidebar'
+export { MockBrowserChrome } from './mock-browser-chrome'
+export { MockKopilotPrompt, type MockKopilotPromptRow } from './mock-kopilot-prompt'
+export { MockKopilotWindow, type Turn } from './mock-kopilot-window'
+export { MockMainPage } from './mock-main-page'
+export { MockPanelFrame } from './mock-panel-frame'

--- a/apps/homepage/src/app/platform/ai/_mocks/mock-app-sidebar.tsx
+++ b/apps/homepage/src/app/platform/ai/_mocks/mock-app-sidebar.tsx
@@ -1,0 +1,210 @@
+// apps/homepage/src/app/platform/ai/_mocks/mock-app-sidebar.tsx
+
+import {
+  Building2,
+  Calendar,
+  ChevronDown,
+  Database,
+  FileQuestion,
+  FileText,
+  Folder,
+  Inbox,
+  type Mail,
+  MessagesSquare,
+  Sparkles,
+  Ticket,
+  Users,
+  Workflow,
+} from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+export type SidebarKey =
+  | 'inbox'
+  | 'drafts'
+  | 'today'
+  | 'kopilot'
+  | 'workflows'
+  | 'datasets'
+  | 'kb'
+  | 'godela'
+  | 'contacts'
+  | 'tickets'
+  | 'companies'
+
+interface MockAppSidebarProps {
+  /** Which sidebar item to highlight as active. Default `'kopilot'`. */
+  activeKey?: SidebarKey
+  /** Sidebar width — passed through as inline style. */
+  width?: number | string
+  className?: string
+}
+
+interface SidebarItem {
+  key: SidebarKey
+  label: string
+  icon: typeof Mail
+  badge?: string
+  /** When set, renders the icon as an `EntityIcon`-style colored badge. */
+  entityColor?:
+    | 'gray'
+    | 'orange'
+    | 'green'
+    | 'blue'
+    | 'indigo'
+    | 'purple'
+    | 'pink'
+    | 'amber'
+    | 'teal'
+    | 'red'
+}
+
+interface SidebarGroup {
+  title: string
+  items: SidebarItem[]
+}
+
+/** Inverse color tokens copied from `packages/ui/src/components/icons.tsx` (ICON_COLORS[*].inverseColor). */
+const ENTITY_COLOR_CLASS: Record<NonNullable<SidebarItem['entityColor']>, string> = {
+  gray: 'bg-zinc-600 text-zinc-100 dark:bg-zinc-500',
+  orange: 'bg-orange-600 text-orange-100 dark:bg-orange-500',
+  green: 'bg-green-500 text-green-100 dark:bg-green-500',
+  blue: 'bg-blue-500 text-blue-100 dark:bg-blue-500',
+  indigo: 'bg-indigo-500 text-indigo-100 dark:bg-indigo-500',
+  purple: 'bg-purple-500 text-purple-100 dark:bg-purple-500',
+  pink: 'bg-pink-500 text-pink-50 dark:bg-pink-500',
+  amber: 'bg-amber-600 text-amber-100 dark:bg-amber-500',
+  teal: 'bg-teal-500 text-teal-100 dark:bg-teal-500',
+  red: 'bg-red-600 text-red-100 dark:bg-red-500',
+}
+
+const SIDEBAR_GROUPS: SidebarGroup[] = [
+  {
+    title: 'Mail',
+    items: [
+      { key: 'inbox', label: 'Inbox', icon: Inbox, badge: '3' },
+      { key: 'drafts', label: 'Drafts', icon: FileText },
+    ],
+  },
+  {
+    title: 'Workspace',
+    items: [
+      { key: 'today', label: 'Today', icon: Calendar },
+      { key: 'kopilot', label: 'Chats', icon: MessagesSquare },
+      { key: 'workflows', label: 'Workflows', icon: Workflow },
+    ],
+  },
+  {
+    title: 'Resources',
+    items: [
+      { key: 'datasets', label: 'Datasets', icon: Database },
+      { key: 'kb', label: 'Knowledge Base', icon: FileQuestion },
+    ],
+  },
+  {
+    title: 'Favorites',
+    items: [{ key: 'godela', label: 'Godela', icon: Folder }],
+  },
+  {
+    title: 'Records',
+    items: [
+      { key: 'contacts', label: 'Contacts', icon: Users, entityColor: 'blue' },
+      { key: 'tickets', label: 'Tickets', icon: Ticket, entityColor: 'orange' },
+      { key: 'companies', label: 'Companies', icon: Building2, entityColor: 'purple' },
+    ],
+  },
+]
+
+/**
+ * Static facsimile of `apps/web/src/components/global/sidebar/index.tsx`.
+ * Non-interactive — buttons render as plain divs, links don't navigate.
+ *
+ * Styling mirrors the real app's sidebar tokens:
+ * - Group label: `h-6 px-2 text-xs font-medium text-sidebar-foreground/70`
+ *   (from `SidebarGroupLabel`)
+ * - Menu item (size sm): `flex h-7 w-full items-center gap-2 rounded-md px-2
+ *   text-xs` (from `sidebarMenuButtonVariants` + `SidebarItem`)
+ * - Active: `bg-sidebar-accent text-sidebar-accent-foreground font-medium`
+ * - NavUser row: `h-8 rounded-2xl ps-1 pe-1.5` with size-6 ring avatar and
+ *   trailing Sparkles button (from `nav-user.tsx`)
+ */
+export function MockAppSidebar({
+  activeKey = 'kopilot',
+  width = 220,
+  className,
+}: MockAppSidebarProps) {
+  return (
+    <aside
+      style={{ width }}
+      className={cn(
+        'flex shrink-0 flex-col bg-mock-sidebar text-mock-sidebar-foreground border-r border-mock-sidebar-border',
+        className
+      )}>
+      <NavUserMock />
+
+      <div className='flex-1 space-y-2 overflow-hidden px-2 pb-3'>
+        {SIDEBAR_GROUPS.map((group) => (
+          <SidebarGroupBlock key={group.title} group={group} activeKey={activeKey} />
+        ))}
+      </div>
+    </aside>
+  )
+}
+
+function NavUserMock() {
+  return (
+    <div className='flex items-center justify-between gap-1 p-2'>
+      <div className='flex h-8 flex-1 items-center gap-2 rounded-2xl px-1 pe-1.5'>
+        <span className='flex size-6 shrink-0 items-center justify-center rounded-full bg-foreground text-[11px] font-medium text-background ring-1 ring-foreground/20'>
+          M
+        </span>
+        <span className='flex-1 truncate text-sm text-mock-sidebar-foreground'>Marki Mark</span>
+        <ChevronDown className='size-3.5 text-mock-sidebar-muted' />
+      </div>
+      <span className='flex size-8 shrink-0 items-center justify-center rounded-2xl text-mock-sidebar-muted'>
+        <Sparkles className='size-4' />
+      </span>
+    </div>
+  )
+}
+
+function SidebarGroupBlock({ group, activeKey }: { group: SidebarGroup; activeKey: SidebarKey }) {
+  return (
+    <div>
+      <div className='flex h-6 items-center rounded-md px-2 text-xs font-medium text-mock-sidebar-muted'>
+        {group.title}
+      </div>
+      <ul className='flex flex-col gap-px'>
+        {group.items.map((item) => {
+          const Icon = item.icon
+          const isActive = item.key === activeKey
+          return (
+            <li
+              key={item.key}
+              className={cn(
+                'flex h-7 w-full items-center gap-2 overflow-hidden rounded-md px-2 text-xs',
+                isActive
+                  ? 'bg-mock-sidebar-accent font-medium text-mock-sidebar-accent-foreground'
+                  : 'text-mock-sidebar-foreground'
+              )}>
+              {item.entityColor ? (
+                <span
+                  className={cn(
+                    'flex size-5 shrink-0 items-center justify-center rounded-md',
+                    ENTITY_COLOR_CLASS[item.entityColor]
+                  )}>
+                  <Icon className='size-3.5' />
+                </span>
+              ) : (
+                <Icon className='size-4 shrink-0' />
+              )}
+              <span className='flex-1 truncate text-left'>{item.label}</span>
+              {item.badge ? (
+                <span className='shrink-0 text-xs text-muted-foreground'>{item.badge}</span>
+              ) : null}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/_mocks/mock-browser-chrome.tsx
+++ b/apps/homepage/src/app/platform/ai/_mocks/mock-browser-chrome.tsx
@@ -1,0 +1,60 @@
+// apps/homepage/src/app/platform/ai/_mocks/mock-browser-chrome.tsx
+
+import { cn } from '~/lib/utils'
+
+interface MockBrowserChromeProps {
+  variant?: 'regular' | 'compact'
+  url?: string
+  className?: string
+  children: React.ReactNode
+}
+
+/**
+ * Outer browser-window frame used to wrap product mocks on the homepage.
+ *
+ * - `regular` — full chrome with three traffic-light dots on the left and a
+ *   centered URL pill. Use for hero-level mocks where the URL should read.
+ * - `compact` — only the three traffic-light dots in the top-left, no URL bar.
+ *   Use for in-section mocks where extra chrome would be noise.
+ */
+export function MockBrowserChrome({
+  variant = 'regular',
+  url = 'app.auxx.ai/app/chats',
+  className,
+  children,
+}: MockBrowserChromeProps) {
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-2xl border border-border bg-card text-card-foreground shadow-xl shadow-black/5',
+        className
+      )}>
+      {variant === 'regular' ? (
+        <div className='relative grid grid-cols-[auto_1fr_auto] items-center gap-3 border-b border-border px-3 py-2'>
+          <TrafficLights />
+          <div className='flex justify-center'>
+            <div className='inline-flex items-center rounded-md bg-muted px-3 py-1 text-xs text-muted-foreground'>
+              {url}
+            </div>
+          </div>
+          <div className='w-12' aria-hidden />
+        </div>
+      ) : (
+        <div className='border-b border-border px-3 py-2'>
+          <TrafficLights />
+        </div>
+      )}
+      {children}
+    </div>
+  )
+}
+
+function TrafficLights() {
+  return (
+    <div className='flex items-center gap-1.5'>
+      <span className='size-2.5 rounded-full bg-foreground/15' />
+      <span className='size-2.5 rounded-full bg-foreground/15' />
+      <span className='size-2.5 rounded-full bg-foreground/15' />
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/_mocks/mock-kopilot-prompt.tsx
+++ b/apps/homepage/src/app/platform/ai/_mocks/mock-kopilot-prompt.tsx
@@ -1,0 +1,93 @@
+// apps/homepage/src/app/platform/ai/_mocks/mock-kopilot-prompt.tsx
+
+'use client'
+
+import { Check, Send, Sparkles, SquareSlash } from 'lucide-react'
+import { motion } from 'motion/react'
+import { cn } from '~/lib/utils'
+
+export interface MockKopilotPromptRow {
+  field: string
+  value: string
+  accept?: boolean
+}
+
+interface MockKopilotPromptProps {
+  prompt: string
+  result: { title: string; rows: MockKopilotPromptRow[] }
+  modelLabel?: string
+  className?: string
+}
+
+const SPRING_BUBBLE = { type: 'spring' as const, stiffness: 400, damping: 25 }
+const SPRING_BLUR = { type: 'spring' as const, stiffness: 200, damping: 25 }
+
+/**
+ * Compact single-prompt variant of `MockKopilotWindow` — used in the personas
+ * tabs. Same animation language as the full window: spring 400/25 for the user
+ * bubble, spring 200/25 (with blur) for the result block + rows.
+ */
+export function MockKopilotPrompt({
+  prompt,
+  result,
+  modelLabel = 'GPT-5.4 Nano',
+  className,
+}: MockKopilotPromptProps) {
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-xl border border-mock-window-border bg-mock-card text-mock-window-foreground shadow-sm',
+        className
+      )}>
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 8 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={SPRING_BUBBLE}
+        className='border-b border-mock-window-border bg-mock-composer px-4 py-3'>
+        <div className='text-xs uppercase tracking-wide text-mock-window-muted'>Prompt</div>
+        <div className='mt-0.5 text-sm text-mock-window-foreground'>{prompt}</div>
+      </motion.div>
+
+      <motion.ul
+        initial={{ filter: 'blur(3px)', opacity: 0, y: 6 }}
+        animate={{ filter: 'blur(0px)', opacity: 1, y: 0 }}
+        transition={{ ...SPRING_BLUR, delay: 0.1 }}
+        className='divide-y divide-mock-window-border'>
+        <li className='px-4 py-2 text-[10px] font-medium uppercase tracking-wide text-mock-window-muted'>
+          {result.title}
+        </li>
+        {result.rows.map((row, i) => (
+          <motion.li
+            key={i}
+            initial={{ filter: 'blur(3px)', opacity: 0, y: 6 }}
+            animate={{ filter: 'blur(0px)', opacity: 1, y: 0 }}
+            transition={{ ...SPRING_BLUR, delay: 0.18 + i * 0.05 }}
+            className='grid grid-cols-[1fr_auto] items-center gap-3 px-4 py-3 text-sm'>
+            <div className='min-w-0'>
+              <div className='text-xs text-mock-window-muted'>{row.field}</div>
+              <div className='truncate text-mock-window-foreground'>{row.value}</div>
+            </div>
+            {row.accept ? (
+              <span className='inline-flex items-center gap-1 rounded-md border border-mock-window-border bg-mock-window px-2 py-1 text-xs text-mock-window-foreground'>
+                <Check className='size-3' />
+                Accept
+              </span>
+            ) : null}
+          </motion.li>
+        ))}
+      </motion.ul>
+
+      <div className='flex items-center justify-between border-t border-mock-window-border bg-mock-composer px-3 py-2 text-mock-window-muted'>
+        <span className='inline-flex items-center gap-1 text-xs'>
+          <Sparkles className='size-3 text-amber-500' />
+          <span>{modelLabel}</span>
+          <span className='rounded-sm bg-mock-bubble px-1 text-[10px]'>×1</span>
+        </span>
+        <span className='flex items-center gap-1'>
+          <SquareSlash className='size-3.5' />
+          <Send className='size-3.5' />
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/_mocks/mock-kopilot-window.tsx
+++ b/apps/homepage/src/app/platform/ai/_mocks/mock-kopilot-window.tsx
@@ -1,0 +1,230 @@
+// apps/homepage/src/app/platform/ai/_mocks/mock-kopilot-window.tsx
+
+'use client'
+
+import {
+  ChevronRight,
+  CornerDownLeft,
+  PanelLeft,
+  Plus,
+  Send,
+  Sparkles,
+  SquareSlash,
+} from 'lucide-react'
+import { motion } from 'motion/react'
+import { cn } from '~/lib/utils'
+
+export type Turn =
+  | { kind: 'user'; text: string }
+  | {
+      kind: 'tool'
+      title: string
+      count?: number
+      headerLabel?: string
+      items: Array<{ code: string; title: string; subtitle: string }>
+    }
+  | { kind: 'assistant'; text: string }
+
+interface MockKopilotWindowProps {
+  breadcrumb?: { trail: string[]; title: string }
+  turns?: Turn[]
+  composerPlaceholder?: string
+  modelLabel?: string
+  status?: 'idle' | 'thinking'
+  className?: string
+}
+
+const SPRING_BUBBLE = { type: 'spring' as const, stiffness: 400, damping: 25 }
+const SPRING_BLUR = { type: 'spring' as const, stiffness: 200, damping: 25 }
+
+/**
+ * Static facsimile of the Kopilot chat surface
+ * (`apps/web/src/components/kopilot/ui/kopilot-page-shell.tsx`).
+ *
+ * Animations mirror the real components:
+ * - User bubble: `kopilot-message-list.tsx` spring 400/25 (opacity + scale + y)
+ * - Tool block + rows: `messages/thinking-steps.tsx` spring 200/25 (blur + opacity + y)
+ * - "Actioning…" dot: `animate-dot-blink` keyframe defined in globals.css
+ */
+export function MockKopilotWindow({
+  breadcrumb,
+  turns = [],
+  composerPlaceholder = 'Ask Kopilot...',
+  modelLabel = 'GPT-5.4 Nano',
+  status = 'idle',
+  className,
+}: MockKopilotWindowProps) {
+  return (
+    <div
+      className={cn(
+        'flex h-full min-h-[480px] flex-1 flex-col text-mock-window-foreground',
+        className
+      )}>
+      <Header breadcrumb={breadcrumb} />
+
+      <div className='flex-1 overflow-hidden px-6 py-6'>
+        <div className='mx-auto flex w-full max-w-2xl flex-col gap-4'>
+          {turns.map((turn, index) => (
+            <TurnRenderer key={index} turn={turn} index={index} />
+          ))}
+
+          {status === 'thinking' ? <ActioningPill /> : null}
+        </div>
+      </div>
+
+      <div className='border-t border-mock-window-border px-6 py-3'>
+        <div className='mx-auto w-full max-w-2xl'>
+          <Composer placeholder={composerPlaceholder} modelLabel={modelLabel} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Header({ breadcrumb }: { breadcrumb?: MockKopilotWindowProps['breadcrumb'] }) {
+  return (
+    <div className='flex items-center justify-between border-b border-mock-window-border px-4 py-2 text-xs'>
+      <div className='flex items-center gap-2 text-mock-window-muted'>
+        <PanelLeft className='size-3.5' />
+        {breadcrumb?.trail.map((label) => (
+          <span key={label} className='flex items-center gap-2'>
+            <span>{label}</span>
+            <ChevronRight className='size-3 text-mock-window-muted' />
+          </span>
+        ))}
+        {breadcrumb?.title ? (
+          <span className='max-w-[28ch] truncate text-mock-window-foreground'>
+            {breadcrumb.title}
+          </span>
+        ) : null}
+      </div>
+      <div className='inline-flex items-center gap-1 rounded-md border border-mock-window-border px-2 py-1 text-mock-window-foreground'>
+        <Plus className='size-3' />
+        <span>New chat</span>
+      </div>
+    </div>
+  )
+}
+
+function TurnRenderer({ turn, index }: { turn: Turn; index: number }) {
+  const delay = index * 0.08
+
+  if (turn.kind === 'user') {
+    return (
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 8 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={{ ...SPRING_BUBBLE, delay }}
+        className='ml-auto w-fit max-w-md rounded-2xl rounded-tr-sm bg-mock-bubble px-3 py-2 text-sm text-mock-window-foreground'>
+        {turn.text}
+      </motion.div>
+    )
+  }
+
+  if (turn.kind === 'assistant') {
+    return (
+      <motion.div
+        initial={{ filter: 'blur(3px)', opacity: 0, y: 6 }}
+        animate={{ filter: 'blur(0px)', opacity: 1, y: 0 }}
+        transition={{ ...SPRING_BLUR, delay }}
+        className='max-w-md text-sm text-mock-window-foreground'>
+        {turn.text}
+      </motion.div>
+    )
+  }
+
+  return <ToolBlock turn={turn} delay={delay} />
+}
+
+function ToolBlock({ turn, delay }: { turn: Extract<Turn, { kind: 'tool' }>; delay: number }) {
+  const headerLabel = turn.headerLabel ?? '3 steps completed'
+
+  return (
+    <motion.div
+      initial={{ filter: 'blur(3px)', opacity: 0, y: 6 }}
+      animate={{ filter: 'blur(0px)', opacity: 1, y: 0 }}
+      transition={{ ...SPRING_BLUR, delay }}
+      className='space-y-2'>
+      <div className='flex items-center gap-1.5 px-1 text-xs text-mock-window-muted'>
+        <Sparkles className='size-3 text-amber-500' />
+        <span>{headerLabel}</span>
+        <ChevronRight className='size-3' />
+      </div>
+
+      <div className='overflow-hidden rounded-xl border border-mock-window-border bg-mock-card'>
+        <div className='flex items-center gap-2 border-b border-mock-window-border px-3 py-2 text-xs'>
+          <span className='size-1.5 rounded-full bg-mock-window-foreground/40' />
+          <span className='font-medium text-mock-window-foreground'>{turn.title}</span>
+          {typeof turn.count === 'number' ? (
+            <span className='ml-auto rounded-md bg-mock-bubble px-1.5 py-0.5 text-[10px] text-mock-window-muted'>
+              {turn.count}
+            </span>
+          ) : null}
+        </div>
+        <ul className='divide-y divide-mock-window-border'>
+          {turn.items.map((item, i) => (
+            <motion.li
+              key={i}
+              initial={{ filter: 'blur(3px)', opacity: 0, y: 6 }}
+              animate={{ filter: 'blur(0px)', opacity: 1, y: 0 }}
+              transition={{ ...SPRING_BLUR, delay: delay + 0.1 + i * 0.05 }}
+              className='flex items-center gap-3 px-3 py-2'>
+              <span className='flex size-7 shrink-0 items-center justify-center rounded-md bg-mock-bubble text-[10px] font-medium text-mock-window-muted'>
+                {item.code}
+              </span>
+              <div className='flex min-w-0 flex-col text-xs'>
+                <span className='truncate text-mock-window-foreground'>{item.title}</span>
+                <span className='truncate text-mock-window-muted'>{item.subtitle}</span>
+              </div>
+            </motion.li>
+          ))}
+        </ul>
+      </div>
+    </motion.div>
+  )
+}
+
+function ActioningPill() {
+  return (
+    <div className='flex items-center gap-1 px-1 text-xs text-mock-window-muted'>
+      <span>Actioning</span>
+      <span className='animate-dot-blink' style={{ animationDelay: '0s' }}>
+        .
+      </span>
+      <span className='animate-dot-blink' style={{ animationDelay: '0.2s' }}>
+        .
+      </span>
+      <span className='animate-dot-blink' style={{ animationDelay: '0.4s' }}>
+        .
+      </span>
+    </div>
+  )
+}
+
+function Composer({ placeholder, modelLabel }: { placeholder: string; modelLabel: string }) {
+  return (
+    <div className='relative flex min-h-[100px] flex-row items-end rounded-xl border border-mock-composer-border bg-mock-composer'>
+      <div className='flex flex-1 flex-col self-stretch px-3 py-2'>
+        <p className='text-sm text-mock-window-muted'>{placeholder}</p>
+      </div>
+      <div className='absolute bottom-1 left-1'>
+        <span className='inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-mock-window-muted'>
+          <Sparkles className='size-3 text-amber-500' />
+          <span>{modelLabel}</span>
+          <span className='rounded-sm bg-mock-bubble px-1 text-[10px]'>×1</span>
+        </span>
+      </div>
+      <div className='absolute bottom-1 right-1 flex items-center gap-0.5 text-mock-window-muted'>
+        <span className='flex size-7 items-center justify-center rounded-md'>
+          <SquareSlash className='size-3.5' />
+        </span>
+        <span className='flex size-7 items-center justify-center rounded-md'>
+          <Send className='size-3.5' />
+        </span>
+        <span className='ml-1 hidden items-center gap-1 text-[10px] sm:inline-flex'>
+          <CornerDownLeft className='size-3' />
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/_mocks/mock-main-page.tsx
+++ b/apps/homepage/src/app/platform/ai/_mocks/mock-main-page.tsx
@@ -1,0 +1,28 @@
+// apps/homepage/src/app/platform/ai/_mocks/mock-main-page.tsx
+
+import { cn } from '~/lib/utils'
+import { MockPanelFrame } from './mock-panel-frame'
+
+interface MockMainPageProps {
+  className?: string
+  children: React.ReactNode
+}
+
+/**
+ * Static facsimile of `packages/ui/src/components/main-page.tsx`.
+ *
+ * Outer container reproduces the real `MainPage`'s padded frame
+ * (`bg-neutral-100 dark:bg-background p-3 pt-0`) and wraps its content in a
+ * `MockPanelFrame` for the nested-border depth effect.
+ */
+export function MockMainPage({ className, children }: MockMainPageProps) {
+  return (
+    <div
+      className={cn(
+        'flex h-full flex-1 flex-col overflow-hidden bg-mock-page-bg p-3 pt-3',
+        className
+      )}>
+      <MockPanelFrame flex>{children}</MockPanelFrame>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/_mocks/mock-panel-frame.tsx
+++ b/apps/homepage/src/app/platform/ai/_mocks/mock-panel-frame.tsx
@@ -1,0 +1,40 @@
+// apps/homepage/src/app/platform/ai/_mocks/mock-panel-frame.tsx
+
+import { cn } from '~/lib/utils'
+
+interface MockPanelFrameProps {
+  width?: number | string
+  flex?: boolean
+  className?: string
+  children: React.ReactNode
+}
+
+/**
+ * Static facsimile of `packages/ui/src/components/panel-frame.tsx`.
+ * Reproduces the four-layer nested border depth effect (alternating
+ * highlight/shadow rings) that wraps every main panel in the real app.
+ */
+export function MockPanelFrame({ width, flex, className, children }: MockPanelFrameProps) {
+  const inlineStyle =
+    width !== undefined ? { width: typeof width === 'number' ? `${width}px` : width } : undefined
+
+  return (
+    <div
+      style={inlineStyle}
+      className={cn(
+        'relative flex h-full min-w-0 flex-col overflow-hidden rounded-2xl border border-mock-panel-border-1 bg-mock-panel-bg',
+        flex ? 'flex-1' : 'shrink-0',
+        className
+      )}>
+      <div className='flex flex-1 flex-col rounded-[calc(var(--radius-2xl)-1px)] border border-mock-panel-border-2'>
+        <div className='flex flex-1 rounded-[calc(var(--radius-2xl)-2px)] border border-mock-panel-border-3'>
+          <div className='flex flex-1 rounded-[calc(var(--radius-2xl)-3px)] border border-mock-panel-border-4'>
+            <div className='flex flex-1 flex-col overflow-clip rounded-[calc(var(--radius-2xl)-4px)] bg-clip-padding'>
+              {children}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/_mocks/mock.css
+++ b/apps/homepage/src/app/platform/ai/_mocks/mock.css
@@ -1,0 +1,101 @@
+/*
+ * apps/homepage/src/app/platform/ai/_mocks/mock.css
+ *
+ * Tokens for the homepage AI mocks (`MockAppSidebar`, `MockKopilotWindow`,
+ * `MockKopilotPrompt`). These mirror the real app's sidebar + chat tokens
+ * (see `packages/ui/src/styles/global.css` and `apps/web/src/app/globals.css`)
+ * so the marketing mocks visually match the live product in both light and
+ * dark themes.
+ *
+ * The homepage uses `[data-theme='dark']` (not `.dark`) for theme switching,
+ * matching the rest of `apps/homepage/src/app/globals.css`.
+ */
+
+@layer base {
+  :root {
+    /* Sidebar — light. Mirrors `--sidebar` in packages/ui/src/styles/global.css. */
+    --mock-sidebar: oklch(0.985 0 0);
+    --mock-sidebar-foreground: oklch(0.145 0 0);
+    --mock-sidebar-muted: color-mix(in oklab, var(--color-zinc-500) 80%, transparent);
+    --mock-sidebar-accent: oklch(0.97 0 0);
+    --mock-sidebar-accent-foreground: oklch(0.205 0 0);
+    --mock-sidebar-border: oklch(0.922 0 0);
+
+    /* Chat surface — light. Slight off-white card. */
+    --mock-window: var(--color-white);
+    --mock-window-foreground: oklch(0.145 0 0);
+    --mock-window-muted-foreground: var(--color-zinc-500);
+    --mock-window-border: var(--color-zinc-200);
+    --mock-card: var(--color-white);
+
+    /* User bubble + composer (matches `bg-primary-150` on the real composer). */
+    --mock-bubble: var(--color-zinc-100);
+    --mock-composer: var(--color-zinc-50);
+    --mock-composer-border: var(--color-zinc-200);
+
+    /* MainPage outer + nested PanelFrame borders. Mirrors the real
+       packages/ui/src/components/main-page.tsx + panel-frame.tsx in light. */
+    --mock-page-bg: var(--color-neutral-100);
+    --mock-panel-bg: color-mix(in oklab, var(--color-zinc-100) 50%, transparent);
+    --mock-panel-border-1: color-mix(in oklab, var(--color-white) 60%, transparent);
+    --mock-panel-border-2: color-mix(in oklab, var(--color-black) 10%, transparent);
+    --mock-panel-border-3: color-mix(in oklab, var(--color-white) 50%, transparent);
+    --mock-panel-border-4: color-mix(in oklab, var(--color-zinc-950) 20%, transparent);
+  }
+
+  [data-theme='dark'] {
+    /* Mirrors `--sidebar: #1e2227` from `packages/ui/src/styles/global.css:488`. */
+    --mock-sidebar: #1e2227;
+    --mock-sidebar-foreground: #abb2bf;
+    --mock-sidebar-muted: color-mix(in oklab, #abb2bf 70%, transparent);
+    --mock-sidebar-accent: #2c313a;
+    --mock-sidebar-accent-foreground: #d7dae0;
+    --mock-sidebar-border: #3e4452;
+
+    /* Mirrors the chat surface bg in dark mode. */
+    --mock-window: #23272e;
+    --mock-window-foreground: oklch(0.985 0 0);
+    --mock-window-muted-foreground: oklch(0.7155 0 0);
+    --mock-window-border: color-mix(in oklab, var(--color-white) 8%, transparent);
+    --mock-card: #1e2227;
+
+    --mock-bubble: #2c313a;
+    --mock-composer: #1e2227;
+    --mock-composer-border: color-mix(in oklab, var(--color-white) 10%, transparent);
+
+    /* Mirrors the dark-mode `border-[#323842]`, `border-[#23272e]`,
+       `border-neutral-900/...`, `border-white/...` stack on PanelFrame. */
+    --mock-page-bg: #23272e;
+    --mock-panel-bg: color-mix(in oklab, #1e2227 80%, transparent);
+    --mock-panel-border-1: #323842;
+    --mock-panel-border-2: color-mix(in oklab, var(--color-neutral-900) 80%, transparent);
+    --mock-panel-border-3: #23272e;
+    --mock-panel-border-4: color-mix(in oklab, var(--color-neutral-900) 70%, transparent);
+  }
+}
+
+@theme inline {
+  --color-mock-sidebar: var(--mock-sidebar);
+  --color-mock-sidebar-foreground: var(--mock-sidebar-foreground);
+  --color-mock-sidebar-muted: var(--mock-sidebar-muted);
+  --color-mock-sidebar-accent: var(--mock-sidebar-accent);
+  --color-mock-sidebar-accent-foreground: var(--mock-sidebar-accent-foreground);
+  --color-mock-sidebar-border: var(--mock-sidebar-border);
+
+  --color-mock-window: var(--mock-window);
+  --color-mock-window-foreground: var(--mock-window-foreground);
+  --color-mock-window-muted: var(--mock-window-muted-foreground);
+  --color-mock-window-border: var(--mock-window-border);
+  --color-mock-card: var(--mock-card);
+
+  --color-mock-bubble: var(--mock-bubble);
+  --color-mock-composer: var(--mock-composer);
+  --color-mock-composer-border: var(--mock-composer-border);
+
+  --color-mock-page-bg: var(--mock-page-bg);
+  --color-mock-panel-bg: var(--mock-panel-bg);
+  --color-mock-panel-border-1: var(--mock-panel-border-1);
+  --color-mock-panel-border-2: var(--mock-panel-border-2);
+  --color-mock-panel-border-3: var(--mock-panel-border-3);
+  --color-mock-panel-border-4: var(--mock-panel-border-4);
+}

--- a/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-context-section.tsx
+++ b/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-context-section.tsx
@@ -1,0 +1,99 @@
+// apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-context-section.tsx
+
+import { Globe, Layers, Plug, Search, Telescope } from 'lucide-react'
+
+const features = [
+  {
+    icon: Search,
+    name: 'Semantic search',
+    description: 'Instant retrieval across tickets, contacts, KB, and datasets.',
+  },
+  {
+    icon: Layers,
+    name: 'Grounded in your context',
+    description: 'Emails, replies, custom fields, orders, and conversation history.',
+  },
+  {
+    icon: Telescope,
+    name: 'Understand patterns',
+    description: 'See repeat issues, churn risk, and trends across signals.',
+  },
+  {
+    icon: Plug,
+    name: 'Connected tools',
+    description: 'Shopify, Gmail, Outlook, Slack, and your knowledge base.',
+  },
+  {
+    icon: Globe,
+    name: 'Say hello.',
+    description: 'Hola. Olá. Bonjour. Hallo. Ask Kopilot in any language.',
+  },
+]
+
+export default function KopilotContextSection() {
+  return (
+    <section
+      data-theme='dark'
+      className='relative overflow-hidden bg-zinc-950 text-zinc-50 border-b border-foreground/10'>
+      <ArcBackground />
+      <div className='relative z-10 mx-auto max-w-6xl px-6 py-24 md:py-32'>
+        <div className='text-center'>
+          <span className='text-zinc-400 text-sm'>Powered by</span>
+          <h2 className='mt-4 text-balance text-5xl font-semibold tracking-tight md:text-7xl'>
+            Auxx Kopilot
+            <sup className='ml-1 text-base align-super text-zinc-400'>™</sup>
+          </h2>
+        </div>
+
+        <ul className='mt-20 grid gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-5'>
+          {features.map((f) => (
+            <li key={f.name} className='space-y-3'>
+              <f.icon className='size-5 text-zinc-300' />
+              <div className='text-zinc-50 font-medium'>{f.name}</div>
+              <p className='text-zinc-400 text-sm'>{f.description}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}
+
+function ArcBackground() {
+  return (
+    <div aria-hidden className='pointer-events-none absolute inset-0 overflow-hidden'>
+      <svg
+        viewBox='0 0 1200 600'
+        preserveAspectRatio='xMidYMin slice'
+        className='absolute inset-0 h-full w-full'>
+        <defs>
+          <radialGradient id='kopilot-arc-fade' cx='50%' cy='-10%' r='65%'>
+            <stop offset='0%' stopColor='rgba(255,255,255,0.2)' />
+            <stop offset='100%' stopColor='rgba(255,255,255,0)' />
+          </radialGradient>
+          <pattern
+            id='kopilot-arc-lines'
+            x='0'
+            y='0'
+            width='6'
+            height='600'
+            patternUnits='userSpaceOnUse'>
+            <line x1='0' y1='0' x2='0' y2='600' stroke='rgba(255,255,255,0.12)' strokeWidth='1' />
+          </pattern>
+          <mask id='kopilot-arc-mask'>
+            <ellipse cx='600' cy='1100' rx='1000' ry='850' fill='white' />
+          </mask>
+        </defs>
+        <rect
+          x='0'
+          y='0'
+          width='1200'
+          height='600'
+          fill='url(#kopilot-arc-lines)'
+          mask='url(#kopilot-arc-mask)'
+        />
+        <rect x='0' y='0' width='1200' height='600' fill='url(#kopilot-arc-fade)' />
+      </svg>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-final-cta.tsx
+++ b/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-final-cta.tsx
@@ -1,0 +1,35 @@
+// apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-final-cta.tsx
+
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+
+export default function KopilotFinalCta() {
+  return (
+    <section
+      data-theme='dark'
+      className='relative overflow-hidden bg-zinc-950 text-zinc-50 border-b border-foreground/10'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_bottom,_rgba(255,255,255,0.08),_transparent_60%)]'
+      />
+      <div className='relative z-10 mx-auto max-w-4xl px-6 py-24 text-center md:py-32'>
+        <h2 className='text-balance text-5xl font-semibold tracking-tight md:text-6xl'>
+          Ask more from support. Ask Kopilot.
+        </h2>
+        <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+          <Button asChild size='sm'>
+            <Link href={config.urls.signup}>Start for free</Link>
+          </Button>
+          <Button
+            asChild
+            size='sm'
+            variant='outline'
+            className='border-zinc-700 bg-transparent text-zinc-50 hover:bg-zinc-900'>
+            <Link href={config.urls.demo}>Talk to sales</Link>
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-hero.tsx
+++ b/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-hero.tsx
@@ -1,0 +1,100 @@
+// apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-hero.tsx
+
+import { ArrowUp, Sparkles } from 'lucide-react'
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+
+const draftLines = [
+  'Refund policy → 30 days, unused items',
+  'Order #4521 → flagged shipping delay',
+  'Suggest reply: "Apologies for the late delivery..."',
+]
+
+export default function KopilotHero() {
+  return (
+    <section className='relative overflow-hidden border-b bg-background'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-x-0 top-0 -z-10 h-[600px] bg-[radial-gradient(ellipse_at_top,_var(--color-primary)/10,_transparent_60%)]'
+      />
+      <div className='mx-auto max-w-5xl px-6 pb-16 pt-32 text-center md:pt-40 lg:pt-48'>
+        <div className='mx-auto inline-flex items-center gap-2 rounded-full border border-foreground/10 bg-muted/40 px-3 py-1 text-xs'>
+          <Sparkles className='size-3.5 text-amber-500' />
+          <span className='text-muted-foreground'>Workspace copilot</span>
+        </div>
+
+        <h1 className='mt-6 text-balance text-5xl font-semibold tracking-tight md:text-7xl'>
+          Ask Kopilot.
+        </h1>
+        <p className='mx-auto mt-4 max-w-xl text-balance text-lg text-muted-foreground'>
+          Search, update, and create with AI.
+        </p>
+        <p className='mx-auto mt-2 max-w-xl text-balance text-sm text-muted-foreground/75'>
+          Engineered for support. Unified by design. Powered by your data.
+        </p>
+
+        <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+          <Button asChild size='sm'>
+            <Link href={config.urls.signup}>Start for free</Link>
+          </Button>
+          <Button asChild size='sm' variant='outline'>
+            <Link href={config.urls.demo}>Talk to sales</Link>
+          </Button>
+        </div>
+
+        <ChatMock />
+      </div>
+    </section>
+  )
+}
+
+function ChatMock() {
+  return (
+    <div className='mx-auto mt-16 max-w-2xl text-left'>
+      <div className='rounded-xl border border-foreground/10 bg-card shadow-xl shadow-black/5'>
+        <div className='flex items-center gap-2 border-b border-foreground/5 px-4 py-2'>
+          <span className='size-2 rounded-full bg-foreground/10' />
+          <span className='size-2 rounded-full bg-foreground/10' />
+          <span className='size-2 rounded-full bg-foreground/10' />
+          <span className='ml-2 text-muted-foreground text-xs'>Kopilot</span>
+        </div>
+
+        <div className='space-y-4 p-5'>
+          <div className='ml-auto w-fit max-w-md rounded-2xl rounded-br-sm bg-foreground/5 px-3 py-2 text-sm'>
+            Why did order #4521 ship late?
+          </div>
+
+          <div className='space-y-2'>
+            <div className='text-muted-foreground text-xs'>Looking up...</div>
+            <ul className='space-y-1.5'>
+              {draftLines.map((line, i) => (
+                <li
+                  key={i}
+                  className='flex items-center gap-2 rounded-md border border-foreground/5 bg-background px-3 py-2 text-sm'>
+                  <span className='size-1.5 rounded-full bg-emerald-500' />
+                  <span className='text-foreground/80'>{line}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className='flex items-center gap-2 border-t border-foreground/5 px-3 py-2'>
+          <input
+            type='text'
+            placeholder='Ask anything...'
+            disabled
+            className='flex-1 bg-transparent px-2 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none'
+          />
+          <button
+            type='button'
+            disabled
+            className='flex size-7 items-center justify-center rounded-full bg-foreground text-background'>
+            <ArrowUp className='size-4' />
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-intelligence-section.tsx
+++ b/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-intelligence-section.tsx
@@ -1,0 +1,178 @@
+// apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-intelligence-section.tsx
+
+import { GRADIENT_PALETTES } from '@auxx/ui/components/gradient-palettes'
+import { RandomGradient } from '@auxx/ui/components/random-gradient'
+import { Check, FileText, Lock, ShieldCheck } from 'lucide-react'
+import { MockAppSidebar, MockBrowserChrome, MockKopilotWindow, MockMainPage } from '../../_mocks'
+
+const sources = [
+  { source: 'Ticket #4521', detail: 'Refund requested · 2d ago' },
+  { source: 'KB · Refund policy', detail: 'v3 · published' },
+  { source: 'Shopify · Order #4521', detail: 'Shipped · 7d late' },
+  { source: 'Contact · Drew Houston', detail: 'VIP · 12 prior tickets' },
+]
+
+const suggestions = [
+  { entity: 'Drew Houston', field: 'Update role', value: 'Head of IT' },
+  { entity: 'Greenleaf', field: 'Funding raised', value: '$100M – $250M' },
+  { entity: 'Order #4521', field: 'Update next step', value: 'Send tracking number' },
+]
+
+const intelligenceTurns = [
+  { kind: 'user' as const, text: 'Summarize my open tickets' },
+  {
+    kind: 'tool' as const,
+    title: 'Tickets',
+    count: 8,
+    headerLabel: '3 steps completed',
+    items: [
+      { code: 'RF', title: 'Request for information', subtitle: 'TKT-0003' },
+      { code: 'GI', title: 'General inquiry about services', subtitle: 'TKT-0001' },
+      { code: 'CI', title: 'Can I change my shipping address?', subtitle: 'TKT-0006' },
+      { code: 'RP', title: 'Replace phone for Carolin Klooth', subtitle: 'TKT-0008' },
+      { code: 'CI', title: 'Can I change my shipping address?', subtitle: 'TKT-0007' },
+    ],
+  },
+]
+
+export default function KopilotIntelligenceSection() {
+  return (
+    <section className='relative bg-background border-b border-foreground/10'>
+      <div className='mx-auto max-w-6xl px-6 pt-24 pb-12'>
+        <h2 className='mx-auto max-w-3xl text-balance text-center text-4xl font-semibold md:text-5xl'>
+          Intelligence built for how you work and what you do.
+        </h2>
+
+        <div className='mt-16'>
+          <MockBrowserChrome variant='compact'>
+            <div className='grid grid-cols-[220px_1fr] min-h-[560px]'>
+              <MockAppSidebar activeKey='kopilot' />
+              <MockMainPage>
+                <MockKopilotWindow
+                  breadcrumb={{ trail: ['Chats'], title: 'Open Support Tickets Summary' }}
+                  turns={intelligenceTurns}
+                  composerPlaceholder='Ask Kopilot...'
+                  modelLabel='GPT-5.4 Nano'
+                  status='idle'
+                />
+              </MockMainPage>
+            </div>
+          </MockBrowserChrome>
+        </div>
+      </div>
+
+      <div className='relative z-10 mx-auto max-w-6xl '>
+        <div className=' @container pt-10 pb-24'>
+          <div className='mx-auto w-full px-6'>
+            <div className='relative overflow-hidden rounded-2xl p-6'>
+              <RandomGradient colors={[...GRADIENT_PALETTES.aurora]} mode='mesh' animated />
+              <div className='@max-4xl:max-w-sm @max-4xl:mx-auto @4xl:grid-cols-3 grid gap-6 *:p-6 relative z-10'>
+                <RealInformationCard />
+                <PermissionsCard />
+                <SuggestionsCard />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function RealInformationCard() {
+  return (
+    <div className='bg-card/80 ring-foreground/5 grid grid-rows-[auto_1fr] space-y-12 overflow-hidden rounded-2xl border border-transparent/50 shadow-md shadow-black/5 ring-1'>
+      <div>
+        <FileText className='fill-foreground/10 mb-5 size-4' />
+        <h3 className='text-foreground text-lg font-semibold'>
+          Real information, not AI invention.
+        </h3>
+        <p className='text-muted-foreground mt-3'>
+          Every answer is sourced from your actual{' '}
+          <span className='text-foreground font-medium'>tickets, contacts, KB, and datasets</span>.
+        </p>
+      </div>
+      <div className='bg-linear-to-b -m-8 flex flex-col justify-end from-transparent via-rose-50 to-amber-50 dark:via-rose-500/10 dark:to-amber-500/10 p-8'>
+        <ul className='space-y-1.5'>
+          {sources.map((s, i) => (
+            <li
+              key={i}
+              className='flex items-center justify-between rounded-md border border-foreground/5 bg-background/70 px-3 py-2 text-xs backdrop-blur-sm'>
+              <span className='text-foreground'>{s.source}</span>
+              <span className='text-muted-foreground'>{s.detail}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+function PermissionsCard() {
+  return (
+    <div className='bg-card/80 ring-foreground/5 grid grid-rows-[auto_1fr] space-y-12 overflow-hidden rounded-2xl border border-transparent shadow-md shadow-black/5 ring-1'>
+      <div>
+        <Lock className='fill-foreground/10 mb-5 size-4' />
+        <h3 className='text-foreground text-lg font-semibold'>Your permissions, enforced.</h3>
+        <p className='text-muted-foreground mt-3'>
+          Kopilot follows your org and role permissions —{' '}
+          <span className='text-foreground font-medium'>
+            every user only sees what they're supposed to
+          </span>
+          .
+        </p>
+      </div>
+      <div className='bg-linear-to-b -m-8 flex flex-col justify-end from-transparent via-purple-50 to-emerald-50 dark:via-purple-500/10 dark:to-emerald-500/10 p-8'>
+        <div className='rounded-md border border-foreground/5 bg-background/70 p-3 text-xs backdrop-blur-sm'>
+          <div className='flex items-center gap-2'>
+            <ShieldCheck className='size-3.5 text-emerald-500' />
+            <span className='text-foreground'>Scoped to organization</span>
+          </div>
+          <div className='mt-2 flex items-center gap-2'>
+            <ShieldCheck className='size-3.5 text-emerald-500' />
+            <span className='text-foreground'>Role-based field visibility</span>
+          </div>
+          <div className='mt-2 flex items-center gap-2'>
+            <ShieldCheck className='size-3.5 text-emerald-500' />
+            <span className='text-foreground'>Audited on every action</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SuggestionsCard() {
+  return (
+    <div className='bg-card/80 ring-foreground/5 grid grid-rows-[auto_1fr] space-y-12 overflow-hidden rounded-2xl border border-transparent/50 shadow-md shadow-black/5 ring-1'>
+      <div>
+        <Check className='fill-foreground/10 mb-5 size-4' />
+        <h3 className='text-foreground text-lg font-semibold'>
+          Intelligent suggestions. Human decisions.
+        </h3>
+        <p className='text-muted-foreground mt-3'>
+          You're always in command —{' '}
+          <span className='text-foreground font-medium'>approve, modify, or reject</span> any
+          suggestion.
+        </p>
+      </div>
+      <div className='bg-linear-to-b -m-8 flex flex-col justify-end from-transparent via-sky-50 to-indigo-50 dark:via-sky-500/10 dark:to-indigo-500/10 p-8'>
+        <ul className='space-y-1.5'>
+          {suggestions.map((s, i) => (
+            <li
+              key={i}
+              className='grid grid-cols-[1fr_auto] items-center gap-2 rounded-md border border-foreground/5 bg-background/70 px-3 py-2 text-xs backdrop-blur-sm'>
+              <div>
+                <div className='text-muted-foreground'>{s.field}</div>
+                <div className='text-foreground'>{s.value}</div>
+              </div>
+              <span className='inline-flex items-center gap-1 rounded border border-foreground/10 bg-background px-1.5 py-0.5 text-[10px] text-foreground/80'>
+                <Check className='size-2.5' /> Accept
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-personas.tsx
+++ b/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-personas.tsx
@@ -1,0 +1,124 @@
+// apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-personas.tsx
+
+'use client'
+
+import { useState } from 'react'
+import { cn } from '~/lib/utils'
+import { MockKopilotPrompt } from '../../_mocks'
+
+interface Suggestion {
+  field: string
+  value: string
+}
+
+interface Persona {
+  id: string
+  label: string
+  heading: string
+  prompt: string
+  description: string
+  suggestions: Suggestion[]
+}
+
+const personas: Persona[] = [
+  {
+    id: 'support',
+    label: 'Support',
+    heading: 'Resolve faster when every reply has full context.',
+    prompt: 'draft refund reply for order #4521',
+    description: 'Pull policy, order history, and prior tickets into a draft you can accept.',
+    suggestions: [
+      { field: 'Suggested reply', value: 'Apologies for the delay. Refund of $89.00 issued...' },
+      { field: 'Tag intent', value: 'Refund · Shipping delay' },
+      { field: 'Update CSAT', value: 'At-risk' },
+      { field: 'Link to KB', value: 'Refund policy (v3)' },
+    ],
+  },
+  {
+    id: 'ops',
+    label: 'Ops',
+    heading: 'Spot patterns across hundreds of tickets at once.',
+    prompt: 'summarize this week’s negative feedback',
+    description: 'Cluster repeated issues, surface root causes, and assign owners.',
+    suggestions: [
+      { field: 'Top theme', value: 'Late shipping (38 mentions)' },
+      { field: 'Second theme', value: 'Missing items (12 mentions)' },
+      { field: 'Suggested action', value: 'Escalate to fulfillment' },
+      { field: 'Affected SKUs', value: '3 SKUs flagged' },
+    ],
+  },
+  {
+    id: 'founders',
+    label: 'Founders',
+    heading: 'Run the business without leaving your inbox.',
+    prompt: 'how is support trending this month?',
+    description: 'Daily briefs, churn-risk customers, and the next thing worth your time.',
+    suggestions: [
+      { field: 'Tickets this week', value: '142 (↑18%)' },
+      { field: 'Avg first response', value: '4m 12s' },
+      { field: 'Churn risk', value: '2 accounts flagged' },
+      { field: 'Recommended next', value: 'Reply to Greenleaf' },
+    ],
+  },
+  {
+    id: 'devs',
+    label: 'Developers',
+    heading: 'Ship faster with the workspace as an API.',
+    prompt: 'add a tag and assign to triage',
+    description: 'Capabilities run actions, not just answers — entities, tasks, mail, knowledge.',
+    suggestions: [
+      { field: 'Run capability', value: 'tag.add(“bug”)' },
+      { field: 'Run capability', value: 'ticket.assign(triage)' },
+      { field: 'Run capability', value: 'task.create(...)' },
+      { field: 'Audit log', value: '3 actions queued' },
+    ],
+  },
+]
+
+export default function KopilotPersonas() {
+  const [active, setActive] = useState(personas[0].id)
+  const persona = personas.find((p) => p.id === active) ?? personas[0]
+
+  return (
+    <section className='relative bg-background border-b border-foreground/10'>
+      <div className='mx-auto max-w-5xl px-6 py-20 md:py-28'>
+        <h2 className='mx-auto max-w-2xl text-balance text-center text-4xl font-semibold md:text-5xl text-muted-foreground'>
+          Simply powerful customer intelligence.
+        </h2>
+
+        <div className='mt-10 flex flex-wrap items-center justify-center gap-2'>
+          {personas.map((p) => (
+            <button
+              key={p.id}
+              type='button'
+              onClick={() => setActive(p.id)}
+              className={cn(
+                'rounded-full border px-3 py-1 text-sm transition',
+                active === p.id
+                  ? 'border-foreground bg-foreground text-background'
+                  : 'border-foreground/10 text-muted-foreground hover:border-foreground/30'
+              )}>
+              {p.label}
+            </button>
+          ))}
+        </div>
+
+        <div className='mt-14 grid gap-12 lg:grid-cols-2'>
+          <div className='space-y-3'>
+            <h3 className='text-balance text-2xl font-semibold md:text-3xl'>{persona.heading}</h3>
+            <p className='text-muted-foreground'>{persona.description}</p>
+          </div>
+
+          <MockKopilotPrompt
+            key={persona.id}
+            prompt={persona.prompt}
+            result={{
+              title: 'Suggestions',
+              rows: persona.suggestions.map((s) => ({ ...s, accept: true })),
+            }}
+          />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-prompt-library.tsx
+++ b/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-prompt-library.tsx
@@ -1,0 +1,77 @@
+// apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-prompt-library.tsx
+
+const prompts = [
+  { name: 'Daily inbox brief', description: 'Start the day with a summary of replies you owe.' },
+  { name: 'Recap last conversation', description: 'Get a structured recap of any thread.' },
+  { name: 'Draft refund reply', description: 'Pull policy and order context into a draft.' },
+  { name: 'Tag tickets by intent', description: 'Auto-categorize incoming tickets.' },
+  { name: 'Find similar past tickets', description: 'Surface prior solutions instantly.' },
+  { name: 'Update contact from email', description: 'Extract role, company, and details.' },
+  { name: 'Negative-feedback summary', description: 'Cluster complaints across this week.' },
+  { name: 'Onboarding handoff brief', description: 'Hand off context to your CSM team.' },
+  { name: 'Coach me on this reply', description: 'Get suggestions to improve tone and clarity.' },
+  { name: 'Find KB gaps', description: 'Spot questions your KB doesn’t answer yet.' },
+  { name: 'Account research', description: 'Run a quick brief on a company.' },
+  { name: 'Suggest next step', description: 'Turn a thread into a follow-up task.' },
+]
+
+const row = [...prompts, ...prompts]
+
+export default function KopilotPromptLibrary() {
+  return (
+    <section className='relative bg-muted/25 border-b border-foreground/10 overflow-hidden'>
+      <div className='mx-auto max-w-6xl px-6 py-24 text-center'>
+        <h2 className='mx-auto max-w-2xl text-balance text-4xl font-semibold md:text-5xl'>
+          From one expert to everyone.
+        </h2>
+        <p className='text-muted-foreground mx-auto mt-4 max-w-xl'>
+          Best practice becomes standard practice with the prompt library.
+        </p>
+      </div>
+
+      <div className='relative pb-24 [--marquee:60s]'>
+        <div className='pointer-events-none absolute inset-y-0 left-0 z-10 w-32 bg-gradient-to-r from-background via-background to-transparent' />
+        <div className='pointer-events-none absolute inset-y-0 right-0 z-10 w-32 bg-gradient-to-l from-background via-background to-transparent' />
+
+        <ul className='flex w-max gap-3 animate-[marquee_var(--marquee)_linear_infinite] hover:[animation-play-state:paused]'>
+          {row.map((prompt, i) => (
+            <li
+              key={i}
+              className='w-72 shrink-0 rounded-xl border border-foreground/10 bg-background p-4 text-left'>
+              <div className='text-foreground text-sm font-medium'>{prompt.name}</div>
+              <p className='text-muted-foreground mt-1 text-xs'>{prompt.description}</p>
+              <div className='text-muted-foreground/60 mt-3 text-[10px] uppercase tracking-wide'>
+                Auxx
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <ul className='mt-3 flex w-max gap-3 animate-[marquee-reverse_var(--marquee)_linear_infinite] hover:[animation-play-state:paused]'>
+          {row.map((prompt, i) => (
+            <li
+              key={i}
+              className='w-72 shrink-0 rounded-xl border border-foreground/10 bg-background p-4 text-left'>
+              <div className='text-foreground text-sm font-medium'>{prompt.name}</div>
+              <p className='text-muted-foreground mt-1 text-xs'>{prompt.description}</p>
+              <div className='text-muted-foreground/60 mt-3 text-[10px] uppercase tracking-wide'>
+                Auxx
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <style>{`
+        @keyframes marquee {
+          from { transform: translateX(0); }
+          to { transform: translateX(-50%); }
+        }
+        @keyframes marquee-reverse {
+          from { transform: translateX(-50%); }
+          to { transform: translateX(0); }
+        }
+      `}</style>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-testimonial.tsx
+++ b/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-testimonial.tsx
@@ -1,0 +1,19 @@
+// apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-testimonial.tsx
+
+export default function KopilotTestimonial() {
+  return (
+    <section className='relative bg-background border-b border-foreground/10'>
+      <div className='mx-auto max-w-4xl px-6 py-24 text-center'>
+        <blockquote className='text-balance text-2xl font-medium md:text-3xl'>
+          “Before every reply, Kopilot pulls the order, the policy, and prior tickets — so my team
+          shows up to every conversation already prepared{' '}
+          <span className='text-muted-foreground'>to close the case.</span>”
+        </blockquote>
+        <div className='mt-6 text-sm'>
+          <div className='text-foreground font-medium'>Customer placeholder</div>
+          <div className='text-muted-foreground'>Head of Support · Placeholder Co.</div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/kopilot/page.tsx
+++ b/apps/homepage/src/app/platform/ai/kopilot/page.tsx
@@ -1,0 +1,44 @@
+// apps/homepage/src/app/platform/ai/kopilot/page.tsx
+import type { Metadata } from 'next'
+import { config } from '~/lib/config'
+import FooterSection from '../../../_components/main/footer-section'
+import Header from '../../../_components/main/header'
+import { BreadcrumbJsonLd } from '../../../_components/seo/breadcrumb-json-ld'
+import KopilotContextSection from './_components/kopilot-context-section'
+import KopilotFinalCta from './_components/kopilot-final-cta'
+import KopilotHero from './_components/kopilot-hero'
+import KopilotIntelligenceSection from './_components/kopilot-intelligence-section'
+import KopilotPersonas from './_components/kopilot-personas'
+import KopilotPromptLibrary from './_components/kopilot-prompt-library'
+import KopilotTestimonial from './_components/kopilot-testimonial'
+
+export const metadata: Metadata = {
+  title: `Kopilot — Workspace AI | ${config.shortName}`,
+  description: `${config.shortName} Kopilot searches, updates, and creates across mail, contacts, tickets, and knowledge. Grounded in your data and powered by your own model.`,
+}
+
+export default function KopilotPage() {
+  return (
+    <div id='root' className='relative h-screen overflow-y-auto bg-background'>
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', href: 'https://auxx.ai' },
+          { name: 'Platform', href: 'https://auxx.ai/platform' },
+          { name: 'AI', href: 'https://auxx.ai/platform/ai/kopilot' },
+          { name: 'Kopilot' },
+        ]}
+      />
+      <Header />
+      <main>
+        <KopilotHero />
+        <KopilotPersonas />
+        <KopilotContextSection />
+        <KopilotIntelligenceSection />
+        <KopilotPromptLibrary />
+        <KopilotTestimonial />
+        <KopilotFinalCta />
+      </main>
+      <FooterSection />
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/data-model-hero.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/data-model-hero.tsx
@@ -1,0 +1,84 @@
+// apps/homepage/src/app/platform/data-model/_components/data-model-hero.tsx
+
+import { GRADIENT_PALETTES } from '@auxx/ui/components/gradient-palettes'
+import { RandomGradient } from '@auxx/ui/components/random-gradient'
+import Link from 'next/link'
+import { AutoplayVideo } from '~/components/autoplay-video'
+import { Button } from '~/components/ui/button'
+import { videoUrl } from '~/lib/cdn'
+import { config } from '~/lib/config'
+
+export default function DataModelHero({ as: Heading = 'h1' }: { as?: 'h1' | 'h2' }) {
+  return (
+    <section className='overflow-hidden relative border-b'>
+      <RandomGradient colors={[...GRADIENT_PALETTES.dawn]} mode='mesh' animated blur={10} />
+      <section className='bg-background/40 relative z-10'>
+        <div
+          aria-hidden
+          className='pointer-events-none absolute inset-0 z-10 mx-1 grid max-w-6xl grid-cols-3 border-x [--color-border:var(--color-border-illustration)] sm:grid-cols-4 md:mx-auto'>
+          <div className='h-full border-r border-dashed' />
+          <div className='h-full border-r border-dashed' />
+          <div className='h-full max-sm:hidden' />
+          <div className='h-full border-l border-dashed max-sm:hidden' />
+        </div>
+        <div className='mb:pb-24 relative pb-16 pt-24 md:pt-36 lg:pt-40'>
+          <div className='mx-auto w-full px-6 lg:max-w-5xl'>
+            <div className='grid items-center max-lg:gap-12 lg:grid-cols-2 '>
+              <div className='sm:h-[550px]'>
+                <div className='lg:max-w-sm'>
+                  <Heading className='text-balance text-4xl font-semibold md:text-5xl'>
+                    Your data model. Two ways to feed AI.
+                  </Heading>
+                  <p className='text-muted-foreground mb-6 mt-4 text-balance text-lg'>
+                    Author rich knowledge base articles or upload existing docs. Auxx turns both
+                    into grounded answers for your customers and your team.
+                  </p>
+
+                  <div className='flex items-center gap-3'>
+                    <Button asChild size='sm'>
+                      <Link href={config.urls.signup}>Start Building</Link>
+                    </Button>
+                    <Button asChild size='sm' variant='outline'>
+                      <Link href={config.urls.demo}>Request demo</Link>
+                    </Button>
+                  </div>
+                </div>
+
+                <div className='mt-12 grid max-w-sm grid-cols-2'>
+                  <div className='space-y-2 *:block'>
+                    <span className='text-lg font-semibold'>
+                      4 <span className='text-muted-foreground text-lg'>+</span>
+                    </span>
+                    <p className='text-muted-foreground text-balance text-sm'>
+                      <strong className='text-foreground font-medium'>Source formats</strong>{' '}
+                      including PDF, DOCX, HTML, and plain text.
+                    </p>
+                  </div>
+
+                  <div className='space-y-2 *:block'>
+                    <span className='text-lg font-semibold'>
+                      1 <span className='text-muted-foreground text-lg'>×</span>
+                    </span>
+                    <p className='text-muted-foreground text-balance text-sm'>
+                      <strong className='text-foreground font-medium'>Source of truth</strong>{' '}
+                      shared by your portal and every AI reply.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div className='max-lg:max-w-[calc(100vw-3rem)] lg:-mr-6 h-[550px] z-100'>
+                <AutoplayVideo
+                  autoPlay
+                  loop
+                  muted
+                  className='size-full rounded-xl object-cover shadow-lg'
+                  src={videoUrl('data-model.mp4')}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/datasets-section.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/datasets-section.tsx
@@ -1,0 +1,107 @@
+// apps/homepage/src/app/platform/data-model/_components/datasets-section.tsx
+
+import { ArrowRight, FileCode, Files, FileText, FileType } from 'lucide-react'
+
+const sources = [
+  { name: 'PDF', description: 'Manuals, contracts, scanned docs.', icon: FileText },
+  { name: 'DOCX', description: 'Word and Google Docs exports.', icon: Files },
+  { name: 'HTML', description: 'Saved web pages and articles.', icon: FileCode },
+  { name: 'Plain text', description: 'TXT, transcripts, notes.', icon: FileType },
+]
+
+const pipeline = [
+  {
+    step: '1',
+    name: 'Extract',
+    description: 'Pull clean text from each format with a dedicated extractor.',
+  },
+  {
+    step: '2',
+    name: 'Segment',
+    description: 'Split into context-aware chunks that respect document structure.',
+  },
+  {
+    step: '3',
+    name: 'Embed',
+    description: 'Vectorize each chunk with your selected embedding model.',
+  },
+  {
+    step: '4',
+    name: 'Search',
+    description: 'Hybrid vector + keyword retrieval with org-scoped filters.',
+  },
+]
+
+export default function DatasetsSection() {
+  return (
+    <section
+      id='datasets'
+      className='relative bg-muted/25 border-foreground/10 border-b scroll-mt-24'>
+      <div className='relative z-10 mx-auto max-w-6xl border-x px-3'>
+        <div className='border-x'>
+          <div className='py-16 md:py-24'>
+            <div className='mx-auto max-w-4xl space-y-12 px-6'>
+              <div className='flex items-baseline gap-3'>
+                <span className='text-muted-foreground text-xs uppercase tracking-wide'>
+                  Datasets
+                </span>
+                <span aria-hidden className='text-muted-foreground'>
+                  /
+                </span>
+                <span className='text-muted-foreground text-xs'>Upload-driven</span>
+              </div>
+
+              <h2 className='text-foreground text-balance text-4xl font-semibold md:w-2/3'>
+                Bring your own docs. We make them searchable.
+              </h2>
+
+              <p className='text-muted-foreground max-w-2xl'>
+                Upload existing PDFs, manuals, exports, and pages. Auxx extracts, segments, and
+                embeds them automatically — ready for Kopilot and ticket AI to cite within minutes.
+              </p>
+
+              <ul className='grid gap-3 sm:grid-cols-2 lg:grid-cols-4'>
+                {sources.map((source) => (
+                  <li
+                    key={source.name}
+                    className='border-foreground/5 bg-background rounded-lg border p-4'>
+                    <source.icon className='text-foreground/70 size-5' />
+                    <div className='mt-3 text-foreground text-sm font-medium'>{source.name}</div>
+                    <p className='text-muted-foreground mt-1 text-xs'>{source.description}</p>
+                  </li>
+                ))}
+              </ul>
+
+              <div className='border-foreground/5 bg-background overflow-hidden rounded-xl border'>
+                <div className='border-foreground/5 border-b px-4 py-2'>
+                  <span className='text-muted-foreground text-xs uppercase tracking-wide'>
+                    Pipeline
+                  </span>
+                </div>
+                <ol className='grid divide-y divide-foreground/5 sm:grid-cols-4 sm:divide-y-0 sm:divide-x'>
+                  {pipeline.map((stage, i) => (
+                    <li key={stage.name} className='relative flex flex-col gap-2 p-5'>
+                      <div className='flex items-center gap-2'>
+                        <span className='text-muted-foreground text-xs font-mono'>
+                          {stage.step}
+                        </span>
+                        <span className='text-foreground text-sm font-medium'>{stage.name}</span>
+                      </div>
+                      <p className='text-muted-foreground text-xs'>{stage.description}</p>
+                      {i < pipeline.length - 1 && (
+                        <ArrowRight
+                          aria-hidden
+                          className='text-foreground/20 absolute right-0 top-1/2 hidden size-4 -translate-y-1/2 translate-x-1/2 sm:block'
+                        />
+                      )}
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/how-ai-uses-both-section.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/how-ai-uses-both-section.tsx
@@ -1,0 +1,60 @@
+// apps/homepage/src/app/platform/data-model/_components/how-ai-uses-both-section.tsx
+
+import { Bot, MessageSquareReply, Search } from 'lucide-react'
+
+const consumers = [
+  {
+    name: 'Kopilot',
+    description: 'Cites articles and dataset chunks back to the user with links.',
+    icon: Bot,
+  },
+  {
+    name: 'Ticket AI replies',
+    description: 'Drafts answers grounded in your KB and uploaded docs.',
+    icon: MessageSquareReply,
+  },
+  {
+    name: 'Self-serve search',
+    description: 'Customers find answers in your portal before opening a ticket.',
+    icon: Search,
+  },
+]
+
+export default function HowAiUsesBothSection() {
+  return (
+    <section className='relative bg-background border-foreground/10 border-b'>
+      <div className='relative z-10 mx-auto max-w-6xl border-x px-3'>
+        <div className='border-x'>
+          <div className='py-16 md:py-24'>
+            <div className='mx-auto max-w-4xl space-y-10 px-6'>
+              <div className='space-y-4'>
+                <span className='text-muted-foreground text-xs uppercase tracking-wide'>
+                  How AI uses both
+                </span>
+                <h2 className='text-foreground text-balance text-4xl font-semibold md:w-2/3'>
+                  One data model. Three places it shows up.
+                </h2>
+                <p className='text-muted-foreground max-w-2xl'>
+                  Kopilot, ticket auto-replies, and your help portal all read the same KB articles
+                  and dataset segments. Update once — every surface gets it.
+                </p>
+              </div>
+
+              <ul className='grid gap-4 md:grid-cols-3'>
+                {consumers.map((c) => (
+                  <li
+                    key={c.name}
+                    className='border-foreground/5 bg-muted/25 rounded-xl border p-5'>
+                    <c.icon className='text-foreground/70 size-5' />
+                    <div className='mt-4 text-foreground font-medium'>{c.name}</div>
+                    <p className='text-muted-foreground mt-1 text-sm'>{c.description}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/knowledge-base-section.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/knowledge-base-section.tsx
@@ -1,0 +1,109 @@
+// apps/homepage/src/app/platform/data-model/_components/knowledge-base-section.tsx
+
+import { CalendarClock, FileText, Link2, Rows3, SquareDashedKanban, Table } from 'lucide-react'
+import Image from 'next/image'
+
+const richBlocks = [
+  {
+    name: 'Tables',
+    description: 'Structured data with sortable rows and headers.',
+    icon: Table,
+  },
+  {
+    name: 'Tabs & accordion',
+    description: 'Group related content without scrolling.',
+    icon: Rows3,
+  },
+  {
+    name: 'Cards',
+    description: 'Visual layouts for grouped articles or topics.',
+    icon: SquareDashedKanban,
+  },
+  {
+    name: 'Internal links',
+    description: 'auxx:// references resolve to the right article.',
+    icon: Link2,
+  },
+  {
+    name: 'Version history',
+    description: 'Preview any earlier draft and restore in one click.',
+    icon: CalendarClock,
+  },
+  {
+    name: 'Markdown round-trip',
+    description: 'Import or export — your KB stays portable.',
+    icon: FileText,
+  },
+]
+
+export default function KnowledgeBaseSection() {
+  return (
+    <section
+      id='knowledge-base'
+      className='relative bg-background border-foreground/10 border-b scroll-mt-24'>
+      <div className='relative z-10 mx-auto max-w-6xl border-x px-3'>
+        <div className='border-x'>
+          <div className='py-16 md:py-24'>
+            <div className='mx-auto max-w-4xl space-y-12 px-6'>
+              <div className='flex items-baseline gap-3'>
+                <span className='text-muted-foreground text-xs uppercase tracking-wide'>
+                  Knowledge base
+                </span>
+                <span aria-hidden className='text-muted-foreground'>
+                  /
+                </span>
+                <span className='text-muted-foreground text-xs'>Author-driven</span>
+              </div>
+
+              <h2 className='text-foreground text-balance text-4xl font-semibold md:w-2/3'>
+                Write articles your way. Publish them everywhere.
+              </h2>
+
+              <div className='bg-background ring-foreground/5 overflow-hidden rounded-xl border border-transparent shadow ring-1'>
+                <Image
+                  src='/images/platform/knowledge-base/kb-editor.png'
+                  width={3070}
+                  height={1994}
+                  alt='Knowledge base editor with rich block content'
+                  className='h-full w-full object-cover'
+                />
+              </div>
+
+              <div className='grid gap-6 md:grid-cols-2 md:gap-12'>
+                <p className='text-muted-foreground'>
+                  Build a fully{' '}
+                  <strong className='text-foreground font-semibold'>
+                    customizable self-service portal
+                  </strong>{' '}
+                  with your logo, colors, and domain. Articles use rich blocks, organize into
+                  categories, and stay in sync across drafts and published versions.
+                </p>
+
+                <p className='text-muted-foreground'>
+                  Every article doubles as{' '}
+                  <strong className='text-foreground font-semibold'>AI grounding</strong>. Kopilot
+                  and ticket auto-replies cite your own articles back to you with links — no
+                  hallucinated answers.
+                </p>
+              </div>
+
+              <ul className='grid gap-3 sm:grid-cols-2 md:grid-cols-3'>
+                {richBlocks.map((block) => (
+                  <li
+                    key={block.name}
+                    className='border-foreground/5 bg-background flex gap-3 rounded-lg border p-4'>
+                    <block.icon className='text-foreground/70 mt-0.5 size-4 shrink-0' />
+                    <div>
+                      <div className='text-foreground text-sm font-medium'>{block.name}</div>
+                      <p className='text-muted-foreground mt-0.5 text-xs'>{block.description}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/page.tsx
+++ b/apps/homepage/src/app/platform/data-model/page.tsx
@@ -1,0 +1,39 @@
+// apps/homepage/src/app/platform/data-model/page.tsx
+import type { Metadata } from 'next'
+import { config } from '~/lib/config'
+import FooterSection from '../../_components/main/footer-section'
+import Header from '../../_components/main/header'
+import { BreadcrumbJsonLd } from '../../_components/seo/breadcrumb-json-ld'
+import { FinalCtaSection } from '../_components/final-cta-section'
+import DataModelHero from './_components/data-model-hero'
+import DatasetsSection from './_components/datasets-section'
+import HowAiUsesBothSection from './_components/how-ai-uses-both-section'
+import KnowledgeBaseSection from './_components/knowledge-base-section'
+
+export const metadata: Metadata = {
+  title: `Data Model — Knowledge Base & Datasets | ${config.shortName}`,
+  description: `Author articles in the ${config.shortName} knowledge base or upload your own PDFs and docs as datasets. Both feed Kopilot and AI replies with grounded, cited answers.`,
+}
+
+export default function DataModelPage() {
+  return (
+    <div id='root' className='relative h-screen overflow-y-auto bg-background'>
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', href: 'https://auxx.ai' },
+          { name: 'Platform', href: 'https://auxx.ai/platform' },
+          { name: 'Data Model' },
+        ]}
+      />
+      <Header />
+      <main>
+        <DataModelHero />
+        <KnowledgeBaseSection />
+        <DatasetsSection />
+        <HowAiUsesBothSection />
+        <FinalCtaSection />
+      </main>
+      <FooterSection />
+    </div>
+  )
+}

--- a/apps/homepage/src/app/sitemap.ts
+++ b/apps/homepage/src/app/sitemap.ts
@@ -61,10 +61,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
-      url: `${baseUrl}/platform/knowledge-base`,
+      url: `${baseUrl}/platform/ai/kopilot`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
-      priority: 0.7,
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/platform/data-model`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
     },
     {
       url: `${baseUrl}/platform/live-chat`,

--- a/apps/homepage/src/app/solutions/customer-support-teams/_components/integration-cards.tsx
+++ b/apps/homepage/src/app/solutions/customer-support-teams/_components/integration-cards.tsx
@@ -25,8 +25,8 @@ export default function IntegrationCards() {
           <div className='row-span-2 grid grid-rows-subgrid gap-8'>
             <div className='px-8 pt-8'>
               <div className='flex items-center gap-3 mb-4'>
-                <div className='w-8 h-8 rounded-full bg-green-100 flex items-center justify-center'>
-                  <CheckCircle className='w-4 h-4 text-green-600' />
+                <div className='w-8 h-8 rounded-full bg-green-900/50 flex items-center justify-center'>
+                  <CheckCircle className='w-4 h-4 text-green-500/80' />
                 </div>
                 <span className='text-sm font-medium text-green-700'>Installation Complete</span>
               </div>

--- a/apps/homepage/src/app/solutions/customer-support-teams/_components/integration-section.tsx
+++ b/apps/homepage/src/app/solutions/customer-support-teams/_components/integration-section.tsx
@@ -103,8 +103,8 @@ export default function IntegrationSection() {
                   <div className='row-span-2 grid grid-rows-subgrid gap-8'>
                     <div className='px-8 pt-8'>
                       <div className='flex items-center gap-3 mb-4'>
-                        <div className='w-8 h-8 rounded-full bg-green-100 flex items-center justify-center'>
-                          <CheckCircle className='w-4 h-4 text-green-600' />
+                        <div className='w-8 h-8 rounded-full bg-green-900/50 flex items-center justify-center'>
+                          <CheckCircle className='w-4 h-4 text-green-500/80' />
                         </div>
                         <span className='text-sm font-medium text-green-700'>
                           Installation Complete

--- a/apps/homepage/src/app/solutions/shopify-stores/_components/integration-cards.tsx
+++ b/apps/homepage/src/app/solutions/shopify-stores/_components/integration-cards.tsx
@@ -25,8 +25,8 @@ export default function IntegrationCards() {
           <div className='row-span-2 grid grid-rows-subgrid gap-8'>
             <div className='px-8 pt-8'>
               <div className='flex items-center gap-3 mb-4'>
-                <div className='w-8 h-8 rounded-full bg-green-100 flex items-center justify-center'>
-                  <CheckCircle className='w-4 h-4 text-green-600' />
+                <div className='w-8 h-8 rounded-full bg-green-900/50 flex items-center justify-center'>
+                  <CheckCircle className='w-4 h-4 text-green-500/80' />
                 </div>
                 <span className='text-sm font-medium text-green-700'>Installation Complete</span>
               </div>

--- a/apps/homepage/src/app/solutions/shopify-stores/_components/integration-section.tsx
+++ b/apps/homepage/src/app/solutions/shopify-stores/_components/integration-section.tsx
@@ -110,8 +110,8 @@ export default function IntegrationSection() {
                   <div className='row-span-2 grid grid-rows-subgrid gap-8'>
                     <div className='px-8 pt-8'>
                       <div className='flex items-center gap-3 mb-4'>
-                        <div className='w-8 h-8 rounded-full bg-green-100 flex items-center justify-center'>
-                          <CheckCircle className='w-4 h-4 text-green-600' />
+                        <div className='w-8 h-8 rounded-full bg-green-900/50 flex items-center justify-center'>
+                          <CheckCircle className='w-4 h-4 text-green-500/80' />
                         </div>
                         <span className='text-sm font-medium text-green-700'>
                           Installation Complete

--- a/apps/homepage/src/app/solutions/small-business/_components/integration-cards.tsx
+++ b/apps/homepage/src/app/solutions/small-business/_components/integration-cards.tsx
@@ -25,8 +25,8 @@ export default function IntegrationCards() {
           <div className='row-span-2 grid grid-rows-subgrid gap-8'>
             <div className='px-8 pt-8'>
               <div className='flex items-center gap-3 mb-4'>
-                <div className='w-8 h-8 rounded-full bg-green-100 flex items-center justify-center'>
-                  <CheckCircle className='w-4 h-4 text-green-600' />
+                <div className='w-8 h-8 rounded-full bg-green-900/50 flex items-center justify-center'>
+                  <CheckCircle className='w-4 h-4 text-green-500/80' />
                 </div>
                 <span className='text-sm font-medium text-green-700'>Installation Complete</span>
               </div>

--- a/apps/homepage/src/app/solutions/small-business/_components/integration-section.tsx
+++ b/apps/homepage/src/app/solutions/small-business/_components/integration-section.tsx
@@ -110,8 +110,8 @@ export default function IntegrationSection() {
                   <div className='row-span-2 grid grid-rows-subgrid gap-8'>
                     <div className='px-8 pt-8'>
                       <div className='flex items-center gap-3 mb-4'>
-                        <div className='w-8 h-8 rounded-full bg-green-100 flex items-center justify-center'>
-                          <CheckCircle className='w-4 h-4 text-green-600' />
+                        <div className='w-8 h-8 rounded-full bg-green-900/50 flex items-center justify-center'>
+                          <CheckCircle className='w-4 h-4 text-green-500/80' />
                         </div>
                         <span className='text-sm font-medium text-green-700'>
                           Installation Complete


### PR DESCRIPTION
## Summary
- New `/platform/ai/kopilot` and `/platform/data-model` marketing pages with their own mock UI components under `_mocks/` and section components under `_components/`
- Permanent redirect from `/platform/knowledge-base` to `/platform/data-model#knowledge-base`; sitemap updated to point at the new URLs
- `globals.css` imports the kopilot mock styles and adds a `dot-blink` keyframe used by the kopilot prompt mock
- "Installation Complete" badge on the three solutions pages retuned to dark-mode-friendly tones (`bg-green-100/text-green-600` → `bg-green-900/50` + `text-green-500/80`)

## Test plan
- [ ] `/platform/ai/kopilot` renders with mocks animating
- [ ] `/platform/data-model` renders, `#knowledge-base` anchor scrolls correctly
- [ ] `/platform/knowledge-base` 308-redirects to `/platform/data-model#knowledge-base`
- [ ] Sitemap includes both new URLs and not the old `knowledge-base` one
- [ ] Solutions pages — Installation Complete badge looks correct in light + dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)