### PR TITLE
feat(web): dataset card redesign + sidebar action prop + designs page tiles

### DIFF
--- a/apps/web/src/app/(protected)/app/examples/designs/page.tsx
+++ b/apps/web/src/app/(protected)/app/examples/designs/page.tsx
@@ -3,14 +3,266 @@
 'use client'
 
 import { AiThinking } from '@auxx/ui/components/ai-thinking'
+import {
+  Braces,
+  Calculator,
+  Calendar,
+  CalendarClock,
+  CaseSensitive,
+  CircleUser,
+  Clock,
+  DollarSign,
+  FileText,
+  Hash,
+  Link,
+  Link2,
+  List,
+  ListChecks,
+  type LucideIcon,
+  Mail,
+  MapPin,
+  Phone,
+  Tags,
+  ToggleLeft,
+  Upload,
+  User,
+} from 'lucide-react'
+
+type FieldBox = {
+  type: string
+  label: string
+  Icon: LucideIcon
+  /** Hue used for the colored variant (icon, tile bg, shadow tint) */
+  tileClass: string
+  iconClass: string
+  shadowClass: string
+}
+
+const FIELD_BOXES: FieldBox[] = [
+  {
+    type: 'TEXT',
+    label: 'Text',
+    Icon: CaseSensitive,
+    tileClass: 'bg-blue-500/10',
+    iconClass: 'text-blue-500',
+    shadowClass: 'shadow-blue-800/10',
+  },
+  {
+    type: 'NAME',
+    label: 'Name',
+    Icon: User,
+    tileClass: 'bg-violet-500/10',
+    iconClass: 'text-violet-500',
+    shadowClass: 'shadow-violet-800/10',
+  },
+  {
+    type: 'NUMBER',
+    label: 'Number',
+    Icon: Hash,
+    tileClass: 'bg-amber-500/10',
+    iconClass: 'text-amber-500',
+    shadowClass: 'shadow-amber-800/10',
+  },
+  {
+    type: 'CURRENCY',
+    label: 'Currency',
+    Icon: DollarSign,
+    tileClass: 'bg-emerald-500/10',
+    iconClass: 'text-emerald-500',
+    shadowClass: 'shadow-emerald-800/10',
+  },
+  {
+    type: 'PHONE_INTL',
+    label: 'Phone Number',
+    Icon: Phone,
+    tileClass: 'bg-teal-500/10',
+    iconClass: 'text-teal-500',
+    shadowClass: 'shadow-teal-800/10',
+  },
+  {
+    type: 'EMAIL',
+    label: 'Email',
+    Icon: Mail,
+    tileClass: 'bg-sky-500/10',
+    iconClass: 'text-sky-500',
+    shadowClass: 'shadow-sky-800/10',
+  },
+  {
+    type: 'URL',
+    label: 'URL',
+    Icon: Link,
+    tileClass: 'bg-cyan-500/10',
+    iconClass: 'text-cyan-500',
+    shadowClass: 'shadow-cyan-800/10',
+  },
+  {
+    type: 'DATE',
+    label: 'Date',
+    Icon: Calendar,
+    tileClass: 'bg-rose-500/10',
+    iconClass: 'text-rose-500',
+    shadowClass: 'shadow-rose-800/10',
+  },
+  {
+    type: 'DATETIME',
+    label: 'Date & Time',
+    Icon: CalendarClock,
+    tileClass: 'bg-pink-500/10',
+    iconClass: 'text-pink-500',
+    shadowClass: 'shadow-pink-800/10',
+  },
+  {
+    type: 'TIME',
+    label: 'Time',
+    Icon: Clock,
+    tileClass: 'bg-fuchsia-500/10',
+    iconClass: 'text-fuchsia-500',
+    shadowClass: 'shadow-fuchsia-800/10',
+  },
+  {
+    type: 'CHECKBOX',
+    label: 'Checkbox',
+    Icon: ToggleLeft,
+    tileClass: 'bg-green-500/10',
+    iconClass: 'text-green-500',
+    shadowClass: 'shadow-green-800/10',
+  },
+  {
+    type: 'TAGS',
+    label: 'Tags',
+    Icon: Tags,
+    tileClass: 'bg-indigo-500/10',
+    iconClass: 'text-indigo-500',
+    shadowClass: 'shadow-indigo-800/10',
+  },
+  {
+    type: 'ADDRESS_STRUCT',
+    label: 'Address',
+    Icon: MapPin,
+    tileClass: 'bg-orange-500/10',
+    iconClass: 'text-orange-500',
+    shadowClass: 'shadow-orange-800/10',
+  },
+  {
+    type: 'SINGLE_SELECT',
+    label: 'Select',
+    Icon: List,
+    tileClass: 'bg-purple-500/10',
+    iconClass: 'text-purple-500',
+    shadowClass: 'shadow-purple-800/10',
+  },
+  {
+    type: 'MULTI_SELECT',
+    label: 'Multi-Select',
+    Icon: ListChecks,
+    tileClass: 'bg-lime-500/10',
+    iconClass: 'text-lime-500',
+    shadowClass: 'shadow-lime-800/10',
+  },
+  {
+    type: 'RICH_TEXT',
+    label: 'Rich Text',
+    Icon: FileText,
+    tileClass: 'bg-slate-500/10',
+    iconClass: 'text-slate-500',
+    shadowClass: 'shadow-slate-800/10',
+  },
+  {
+    type: 'FILE',
+    label: 'File Upload',
+    Icon: Upload,
+    tileClass: 'bg-stone-500/10',
+    iconClass: 'text-stone-500',
+    shadowClass: 'shadow-stone-800/10',
+  },
+  {
+    type: 'RELATIONSHIP',
+    label: 'Relationship',
+    Icon: Link2,
+    tileClass: 'bg-yellow-500/10',
+    iconClass: 'text-yellow-500',
+    shadowClass: 'shadow-yellow-800/10',
+  },
+  {
+    type: 'CALC',
+    label: 'Calculated',
+    Icon: Calculator,
+    tileClass: 'bg-red-500/10',
+    iconClass: 'text-red-500',
+    shadowClass: 'shadow-red-800/10',
+  },
+  {
+    type: 'ACTOR',
+    label: 'Actor',
+    Icon: CircleUser,
+    tileClass: 'bg-neutral-500/10',
+    iconClass: 'text-neutral-500',
+    shadowClass: 'shadow-neutral-800/10',
+  },
+  {
+    type: 'JSON',
+    label: 'JSON',
+    Icon: Braces,
+    tileClass: 'bg-zinc-500/10',
+    iconClass: 'text-zinc-500',
+    shadowClass: 'shadow-zinc-800/10',
+  },
+]
+
+function FieldBoxRow({ box, grayscale }: { box: FieldBox; grayscale: boolean }) {
+  const tileClass = grayscale ? 'bg-zinc-500/10' : box.tileClass
+  const iconClass = grayscale ? 'text-zinc-500' : box.iconClass
+  const shadowClass = grayscale ? 'shadow-zinc-800/10' : box.shadowClass
+  return (
+    <div
+      className={`bg-illustration ring-border-illustration flex items-center gap-1.5 rounded-xl p-1 pr-3 shadow-md ring-1 ${shadowClass}`}>
+      <div
+        className={`after:border-foreground/5 relative flex size-8 items-center justify-center rounded-lg after:absolute after:inset-0 after:rounded-lg after:border ${tileClass}`}>
+        <box.Icon className={`size-4 ${iconClass}`} />
+      </div>
+      <div className='text-[10px] font-medium'>{box.label}</div>
+    </div>
+  )
+}
 
 export default function DesignsPage() {
   return (
-    <div className='container mx-auto py-6 space-y-6 overflow-y-auto'>
+    <div className='container mx-auto py-6 space-y-10 overflow-y-auto'>
       <div className='space-y-2'>
         <h1 className='text-3xl font-bold'>Designs</h1>
         <p className='text-muted-foreground'>Component design previews.</p>
       </div>
+
+      <section className='space-y-6'>
+        <div className='space-y-1'>
+          <h2 className='text-xl font-semibold'>Custom Field Type Boxes</h2>
+          <p className='text-muted-foreground text-sm'>
+            Promo-video tiles for each FieldType. Colored on top, grayscale below.
+          </p>
+        </div>
+
+        <div className='space-y-3'>
+          <div className='text-muted-foreground text-xs font-medium uppercase tracking-wide'>
+            Colored
+          </div>
+          <div className='flex flex-wrap gap-3'>
+            {FIELD_BOXES.map((box) => (
+              <FieldBoxRow key={box.type} box={box} grayscale={false} />
+            ))}
+          </div>
+        </div>
+
+        <div className='space-y-3'>
+          <div className='text-muted-foreground text-xs font-medium uppercase tracking-wide'>
+            Grayscale
+          </div>
+          <div className='flex flex-wrap gap-3'>
+            {FIELD_BOXES.map((box) => (
+              <FieldBoxRow key={box.type} box={box} grayscale={true} />
+            ))}
+          </div>
+        </div>
+      </section>
 
       <div className='flex items-center justify-center py-12'>
         <AiThinking />

--- a/apps/web/src/components/datasets/dataset-card.tsx
+++ b/apps/web/src/components/datasets/dataset-card.tsx
@@ -3,9 +3,9 @@
 'use client'
 
 import type { DatasetWithRelations } from '@auxx/lib/datasets'
+import { Avatar, AvatarFallback } from '@auxx/ui/components/avatar'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@auxx/ui/components/card'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,18 +13,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
-import { formatBytes, formatRelativeTime } from '@auxx/utils'
-import {
-  Archive,
-  Calendar,
-  Database,
-  FileText,
-  MoreVertical,
-  Search,
-  Settings,
-  Trash,
-} from 'lucide-react'
+import { LastUpdated } from '@auxx/ui/components/last-updated'
+import { formatBytes } from '@auxx/utils'
+import { Archive, Database, MoreVertical, Search, Settings, Trash } from 'lucide-react'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
+import { Tooltip } from '~/components/global/tooltip'
 import { useDatasetActions } from './hooks/use-dataset-actions'
 
 interface DatasetCardProps {
@@ -33,9 +26,13 @@ interface DatasetCardProps {
   onActionComplete?: () => void
 }
 
-/**
- * Card component for displaying dataset information in grid view
- */
+const STATUS_DOT: Record<string, { color: string; label: string }> = {
+  ACTIVE: { color: 'bg-good-500', label: 'Active' },
+  PROCESSING: { color: 'bg-warning-500', label: 'Processing' },
+  ERROR: { color: 'bg-destructive', label: 'Error' },
+  ARCHIVED: { color: 'bg-muted-foreground/40', label: 'Archived' },
+}
+
 export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardProps) {
   const { handleBrowse, handleSettings, handleDelete, handleArchive, ConfirmDialog } =
     useDatasetActions({
@@ -44,55 +41,79 @@ export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardP
       onSuccess: onActionComplete,
     })
 
-  /**
-   * Get badge color based on dataset status
-   */
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'ACTIVE':
-        return 'bg-green-100 text-green-800'
-      case 'PROCESSING':
-        return 'bg-yellow-100 text-yellow-800'
-      case 'ERROR':
-        return 'bg-red-100 text-red-800'
-      case 'ARCHIVED':
-        return 'bg-gray-100 text-gray-800'
-      default:
-        return 'bg-gray-100 text-gray-800'
-    }
+  const status = STATUS_DOT[dataset.status] ?? STATUS_DOT.ARCHIVED
+  const creatorName = dataset.createdBy.name ?? dataset.createdBy.email ?? '?'
+  const creatorInitial = creatorName.charAt(0).toUpperCase()
+
+  const stop = (e: React.MouseEvent) => e.stopPropagation()
+  const wrap = (fn: () => void | Promise<void>) => (e: React.MouseEvent) => {
+    e.stopPropagation()
+    void fn()
   }
 
   return (
     <>
-      <Card className='group cursor-pointer transition-shadow hover:shadow-md' onClick={onClick}>
-        <CardHeader>
-          <div className='flex items-start justify-between'>
-            <div className='relative'>
-              <div className={`p-2 rounded-lg bg-good-50 text-good-500`}>
-                <Database className='size-4' />
-              </div>
-              <div className='absolute -top-1 -right-1'>
-                <div className='flex items-center gap-2'>
-                  <div className={`size-2.5 rounded-full bg-good-500 flex-shrink-0`} />
-                </div>
-              </div>
+      <ConfirmDialog />
+      <div
+        className='rounded-2xl bg-background dark:bg-primary-50 hover:bg-primary-50/50 hover:outline-5 dark:hover:outline-primary-50/50 hover:outline-primary-100 flex flex-col p-3 gap-2 border cursor-pointer group/dataset-card relative'
+        onClick={onClick}>
+        <div className='flex flex-row items-start gap-2 w-full'>
+          <div className='relative shrink-0'>
+            <div className='size-8 rounded-xl border flex items-center justify-center overflow-hidden'>
+              <Database className='size-4' />
             </div>
+            <Tooltip content={status.label}>
+              <div
+                className={`absolute -top-0.5 -right-0.5 size-2.5 rounded-full border-2 border-primary-50 ${status.color}`}
+              />
+            </Tooltip>
+          </div>
+
+          <div className='flex flex-col flex-1 min-w-0'>
+            <div className='flex flex-row justify-between items-start gap-1'>
+              <p className='text-sm font-semibold line-clamp-2 group-hover/dataset-card:text-info'>
+                {dataset.name}
+              </p>
+            </div>
+            <LastUpdated
+              timestamp={dataset.updatedAt}
+              prefix=''
+              includeSeconds={true}
+              className='text-xs text-muted-foreground'
+            />
+          </div>
+        </div>
+
+        <div className='flex items-center justify-between mt-auto gap-2'>
+          <Badge variant='pill' size='sm' className='shrink-0 mt-0.5'>
+            {dataset.documentCount} docs
+            <span className='mx-1 text-muted-foreground/60'>|</span>
+            {formatBytes(Number(dataset.totalSize))}
+          </Badge>
+          <div className='flex items-center gap-1'>
+            <Tooltip content={`Created by ${creatorName}`}>
+              <Avatar className='size-5'>
+                <AvatarFallback className='text-[10px] font-medium'>
+                  {creatorInitial}
+                </AvatarFallback>
+              </Avatar>
+            </Tooltip>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
+                  className='opacity-0 group-hover/dataset-card:opacity-100 duration-300 data-[state=open]:opacity-100! data-[state=open]:bg-muted! transition-opacity rounded-lg'
                   variant='ghost'
-                  size='icon-sm'
-                  className='opacity-0 group-hover:opacity-100'
-                  onClick={(e) => e.stopPropagation()}>
+                  size='icon-xs'
+                  onClick={stop}>
                   <MoreVertical />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align='end' onClick={(e) => e.stopPropagation()}>
-                <DropdownMenuItem onClick={handleBrowse}>
+              <DropdownMenuContent align='end' onClick={stop}>
+                <DropdownMenuItem onClick={wrap(handleBrowse)}>
                   <Search />
                   Browse
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={handleSettings}>
+                <DropdownMenuItem onClick={wrap(handleSettings)}>
                   <Settings />
                   Settings
                 </DropdownMenuItem>
@@ -101,55 +122,19 @@ export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardP
                   targetIds={{ datasetId: dataset.id }}
                 />
                 <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={handleArchive}>
+                <DropdownMenuItem onClick={wrap(handleArchive)}>
                   <Archive />
                   Archive
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={handleDelete} variant='destructive'>
+                <DropdownMenuItem onClick={wrap(handleDelete)} variant='destructive'>
                   <Trash />
                   Delete
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
-
-          <CardTitle className='text-sm truncate'>
-            <div className='flex justify-between items-center'>
-              <span className=''>{dataset.name}</span>
-              <Badge className={getStatusColor(dataset.status)} size='xs'>
-                {dataset.status.toLowerCase()}
-              </Badge>
-            </div>
-          </CardTitle>
-        </CardHeader>
-
-        <CardContent onClick={onClick}>
-          {/* Status */}
-          <div className='flex items-center gap-2 mb-3'></div>
-
-          {/* Stats */}
-          <div className='grid grid-cols-2 gap-4 text-sm'>
-            <div className='flex items-center gap-2'>
-              <FileText className='h-4 w-4 text-muted-foreground' />
-              <span className='text-muted-foreground'>{dataset.documentCount} docs</span>
-            </div>
-            <div className='flex items-center gap-2'>
-              <Calendar className='h-4 w-4 text-muted-foreground' />
-              <span className='text-muted-foreground'>{formatRelativeTime(dataset.updatedAt)}</span>
-            </div>
-          </div>
-
-          {/* Size and Created By */}
-          <div className='mt-3 pt-3 border-t text-xs text-muted-foreground'>
-            <div className='flex justify-between items-center'>
-              <span>Size: {formatBytes(Number(dataset.totalSize))}</span>
-              <span>by {dataset.createdBy.name}</span>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      <ConfirmDialog />
+        </div>
+      </div>
     </>
   )
 }

--- a/apps/web/src/components/datasets/datasets-grid-view.tsx
+++ b/apps/web/src/components/datasets/datasets-grid-view.tsx
@@ -21,7 +21,7 @@ export function DatasetsGridView() {
   }
 
   return (
-    <div className='grid gap-4 @md:grid-cols-2 @4xl:grid-cols-3 @5xl:grid-cols-4 @6xl:grid-cols-5 p-3'>
+    <div className='grid gap-4 @md:grid-cols-2 @lg:grid-cols-3 @xl:grid-cols-4 p-3'>
       {items.map((dataset) => (
         <DatasetCard
           key={dataset.id}

--- a/apps/web/src/components/favorites/ui/favorite-item-row.tsx
+++ b/apps/web/src/components/favorites/ui/favorite-item-row.tsx
@@ -1,8 +1,9 @@
 // apps/web/src/components/favorites/ui/favorite-item-row.tsx
 'use client'
 
-import { DropdownMenuItem } from '@auxx/ui/components/dropdown-menu'
-import { Star } from 'lucide-react'
+import { Button } from '@auxx/ui/components/button'
+import { cn } from '@auxx/ui/lib/utils'
+import { BookmarkX } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
 import { api } from '~/trpc/react'
@@ -37,11 +38,22 @@ export function FavoriteItemRow({
     removeMutation.mutate({ favoriteId })
   }
 
-  const editItems = (
-    <DropdownMenuItem onClick={handleRemove}>
-      <Star />
-      Remove from favorites
-    </DropdownMenuItem>
+  const action = (
+    <Button
+      variant='ghost'
+      size='icon'
+      aria-label='Remove from favorites'
+      onClick={(e) => {
+        e.stopPropagation()
+        e.preventDefault()
+        handleRemove()
+      }}
+      className={cn(
+        'size-6 shrink-0 rounded-md opacity-100 sm:opacity-0 sm:group-hover/item:opacity-100',
+        'hover:bg-primary-200/50 hover:text-foreground/50 focus-visible:ring-primary/10'
+      )}>
+      <BookmarkX className='size-3.5' />
+    </Button>
   )
 
   return (
@@ -52,7 +64,7 @@ export function FavoriteItemRow({
       icon={icon}
       isSubmenu
       isActive={isActive}
-      editItems={editItems}
+      action={action}
       className={subtitle ? '' : ''}
     />
   )

--- a/apps/web/src/components/global/sidebar/sidebar-item.tsx
+++ b/apps/web/src/components/global/sidebar/sidebar-item.tsx
@@ -28,6 +28,8 @@ interface SidebarItemProps {
   isActive?: boolean
   isInbox?: boolean
   editItems?: ReactNode
+  /** Inline action button rendered in place of the 3-dot dropdown. Mutually exclusive with editItems/onToggleEditMode. */
+  action?: ReactNode
   onToggleEditMode?: () => void
   /** When true, renders the name as an editable input. Click-through to navigation is suppressed. */
   isEditing?: boolean
@@ -52,6 +54,7 @@ export function SidebarItem({
   className = '',
   isActive,
   editItems,
+  action,
   isInbox = false,
   onToggleEditMode,
   isEditing = false,
@@ -133,6 +136,15 @@ export function SidebarItem({
                 {count}
               </div>
             </>
+          )}
+          {action && !hasDropdownContent && (
+            <div
+              onClick={(e) => {
+                e.stopPropagation()
+                e.preventDefault()
+              }}>
+              {action}
+            </div>
           )}
           {hasDropdownContent && (
             <div


### PR DESCRIPTION
## Summary
- **Dataset card**: replace the shadcn Card scaffolding with a compact rounded panel — single-line title, status dot tooltip, last-updated meta, pill stat (docs · size), creator avatar, hover-only menu trigger. Tighter grid breakpoints (2 / 3 / 4 cols).
- **SidebarItem**: add an \`action\` prop for an inline action button rendered in place of the 3-dot dropdown when there's a single primary action. Mutually exclusive with \`editItems\` / \`onToggleEditMode\`.
- **FavoriteItemRow**: switch to the new \`action\` slot with a hover-only \`BookmarkX\` button instead of a dropdown menu item.
- **Designs page**: add the FieldType promo tiles (colored + grayscale variants) used in marketing material.

## Test plan
- [ ] Datasets grid: cards render at 2/3/4 cols across breakpoints, status dot tooltip works, hover reveals the menu trigger, all dropdown actions still fire (browse, settings, archive, delete, favorite toggle)
- [ ] Sidebar favorites: hover a row, click the bookmark-x button, confirm removal works without triggering navigation
- [ ] Sidebar items elsewhere with \`editItems\` still show the existing 3-dot menu unchanged
- [ ] \`/app/examples/designs\` page renders the colored and grayscale FieldType tile rows