### PR TITLE
feat(kb): preview hint nudge to Articles tab, gate Layout tab, settings shuffle

### DIFF
--- a/apps/web/src/components/kb/constant.ts
+++ b/apps/web/src/components/kb/constant.ts
@@ -1,0 +1,4 @@
+// apps/web/src/components/kb/constant.ts
+
+/** Gate for the KB editor's Layout tab. Hide until the layout features are ready to ship. */
+export const LAYOUT_TAB_ENABLED = false

--- a/apps/web/src/components/kb/ui/editor/kb-editor-frame.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-frame.tsx
@@ -7,6 +7,8 @@ import type React from 'react'
 import { useMemo } from 'react'
 import { LoadingSpinner } from '~/components/global/loading-content'
 import { useKnowledgeBase } from '../../hooks/use-knowledge-base'
+import { ArticlesTabArrow } from '../preview/articles-tab-arrow'
+import { KBPreviewHintProvider } from '../preview/preview-hint-context'
 import { KBEditorHeader } from './kb-editor-header'
 import { KBTabPanel } from './kb-tab-panel'
 
@@ -45,9 +47,12 @@ export function KBEditorFrame({ knowledgeBaseId, children }: KBEditorFrameProps)
   }
 
   return (
-    <MainPage>
-      <KBEditorHeader knowledgeBaseId={knowledgeBaseId} knowledgeBase={knowledgeBase} />
-      <MainPageContent leftPanels={leftPanels}>{children}</MainPageContent>
-    </MainPage>
+    <KBPreviewHintProvider>
+      <MainPage>
+        <KBEditorHeader knowledgeBaseId={knowledgeBaseId} knowledgeBase={knowledgeBase} />
+        <MainPageContent leftPanels={leftPanels}>{children}</MainPageContent>
+        <ArticlesTabArrow />
+      </MainPage>
+    </KBPreviewHintProvider>
   )
 }

--- a/apps/web/src/components/kb/ui/editor/kb-editor-header.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-header.tsx
@@ -12,8 +12,10 @@ import {
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { Book, Cog, Layout } from 'lucide-react'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
+import { LAYOUT_TAB_ENABLED } from '../../constant'
 import type { KnowledgeBase } from '../../store/knowledge-base-store'
+import { useKBPreviewHint } from '../preview/preview-hint-context'
 import { KBSwitcherDropdownContent } from '../sidebar/kb-switcher'
 import { KBPublishCluster } from './kb-publish-cluster'
 
@@ -45,6 +47,13 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
     'panel',
     parseAsStringLiteral(PANEL_VALUES).withDefault('general')
   )
+  const { lockSession } = useKBPreviewHint()
+
+  // Once the user has reached the Articles panel they've found the answer the
+  // hint was pointing at — never show it again this session.
+  useEffect(() => {
+    if (panel === 'articles') lockSession()
+  }, [panel, lockSession])
 
   const merged = useMemo(
     () => mergeDraftOverLive(knowledgeBase as Record<string, unknown>) as KnowledgeBase,
@@ -83,11 +92,13 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
           <Cog />
           <span className='hidden sm:inline'>General</span>
         </RadioTabItem>
-        <RadioTabItem value='layout' tooltip='Layout'>
-          <Layout />
-          <span className='hidden sm:inline'>Layout</span>
-        </RadioTabItem>
-        <RadioTabItem value='articles' tooltip='Articles'>
+        {LAYOUT_TAB_ENABLED && (
+          <RadioTabItem value='layout' tooltip='Layout'>
+            <Layout />
+            <span className='hidden sm:inline'>Layout</span>
+          </RadioTabItem>
+        )}
+        <RadioTabItem value='articles' tooltip='Articles' data-kb-articles-tab=''>
           <Book />
           <span className='hidden sm:inline'>Articles</span>
         </RadioTabItem>

--- a/apps/web/src/components/kb/ui/editor/kb-tab-panel.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-tab-panel.tsx
@@ -6,6 +6,7 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { cn } from '@auxx/ui/lib/utils'
 import { Loader2 } from 'lucide-react'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
+import { LAYOUT_TAB_ENABLED } from '../../constant'
 import type { KnowledgeBase } from '../../store/knowledge-base-store'
 import { useKnowledgeBaseStore } from '../../store/knowledge-base-store'
 import { GeneralTab } from '../settings/general/general-tab'
@@ -58,7 +59,7 @@ export function KBTabPanel({ knowledgeBaseId, knowledgeBase }: KBTabPanelProps) 
         {activePanel === 'general' && (
           <GeneralTab knowledgeBaseId={knowledgeBaseId} knowledgeBase={knowledgeBase} />
         )}
-        {activePanel === 'layout' && (
+        {LAYOUT_TAB_ENABLED && activePanel === 'layout' && (
           <LayoutTab knowledgeBaseId={knowledgeBaseId} knowledgeBase={knowledgeBase} />
         )}
         {activePanel === 'articles' && <KBArticlesPanel knowledgeBaseId={knowledgeBaseId} />}

--- a/apps/web/src/components/kb/ui/preview/articles-tab-arrow.tsx
+++ b/apps/web/src/components/kb/ui/preview/articles-tab-arrow.tsx
@@ -1,0 +1,83 @@
+// apps/web/src/components/kb/ui/preview/articles-tab-arrow.tsx
+'use client'
+
+import { ArrowDown } from 'lucide-react'
+import * as React from 'react'
+import { createPortal } from 'react-dom'
+import { useKBPreviewHint } from './preview-hint-context'
+
+interface Rect {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+/**
+ * Floating chevron portal anchored above the Articles RadioTabItem (looked up
+ * via [data-kb-articles-tab]). Re-measures on resize/scroll while visible.
+ */
+export function ArticlesTabArrow() {
+  const { isVisible } = useKBPreviewHint()
+  const [rect, setRect] = React.useState<Rect | null>(null)
+  const [mounted, setMounted] = React.useState(false)
+
+  React.useEffect(() => setMounted(true), [])
+
+  React.useEffect(() => {
+    if (!isVisible) {
+      setRect(null)
+      return
+    }
+
+    let rafId: number | null = null
+    let attempts = 0
+
+    const measure = () => {
+      const el = document.querySelector<HTMLElement>('[data-kb-articles-tab]')
+      if (!el) {
+        // The tab might not be mounted yet — retry briefly on rAF.
+        if (attempts < 30) {
+          attempts += 1
+          rafId = requestAnimationFrame(measure)
+        }
+        return
+      }
+      const r = el.getBoundingClientRect()
+      setRect({ top: r.top, left: r.left, width: r.width, height: r.height })
+    }
+
+    measure()
+
+    const onResizeOrScroll = () => measure()
+    window.addEventListener('resize', onResizeOrScroll)
+    window.addEventListener('scroll', onResizeOrScroll, true)
+
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId)
+      window.removeEventListener('resize', onResizeOrScroll)
+      window.removeEventListener('scroll', onResizeOrScroll, true)
+    }
+  }, [isVisible])
+
+  if (!mounted || !isVisible || !rect) return null
+
+  // Position the arrow above the center of the tab, pointing down at it.
+  const ARROW_SIZE = 28
+  const GAP = 6
+  const top = rect.top - ARROW_SIZE - GAP
+  const left = rect.left + rect.width / 2 - ARROW_SIZE / 2
+
+  return createPortal(
+    <div
+      data-slot='kb-articles-tab-arrow'
+      className='pointer-events-none fixed z-[60] motion-safe:animate-bounce motion-reduce:animate-none'
+      style={{ top, left, width: ARROW_SIZE, height: ARROW_SIZE }}
+      aria-hidden>
+      <div className='flex size-full items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg'>
+        <ArrowDown className='size-4' />
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/apps/web/src/components/kb/ui/preview/kb-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview.tsx
@@ -18,6 +18,8 @@ import { KBPreviewTopBar } from './kb-preview-topbar'
 import { mapKBForPreview } from './map-kb-for-preview'
 import { PreviewProvider, usePreview } from './preview-context'
 import { DesktopPreviewFrame, MobilePreviewFrame } from './preview-frames'
+import { useKBPreviewHint } from './preview-hint-context'
+import { PreviewHintOverlay } from './preview-hint-overlay'
 
 interface KBPreviewProps {
   knowledgeBase: KnowledgeBase
@@ -36,6 +38,7 @@ export function KBPreview({ knowledgeBase, activeSlugPath }: KBPreviewProps) {
 function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath?: string[] }) {
   const { isMobile, effectiveMode, knowledgeBase, previewMode, setPreviewMode, setOverride } =
     usePreview()
+  const hint = useKBPreviewHint()
   const articles = useArticleList(kbId)
 
   // Article from the editor's slug path; resets the override when the editor switches.
@@ -123,12 +126,16 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
   return (
     <div className='flex min-h-0 flex-1 flex-col'>
       <KBPreviewTopBar kbId={kbId} activeSlugPath={activeSlugPath} articleId={articleId} />
-      <div className='flex min-h-0 flex-1 justify-center bg-muted p-4'>
+      <div
+        className='relative flex min-h-0 flex-1 justify-center bg-muted p-4'
+        onPointerEnter={hint.onPointerEnter}
+        onPointerLeave={hint.onPointerLeave}>
         {isMobile ? (
           <MobilePreviewFrame>{layout}</MobilePreviewFrame>
         ) : (
           <DesktopPreviewFrame url={browserUrl}>{layout}</DesktopPreviewFrame>
         )}
+        <PreviewHintOverlay />
       </div>
     </div>
   )

--- a/apps/web/src/components/kb/ui/preview/preview-hint-context.tsx
+++ b/apps/web/src/components/kb/ui/preview/preview-hint-context.tsx
@@ -1,0 +1,134 @@
+// apps/web/src/components/kb/ui/preview/preview-hint-context.tsx
+'use client'
+
+import * as React from 'react'
+
+interface KBPreviewHintContextValue {
+  isVisible: boolean
+  onPointerEnter: () => void
+  onPointerLeave: () => void
+  hide: () => void
+}
+
+const KBPreviewHintContext = React.createContext<KBPreviewHintContextValue | undefined>(undefined)
+
+const STORAGE_KEY = 'kb-preview-edit-hint-shown-count'
+const MAX_SHOWS = 3
+const AUTO_DISMISS_MS = 4000
+// A "qualifying" show — visible long enough to be read. Below this, we treat
+// the hover as a flyover and don't burn a counter.
+const CONSUME_AFTER_MS = 1500
+
+function readShownCount(): number {
+  if (typeof window === 'undefined') return 0
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) return 0
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function writeShownCount(count: number) {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(STORAGE_KEY, String(count))
+}
+
+interface KBPreviewHintProviderProps {
+  children: React.ReactNode
+}
+
+export function KBPreviewHintProvider({ children }: KBPreviewHintProviderProps) {
+  const [isVisible, setIsVisible] = React.useState(false)
+  // Locked-out for the rest of the session once the user has seen the hint
+  // enough times or proven they know about Articles. Starts pessimistic — we
+  // re-check localStorage on mount to avoid SSR mismatch.
+  const [locked, setLocked] = React.useState(true)
+  const shownCountRef = React.useRef(0)
+  const visibleSinceRef = React.useRef<number | null>(null)
+  const autoDismissTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  React.useEffect(() => {
+    shownCountRef.current = readShownCount()
+    setLocked(shownCountRef.current >= MAX_SHOWS)
+  }, [])
+
+  const clearAutoDismiss = React.useCallback(() => {
+    if (autoDismissTimerRef.current) {
+      clearTimeout(autoDismissTimerRef.current)
+      autoDismissTimerRef.current = null
+    }
+  }, [])
+
+  const consumeIfQualifying = React.useCallback(() => {
+    const since = visibleSinceRef.current
+    visibleSinceRef.current = null
+    if (since === null) return
+    const elapsed = Date.now() - since
+    if (elapsed < CONSUME_AFTER_MS) return
+    const next = shownCountRef.current + 1
+    shownCountRef.current = next
+    writeShownCount(next)
+    if (next >= MAX_SHOWS) setLocked(true)
+  }, [])
+
+  const hide = React.useCallback(() => {
+    clearAutoDismiss()
+    setIsVisible((wasVisible) => {
+      if (wasVisible) consumeIfQualifying()
+      return false
+    })
+  }, [clearAutoDismiss, consumeIfQualifying])
+
+  const onPointerEnter = React.useCallback(() => {
+    if (locked) return
+    setIsVisible(true)
+    visibleSinceRef.current = Date.now()
+    clearAutoDismiss()
+    autoDismissTimerRef.current = setTimeout(() => {
+      consumeIfQualifying()
+      setIsVisible(false)
+    }, AUTO_DISMISS_MS)
+  }, [locked, clearAutoDismiss, consumeIfQualifying])
+
+  const onPointerLeave = React.useCallback(() => {
+    hide()
+  }, [hide])
+
+  // Lock for good once the user clicks Articles (or when mount happens already
+  // on Articles): the dismiss path runs through hide() so any in-flight show
+  // is consumed correctly.
+  const lockSession = React.useCallback(() => {
+    hide()
+    setLocked(true)
+  }, [hide])
+
+  React.useEffect(() => {
+    return () => {
+      clearAutoDismiss()
+    }
+  }, [clearAutoDismiss])
+
+  const value = React.useMemo<KBPreviewHintContextValue & { lockSession: () => void }>(
+    () => ({ isVisible, onPointerEnter, onPointerLeave, hide, lockSession }),
+    [isVisible, onPointerEnter, onPointerLeave, hide, lockSession]
+  )
+
+  return <KBPreviewHintContext.Provider value={value}>{children}</KBPreviewHintContext.Provider>
+}
+
+export function useKBPreviewHint(): KBPreviewHintContextValue & { lockSession: () => void } {
+  const ctx = React.useContext(KBPreviewHintContext) as
+    | (KBPreviewHintContextValue & { lockSession: () => void })
+    | undefined
+  if (!ctx) {
+    // Outside the provider (e.g. used somewhere unexpected) — degrade to no-op
+    // rather than throw, so a missing wrapper doesn't crash the editor.
+    return {
+      isVisible: false,
+      onPointerEnter: () => {},
+      onPointerLeave: () => {},
+      hide: () => {},
+      lockSession: () => {},
+    }
+  }
+  return ctx
+}

--- a/apps/web/src/components/kb/ui/preview/preview-hint-overlay.tsx
+++ b/apps/web/src/components/kb/ui/preview/preview-hint-overlay.tsx
@@ -1,0 +1,27 @@
+// apps/web/src/components/kb/ui/preview/preview-hint-overlay.tsx
+'use client'
+
+import { ArrowRight } from 'lucide-react'
+import { useKBPreviewHint } from './preview-hint-context'
+
+/**
+ * In-frame badge shown on first hovers of the preview, nudging the user toward
+ * the Articles tab. Pointer-events-none so it never blocks the preview.
+ */
+export function PreviewHintOverlay() {
+  const { isVisible } = useKBPreviewHint()
+  if (!isVisible) return null
+
+  return (
+    <div
+      data-slot='kb-preview-hint-overlay'
+      className='pointer-events-none absolute inset-0 z-40 flex items-center justify-center'
+      aria-hidden>
+      <div className='absolute inset-0 bg-background/40 backdrop-blur-[2px] motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200' />
+      <div className='relative flex items-center gap-2 rounded-full border border-foreground/10 bg-background px-4 py-2 text-sm font-medium text-foreground shadow-lg motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-95 motion-safe:duration-200'>
+        <span>This is a live preview. Go to Articles to edit</span>
+        <ArrowRight className='size-4 text-primary' />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/kb/ui/settings/general/identity-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/identity-section.tsx
@@ -60,7 +60,6 @@ export function IdentitySection({ knowledgeBaseId, knowledgeBase }: IdentitySect
   const onSubmit = async (data: IdentityFormValues) => {
     await updateKnowledgeBase(knowledgeBaseId, {
       slug: data.slug,
-      customDomain: data.customDomain ?? null,
       visibility: data.visibility,
     })
   }
@@ -76,7 +75,7 @@ export function IdentitySection({ knowledgeBaseId, knowledgeBase }: IdentitySect
   }, [knowledgeBaseId])
 
   return (
-    <Section title='Identity' description='URL, custom domain, and access for this knowledge base.'>
+    <Section title='Identity' description='URL and access for this knowledge base.'>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <VarEditorField orientation='vertical' className='p-0'>
@@ -96,27 +95,6 @@ export function IdentitySection({ knowledgeBaseId, knowledgeBase }: IdentitySect
                     value={field.value}
                     onChange={(v) => field.onChange(v ?? '')}
                     placeholder='my-knowledge-base'
-                    disabled={isUpdating}
-                  />
-                </VarEditorFieldRow>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name='customDomain'
-              render={({ field, fieldState }) => (
-                <VarEditorFieldRow
-                  title='Custom domain'
-                  description='Set a custom domain for your knowledge base.'
-                  type={BaseType.STRING}
-                  showIcon
-                  validationError={fieldState.error?.message}>
-                  <FieldInputAdapter
-                    fieldType={FieldType.TEXT}
-                    value={field.value ?? ''}
-                    onChange={(v) => field.onChange(v ?? '')}
-                    placeholder='docs.example.com'
                     disabled={isUpdating}
                   />
                 </VarEditorFieldRow>

--- a/apps/web/src/components/kb/ui/settings/general/styling-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/styling-section.tsx
@@ -31,6 +31,11 @@ const CORNER_OPTIONS = [
   { label: 'Straight', value: 'straight' },
 ]
 
+const SEARCHBAR_OPTIONS = [
+  { label: 'Center', value: 'center' },
+  { label: 'Corner', value: 'corner' },
+]
+
 const sidebarStyles = [
   {
     value: 'default' as const,
@@ -56,6 +61,7 @@ const stylingSchema = z.object({
   fontFamily: z.string().nullish(),
   cornerStyle: z.enum(['rounded', 'straight']).default('rounded'),
   sidebarListStyle: z.enum(['default', 'pill', 'line']).default('default'),
+  searchbarPosition: z.enum(['center', 'corner']).default('center'),
 })
 
 type StylingFormValues = z.infer<typeof stylingSchema>
@@ -69,6 +75,8 @@ function buildDefaults(kb: KnowledgeBase): StylingFormValues {
     cornerStyle: (lower(merged.cornerStyle) as StylingFormValues['cornerStyle']) || 'rounded',
     sidebarListStyle:
       (lower(merged.sidebarListStyle) as StylingFormValues['sidebarListStyle']) || 'default',
+    searchbarPosition:
+      (merged.searchbarPosition as StylingFormValues['searchbarPosition']) || 'center',
   }
 }
 
@@ -135,6 +143,27 @@ export function StylingSection({ knowledgeBaseId, knowledgeBase }: StylingSectio
                   fieldOptions={{ options: CORNER_OPTIONS }}
                   value={field.value}
                   onChange={(v) => field.onChange((v as string[])[0] ?? 'rounded')}
+                  placeholder='Pick…'
+                  triggerProps={{ className: 'w-full' }}
+                />
+              </VarEditorFieldRow>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name='searchbarPosition'
+            render={({ field, fieldState }) => (
+              <VarEditorFieldRow
+                title='Search bar'
+                description="Pick the style of the search bar. On small screens it's displayed as an icon button."
+                type={BaseType.ENUM}
+                showIcon
+                validationError={fieldState.error?.message}>
+                <FieldInputAdapter
+                  fieldType={FieldType.SINGLE_SELECT}
+                  fieldOptions={{ options: SEARCHBAR_OPTIONS }}
+                  value={field.value}
+                  onChange={(v) => field.onChange((v as string[])[0] ?? 'center')}
                   placeholder='Pick…'
                   triggerProps={{ className: 'w-full' }}
                 />

--- a/apps/web/src/components/kb/ui/settings/layout/header-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/layout/header-section.tsx
@@ -1,7 +1,6 @@
 // apps/web/src/components/kb/ui/settings/layout/header-section.tsx
 'use client'
 
-import { FieldType } from '@auxx/database/enums'
 import { mergeDraftOverLive } from '@auxx/lib/kb/client'
 import { Form, FormField } from '@auxx/ui/components/form'
 import { Section } from '@auxx/ui/components/section'
@@ -9,7 +8,6 @@ import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
-import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { BaseType } from '~/components/workflow/types'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { useDraftSettingsAutosave } from '../../../hooks/use-draft-settings-autosave'
@@ -24,23 +22,15 @@ const navigationItemSchema = z.object({
 
 const headerSchema = z.object({
   headerEnabled: z.boolean().default(true),
-  searchbarPosition: z.enum(['center', 'corner']).default('center'),
   headerNavigation: z.array(navigationItemSchema).default([]),
 })
 
 type HeaderFormValues = z.infer<typeof headerSchema>
 
-const SEARCHBAR_OPTIONS = [
-  { label: 'Center', value: 'center' },
-  { label: 'Corner', value: 'corner' },
-]
-
 function buildDefaults(kb: KnowledgeBase): HeaderFormValues {
   const merged = mergeDraftOverLive(kb as any) as KnowledgeBase
   return {
     headerEnabled: merged.headerEnabled ?? true,
-    searchbarPosition:
-      (merged.searchbarPosition as HeaderFormValues['searchbarPosition']) || 'center',
     headerNavigation:
       ((merged.headerNavigation ?? []) as HeaderFormValues['headerNavigation']) ?? [],
   }
@@ -79,28 +69,6 @@ export function HeaderSection({ knowledgeBaseId, knowledgeBase }: HeaderSectionP
       actions={<SectionStatusBadge drafted={drafted} saving={isSaving} savedAt={lastSavedAt} />}>
       <Form {...form}>
         <VarEditorField orientation='vertical' className='p-0'>
-          <FormField
-            control={form.control}
-            name='searchbarPosition'
-            render={({ field, fieldState }) => (
-              <VarEditorFieldRow
-                title='Search bar'
-                description="Pick the style of the search bar. On small screens it's displayed as an icon button."
-                type={BaseType.ENUM}
-                showIcon
-                validationError={fieldState.error?.message}>
-                <FieldInputAdapter
-                  fieldType={FieldType.SINGLE_SELECT}
-                  fieldOptions={{ options: SEARCHBAR_OPTIONS }}
-                  value={field.value}
-                  onChange={(v) => field.onChange((v as string[])[0] ?? 'center')}
-                  placeholder='Pick…'
-                  triggerProps={{ className: 'w-full' }}
-                />
-              </VarEditorFieldRow>
-            )}
-          />
-
           <FormField
             control={form.control}
             name='headerNavigation'

--- a/packages/ui/src/components/radio-tab.tsx
+++ b/packages/ui/src/components/radio-tab.tsx
@@ -94,6 +94,8 @@ export interface RadioTabItemProps extends VariantProps<typeof radioTabItemVaria
   disabled?: boolean
   /** Optional tooltip text to display on hover */
   tooltip?: string
+  /** Pass-through data-* attributes (e.g. for anchor lookups). */
+  [dataAttr: `data-${string}`]: string | undefined
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add a hover-triggered preview hint (in-frame overlay + floating arrow above the Articles tab) that nudges users from the live KB preview toward the Articles tab where editing actually happens. Capped at 3 qualifying shows via localStorage and auto-locked once the user lands on Articles.
- Gate the KB editor's Layout tab behind `LAYOUT_TAB_ENABLED` until those features ship; move the search bar position control from Layout/Header into General/Styling so it stays reachable while Layout is hidden.
- Drop the unused `customDomain` field from the Identity section.
- Allow `data-*` pass-through on `RadioTabItem` so the floating arrow can anchor to the Articles tab.

## Test plan
- [ ] Open the KB editor, hover the preview, and confirm the overlay + bouncing arrow appear and dismiss on pointer leave / 4s auto-dismiss.
- [ ] Hover the preview 3+ times for 1.5s+ each; confirm the hint stops appearing afterwards (localStorage `kb-preview-edit-hint-shown-count`).
- [ ] Click the Articles tab and confirm the hint is locked for the rest of the session.
- [ ] Confirm the Layout tab is no longer visible in the editor header.
- [ ] In General → Styling, confirm the new "Search bar" select works and persists.
- [ ] In Identity, confirm the custom domain field is gone and slug/visibility still save.
- [ ] Verify floating arrow re-positions on window resize and scroll.