### PR TITLE
feat(mail): per-inbox realtime sync for thread/message/participant events

### DIFF
--- a/apps/web/src/app/api/pusher/auth/route.ts
+++ b/apps/web/src/app/api/pusher/auth/route.ts
@@ -1,9 +1,11 @@
 // ~/app/api/pusher/auth/route.ts
 
 import { database, schema } from '@auxx/database'
+import { InboxService } from '@auxx/lib/inboxes'
 import { findMemberByUser } from '@auxx/lib/members'
 import { getRealtimeService } from '@auxx/lib/realtime'
 import { createScopedLogger } from '@auxx/logger'
+import { toRecordId } from '@auxx/types/resource'
 import { eq } from 'drizzle-orm'
 import { headers } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
@@ -96,9 +98,19 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // Optional: Verify organization membership for presence-org channels
+    // Optional: Verify organization membership for presence-org channels.
+    // Per-inbox channels (`presence-org-{org}-inbox-{inboxId|none}`) require
+    // an additional access check below.
     if (channel_name.startsWith('presence-org-')) {
-      const orgId = channel_name.replace('presence-org-', '')
+      // Match `presence-org-{orgId}` and optionally `-inbox-{slug}`
+      const orgChannelMatch = channel_name.match(
+        /^presence-org-([^-]+(?:-[^-]+)*?)(?:-inbox-([^-]+))?$/
+      )
+      // Fallback: split on `-inbox-` boundary which is unambiguous.
+      const inboxSplit = channel_name.split('-inbox-')
+      const orgId = inboxSplit[0].replace('presence-org-', '')
+      const inboxSlug = inboxSplit[1] ?? null
+      void orgChannelMatch
 
       try {
         const membership = await findMemberByUser(orgId, session.user.id)
@@ -107,10 +119,30 @@ export async function POST(req: NextRequest) {
           logger.warn('User not part of organization', { userId: session.user.id, orgId })
           return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
         }
+
+        // Per-inbox channel: verify inbox access.
+        // - `none` (triage / unassigned) is allowed for any org member.
+        // - Otherwise check the user's view permission on that inbox.
+        if (inboxSlug && inboxSlug !== 'none') {
+          const inboxService = new InboxService(database, orgId, session.user.id)
+          const allowed = await inboxService.hasUserAccess(
+            toRecordId('inbox', inboxSlug),
+            session.user.id
+          )
+          if (!allowed && process.env.NODE_ENV !== 'development') {
+            logger.warn('User has no access to requested inbox channel', {
+              userId: session.user.id,
+              orgId,
+              inboxId: inboxSlug,
+            })
+            return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+          }
+        }
       } catch (error) {
-        logger.error('Error verifying organization membership', {
+        logger.error('Error verifying organization / inbox membership', {
           userId: session.user.id,
           orgId,
+          inboxSlug,
           error,
         })
         // We'll continue with auth in development mode

--- a/apps/web/src/components/global/auxx-app-providers.tsx
+++ b/apps/web/src/components/global/auxx-app-providers.tsx
@@ -7,6 +7,7 @@ import { FavoritesProvider } from '~/components/favorites/providers/favorites-pr
 import { FilesystemProvider } from '~/components/files/provider/filesystem-provider'
 import { ResourceProvider } from '~/components/resources'
 import { useResourceSync } from '~/components/resources/hooks/use-resource-sync'
+import { useMailSync } from '~/components/threads/realtime'
 import { useRealtimeLifecycle } from '~/realtime/use-realtime-lifecycle'
 
 interface AuxxAppProvidersProps {
@@ -29,6 +30,7 @@ interface AuxxAppProvidersProps {
 export function AuxxAppProviders({ children }: AuxxAppProvidersProps) {
   useRealtimeLifecycle()
   useResourceSync()
+  useMailSync()
 
   return (
     <ResourceProvider>

--- a/apps/web/src/components/threads/realtime/index.ts
+++ b/apps/web/src/components/threads/realtime/index.ts
@@ -13,4 +13,5 @@ export type {
   UserTypingEvent,
   VisitorUpdatedEvent,
 } from './types'
+export { useMailSync } from './use-mail-sync'
 export { useThreadRealtime } from './use-thread-realtime'

--- a/apps/web/src/components/threads/realtime/use-mail-sync.ts
+++ b/apps/web/src/components/threads/realtime/use-mail-sync.ts
@@ -1,0 +1,250 @@
+// apps/web/src/components/threads/realtime/use-mail-sync.ts
+
+'use client'
+
+import type {
+  MailBatchEvent,
+  MailSyncEvent,
+  MessageCreatedEvent,
+  MessageDeletedEvent,
+  MessageUpdatedEvent,
+  ParticipantUpdatedEvent,
+  ThreadCreatedEvent,
+  ThreadDeletedEvent,
+  ThreadUpdatedEvent,
+} from '@auxx/lib/realtime/client'
+import { useCallback, useEffect, useMemo } from 'react'
+import { useUser } from '~/hooks/use-user'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { useInboxChannels, useOrgChannel } from '~/realtime/hooks'
+import { api } from '~/trpc/react'
+import { useInboxes } from '../hooks'
+import { useMessageListStore } from '../store/message-list-store'
+import { useMessageStore } from '../store/message-store'
+import { useParticipantStore } from '../store/participant-store'
+import { useThreadStore } from '../store/thread-store'
+
+/**
+ * Mail-side counterpart to `useResourceSync`. Subscribes to per-inbox channels
+ * for thread/message events and to the org channel for participant events,
+ * then fans events into the thread / message / message-list / participant
+ * stores. Mounted once in `AuxxAppProviders`.
+ *
+ * Gated on the `realtimeMail` feature flag — when off, the hook does nothing.
+ */
+export function useMailSync() {
+  const { user } = useUser()
+  const currentUserId = user?.id ?? null
+  const { hasAccess } = useFeatureFlags()
+  const realtimeMailEnabled = hasAccess('realtimeMail')
+
+  const orgChannel = useOrgChannel()
+  const { inboxes } = useInboxes()
+
+  // Build the slug set from accessible inboxes plus the implicit `none`
+  // (unassigned-triage) channel that every org member subscribes to.
+  const slugs = useMemo(() => {
+    const list = inboxes.map((i) => i.id)
+    list.push('none')
+    return list
+  }, [inboxes])
+
+  const inboxChannels = useInboxChannels(realtimeMailEnabled ? slugs : [])
+
+  // Store actions (selectors to avoid re-renders).
+  const requestThread = useThreadStore((s) => s.requestThread)
+  const setThreadPatch = useThreadStore((s) => s.setThreadPatch)
+  const removeThread = useThreadStore((s) => s.removeThread)
+  const invalidateAllContexts = useThreadStore((s) => s.invalidateAllContexts)
+
+  const requestMessage = useMessageStore((s) => s.requestMessage)
+  const updateMessage = useMessageStore((s) => s.updateMessage)
+  const removeMessage = useMessageStore((s) => s.removeMessage)
+
+  const appendMessage = useMessageListStore((s) => s.appendMessage)
+  const removeFromMessageList = useMessageListStore((s) => s.removeMessage)
+  const invalidateMessageList = useMessageListStore((s) => s.invalidate)
+
+  const updateParticipant = useParticipantStore((s) => s.updateParticipant)
+
+  const utils = api.useUtils()
+
+  const handleThreadCreated = useCallback(
+    (raw: unknown) => {
+      const data = (raw as ThreadCreatedEvent['data']) ?? null
+      if (!data?.threadId) return
+      requestThread(data.threadId)
+      invalidateAllContexts()
+      utils.thread.listIds.invalidate()
+    },
+    [requestThread, invalidateAllContexts, utils]
+  )
+
+  // Merge a partial patch into the cached thread via `setThreadPatch`, which
+  // already skips keys with pending optimistic mutations. Drops events whose
+  // `userId` belongs to a different user (per-user unread fanout).
+  const handleThreadUpdated = useCallback(
+    (raw: unknown) => {
+      const data = (raw as ThreadUpdatedEvent['data']) ?? null
+      if (!data?.threadId || !data.patch) return
+      const patch = { ...(data.patch as Record<string, unknown>) }
+      if (patch.userId && currentUserId && patch.userId !== currentUserId) return
+      delete patch.userId
+      delete patch.id
+      if (Object.keys(patch).length === 0) return
+      setThreadPatch(data.threadId, patch as Record<string, unknown>)
+    },
+    [currentUserId, setThreadPatch]
+  )
+
+  const handleThreadDeleted = useCallback(
+    (raw: unknown) => {
+      const data = (raw as ThreadDeletedEvent['data']) ?? null
+      if (!data?.threadId) return
+      removeThread(data.threadId)
+      invalidateMessageList(data.threadId)
+      utils.thread.listIds.invalidate()
+    },
+    [removeThread, invalidateMessageList, utils]
+  )
+
+  const handleMessageCreated = useCallback(
+    (raw: unknown) => {
+      const data = (raw as MessageCreatedEvent['data']) ?? null
+      if (!data?.messageId || !data?.threadId) return
+      requestMessage(data.messageId)
+      appendMessage(data.threadId, data.messageId)
+      // Thread metadata (lastMessageAt, latestMessageId, messageCount) lands
+      // via the metadata-recompute thread:updated event published by the
+      // ingest seam.
+    },
+    [requestMessage, appendMessage]
+  )
+
+  const handleMessageUpdated = useCallback(
+    (raw: unknown) => {
+      const data = (raw as MessageUpdatedEvent['data']) ?? null
+      if (!data?.messageId || !data.patch) return
+      const patch = { ...(data.patch as Record<string, unknown>) }
+      delete patch.id
+      delete patch.threadId
+      if (Object.keys(patch).length === 0) return
+      updateMessage(data.messageId, patch)
+    },
+    [updateMessage]
+  )
+
+  const handleMessageDeleted = useCallback(
+    (raw: unknown) => {
+      const data = (raw as MessageDeletedEvent['data']) ?? null
+      if (!data?.messageId || !data?.threadId) return
+      removeMessage(data.messageId)
+      removeFromMessageList(data.threadId, data.messageId)
+    },
+    [removeMessage, removeFromMessageList]
+  )
+
+  const handleParticipantUpdated = useCallback(
+    (raw: unknown) => {
+      const data = (raw as ParticipantUpdatedEvent['data']) ?? null
+      if (!data?.participantId || !data.patch) return
+      const patch = { ...(data.patch as Record<string, unknown>) }
+      delete patch.id
+      if (Object.keys(patch).length === 0) return
+      updateParticipant(data.participantId, patch)
+    },
+    [updateParticipant]
+  )
+
+  // Recursively dispatch a single mail event to its handler. Used both for
+  // direct binds and for `mail:batch` frames (which carry an array).
+  const dispatchEvent = useCallback(
+    (e: MailSyncEvent) => {
+      switch (e.event) {
+        case 'thread:created':
+          return handleThreadCreated(e.data)
+        case 'thread:updated':
+          return handleThreadUpdated(e.data)
+        case 'thread:deleted':
+          return handleThreadDeleted(e.data)
+        case 'message:created':
+          return handleMessageCreated(e.data)
+        case 'message:updated':
+          return handleMessageUpdated(e.data)
+        case 'message:deleted':
+          return handleMessageDeleted(e.data)
+        case 'participant:updated':
+          return handleParticipantUpdated(e.data)
+        case 'mail:batch':
+          for (const inner of e.data.events) dispatchEvent(inner)
+          return
+      }
+    },
+    [
+      handleThreadCreated,
+      handleThreadUpdated,
+      handleThreadDeleted,
+      handleMessageCreated,
+      handleMessageUpdated,
+      handleMessageDeleted,
+      handleParticipantUpdated,
+    ]
+  )
+
+  const handleMailBatch = useCallback(
+    (raw: unknown) => {
+      const data = (raw as MailBatchEvent['data']) ?? null
+      if (!Array.isArray(data?.events)) return
+      for (const e of data.events) dispatchEvent(e)
+      // One list invalidation at the end of a bundle.
+      utils.thread.listIds.invalidate()
+    },
+    [dispatchEvent, utils]
+  )
+
+  // Bind handlers on every active inbox channel.
+  useEffect(() => {
+    if (!realtimeMailEnabled) return
+    const cleanups: Array<() => void> = []
+    for (const channel of inboxChannels.values()) {
+      channel.bind('thread:created', handleThreadCreated)
+      channel.bind('thread:updated', handleThreadUpdated)
+      channel.bind('thread:deleted', handleThreadDeleted)
+      channel.bind('message:created', handleMessageCreated)
+      channel.bind('message:updated', handleMessageUpdated)
+      channel.bind('message:deleted', handleMessageDeleted)
+      channel.bind('mail:batch', handleMailBatch)
+      cleanups.push(() => {
+        channel.unbind('thread:created', handleThreadCreated)
+        channel.unbind('thread:updated', handleThreadUpdated)
+        channel.unbind('thread:deleted', handleThreadDeleted)
+        channel.unbind('message:created', handleMessageCreated)
+        channel.unbind('message:updated', handleMessageUpdated)
+        channel.unbind('message:deleted', handleMessageDeleted)
+        channel.unbind('mail:batch', handleMailBatch)
+      })
+    }
+    return () => {
+      for (const c of cleanups) c()
+    }
+  }, [
+    realtimeMailEnabled,
+    inboxChannels,
+    handleThreadCreated,
+    handleThreadUpdated,
+    handleThreadDeleted,
+    handleMessageCreated,
+    handleMessageUpdated,
+    handleMessageDeleted,
+    handleMailBatch,
+  ])
+
+  // Participant events ride on the org channel.
+  useEffect(() => {
+    if (!realtimeMailEnabled || !orgChannel) return
+    orgChannel.bind('participant:updated', handleParticipantUpdated)
+    return () => {
+      orgChannel.unbind('participant:updated', handleParticipantUpdated)
+    }
+  }, [realtimeMailEnabled, orgChannel, handleParticipantUpdated])
+}

--- a/apps/web/src/components/threads/store/thread-store.ts
+++ b/apps/web/src/components/threads/store/thread-store.ts
@@ -174,6 +174,11 @@ interface ThreadStoreState {
   // Thread CRUD
   setThreads: (threads: ThreadMeta[]) => void
   updateThread: (id: string, updates: Partial<ThreadMeta>) => void
+  /**
+   * Apply a realtime patch. Skips keys present in `pendingMutations` so an
+   * in-flight optimistic write isn't clobbered by an out-of-order echo.
+   */
+  setThreadPatch: (id: string, patch: Partial<ThreadMeta>) => void
   removeThread: (id: string) => void
 
   // Optimistic updates (version-tracked for concurrent mutation safety)
@@ -287,6 +292,26 @@ export const useThreadStore = create<ThreadStoreState>()(
           if (existing) {
             state.threads.set(id, { ...existing, ...updates })
           }
+        }),
+
+      setThreadPatch: (id, patch) =>
+        set((state) => {
+          const existing = state.threads.get(id)
+          if (!existing) return
+          const pending = state.pendingMutations.get(id)
+          let effective: Partial<ThreadMeta> = patch
+          if (pending && pending.size > 0) {
+            const skip = new Set<string>()
+            for (const m of pending.values()) {
+              for (const k of Object.keys(m.changes)) skip.add(k)
+            }
+            effective = {}
+            for (const [k, v] of Object.entries(patch)) {
+              if (!skip.has(k)) (effective as Record<string, unknown>)[k] = v
+            }
+          }
+          if (Object.keys(effective).length === 0) return
+          state.threads.set(id, { ...existing, ...effective })
         }),
 
       removeThread: (id) =>

--- a/apps/web/src/realtime/hooks.ts
+++ b/apps/web/src/realtime/hooks.ts
@@ -3,7 +3,8 @@
 'use client'
 
 import type { ChannelSubscription } from '@auxx/lib/realtime/client'
-import { useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import { useUser } from '~/hooks/use-user'
 import { realtimeAdapter } from './adapter'
 
 /** Subscribe to the org channel. Re-renders only when channel reference changes. */
@@ -27,4 +28,72 @@ export function useRealtimeConnected(): boolean {
 /** Non-reactive read of current socket ID (for headers, not rendering). */
 export function getRealtimeSocketId(): string | undefined {
   return realtimeAdapter.getSocketId()
+}
+
+/**
+ * Subscribe to a single inbox channel by slug. Pass `'none'` for the
+ * unassigned-triage channel. The hook reference-counts subscriptions so
+ * multiple components can call it safely.
+ *
+ * Returns the channel once subscription is established, or null while pending.
+ */
+export function useInboxChannel(inboxSlug: string | null | undefined): ChannelSubscription | null {
+  const { organizationId } = useUser()
+
+  useEffect(() => {
+    if (!organizationId || !inboxSlug) return
+    realtimeAdapter.subscribeToInbox(organizationId, inboxSlug)
+    return () => {
+      realtimeAdapter.unsubscribeFromInbox(organizationId, inboxSlug)
+    }
+  }, [organizationId, inboxSlug])
+
+  const getSnapshot = useCallback(
+    () => (inboxSlug ? realtimeAdapter.getInboxChannelSnapshot(inboxSlug) : null),
+    [inboxSlug]
+  )
+  const getServerSnapshot = useCallback(
+    () => (inboxSlug ? realtimeAdapter.getServerInboxChannelSnapshot(inboxSlug) : null),
+    [inboxSlug]
+  )
+  return useSyncExternalStore(
+    realtimeAdapter.subscribeToInboxChannels,
+    getSnapshot,
+    getServerSnapshot
+  )
+}
+
+/**
+ * Subscribe to many inbox channels at once. Manages add/remove based on the
+ * given slugs and notifies React on any change. Returns the adapter's full
+ * inbox-channel map snapshot (stable until membership changes).
+ *
+ * Always include `'none'` in the slug set if you want unassigned-triage events.
+ */
+export function useInboxChannels(
+  slugs: readonly string[]
+): ReadonlyMap<string, ChannelSubscription> {
+  const { organizationId } = useUser()
+
+  // Stable comma-joined key so the effect only re-runs when the slug set changes.
+  const slugKey = [...slugs].sort().join(',')
+
+  useEffect(() => {
+    if (!organizationId) return
+    const list = slugKey ? slugKey.split(',') : []
+    for (const slug of list) {
+      realtimeAdapter.subscribeToInbox(organizationId, slug)
+    }
+    return () => {
+      for (const slug of list) {
+        realtimeAdapter.unsubscribeFromInbox(organizationId, slug)
+      }
+    }
+  }, [organizationId, slugKey])
+
+  return useSyncExternalStore(
+    realtimeAdapter.subscribeToInboxChannels,
+    realtimeAdapter.getInboxChannelMapSnapshot,
+    realtimeAdapter.getServerInboxChannelMapSnapshot
+  )
 }

--- a/apps/web/src/server/api/routers/thread.ts
+++ b/apps/web/src/server/api/routers/thread.ts
@@ -78,6 +78,7 @@ const getServiceDependencies = (
   messageSender: MessageSenderService
   organizationId: string
   userId: string
+  socketId: string | undefined
 } => {
   const userId = ctx.session.user.id as string
   const organizationId = getUserOrganizationId(ctx.session)
@@ -85,18 +86,21 @@ const getServiceDependencies = (
     logger.error('Organization ID not found for user', { userId })
     throw new TRPCError({ code: 'UNAUTHORIZED', message: 'User organization context not found.' })
   }
+  // Realtime self-echo suppression — see plans/realtime/mail/plan.md §2.4.
+  const socketId = ctx.headers?.get?.('x-realtime-socket-id') ?? undefined
   // Instantiate new modular services
   const providerRegistry = new ProviderRegistryService(organizationId)
-  const messageSender = new MessageSenderService(organizationId, providerRegistry, ctx.db)
+  const messageSender = new MessageSenderService(organizationId, providerRegistry, ctx.db, socketId)
   // New specialized services
   const threadQuery = new ThreadQueryService(organizationId, ctx.db)
-  const threadMutation = new ThreadMutationService(organizationId, ctx.db)
+  const threadMutation = new ThreadMutationService(organizationId, ctx.db, socketId)
   return {
     threadQuery,
     threadMutation,
     messageSender,
     organizationId,
     userId,
+    socketId,
   }
 }
 /**
@@ -782,7 +786,8 @@ export const threadRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { userId, organizationId } = ctx.session
-      const unreadService = new UnreadService(organizationId, userId)
+      const socketId = ctx.headers?.get?.('x-realtime-socket-id') ?? undefined
+      const unreadService = new UnreadService(organizationId, userId, undefined, socketId)
       await unreadService.setReadStatus(input.threadId, input.isRead)
     }),
   /**

--- a/packages/lib/src/comments/comment-service.ts
+++ b/packages/lib/src/comments/comment-service.ts
@@ -973,11 +973,14 @@ export class CommentService {
       const attachmentService = new AttachmentService(this.organizationId, this.userId, tx)
       for (const attachment of fileAttachments) {
         if (attachment.type === 'asset') {
-          // Handle MediaAsset - convert temp to permanent first
+          // Handle MediaAsset - convert temp to permanent first.
+          // Pass `tx` so the read+update inside convertTempToPermanent share
+          // this tx's connection instead of reaching into the pool.
           await this.mediaAssetService.convertTempToPermanent(
             attachment.id,
             'EMAIL_ATTACHMENT',
-            this.organizationId
+            this.organizationId,
+            tx
           )
           // Use AttachmentService create method
           await attachmentService.create({

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/field-values/field-value-mutations.ts
 
-import { schema } from '@auxx/database'
+import { type Database, schema } from '@auxx/database'
 import type { FieldType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import {
@@ -1203,6 +1203,13 @@ export async function addValues(
   const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
 
   return await ctx.db.transaction(async (tx) => {
+    // Rebuild the context around `tx` so any helper called inside this
+    // transaction reads/writes through the same connection. Without this,
+    // helpers like getValue / maybeUpdateDisplayValue would do `ctx.db.<op>`
+    // against the pool, grab a fresh connection, and deadlock under
+    // bulk fan-out (idle-in-transaction timeout cascade).
+    const txCtx: FieldValueContext = { ...ctx, db: tx as unknown as Database }
+
     // Serialize concurrent add-with-dedup on the same (entity, field).
     // Other non-conflicting writes elsewhere are unaffected.
     await acquireFieldValueLock(tx, entityInstanceId, fieldId)
@@ -1228,7 +1235,7 @@ export async function addValues(
     }
 
     if (typedInputs.length === 0) {
-      const fullValues = await getValue(ctx, { recordId, fieldId })
+      const fullValues = await getValue(txCtx, { recordId, fieldId })
       if (fullValues === null) return []
       return Array.isArray(fullValues) ? fullValues : [fullValues]
     }
@@ -1296,7 +1303,9 @@ export async function addValues(
     const allTyped = allRows.map((r) => rowToTypedValue(r, fieldType))
 
     // Update display value (safe no-op when the field isn't a display source).
-    await maybeUpdateDisplayValue(ctx, recordId, field, survivors)
+    // Pass txCtx so the inner update + searchText + cascade writes go through
+    // the active tx, not the pool.
+    await maybeUpdateDisplayValue(txCtx, recordId, field, survivors)
 
     // Publish the full post-state. Array-return fields publish arrays;
     // scalar-multi (TEXT/etc. with options.multi) are array-return too.

--- a/packages/lib/src/files/core/media-asset-service.ts
+++ b/packages/lib/src/files/core/media-asset-service.ts
@@ -504,14 +504,20 @@ export class MediaAssetService
   }
 
   /**
-   * Convert temporary upload to permanent attachment
+   * Convert temporary upload to permanent attachment.
+   *
+   * @param tx Optional active tx — when called from inside a transaction
+   *   (e.g. comment creation), pass it through so the read+update share the
+   *   tx connection instead of grabbing fresh ones from the pool.
    */
   async convertTempToPermanent(
     mediaAssetId: string,
     newKind: AssetKind,
-    organizationId: string
+    organizationId: string,
+    tx?: DatabaseClient
   ): Promise<void> {
-    const mediaAsset = await this.db.query.MediaAsset.findFirst({
+    const dbOrTx = tx ?? this.db
+    const mediaAsset = await dbOrTx.query.MediaAsset.findFirst({
       where: and(
         eq(schema.MediaAsset.id, mediaAssetId),
         eq(schema.MediaAsset.organizationId, organizationId)
@@ -523,7 +529,7 @@ export class MediaAssetService
     }
 
     // Convert temp upload to permanent attachment
-    await this.db
+    await dbOrTx
       .update(schema.MediaAsset)
       .set({
         kind: newKind,

--- a/packages/lib/src/ingest/batch-store-messages.ts
+++ b/packages/lib/src/ingest/batch-store-messages.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/ingest/batch-store-messages.ts
 
 import { v4 as uuidv4 } from 'uuid'
+import { flushMailBatch, getRealtimeService } from '../realtime'
 import { type IngestContext, resetBatchCaches } from './context'
 import { storeMessage } from './store-message'
 import type { MessageData } from './types'
@@ -82,6 +83,17 @@ export async function batchStoreMessages(
   if (isInitialSync) {
     await ctx.selectiveCache.completeBatch(organizationId, actualBatchId, successCount)
     ctx.isInitialSync = false
+  }
+
+  // Flush any mail realtime events buffered during the batch (initial-sync
+  // path appends instead of publishing per message). flushMailBatch chunks
+  // into 50-event `mail:batch` frames per inbox channel.
+  if (ctx.batchedEvents.length > 0) {
+    const buffered = ctx.batchedEvents
+    ctx.batchedEvents = []
+    await flushMailBatch(getRealtimeService(), organizationId, buffered, {
+      excludeSocketId: ctx.socketId,
+    })
   }
 
   ctx.logger.info(`Batch store completed: ${successCount} of ${messages.length} messages stored.`, {

--- a/packages/lib/src/ingest/context.ts
+++ b/packages/lib/src/ingest/context.ts
@@ -5,6 +5,7 @@ import { createScopedLogger, type Logger } from '@auxx/logger'
 import { SelectiveModeCache } from '../cache/selective-mode-cache'
 import { MessageReconcilerService } from '../messages/message-reconciler.service'
 import { ThreadManagerService } from '../messages/thread-manager.service'
+import type { MailSyncEvent } from '../realtime/events'
 import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import { SystemUserService } from '../users/system-user-service'
 import type { IntegrationSettings } from './types'
@@ -45,6 +46,20 @@ export interface IngestContext {
    */
   ownEmails: Set<string>
 
+  /**
+   * Originating socket id for self-echo suppression on realtime publishes.
+   * tRPC routers populate from the `x-realtime-socket-id` header; webhooks /
+   * workers / workflow nodes leave it undefined and accept the echo.
+   */
+  socketId?: string
+
+  /**
+   * Buffer for mail realtime events accumulated during initial / polling sync.
+   * Per-message publishes append here when `isInitialSync` is true; the
+   * batch orchestrator flushes them in chunks at the end of the batch.
+   */
+  batchedEvents: Array<{ inboxId: string | null; event: MailSyncEvent }>
+
   readonly companyIdByDomain: Map<string, string | null>
   readonly ownDomainsByOrg: Map<string, Set<string>>
   readonly providerByIntegrationId: Map<string, string>
@@ -56,6 +71,7 @@ export interface CreateIngestContextOptions {
   integrationSettings?: IntegrationSettings
   ownEmails?: Iterable<string>
   selectiveCache?: SelectiveModeCache
+  socketId?: string
 }
 
 /**
@@ -82,6 +98,8 @@ export async function createIngestContext(
     integrationSettings: opts.integrationSettings,
     isInitialSync: opts.isInitialSync ?? false,
     ownEmails: normalizeOwnEmails(opts.ownEmails),
+    socketId: opts.socketId,
+    batchedEvents: [],
     companyIdByDomain: new Map(),
     ownDomainsByOrg: new Map(),
     providerByIntegrationId: new Map(),

--- a/packages/lib/src/ingest/delete-messages.ts
+++ b/packages/lib/src/ingest/delete-messages.ts
@@ -2,6 +2,7 @@
 
 import { schema } from '@auxx/database'
 import { and, eq, inArray, sql } from 'drizzle-orm'
+import { getRealtimeService, publishMessageDeleted, publishThreadDeleted } from '../realtime'
 import type { IngestContext } from './context'
 import { updateThreadMetadataEfficient } from './threads/update-metadata'
 
@@ -33,6 +34,18 @@ export async function deleteMessagesByExternalIds(
   const messageIds = messages.map((m) => m.id)
   const affectedThreadIds = [...new Set(messages.map((m) => m.threadId).filter(Boolean))]
 
+  // Capture inboxIds before delete so we can route realtime events.
+  const threadInboxRows = affectedThreadIds.length
+    ? await ctx.db
+        .select({ id: schema.Thread.id, inboxId: schema.Thread.inboxId })
+        .from(schema.Thread)
+        .where(inArray(schema.Thread.id, affectedThreadIds as string[]))
+    : []
+  const inboxIdByThread = new Map<string, string | null>()
+  for (const row of threadInboxRows) {
+    inboxIdByThread.set(row.id, row.inboxId ?? null)
+  }
+
   await ctx.db.delete(schema.Message).where(inArray(schema.Message.id, messageIds))
 
   ctx.logger.info('Deleted messages by external IDs', {
@@ -40,6 +53,36 @@ export async function deleteMessagesByExternalIds(
     deletedCount: messageIds.length,
     affectedThreads: affectedThreadIds.length,
   })
+
+  const realtime = getRealtimeService()
+
+  // Publish message:deleted for each removed message (skipped during initial sync).
+  if (!ctx.isInitialSync) {
+    for (const msg of messages) {
+      if (!msg.threadId) continue
+      await publishMessageDeleted(
+        realtime,
+        ctx.organizationId,
+        {
+          messageId: msg.id,
+          threadId: msg.threadId,
+          inboxId: inboxIdByThread.get(msg.threadId) ?? null,
+        },
+        { excludeSocketId: ctx.socketId }
+      )
+    }
+  } else {
+    for (const msg of messages) {
+      if (!msg.threadId) continue
+      ctx.batchedEvents.push({
+        inboxId: inboxIdByThread.get(msg.threadId) ?? null,
+        event: {
+          event: 'message:deleted',
+          data: { messageId: msg.id, threadId: msg.threadId },
+        },
+      })
+    }
+  }
 
   for (const threadId of affectedThreadIds) {
     if (!threadId) continue
@@ -52,6 +95,21 @@ export async function deleteMessagesByExternalIds(
     if (remaining.count === 0) {
       await ctx.db.delete(schema.Thread).where(eq(schema.Thread.id, threadId))
       ctx.logger.debug('Deleted empty thread after message removal', { threadId })
+
+      const inboxId = inboxIdByThread.get(threadId) ?? null
+      if (ctx.isInitialSync) {
+        ctx.batchedEvents.push({
+          inboxId,
+          event: { event: 'thread:deleted', data: { threadId } },
+        })
+      } else {
+        await publishThreadDeleted(
+          realtime,
+          ctx.organizationId,
+          { threadId, inboxId },
+          { excludeSocketId: ctx.socketId }
+        )
+      }
     } else {
       await updateThreadMetadataEfficient(ctx, threadId)
     }

--- a/packages/lib/src/ingest/participants/find-or-create.ts
+++ b/packages/lib/src/ingest/participants/find-or-create.ts
@@ -10,7 +10,9 @@ import type {
   ParticipantEntity as Participant,
   ParticipantRole,
 } from '@auxx/database/types'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
+import { getRealtimeService, publishParticipantUpdated } from '../../realtime'
+import type { ParticipantMeta } from '../../realtime/events'
 import { findOrCreateContactForParticipant } from '../contacts/find-or-create'
 import type { IngestContext } from '../context'
 import { extractRegistrableDomain, getOwnDomains, normalizeDomain } from '../domain/classifier'
@@ -77,6 +79,28 @@ export async function findOrCreateParticipantRecord(
 
     const isInternal = await classifyIsInternal(ctx, normalizedIdentifier, identifierType)
 
+    // Capture pre-upsert state so we can detect column changes for
+    // participant:updated emission. Cheap point-lookup on the unique index.
+    const [previous] = await ctx.db
+      .select({
+        id: schema.Participant.id,
+        name: schema.Participant.name,
+        displayName: schema.Participant.displayName,
+        avatarUrl: schema.Participant.avatarUrl,
+        hasReceivedMessage: schema.Participant.hasReceivedMessage,
+        lastSentMessageAt: schema.Participant.lastSentMessageAt,
+        isInternal: schema.Participant.isInternal,
+      })
+      .from(schema.Participant)
+      .where(
+        and(
+          eq(schema.Participant.organizationId, ctx.organizationId),
+          eq(schema.Participant.identifier, normalizedIdentifier),
+          eq(schema.Participant.identifierType, identifierType)
+        )
+      )
+      .limit(1)
+
     const participantData = await ctx.db
       .insert(schema.Participant)
       .values({
@@ -115,6 +139,39 @@ export async function findOrCreateParticipantRecord(
       .returning()
 
     const participant = participantData[0]
+
+    // Emit `participant:updated` only when this was an UPDATE (previous row
+    // existed) AND at least one tracked column actually changed. New rows
+    // don't get a `participant:created` event in v1 — the FE looks them up
+    // on demand via `requestParticipant` when a message references them.
+    if (previous) {
+      const patch: Partial<ParticipantMeta> = {}
+      if (participant.name !== previous.name) patch.name = participant.name
+      if (participant.displayName !== previous.displayName) {
+        patch.displayName = participant.displayName
+      }
+      if (participant.avatarUrl !== previous.avatarUrl) patch.avatarUrl = participant.avatarUrl
+      if (participant.hasReceivedMessage !== previous.hasReceivedMessage) {
+        patch.hasReceivedMessage = participant.hasReceivedMessage
+      }
+      const prevSent = previous.lastSentMessageAt?.getTime() ?? null
+      const nextSent = participant.lastSentMessageAt?.getTime() ?? null
+      if (prevSent !== nextSent) {
+        patch.lastSentMessageAt = participant.lastSentMessageAt
+          ? participant.lastSentMessageAt.toISOString()
+          : null
+      }
+      if (participant.isInternal !== previous.isInternal) patch.isInternal = participant.isInternal
+
+      if (Object.keys(patch).length > 0) {
+        await publishParticipantUpdated(
+          getRealtimeService(),
+          ctx.organizationId,
+          { participantId: participant.id, patch },
+          { excludeSocketId: ctx.socketId }
+        )
+      }
+    }
 
     if (!participant.entityInstanceId) {
       const entityInstanceId = await findOrCreateContactForParticipant(

--- a/packages/lib/src/ingest/store-message.ts
+++ b/packages/lib/src/ingest/store-message.ts
@@ -3,8 +3,10 @@
 import { schema } from '@auxx/database'
 import { ParticipantRole as ParticipantRoleEnum, ThreadStatus } from '@auxx/database/enums'
 import type { ParticipantEntity as Participant, ParticipantRole } from '@auxx/database/types'
+import { toRecordId } from '@auxx/types/resource'
 import { and, eq, isNull } from 'drizzle-orm'
 import { touchActivityForThreadLinks } from '../entity-instances/activity'
+import { getRealtimeService, publishMessageCreated, publishThreadCreated } from '../realtime'
 import type { IngestContext } from './context'
 import { shouldIgnoreMessage } from './filtering/should-ignore'
 import { storeIgnoredMessage } from './filtering/store-ignored'
@@ -283,6 +285,7 @@ export async function storeMessage(
       })
       .returning({
         id: schema.Thread.id,
+        inboxId: schema.Thread.inboxId,
         messageCount: schema.Thread.messageCount,
         firstMessageAt: schema.Thread.firstMessageAt,
         lastMessageAt: schema.Thread.lastMessageAt,
@@ -397,6 +400,55 @@ export async function storeMessage(
     // Advance lastActivityAt for any entity linked to this thread (primary +
     // active secondaries). Best-effort; helper logs and swallows on failure.
     await touchActivityForThreadLinks(thread.id, messageData.organizationId, messageData.sentAt)
+
+    // Realtime publish — message:created (and thread:created on a brand-new
+    // thread). During initial / polling sync, append to ctx.batchedEvents so
+    // the batch orchestrator can flush a small number of `mail:batch` frames
+    // at the end instead of one publish per message.
+    const inboxIdForChannel = thread.inboxId ?? null
+    const inboxRecordId = inboxIdForChannel ? toRecordId('inbox', inboxIdForChannel) : null
+    if (ctx.isInitialSync) {
+      if (isNewThread) {
+        ctx.batchedEvents.push({
+          inboxId: inboxIdForChannel,
+          event: {
+            event: 'thread:created',
+            data: { threadId: thread.id, inboxId: inboxRecordId },
+          },
+        })
+      }
+      ctx.batchedEvents.push({
+        inboxId: inboxIdForChannel,
+        event: {
+          event: 'message:created',
+          data: { messageId: messageRecord.id, threadId: thread.id },
+        },
+      })
+    } else {
+      const realtime = getRealtimeService()
+      if (isNewThread) {
+        await publishThreadCreated(
+          realtime,
+          messageData.organizationId,
+          {
+            threadId: thread.id,
+            inboxId: inboxIdForChannel,
+            inboxRecordId,
+          },
+          { excludeSocketId: ctx.socketId }
+        )
+      }
+      await publishMessageCreated(
+        realtime,
+        messageData.organizationId,
+        {
+          messageId: messageRecord.id,
+          threadId: thread.id,
+          inboxId: inboxIdForChannel,
+        },
+        { excludeSocketId: ctx.socketId }
+      )
+    }
 
     ctx.logger.info('Message stored successfully (Revised Schema v2)', {
       messageId: messageRecord.id,

--- a/packages/lib/src/ingest/threads/update-metadata.ts
+++ b/packages/lib/src/ingest/threads/update-metadata.ts
@@ -1,12 +1,19 @@
 // packages/lib/src/ingest/threads/update-metadata.ts
 
-import { sql } from 'drizzle-orm'
+import { schema } from '@auxx/database'
+import { eq, sql } from 'drizzle-orm'
+import { getRealtimeService, publishThreadUpdated } from '../../realtime'
 import type { IngestContext } from '../context'
 
 /**
  * Single-query recompute of Thread.messageCount / firstMessageAt / lastMessageAt
  * / latestMessageId / participantCount for a thread. Non-critical — errors are
  * logged and swallowed so ingest can continue.
+ *
+ * After the recompute, re-reads the affected columns and publishes a
+ * `thread:updated` patch on the inbox channel so other tabs see the metadata
+ * change without waiting for a refetch. During initial sync the patch is
+ * appended to `ctx.batchedEvents` instead of being sent immediately.
  */
 export async function updateThreadMetadataEfficient(
   ctx: IngestContext,
@@ -53,6 +60,51 @@ export async function updateThreadMetadataEfficient(
       WHERE t.id = ${threadId}
     `)
     ctx.logger.debug('Efficiently updated thread metadata', { threadId })
+
+    const [row] = await ctx.db
+      .select({
+        inboxId: schema.Thread.inboxId,
+        messageCount: schema.Thread.messageCount,
+        participantCount: schema.Thread.participantCount,
+        firstMessageAt: schema.Thread.firstMessageAt,
+        lastMessageAt: schema.Thread.lastMessageAt,
+        latestMessageId: schema.Thread.latestMessageId,
+      })
+      .from(schema.Thread)
+      .where(eq(schema.Thread.id, threadId))
+      .limit(1)
+
+    if (!row) return
+
+    const patch = {
+      messageCount: row.messageCount ?? undefined,
+      participantCount: row.participantCount ?? undefined,
+      firstMessageAt: row.firstMessageAt ? row.firstMessageAt.toISOString() : null,
+      lastMessageAt: row.lastMessageAt ? row.lastMessageAt.toISOString() : null,
+      latestMessageId: row.latestMessageId ?? null,
+    }
+
+    if (ctx.isInitialSync) {
+      ctx.batchedEvents.push({
+        inboxId: row.inboxId ?? null,
+        event: {
+          event: 'thread:updated',
+          data: { threadId, patch: { id: threadId, ...patch } },
+        },
+      })
+      return
+    }
+
+    await publishThreadUpdated(
+      getRealtimeService(),
+      ctx.organizationId,
+      {
+        threadId,
+        inboxId: row.inboxId ?? null,
+        patch,
+      },
+      { excludeSocketId: ctx.socketId }
+    )
   } catch (error) {
     ctx.logger.error('Failed to update thread metadata efficiently', { threadId, error })
   }

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -12,6 +12,7 @@ import { MediaAssetService } from '../files/core/media-asset-service'
 import { ParticipantService } from '../participants/participant-service'
 import type { AttachmentFile } from '../providers/message-provider-interface'
 import type { ProviderRegistryService } from '../providers/provider-registry-service'
+import { getRealtimeService, publishMessageCreated } from '../realtime'
 import { createUsageGuard } from '../usage/create-usage-guard'
 import { MessageComposerService } from './message-composer.service'
 import { MessageReconcilerService } from './message-reconciler.service'
@@ -41,10 +42,14 @@ export class MessageSenderService {
   private participantService: ParticipantService
   private mediaAssetService: MediaAssetService
   private fileService: FileService
+  /** Originating socket id for self-echo suppression on realtime publishes. */
+  private readonly socketId?: string
+
   constructor(
     private organizationId: string,
     private providerRegistry?: ProviderRegistryService,
-    private db?: Database
+    private db?: Database,
+    socketId?: string
   ) {
     this.threadManager = new ThreadManagerService(organizationId, db)
     this.composer = new MessageComposerService(organizationId, db)
@@ -52,6 +57,7 @@ export class MessageSenderService {
     this.participantService = new ParticipantService(organizationId, db)
     this.mediaAssetService = new MediaAssetService(organizationId, undefined, db)
     this.fileService = new FileService(organizationId, undefined, db)
+    this.socketId = socketId
   }
   /**
    * Check if a thread ID is a placeholder
@@ -162,6 +168,33 @@ export class MessageSenderService {
         providerResponse: sendResult,
         threadContext: threadContext,
       })
+
+      // Realtime: publish `message:created` for the freshly sent message so
+      // open tabs see the outbound row land without waiting for the post-send
+      // sync re-import. The post-send sync emits `message:updated` later for
+      // provider-authoritative columns — accepted duplicate.
+      try {
+        const [threadRow] = await (this.db ?? db)
+          .select({ inboxId: schema.Thread.inboxId })
+          .from(schema.Thread)
+          .where(eq(schema.Thread.id, threadContext.id))
+          .limit(1)
+        await publishMessageCreated(
+          getRealtimeService(),
+          this.organizationId,
+          {
+            messageId: composed.id,
+            threadId: threadContext.id,
+            inboxId: threadRow?.inboxId ?? null,
+          },
+          { excludeSocketId: this.socketId }
+        )
+      } catch (err) {
+        logger.debug('Failed to publish message:created for outbound send (non-critical)', {
+          err: err instanceof Error ? err.message : err,
+        })
+      }
+
       // Step 8: Update thread metadata
       await this.threadManager.updateThreadMetadata(threadContext.id)
       await this.threadManager.updateThreadParticipants(threadContext.id)

--- a/packages/lib/src/permissions/types.ts
+++ b/packages/lib/src/permissions/types.ts
@@ -41,6 +41,7 @@ export enum FeatureKey {
   unverifiedApps = 'unverifiedApps',
   kopilot = 'kopilot',
   realtimeSync = 'realtimeSync',
+  realtimeMail = 'realtimeMail',
   callRecordings = 'callRecordings',
   todayInbox = 'todayInbox',
 
@@ -127,6 +128,13 @@ export const FEATURE_REGISTRY: FeatureMetadata[] = [
   },
   { key: FeatureKey.kopilot, type: 'boolean', label: 'Kopilot', group: 'AI' },
   { key: FeatureKey.realtimeSync, type: 'boolean', label: 'Real-Time Sync', group: 'Core' },
+  {
+    key: FeatureKey.realtimeMail,
+    type: 'boolean',
+    label: 'Real-Time Mail',
+    description: 'Per-inbox realtime patches for thread/message/participant changes.',
+    group: 'Core',
+  },
   {
     key: FeatureKey.callRecordings,
     type: 'boolean',

--- a/packages/lib/src/realtime/client/adapters/pusher.ts
+++ b/packages/lib/src/realtime/client/adapters/pusher.ts
@@ -25,6 +25,15 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
   private connectionListeners = new Set<() => void>()
   private orgChannelListeners = new Set<() => void>()
 
+  /** slug → channel wrapper; slug is the raw inbox UUID or `'none'`. */
+  private inboxChannels: Map<string, ChannelSubscription> = new Map()
+  /** Frozen snapshot — replaced (new reference) only on membership change. */
+  private inboxChannelsSnapshot: ReadonlyMap<string, ChannelSubscription> = new Map()
+  /** Reference count per slug so multiple consumers can subscribe safely. */
+  private inboxRefCounts = new Map<string, number>()
+  private inboxChannelListeners = new Set<() => void>()
+  private static readonly EMPTY_INBOX_MAP: ReadonlyMap<string, ChannelSubscription> = new Map()
+
   connect(config: { key: string; cluster: string; authEndpoint: string }) {
     if (this.pusher) return // Already connected
     this.pusher = new Pusher(config.key, {
@@ -49,8 +58,12 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
       this.connected = false
       this.orgChannel = null
       this.currentOrgId = null
+      this.inboxChannels.clear()
+      this.inboxRefCounts.clear()
+      this.refreshInboxSnapshot()
       this.notifyConnectionListeners()
       this.notifyOrgChannelListeners()
+      this.notifyInboxChannelListeners()
     }
   }
 
@@ -62,12 +75,51 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
     // Unsubscribe from previous org channel
     if (this.currentOrgId) {
       this.pusher.unsubscribe(`presence-org-${this.currentOrgId}`)
+      // Drop any stale per-inbox subscriptions tied to the previous org.
+      for (const slug of this.inboxChannels.keys()) {
+        this.pusher.unsubscribe(`presence-org-${this.currentOrgId}-inbox-${slug}`)
+      }
+      this.inboxChannels.clear()
+      this.inboxRefCounts.clear()
+      this.refreshInboxSnapshot()
+      this.notifyInboxChannelListeners()
     }
 
     const channel = this.pusher.subscribe(`presence-org-${organizationId}`)
     this.orgChannel = wrapPusherChannel(channel)
     this.currentOrgId = organizationId
     this.notifyOrgChannelListeners()
+  }
+
+  subscribeToInbox(organizationId: string, inboxSlug: string) {
+    if (!this.pusher) return
+    if (this.currentOrgId !== organizationId) return
+
+    const refCount = (this.inboxRefCounts.get(inboxSlug) ?? 0) + 1
+    this.inboxRefCounts.set(inboxSlug, refCount)
+    if (this.inboxChannels.has(inboxSlug)) return
+
+    const channelName = `presence-org-${organizationId}-inbox-${inboxSlug}`
+    const channel = this.pusher.subscribe(channelName)
+    this.inboxChannels.set(inboxSlug, wrapPusherChannel(channel))
+    this.refreshInboxSnapshot()
+    this.notifyInboxChannelListeners()
+  }
+
+  unsubscribeFromInbox(organizationId: string, inboxSlug: string) {
+    if (!this.pusher) return
+    if (this.currentOrgId !== organizationId) return
+
+    const refCount = this.inboxRefCounts.get(inboxSlug) ?? 0
+    if (refCount <= 1) {
+      this.inboxRefCounts.delete(inboxSlug)
+      this.inboxChannels.delete(inboxSlug)
+      this.pusher.unsubscribe(`presence-org-${organizationId}-inbox-${inboxSlug}`)
+      this.refreshInboxSnapshot()
+      this.notifyInboxChannelListeners()
+    } else {
+      this.inboxRefCounts.set(inboxSlug, refCount - 1)
+    }
   }
 
   getSocketId(): string | undefined {
@@ -98,7 +150,28 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
 
   getServerOrgChannelSnapshot = (): ChannelSubscription | null => null
 
+  subscribeToInboxChannels = (callback: () => void): (() => void) => {
+    this.inboxChannelListeners.add(callback)
+    return () => this.inboxChannelListeners.delete(callback)
+  }
+
+  getInboxChannelSnapshot = (inboxSlug: string): ChannelSubscription | null =>
+    this.inboxChannels.get(inboxSlug) ?? null
+
+  getServerInboxChannelSnapshot = (_inboxSlug: string): ChannelSubscription | null => null
+
+  getInboxChannelMapSnapshot = (): ReadonlyMap<string, ChannelSubscription> =>
+    this.inboxChannelsSnapshot
+
+  getServerInboxChannelMapSnapshot = (): ReadonlyMap<string, ChannelSubscription> =>
+    PusherRealtimeAdapter.EMPTY_INBOX_MAP
+
   // --- Internal ---
+
+  /** Replace the public snapshot with a frozen copy of the live map. */
+  private refreshInboxSnapshot() {
+    this.inboxChannelsSnapshot = new Map(this.inboxChannels)
+  }
 
   private notifyConnectionListeners() {
     for (const cb of this.connectionListeners) cb()
@@ -106,5 +179,9 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
 
   private notifyOrgChannelListeners() {
     for (const cb of this.orgChannelListeners) cb()
+  }
+
+  private notifyInboxChannelListeners() {
+    for (const cb of this.inboxChannelListeners) cb()
   }
 }

--- a/packages/lib/src/realtime/client/index.ts
+++ b/packages/lib/src/realtime/client/index.ts
@@ -5,7 +5,19 @@ export type {
   AiValueMetadata,
   FieldValuesUpdatedEvent,
   FieldValueUpdateEntry,
+  MailBatchEvent,
+  MailSyncEvent,
+  MessageCreatedEvent,
+  MessageDeletedEvent,
+  MessageMeta,
+  MessageUpdatedEvent,
+  ParticipantMeta,
+  ParticipantUpdatedEvent,
   ResourceSyncEvent,
+  ThreadCreatedEvent,
+  ThreadDeletedEvent,
+  ThreadMeta,
+  ThreadUpdatedEvent,
 } from '../events'
 export { getPusherClient } from '../pusher-client'
 export { PusherRealtimeAdapter } from './adapters/pusher'

--- a/packages/lib/src/realtime/client/types.ts
+++ b/packages/lib/src/realtime/client/types.ts
@@ -19,6 +19,16 @@ export interface RealtimeAdapter {
   // Channel management
   subscribeToOrg(organizationId: string): void
 
+  /**
+   * Subscribe to a per-inbox channel. `inboxSlug` is the raw inbox UUID, or
+   * the literal string `'none'` for the unassigned-triage channel. Idempotent
+   * — multiple subscriptions to the same slug return the same channel.
+   */
+  subscribeToInbox(organizationId: string, inboxSlug: string): void
+
+  /** Unsubscribe from a per-inbox channel. */
+  unsubscribeFromInbox(organizationId: string, inboxSlug: string): void
+
   // State reads (non-reactive, for imperative access)
   getSocketId(): string | undefined
   isConnected(): boolean
@@ -32,4 +42,14 @@ export interface RealtimeAdapter {
   subscribeToOrgChannel(callback: () => void): () => void
   getOrgChannelSnapshot(): ChannelSubscription | null
   getServerOrgChannelSnapshot(): ChannelSubscription | null
+
+  // useSyncExternalStore-compatible subscriptions for inbox channels.
+  // Listeners are notified whenever any inbox channel is added or removed.
+  // The map snapshot is stable until membership changes (referentially equal).
+  subscribeToInboxChannels(callback: () => void): () => void
+  getInboxChannelSnapshot(inboxSlug: string): ChannelSubscription | null
+  getServerInboxChannelSnapshot(inboxSlug: string): ChannelSubscription | null
+  /** Stable map snapshot — same reference until membership changes. */
+  getInboxChannelMapSnapshot(): ReadonlyMap<string, ChannelSubscription>
+  getServerInboxChannelMapSnapshot(): ReadonlyMap<string, ChannelSubscription>
 }

--- a/packages/lib/src/realtime/events.ts
+++ b/packages/lib/src/realtime/events.ts
@@ -119,3 +119,143 @@ export interface RecordArchivedEvent {
     entityDefinitionId: string
   }
 }
+
+// ════════════════════════════════════════════════════════════════════════════
+// Mail sync events (thread / message / participant)
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Partial-by-design thread metadata for mail realtime patches.
+ * Missing keys mean "don't touch", `null` means "clear".
+ */
+export interface ThreadMeta {
+  id: string
+  inboxId?: RecordId | null
+  status?: 'OPEN' | 'ARCHIVED' | 'SPAM' | 'TRASH' | 'IGNORED'
+  subject?: string
+  assigneeId?: string | null
+  ticketId?: RecordId | null
+  isUnread?: boolean
+  /** Per-user unread fanout: when present, FE filters to current user before applying */
+  userId?: string
+  messageCount?: number
+  participantCount?: number
+  firstMessageAt?: string | null
+  lastMessageAt?: string | null
+  latestMessageId?: string | null
+  updatedAt?: string
+}
+
+/**
+ * Partial-by-design message metadata for mail realtime patches.
+ */
+export interface MessageMeta {
+  id: string
+  threadId: string
+  subject?: string | null
+  snippet?: string | null
+  sentAt?: string | null
+  receivedAt?: string | null
+  isInbound?: boolean
+  hasAttachments?: boolean
+  fromId?: string | null
+  sendStatus?: 'PENDING' | 'SENT' | 'FAILED' | null
+  providerError?: string | null
+  attempts?: number
+  updatedAt?: string
+}
+
+/**
+ * Partial-by-design participant metadata for mail realtime patches.
+ */
+export interface ParticipantMeta {
+  id: string
+  displayName?: string
+  name?: string | null
+  avatarUrl?: string | null
+  hasReceivedMessage?: boolean
+  lastSentMessageAt?: string | null
+  isInternal?: boolean
+}
+
+/** A new thread was created. Payload carries threadId + inboxId for routing. */
+export interface ThreadCreatedEvent {
+  event: 'thread:created'
+  data: {
+    threadId: string
+    inboxId: RecordId | null
+  }
+}
+
+/** Thread metadata changed. Carries inline partial patch. */
+export interface ThreadUpdatedEvent {
+  event: 'thread:updated'
+  data: {
+    threadId: string
+    patch: Partial<ThreadMeta>
+  }
+}
+
+/** Thread was hard-deleted. */
+export interface ThreadDeletedEvent {
+  event: 'thread:deleted'
+  data: {
+    threadId: string
+  }
+}
+
+/** A new message was created on a thread. */
+export interface MessageCreatedEvent {
+  event: 'message:created'
+  data: {
+    messageId: string
+    threadId: string
+  }
+}
+
+/** Message metadata changed. */
+export interface MessageUpdatedEvent {
+  event: 'message:updated'
+  data: {
+    messageId: string
+    threadId: string
+    patch: Partial<MessageMeta>
+  }
+}
+
+/** Message was deleted. */
+export interface MessageDeletedEvent {
+  event: 'message:deleted'
+  data: {
+    messageId: string
+    threadId: string
+  }
+}
+
+/** Participant metadata changed (org channel). */
+export interface ParticipantUpdatedEvent {
+  event: 'participant:updated'
+  data: {
+    participantId: string
+    patch: Partial<ParticipantMeta>
+  }
+}
+
+/** Initial-sync / polling-sync flush — bundles many events into a single frame. */
+export interface MailBatchEvent {
+  event: 'mail:batch'
+  data: {
+    events: MailSyncEvent[]
+  }
+}
+
+/** Union of all mail sync events. */
+export type MailSyncEvent =
+  | ThreadCreatedEvent
+  | ThreadUpdatedEvent
+  | ThreadDeletedEvent
+  | MessageCreatedEvent
+  | MessageUpdatedEvent
+  | MessageDeletedEvent
+  | ParticipantUpdatedEvent
+  | MailBatchEvent

--- a/packages/lib/src/realtime/index.ts
+++ b/packages/lib/src/realtime/index.ts
@@ -18,6 +18,14 @@ export type {
   AiValueMetadata,
   FieldValuesUpdatedEvent,
   FieldValueUpdateEntry,
+  MailBatchEvent,
+  MailSyncEvent,
+  MessageCreatedEvent,
+  MessageDeletedEvent,
+  MessageMeta,
+  MessageUpdatedEvent,
+  ParticipantMeta,
+  ParticipantUpdatedEvent,
   RecordArchivedEvent,
   RecordCreatedEvent,
   RecordDeletedEvent,
@@ -25,7 +33,21 @@ export type {
   RecordUpdatedEvent,
   ResourceSyncEvent,
   StoredFieldValue,
+  ThreadCreatedEvent,
+  ThreadDeletedEvent,
+  ThreadMeta,
+  ThreadUpdatedEvent,
 } from './events'
-export { publishFieldValueUpdates } from './publish-helpers'
+export {
+  flushMailBatch,
+  publishFieldValueUpdates,
+  publishMessageCreated,
+  publishMessageDeleted,
+  publishMessageUpdated,
+  publishParticipantUpdated,
+  publishThreadCreated,
+  publishThreadDeleted,
+  publishThreadUpdated,
+} from './publish-helpers'
 export { RealtimeService } from './realtime-service'
 export type { RealtimeProvider } from './types'

--- a/packages/lib/src/realtime/publish-helpers.ts
+++ b/packages/lib/src/realtime/publish-helpers.ts
@@ -1,7 +1,13 @@
 // @auxx/lib/realtime/publish-helpers.ts
 
 import { getOrgCache } from '../cache'
-import type { FieldValueUpdateEntry } from './events'
+import type {
+  FieldValueUpdateEntry,
+  MailSyncEvent,
+  MessageMeta,
+  ParticipantMeta,
+  ThreadMeta,
+} from './events'
 import type { RealtimeService } from './realtime-service'
 
 const CHUNK_SIZE = 50
@@ -53,5 +59,224 @@ export async function publishFieldValueUpdates(
     )
   }
 
+  await Promise.allSettled(promises)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Mail publish helpers — gated on `realtimeMail` feature flag
+// ════════════════════════════════════════════════════════════════════════════
+
+interface MailPublishOptions {
+  excludeSocketId?: string
+}
+
+async function isMailRealtimeEnabled(organizationId: string): Promise<boolean> {
+  const { features } = await getOrgCache().getOrRecompute(organizationId, ['features'])
+  return Boolean(features?.realtimeMail)
+}
+
+/**
+ * Publish `thread:created` on the inbox channel for the given thread.
+ * `inboxId` is the raw EntityInstance id (or null for triage).
+ */
+export async function publishThreadCreated(
+  realtimeService: RealtimeService,
+  organizationId: string,
+  args: { threadId: string; inboxId: string | null; inboxRecordId?: string | null },
+  options?: MailPublishOptions
+) {
+  if (!(await isMailRealtimeEnabled(organizationId))) return
+  await realtimeService
+    .sendToInbox(
+      organizationId,
+      args.inboxId,
+      'thread:created',
+      { threadId: args.threadId, inboxId: args.inboxRecordId ?? null },
+      options
+    )
+    .catch(() => {})
+}
+
+/**
+ * Publish `thread:updated` with a partial patch on the inbox channel.
+ * Pass `previousInboxId` when a thread's inboxId changes — the helper will
+ * publish on both the old and new channels so users on each side see the
+ * transition (FE drops the row from the old via filter, fetches on the new).
+ */
+export async function publishThreadUpdated(
+  realtimeService: RealtimeService,
+  organizationId: string,
+  args: {
+    threadId: string
+    inboxId: string | null
+    previousInboxId?: string | null
+    patch: Partial<ThreadMeta>
+  },
+  options?: MailPublishOptions
+) {
+  if (!(await isMailRealtimeEnabled(organizationId))) return
+  const payload = { threadId: args.threadId, patch: { id: args.threadId, ...args.patch } }
+  const targets = new Set<string | null>([args.inboxId])
+  if (args.previousInboxId !== undefined && args.previousInboxId !== args.inboxId) {
+    targets.add(args.previousInboxId ?? null)
+  }
+  await Promise.allSettled(
+    Array.from(targets).map((inboxId) =>
+      realtimeService.sendToInbox(organizationId, inboxId, 'thread:updated', payload, options)
+    )
+  )
+}
+
+/** Publish `thread:deleted` on the inbox channel. */
+export async function publishThreadDeleted(
+  realtimeService: RealtimeService,
+  organizationId: string,
+  args: { threadId: string; inboxId: string | null },
+  options?: MailPublishOptions
+) {
+  if (!(await isMailRealtimeEnabled(organizationId))) return
+  await realtimeService
+    .sendToInbox(
+      organizationId,
+      args.inboxId,
+      'thread:deleted',
+      { threadId: args.threadId },
+      options
+    )
+    .catch(() => {})
+}
+
+/** Publish `message:created` on the inbox channel. */
+export async function publishMessageCreated(
+  realtimeService: RealtimeService,
+  organizationId: string,
+  args: { messageId: string; threadId: string; inboxId: string | null },
+  options?: MailPublishOptions
+) {
+  if (!(await isMailRealtimeEnabled(organizationId))) return
+  await realtimeService
+    .sendToInbox(
+      organizationId,
+      args.inboxId,
+      'message:created',
+      { messageId: args.messageId, threadId: args.threadId },
+      options
+    )
+    .catch(() => {})
+}
+
+/** Publish `message:updated` with a partial patch on the inbox channel. */
+export async function publishMessageUpdated(
+  realtimeService: RealtimeService,
+  organizationId: string,
+  args: {
+    messageId: string
+    threadId: string
+    inboxId: string | null
+    patch: Partial<MessageMeta>
+  },
+  options?: MailPublishOptions
+) {
+  if (!(await isMailRealtimeEnabled(organizationId))) return
+  await realtimeService
+    .sendToInbox(
+      organizationId,
+      args.inboxId,
+      'message:updated',
+      {
+        messageId: args.messageId,
+        threadId: args.threadId,
+        patch: { id: args.messageId, threadId: args.threadId, ...args.patch },
+      },
+      options
+    )
+    .catch(() => {})
+}
+
+/** Publish `message:deleted` on the inbox channel. */
+export async function publishMessageDeleted(
+  realtimeService: RealtimeService,
+  organizationId: string,
+  args: { messageId: string; threadId: string; inboxId: string | null },
+  options?: MailPublishOptions
+) {
+  if (!(await isMailRealtimeEnabled(organizationId))) return
+  await realtimeService
+    .sendToInbox(
+      organizationId,
+      args.inboxId,
+      'message:deleted',
+      { messageId: args.messageId, threadId: args.threadId },
+      options
+    )
+    .catch(() => {})
+}
+
+/**
+ * Publish `participant:updated` on the org channel. Participants aren't
+ * inbox-scoped (a contact can be on threads across many inboxes) so this
+ * stays org-wide for v1.
+ */
+export async function publishParticipantUpdated(
+  realtimeService: RealtimeService,
+  organizationId: string,
+  args: { participantId: string; patch: Partial<ParticipantMeta> },
+  options?: MailPublishOptions
+) {
+  if (!(await isMailRealtimeEnabled(organizationId))) return
+  await realtimeService
+    .sendToOrganization(
+      organizationId,
+      'participant:updated',
+      {
+        participantId: args.participantId,
+        patch: { id: args.participantId, ...args.patch },
+      },
+      options
+    )
+    .catch(() => {})
+}
+
+/**
+ * Flush a list of mail events as one or more `mail:batch` frames on the inbox
+ * channel. Used by ingest's initial-sync / polling-sync paths to coalesce
+ * many events into a small number of frames. Events are chunked at
+ * `CHUNK_SIZE` (50) per frame to stay under Pusher's 10KB limit.
+ *
+ * Events of mixed inboxId may be passed — they are bucketed and flushed per
+ * inbox. Use `inboxId = null` for triage (unassigned).
+ */
+export async function flushMailBatch(
+  realtimeService: RealtimeService,
+  organizationId: string,
+  events: Array<{ inboxId: string | null; event: MailSyncEvent }>,
+  options?: MailPublishOptions
+) {
+  if (events.length === 0) return
+  if (!(await isMailRealtimeEnabled(organizationId))) return
+
+  const buckets = new Map<string, MailSyncEvent[]>()
+  for (const { inboxId, event } of events) {
+    const slug = inboxId ?? 'none'
+    if (!buckets.has(slug)) buckets.set(slug, [])
+    buckets.get(slug)!.push(event)
+  }
+
+  const promises: Promise<boolean>[] = []
+  for (const [slug, list] of buckets) {
+    const inboxId = slug === 'none' ? null : slug
+    for (let i = 0; i < list.length; i += CHUNK_SIZE) {
+      const chunk = list.slice(i, i + CHUNK_SIZE)
+      promises.push(
+        realtimeService.sendToInbox(
+          organizationId,
+          inboxId,
+          'mail:batch',
+          { events: chunk },
+          options
+        )
+      )
+    }
+  }
   await Promise.allSettled(promises)
 }

--- a/packages/lib/src/realtime/realtime-service.ts
+++ b/packages/lib/src/realtime/realtime-service.ts
@@ -23,6 +23,28 @@ export class RealtimeService {
     return this.provider.publish(`presence-org-${organizationId}`, event, data, options)
   }
 
+  /**
+   * Publish to `presence-org-{organizationId}-inbox-{inboxId | 'none'}`.
+   * Mail events publish per-inbox so users only receive events for inboxes they
+   * can read. Unassigned threads (`inboxId = null`) ride on the `none` slug,
+   * which every org member subscribes to as the org-triage default.
+   */
+  async sendToInbox(
+    organizationId: string,
+    inboxId: string | null,
+    event: string,
+    data: unknown,
+    options?: { excludeSocketId?: string }
+  ): Promise<boolean> {
+    const slug = inboxId ?? 'none'
+    return this.provider.publish(
+      `presence-org-${organizationId}-inbox-${slug}`,
+      event,
+      data,
+      options
+    )
+  }
+
   /** Publish to `private-user-{userId}` */
   async sendToUser(
     userId: string,

--- a/packages/lib/src/threads/thread-mutation.service.ts
+++ b/packages/lib/src/threads/thread-mutation.service.ts
@@ -7,6 +7,8 @@ import { getInstanceId, parseRecordId, type RecordId, toRecordId } from '@auxx/t
 import { and, eq, exists, ilike, inArray, notExists, or, sql } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
 import { FieldValueService } from '../field-values'
+import { getRealtimeService, publishThreadDeleted, publishThreadUpdated } from '../realtime'
+import type { ThreadMeta } from '../realtime/events'
 
 const logger = createScopedLogger('thread-mutation-service')
 
@@ -48,9 +50,17 @@ export class ThreadMutationService {
 
   private db: Database
 
-  constructor(organizationId: string, db: Database) {
+  /**
+   * Originating socket id for self-echo suppression on realtime publishes.
+   * tRPC routers populate from `x-realtime-socket-id`; workers / workflow
+   * nodes leave this undefined and accept the echo.
+   */
+  private readonly socketId?: string
+
+  constructor(organizationId: string, db: Database, socketId?: string) {
     this.organizationId = organizationId
     this.db = db
+    this.socketId = socketId
   }
 
   // ═══════════════════════════════════════════════════════════════
@@ -126,16 +136,58 @@ export class ThreadMutationService {
         }
       }
 
+      // Capture pre-update inboxId so we can fan out the realtime event onto
+      // both the old and new inbox channels when inboxId changes.
+      const [previous] = await this.db
+        .select({ inboxId: schema.Thread.inboxId })
+        .from(schema.Thread)
+        .where(
+          and(eq(schema.Thread.id, threadId), eq(schema.Thread.organizationId, this.organizationId))
+        )
+        .limit(1)
+
       const result = await this.db
         .update(schema.Thread)
         .set(dbUpdates)
         .where(
           and(eq(schema.Thread.id, threadId), eq(schema.Thread.organizationId, this.organizationId))
         )
-        .returning({ id: schema.Thread.id })
+        .returning({ id: schema.Thread.id, inboxId: schema.Thread.inboxId })
 
       if (result.length === 0) {
         throw new Error(`Thread ${threadId} not found`)
+      }
+
+      // Build a partial patch for the realtime event from the dbUpdates we
+      // actually wrote. Mirrors the entity layer's "publish only what changed"
+      // pattern in maybeUpdateDisplayValue.
+      const patch: Partial<ThreadMeta> = {}
+      if ('status' in dbUpdates) patch.status = dbUpdates.status
+      if ('subject' in dbUpdates) patch.subject = dbUpdates.subject
+      if ('assigneeId' in dbUpdates) patch.assigneeId = dbUpdates.assigneeId
+      if ('inboxId' in dbUpdates) {
+        patch.inboxId = dbUpdates.inboxId ? toRecordId('inbox', dbUpdates.inboxId) : null
+      }
+      if ('primaryEntityInstanceId' in dbUpdates) {
+        patch.ticketId = dbUpdates.primaryEntityInstanceId
+          ? toRecordId(
+              dbUpdates.primaryEntityDefinitionId ?? 'ticket',
+              dbUpdates.primaryEntityInstanceId
+            )
+          : null
+      }
+      if (Object.keys(patch).length > 0) {
+        await publishThreadUpdated(
+          getRealtimeService(),
+          this.organizationId,
+          {
+            threadId,
+            inboxId: result[0].inboxId ?? null,
+            previousInboxId: previous?.inboxId ?? null,
+            patch,
+          },
+          { excludeSocketId: this.socketId }
+        )
       }
 
       return {
@@ -215,6 +267,19 @@ export class ThreadMutationService {
         return { count: threadIds.length }
       }
 
+      // Capture pre-update inboxIds so we can fan out per-thread updates
+      // onto both old and new channels (only matters when inboxId changes).
+      const previousRows = await this.db
+        .select({ id: schema.Thread.id, inboxId: schema.Thread.inboxId })
+        .from(schema.Thread)
+        .where(
+          and(
+            inArray(schema.Thread.id, threadIds),
+            eq(schema.Thread.organizationId, this.organizationId)
+          )
+        )
+      const prevInboxIdById = new Map(previousRows.map((r) => [r.id, r.inboxId ?? null]))
+
       const result = await this.db
         .update(schema.Thread)
         .set(dbUpdates)
@@ -224,7 +289,40 @@ export class ThreadMutationService {
             eq(schema.Thread.organizationId, this.organizationId)
           )
         )
-        .returning({ id: schema.Thread.id })
+        .returning({ id: schema.Thread.id, inboxId: schema.Thread.inboxId })
+
+      const patch: Partial<ThreadMeta> = {}
+      if ('status' in dbUpdates) patch.status = dbUpdates.status
+      if ('assigneeId' in dbUpdates) patch.assigneeId = dbUpdates.assigneeId
+      if ('inboxId' in dbUpdates) {
+        patch.inboxId = dbUpdates.inboxId ? toRecordId('inbox', dbUpdates.inboxId) : null
+      }
+      if ('primaryEntityInstanceId' in dbUpdates) {
+        patch.ticketId = dbUpdates.primaryEntityInstanceId
+          ? toRecordId(
+              dbUpdates.primaryEntityDefinitionId ?? 'ticket',
+              dbUpdates.primaryEntityInstanceId
+            )
+          : null
+      }
+      if (Object.keys(patch).length > 0) {
+        const realtime = getRealtimeService()
+        await Promise.allSettled(
+          result.map((row) =>
+            publishThreadUpdated(
+              realtime,
+              this.organizationId,
+              {
+                threadId: row.id,
+                inboxId: row.inboxId ?? null,
+                previousInboxId: prevInboxIdById.get(row.id) ?? null,
+                patch,
+              },
+              { excludeSocketId: this.socketId }
+            )
+          )
+        )
+      }
 
       return { count: result.length }
     } catch (error: unknown) {
@@ -524,12 +622,19 @@ export class ThreadMutationService {
         .where(
           and(eq(schema.Thread.id, threadId), eq(schema.Thread.organizationId, this.organizationId))
         )
-        .returning({ id: schema.Thread.id })
+        .returning({ id: schema.Thread.id, inboxId: schema.Thread.inboxId })
 
       if (result.length === 0) {
         logger.error('Thread not found for permanent deletion.', { threadId })
         throw new Error(`Thread ${threadId} not found for deletion.`)
       }
+
+      await publishThreadDeleted(
+        getRealtimeService(),
+        this.organizationId,
+        { threadId, inboxId: result[0].inboxId ?? null },
+        { excludeSocketId: this.socketId }
+      )
 
       logger.info('Thread permanently deleted', { threadId })
       return { success: true }
@@ -565,12 +670,24 @@ export class ThreadMutationService {
             eq(schema.Thread.organizationId, this.organizationId)
           )
         )
-        .returning({ id: schema.Thread.id })
+        .returning({ id: schema.Thread.id, inboxId: schema.Thread.inboxId })
 
       logger.info('Threads permanently deleted in bulk', {
         requestedCount: threadIds.length,
         deletedCount: result.length,
       })
+
+      const realtime = getRealtimeService()
+      await Promise.allSettled(
+        result.map((row) =>
+          publishThreadDeleted(
+            realtime,
+            this.organizationId,
+            { threadId: row.id, inboxId: row.inboxId ?? null },
+            { excludeSocketId: this.socketId }
+          )
+        )
+      )
 
       return { count: result.length }
     } catch (error: unknown) {

--- a/packages/lib/src/threads/unread-service.ts
+++ b/packages/lib/src/threads/unread-service.ts
@@ -1,10 +1,14 @@
 // packages/lib/src/threads/unread-service.ts
-import { database as db, schema } from '@auxx/database'
+import { type Database, database as db, schema, type Transaction } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, count, eq, inArray, isNull, lt, or, sql } from 'drizzle-orm'
+
+type DbOrTx = Database | Transaction
+
 import { resolveConditionContext } from '../conditions/resolve-context'
 import type { ConditionGroup } from '../conditions/types'
 import { buildConditionGroupsQuery } from '../mail-query/condition-query-builder'
+import { getRealtimeService, publishThreadUpdated } from '../realtime'
 import type { FullCountsResponse, UserUnreadCounts } from './types'
 
 const logger = createScopedLogger('unread-service')
@@ -12,10 +16,13 @@ const logger = createScopedLogger('unread-service')
 export class UnreadService {
   private organizationId: string
   private userId: string
+  /** Originating socket id for self-echo suppression on realtime publishes. */
+  private socketId?: string
 
-  constructor(organizationId: string, userId: string, _db?: any) {
+  constructor(organizationId: string, userId: string, _db?: any, socketId?: string) {
     this.organizationId = organizationId
     this.userId = userId
+    this.socketId = socketId
     // _db parameter is kept for compatibility but not used - we use the imported db directly
   }
 
@@ -27,10 +34,15 @@ export class UnreadService {
   /**
    * Calculates the unread count for a specific user and inbox.
    * This is the core logic based on last message date vs last read date.
+   *
+   * @param tx Optional active tx — when called from inside `db.transaction()`,
+   *   pass it through so reads share the same connection instead of grabbing
+   *   another from the pool (which would deadlock under fan-out).
    */
-  async calculateUnreadCountForUserInbox(inboxId: string): Promise<number> {
+  async calculateUnreadCountForUserInbox(inboxId: string, tx?: DbOrTx): Promise<number> {
+    const dbOrTx = tx ?? db
     // Count threads without read status entries for the user
-    const threadsWithoutReadStatus = await db
+    const threadsWithoutReadStatus = await dbOrTx
       .select({ threadId: schema.Thread.id })
       .from(schema.Thread)
       .leftJoin(
@@ -50,7 +62,7 @@ export class UnreadService {
       )
 
     // Count threads with explicit unread status
-    const threadsWithUnreadStatus = await db
+    const threadsWithUnreadStatus = await dbOrTx
       .select({ threadId: schema.Thread.id })
       .from(schema.Thread)
       .innerJoin(schema.ThreadReadStatus, eq(schema.ThreadReadStatus.threadId, schema.Thread.id))
@@ -82,10 +94,13 @@ export class UnreadService {
 
   /**
    * Updates the aggregated unread count in the database and Redis cache.
+   *
+   * @param tx Optional active tx — see {@link calculateUnreadCountForUserInbox}.
    */
-  async updateUserInboxUnreadCount(inboxId: string, userId?: string): Promise<any> {
+  async updateUserInboxUnreadCount(inboxId: string, userId?: string, tx?: DbOrTx): Promise<any> {
     if (!userId) userId = this.userId // Use the class userId if not provided
-    const calculatedCount = await this.calculateUnreadCountForUserInbox(inboxId)
+    const dbOrTx = tx ?? db
+    const calculatedCount = await this.calculateUnreadCountForUserInbox(inboxId, tx)
     const _redisKey = this.getRedisCountKey(inboxId, userId)
 
     logger.info(
@@ -93,7 +108,7 @@ export class UnreadService {
     )
 
     // Check if record exists
-    const [existingRecord] = await db
+    const [existingRecord] = await dbOrTx
       .select()
       .from(schema.UserInboxUnreadCount)
       .where(
@@ -110,7 +125,7 @@ export class UnreadService {
 
     if (existingRecord) {
       // Update existing record
-      await db
+      await dbOrTx
         .update(schema.UserInboxUnreadCount)
         .set({
           unreadCount: calculatedCount,
@@ -127,7 +142,7 @@ export class UnreadService {
       updatedRecord = { ...existingRecord, unreadCount: calculatedCount, updatedAt: now }
     } else {
       // Create new record
-      const [newRecord] = await db
+      const [newRecord] = await dbOrTx
         .insert(schema.UserInboxUnreadCount)
         .values({
           organizationId: this.organizationId,
@@ -228,12 +243,32 @@ export class UnreadService {
 
       // Update counts for all affected inboxes
       await Promise.all(
-        affectedInboxIds.map((inboxId) => this.updateUserInboxUnreadCount(inboxId, targetUserId))
+        affectedInboxIds.map((inboxId) =>
+          this.updateUserInboxUnreadCount(inboxId, targetUserId, tx)
+        )
       )
     })
 
     logger.info(
       `Set ${threads.length} thread(s) to ${isRead ? 'read' : 'unread'} for user ${targetUserId}`
+    )
+
+    // Publish per-thread `thread:updated` with `{ isUnread, userId }`. The FE
+    // filters by userId so only the affected user's tabs apply the patch.
+    const realtime = getRealtimeService()
+    await Promise.allSettled(
+      threads.map((thread) =>
+        publishThreadUpdated(
+          realtime,
+          this.organizationId,
+          {
+            threadId: thread.id,
+            inboxId: thread.inboxId ?? null,
+            patch: { isUnread: !isRead, userId: targetUserId },
+          },
+          { excludeSocketId: this.socketId }
+        )
+      )
     )
   }
 
@@ -418,15 +453,34 @@ export class UnreadService {
             )
           )
 
-        // Update aggregate counts for all affected users in this inbox
-        const updateCountPromises = userIds.map(
-          (userId) => this.updateUserInboxUnreadCount(inboxId, userId) // Assumes this runs within the tx context if called directly
-          // Or call a tx-aware version
+        // Update aggregate counts for all affected users in this inbox.
+        // Pass `tx` so the inner SELECTs/UPDATEs share this connection instead
+        // of grabbing fresh ones (which deadlocks under bulk fan-out).
+        const updateCountPromises = userIds.map((userId) =>
+          this.updateUserInboxUnreadCount(inboxId, userId, tx)
         )
         await Promise.all(updateCountPromises)
       })
       logger.info(
         `Marked thread ${threadId} as unread for ${userIds.length} users due to new message`
+      )
+
+      // Per-user `thread:updated { isUnread: true, userId }` so each affected
+      // user's open tabs flip the unread badge without a refetch.
+      const realtime = getRealtimeService()
+      await Promise.allSettled(
+        userIds.map((userId) =>
+          publishThreadUpdated(
+            realtime,
+            this.organizationId,
+            {
+              threadId,
+              inboxId,
+              patch: { isUnread: true, userId },
+            },
+            { excludeSocketId: this.socketId }
+          )
+        )
       )
     }
   }


### PR DESCRIPTION
## Summary

Adds a `realtimeMail` feature-flagged path that fans thread/message/participant changes to open browser tabs over per-inbox Pusher channels. Mail mutations and ingest seams emit `thread:*` / `message:*` / `participant:*` events; the new `useMailSync` hook subscribes to inboxes the user can read (plus the implicit `none` triage channel) and applies partial patches into the existing Zustand stores.

- **New event types + publish helpers** — `flushMailBatch`, `publishThreadCreated/Updated/Deleted`, `publishMessageCreated/Updated/Deleted`, `publishParticipantUpdated`. All gated on the new `FeatureKey.realtimeMail` flag.
- **Per-inbox channels** — `RealtimeService.sendToInbox` publishes to `presence-org-{org}-inbox-{slug}`; the Pusher adapter ref-counts subscriptions so multiple consumers can co-exist, and exposes a stable map snapshot for `useSyncExternalStore`.
- **Auth gate** — `/api/pusher/auth` authorizes `presence-org-{org}-inbox-{slug}` via `InboxService.hasUserAccess`. The `none` slug (unassigned triage) is open to all org members.
- **Batch coalescing on initial / polling sync** — ingest's `ctx.batchedEvents` buffers per-message events; `batchStoreMessages` flushes them via `flushMailBatch` in 50-event `mail:batch` frames per inbox channel to stay under Pusher's 10KB payload limit.
- **Optimistic-write protection** — `setThreadPatch` in `thread-store.ts` skips keys present in `pendingMutations` so out-of-order echoes can't clobber a pending optimistic write.
- **Self-echo suppression** — tRPC routers thread `x-realtime-socket-id` from the request headers into `ThreadMutationService`, `MessageSenderService`, `UnreadService`. The originating tab is excluded from the publish.
- **Tx propagation (deadlock fix)** — `UnreadService.calculateUnreadCountForUserInbox/updateUserInboxUnreadCount`, `addValues` in field-values, `MediaAssetService.convertTempToPermanent`, and `CommentService` now accept / pass through the active tx so fan-out reads and writes share the same connection. Without this, bulk fan-out triggers idle-in-transaction timeout cascades.

Files of note:
- `packages/lib/src/realtime/events.ts` — new event/meta types
- `packages/lib/src/realtime/publish-helpers.ts` — feature-flag-gated publishers
- `packages/lib/src/realtime/client/adapters/pusher.ts` — per-inbox subscription state
- `apps/web/src/components/threads/realtime/use-mail-sync.ts` — single-mount subscriber
- `apps/web/src/realtime/hooks.ts` — `useInboxChannel` / `useInboxChannels`

## Test plan

- [ ] With `realtimeMail` flag **off**, mail flows behave exactly as today (no extra Pusher subscribes, no publishes from ingest / mutation services)
- [ ] With flag **on**, opening two browser tabs on the same inbox: an action in tab A (assign, archive, reply, mark read/unread) appears in tab B without a refetch, while tab A's optimistic write is not clobbered by its own echo
- [ ] Inbound webhook ingest publishes `thread:created` / `message:created` to subscribed tabs; outbound send publishes `message:created` immediately (post-send sync may emit a follow-up `message:updated`, accepted)
- [ ] Initial/polling sync of a busy inbox produces a small number of `mail:batch` frames rather than per-message publishes (verify in Pusher debug console)
- [ ] `presence-org-{org}-inbox-{otherUsersInbox}` is rejected by `/api/pusher/auth` for users without view access on that inbox
- [ ] `presence-org-{org}-inbox-none` works for any org member (triage channel)
- [ ] Bulk-mark-read across many threads completes without idle-in-transaction errors (tx propagation in unread-service)
- [ ] Comment creation with media-asset attachments completes inside one tx (no pool grab from `convertTempToPermanent`)