### PR TITLE
feat(homepage): kb surfaces carousel on data-model page

### DIFF
--- a/apps/homepage/src/app/globals.css
+++ b/apps/homepage/src/app/globals.css
@@ -288,6 +288,43 @@
       transform: translateY(-2px);
     }
   }
+
+  @keyframes breathe {
+    0%,
+    100% {
+      transform: scale(1);
+    }
+    50% {
+      transform: scale(1.06);
+    }
+  }
+
+  @keyframes scroll-code {
+    0% {
+      transform: translateY(0);
+    }
+    100% {
+      transform: translateY(-50%);
+    }
+  }
+
+  @keyframes spin-slow {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes visor-wipe {
+    0% {
+      mask-position: 200% 0;
+    }
+    100% {
+      mask-position: -250% 0;
+    }
+  }
 }
 
 @layer base {

--- a/apps/homepage/src/app/platform/data-model/_components/kb-surface-card.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/kb-surface-card.tsx
@@ -1,0 +1,50 @@
+// apps/homepage/src/app/platform/data-model/_components/kb-surface-card.tsx
+
+import type { LucideIcon } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { cn } from '~/lib/utils'
+
+type KbSurfaceCardProps = {
+  title: string
+  icon: LucideIcon
+  bgClass: string
+  accentClass?: string
+  tone?: 'light' | 'dark'
+  children: ReactNode
+}
+
+export function KbSurfaceCard({
+  title,
+  icon: Icon,
+  bgClass,
+  accentClass,
+  tone = 'light',
+  children,
+}: KbSurfaceCardProps) {
+  const isDark = tone === 'dark'
+  return (
+    <div
+      className={cn(
+        'group/card relative h-[420px] w-[280px] shrink-0 snap-start overflow-hidden rounded-3xl',
+        'md:h-[480px] md:w-[320px]',
+        'md:[&:nth-child(2n)]:-mt-[60px]',
+        bgClass
+      )}>
+      <div className='absolute inset-0'>{children}</div>
+
+      <div className='absolute left-8 top-8 flex items-center gap-2'>
+        <span
+          className={cn(
+            'grid size-7 place-items-center rounded-md',
+            isDark ? 'bg-white/10 text-white' : 'bg-foreground/10 text-foreground/80',
+            accentClass
+          )}>
+          <Icon className='size-4' />
+        </span>
+        <span className={cn('text-sm font-medium', isDark ? 'text-white' : 'text-foreground')}>
+          {title}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/kb-surfaces-carousel.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/kb-surfaces-carousel.tsx
@@ -1,0 +1,78 @@
+// apps/homepage/src/app/platform/data-model/_components/kb-surfaces-carousel.tsx
+
+import { Bot, Globe, type LucideIcon, Mail, MessageSquare, Sparkles } from 'lucide-react'
+import type { ComponentType } from 'react'
+import { KbSurfaceCard } from './kb-surface-card'
+import { AutoReplyHero } from './surfaces/auto-reply-hero'
+import { KopilotHero } from './surfaces/kopilot-hero'
+import { PortalHero } from './surfaces/portal-hero'
+import { SerpHero } from './surfaces/serp-hero'
+import { WidgetHero } from './surfaces/widget-hero'
+
+type Surface = {
+  title: string
+  icon: LucideIcon
+  bgClass: string
+  accentClass?: string
+  tone?: 'light' | 'dark'
+  Hero: ComponentType
+}
+
+const surfaces: Surface[] = [
+  {
+    title: 'Self-service portal',
+    icon: Globe,
+    bgClass: 'bg-[#FDEDE7] dark:bg-[#2A1E1A]',
+    accentClass: 'bg-orange-400/20 text-orange-700 dark:text-orange-300',
+    Hero: PortalHero,
+  },
+  {
+    title: 'Help widget',
+    icon: MessageSquare,
+    bgClass: 'bg-[#EDF6FD] dark:bg-[#1A2230]',
+    accentClass: 'bg-sky-400/20 text-sky-700 dark:text-sky-300',
+    Hero: WidgetHero,
+  },
+  {
+    title: 'AI auto-reply',
+    icon: Mail,
+    bgClass: 'bg-[#EDFDED] dark:bg-[#1A2A20]',
+    accentClass: 'bg-emerald-400/20 text-emerald-700 dark:text-emerald-300',
+    Hero: AutoReplyHero,
+  },
+  {
+    title: 'Kopilot grounding',
+    icon: Bot,
+    bgClass: 'bg-[#EFEDFD] dark:bg-[#221E2E]',
+    accentClass: 'bg-violet-400/20 text-violet-700 dark:text-violet-300',
+    Hero: KopilotHero,
+  },
+  {
+    title: 'Public search',
+    icon: Sparkles,
+    bgClass:
+      'bg-gradient-to-br from-zinc-800 via-zinc-900 to-black dark:from-zinc-900 dark:via-zinc-950 dark:to-black',
+    tone: 'dark',
+    Hero: SerpHero,
+  },
+]
+
+export function KbSurfacesCarousel() {
+  return (
+    <div>
+      <div className='flex snap-x snap-mandatory items-start gap-4 overflow-x-auto scroll-smooth scroll-pl-6 px-6 py-[60px] md:scroll-pl-12 md:px-12 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
+        {surfaces.map((s) => (
+          <KbSurfaceCard
+            key={s.title}
+            title={s.title}
+            icon={s.icon}
+            bgClass={s.bgClass}
+            accentClass={s.accentClass}
+            tone={s.tone}>
+            <s.Hero />
+          </KbSurfaceCard>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/knowledge-base-section.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/knowledge-base-section.tsx
@@ -1,39 +1,15 @@
 // apps/homepage/src/app/platform/data-model/_components/knowledge-base-section.tsx
 
 import { CalendarClock, FileText, Link2, Rows3, SquareDashedKanban, Table } from 'lucide-react'
-import Image from 'next/image'
+import { KbSurfacesCarousel } from './kb-surfaces-carousel'
 
-const richBlocks = [
-  {
-    name: 'Tables',
-    description: 'Structured data with sortable rows and headers.',
-    icon: Table,
-  },
-  {
-    name: 'Tabs & accordion',
-    description: 'Group related content without scrolling.',
-    icon: Rows3,
-  },
-  {
-    name: 'Cards',
-    description: 'Visual layouts for grouped articles or topics.',
-    icon: SquareDashedKanban,
-  },
-  {
-    name: 'Internal links',
-    description: 'auxx:// references resolve to the right article.',
-    icon: Link2,
-  },
-  {
-    name: 'Version history',
-    description: 'Preview any earlier draft and restore in one click.',
-    icon: CalendarClock,
-  },
-  {
-    name: 'Markdown round-trip',
-    description: 'Import or export — your KB stays portable.',
-    icon: FileText,
-  },
+const editorBlocks = [
+  { name: 'Tables', icon: Table },
+  { name: 'Tabs & accordion', icon: Rows3 },
+  { name: 'Cards', icon: SquareDashedKanban },
+  { name: 'Internal links', icon: Link2 },
+  { name: 'Version history', icon: CalendarClock },
+  { name: 'Markdown round-trip', icon: FileText },
 ]
 
 export default function KnowledgeBaseSection() {
@@ -59,16 +35,6 @@ export default function KnowledgeBaseSection() {
                 Write articles your way. Publish them everywhere.
               </h2>
 
-              <div className='bg-background ring-foreground/5 overflow-hidden rounded-xl border border-transparent shadow ring-1'>
-                <Image
-                  src='/images/platform/knowledge-base/kb-editor.png'
-                  width={2652}
-                  height={1938}
-                  alt='Knowledge base editor with rich block content'
-                  className='h-full w-full object-cover'
-                />
-              </div>
-
               <div className='grid gap-6 md:grid-cols-2 md:gap-12'>
                 <p className='text-muted-foreground'>
                   Build a fully{' '}
@@ -86,20 +52,26 @@ export default function KnowledgeBaseSection() {
                   hallucinated answers.
                 </p>
               </div>
+            </div>
 
-              <ul className='grid gap-3 sm:grid-cols-2 md:grid-cols-3'>
-                {richBlocks.map((block) => (
-                  <li
-                    key={block.name}
-                    className='border-foreground/5 bg-background flex gap-3 rounded-lg border p-4'>
-                    <block.icon className='text-foreground/70 mt-0.5 size-4 shrink-0' />
-                    <div>
-                      <div className='text-foreground text-sm font-medium'>{block.name}</div>
-                      <p className='text-muted-foreground mt-0.5 text-xs'>{block.description}</p>
-                    </div>
-                  </li>
+            <div className='mt-12 md:mt-16'>
+              <KbSurfacesCarousel />
+            </div>
+
+            <div className='mx-auto mt-10 max-w-4xl px-6 md:mt-12'>
+              <div className='border-foreground/5 flex flex-wrap items-center gap-2 border-t pt-6'>
+                <span className='text-muted-foreground mr-1 text-xs uppercase tracking-wide'>
+                  Editor supports
+                </span>
+                {editorBlocks.map((b) => (
+                  <span
+                    key={b.name}
+                    className='border-foreground/10 text-foreground/80 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs'>
+                    <b.icon className='size-3.5' />
+                    {b.name}
+                  </span>
                 ))}
-              </ul>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/homepage/src/app/platform/data-model/_components/surfaces/auto-reply-hero.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/surfaces/auto-reply-hero.tsx
@@ -1,0 +1,111 @@
+// apps/homepage/src/app/platform/data-model/_components/surfaces/auto-reply-hero.tsx
+
+import { Sparkles } from 'lucide-react'
+
+const articleSnippet = `# Returns policy
+
+You can return any unworn item within 30 days
+of delivery. Items must be unwashed, with all
+tags attached.
+
+## Free shipping
+We cover return shipping for orders over $50.
+Smaller orders pay a flat $5.95 label fee.
+
+## Refunds
+Refunds post to your original payment method
+within 3-5 business days of receiving the item.
+
+# Shipping
+
+Standard ground delivery: 3-5 business days.
+Express: 1-2 days. We ship to all 50 states.
+
+`
+
+export function AutoReplyHero() {
+  return (
+    <>
+      <div className='pointer-events-none absolute inset-x-0 top-0 bottom-[42%] overflow-hidden opacity-30 transition-opacity duration-500 ease-out group-hover/card:opacity-100'>
+        <div className='absolute inset-x-0 top-0 z-10 h-20 bg-gradient-to-b from-[#EDFDED] via-[#EDFDED]/80 to-transparent dark:from-[#1A2A20] dark:via-[#1A2A20]/80' />
+        <div className='absolute inset-x-0 bottom-0 z-10 h-12 bg-gradient-to-t from-[#EDFDED] to-transparent dark:from-[#1A2A20]' />
+        <div className='flex flex-col px-5 pt-12 [animation:scroll-code_25s_linear_infinite_paused] group-hover/card:[animation-play-state:running]'>
+          {[0, 1].map((i) => (
+            <pre
+              key={i}
+              className='m-0 whitespace-pre-wrap break-words pt-12 font-mono text-[11px] leading-[1.6] text-emerald-700/70 dark:text-emerald-300/60'>
+              {articleSnippet}
+              {articleSnippet}
+              {articleSnippet}
+            </pre>
+          ))}
+        </div>
+      </div>
+
+      <div className='absolute inset-x-5 bottom-5 transition-transform duration-500 ease-out group-hover/card:-translate-y-1 group-hover/card:scale-[1.02]'>
+        <div className='ring-foreground/10 bg-background overflow-hidden rounded-2xl shadow-xl ring-1 transition-shadow duration-500 group-hover/card:shadow-2xl'>
+          <div className='border-foreground/10 flex items-center justify-between gap-2 border-b px-3 py-2'>
+            <div className='flex items-center gap-1.5'>
+              <span className='grid size-4 place-items-center rounded bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'>
+                <Sparkles className='size-2.5' />
+              </span>
+              <span className='text-foreground text-[9px] font-semibold'>AI auto-reply</span>
+            </div>
+            <span className='rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[7px] font-medium text-emerald-600 dark:text-emerald-400'>
+              Sent
+            </span>
+          </div>
+
+          <div className='space-y-2 p-3'>
+            <div className='flex items-baseline justify-between'>
+              <span className='text-foreground/50 text-[8px]'>To: sarah@gmail.com</span>
+              <span className='text-foreground/40 text-[7px]'>2:14 PM</span>
+            </div>
+            <div className='text-foreground text-[10px] font-medium leading-tight'>
+              Re: Question about returns
+            </div>
+
+            <div className='space-y-1.5 pt-1'>
+              <p className='text-foreground/80 text-[9px] leading-relaxed'>
+                Hi Sarah — yes, you can return any unworn item within{' '}
+                <span className='border-b-2 border-emerald-400/60 font-medium'>
+                  30 days of delivery
+                </span>{' '}
+                <sup className='text-emerald-600 dark:text-emerald-400 text-[7px] font-bold'>
+                  [1]
+                </sup>
+                .
+              </p>
+              <p className='text-foreground/80 text-[9px] leading-relaxed'>
+                We&apos;ll cover the return shipping for orders over{' '}
+                <span className='border-b-2 border-emerald-400/60 font-medium'>$50</span>
+                <sup className='text-emerald-600 dark:text-emerald-400 text-[7px] font-bold'>
+                  [2]
+                </sup>
+                . Let me know if you want a label.
+              </p>
+            </div>
+
+            <div className='space-y-1 pt-2'>
+              <div className='text-foreground/40 text-[7px] font-medium uppercase tracking-wide'>
+                Sources
+              </div>
+              <div className='border-foreground/10 flex items-center gap-1.5 rounded border bg-foreground/[0.02] px-1.5 py-1'>
+                <span className='text-emerald-600 dark:text-emerald-400 text-[7px] font-bold'>
+                  [1]
+                </span>
+                <span className='text-foreground/70 text-[8px]'>Returns policy</span>
+              </div>
+              <div className='border-foreground/10 flex items-center gap-1.5 rounded border bg-foreground/[0.02] px-1.5 py-1'>
+                <span className='text-emerald-600 dark:text-emerald-400 text-[7px] font-bold'>
+                  [2]
+                </span>
+                <span className='text-foreground/70 text-[8px]'>Shipping & costs</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/surfaces/kopilot-hero.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/surfaces/kopilot-hero.tsx
@@ -1,0 +1,98 @@
+// apps/homepage/src/app/platform/data-model/_components/surfaces/kopilot-hero.tsx
+
+import { BookOpen, Wand2 } from 'lucide-react'
+import { WaveCanvas } from './wave-canvas'
+
+export function KopilotHero() {
+  return (
+    <>
+      <WaveCanvas color='rgb(167, 139, 250)' />
+
+      <div
+        className='pointer-events-none absolute bottom-24 left-1/2 z-[3] size-[120px] -translate-x-1/2 transition-[transform] duration-500 group-hover/card:scale-125 group-hover/card:-translate-y-10'
+        style={{ perspective: '600px' }}>
+        <div className='relative size-full [transform-style:preserve-3d] animate-[spin-slow_10s_linear_infinite]'>
+          {[
+            { transform: 'translateZ(60px)', face: 'front' },
+            { transform: 'rotateY(180deg) translateZ(60px)', face: 'back' },
+            { transform: 'rotateY(90deg) translateZ(60px)', face: 'right' },
+            { transform: 'rotateY(-90deg) translateZ(60px)', face: 'left' },
+            { transform: 'rotateX(90deg) translateZ(60px)', face: 'top' },
+            { transform: 'rotateX(-90deg) translateZ(60px)', face: 'bottom' },
+          ].map((f) => (
+            <div
+              key={f.face}
+              className='absolute inset-0 rounded-lg border border-violet-400/40 bg-gradient-to-br from-violet-300/30 to-violet-500/40 shadow-[inset_0_0_40px_rgba(167,139,250,0.4)] backdrop-blur-sm dark:from-violet-400/20 dark:to-violet-600/30'
+              style={{ transform: f.transform }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className='absolute inset-x-4 bottom-0 top-28'>
+        <div className='ring-foreground/10 bg-background absolute inset-0 overflow-hidden rounded-2xl shadow-xl ring-1'>
+          <div className='border-foreground/10 flex items-center gap-2 border-b px-3 py-1.5'>
+            <div className='flex gap-1'>
+              <span className='size-1.5 rounded-full bg-rose-300' />
+              <span className='size-1.5 rounded-full bg-amber-300' />
+              <span className='size-1.5 rounded-full bg-emerald-300' />
+            </div>
+            <span className='text-foreground/40 text-[7px]'>Ticket #2841</span>
+          </div>
+
+          <div className='flex h-full'>
+            <div className='flex-1 space-y-2 p-3'>
+              <div className='space-y-1'>
+                <div className='h-1 w-1/3 rounded bg-foreground/20' />
+                <div className='h-1 w-2/3 rounded bg-foreground/10' />
+                <div className='h-1 w-1/2 rounded bg-foreground/10' />
+              </div>
+              <div className='border-foreground/10 mt-2 rounded border bg-foreground/[0.02] p-2'>
+                <div className='space-y-1'>
+                  <div className='h-1 w-2/3 rounded bg-foreground/15' />
+                  <div className='h-1 w-3/4 rounded bg-foreground/10' />
+                  <div className='h-1 w-1/2 rounded bg-foreground/10' />
+                </div>
+              </div>
+            </div>
+
+            <div className='border-foreground/10 w-[140px] border-l bg-violet-50/40 p-2 dark:bg-violet-950/20'>
+              <div className='flex items-center gap-1'>
+                <span className='grid size-4 place-items-center rounded bg-violet-500 text-white'>
+                  <Wand2 className='size-2.5' />
+                </span>
+                <span className='text-foreground text-[9px] font-semibold'>Kopilot</span>
+              </div>
+
+              <div className='mt-2 space-y-1.5'>
+                <div className='text-foreground/50 text-[7px] uppercase tracking-wide'>
+                  Suggested reply
+                </div>
+                <div className='ring-foreground/10 bg-background space-y-1 rounded-md p-1.5 ring-1'>
+                  <div className='h-1 w-full rounded bg-foreground/15' />
+                  <div className='h-1 w-3/4 rounded bg-foreground/15' />
+                  <div className='h-1 w-5/6 rounded bg-foreground/10' />
+                </div>
+
+                <div className='text-foreground/50 mt-2 text-[7px] uppercase tracking-wide'>
+                  Grounded in
+                </div>
+                <div className='ring-violet-500/30 bg-violet-500/5 flex translate-x-3 items-start gap-1 rounded p-1.5 opacity-0 ring-1 transition-all duration-500 group-hover/card:translate-x-0 group-hover/card:opacity-100'>
+                  <BookOpen className='text-violet-600 dark:text-violet-400 mt-0.5 size-2.5 shrink-0' />
+                  <div className='min-w-0 flex-1'>
+                    <div className='text-foreground truncate text-[8px] font-medium'>
+                      Returns policy
+                    </div>
+                    <div className='text-foreground/50 truncate text-[7px]'>
+                      30-day window applies…
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/surfaces/pixel-canvas.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/surfaces/pixel-canvas.tsx
@@ -1,0 +1,142 @@
+// apps/homepage/src/app/platform/data-model/_components/surfaces/pixel-canvas.tsx
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+type Props = {
+  color: string
+  gap?: number
+  pixelSize?: number
+}
+
+type Pixel = {
+  x: number
+  y: number
+  size: number
+  maxSize: number
+  delay: number
+  state: 'idle' | 'appear' | 'shimmer' | 'disappear'
+  phase: number
+  startedAt?: number
+}
+
+export function PixelCanvas({ color, gap = 5, pixelSize = 2 }: Props) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current
+    const canvas = canvasRef.current
+    if (!wrapper || !canvas) return
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const dpr = window.devicePixelRatio || 1
+    let pixels: Pixel[] = []
+    let raf = 0
+    let mounted = true
+    const max = pixelSize + gap
+
+    const build = () => {
+      const rect = wrapper.getBoundingClientRect()
+      canvas.width = rect.width * dpr
+      canvas.height = rect.height * dpr
+      canvas.style.width = `${rect.width}px`
+      canvas.style.height = `${rect.height}px`
+      ctx.setTransform(1, 0, 0, 1, 0, 0)
+      ctx.scale(dpr, dpr)
+
+      pixels = []
+      const cx = rect.width / 2
+      const cy = rect.height / 2
+      const maxDist = Math.hypot(cx, cy)
+      for (let y = pixelSize; y < rect.height; y += pixelSize + gap) {
+        for (let x = pixelSize; x < rect.width; x += pixelSize + gap) {
+          const dist = Math.hypot(x - cx, y - cy) / maxDist
+          pixels.push({
+            x,
+            y,
+            size: 0,
+            maxSize: max,
+            delay: dist * 600,
+            state: 'idle',
+            phase: Math.random() * Math.PI * 2,
+          })
+        }
+      }
+    }
+
+    const drawFrame = (now: number) => {
+      if (!mounted) return
+      const rect = wrapper.getBoundingClientRect()
+      ctx.clearRect(0, 0, rect.width, rect.height)
+      let active = false
+      for (const p of pixels) {
+        if (p.state === 'appear') {
+          if (now > p.startedAt! + p.delay) {
+            p.size = Math.min(p.maxSize, p.size + 0.2)
+            if (p.size >= p.maxSize) {
+              p.state = 'shimmer'
+              p.startedAt = now
+            }
+          }
+          active = true
+        } else if (p.state === 'shimmer') {
+          const t = (now - (p.startedAt ?? now)) / 1000
+          p.size = p.maxSize * (0.7 + 0.3 * Math.sin(t * 4 + p.phase))
+          active = true
+        } else if (p.state === 'disappear') {
+          p.size = Math.max(0, p.size - 0.25)
+          if (p.size <= 0) p.state = 'idle'
+          else active = true
+        }
+        if (p.size > 0) {
+          ctx.fillStyle = color
+          ctx.fillRect(p.x - p.size / 2, p.y - p.size / 2, p.size, p.size)
+        }
+      }
+      if (active) raf = requestAnimationFrame(drawFrame)
+      else raf = 0
+    }
+
+    const onEnter = () => {
+      if (reduced) return
+      const now = performance.now()
+      for (const p of pixels) {
+        p.state = 'appear'
+        p.startedAt = now
+      }
+      if (!raf) raf = requestAnimationFrame(drawFrame)
+    }
+    const onLeave = () => {
+      for (const p of pixels) p.state = p.size > 0 ? 'disappear' : 'idle'
+      if (!raf) raf = requestAnimationFrame(drawFrame)
+    }
+
+    build()
+    const ro = new ResizeObserver(build)
+    ro.observe(wrapper)
+    const card = wrapper.closest('.group\\/card') as HTMLElement | null
+    const targetEl = card ?? wrapper
+    targetEl.addEventListener('mouseenter', onEnter)
+    targetEl.addEventListener('mouseleave', onLeave)
+
+    return () => {
+      mounted = false
+      targetEl.removeEventListener('mouseenter', onEnter)
+      targetEl.removeEventListener('mouseleave', onLeave)
+      ro.disconnect()
+      if (raf) cancelAnimationFrame(raf)
+    }
+  }, [color, gap, pixelSize])
+
+  return (
+    <div
+      ref={wrapperRef}
+      className='pointer-events-none absolute inset-0 overflow-hidden [mask-image:radial-gradient(circle,#000_0,#000_40%,transparent_70%)]'>
+      <canvas ref={canvasRef} className='block size-full' />
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/surfaces/portal-hero.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/surfaces/portal-hero.tsx
@@ -1,0 +1,76 @@
+// apps/homepage/src/app/platform/data-model/_components/surfaces/portal-hero.tsx
+
+import { ChevronRight, Search } from 'lucide-react'
+import { RippleCanvas } from './ripple-canvas'
+
+export function PortalHero() {
+  return (
+    <>
+      <RippleCanvas color='rgb(251, 146, 60)' />
+      <div className='absolute inset-x-6 bottom-0 top-32 origin-bottom rotate-[-2deg] transition-transform duration-500 ease-out group-hover/card:translate-x-[-12px] group-hover/card:-rotate-1'>
+        <div className='ring-foreground/10 bg-background absolute inset-x-0 top-0 h-[calc(100%+24px)] overflow-hidden rounded-2xl shadow-xl ring-1'>
+          <div className='border-foreground/10 flex items-center gap-2 border-b px-3 py-2'>
+            <div className='flex gap-1'>
+              <span className='size-2 rounded-full bg-rose-300' />
+              <span className='size-2 rounded-full bg-amber-300' />
+              <span className='size-2 rounded-full bg-emerald-300' />
+            </div>
+            <div className='border-foreground/10 bg-foreground/5 mx-auto flex w-2/3 items-center gap-1 rounded border px-2 py-1'>
+              <span className='text-foreground/40 text-[8px]'>help.acme.com</span>
+            </div>
+          </div>
+
+          <div className='flex h-full flex-col px-4 pb-6 pt-3'>
+            <div className='flex items-center gap-1.5'>
+              <div className='size-4 rounded bg-orange-400' />
+              <span className='text-foreground text-[10px] font-semibold'>Acme Help</span>
+            </div>
+
+            <div className='border-foreground/10 mt-3 flex items-center gap-1.5 rounded-md border bg-foreground/[0.03] px-2 py-1.5'>
+              <Search className='text-foreground/40 size-3' />
+              <span className='text-foreground/40 text-[9px]'>Search articles…</span>
+            </div>
+
+            <div className='mt-3 space-y-1'>
+              {[
+                { label: 'Getting started', count: 12, open: true },
+                { label: 'Returns & refunds', count: 8 },
+                { label: 'Shipping', count: 6 },
+                { label: 'Account', count: 4 },
+              ].map((cat) => (
+                <div key={cat.label}>
+                  <div className='flex items-center justify-between rounded px-1.5 py-1'>
+                    <div className='flex items-center gap-1'>
+                      <ChevronRight
+                        className={`text-foreground/40 size-2.5 transition-transform ${
+                          cat.open ? 'rotate-90' : ''
+                        }`}
+                      />
+                      <span className='text-foreground/80 text-[9px] font-medium'>{cat.label}</span>
+                    </div>
+                    <span className='text-foreground/40 text-[8px]'>{cat.count}</span>
+                  </div>
+                  {cat.open && (
+                    <div className='ml-3.5 space-y-0.5'>
+                      {[
+                        'How to set up your store',
+                        'Connecting your domain',
+                        'First-time guide',
+                      ].map((a) => (
+                        <div
+                          key={a}
+                          className='text-foreground/60 truncate rounded px-1.5 py-0.5 text-[9px] hover:bg-foreground/5'>
+                          {a}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/surfaces/ripple-canvas.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/surfaces/ripple-canvas.tsx
@@ -1,0 +1,121 @@
+// apps/homepage/src/app/platform/data-model/_components/surfaces/ripple-canvas.tsx
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+type Props = {
+  color: string
+  count?: number
+}
+
+export function RippleCanvas({ color, count = 5 }: Props) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current
+    const canvas = canvasRef.current
+    if (!wrapper || !canvas) return
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const dpr = window.devicePixelRatio || 1
+    let intensity = 0
+    let target = 0
+    let raf = 0
+    let start = performance.now()
+    let mounted = true
+
+    const resize = () => {
+      const rect = wrapper.getBoundingClientRect()
+      canvas.width = rect.width * dpr
+      canvas.height = rect.height * dpr
+      canvas.style.width = `${rect.width}px`
+      canvas.style.height = `${rect.height}px`
+      ctx.scale(dpr, dpr)
+    }
+
+    const draw = (now: number) => {
+      if (!mounted) return
+      intensity += (target - intensity) * 0.08
+      if (intensity < 0.01 && target === 0) {
+        ctx.clearRect(0, 0, canvas.width, canvas.height)
+        raf = 0
+        return
+      }
+      const w = canvas.width / dpr
+      const h = canvas.height / dpr
+      ctx.clearRect(0, 0, w, h)
+      const cx = w / 2
+      const cy = h / 2
+      const max = Math.max(w, h) * 0.55
+      const t = (now - start) / 1000
+      ctx.lineWidth = 1.25
+
+      for (let i = 0; i < count; i++) {
+        const offset = (t * 0.35 + i / count) % 1
+        const radius = 10 + offset * (max - 10)
+        const ease = Math.min(4 * offset, 1) * (1 - offset * offset)
+        const alpha = ease * intensity
+        if (alpha <= 0) continue
+
+        ctx.strokeStyle = color.replace('rgb(', 'rgba(').replace(')', `, ${alpha.toFixed(3)})`)
+        ctx.beginPath()
+        const steps = 60
+        for (let s = 0; s <= steps; s++) {
+          const a = (s / steps) * Math.PI * 2
+          const wob =
+            Math.sin(a * 3 + t * 0.8 + i) * 1.5 +
+            Math.sin(a * 5 - t * 1.2 + i * 0.7) * 1 +
+            Math.sin(a * 2 + t * 0.4) * 0.6
+          const r = radius + wob
+          const x = cx + Math.cos(a) * r
+          const y = cy + Math.sin(a) * r
+          if (s === 0) ctx.moveTo(x, y)
+          else ctx.lineTo(x, y)
+        }
+        ctx.stroke()
+      }
+      raf = requestAnimationFrame(draw)
+    }
+
+    const onEnter = () => {
+      if (reduced) return
+      target = 1
+      if (!raf) {
+        start = performance.now()
+        raf = requestAnimationFrame(draw)
+      }
+    }
+    const onLeave = () => {
+      target = 0
+      if (!raf) raf = requestAnimationFrame(draw)
+    }
+
+    const card = wrapper.closest('.group\\/card') as HTMLElement | null
+    const target_ = card ?? wrapper
+    target_.addEventListener('mouseenter', onEnter)
+    target_.addEventListener('mouseleave', onLeave)
+    resize()
+    const ro = new ResizeObserver(resize)
+    ro.observe(wrapper)
+
+    return () => {
+      mounted = false
+      target_.removeEventListener('mouseenter', onEnter)
+      target_.removeEventListener('mouseleave', onLeave)
+      ro.disconnect()
+      if (raf) cancelAnimationFrame(raf)
+    }
+  }, [color, count])
+
+  return (
+    <div
+      ref={wrapperRef}
+      className='pointer-events-none absolute inset-0 overflow-hidden [mask-image:radial-gradient(circle,#000_0,#000_40%,transparent_70%)]'>
+      <canvas ref={canvasRef} className='block size-full' />
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/surfaces/serp-hero.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/surfaces/serp-hero.tsx
@@ -1,0 +1,100 @@
+// apps/homepage/src/app/platform/data-model/_components/surfaces/serp-hero.tsx
+
+import { Search } from 'lucide-react'
+
+const grainSvg =
+  "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.5'/></svg>"
+
+function SerpMock() {
+  return (
+    <div className='ring-foreground/10 bg-background/95 absolute inset-0 overflow-hidden rounded-2xl shadow-xl ring-1 backdrop-blur'>
+      <div className='border-foreground/10 flex items-center gap-2 border-b px-3 py-2'>
+        <div className='flex gap-1'>
+          <span className='size-2 rounded-full bg-rose-300' />
+          <span className='size-2 rounded-full bg-amber-300' />
+          <span className='size-2 rounded-full bg-emerald-300' />
+        </div>
+        <div className='border-foreground/10 ml-auto flex w-2/3 items-center gap-1.5 rounded-full border bg-foreground/[0.03] px-2 py-1'>
+          <Search className='text-foreground/40 size-2.5' />
+          <span className='text-foreground/40 truncate text-[7px]'>
+            acme returns policy 30 days
+          </span>
+        </div>
+      </div>
+
+      <div className='space-y-3 p-3'>
+        <div className='flex gap-2'>
+          <span className='text-foreground/40 text-[8px]'>All</span>
+          <span className='text-foreground/40 text-[8px]'>Images</span>
+          <span className='text-foreground/40 text-[8px]'>Shopping</span>
+          <span className='text-foreground/70 border-b-2 border-blue-500 pb-1 text-[8px] font-medium'>
+            News
+          </span>
+        </div>
+
+        <div className='ring-foreground/10 space-y-1 rounded-lg p-1.5 ring-1'>
+          <div className='flex items-center gap-1'>
+            <span className='size-3 rounded-full bg-orange-400' />
+            <span className='text-foreground/60 text-[7px]'>help.acme.com › returns</span>
+          </div>
+          <div className='text-blue-600 dark:text-blue-400 text-[10px] font-medium underline-offset-2 group-hover/card:underline'>
+            Returns Policy — Acme Help Center
+          </div>
+          <p className='text-foreground/70 text-[8px] leading-snug'>
+            You can return any unworn item within{' '}
+            <span className='font-semibold'>30 days of delivery</span>. Free return shipping for
+            orders over $50…
+          </p>
+
+          <div className='border-foreground/10 mt-1 grid grid-cols-3 gap-1 border-t pt-1.5'>
+            <div className='space-y-0.5'>
+              <div className='text-foreground/40 text-[6px] uppercase'>Window</div>
+              <div className='text-foreground text-[7px] font-medium'>30 days</div>
+            </div>
+            <div className='space-y-0.5'>
+              <div className='text-foreground/40 text-[6px] uppercase'>Free over</div>
+              <div className='text-foreground text-[7px] font-medium'>$50</div>
+            </div>
+            <div className='space-y-0.5'>
+              <div className='text-foreground/40 text-[6px] uppercase'>Refund</div>
+              <div className='text-foreground text-[7px] font-medium'>3-5 days</div>
+            </div>
+          </div>
+        </div>
+
+        <div className='space-y-1'>
+          <div className='text-foreground/60 text-[7px]'>shop.acme.com › faq</div>
+          <div className='text-blue-600/70 dark:text-blue-400/70 text-[9px]'>
+            Frequently asked questions
+          </div>
+          <div className='h-1 w-full rounded bg-foreground/5' />
+          <div className='h-1 w-2/3 rounded bg-foreground/5' />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function SerpHero() {
+  return (
+    <>
+      <div className='absolute inset-0 bg-[radial-gradient(circle_at_30%_120%,rgba(157,127,255,0.4),transparent_60%),radial-gradient(circle_at_80%_-20%,rgba(255,107,157,0.35),transparent_50%)]' />
+      <div
+        aria-hidden
+        className='absolute inset-0 opacity-[0.08]'
+        style={{
+          backgroundImage: `url("${grainSvg}")`,
+          backgroundSize: '160px 160px',
+        }}
+      />
+
+      <div className='absolute inset-x-4 bottom-0 top-28' style={{ perspective: '800px' }}>
+        <div className='absolute inset-0 transition-transform duration-500 ease-out [transform-style:preserve-3d] group-hover/card:[transform:scale(1.05)_translateZ(40px)]'>
+          <SerpMock />
+
+          <div className='pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-r from-transparent via-white/40 to-transparent opacity-0 [mask-image:linear-gradient(90deg,transparent_0%,#000_45%,#000_55%,transparent_100%)] [mask-position:-250%_0] [mask-size:80%_100%] [mask-repeat:no-repeat] group-hover/card:opacity-100 group-hover/card:[animation:visor-wipe_0.9s_ease_forwards]' />
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/surfaces/wave-canvas.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/surfaces/wave-canvas.tsx
@@ -1,0 +1,114 @@
+// apps/homepage/src/app/platform/data-model/_components/surfaces/wave-canvas.tsx
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+type Props = {
+  color: string
+  bands?: number
+}
+
+export function WaveCanvas({ color, bands = 6 }: Props) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current
+    const canvas = canvasRef.current
+    if (!wrapper || !canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const dpr = window.devicePixelRatio || 1
+    let intensity = 0
+    let target = 0
+    let raf = 0
+    let start = performance.now()
+    let mounted = true
+
+    const resize = () => {
+      const rect = wrapper.getBoundingClientRect()
+      canvas.width = rect.width * dpr
+      canvas.height = rect.height * dpr
+      canvas.style.width = `${rect.width}px`
+      canvas.style.height = `${rect.height}px`
+      ctx.setTransform(1, 0, 0, 1, 0, 0)
+      ctx.scale(dpr, dpr)
+    }
+
+    const noise = (x: number, t: number, seed: number) =>
+      Math.sin(x * 0.018 + t * 0.6 + seed) * 0.5 +
+      Math.sin(x * 0.034 - t * 0.4 + seed * 1.7) * 0.3 +
+      Math.sin(x * 0.07 + t * 0.9 + seed * 2.3) * 0.2
+
+    const draw = (now: number) => {
+      if (!mounted) return
+      intensity += (target - intensity) * 0.08
+      if (intensity < 0.01 && target === 0) {
+        const w = canvas.width / dpr
+        const h = canvas.height / dpr
+        ctx.clearRect(0, 0, w, h)
+        raf = 0
+        return
+      }
+      const w = canvas.width / dpr
+      const h = canvas.height / dpr
+      ctx.clearRect(0, 0, w, h)
+      const t = (now - start) / 1000
+      ctx.lineWidth = 1.25
+
+      for (let i = 0; i < bands; i++) {
+        const baseY = (h / (bands + 1)) * (i + 1)
+        const alpha = (0.4 + 0.6 * (i / bands)) * intensity
+        ctx.strokeStyle = color.replace('rgb(', 'rgba(').replace(')', `, ${alpha.toFixed(3)})`)
+        ctx.beginPath()
+        const step = 6
+        for (let x = 0; x <= w; x += step) {
+          const y = baseY + noise(x, t, i) * 22
+          if (x === 0) ctx.moveTo(x, y)
+          else ctx.lineTo(x, y)
+        }
+        ctx.stroke()
+      }
+      raf = requestAnimationFrame(draw)
+    }
+
+    const onEnter = () => {
+      if (reduced) return
+      target = 1
+      if (!raf) {
+        start = performance.now()
+        raf = requestAnimationFrame(draw)
+      }
+    }
+    const onLeave = () => {
+      target = 0
+      if (!raf) raf = requestAnimationFrame(draw)
+    }
+
+    resize()
+    const ro = new ResizeObserver(resize)
+    ro.observe(wrapper)
+    const card = wrapper.closest('.group\\/card') as HTMLElement | null
+    const targetEl = card ?? wrapper
+    targetEl.addEventListener('mouseenter', onEnter)
+    targetEl.addEventListener('mouseleave', onLeave)
+
+    return () => {
+      mounted = false
+      targetEl.removeEventListener('mouseenter', onEnter)
+      targetEl.removeEventListener('mouseleave', onLeave)
+      ro.disconnect()
+      if (raf) cancelAnimationFrame(raf)
+    }
+  }, [color, bands])
+
+  return (
+    <div
+      ref={wrapperRef}
+      className='pointer-events-none absolute inset-0 overflow-hidden [mask-image:radial-gradient(circle,#000_0,#000_40%,transparent_70%)]'>
+      <canvas ref={canvasRef} className='block size-full' />
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/data-model/_components/surfaces/widget-hero.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/surfaces/widget-hero.tsx
@@ -1,0 +1,66 @@
+// apps/homepage/src/app/platform/data-model/_components/surfaces/widget-hero.tsx
+
+import { MessageCircle } from 'lucide-react'
+import { PixelCanvas } from './pixel-canvas'
+
+export function WidgetHero() {
+  return (
+    <>
+      <PixelCanvas color='rgba(56, 189, 248, 0.7)' />
+      <div className='absolute inset-x-4 bottom-0 top-28'>
+        <div className='ring-foreground/10 bg-background absolute inset-0 overflow-hidden rounded-2xl shadow-xl ring-1'>
+          <div className='border-foreground/10 flex items-center gap-2 border-b px-3 py-1.5'>
+            <div className='flex gap-1'>
+              <span className='size-1.5 rounded-full bg-rose-300' />
+              <span className='size-1.5 rounded-full bg-amber-300' />
+              <span className='size-1.5 rounded-full bg-emerald-300' />
+            </div>
+          </div>
+
+          <div className='relative h-full bg-gradient-to-br from-sky-50 to-white p-3 dark:from-sky-950/30 dark:to-background'>
+            <div className='flex items-center justify-between'>
+              <span className='text-foreground text-[10px] font-bold'>STORE</span>
+              <div className='flex gap-2'>
+                <span className='text-foreground/60 text-[8px]'>Shop</span>
+                <span className='text-foreground/60 text-[8px]'>About</span>
+              </div>
+            </div>
+
+            <div className='mt-3 grid grid-cols-2 gap-2'>
+              <div className='border-foreground/10 aspect-square rounded-md border bg-foreground/[0.03]' />
+              <div className='space-y-1 pt-1'>
+                <div className='h-1.5 w-3/4 rounded bg-foreground/20' />
+                <div className='h-1.5 w-1/2 rounded bg-foreground/10' />
+                <div className='h-2 w-1/3 rounded bg-foreground/30' />
+                <div className='mt-2 h-3 rounded bg-foreground' />
+              </div>
+            </div>
+
+            <div className='absolute bottom-3 right-3 w-[140px]'>
+              <div className='ring-foreground/10 bg-background origin-bottom-right -translate-y-2 scale-95 overflow-hidden rounded-xl opacity-0 shadow-lg ring-1 transition-all duration-500 ease-out group-hover/card:translate-y-0 group-hover/card:scale-100 group-hover/card:opacity-100'>
+                <div className='bg-sky-500 px-2 py-1.5 text-white'>
+                  <div className='flex items-center gap-1'>
+                    <MessageCircle className='size-2.5' />
+                    <span className='text-[8px] font-semibold'>Acme Help</span>
+                  </div>
+                </div>
+                <div className='space-y-1 p-2'>
+                  <div className='text-foreground/60 text-[7px]'>Suggested:</div>
+                  <div className='border-foreground/10 rounded border px-1.5 py-1'>
+                    <span className='text-foreground/80 text-[8px]'>Return policy</span>
+                  </div>
+                  <div className='border-foreground/10 rounded border px-1.5 py-1'>
+                    <span className='text-foreground/80 text-[8px]'>Shipping times</span>
+                  </div>
+                </div>
+              </div>
+              <div className='ml-auto mt-1 grid size-7 origin-center animate-[breathe_4s_ease-in-out_infinite] place-items-center rounded-full bg-sky-500 text-white shadow-md transition-transform duration-500 group-hover/card:scale-125'>
+                <MessageCircle className='size-3.5' />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- Replace the static KB editor screenshot in `knowledge-base-section` with a rotating carousel of animated surface cards.
- Adds 8 surface mocks (`kopilot-hero`, `auto-reply-hero`, `portal-hero`, `widget-hero`, `serp-hero`, plus `pixel-canvas`, `ripple-canvas`, `wave-canvas` backdrops) and a shared `kb-surface-card` shell.
- Demotes the rich-block list to a single chip row under the carousel; adds `breathe`, `scroll-code`, `spin-slow`, `visor-wipe` keyframes to homepage `globals.css`.

## Test plan
- [ ] `/platform/data-model` renders carousel; cards rotate and animations play smoothly.
- [ ] Editor-supports chip row reads correctly under the carousel.
- [ ] Mobile breakpoint: carousel + chips wrap without overflow.