### PR TITLE
fix(mail): mail-view dialog deletion redirect, fresh-create defaults, nested-layer guard

### DIFF
--- a/apps/web/src/components/global/sidebar/views-group.tsx
+++ b/apps/web/src/components/global/sidebar/views-group.tsx
@@ -24,7 +24,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { TableProperties, Trash2 } from 'lucide-react'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { useCallback, useState } from 'react'
 import { useDndState } from '~/app/context/dnd-state-context'
 import { CollapsibleSidebarSection } from '~/components/global/sidebar/collapsible-sidebar-section'
@@ -73,9 +73,15 @@ const DroppableViewSidebarItem = ({
   const [confirm, ConfirmDialog] = useConfirm()
   const isDraggingThread = activeDndItem?.data.current?.type === 'thread'
   const utils = api.useUtils()
+  const router = useRouter()
+  const pathname = usePathname()
 
   const deleteMailView = api.mailView.delete.useMutation({
     onSuccess: () => {
+      // If the user is currently viewing the deleted view, send them back to inbox.
+      if (pathname?.startsWith(`/app/mail/views/${view.id}`)) {
+        router.push('/app/mail')
+      }
       utils.mailView.getUserMailViews.invalidate()
       utils.mailView.getAllAccessibleMailViews.invalidate()
     },
@@ -108,7 +114,6 @@ const DroppableViewSidebarItem = ({
   })
 
   const itemHref = `/app/mail/views/${view.id}/unassigned`
-  const pathname = usePathname()
   const isActive = pathname?.startsWith(`/app/mail/views/${view.id}`)
 
   const editItems = (

--- a/apps/web/src/components/mail-views/mail-view-dialog.tsx
+++ b/apps/web/src/components/mail-views/mail-view-dialog.tsx
@@ -14,6 +14,7 @@ import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { FileText, Filter, Sliders, Trash2 } from 'lucide-react'
+import { usePathname, useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import * as z from 'zod'
@@ -40,6 +41,23 @@ const mailViewFormSchema = z.object({
 
 export type MailViewFormValues = z.infer<typeof mailViewFormSchema>
 
+const createDefaultGroup = (): ConditionGroup => ({
+  id: 'default',
+  conditions: [],
+  logicalOperator: 'AND',
+})
+
+const getCreateDefaults = (): MailViewFormValues => ({
+  name: '',
+  description: '',
+  isDefault: false,
+  isPinned: false,
+  isShared: false,
+  sortField: 'lastMessageAt',
+  sortDirection: 'desc',
+  filterGroups: [createDefaultGroup()],
+})
+
 interface MailViewDialogProps {
   isOpen: boolean
   onClose: () => void
@@ -49,20 +67,13 @@ interface MailViewDialogProps {
 export function MailViewDialog({ isOpen, onClose, mailViewId }: MailViewDialogProps) {
   const [activeTab, setActiveTab] = useState<'details' | 'filters' | 'options'>('details')
   const [confirm, DeleteConfirmDialog] = useConfirm()
+  const router = useRouter()
+  const pathname = usePathname()
 
   // Setup form
   const methods = useForm<MailViewFormValues>({
     resolver: standardSchemaResolver(mailViewFormSchema),
-    defaultValues: {
-      name: '',
-      description: '',
-      isDefault: false,
-      isPinned: false,
-      isShared: false,
-      sortField: 'lastMessageAt',
-      sortDirection: 'desc',
-      filterGroups: [] as ConditionGroup[],
-    },
+    defaultValues: getCreateDefaults(),
   })
 
   // Guard against accidental close with unsaved changes
@@ -128,6 +139,12 @@ export function MailViewDialog({ isOpen, onClose, mailViewId }: MailViewDialogPr
 
   const deleteMailView = api.mailView.delete.useMutation({
     onSuccess: () => {
+      // Clear dirty state so the unsaved-changes guard doesn't fire on close
+      methods.reset(methods.getValues())
+      // If the user is currently viewing the deleted view, send them back to inbox.
+      if (mailViewId && pathname?.startsWith(`/app/mail/views/${mailViewId}`)) {
+        router.push('/app/mail')
+      }
       onClose()
       utils.mailView.getUserMailViews.invalidate()
       utils.mailView.getAllAccessibleMailViews.invalidate()
@@ -142,6 +159,7 @@ export function MailViewDialog({ isOpen, onClose, mailViewId }: MailViewDialogPr
   // Load mail view data when editing
   useEffect(() => {
     if (mailView) {
+      const savedGroups = (mailView.filters as ConditionGroup[]) || []
       methods.reset({
         name: mailView.name,
         description: mailView.description || '',
@@ -151,10 +169,19 @@ export function MailViewDialog({ isOpen, onClose, mailViewId }: MailViewDialogPr
         sortField: mailView.sortField || 'lastMessageAt',
         sortDirection: (mailView.sortDirection as 'asc' | 'desc') || 'desc',
         // Database stores filterGroups in 'filters' column (backwards compatible)
-        filterGroups: (mailView.filters as ConditionGroup[]) || [],
+        filterGroups: savedGroups.length > 0 ? savedGroups : [createDefaultGroup()],
       })
     }
   }, [mailView, methods])
+
+  // Reset form to fresh defaults whenever the dialog opens in create mode.
+  // Without this, the previously-submitted values stick around when the
+  // user reopens the "New View" dialog after creating one.
+  useEffect(() => {
+    if (!isOpen || mailViewId) return
+    methods.reset(getCreateDefaults())
+    setActiveTab('details')
+  }, [isOpen, mailViewId, methods])
 
   /** Handles the delete action with confirmation */
   const handleDelete = async () => {

--- a/apps/web/src/hooks/use-unsaved-changes-guard.tsx
+++ b/apps/web/src/hooks/use-unsaved-changes-guard.tsx
@@ -125,13 +125,23 @@ export function useUnsavedChangesGuard({
 
   /**
    * Handle click outside - prevent close and show confirmation if dirty
-   * Ignores clicks on toast notifications
+   * Ignores clicks on toast notifications and clicks inside nested dialogs/popovers
+   * (e.g. a confirm dialog opened from a button inside the guarded dialog).
    */
   const handleInteractOutside = useCallback(
     (event: Event) => {
-      // Ignore clicks on toast notifications
-      if (event.target instanceof HTMLElement && event.target.closest('[data-toast-container]')) {
-        return
+      if (event.target instanceof HTMLElement) {
+        // Ignore clicks on toast notifications
+        if (event.target.closest('[data-toast-container]')) return
+        // Ignore clicks that landed inside another dialog/popover/menu — the
+        // topmost layer should own the interaction, not the dialog underneath.
+        if (
+          event.target.closest(
+            '[role="dialog"], [role="alertdialog"], [data-radix-popper-content-wrapper], [cmdk-root]'
+          )
+        ) {
+          return
+        }
       }
       if (isDirty) {
         event.preventDefault()


### PR DESCRIPTION
## Summary
- **Deletion redirect**: when the user deletes the mail view they're currently viewing (from the sidebar or from inside the edit dialog), redirect to `/app/mail`. The dialog flow also resets the form first so the unsaved-changes guard doesn't fire on close.
- **Fresh-create defaults**: seed a default condition group on create, and re-apply fresh defaults whenever the "New View" dialog reopens. Previously, values from a just-submitted view stuck around.
- **Nested-layer guard**: `useUnsavedChangesGuard` now ignores `onInteractOutside` events whose target sits inside another dialog/alertdialog/popover/cmdk. Without this, opening a confirm dialog from inside a guarded dialog fired the unsaved-changes prompt against the underlying dialog.

## Test plan
- [ ] Open `/app/mail/views/<id>/...`, delete the view from the sidebar → redirected to `/app/mail`
- [ ] Open `/app/mail/views/<id>/...`, open edit dialog, delete from inside dialog → redirected to `/app/mail`, no unsaved-changes prompt
- [ ] Click "New View", set fields, save; click "New View" again → form is empty with one default condition group
- [ ] Inside any dialog, open a confirm dialog → confirming/cancelling does not prompt the unsaved-changes guard for the underlying dialog