### PR TITLE
feat(kb): editor paste, code block, and tabs polish

### DIFF
--- a/apps/web/src/components/editor/kb-article/block-node-view.module.css
+++ b/apps/web/src/components/editor/kb-article/block-node-view.module.css
@@ -470,6 +470,27 @@
   word-break: break-word;
 }
 
+/* Positioning anchor for the placeholder so it lands at the top-left of
+   the code body, not at the top of the outer code-block card (which would
+   put it under the language-picker header). */
+.codeBlockBody {
+  position: relative;
+  width: 100%;
+}
+
+/* Placeholder styled to match the code body so it reads as ghost code
+   rather than ghost prose. Offsets match `.blockContent--codeBlock` padding.
+   Two-class selector (`.placeholder.placeholderInCode`) bumps specificity
+   above the base `.placeholder { top: 0; left: ... }` rule, which is
+   declared later in this file and would otherwise win the tie. */
+.placeholder.placeholderInCode {
+  top: 0.8rem;
+  left: 1.1rem;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
 /* ============================================
    Placeholder — rendered as sibling span by BlockNodeView
    when the block is empty AND (first in doc OR currently focused).

--- a/apps/web/src/components/editor/kb-article/block-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/block-node-view.tsx
@@ -421,7 +421,20 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
-              <NodeViewContent className={contentClasses} />
+              {/* Anchor: gives the placeholder a positioning context that
+                  starts where the code body starts, not at the top of the
+                  outer card (which would put it under the language picker). */}
+              <div className={styles.codeBlockBody}>
+                <NodeViewContent className={contentClasses} />
+                {showPlaceholder && (
+                  <span
+                    className={`${styles.placeholder} ${styles.placeholderInCode}`}
+                    contentEditable={false}
+                    aria-hidden='true'>
+                    {placeholderText}
+                  </span>
+                )}
+              </div>
             </>
           ) : (
             <NodeViewContent className={contentClasses} />
@@ -461,7 +474,7 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
             />
           )}
 
-          {showPlaceholder && (
+          {showPlaceholder && !isCodeBlock && (
             <span className={styles.placeholder} contentEditable={false} aria-hidden='true'>
               {placeholderText}
             </span>

--- a/apps/web/src/components/editor/kb-article/block-node.ts
+++ b/apps/web/src/components/editor/kb-article/block-node.ts
@@ -1,6 +1,7 @@
 // apps/web/src/components/editor/kb-article/block-node.ts
 
 import { mergeAttributes, Node } from '@tiptap/core'
+import { TextSelection } from '@tiptap/pm/state'
 import { ReactNodeViewRenderer } from '@tiptap/react'
 import { blockDragPlugin } from './block-drag-plugin'
 import { BlockNodeView } from './block-node-view'
@@ -159,6 +160,26 @@ export const Block = Node.create({
       typeof type === 'string' && LIST_TYPES.includes(type as BlockType)
 
     return {
+      // Mod-A inside a code block selects only the code's content (mirrors
+      // the same shortcut on `panel`). Default Mod-A would select the whole
+      // doc, which is rarely what you want when you're typing code.
+      'Mod-a': ({ editor }) => {
+        const { $from } = editor.state.selection
+        for (let depth = $from.depth; depth >= 0; depth--) {
+          const node = $from.node(depth)
+          if (node.type.name !== 'block') continue
+          if (node.attrs.blockType !== 'codeBlock') return false
+          const blockStart = $from.before(depth) + 1
+          const blockEnd = blockStart + node.content.size
+          editor.view.dispatch(
+            editor.state.tr.setSelection(
+              TextSelection.create(editor.state.doc, blockStart, blockEnd)
+            )
+          )
+          return true
+        }
+        return false
+      },
       Tab: ({ editor }) => {
         const { $from } = editor.state.selection
         for (let depth = $from.depth; depth >= 0; depth--) {
@@ -258,6 +279,38 @@ export const Block = Node.create({
           return editor
             .chain()
             .insertContentAt(blockEnd, { type: 'block' })
+            .focus(blockEnd + 1)
+            .run()
+        }
+        return false
+      },
+      // Inside a code block, code lines are inline text separated by literal
+      // `\n`, so PM's default ArrowDown can't escape the inline range and the
+      // caret gets stuck on the last line. If there are no more newlines
+      // after the cursor (i.e. we're already on the visual last line), step
+      // out to the next block — creating one if this is the last block in
+      // the doc. Returning `false` otherwise lets default Down move down a
+      // visual line within the code body.
+      ArrowDown: ({ editor }) => {
+        const { $from, empty } = editor.state.selection
+        if (!empty) return false
+        for (let depth = $from.depth; depth >= 0; depth--) {
+          const node = $from.node(depth)
+          if (node.type.name !== 'block') continue
+          if (node.attrs.blockType !== 'codeBlock') return false
+          const remaining = node.textContent.slice($from.parentOffset)
+          if (remaining.includes('\n')) return false
+          const blockEnd = $from.before(depth) + node.nodeSize
+          const doc = editor.state.doc
+          if (blockEnd >= doc.content.size) {
+            return editor
+              .chain()
+              .insertContentAt(blockEnd, { type: 'block' })
+              .focus(blockEnd + 1)
+              .run()
+          }
+          return editor
+            .chain()
             .focus(blockEnd + 1)
             .run()
         }

--- a/apps/web/src/components/editor/kb-article/kb-slash-command-picker.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-slash-command-picker.tsx
@@ -14,6 +14,7 @@ import {
 } from '@auxx/ui/components/command'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { generateId } from '@auxx/utils'
+import { TextSelection } from '@tiptap/pm/state'
 import type { Editor } from '@tiptap/react'
 import { ChevronRight } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -328,11 +329,31 @@ const BASE_COMMANDS: CommandItemDef[] = [
       // built-in `insertTable` command) tries to fit the table INSIDE the
       // block, fails, and substitutes a default block. `insertContent`
       // takes a different path that lifts out of the wrapping block.
+      // After insertion PM leaves the cursor at the end of the inserted
+      // content (last cell). Walk the doc forward from `range.from` to
+      // find the first cell and place the cursor inside its empty block.
       editor
         .chain()
         .focus()
         .deleteRange(range)
         .insertContent(makeEmptyTableJSON(3, 3, true))
+        .command(({ tr, dispatch }) => {
+          let target: number | null = null
+          tr.doc.nodesBetween(range.from, tr.doc.content.size, (node, pos) => {
+            if (target !== null) return false
+            if (node.type.name === 'tableHeader' || node.type.name === 'tableCell') {
+              // pos = before the cell's open token; +2 lands inside the
+              // empty block that lives inside the cell.
+              target = pos + 2
+              return false
+            }
+            return true
+          })
+          if (target !== null && dispatch) {
+            dispatch(tr.setSelection(TextSelection.near(tr.doc.resolve(target))))
+          }
+          return true
+        })
         .run()
     },
   },

--- a/apps/web/src/components/editor/kb-article/markdown-paste.ts
+++ b/apps/web/src/components/editor/kb-article/markdown-paste.ts
@@ -3,6 +3,21 @@
 import { type Editor, Extension } from '@tiptap/core'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 
+// Blocks whose shape forbids "lift out and insert N new blocks" semantics.
+// Pasting markdown inside one of these falls through to PM's plain-text
+// paste so the caret stays inside the existing block. `text` (the default
+// flowing paragraph) is intentionally absent — that's the one place full
+// markdown auto-format makes sense.
+const PLAINTEXT_BLOCK_TYPES = new Set([
+  'codeBlock',
+  'heading',
+  'callout',
+  'quote',
+  'bulletListItem',
+  'orderedListItem',
+  'todoListItem',
+])
+
 const MARKDOWN_HEURISTIC = [
   /^#{1,6}\s/m,
   /^\s*[-*]\s/m,
@@ -13,6 +28,12 @@ const MARKDOWN_HEURISTIC = [
   /\*\*[^*\n]+\*\*/,
   /\[[^\]\n]+\]\([^\s)]+\)/,
   /^:::\w+/m,
+  // GFM pipe table — strict separator row (`|---|---|`, `|:--|--:|`, …).
+  // High-confidence signal that a real table was pasted.
+  /^\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$/m,
+  // Loose fallback: any line that opens and closes with `|`. Catches
+  // tables that paste without trailing pipes, single-row matrices, etc.
+  /^\|.*\|\s*$/m,
 ]
 
 function looksLikeMarkdown(text: string): boolean {
@@ -40,17 +61,38 @@ export const MarkdownPaste = Extension.create({
             if (!cd) return false
 
             const text = cd.getData('text/plain')
-            if (!text || !looksLikeMarkdown(text)) return false
+            if (!text) return false
 
-            // Don't transform when pasting into a code block — code paste
-            // should stay verbatim.
+            // Find the closest enclosing `block` ancestor so we can route on
+            // its `blockType` (codeBlock vs heading vs callout vs other).
             const $from = view.state.selection.$from
+            let blockType: string | null = null
             for (let depth = $from.depth; depth >= 0; depth--) {
               const node = $from.node(depth)
-              if (node.type.name === 'block' && node.attrs.blockType === 'codeBlock') {
-                return false
+              if (node.type.name === 'block') {
+                blockType = (node.attrs.blockType as string | undefined) ?? null
+                break
               }
             }
+
+            // Code block: force-insert text/plain verbatim. PM's default
+            // paste reads text/html (e.g. `<pre><code>…</code></pre>` from
+            // an IDE / website), parses it via the schema, and lifts out of
+            // the codeBlock when the resulting slice doesn't fit `inline*`
+            // — which deletes the codeBlock and leaves plain text behind.
+            if (blockType === 'codeBlock') {
+              event.preventDefault()
+              view.dispatch(view.state.tr.insertText(text))
+              return true
+            }
+
+            if (!looksLikeMarkdown(text)) return false
+
+            // Other plaintext-only blocks (heading, callout, list item,
+            // quote): opt out of markdown auto-format so the caret stays
+            // inside the current block. PM's default paste handles plain
+            // text fine here and preserves any inline marks from the HTML.
+            if (blockType && PLAINTEXT_BLOCK_TYPES.has(blockType)) return false
 
             event.preventDefault()
             void importAndInsert(editor, text)

--- a/apps/web/src/components/editor/kb-article/panel-node.ts
+++ b/apps/web/src/components/editor/kb-article/panel-node.ts
@@ -65,6 +65,16 @@ export const Panel = Node.create({
   },
 
   addNodeView() {
-    return ReactNodeViewRenderer(PanelNodeView)
+    // Mirror `id` onto the outer `.react-renderer.node-panel` wrapper so a
+    // scoped CSS rule on the parent tabs container can hide the wrapper of
+    // non-active panels declaratively (see `tabs-node-view.tsx`). Without
+    // this, only the inner NodeViewWrapper carries `data-panel-id` and the
+    // outer wrapper still claims box space when its content is hidden.
+    return ReactNodeViewRenderer(PanelNodeView, {
+      attrs: ({ node }) => {
+        const id = (node.attrs as { id?: string }).id
+        return id ? { 'data-panel-id': id } : {}
+      },
+    })
   },
 })

--- a/apps/web/src/components/editor/kb-article/tabs-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/tabs-node-view.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/editor/kb-article/tabs-node-view.tsx
 'use client'
 
+import { generateId } from '@auxx/utils'
 import {
   closestCenter,
   DndContext,
@@ -21,7 +22,7 @@ import { CSS } from '@dnd-kit/utilities'
 import type { NodeViewProps } from '@tiptap/react'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import { Plus, X } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import blockStyles from './block-node-view.module.css'
 import {
   addPanel,
@@ -45,9 +46,14 @@ export function TabsNodeView({ node, editor, getPos }: NodeViewProps) {
   // biome-ignore lint/correctness/useExhaustiveDependencies: panelIdsKey encodes the relevant change
   const panelIds = useMemo(() => panels.map((p) => p.id), [panelIdsKey])
 
+  // Stable scope id used by an inline <style> rule below. Hides non-active
+  // panels declaratively — an earlier `useEffect` that mutated `display` via
+  // `querySelectorAll` raced PM mounting child panels (the effect fired
+  // before the panel DOMs existed), leaving every panel visible.
+  const tabsUid = useMemo(() => generateId(), [])
+
   const [activeId, setActiveId] = useState<string>(() => panels[0]?.id ?? '')
   const [editingId, setEditingId] = useState<string | null>(null)
-  const bodyRef = useRef<HTMLDivElement>(null)
 
   // Fall back to first panel if active was deleted.
   useEffect(() => {
@@ -56,18 +62,6 @@ export function TabsNodeView({ node, editor, getPos }: NodeViewProps) {
       setActiveId(panels[0].id)
     }
   }, [panels, activeId])
-
-  // Toggle panel body visibility. Runs only when active changes or the panel
-  // SET changes — not on every keystroke inside the body.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: panelIdsKey covers the panel-set change
-  useEffect(() => {
-    const body = bodyRef.current
-    if (!body) return
-    const items = body.querySelectorAll<HTMLElement>('[data-panel][data-panel-id]')
-    items.forEach((el) => {
-      el.style.display = el.getAttribute('data-panel-id') === activeId ? '' : 'none'
-    })
-  }, [activeId, panelIdsKey])
 
   const containerPos = typeof getPos === 'function' ? getPos() : null
 
@@ -136,6 +130,12 @@ export function TabsNodeView({ node, editor, getPos }: NodeViewProps) {
 
   return (
     <NodeViewWrapper as='div' className={blockStyles.blockWrapper} data-tabs=''>
+      {/* Scoped CSS rule: hide every panel wrapper inside this tabs body whose
+          id doesn't match the active tab. nanoid-based ids are URL-safe so no
+          escaping is needed. */}
+      <style>
+        {`[data-tabs-id="${tabsUid}"] [data-panel-id]:not([data-panel-id="${activeId}"]){display:none}`}
+      </style>
       <div className={blockStyles.blockContainer}>
         <div
           className={blockStyles.lineGutter}
@@ -179,7 +179,7 @@ export function TabsNodeView({ node, editor, getPos }: NodeViewProps) {
             </button>
           </div>
 
-          <div ref={bodyRef} className={styles.tabsBody}>
+          <div data-tabs-id={tabsUid} className={styles.tabsBody}>
             <NodeViewContent />
           </div>
         </div>


### PR DESCRIPTION
## Summary

A handful of follow-ups from manual testing of the KB editor.

- **Tabs panel toggle** — adding a tab used to leave both panels visible. The previous `useEffect` raced PM mounting child panel DOMs and applied `display: none` to nothing. Replaced with a per-instance scoped CSS rule (`data-tabs-id` + inline `<style>`) so the toggle is declarative. Mirrored `id` onto the outer `ReactNodeViewRenderer` wrapper via `attrs` so the rule reaches the wrapper that holds the layout box.
- **Paste handler** — routed on the enclosing block's `blockType`. Code blocks now force-insert `text/plain` so PM never parses `<pre><code>…</code></pre>` and lifts out of the block. Heading / callout / quote / list-items opt out of markdown auto-format so the caret stays inside the current block. Added GFM pipe-table heuristics (strict separator + loose `|…|` fallback) so tables actually round-trip into a real table block.
- **Code block placeholder** — was rendered as an absolute child of `.blockContentWrapper--codeBlock` and landed on top of the language picker. Now wrapped in a relative `.codeBlockBody` anchor with a `.placeholder.placeholderInCode` two-class selector for specificity.
- **Code block keys** — `Mod-A` now selects only the code content (mirrors the `panel` shortcut). `ArrowDown` on the last visual line steps out of the block, creating a new block when at the doc end.
- **Slash → Table** — after `insertContent(table)` PM left the caret in the last cell. Now walks forward to the first cell and places the cursor inside its empty block.

## Test plan

- [ ] Insert a Tabs block — only the active panel body shows; Add tab focuses the new tab; switch tabs hides the other panel.
- [ ] Paste a markdown code fence and a raw `const Doc = …` snippet into an empty code block — both land verbatim, code block stays intact.
- [ ] Paste markdown into a callout / heading / list item — caret stays inside, no markdown auto-format breaks the block.
- [ ] Paste a GFM pipe table (with header + separator) — converts to a table block.
- [ ] Empty code block shows placeholder inside the code body, not on top of the language picker.
- [ ] In code block: `Cmd+A` selects only code content; `ArrowDown` on the last line exits.
- [ ] `/table` from the slash menu — caret blinks in the top-left cell.