### PR TITLE
feat(mail): processing indicator on threads/drafts with running workflows

### DIFF
--- a/apps/web/src/components/fields/ai-overlay/ai-generating-indicator-css.tsx
+++ b/apps/web/src/components/fields/ai-overlay/ai-generating-indicator-css.tsx
@@ -1,0 +1,27 @@
+// apps/web/src/components/fields/ai-overlay/ai-generating-indicator-css.tsx
+
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { AnimatedDots } from '~/components/kopilot/ui/kopilot-status-bar'
+
+/**
+ * Pure-CSS twin of `AiGeneratingIndicator`. Same visual design — shimmering
+ * "Generating" + animated dots — but driven by the existing `text-shimmer`
+ * keyframe in global.css instead of framer-motion. Use this in heavily
+ * memoized list rows where motion's animate prop can stall.
+ */
+export function AiGeneratingIndicatorCss({ className }: { className?: string }) {
+  return (
+    <div
+      role='status'
+      aria-live='polite'
+      aria-label='Generating AI value'
+      className={cn('flex items-center pointer-events-none', className)}>
+      <span className='animate-text-shimmer-smooth [animation-duration:4s] [animation-direction:reverse] inline-block bg-clip-text text-transparent [background-image:linear-gradient(90deg,#a1a1aa_40%,#000_50%,#a1a1aa_60%)] [background-size:250%_100%] dark:[background-image:linear-gradient(90deg,#71717a_40%,#ffffff_50%,#71717a_60%)]'>
+        Generating
+      </span>
+      <AnimatedDots />
+    </div>
+  )
+}

--- a/apps/web/src/components/mail/compact-draft-item.tsx
+++ b/apps/web/src/components/mail/compact-draft-item.tsx
@@ -1,11 +1,15 @@
 // apps/web/src/components/mail/compact-draft-item.tsx
 'use client'
 
+import { toRecordId } from '@auxx/types/resource'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatDistanceToNowStrict } from 'date-fns'
 import { Clock } from 'lucide-react'
 import { memo, useMemo } from 'react'
+import { AiGeneratingIndicatorCss } from '~/components/fields/ai-overlay/ai-generating-indicator-css'
+import { SparkleIcon } from '~/components/kopilot/ui/sparkle-icon'
 import { useThreadStore } from '~/components/threads/store'
+import { useIsRecordProcessing } from '~/components/workflow/use-is-record-processing'
 import { useCompose } from '~/hooks/use-compose'
 import type { DraftMessageType } from './email-editor/types'
 import { getIntegrationIcon } from './mail-status-config'
@@ -18,6 +22,7 @@ export const CompactDraftItem = memo(function CompactDraftItem({ draftId }: Comp
   const { openDraft } = useCompose()
   const draft = useThreadStore((s) => s.standaloneDrafts.get(draftId))
   const isDraftLoading = useThreadStore((s) => s.isDraftLoading(draftId))
+  const isProcessing = useIsRecordProcessing(toRecordId('draft', draftId))
 
   const formattedDate = useMemo(() => {
     if (draft?.scheduledAt) {
@@ -70,14 +75,27 @@ export const CompactDraftItem = memo(function CompactDraftItem({ draftId }: Comp
 
       {/* Integration icon */}
       <div className='flex w-5 shrink-0 items-center justify-center ms-0.5'>
-        <div className='rounded-full border p-0.5 text-blue-500'>
-          {getIntegrationIcon(draft.integrationProvider)}
-        </div>
+        {isProcessing ? (
+          <SparkleIcon variant='generating' className='shrink-0' />
+        ) : (
+          <div className='rounded-full border p-0.5 text-blue-500'>
+            {getIntegrationIcon(draft.integrationProvider)}
+          </div>
+        )}
       </div>
 
       {/* Recipient */}
       <div className='w-[140px] shrink-0 truncate text-xs font-semibold text-foreground ms-2'>
-        {draft.recipientSummary || '(no recipients)'}
+        {isProcessing ? (
+          <>
+            <AiGeneratingIndicatorCss className='group-hover:hidden' />
+            <span className='hidden truncate group-hover:inline-flex'>
+              {draft.recipientSummary || '(no recipients)'}
+            </span>
+          </>
+        ) : (
+          draft.recipientSummary || '(no recipients)'
+        )}
       </div>
 
       {/* Subject + Snippet */}

--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { evaluateConditions, normalizeStatusConditions } from '@auxx/lib/conditions/client'
+import { toRecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
 import { Skeleton } from '@auxx/ui/components/skeleton'
@@ -13,7 +14,9 @@ import { AnimatePresence, motion } from 'motion/react'
 import type React from 'react'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { useSession } from '~/auth/auth-client'
+import { AiGeneratingIndicatorCss } from '~/components/fields/ai-overlay/ai-generating-indicator-css'
 import { Tooltip } from '~/components/global/tooltip'
+import { SparkleIcon } from '~/components/kopilot/ui/sparkle-icon'
 import { TagBadge } from '~/components/tags/ui/tag-badge'
 import {
   useMessage,
@@ -24,6 +27,7 @@ import {
 } from '~/components/threads/hooks'
 import { useSelectionAnchorId, useThreadSelectionStore } from '~/components/threads/store'
 import { threadFieldResolver } from '~/components/threads/utils/thread-field-resolver'
+import { useIsRecordProcessing } from '~/components/workflow/use-is-record-processing'
 import { useMailFilter } from './mail-filter-context'
 import { getIntegrationIcon } from './mail-status-config'
 import { ProcessingMenu } from './mail-thread-item'
@@ -90,6 +94,7 @@ export const CompactThreadItem = memo(function CompactThreadItem({
   )
 
   const isFocused = useThreadSelectionStore((s) => s.focusedThreadId === threadId)
+  const isProcessing = useIsRecordProcessing(toRecordId('thread', threadId))
 
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
@@ -162,7 +167,7 @@ export const CompactThreadItem = memo(function CompactThreadItem({
         <motion.div
           key={threadId}
           initial={{ opacity: 0, height: 0, overflow: 'hidden' }}
-          animate={{ opacity: 1, height: 'auto', overflow: 'clip' }}
+          animate={{ opacity: 1, height: 'auto', overflow: 'visible' }}
           exit={{ opacity: 0, height: 0, overflow: 'hidden' }}
           transition={{ duration: 0.15, ease: 'easeOut' }}
           onMouseEnter={() => {
@@ -216,9 +221,13 @@ export const CompactThreadItem = memo(function CompactThreadItem({
 
             {/* Integration icon */}
             <div className='flex w-5 shrink-0 items-center justify-center ms-0.5'>
-              <div className='rounded-full border p-0.5 text-blue-500'>
-                {getIntegrationIcon(thread.integrationProvider)}
-              </div>
+              {isProcessing ? (
+                <SparkleIcon variant='generating' className='shrink-0' />
+              ) : (
+                <div className='rounded-full border p-0.5 text-blue-500'>
+                  {getIntegrationIcon(thread.integrationProvider)}
+                </div>
+              )}
             </div>
 
             {/* Sender - fixed width */}
@@ -227,7 +236,16 @@ export const CompactThreadItem = memo(function CompactThreadItem({
                 'w-[140px] shrink-0 truncate text-xs ms-2',
                 isUnread ? 'text-foreground' : 'text-foreground/80'
               )}>
-              {senderName ?? <Skeleton className='h-3 w-24' />}
+              {isProcessing ? (
+                <>
+                  <AiGeneratingIndicatorCss className='group-hover:hidden' />
+                  <span className='hidden truncate group-hover:inline-flex'>
+                    {senderName ?? <Skeleton className='h-3 w-24' />}
+                  </span>
+                </>
+              ) : (
+                (senderName ?? <Skeleton className='h-3 w-24' />)
+              )}
             </div>
 
             {/* Tags */}

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -27,6 +27,8 @@ import { AnimatePresence, motion } from 'motion/react'
 import type React from 'react'
 import { memo, useCallback, useMemo } from 'react'
 import { useSession } from '~/auth/auth-client'
+import { AiGeneratingIndicatorCss } from '~/components/fields/ai-overlay/ai-generating-indicator-css'
+import { SparkleIcon } from '~/components/kopilot/ui/sparkle-icon'
 import { TagBadge } from '~/components/tags/ui/tag-badge'
 // NEW: Import from new hooks
 import {
@@ -42,6 +44,7 @@ import {
   useThreadSelectionStore,
 } from '~/components/threads/store'
 import { threadFieldResolver } from '~/components/threads/utils/thread-field-resolver'
+import { useIsRecordProcessing } from '~/components/workflow/use-is-record-processing'
 import { WorkflowSubMenu } from '~/components/workflow/workflow-submenu'
 import { api } from '~/trpc/react'
 import { useMailFilter } from './mail-filter-context'
@@ -222,6 +225,7 @@ export const MailThreadItem = memo(function MailThreadItem({
   )
   const isActive = useIsThreadActive(threadId)
   const isHighlighted = isActive || isMultiSelected
+  const isProcessing = useIsRecordProcessing(toRecordId('thread', threadId))
 
   // --- Drag and Drop Setup ---
   const { attributes, listeners, setNodeRef } = useDraggable({
@@ -355,7 +359,7 @@ export const MailThreadItem = memo(function MailThreadItem({
                 />
               ))}
 
-            <div className='absolute top-3 left-1'>
+            <div className={cn('absolute left-1', isProcessing ? 'top-1' : 'top-3')}>
               {viewMode === 'edit' ? (
                 <div
                   onClick={(e) => {
@@ -369,6 +373,8 @@ export const MailThreadItem = memo(function MailThreadItem({
                   }}>
                   <Checkbox checked={isMultiSelected} />
                 </div>
+              ) : isProcessing ? (
+                <SparkleIcon variant='generating' className='shrink-0' />
               ) : (
                 <div className='flex-none rounded-full border p-0.5 text-blue-500 group-aria-selected:bg-background group-aria-selected:border-info/90'>
                   {getIntegrationIcon(thread.integrationProvider)}
@@ -380,9 +386,18 @@ export const MailThreadItem = memo(function MailThreadItem({
             <div className='flex w-full flex-col gap-1'>
               <div className='flex items-center'>
                 <div className='flex items-center ms-0.5 gap-0.5 overflow-hidden'>
-                  <div className='flex-1 truncate font-semibold group-aria-selected:text-white'>
-                    {senderName}
-                  </div>
+                  {isProcessing ? (
+                    <>
+                      <AiGeneratingIndicatorCss className='group-hover:hidden' />
+                      <div className='hidden flex-1 truncate font-semibold group-hover:block group-aria-selected:text-white'>
+                        {senderName}
+                      </div>
+                    </>
+                  ) : (
+                    <div className='flex-1 truncate font-semibold group-aria-selected:text-white'>
+                      {senderName}
+                    </div>
+                  )}
                 </div>
                 <div className='ml-auto shrink-0 whitespace-nowrap pl-2 text-xs text-muted-foreground group-aria-selected:text-background/50'>
                   {formattedDate}

--- a/apps/web/src/components/workflow/use-is-record-processing.ts
+++ b/apps/web/src/components/workflow/use-is-record-processing.ts
@@ -1,0 +1,25 @@
+// apps/web/src/components/workflow/use-is-record-processing.ts
+
+import type { RecordId } from '@auxx/types/resource'
+import { useWorkflowRunStatusStore } from '~/stores/workflow-run-status-store'
+
+/** Design-only override: flip to `true` to force every row into processing state. */
+const FORCE_PROCESSING_DEBUG = false
+
+/**
+ * Returns `true` while at least one workflow run is currently `running` for
+ * the given record. `paused`, `completed`, and `failed` runs do not count.
+ *
+ * v1: reads the local in-tab store. Only reflects runs triggered in the
+ * current tab — see `plans/mail/processing-indicator.md` for v2 plans.
+ */
+export function useIsRecordProcessing(recordId: RecordId | null | undefined): boolean {
+  return useWorkflowRunStatusStore((s) => {
+    if (FORCE_PROCESSING_DEBUG) return !!recordId
+    if (!recordId) return false
+    for (const run of s.runs.values()) {
+      if (run.recordId === recordId && run.status === 'running') return true
+    }
+    return false
+  })
+}


### PR DESCRIPTION
## Summary
- New `useIsRecordProcessing(recordId)` hook reads `useWorkflowRunStatusStore` and returns `true` while at least one workflow run is in `running` state for the given thread/draft. v1 is scoped to runs triggered in the same tab.
- New `AiGeneratingIndicatorCss` — CSS-only twin of `AiGeneratingIndicator` (no framer-motion) for heavily memoized list rows where the JS animate prop can stall.
- `MailThreadItem`, `CompactThreadItem`, `CompactDraftItem`: while processing, swap the integration icon for `SparkleIcon`, hide the sender/recipient line and show a shimmering "Generating…" label. On hover the original text is revealed so the row stays scannable.

## Dependencies
Depends on #559 (uses the `animate-text-shimmer-smooth` utility added there). Merge that first, then rebase this onto main.

## Test plan
- [ ] Trigger a workflow run on a thread → its row shows the sparkle + "Generating…" indicator
- [ ] Hover the row → sender/subject is revealed
- [ ] Run completes/fails/pauses → row reverts to normal
- [ ] Same for draft rows in the compact list
- [ ] No regression for non-processing rows