### PR TITLE
feat(kb): table frame + restyled row/column delete buttons

### DIFF
--- a/apps/web/src/components/editor/kb-article/container-node-view.module.css
+++ b/apps/web/src/components/editor/kb-article/container-node-view.module.css
@@ -440,7 +440,11 @@
   flex-direction: column;
   align-items: stretch;
   background: color-mix(in srgb, var(--color-foreground) 3%, transparent);
-  padding: 0.125rem 0.125rem 1rem 0.125rem;
+  /* Tight uniform padding (matches `.tabsContainerContent`). The per-column
+     delete strip at `.colDeleteStrip { bottom: -1.25rem }` overflows the
+     bottom of the frame on purpose so the trash button sits clear of the
+     body card edge instead of pushing the frame taller. */
+  padding: 0.125rem;
   gap: 0;
 }
 
@@ -478,12 +482,15 @@
   color: var(--color-foreground);
 }
 
+/* Body card is now an invisible positioning container. The visual card
+   is faked by the body cells' per-side borders + corner radii, so the
+   transparent header `<th>` cells appear to sit in the outer frame
+   without any wrapper-level chrome cutting across them. */
 .tableBodyCard {
   position: relative;
   width: 100%;
-  border: 1px solid var(--color-border);
-  border-radius: 0.5rem;
-  background: var(--color-background);
+  background: transparent;
+  border: none;
 }
 
 /* Horizontal scroll for tables wider than the article column. Explicit
@@ -500,24 +507,77 @@
 }
 
 .editorTable {
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   width: 100%;
-  margin:0!important;
+  margin: 0 !important;
+  background: transparent;
 }
 
-.editorTable th,
+/* Header cells — transparent labels in the outer frame, no borders.
+   PM produces `<tbody><tr><th></th></tr><tr><td></td></tr></tbody>`
+   with no `<thead>`, so we target `th` directly. */
+.editorTable th {
+  background: transparent;
+  border: none;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-foreground);
+  opacity: 0.85;
+  text-align: left;
+  vertical-align: top;
+  min-width: 4rem;
+  position: relative;
+}
+
+/* Body cells own the right + bottom borders; first-column cells add
+   the left border. The first body row adds the top border (selectors
+   below). Each grid line is drawn exactly once. */
 .editorTable td {
-  border: 1px solid var(--color-border);
+  background: var(--color-background);
+  border-right: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
   padding: 0.5rem 0.625rem;
   vertical-align: top;
   min-width: 4rem;
   position: relative;
 }
 
-.editorTable th {
-  background: color-mix(in srgb, var(--color-foreground) 4%, transparent);
-  font-weight: 600;
-  text-align: left;
+.editorTable td:first-child {
+  border-left: 1px solid var(--color-border);
+}
+
+/* "First body row" = the first `<tr>` whose cells are `<td>`. PM doesn't
+   emit `<thead>` — header rows live in `<tbody>` with `<th>` cells —
+   so we need TWO selectors:
+     1. `tr:first-child:has(> td)` — header-off case: row 0 is body.
+     2. `tr:has(> th) + tr` — header-on case: the row right after the
+        header `<tr>`. Header rows can only live at index 0 in our
+        schema, so this is unambiguously the first body row.
+   `:first-of-type` does NOT work here: it resolves to the first `<tr>`
+   sibling regardless of cell type, then ANDs with `:has(> td)` — which
+   fails when the first row is a header. */
+.editorTable tr:first-child:has(> td) td,
+.editorTable tr:has(> th) + tr td {
+  border-top: 1px solid var(--color-border);
+}
+.editorTable tr:first-child:has(> td) td:first-child,
+.editorTable tr:has(> th) + tr td:first-child {
+  border-top-left-radius: 0.5rem;
+}
+.editorTable tr:first-child:has(> td) td:last-child,
+.editorTable tr:has(> th) + tr td:last-child {
+  border-top-right-radius: 0.5rem;
+}
+
+/* Last row's bottom corners. Header rows can only be the first row in
+   our schema, so `tr:last-child` is always a body row. */
+.editorTable tr:last-child td:first-child {
+  border-bottom-left-radius: 0.5rem;
+}
+.editorTable tr:last-child td:last-child {
+  border-bottom-right-radius: 0.5rem;
 }
 
 /* Block content inside cells: ReactNodeViewRenderer wraps every `block` node
@@ -610,8 +670,8 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  right: -1.5rem;
-  width: 1.25rem;
+  right: -1.75rem;
+  width: 1.5rem;
   pointer-events: none;
 }
 
@@ -623,20 +683,27 @@
   pointer-events: auto;
 }
 
+/* Mirrors the `destructive-hover` Button variant: subtle resting chrome
+   that turns destructive on direct hover. Border-1px-transparent at rest
+   would cause layout shift on hover, so the resting border lives at
+   `--color-primary-150` and just shifts color on hover. */
 .rowDeleteButton {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.125rem;
-  height: 1.125rem;
-  border: none;
-  background: transparent;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid var(--color-primary-150);
+  background: var(--color-primary-100);
   color: var(--color-muted-foreground);
   cursor: pointer;
   padding: 0;
-  border-radius: 4px;
+  border-radius: 0.375rem;
+  box-sizing: border-box;
+  box-shadow: none;
   opacity: 0;
-  transition: opacity 0.15s, color 0.12s, background 0.12s;
+  transition: opacity 0.15s, color 0.12s, background 0.12s, border-color 0.12s,
+    box-shadow 0.12s;
 }
 
 .rowDeleteRow:hover .rowDeleteButton,
@@ -645,8 +712,10 @@
 }
 
 .rowDeleteButton:hover {
-  color: var(--color-foreground);
-  background: var(--color-muted);
+  color: var(--color-destructive);
+  background: color-mix(in srgb, var(--color-destructive) 10%, transparent);
+  border-color: color-mix(in srgb, var(--color-destructive) 20%, transparent);
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 }
 
 /* ============================================
@@ -697,9 +766,9 @@
 
 .colDeleteStrip {
   position: absolute;
-  bottom: -1.25rem;
+  bottom: -1.5rem;
   left: 0;
-  height: 1.25rem;
+  height: 1.5rem;
   pointer-events: none;
   z-index: 2;
 }
@@ -712,20 +781,24 @@
   pointer-events: auto;
 }
 
+/* Mirrors `destructive-hover` Button variant — see `.rowDeleteButton`. */
 .colDeleteButton {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.125rem;
-  height: 1.125rem;
-  border: none;
-  background: transparent;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid var(--color-primary-150);
+  background: var(--color-primary-100);
   color: var(--color-muted-foreground);
   cursor: pointer;
   padding: 0;
-  border-radius: 4px;
+  border-radius: 0.375rem;
+  box-sizing: border-box;
+  box-shadow: none;
   opacity: 0;
-  transition: opacity 0.15s, color 0.12s, background 0.12s;
+  transition: opacity 0.15s, color 0.12s, background 0.12s, border-color 0.12s,
+    box-shadow 0.12s;
 }
 
 .colDeleteCol:hover .colDeleteButton,
@@ -734,8 +807,10 @@
 }
 
 .colDeleteButton:hover {
-  color: var(--color-foreground);
-  background: var(--color-muted);
+  color: var(--color-destructive);
+  background: color-mix(in srgb, var(--color-destructive) 10%, transparent);
+  border-color: color-mix(in srgb, var(--color-destructive) 20%, transparent);
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 }
 
 /* ============================================

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.module.css
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.module.css
@@ -74,32 +74,11 @@
 }
 
 /* ============================================
-   Tables — kept top-level alongside `block`.
-   Tables don't render a gutter; styled minimally.
+   Tables — all tables in this editor render via `TableNodeView`
+   (see `extensions/table/table.ts`), which owns table chrome via
+   `container-node-view.module.css` (`.editorTable` etc.). Only
+   the PM-driven cell-selection overlay lives here.
    ============================================ */
-
-.editorContent :global(.ProseMirror) :global(table) {
-  border-collapse: collapse;
-  margin: 1.5rem 0;
-  table-layout: fixed;
-  width: 100%;
-}
-
-.editorContent :global(.ProseMirror) :global(table) :global(td),
-.editorContent :global(.ProseMirror) :global(table) :global(th) {
-  border: 1px solid var(--color-border);
-  box-sizing: border-box;
-  min-width: 1em;
-  padding: 6px 8px;
-  position: relative;
-  vertical-align: top;
-}
-
-.editorContent :global(.ProseMirror) :global(table) :global(th) {
-  background-color: var(--color-muted);
-  font-weight: 600;
-  text-align: left;
-}
 
 .editorContent :global(.ProseMirror) :global(table) :global(.selectedCell)::after {
   background: color-mix(in oklab, var(--color-primary) 15%, transparent);
@@ -108,16 +87,6 @@
   pointer-events: none;
   position: absolute;
   z-index: 2;
-}
-
-.editorContent :global(.ProseMirror) :global(table) :global(.column-resize-handle) {
-  background-color: var(--color-primary);
-  bottom: -2px;
-  pointer-events: none;
-  position: absolute;
-  right: -2px;
-  top: 0;
-  width: 4px;
 }
 
 .editorContent :global(.ProseMirror.resize-cursor) {

--- a/apps/web/src/components/editor/kb-article/table-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/table-node-view.tsx
@@ -379,7 +379,12 @@ export function TableNodeView({ node, editor, getPos }: NodeViewProps) {
                           cloneTable.style.background = 'var(--color-background, white)'
                           cloneTable.style.boxShadow = '0 4px 12px rgba(0,0,0,0.15)'
                           cloneTable.style.opacity = '0.95'
-                          cloneTable.style.borderCollapse = 'collapse'
+                          // Editor table now uses `border-collapse: separate` so
+                          // body cells can carry corner border-radius. Match it
+                          // here so the dragged row shows full grid lines (cells
+                          // own their right + bottom borders via the CSS module).
+                          cloneTable.style.borderCollapse = 'separate'
+                          cloneTable.style.borderSpacing = '0'
                           const cloneTbody = document.createElement('tbody')
                           cloneTbody.appendChild(tr.cloneNode(true))
                           cloneTable.appendChild(cloneTbody)
@@ -397,10 +402,12 @@ export function TableNodeView({ node, editor, getPos }: NodeViewProps) {
               })}
             </div>
 
-            {/* RIGHT: per-row delete (Trash). */}
+            {/* RIGHT: per-row delete (Trash). Hidden on the header row —
+                same rule as the left drag handle (i === 0 && hasHeaderRow). */}
             <div className={styles.rowDeleteGutter} contentEditable={false}>
-              {rowRects.map((rect, i) =>
-                rowCount > 1 ? (
+              {rowRects.map((rect, i) => {
+                if (i === 0 && hasHeaderRow) return null
+                return rowCount > 1 ? (
                   <RowDeleteButton
                     key={`row-delete-${i}`}
                     index={i}
@@ -409,7 +416,7 @@ export function TableNodeView({ node, editor, getPos }: NodeViewProps) {
                     onDelete={() => handleRemoveRow(i)}
                   />
                 ) : null
-              )}
+              })}
             </div>
 
             {/* TOP: per-column drag handle. Lives OUTSIDE `.tableScroll`
@@ -650,7 +657,7 @@ function RowDeleteButton({ index, rect, isHovered, onDelete }: RowDeleteButtonPr
           e.stopPropagation()
           onDelete()
         }}>
-        <Trash2 size={12} />
+        <Trash2 size={14} />
       </button>
     </div>
   )
@@ -728,7 +735,7 @@ function ColumnDeleteButton({ index, rect, isHovered, onDelete }: ColumnDeleteBu
           e.stopPropagation()
           onDelete()
         }}>
-        <Trash2 size={12} />
+        <Trash2 size={14} />
       </button>
     </div>
   )

--- a/packages/ui/src/components/kb/article/kb-article-renderer.module.css
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.module.css
@@ -614,44 +614,78 @@
 
 /* ============================================
    Table block (public renderer)
+   Outer subtly-tinted frame holds an optional transparent <thead>
+   strip + a <tbody> whose cells fake a nested rounded card via
+   per-side borders and corner radii on the first/last body row.
+   Mirrors `.tabsContainer` / `.tabsBody`.
    ============================================ */
+
+.tableFrame {
+  margin: 1.25rem 0;
+  border: 1px solid var(--kb-border);
+  border-radius: 0.625rem;
+  background: color-mix(in srgb, var(--kb-fg) 3%, transparent);
+  padding: 0.125rem;
+}
 
 .tableScrollWrap {
   width: 100%;
   overflow-x: auto;
-  margin: 1.25rem 0;
-  border: 1px solid var(--kb-border);
-  border-radius: var(--kb-radius);
 }
 
 .publicTable {
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   width: 100%;
   font-size: 0.9375rem;
+  background: transparent;
 }
 
-.publicTable th,
+/* Header — transparent strip in the outer frame, mirrors tab buttons. */
+.publicTable thead th {
+  background: transparent;
+  border: none;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--kb-fg);
+  opacity: 0.85;
+  text-align: left;
+  vertical-align: top;
+}
+
+/* Body cells — every cell owns its right + bottom borders. First-column
+   cells add the left border; the first body row adds the top border.
+   Each grid line is drawn exactly once with no doubling. */
 .publicTable td {
-  border-bottom: 1px solid var(--kb-border);
+  background: var(--kb-bg, #fff);
   border-right: 1px solid var(--kb-border);
-  padding: 0.625rem 0.875rem;
+  border-bottom: 1px solid var(--kb-border);
+  padding: 0.5rem 0.625rem;
   vertical-align: top;
   text-align: left;
 }
 
-.publicTable th:last-child,
-.publicTable td:last-child {
-  border-right: none;
+.publicTable td:first-child {
+  border-left: 1px solid var(--kb-border);
 }
 
-.publicTable tr:last-child td {
-  border-bottom: none;
+.publicTable tbody tr:first-child td {
+  border-top: 1px solid var(--kb-border);
 }
 
-.publicTable th {
-  background: color-mix(in srgb, var(--kb-fg) 4%, transparent);
-  font-weight: 600;
-  font-size: 0.875rem;
+/* Corner radii — the four body corners draw the faked card. */
+.publicTable tbody tr:first-child td:first-child {
+  border-top-left-radius: 0.5rem;
+}
+.publicTable tbody tr:first-child td:last-child {
+  border-top-right-radius: 0.5rem;
+}
+.publicTable tbody tr:last-child td:first-child {
+  border-bottom-left-radius: 0.5rem;
+}
+.publicTable tbody tr:last-child td:last-child {
+  border-bottom-right-radius: 0.5rem;
 }
 
 .publicTable th p,
@@ -667,5 +701,8 @@
 @media print {
   .tableScrollWrap {
     overflow-x: visible;
+  }
+  .tableFrame {
+    background: transparent;
   }
 }

--- a/packages/ui/src/components/kb/article/table-block.tsx
+++ b/packages/ui/src/components/kb/article/table-block.tsx
@@ -48,20 +48,22 @@ export function TableBlock({ node, resolveAuxxHref }: TableBlockProps): ReactNod
   const bodyRows = firstRowIsHeader ? restRows : node.content
 
   return (
-    <div className={styles.tableScrollWrap}>
-      <table className={styles.publicTable}>
-        {firstRowIsHeader ? (
-          <thead>
-            <tr>{firstRow.content.map((cell, i) => renderCell(cell, 'col', i))}</tr>
-          </thead>
-        ) : null}
-        <tbody>
-          {bodyRows.map((row, ri) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: row order is stable per render
-            <tr key={ri}>{row.content.map((cell, i) => renderCell(cell, 'row', i))}</tr>
-          ))}
-        </tbody>
-      </table>
+    <div className={styles.tableFrame}>
+      <div className={styles.tableScrollWrap}>
+        <table className={styles.publicTable}>
+          {firstRowIsHeader ? (
+            <thead>
+              <tr>{firstRow.content.map((cell, i) => renderCell(cell, 'col', i))}</tr>
+            </thead>
+          ) : null}
+          <tbody>
+            {bodyRows.map((row, ri) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: row order is stable per render
+              <tr key={ri}>{row.content.map((cell, i) => renderCell(cell, 'row', i))}</tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Editor + public renderer share a new table chrome — subtly-tinted outer frame (mirrors tabs/accordion) wrapping body cells whose per-side borders + corner radii on the first/last body row fake a nested rounded card
- Header `<th>` cells render as transparent labels in the outer frame so optional headers don't cut a chrome line across the frame
- `border-collapse: separate` (was `collapse`) so body cells can carry corner radii; row-drag clone in `table-node-view.tsx` matches so dropped rows show full grid lines
- Per-row/column trash buttons restyled to mirror the `destructive-hover` Button variant — resting `--color-primary-100` chrome turning destructive-tinted on hover; gutters widened for the larger buttons and the row trash is hidden on the header row (mirrors the left drag-handle rule)
- Drop legacy plain-table styles from `kb-article-editor.module.css` since `TableNodeView` owns the chrome via `container-node-view.module.css`

## Test plan
- [ ] Editor: insert a table — outer frame, headers transparent, body cells form a rounded card; with header off, the first body row's top corners round
- [ ] Editor: hover row/column — trash button appears with primary-100 chrome, turns destructive on direct hover
- [ ] Editor: trash button is hidden on the header row
- [ ] Editor: drag a row — drop clone shows full grid lines (not collapsed/borderless)
- [ ] Editor: column-resize handle still works (PM-driven, unchanged)
- [ ] Public renderer: table renders with the frame in light + dark mode; mobile (`overflow-x: visible`) drops the tinted background