### PR TITLE
feat(kb): nested callout frame, plaintext paste, mod-a scoping

### DIFF
--- a/apps/web/src/components/editor/extensions/table/table-cell.ts
+++ b/apps/web/src/components/editor/extensions/table/table-cell.ts
@@ -1,5 +1,5 @@
 import { mergeAttributes, Node } from '@tiptap/core'
-import { TextSelection } from '@tiptap/pm/state'
+import { selectAncestorContent } from '../../keymap-helpers'
 
 export interface TableCellOptions {
   /**
@@ -59,20 +59,11 @@ export const TableCell = Node.create<TableCellOptions>({
   // Mirrors the same fix on `panel-node.ts`.
   addKeyboardShortcuts() {
     return {
-      'Mod-a': ({ editor }) => {
-        const { $from } = editor.state.selection
-        for (let depth = $from.depth; depth >= 0; depth--) {
-          const node = $from.node(depth)
-          if (node.type.name !== 'tableCell' && node.type.name !== 'tableHeader') continue
-          const cellStart = $from.before(depth) + 1
-          const cellEnd = cellStart + node.content.size
-          editor.view.dispatch(
-            editor.state.tr.setSelection(TextSelection.create(editor.state.doc, cellStart, cellEnd))
-          )
-          return true
-        }
-        return false
-      },
+      'Mod-a': ({ editor }) =>
+        selectAncestorContent(
+          editor,
+          (n) => n.type.name === 'tableCell' || n.type.name === 'tableHeader'
+        ),
     }
   },
 })

--- a/apps/web/src/components/editor/extensions/table/table-header.ts
+++ b/apps/web/src/components/editor/extensions/table/table-header.ts
@@ -1,5 +1,5 @@
 import { mergeAttributes, Node } from '@tiptap/core'
-import { TextSelection } from '@tiptap/pm/state'
+import { selectAncestorContent } from '../../keymap-helpers'
 
 export interface TableHeaderOptions {
   /**
@@ -64,20 +64,11 @@ export const TableHeader = Node.create<TableHeaderOptions>({
   // Mod-A inside a header cell selects the cell's content range, mirrors TableCell.
   addKeyboardShortcuts() {
     return {
-      'Mod-a': ({ editor }) => {
-        const { $from } = editor.state.selection
-        for (let depth = $from.depth; depth >= 0; depth--) {
-          const node = $from.node(depth)
-          if (node.type.name !== 'tableCell' && node.type.name !== 'tableHeader') continue
-          const cellStart = $from.before(depth) + 1
-          const cellEnd = cellStart + node.content.size
-          editor.view.dispatch(
-            editor.state.tr.setSelection(TextSelection.create(editor.state.doc, cellStart, cellEnd))
-          )
-          return true
-        }
-        return false
-      },
+      'Mod-a': ({ editor }) =>
+        selectAncestorContent(
+          editor,
+          (n) => n.type.name === 'tableCell' || n.type.name === 'tableHeader'
+        ),
     }
   },
 })

--- a/apps/web/src/components/editor/kb-article/block-node-view.module.css
+++ b/apps/web/src/components/editor/kb-article/block-node-view.module.css
@@ -568,14 +568,40 @@
   margin-bottom: 0.5rem;
 }
 
+/* Outer frame — thin border all around + darker variant tint, matching
+   tabs/accordion/codeBlock. Inner card carries the lighter tint. Both
+   bgs are mixed with `--color-background` (opaque) so the inner doesn't
+   composite on top of the outer's transparent tint and appear darker. */
 .blockContentWrapper--callout {
+  width: 100%;
+  flex-direction: column;
+  align-items: stretch;
+  background: color-mix(
+    in srgb,
+    var(--callout-accent, var(--color-primary)) 18%,
+    var(--color-background)
+  );
+  border: 1px solid color-mix(in srgb, var(--callout-accent, var(--color-primary)) 40%, transparent);
+  border-radius: 0.625rem;
+  padding: 0.125rem;
+  gap: 0;
+}
+
+.calloutBody {
+  position: relative;
+  display: flex;
+  flex-direction: row;
   align-items: flex-start;
+  gap: 0.625rem;
+  background: color-mix(
+    in srgb,
+    var(--callout-accent, var(--color-primary)) 7%,
+    var(--color-background)
+  );
+  border: 1px solid var(--color-border);
   border-radius: 0.5rem;
-  border-left: 3px solid var(--callout-accent, var(--color-primary));
-  background: var(--callout-bg, var(--color-muted));
   padding: 0.625rem 0.875rem;
   padding-right: 2.5rem;
-  gap: 0.625rem;
 }
 
 .callout--info .blockContentWrapper--callout {

--- a/apps/web/src/components/editor/kb-article/block-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/block-node-view.tsx
@@ -303,12 +303,6 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
 
           {blockType === 'quote' && <div className={styles.quoteBar} contentEditable={false} />}
 
-          {isCallout && (
-            <span className={styles.calloutIcon} contentEditable={false}>
-              <CalloutIcon variant={calloutVariantValue} size={16} />
-            </span>
-          )}
-
           {isDivider ? (
             <>
               <div
@@ -436,32 +430,36 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
                 )}
               </div>
             </>
+          ) : isCallout ? (
+            <div className={styles.calloutBody}>
+              <span className={styles.calloutIcon} contentEditable={false}>
+                <CalloutIcon variant={calloutVariantValue} size={16} />
+              </span>
+              <NodeViewContent className={contentClasses} />
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type='button'
+                    className={styles.calloutVariantPicker}
+                    contentEditable={false}
+                    aria-label='Change callout variant'>
+                    <CalloutIcon variant={calloutVariantValue} size={14} />
+                    <ChevronDown size={12} />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end'>
+                  {CALLOUT_VARIANTS.map((variant) => (
+                    <DropdownMenuItem
+                      key={variant}
+                      onSelect={() => updateAttributes({ calloutVariant: variant })}>
+                      <CalloutIcon variant={variant} size={14} /> {CALLOUT_LABELS[variant]}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           ) : (
             <NodeViewContent className={contentClasses} />
-          )}
-
-          {isCallout && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type='button'
-                  className={styles.calloutVariantPicker}
-                  contentEditable={false}
-                  aria-label='Change callout variant'>
-                  <CalloutIcon variant={calloutVariantValue} size={14} />
-                  <ChevronDown size={12} />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align='end'>
-                {CALLOUT_VARIANTS.map((variant) => (
-                  <DropdownMenuItem
-                    key={variant}
-                    onSelect={() => updateAttributes({ calloutVariant: variant })}>
-                    <CalloutIcon variant={variant} size={14} /> {CALLOUT_LABELS[variant]}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
           )}
 
           {isImage && (

--- a/apps/web/src/components/editor/kb-article/block-node.ts
+++ b/apps/web/src/components/editor/kb-article/block-node.ts
@@ -1,8 +1,9 @@
 // apps/web/src/components/editor/kb-article/block-node.ts
 
-import { mergeAttributes, Node } from '@tiptap/core'
-import { TextSelection } from '@tiptap/pm/state'
+import { type Editor, mergeAttributes, Node } from '@tiptap/core'
+import type { ResolvedPos } from '@tiptap/pm/model'
 import { ReactNodeViewRenderer } from '@tiptap/react'
+import { selectAncestorContent } from '../keymap-helpers'
 import { blockDragPlugin } from './block-drag-plugin'
 import { BlockNodeView } from './block-node-view'
 
@@ -21,6 +22,33 @@ export type BlockType =
   | 'cards'
 
 const LIST_TYPES: BlockType[] = ['bulletListItem', 'numberedListItem', 'todoListItem']
+
+const findBlockDepth = ($from: ResolvedPos): number => {
+  for (let depth = $from.depth; depth >= 0; depth--) {
+    if ($from.node(depth).type.name === 'block') return depth
+  }
+  return -1
+}
+
+// Step out the bottom of the `block` at `depth`: focus the next block,
+// or append a new empty text block first if this is the last in doc.
+const escapeBlockDownward = (editor: Editor, depth: number): boolean => {
+  const { $from } = editor.state.selection
+  const node = $from.node(depth)
+  const blockEnd = $from.before(depth) + node.nodeSize
+  const isLastInDoc = blockEnd >= editor.state.doc.content.size
+  if (isLastInDoc) {
+    return editor
+      .chain()
+      .insertContentAt(blockEnd, { type: 'block' })
+      .focus(blockEnd + 1)
+      .run()
+  }
+  return editor
+    .chain()
+    .focus(blockEnd + 1)
+    .run()
+}
 
 export const Block = Node.create({
   name: 'block',
@@ -160,26 +188,16 @@ export const Block = Node.create({
       typeof type === 'string' && LIST_TYPES.includes(type as BlockType)
 
     return {
-      // Mod-A inside a code block selects only the code's content (mirrors
-      // the same shortcut on `panel`). Default Mod-A would select the whole
-      // doc, which is rarely what you want when you're typing code.
-      'Mod-a': ({ editor }) => {
-        const { $from } = editor.state.selection
-        for (let depth = $from.depth; depth >= 0; depth--) {
-          const node = $from.node(depth)
-          if (node.type.name !== 'block') continue
-          if (node.attrs.blockType !== 'codeBlock') return false
-          const blockStart = $from.before(depth) + 1
-          const blockEnd = blockStart + node.content.size
-          editor.view.dispatch(
-            editor.state.tr.setSelection(
-              TextSelection.create(editor.state.doc, blockStart, blockEnd)
-            )
-          )
-          return true
-        }
-        return false
-      },
+      // Mod-A inside a code block or callout selects only that block's
+      // content. Default Mod-A would select the whole doc, which is rarely
+      // what you want when you're typing inside a contained block.
+      'Mod-a': ({ editor }) =>
+        selectAncestorContent(
+          editor,
+          (n) =>
+            n.type.name === 'block' &&
+            (n.attrs.blockType === 'codeBlock' || n.attrs.blockType === 'callout')
+        ),
       Tab: ({ editor }) => {
         const { $from } = editor.state.selection
         for (let depth = $from.depth; depth >= 0; depth--) {
@@ -271,50 +289,36 @@ export const Block = Node.create({
       },
       'Mod-Enter': ({ editor }) => {
         const { $from } = editor.state.selection
-        for (let depth = $from.depth; depth >= 0; depth--) {
-          const node = $from.node(depth)
-          if (node.type.name !== 'block') continue
-          if (node.attrs.blockType !== 'codeBlock') return false
-          const blockEnd = $from.before(depth) + node.nodeSize
-          return editor
-            .chain()
-            .insertContentAt(blockEnd, { type: 'block' })
-            .focus(blockEnd + 1)
-            .run()
-        }
-        return false
+        const depth = findBlockDepth($from)
+        if (depth < 0) return false
+        if ($from.node(depth).attrs.blockType !== 'codeBlock') return false
+        return escapeBlockDownward(editor, depth)
       },
-      // Inside a code block, code lines are inline text separated by literal
-      // `\n`, so PM's default ArrowDown can't escape the inline range and the
-      // caret gets stuck on the last line. If there are no more newlines
-      // after the cursor (i.e. we're already on the visual last line), step
-      // out to the next block — creating one if this is the last block in
-      // the doc. Returning `false` otherwise lets default Down move down a
-      // visual line within the code body.
+      // codeBlock holds multi-line code as a single inline range with literal
+      // `\n`s, so PM's default Down can't escape it. Other block types only
+      // escape at end of doc to avoid inserting stray blocks mid-doc.
       ArrowDown: ({ editor }) => {
         const { $from, empty } = editor.state.selection
         if (!empty) return false
-        for (let depth = $from.depth; depth >= 0; depth--) {
-          const node = $from.node(depth)
-          if (node.type.name !== 'block') continue
-          if (node.attrs.blockType !== 'codeBlock') return false
+
+        const depth = findBlockDepth($from)
+        if (depth < 0) return false
+
+        const node = $from.node(depth)
+
+        if (node.attrs.blockType === 'codeBlock') {
           const remaining = node.textContent.slice($from.parentOffset)
           if (remaining.includes('\n')) return false
-          const blockEnd = $from.before(depth) + node.nodeSize
-          const doc = editor.state.doc
-          if (blockEnd >= doc.content.size) {
-            return editor
-              .chain()
-              .insertContentAt(blockEnd, { type: 'block' })
-              .focus(blockEnd + 1)
-              .run()
-          }
-          return editor
-            .chain()
-            .focus(blockEnd + 1)
-            .run()
+          return escapeBlockDownward(editor, depth)
         }
-        return false
+
+        const blockEnd = $from.before(depth) + node.nodeSize
+        const isLastInDoc = blockEnd >= editor.state.doc.content.size
+        if (!isLastInDoc) return false
+        const isEmpty = node.content.size === 0
+        const atTextEnd = $from.parentOffset === node.content.size
+        if (!isEmpty && !atTextEnd) return false
+        return escapeBlockDownward(editor, depth)
       },
     }
   },

--- a/apps/web/src/components/editor/kb-article/markdown-paste.ts
+++ b/apps/web/src/components/editor/kb-article/markdown-paste.ts
@@ -75,24 +75,20 @@ export const MarkdownPaste = Extension.create({
               }
             }
 
-            // Code block: force-insert text/plain verbatim. PM's default
-            // paste reads text/html (e.g. `<pre><code>…</code></pre>` from
-            // an IDE / website), parses it via the schema, and lifts out of
-            // the codeBlock when the resulting slice doesn't fit `inline*`
-            // — which deletes the codeBlock and leaves plain text behind.
-            if (blockType === 'codeBlock') {
+            // Plaintext-only blocks (codeBlock, heading, callout, list item,
+            // quote): force-insert text/plain verbatim. PM's default paste
+            // reads text/html (e.g. `<pre><code>…</code></pre>` from an IDE,
+            // or `<p>…</p>` from a webpage), parses it via the schema, and
+            // lifts out of the wrapping block when the resulting slice
+            // doesn't fit `inline*` — which deletes the block and leaves
+            // plain text behind. Force-plaintext keeps the caret inside.
+            if (blockType && PLAINTEXT_BLOCK_TYPES.has(blockType)) {
               event.preventDefault()
               view.dispatch(view.state.tr.insertText(text))
               return true
             }
 
             if (!looksLikeMarkdown(text)) return false
-
-            // Other plaintext-only blocks (heading, callout, list item,
-            // quote): opt out of markdown auto-format so the caret stays
-            // inside the current block. PM's default paste handles plain
-            // text fine here and preserves any inline marks from the HTML.
-            if (blockType && PLAINTEXT_BLOCK_TYPES.has(blockType)) return false
 
             event.preventDefault()
             void importAndInsert(editor, text)

--- a/apps/web/src/components/editor/kb-article/panel-node.ts
+++ b/apps/web/src/components/editor/kb-article/panel-node.ts
@@ -1,8 +1,8 @@
 // apps/web/src/components/editor/kb-article/panel-node.ts
 
 import { mergeAttributes, Node } from '@tiptap/core'
-import { TextSelection } from '@tiptap/pm/state'
 import { ReactNodeViewRenderer } from '@tiptap/react'
+import { selectAncestorContent } from '../keymap-helpers'
 import { PanelNodeView } from './panel-node-view'
 
 export const Panel = Node.create({
@@ -17,22 +17,7 @@ export const Panel = Node.create({
       // Mod-A inside a panel selects only the panel's body (Cmd+A would
       // otherwise select the entire doc, including sibling tabs and the
       // surrounding article content).
-      'Mod-a': ({ editor }) => {
-        const { $from } = editor.state.selection
-        for (let depth = $from.depth; depth >= 0; depth--) {
-          const node = $from.node(depth)
-          if (node.type.name !== 'panel') continue
-          const panelStart = $from.before(depth) + 1
-          const panelEnd = panelStart + node.content.size
-          editor.view.dispatch(
-            editor.state.tr.setSelection(
-              TextSelection.create(editor.state.doc, panelStart, panelEnd)
-            )
-          )
-          return true
-        }
-        return false
-      },
+      'Mod-a': ({ editor }) => selectAncestorContent(editor, (n) => n.type.name === 'panel'),
     }
   },
 

--- a/apps/web/src/components/editor/keymap-helpers.ts
+++ b/apps/web/src/components/editor/keymap-helpers.ts
@@ -1,0 +1,29 @@
+// apps/web/src/components/editor/keymap-helpers.ts
+
+import type { Editor } from '@tiptap/core'
+import type { Node as PMNode } from '@tiptap/pm/model'
+import { TextSelection } from '@tiptap/pm/state'
+
+/**
+ * Walk up from the current selection, find the first ancestor matching
+ * `predicate`, and select the range of its content. Used by Mod-A
+ * keymaps on contained blocks (codeBlock, callout, panel, table cell)
+ * so Cmd+A scopes to the inner content instead of the whole doc.
+ */
+export const selectAncestorContent = (
+  editor: Editor,
+  predicate: (node: PMNode) => boolean
+): boolean => {
+  const { $from } = editor.state.selection
+  for (let depth = $from.depth; depth >= 0; depth--) {
+    const node = $from.node(depth)
+    if (!predicate(node)) continue
+    const start = $from.before(depth) + 1
+    const end = start + node.content.size
+    editor.view.dispatch(
+      editor.state.tr.setSelection(TextSelection.create(editor.state.doc, start, end))
+    )
+    return true
+  }
+  return false
+}

--- a/packages/ui/src/components/kb/article/block-renderer.tsx
+++ b/packages/ui/src/components/kb/article/block-renderer.tsx
@@ -93,10 +93,12 @@ export function BlockRenderer({ node, idx, doc, headingIds, resolveAuxxHref }: B
       const variant: CalloutVariant = node.attrs?.calloutVariant ?? 'info'
       return (
         <aside role='note' data-variant={variant} className={styles.callout}>
-          <span className={styles.calloutIcon} aria-hidden='true'>
-            <CalloutIcon variant={variant} />
-          </span>
-          <div className={styles.calloutBody}>{inline}</div>
+          <div className={styles.calloutInner}>
+            <span className={styles.calloutIcon} aria-hidden='true'>
+              <CalloutIcon variant={variant} />
+            </span>
+            <div className={styles.calloutBody}>{inline}</div>
+          </div>
         </aside>
       )
     }

--- a/packages/ui/src/components/kb/article/kb-article-renderer.module.css
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.module.css
@@ -276,16 +276,29 @@
    Callout
    ============================================ */
 
+/* Outer frame — thin border all around + darker variant tint, matching
+   the editor's `.blockContentWrapper--callout`. Inner card carries the
+   lighter tint. Both bgs are mixed with `--kb-bg` (opaque) so the inner
+   doesn't composite on top of the outer and appear darker. */
 .callout {
-  display: flex;
-  gap: 0.75em;
-  align-items: flex-start;
   margin: 1em 0;
-  padding: 0.875em 1em;
-  border-radius: var(--kb-radius);
-  border-left: 3px solid var(--callout-accent, var(--kb-primary));
-  background: var(--callout-bg, var(--kb-tint));
+  padding: 0.125rem;
+  border-radius: 0.625rem;
+  border: 1px solid color-mix(in srgb, var(--callout-accent, var(--kb-primary)) 40%, transparent);
+  background: color-mix(in srgb, var(--callout-accent, var(--kb-primary)) 18%, var(--kb-bg));
+}
+
+.calloutInner {
+  display: flex;
+  gap: 0.625rem;
+  align-items: flex-start;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid var(--kb-border);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--callout-accent, var(--kb-primary)) 7%, var(--kb-bg));
   color: var(--kb-fg);
+  font-size: 0.875rem;
+  line-height: 1.5;
 }
 
 .callout[data-variant='info'] {
@@ -538,7 +551,7 @@
 }
 
 .tabPanel {
-  padding: 0.875rem 1rem;
+  padding: 0.5rem 0.75rem;
 }
 
 .tabPanel[hidden] {


### PR DESCRIPTION
## Summary
- Callouts render as a tinted outer frame around an inner card (editor + public renderer), matching tabs/accordion/codeBlock styling.
- Markdown paste: extend force-plaintext insert to all plaintext-only blocks (heading, callout, list item, quote) so PM's default HTML paste doesn't lift out and delete the wrapping block.
- Extract Mod-A "select ancestor content" into `keymap-helpers.ts`, shared by codeBlock/callout (block-node), panel-node, and table cell/header. Block-node ArrowDown / Mod-Enter / Shift-Enter share an `escapeBlockDownward` helper, and ArrowDown now also escapes the last-in-doc block at end-of-block.

## Test plan
- [ ] Paste plain text into a heading/callout/list item/quote — caret stays inside the block, no lift-out.
- [ ] Paste markdown into a regular paragraph — still imports as formatted blocks.
- [ ] Cmd+A inside codeBlock / callout / panel / table cell selects only that block's content.
- [ ] ArrowDown from end of last block in doc creates a fresh block; Mod-Enter / Shift-Enter from inside codeBlock escapes downward.
- [ ] Callout renders correctly in the editor and on the published renderer (both light/dark).