### PR TITLE
feat(kb): collapsible TOC rail, h4 in TOC, sticky-aware scroll-margin

### DIFF
--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/[...articleSlug]/page.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/[...articleSlug]/page.tsx
@@ -3,15 +3,13 @@
 import { WEBAPP_URL } from '@auxx/config/urls'
 import { isOrgMember } from '@auxx/lib/cache'
 import {
-  extractKBHeadings,
   findArticleBySlugPath,
   findFirstNavigableUnder,
   getArticleNeighbours,
   getArticleParentLink,
   getFullSlugPath,
   KBArticlePager,
-  KBArticleRenderer,
-  KBTableOfContents,
+  KBArticleWithToc,
 } from '@auxx/ui/components/kb'
 import type { Metadata } from 'next'
 import { cacheLife, cacheTag } from 'next/cache'
@@ -182,7 +180,6 @@ function ArticleBodyContent({
     redirect(`${basePath}/${getFullSlugPath(first, articles)}`)
   }
 
-  const headings = extractKBHeadings(article.contentJson)
   const { prev, next } = getArticleNeighbours(articles, article.id)
   const parent = getArticleParentLink(article, articles, basePath)
   const fullSlug = getFullSlugPath(article, articles)
@@ -190,28 +187,21 @@ function ArticleBodyContent({
 
   return (
     <div className='flex min-w-0 flex-1 flex-col'>
-      <div className='flex flex-col gap-6 @kb-lg:flex-row @kb-lg:items-start'>
-        <aside className='hidden @kb-lg:sticky @kb-lg:top-20 @kb-lg:order-2 @kb-lg:block @kb-lg:max-h-[calc(100dvh-5rem)] @kb-lg:w-64 @kb-lg:max-w-none @kb-lg:flex-none @kb-lg:overflow-y-auto @kb-lg:px-4 @kb-lg:pt-8'>
-          <KBTableOfContents headings={headings} />
-        </aside>
-        <div className='min-w-0 flex-1 @kb-lg:order-1'>
-          <KBArticleRenderer
+      <KBArticleWithToc
+        doc={article.contentJson}
+        title={article.title}
+        emoji={article.emoji}
+        description={article.description}
+        updatedAt={article.updatedAt}
+        parent={parent}
+        copyMenu={
+          <ArticleMarkdownCopy
             doc={article.contentJson}
             title={article.title}
-            emoji={article.emoji}
-            description={article.description}
-            updatedAt={article.updatedAt}
-            parent={parent}
-            copyMenu={
-              <ArticleMarkdownCopy
-                doc={article.contentJson}
-                title={article.title}
-                markdownHref={markdownHref}
-              />
-            }
+            markdownHref={markdownHref}
           />
-        </div>
-      </div>
+        }
+      />
       <div className='mt-auto w-full max-w-3xl px-6'>
         <KBArticlePager articles={articles} prev={prev} next={next} basePath={basePath} />
       </div>

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/page.tsx
@@ -158,7 +158,7 @@ function LandingBody({
           />
         </div>
       </div>
-      <div className='mt-auto w-full max-w-3xl px-6'>
+      <div className='mt-auto w-full max-w-3xl ps-6'>
         <KBArticlePager articles={articles} prev={undefined} next={undefined} basePath={basePath} />
       </div>
     </div>

--- a/apps/web/src/components/editor/kb-article/container-node-view.module.css
+++ b/apps/web/src/components/editor/kb-article/container-node-view.module.css
@@ -433,6 +433,7 @@
    article column. Same fix as `.tabsContainerContent` /
    `.accordionContainerContent`. */
 .tableContainerContent {
+  position: relative;
   width: 100%;
   flex: 1 1 0%;
   min-width: 0;
@@ -448,38 +449,54 @@
   gap: 0;
 }
 
+/* Floats over the top-right of the table — partially overlaps the header
+   row. Reveals on container hover so the chrome stays out of the way at
+   rest. z-index sits above `.editorTable` cells but below the column
+   drag strip + delete buttons. */
 .tableToolbar {
-  width: 100%;
-  display: flex;
+  position: absolute;
+  top: 0.125rem;
+  right: 0.125rem;
+  z-index: 2;
+  display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.25rem 0.125rem;
-  font-size: 0.75rem;
-  color: var(--color-muted-foreground);
+  pointer-events: auto;
 }
 
 .tableToolbarToggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.25rem 0.5rem;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  border: 1px solid var(--color-primary-150);
   border-radius: 0.375rem;
-  border: 1px dashed transparent;
-  background: transparent;
-  cursor: pointer;
-  font-size: 0.75rem;
+  background: var(--color-primary-100);
   color: var(--color-muted-foreground);
-  margin-left: auto;
-  transition: color 0.12s, background 0.12s, border-color 0.12s;
+  box-sizing: border-box;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.12s, background 0.12s, border-color 0.12s,
+    box-shadow 0.12s;
+}
+
+.tableContainerContent:hover .tableToolbarToggle,
+.tableToolbarToggle:focus-visible,
+.tableToolbarToggle[aria-pressed='true'] {
+  opacity: 1;
 }
 
 .tableToolbarToggle:hover {
-  border-color: var(--color-border);
   color: var(--color-foreground);
+  border-color: var(--color-border);
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 }
 
 .tableToolbarToggle[aria-pressed='true'] {
   color: var(--color-foreground);
+  border-color: var(--color-border);
+  background: var(--color-background);
 }
 
 /* Body card is now an invisible positioning container. The visual card

--- a/apps/web/src/components/editor/kb-article/table-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/table-node-view.tsx
@@ -3,8 +3,9 @@
 
 import type { NodeViewProps } from '@tiptap/react'
 import { NodeViewWrapper, useReactNodeView } from '@tiptap/react'
-import { GripHorizontal, GripVertical, Trash2 } from 'lucide-react'
+import { GripHorizontal, GripVertical, PanelTop, Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { Tooltip } from '~/components/global/tooltip'
 import blockStyles from './block-node-view.module.css'
 import styles from './container-node-view.module.css'
 import {
@@ -322,13 +323,18 @@ export function TableNodeView({ node, editor, getPos }: NodeViewProps) {
         <div
           className={`${blockStyles.blockContentWrapper} ${styles.containerContent} ${styles.tableContainerContent}`}>
           <div className={styles.tableToolbar} contentEditable={false}>
-            <button
-              type='button'
-              className={styles.tableToolbarToggle}
-              aria-pressed={hasHeaderRow}
-              onClick={handleToggleHeader}>
-              {hasHeaderRow ? 'Header row' : 'No header'}
-            </button>
+            <Tooltip
+              content={hasHeaderRow ? 'Style first row as body' : 'Style first row as header'}
+              side='top'>
+              <button
+                type='button'
+                className={styles.tableToolbarToggle}
+                aria-pressed={hasHeaderRow}
+                aria-label={hasHeaderRow ? 'Style first row as body' : 'Style first row as header'}
+                onClick={handleToggleHeader}>
+                <PanelTop size={14} aria-hidden='true' />
+              </button>
+            </Tooltip>
           </div>
 
           <div className={styles.tableBodyCard} ref={wrapperRef}>

--- a/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
@@ -5,16 +5,14 @@ import { Banner } from '@auxx/ui/components/banner'
 import { Button } from '@auxx/ui/components/button'
 import {
   type DocJSON,
-  extractKBHeadings,
   findArticleBySlugPath,
   findFirstNavigableUnder,
   getArticleNeighbours,
   getArticleParentLink,
   getFullSlugPath,
   KBArticlePager,
-  KBArticleRenderer,
+  KBArticleWithToc,
   KBLayout,
-  KBTableOfContents,
 } from '@auxx/ui/components/kb'
 import { ExternalLink, Eye, Undo2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
@@ -126,7 +124,6 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath, mode }: KBFulls
 
   const basePath = `/preview/kb/${knowledgeBaseId}`
   const docJson = (previewContentJson ?? null) as DocJSON | null
-  const headings = docJson ? extractKBHeadings(docJson) : []
   const { prev, next } = articleId
     ? getArticleNeighbours(articles, articleId)
     : { prev: undefined, next: undefined }
@@ -244,29 +241,22 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath, mode }: KBFulls
         activeArticleId={activeArticle?.id}>
         {articleId ? (
           <div className='flex min-w-0 flex-1 flex-col'>
-            <div className='flex flex-col gap-6 @kb-lg:flex-row @kb-lg:items-start'>
-              <aside className='hidden @kb-lg:sticky @kb-lg:top-[calc(var(--kb-top-offset,0px)+5rem)] @kb-lg:order-2 @kb-lg:block @kb-lg:max-h-[calc(100dvh-var(--kb-top-offset,0px)-5rem)] @kb-lg:w-64 @kb-lg:max-w-none @kb-lg:flex-none @kb-lg:overflow-y-auto @kb-lg:px-4 @kb-lg:pt-8'>
-                <KBTableOfContents headings={headings} />
-              </aside>
-              <div className='min-w-0 flex-1 @kb-lg:order-1'>
-                <KBArticleRenderer
+            <KBArticleWithToc
+              doc={docJson}
+              title={previewTitle ?? activeArticle?.title}
+              emoji={previewEmoji ?? activeArticle?.emoji}
+              description={previewDescription ?? activeArticle?.description}
+              parent={parent}
+              resolveAuxxHref={(id) => `/preview/kb/${knowledgeBaseId}/r/${id}`}
+              copyMenu={
+                <ArticleMarkdownCopy
                   doc={docJson}
                   title={previewTitle ?? activeArticle?.title}
-                  emoji={previewEmoji ?? activeArticle?.emoji}
-                  description={previewDescription ?? activeArticle?.description}
-                  parent={parent}
-                  resolveAuxxHref={(id) => `/preview/kb/${knowledgeBaseId}/r/${id}`}
-                  copyMenu={
-                    <ArticleMarkdownCopy
-                      doc={docJson}
-                      title={previewTitle ?? activeArticle?.title}
-                      markdownHref={markdownHref}
-                    />
-                  }
+                  markdownHref={markdownHref}
                 />
-              </div>
-            </div>
-            <div className='mt-auto w-full max-w-3xl px-6'>
+              }
+            />
+            <div className='mt-auto w-full max-w-3xl ps-6'>
               <KBArticlePager articles={articles} prev={prev} next={next} basePath={basePath} />
             </div>
           </div>

--- a/apps/web/src/components/kb/ui/preview/kb-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview.tsx
@@ -3,13 +3,11 @@
 
 import {
   type DocJSON,
-  extractKBHeadings,
   getArticleNeighbours,
   getArticleParentLink,
   KBArticlePager,
-  KBArticleRenderer,
+  KBArticleWithToc,
   KBLayout,
-  KBTableOfContents,
 } from '@auxx/ui/components/kb'
 import { useEffect, useState } from 'react'
 import { useArticleContent } from '../../hooks/use-article-content'
@@ -69,7 +67,6 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
   if (!knowledgeBase) return null
 
   const docJson = (previewContentJson ?? null) as DocJSON | null
-  const headings = docJson ? extractKBHeadings(docJson) : []
   const { prev, next } = articleId
     ? getArticleNeighbours(articles, articleId)
     : { prev: undefined, next: undefined }
@@ -96,30 +93,23 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
         onModeChange={setOverride}>
         {articleId ? (
           <div className='flex min-w-0 flex-1 flex-col'>
-            <div className='flex flex-col gap-6 @kb-lg:flex-row @kb-lg:items-start'>
-              <aside className='hidden @kb-lg:sticky @kb-lg:top-20 @kb-lg:order-2 @kb-lg:block @kb-lg:max-h-[calc(100dvh-5rem)] @kb-lg:w-64 @kb-lg:max-w-none @kb-lg:flex-none @kb-lg:overflow-y-auto @kb-lg:px-4 @kb-lg:pt-8'>
-                <KBTableOfContents headings={headings} />
-              </aside>
-              <div className='min-w-0 flex-1 @kb-lg:order-1'>
-                <KBArticleRenderer
-                  doc={docJson}
-                  title={
-                    previewTitle ??
-                    activeArticle?.title ??
-                    articles.find((a) => a.id === articleId)?.title
-                  }
-                  emoji={
-                    previewEmoji ??
-                    activeArticle?.emoji ??
-                    articles.find((a) => a.id === articleId)?.emoji
-                  }
-                  description={previewDescription ?? activeArticle?.description}
-                  parent={parent}
-                  resolveAuxxHref={(id) => `/preview/kb/${kbId}/r/${id}`}
-                />
-              </div>
-            </div>
-            <div className='mt-auto w-full max-w-3xl px-6'>
+            <KBArticleWithToc
+              doc={docJson}
+              title={
+                previewTitle ??
+                activeArticle?.title ??
+                articles.find((a) => a.id === articleId)?.title
+              }
+              emoji={
+                previewEmoji ??
+                activeArticle?.emoji ??
+                articles.find((a) => a.id === articleId)?.emoji
+              }
+              description={previewDescription ?? activeArticle?.description}
+              parent={parent}
+              resolveAuxxHref={(id) => `/preview/kb/${kbId}/r/${id}`}
+            />
+            <div className='mt-auto w-full max-w-3xl ps-6'>
               <KBArticlePager articles={articles} prev={prev} next={next} basePath='#preview' />
             </div>
           </div>

--- a/packages/ui/src/components/kb/article/extract-headings.ts
+++ b/packages/ui/src/components/kb/article/extract-headings.ts
@@ -6,13 +6,13 @@ import type { DocJSON } from './types'
 export interface KBHeading {
   id: string
   text: string
-  /** 2 = h2 (level 1 in editor), 3 = h3 (level 2 in editor). */
-  depth: 2 | 3
+  /** Rendered HTML depth: 2 = h2 (editor level 1), 3 = h3 (editor level 2), 4 = h4 (editor level 3). */
+  depth: 2 | 3 | 4
 }
 
 /**
- * Walk the doc JSON and extract h2/h3 headings with stable, collision-free anchor ids.
- * Editor stores level=1 → renders as h2, level=2 → renders as h3, level=3 → h4 (skipped).
+ * Walk the doc JSON and extract h2/h3/h4 headings with stable, collision-free anchor ids.
+ * Editor stores level=1 → renders as h2, level=2 → renders as h3, level=3 → renders as h4.
  */
 export function extractKBHeadings(doc: DocJSON | null | undefined): KBHeading[] {
   if (!doc?.content) return []
@@ -22,14 +22,15 @@ export function extractKBHeadings(doc: DocJSON | null | undefined): KBHeading[] 
     if (node.type !== 'block') return
     if (node.attrs?.blockType !== 'heading') return
     const level = node.attrs?.level ?? 1
-    if (level !== 1 && level !== 2) return
+    if (level !== 1 && level !== 2 && level !== 3) return
     const text = walkInlineToText(node.content).trim()
     if (!text) return
     const baseId = slugify(text) || `h-${idx}`
     const count = seen.get(baseId) ?? 0
     seen.set(baseId, count + 1)
     const id = count === 0 ? baseId : `${baseId}-${count + 1}`
-    out.push({ id, text, depth: level === 1 ? 2 : 3 })
+    const depth: 2 | 3 | 4 = level === 1 ? 2 : level === 2 ? 3 : 4
+    out.push({ id, text, depth })
   })
   return out
 }

--- a/packages/ui/src/components/kb/article/index.ts
+++ b/packages/ui/src/components/kb/article/index.ts
@@ -8,6 +8,7 @@ export { InlineRenderer } from './inline-renderer'
 export { KBArticleCopyMenu } from './kb-article-copy-menu'
 export { KBArticlePager } from './kb-article-pager'
 export { KBArticleRenderer } from './kb-article-renderer'
+export { KBArticleWithToc } from './kb-article-with-toc'
 export { KBTableOfContents } from './kb-toc'
 export type {
   AccordionJSON,

--- a/packages/ui/src/components/kb/article/kb-article-renderer.module.css
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.module.css
@@ -7,7 +7,14 @@
   font-size: 16px;
   max-width: 768px;
   margin: 0;
-  padding-left:1.5rem;
+  padding-left: 1.5rem;
+  transition: max-width 0.2s ease;
+}
+
+/* When the TOC rail is collapsed, the article reclaims the rail's column
+   width (w-64 = 16rem) plus the layout gap (gap-6 = 1.5rem) = 17.5rem. */
+[data-kb-toc-collapsed='true'] .article {
+  max-width: calc(768px + 17.5rem);
 }
 
 .article :global(.kb-link) {
@@ -79,7 +86,9 @@
   font-weight: 700;
   line-height: 1.2;
   margin: 0;
-  scroll-margin-top: 4rem;
+  scroll-margin-top: calc(
+    var(--kb-top-offset, 0px) + var(--kb-header-h, 3.5rem) + var(--kb-tabs-h, 0px) + 0.5rem
+  );
 }
 
 .parentLink {
@@ -112,7 +121,9 @@
   font-weight: 600;
   line-height: 1.3;
   margin: 1.25em 0 0.5em;
-  scroll-margin-top: 4rem;
+  scroll-margin-top: calc(
+    var(--kb-top-offset, 0px) + var(--kb-header-h, 3.5rem) + var(--kb-tabs-h, 0px) + 0.5rem
+  );
 }
 
 .h3 {
@@ -120,7 +131,9 @@
   font-weight: 600;
   line-height: 1.4;
   margin: 1em 0 0.5em;
-  scroll-margin-top: 4rem;
+  scroll-margin-top: calc(
+    var(--kb-top-offset, 0px) + var(--kb-header-h, 3.5rem) + var(--kb-tabs-h, 0px) + 0.5rem
+  );
 }
 
 .quote {

--- a/packages/ui/src/components/kb/article/kb-article-renderer.tsx
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.tsx
@@ -21,7 +21,7 @@ import type {
   TabsJSON,
 } from './types'
 
-interface KBArticleRendererProps {
+export interface KBArticleRendererProps {
   doc: DocJSON | null | undefined
   /** Optional title rendered as <h1>; the doc's heading levels start at <h2>. */
   title?: string
@@ -37,6 +37,13 @@ interface KBArticleRendererProps {
    * (`@auxx/lib/kb/markdown`) lives outside the UI package's dep tier.
    */
   copyMenu?: ReactNode
+  /**
+   * Slot for the desktop "show TOC" toggle button. Rendered to the right of
+   * the mobile drawer trigger. Apps using `KBArticleWithToc` pass a
+   * visibility-managed button here so the layout stays stable when the
+   * rail is collapsed.
+   */
+  tocToggle?: ReactNode
   /** Override how `auxx://kb/article/{id}` link/card hrefs are emitted.
    * Defaults to `/r/{id}` — public KB hosts a redirect handler at that
    * path. Preview/embed contexts override to nest under their URL prefix. */
@@ -51,6 +58,7 @@ export function KBArticleRenderer({
   updatedAt,
   parent,
   copyMenu,
+  tocToggle,
   resolveAuxxHref,
 }: KBArticleRendererProps) {
   const headings = doc ? extractKBHeadings(doc) : []
@@ -77,7 +85,7 @@ export function KBArticleRenderer({
             ) : null}
             {title ? (
               <h1 className={styles.h1}>
-                <span className='inline-flex flex-row items-center gap-3'>
+                <span className='inline-flex flex-row items-center'>
                   {emoji ? <EntityIcon iconId={emoji} variant='bare' size='xl' /> : null}
                   <span>{title}</span>
                 </span>
@@ -89,8 +97,9 @@ export function KBArticleRenderer({
             ) : null}
           </div>
           <div className='flex items-center gap-2'>
-            <KBTableOfContentsDrawer headings={headings} className='@kb-lg:hidden' />
             {copyMenu}
+            <KBTableOfContentsDrawer headings={headings} className='@kb-lg:hidden' />
+            {tocToggle}
           </div>
         </header>
       ) : null}
@@ -205,7 +214,7 @@ function buildHeadingIdMap(doc: DocJSON, headings: KBHeading[]): Record<number, 
     if (node.type !== 'block') return
     if (node.attrs?.blockType !== 'heading') return
     const level = node.attrs?.level ?? 1
-    if (level !== 1 && level !== 2) return
+    if (level !== 1 && level !== 2 && level !== 3) return
     const heading = headings[cursor]
     if (heading) map[idx] = heading.id
     cursor++

--- a/packages/ui/src/components/kb/article/kb-article-with-toc.tsx
+++ b/packages/ui/src/components/kb/article/kb-article-with-toc.tsx
@@ -1,0 +1,53 @@
+// packages/ui/src/components/kb/article/kb-article-with-toc.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { cn } from '@auxx/ui/lib/utils'
+import { List } from 'lucide-react'
+import { useState } from 'react'
+import { extractKBHeadings } from './extract-headings'
+import { KBArticleRenderer, type KBArticleRendererProps } from './kb-article-renderer'
+import { KBTableOfContents } from './kb-toc'
+
+type KBArticleWithTocProps = Omit<KBArticleRendererProps, 'tocToggle'>
+
+/**
+ * Two-column layout: TOC rail on the right, article on the left. Owns the
+ * desktop "rail collapsed" state — clicking "On this page" hides the rail
+ * and reveals an icon button next to the copy menu that re-expands it.
+ * Mobile is unaffected (the renderer's own drawer handles small screens).
+ */
+export function KBArticleWithToc(props: KBArticleWithTocProps) {
+  const [collapsed, setCollapsed] = useState(false)
+  const headings = props.doc ? extractKBHeadings(props.doc) : []
+  const hasHeadings = headings.length > 0
+  const showRail = hasHeadings && !collapsed
+
+  const desktopToggle = hasHeadings ? (
+    <Button
+      variant='outline'
+      size='icon-xs'
+      aria-label='Show table of contents'
+      onClick={() => setCollapsed(false)}
+      className={cn('hidden @kb-lg:inline-flex', !collapsed && 'invisible')}>
+      <List />
+    </Button>
+  ) : null
+
+  return (
+    <div className='flex flex-col gap-6 @kb-lg:flex-row @kb-lg:items-start'>
+      <aside
+        className={cn(
+          'hidden @kb-lg:order-2 @kb-lg:sticky @kb-lg:top-[calc(var(--kb-top-offset,0px)+5rem)] @kb-lg:max-h-[calc(100dvh-var(--kb-top-offset,0px)-5rem)] @kb-lg:w-64 @kb-lg:max-w-none @kb-lg:flex-none @kb-lg:overflow-y-auto @kb-lg:px-4 @kb-lg:pt-8',
+          showRail && '@kb-lg:block'
+        )}>
+        <KBTableOfContents headings={headings} onCollapse={() => setCollapsed(true)} />
+      </aside>
+      <div
+        className='min-w-0 flex-1 @kb-lg:order-1'
+        data-kb-toc-collapsed={hasHeadings && collapsed ? 'true' : undefined}>
+        <KBArticleRenderer {...props} tocToggle={desktopToggle} />
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/src/components/kb/article/kb-toc-drawer.tsx
+++ b/packages/ui/src/components/kb/article/kb-toc-drawer.tsx
@@ -44,7 +44,7 @@ export function KBTableOfContentsDrawer({ headings, className }: KBTableOfConten
     <span ref={anchorRef} className='contents'>
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
-          <Button variant='outline' size='icon' aria-label='On this page' className={className}>
+          <Button variant='outline' size='icon-xs' aria-label='On this page' className={className}>
             <List />
           </Button>
         </SheetTrigger>

--- a/packages/ui/src/components/kb/article/kb-toc.tsx
+++ b/packages/ui/src/components/kb/article/kb-toc.tsx
@@ -3,7 +3,7 @@
 
 import { cn } from '@auxx/ui/lib/utils'
 import { Text } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { KBHeading } from './extract-headings'
 
 interface KBTableOfContentsProps {
@@ -12,13 +12,22 @@ interface KBTableOfContentsProps {
   hideHeading?: boolean
   /** Called when a heading link is clicked — used by the drawer to auto-close. */
   onLinkClick?: () => void
+  /** When set, the "On this page" header becomes a button that calls this. */
+  onCollapse?: () => void
 }
 
-export function KBTableOfContents({ headings, hideHeading, onLinkClick }: KBTableOfContentsProps) {
+export function KBTableOfContents({
+  headings,
+  hideHeading,
+  onLinkClick,
+  onCollapse,
+}: KBTableOfContentsProps) {
   const [active, setActive] = useState<string | null>(headings[0]?.id ?? null)
+  const navRef = useRef<HTMLElement>(null)
 
   useEffect(() => {
     if (headings.length === 0) return
+    const topPx = computeStickyOffset(navRef.current)
     const observer = new IntersectionObserver(
       (entries) => {
         const visible = entries
@@ -26,7 +35,7 @@ export function KBTableOfContents({ headings, hideHeading, onLinkClick }: KBTabl
           .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
         if (visible[0]?.target.id) setActive(visible[0].target.id)
       },
-      { rootMargin: '-80px 0px -70% 0px' }
+      { rootMargin: `-${topPx}px 0px -70% 0px` }
     )
     for (const h of headings) {
       const el = document.getElementById(h.id)
@@ -38,8 +47,17 @@ export function KBTableOfContents({ headings, hideHeading, onLinkClick }: KBTabl
   if (headings.length === 0) return null
 
   return (
-    <nav data-slot='kb-toc' aria-label='Table of contents' className='text-sm'>
-      {hideHeading ? null : (
+    <nav ref={navRef} data-slot='kb-toc' aria-label='Table of contents' className='text-sm'>
+      {hideHeading ? null : onCollapse ? (
+        <button
+          type='button'
+          onClick={onCollapse}
+          aria-label='Hide table of contents'
+          className='mb-3 -ml-1 flex w-full cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-left font-medium text-[var(--kb-fg)] transition-colors hover:text-[var(--kb-fg)]/70'>
+          <Text className='size-4 text-[var(--kb-fg)]/70' aria-hidden />
+          On this page
+        </button>
+      ) : (
         <p className='mb-3 flex items-center gap-2 font-medium text-[var(--kb-fg)]'>
           <Text className='size-4 text-[var(--kb-fg)]/70' aria-hidden />
           On this page
@@ -68,4 +86,30 @@ export function KBTableOfContents({ headings, hideHeading, onLinkClick }: KBTabl
       </ul>
     </nav>
   )
+}
+
+/**
+ * Resolve the sticky-chrome height in px by reading the same CSS variables
+ * the article's `scroll-margin-top` uses (`--kb-top-offset`, `--kb-header-h`,
+ * `--kb-tabs-h`). Keeps the IntersectionObserver's "active heading" cutoff
+ * aligned with where headings actually land after a click.
+ */
+function computeStickyOffset(scope: Element | null): number {
+  if (typeof window === 'undefined') return 80
+  const el = scope ?? document.documentElement
+  const style = getComputedStyle(el)
+  const px = (raw: string, fallback: number): number => {
+    const v = raw.trim()
+    if (!v) return fallback
+    if (v.endsWith('px')) return Number.parseFloat(v) || fallback
+    if (v.endsWith('rem')) {
+      const root = Number.parseFloat(getComputedStyle(document.documentElement).fontSize) || 16
+      return (Number.parseFloat(v) || 0) * root
+    }
+    return Number.parseFloat(v) || fallback
+  }
+  const top = px(style.getPropertyValue('--kb-top-offset'), 0)
+  const header = px(style.getPropertyValue('--kb-header-h'), 56)
+  const tabs = px(style.getPropertyValue('--kb-tabs-h'), 0)
+  return top + header + tabs + 8
 }

--- a/packages/ui/src/components/kb/layout/kb-layout-context.tsx
+++ b/packages/ui/src/components/kb/layout/kb-layout-context.tsx
@@ -11,6 +11,10 @@ export interface KBLayoutContextValue {
   setMobileOpen: (value: boolean) => void
   searchOpen: boolean
   setSearchOpen: (value: boolean) => void
+  /** When true, `<main>` owns the scroll instead of the document. Used to
+   * decide whether the mobile drawer should pin to the viewport (`fixed`)
+   * or stay scoped to the layout root (`absolute` — preview frames). */
+  mainScroll: boolean
 }
 
 const KBLayoutContext = createContext<KBLayoutContextValue | null>(null)

--- a/packages/ui/src/components/kb/layout/kb-layout-shell.tsx
+++ b/packages/ui/src/components/kb/layout/kb-layout-shell.tsx
@@ -148,6 +148,7 @@ export function KBLayoutShell<T extends KBSidebarArticle>({
         setMobileOpen,
         searchOpen,
         setSearchOpen,
+        mainScroll,
       }}>
       <KBHeader
         kbId={kbId}
@@ -201,7 +202,7 @@ export function KBLayoutShell<T extends KBSidebarArticle>({
         />
         <main
           className={cn(
-            'flex min-w-0 flex-1 flex-col px-4 py-8 @kb-md:px-8',
+            'flex min-w-0 flex-1 flex-col px-4 pt-4 md:pt-8 pb-8 @kb-md:px-8',
             mainScroll && 'min-h-0 overflow-y-auto'
           )}>
           {children}

--- a/packages/ui/src/components/kb/layout/kb-sidebar.tsx
+++ b/packages/ui/src/components/kb/layout/kb-sidebar.tsx
@@ -57,7 +57,8 @@ export function KBSidebar<T extends KBSidebarArticle>({
   onTabSelect,
   onModeChange,
 }: KBSidebarProps<T>) {
-  const { kbId, collapsed, setCollapsed, mobileOpen, setMobileOpen } = useKBLayoutContext()
+  const { kbId, collapsed, setCollapsed, mobileOpen, setMobileOpen, mainScroll } =
+    useKBLayoutContext()
 
   const [openIds, setOpenIds] = useState<Record<string, boolean>>({})
   const [animateTree, setAnimateTree] = useState(false)
@@ -158,11 +159,15 @@ export function KBSidebar<T extends KBSidebarArticle>({
         ) : null}
       </div>
 
-      {/* Mobile in-place drawer (constrained to KB layout root, not document.body) */}
+      {/* Mobile drawer. Pins to the viewport on the public KB (`fixed`) and
+          stays scoped to the layout root inside admin previews where the
+          layout is contained (`absolute`). Without this split the drawer
+          stretches the full document height on the public site. */}
       <div
         aria-hidden={!mobileOpen}
         className={cn(
-          'absolute inset-0 z-40 transition-opacity duration-200 @kb-md:hidden',
+          'inset-0 z-40 transition-opacity duration-200 @kb-md:hidden',
+          mainScroll ? 'absolute' : 'fixed',
           mobileOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
         )}>
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop is decorative; Escape handler covers keyboard close */}
@@ -173,7 +178,7 @@ export function KBSidebar<T extends KBSidebarArticle>({
         />
         <aside
           className={cn(
-            'absolute top-3 bottom-3 left-3 flex w-[min(18rem,calc(100%-1.5rem))] flex-col overflow-hidden rounded-[var(--kb-radius)] border border-[var(--kb-border)] bg-[var(--kb-sidebar-bg)] shadow-2xl transition-transform duration-200 ease-out',
+            'absolute top-3 bottom-3 left-3 flex w-[min(18rem,calc(100%-1.5rem))] flex-col overflow-hidden rounded-[var(--kb-radius)] border border-[var(--kb-border)] bg-[var(--kb-content-bg)] shadow-2xl transition-transform duration-200 ease-out',
             mobileOpen ? 'translate-x-0' : '-translate-x-[calc(100%+1rem)]'
           )}>
           <KBSidebarMobileHeader


### PR DESCRIPTION
## Summary

- New `KBArticleWithToc` wrapper lets the desktop TOC rail collapse and reclaim its column width — article `max-width` grows by 17.5rem when collapsed.
- Tie heading `scroll-margin-top` to `--kb-top-offset` / `--kb-header-h` / `--kb-tabs-h` so anchor jumps land below the sticky chrome regardless of host (public KB vs. admin preview). The TOC's IntersectionObserver root margin reads the same vars.
- Surface h4 (editor level 3) headings in the TOC and the heading-id map.
- Mobile sidebar drawer pins to the viewport with `fixed` on the public KB and stays scoped (`absolute`) inside contained preview frames — controlled by the new `mainScroll` flag on the layout context.
- Restyle the editor table's header-row toggle as a floating icon button in the table's top-right that reveals on container hover.

## Test plan
- [ ] Public KB article: desktop TOC collapses and re-expands; article width grows when collapsed; h2/h3/h4 all show in the TOC.
- [ ] Click any heading link — destination lands below the sticky header on both public KB and admin preview.
- [ ] Mobile drawer on public KB pins to viewport (does not stretch full document height).
- [ ] Mobile drawer in `/preview/kb/...` admin preview stays inside the layout.
- [ ] Editor: hovering a table reveals the header-toggle icon top-right; click toggles header row with new tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)