### PR TITLE
feat(ui): form-safe Button default, dialog Enter handling, CSS TextShimmer

### DIFF
--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -64,16 +64,23 @@ function Button({
   asChild = false,
   loading = false,
   loadingText = 'Loading...',
+  type,
   children,
   ...props
 }: ButtonProps) {
   // Choose the component type based on asChild prop
   const Comp = asChild ? SlotPrimitive.Slot : 'button'
 
+  // Default plain <button> to type="button" so a stray Button inside a <form>
+  // doesn't trigger implicit form submission. Slotted children (asChild) keep
+  // their own element semantics — don't force a button type onto a non-button.
+  const resolvedType = !asChild ? (type ?? 'button') : type
+
   return (
     <Comp
       data-slot={`button-${variant ?? 'default'}`}
       data-size={size}
+      type={resolvedType}
       className={cn(buttonVariants({ variant, size, className }))}
       disabled={loading || props.disabled}
       aria-busy={loading}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -111,34 +111,61 @@ function DialogContent({
   const portalContainerRef = React.useRef<HTMLDivElement>(null)
   const contentRef = React.useRef<HTMLDivElement>(null)
 
-  // Handle Meta+Enter keyboard shortcut - DOM-based approach
-  // This queries the DOM directly for the submit button, avoiding context timing issues
+  // Handle Enter keyboard behavior inside the dialog:
+  // - Cmd/Ctrl+Enter clicks the submit button (works from any focusable element).
+  // - Plain Enter in a single-line <input> would otherwise trigger native form
+  //   submission. We suppress that so Cmd/Ctrl+Enter is the only way to submit.
   React.useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Check for Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux)
-      if (!((e.metaKey || e.ctrlKey) && e.key === 'Enter')) return
+      if (e.key !== 'Enter') return
 
       const content = contentRef.current
       if (!content) return
-
-      // Only handle if the event target is inside this dialog
-      // This prevents handling events from other dialogs
       if (!content.contains(e.target as Node)) return
 
-      // Find submit button - supports both form buttons and standalone buttons
-      // Priority: [data-dialog-submit] > button[type="submit"]
-      const submitButton = content.querySelector<HTMLButtonElement>(
-        '[data-dialog-submit]:not(:disabled), button[type="submit"]:not(:disabled)'
-      )
+      const hasModifier = e.metaKey || e.ctrlKey
 
-      if (submitButton) {
-        e.preventDefault()
-        e.stopImmediatePropagation() // Prevent other dialog listeners
-        submitButton.click()
+      if (hasModifier) {
+        const submitButton = content.querySelector<HTMLButtonElement>(
+          '[data-dialog-submit]:not(:disabled), button[type="submit"]:not(:disabled)'
+        )
+        if (submitButton) {
+          e.preventDefault()
+          e.stopImmediatePropagation()
+          submitButton.click()
+        }
+        return
       }
+
+      // Plain Enter — block native implicit form submission when focused in a
+      // single-line input. Leave textareas, contenteditable, buttons, links,
+      // and selects alone so they keep their normal Enter behavior.
+      const target = e.target as HTMLElement | null
+      if (!target) return
+      const tag = target.tagName
+      if (tag !== 'INPUT') return
+      const inputType = (target as HTMLInputElement).type
+      // Don't block Enter on inputs where Enter has meaningful native behavior
+      // (submit/reset/button/checkbox/radio/file).
+      const blockableTypes = [
+        'text',
+        'email',
+        'password',
+        'search',
+        'tel',
+        'url',
+        'number',
+        'date',
+        'datetime-local',
+        'month',
+        'time',
+        'week',
+      ]
+      if (!blockableTypes.includes(inputType)) return
+
+      e.preventDefault()
     }
 
-    // Use capture phase so it works even when focused in inputs
     document.addEventListener('keydown', handleKeyDown, true)
     return () => document.removeEventListener('keydown', handleKeyDown, true)
   }, [])

--- a/packages/ui/src/components/text-shimmer-motion.tsx
+++ b/packages/ui/src/components/text-shimmer-motion.tsx
@@ -1,0 +1,71 @@
+// packages/ui/src/components/text-shimmer-motion.tsx
+
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { motion } from 'motion/react'
+import React, { useMemo } from 'react'
+
+export type TextShimmerMotionProps = {
+  children: string
+  as?: React.ElementType
+  className?: string
+  duration?: number
+  spread?: number
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: motion.create returns a dynamic component type
+const motionCreateCache = new Map<React.ElementType, any>()
+
+function getMotionComponent(el: React.ElementType) {
+  if (!motionCreateCache.has(el)) {
+    motionCreateCache.set(el, motion.create(el as keyof React.JSX.IntrinsicElements))
+  }
+  return motionCreateCache.get(el)!
+}
+
+/**
+ * Framer-motion-driven shimmer. Kept for cases where the JS-driven animate
+ * prop is preferred. Most callers should use the CSS-only `TextShimmer`
+ * instead — it renders reliably even in heavily memoized list rows where
+ * motion's animate prop can stall.
+ */
+function TextShimmerMotionComponent({
+  children,
+  as: Component = 'p',
+  className,
+  duration = 2,
+  spread = 2,
+}: TextShimmerMotionProps) {
+  const MotionComponent = getMotionComponent(Component)
+
+  const dynamicSpread = useMemo(() => children.length * spread, [children, spread])
+
+  return (
+    <MotionComponent
+      className={cn(
+        'bg-size-[250%_100%,auto] relative inline-block bg-clip-text',
+        'text-transparent [--base-color:#a1a1aa] [--base-gradient-color:#000]',
+        '[--bg:linear-gradient(90deg,#0000_calc(50%-var(--spread)),var(--base-gradient-color),#0000_calc(50%+var(--spread)))] [background-repeat:no-repeat,padding-box]',
+        'dark:[--base-color:#71717a] dark:[--base-gradient-color:#ffffff] dark:[--bg:linear-gradient(90deg,#0000_calc(50%-var(--spread)),var(--base-gradient-color),#0000_calc(50%+var(--spread)))]',
+        className
+      )}
+      initial={{ backgroundPosition: '100% center' }}
+      animate={{ backgroundPosition: '0% center' }}
+      transition={{
+        repeat: Number.POSITIVE_INFINITY,
+        duration,
+        ease: 'linear',
+      }}
+      style={
+        {
+          '--spread': `${dynamicSpread}px`,
+          backgroundImage: 'var(--bg), linear-gradient(var(--base-color), var(--base-color))',
+        } as React.CSSProperties
+      }>
+      {children}
+    </MotionComponent>
+  )
+}
+
+export const TextShimmerMotion = React.memo(TextShimmerMotionComponent)

--- a/packages/ui/src/components/text-shimmer.tsx
+++ b/packages/ui/src/components/text-shimmer.tsx
@@ -3,62 +3,54 @@
 'use client'
 
 import { cn } from '@auxx/ui/lib/utils'
-import { motion } from 'motion/react'
 import React, { useMemo } from 'react'
 
 export type TextShimmerProps = {
   children: string
   as?: React.ElementType
   className?: string
+  /** Duration of one full sweep, in seconds. Defaults to 4. */
   duration?: number
+  /** Pixels per character; controls the width of the highlight band. */
   spread?: number
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: motion.create returns a dynamic component type
-const motionCreateCache = new Map<React.ElementType, any>()
-
-function getMotionComponent(el: React.ElementType) {
-  if (!motionCreateCache.has(el)) {
-    motionCreateCache.set(el, motion.create(el as keyof React.JSX.IntrinsicElements))
-  }
-  return motionCreateCache.get(el)!
-}
-
+/**
+ * CSS-only text shimmer. Pure keyframe animation (`text-shimmer-smooth`
+ * defined in global.css) — no framer-motion, so it renders reliably in
+ * memoized list rows. Sweeps right-to-left at constant speed; override
+ * `duration` per instance.
+ *
+ * For the legacy framer-motion implementation see `TextShimmerMotion` in
+ * `./text-shimmer-motion`.
+ */
 function TextShimmerComponent({
   children,
   as: Component = 'p',
   className,
-  duration = 2,
+  duration = 4,
   spread = 2,
 }: TextShimmerProps) {
-  const MotionComponent = getMotionComponent(Component)
-
   const dynamicSpread = useMemo(() => children.length * spread, [children, spread])
 
   return (
-    <MotionComponent
+    <Component
       className={cn(
-        'bg-size-[250%_100%,auto] relative inline-block bg-clip-text',
+        'animate-text-shimmer-smooth [animation-direction:reverse] bg-size-[250%_100%,auto] relative inline-block bg-clip-text',
         'text-transparent [--base-color:#a1a1aa] [--base-gradient-color:#000]',
         '[--bg:linear-gradient(90deg,#0000_calc(50%-var(--spread)),var(--base-gradient-color),#0000_calc(50%+var(--spread)))] [background-repeat:no-repeat,padding-box]',
         'dark:[--base-color:#71717a] dark:[--base-gradient-color:#ffffff] dark:[--bg:linear-gradient(90deg,#0000_calc(50%-var(--spread)),var(--base-gradient-color),#0000_calc(50%+var(--spread)))]',
         className
       )}
-      initial={{ backgroundPosition: '100% center' }}
-      animate={{ backgroundPosition: '0% center' }}
-      transition={{
-        repeat: Number.POSITIVE_INFINITY,
-        duration,
-        ease: 'linear',
-      }}
       style={
         {
           '--spread': `${dynamicSpread}px`,
+          '--duration': `${duration}s`,
           backgroundImage: 'var(--bg), linear-gradient(var(--base-color), var(--base-color))',
         } as React.CSSProperties
       }>
       {children}
-    </MotionComponent>
+    </Component>
   )
 }
 

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -95,6 +95,15 @@
   }
 }
 
+@keyframes text-shimmer-smooth {
+  0% {
+    background-position: -250% center;
+  }
+  100% {
+    background-position: 250% center;
+  }
+}
+
 @keyframes dot-blink {
   0%, 80%, 100% {
     opacity: 0;
@@ -660,6 +669,7 @@
   --animate-scale-in: scale-in 120ms ease-out;
   --animate-scale-out: scale-out 120ms ease-in;
   --animate-text-shimmer: text-shimmer var(--duration, 2.5s) ease-in-out infinite;
+  --animate-text-shimmer-smooth: text-shimmer-smooth var(--duration, 2.5s) linear infinite;
   --animate-dot-blink: dot-blink 1.4s infinite both;
 
   --shadow-left: -2px 4px 16px 0 rgba(0, 0, 0, 0.12), 0 2px 4px 0 rgba(0, 0, 0, 0.04);


### PR DESCRIPTION
## Summary
- **Button**: plain `<button>` now defaults to `type=\"button\"` so a stray `<Button>` inside a `<form>` no longer triggers implicit submission. Slotted (`asChild`) children keep their own element semantics.
- **DialogContent**: Cmd/Ctrl+Enter clicks the submit button (`[data-dialog-submit]` or `button[type=\"submit\"]`). Plain Enter inside a single-line input now blocks the browser's native form submission so Cmd/Ctrl+Enter is the only way to submit. Textareas, contenteditables, buttons, links, and selects keep their normal Enter behavior.
- **TextShimmer**: converted to a pure CSS keyframe (`text-shimmer-smooth` + `--animate-text-shimmer-smooth` utility). The previous framer-motion implementation is preserved as `TextShimmerMotion` for callers that prefer JS-driven animation. The CSS variant renders reliably inside heavily memoized list rows where motion's `animate` prop can stall.

## Test plan
- [ ] Open any dialog with a form: Cmd/Ctrl+Enter submits, plain Enter in a text input does nothing
- [ ] Plain Enter in a textarea inside a dialog still inserts a newline
- [ ] A non-submit `<Button>` placed inside a `<form>` does not submit when clicked
- [ ] `<TextShimmer>` animates with a steady right-to-left sweep
- [ ] `<TextShimmerMotion>` (where used) still animates as before