### PR TITLE
fix(redis): recover dead singleton clients, isolate SSE subscribers

### DIFF
--- a/apps/web/src/app/api/files/upload/[sessionId]/events/route.ts
+++ b/apps/web/src/app/api/files/upload/[sessionId]/events/route.ts
@@ -2,7 +2,7 @@
 
 import { SessionManager } from '@auxx/lib/files/server'
 import { createScopedLogger } from '@auxx/logger'
-import { getSubscriptionClient } from '@auxx/redis'
+import { createDedicatedClient } from '@auxx/redis'
 import type { NextRequest } from 'next/server'
 
 const logger = createScopedLogger('upload-sse')
@@ -42,7 +42,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       // Set up Redis subscriber for session updates
       const setupSubscription = async () => {
         try {
-          const subscriber = await getSubscriptionClient(false)
+          // Per-request dedicated client — cleanup .quit() must not affect any
+          // shared singleton.
+          const subscriber = await createDedicatedClient()
           if (!subscriber) {
             logger.warn('Redis not available for SSE', { sessionId })
             return

--- a/apps/web/src/app/api/workflow/run/[runId]/events/route.ts
+++ b/apps/web/src/app/api/workflow/run/[runId]/events/route.ts
@@ -3,7 +3,7 @@
 import { database as db, schema } from '@auxx/database'
 import { safeJsonStringify } from '@auxx/lib/workflow-engine'
 import { createScopedLogger } from '@auxx/logger'
-import { getRedisClient } from '@auxx/redis'
+import { createDedicatedClient } from '@auxx/redis'
 import { and, asc, eq } from 'drizzle-orm'
 import { headers } from 'next/headers'
 import type { NextRequest } from 'next/server'
@@ -78,7 +78,7 @@ export async function GET(
       }, 15000)
 
       // Create dedicated Redis subscriber
-      let subscriber: Awaited<ReturnType<typeof getRedisClient>> | null = null
+      let subscriber: Awaited<ReturnType<typeof createDedicatedClient>> | null = null
       const channel = `workflow:run:${runId}`
 
       // Track cleanup
@@ -109,8 +109,10 @@ export async function GET(
       }
 
       try {
-        // Get Redis subscriber client
-        subscriber = await getRedisClient(true)
+        // Per-request dedicated client — never use the shared main singleton here,
+        // because cleanup calls .quit() and would close the connection used by every
+        // other Redis-backed feature (cache, reporters, etc).
+        subscriber = await createDedicatedClient()
 
         // Send initial connection event (normalize status to lowercase to match event schema)
         send('connected', {

--- a/packages/lib/src/workflow-engine/execution/trigger-manual-resource-workflow-bulk.ts
+++ b/packages/lib/src/workflow-engine/execution/trigger-manual-resource-workflow-bulk.ts
@@ -197,8 +197,19 @@ export async function triggerManualResourceWorkflowBulk(params: {
           organizationId,
         })
 
-        // Execute workflow asynchronously with reporter for node execution persistence
-        const reporter = new RedisWorkflowExecutionReporter(workflowRun.id)
+        // Execute workflow asynchronously with reporter for node execution persistence.
+        // Reporter setup must not block the bulk trigger — if Redis is unavailable, the
+        // run still exists in Postgres and shows up in the runs list; clients just lose
+        // live node-by-node UI updates for this run.
+        let reporter: RedisWorkflowExecutionReporter | undefined
+        try {
+          reporter = new RedisWorkflowExecutionReporter(workflowRun.id)
+        } catch (error) {
+          logger.warn('Failed to construct Redis reporter; running without live events', {
+            workflowRunId: workflowRun.id,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
         executionService.executeWorkflowAsync(workflowRun, reporter).catch((error) => {
           logger.error('Async workflow execution failed', {
             workflowRunId: workflowRun.id,

--- a/packages/redis/src/client.ts
+++ b/packages/redis/src/client.ts
@@ -126,6 +126,13 @@ export async function getRedisClient(required = true): Promise<RedisClient | und
   }
 
   try {
+    // Drop a dead reference so we recreate. The factory does the same internally,
+    // but our module-scope variable would otherwise pin the old (closed) client.
+    if (redisClient && !redisClient.isAlive()) {
+      logger.warn('Cached main Redis client is no longer alive; recreating')
+      redisClient = null
+    }
+
     if (!redisClient) {
       // Use the new factory to create the client
       redisClient = await RedisClientFactory.createClient(undefined, 'main')
@@ -152,6 +159,10 @@ export async function getRedisClient(required = true): Promise<RedisClient | und
  */
 export async function getPublishingClient(required = true): Promise<RedisClient | null> {
   try {
+    if (publishingClient && !publishingClient.isAlive()) {
+      logger.warn('Cached publishing Redis client is no longer alive; recreating')
+      publishingClient = null
+    }
     if (!publishingClient) {
       // Use the new factory to create the publishing client
       publishingClient = await RedisClientFactory.createClient(undefined, 'publishing')
@@ -179,6 +190,10 @@ export async function getPublishingClient(required = true): Promise<RedisClient 
  */
 export async function getSubscriptionClient(required = true): Promise<RedisClient | null> {
   try {
+    if (subscriptionClient && !subscriptionClient.isAlive()) {
+      logger.warn('Cached subscription Redis client is no longer alive; recreating')
+      subscriptionClient = null
+    }
     if (!subscriptionClient) {
       // Use the new factory to create the subscription client
       subscriptionClient = await RedisClientFactory.createClient(undefined, 'subscription')

--- a/packages/redis/src/core/redis-client-factory.ts
+++ b/packages/redis/src/core/redis-client-factory.ts
@@ -82,9 +82,16 @@ export class RedisClientFactory {
   ): Promise<RedisClient> {
     const cacheKey = `${provider ?? 'auto'}-${instanceId}`
 
-    // Return existing instance if available (no ping — verified on creation)
-    if (RedisClientFactory.instances.has(cacheKey)) {
-      return RedisClientFactory.instances.get(cacheKey)!
+    // Return existing instance if it's still alive. A previous caller may have
+    // closed the connection (e.g. an SSE route calling .quit() on the shared
+    // singleton); without this check we'd hand back a dead client forever.
+    const cached = RedisClientFactory.instances.get(cacheKey)
+    if (cached) {
+      if (cached.isAlive()) {
+        return cached
+      }
+      logger.warn(`Cached Redis client ${cacheKey} is no longer alive; recreating`)
+      RedisClientFactory.instances.delete(cacheKey)
     }
 
     const detectedProvider = provider ?? getRedisProvider()
@@ -97,16 +104,24 @@ export class RedisClientFactory {
 
     let client: RedisClient
 
+    // Eviction callback — when the underlying socket ends, drop the cached
+    // reference so the next caller creates a fresh client.
+    const evict = () => {
+      if (RedisClientFactory.instances.get(cacheKey) === client) {
+        RedisClientFactory.instances.delete(cacheKey)
+      }
+    }
+
     // Create client based on provider
     switch (detectedProvider) {
       case 'upstash':
         client = createUpstashClient()
         break
       case 'aws':
-        client = createIORedisClient('aws')
+        client = createIORedisClient('aws', evict)
         break
       case 'hosted':
-        client = createIORedisClient('hosted')
+        client = createIORedisClient('hosted', evict)
         break
       default:
         throw new Error(`Unsupported Redis provider: ${detectedProvider}`)

--- a/packages/redis/src/providers/ioredis-provider.ts
+++ b/packages/redis/src/providers/ioredis-provider.ts
@@ -7,8 +7,13 @@ import { logger, type RedisClient } from '../types'
 /**
  * Enhanced IORedis provider that supports all Redis operations
  * Used for AWS ElastiCache and hosted Redis instances
+ *
+ * @param provider - 'aws' or 'hosted'
+ * @param onDead - optional callback invoked when the underlying ioredis client
+ *   transitions to a terminal state ('end'). Used by the factory to evict the
+ *   instance from its cache so the next caller gets a fresh connection.
  */
-export function createIORedisClient(provider: 'aws' | 'hosted'): RedisClient {
+export function createIORedisClient(provider: 'aws' | 'hosted', onDead?: () => void): RedisClient {
   let client: Redis
 
   if (provider === 'aws') {
@@ -105,6 +110,20 @@ export function createIORedisClient(provider: 'aws' | 'hosted'): RedisClient {
     logger.info(`${provider} Redis client connected`)
   })
 
+  // 'end' is terminal — ioredis will not auto-reconnect after this. We surface
+  // it so the factory can drop the instance from its cache, otherwise every
+  // subsequent caller hits "Connection is closed." until process restart.
+  client.on('end', () => {
+    logger.warn(`${provider} Redis client ended; will be evicted from cache`)
+    if (onDead) {
+      try {
+        onDead()
+      } catch (err) {
+        logger.error('onDead callback threw', { error: (err as Error).message })
+      }
+    }
+  })
+
   // Create enhanced client wrapper
   const enhancedClient: RedisClient = {
     // Standard Redis operations
@@ -143,6 +162,7 @@ export function createIORedisClient(provider: 'aws' | 'hosted'): RedisClient {
       await client.connect()
     },
     disconnect: () => client.disconnect(),
+    isAlive: () => client.status !== 'end' && client.status !== 'close',
 
     // Event handling
     on: (event: string, listener: (...args: any[]) => void) => client.on(event, listener),

--- a/packages/redis/src/providers/upstash-provider.ts
+++ b/packages/redis/src/providers/upstash-provider.ts
@@ -107,6 +107,8 @@ export function createUpstashClient(): RedisClient {
       logger.info('Force disconnecting Upstash Redis client')
       // No-op for REST client
     },
+    // Upstash is stateless HTTP — there is no persistent connection to die.
+    isAlive: () => true,
 
     // Publish operation (using lists as message queues)
     publish: async (channel: string, message: string) => {

--- a/packages/redis/src/types.ts
+++ b/packages/redis/src/types.ts
@@ -53,6 +53,11 @@ export interface RedisClient {
   connect(): Promise<void>
   disconnect(): void
 
+  // True when the underlying client is in a usable state (not 'end' / 'close').
+  // Lets callers and the factory detect dead singletons and recreate them
+  // instead of forever returning a closed connection.
+  isAlive(): boolean
+
   // Event handling
   on(event: string, listener: (...args: any[]) => void): void
   removeListener(event: string, listener: (...args: any[]) => void): void


### PR DESCRIPTION
## Summary
- Add `isAlive()` to `RedisClient`; factory and module-level caches now evict and recreate when a cached client's socket has ended (previously: dead client returned forever until process restart).
- Wire an `end`-event eviction callback through `createIORedisClient` so the factory cache stays consistent with the underlying ioredis state.
- Switch workflow-run and file-upload SSE routes to `createDedicatedClient()` so their cleanup `.quit()` cannot close the shared singleton used by cache, reporters, and other Redis-backed features.
- Make the bulk manual workflow trigger tolerate a Redis-reporter construction failure — the run still persists in Postgres; only live node-by-node updates are lost.

## Test plan
- [ ] Open a workflow run SSE stream, kill it, then verify other Redis-backed features (cache reads, queue ops) still work.
- [ ] Open the file upload SSE stream, abort the request, verify shared Redis singletons remain healthy.
- [ ] Force-disconnect Redis (or simulate `end`) and confirm the next caller of `getRedisClient` / `getPublishingClient` / `getSubscriptionClient` gets a fresh, working client instead of a closed one.
- [ ] Trigger a manual bulk workflow run with Redis unavailable — bulk trigger succeeds, run row exists in Postgres, log warns about missing live events.