### PR TITLE
feat(kb): editor enter-to-advance, public cover uploads, header layout

### DIFF
--- a/apps/build/Dockerfile
+++ b/apps/build/Dockerfile
@@ -6,12 +6,12 @@ FROM node:22.22-bookworm-slim AS slim
 
 FROM slim AS base
 
-RUN npm install -g corepack@0.31.0 && corepack enable
+RUN corepack enable && corepack prepare pnpm@10.17.0 --activate
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
-RUN pnpm install -g turbo
+RUN pnpm add -g turbo@2.5.2
 
 FROM base AS pruner
 

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -7,10 +7,10 @@ FROM node:22.22-bookworm-slim AS slim
 FROM slim AS base
 
 # Install pnpm and turbo
-RUN npm install -g corepack@0.31.0 && corepack enable
+RUN corepack enable && corepack prepare pnpm@10.17.0 --activate
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN pnpm install -g turbo
+RUN pnpm add -g turbo@2.5.2
 
 FROM base AS pruner
 

--- a/apps/homepage/Dockerfile
+++ b/apps/homepage/Dockerfile
@@ -7,10 +7,10 @@ FROM node:22.22-bookworm-slim AS slim
 FROM slim AS base
 
 # Install pnpm and turbo
-RUN npm install -g corepack@0.31.0 && corepack enable
+RUN corepack enable && corepack prepare pnpm@10.17.0 --activate
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN pnpm install -g turbo
+RUN pnpm add -g turbo@2.5.2
 
 FROM base AS pruner
 

--- a/apps/kb/Dockerfile
+++ b/apps/kb/Dockerfile
@@ -7,10 +7,10 @@ FROM node:22.22-bookworm-slim AS slim
 FROM slim AS base
 
 # Install pnpm and turbo
-RUN npm install -g corepack@0.31.0 && corepack enable
+RUN corepack enable && corepack prepare pnpm@10.17.0 --activate
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN pnpm install -g turbo
+RUN pnpm add -g turbo@2.5.2
 
 FROM base AS pruner
 

--- a/apps/lambda/Dockerfile
+++ b/apps/lambda/Dockerfile
@@ -1,6 +1,6 @@
 # Build @auxx/sdk artifacts for runtime import-map resolution
 FROM node:22-slim AS sdk-builder
-RUN npm install -g corepack@0.31.0 && corepack enable
+RUN corepack enable && corepack prepare pnpm@10.17.0 --activate
 WORKDIR /app
 COPY package.json ./package.json
 COPY pnpm-lock.yaml ./pnpm-lock.yaml

--- a/apps/web/src/components/editor/editable-text.tsx
+++ b/apps/web/src/components/editor/editable-text.tsx
@@ -1,11 +1,17 @@
 import { cn } from '@auxx/ui/lib/utils' // Assuming this utility exists for class names
 import type React from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import { sanitizeSimple } from '~/lib/sanitize'
+
+export type EditableTextSaveReason = 'enter' | 'blur'
+
+export interface EditableTextHandle {
+  enterEdit: () => void
+}
 
 interface EditableTextProps {
   initialText: string
-  onSave?: (text: string) => void
+  onSave?: (text: string, meta: { reason: EditableTextSaveReason }) => void
   className?: string
   placeholder?: string
   /** The CSS color class for the placeholder text (e.g., 'text-gray-500') */
@@ -14,15 +20,18 @@ interface EditableTextProps {
   containerClassName?: string
 }
 
-export const EditableText = ({
-  initialText,
-  onSave,
-  className = '',
-  placeholder = 'Click to edit...',
-  placeholderColor = 'text-gray-500', // Default placeholder color
-  maxWidth = '100%',
-  containerClassName = '',
-}: EditableTextProps) => {
+export const EditableText = forwardRef<EditableTextHandle, EditableTextProps>(function EditableText(
+  {
+    initialText,
+    onSave,
+    className = '',
+    placeholder = 'Click to edit...',
+    placeholderColor = 'text-gray-500', // Default placeholder color
+    maxWidth = '100%',
+    containerClassName = '',
+  },
+  ref
+) {
   const [isEditing, setIsEditing] = useState(false)
   const [text, setText] = useState(initialText)
   const editableRef = useRef<HTMLDivElement>(null)
@@ -74,14 +83,23 @@ export const EditableText = ({
     // the editing view will only render the 'text' state.
   }
 
+  useImperativeHandle(ref, () => ({
+    enterEdit: () => {
+      if (textRef.current) {
+        setMinWidth(textRef.current.offsetWidth)
+      }
+      setIsEditing(true)
+    },
+  }))
+
   const handleBlur = () => {
-    finishEditing()
+    finishEditing('blur')
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault() // Prevent adding a new line
-      finishEditing()
+      finishEditing('enter')
     } else if (e.key === 'Escape') {
       // Revert to the original text before editing started
       // If editing started from placeholder, original was ''
@@ -91,15 +109,14 @@ export const EditableText = ({
     }
   }
 
-  const finishEditing = () => {
+  const finishEditing = (reason: EditableTextSaveReason) => {
     if (editableRef.current) {
       // Use innerText which represents rendered text, trim whitespace
       const newText = editableRef.current.innerText.trim()
       setText(newText) // Update state with the potentially empty or new text
       setIsEditing(false)
-      // Only call onSave if the text actually changed from the initial prop value
-      if (onSave && newText !== initialText) {
-        onSave(newText)
+      if (onSave) {
+        onSave(newText, { reason })
       }
       // If text is now empty, the placeholder will show again in the display view
     } else {
@@ -120,7 +137,7 @@ export const EditableText = ({
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
           className={cn(
-            'whitespace-pre-wrap break-words rounded border border-blue-400 px-2 py-1 focus:outline-hidden focus:ring-2 focus:ring-blue-500',
+            'whitespace-pre-wrap break-words rounded-2xl border border-blue-400 px-2 py-1 focus:outline-hidden focus:ring-2 focus:ring-blue-500',
             className // Apply user-provided class names here too
           )}
           style={{
@@ -139,7 +156,7 @@ export const EditableText = ({
           ref={textRef}
           onClick={handleClick}
           className={cn(
-            `cursor-pointer whitespace-pre-wrap break-words rounded border border-transparent px-2 py-1 hover:border-gray-300 hover:dark:border-primary-300`,
+            `cursor-pointer whitespace-pre-wrap break-words rounded-2xl border border-transparent px-2 py-1 hover:border-gray-300 hover:dark:border-primary-300`,
             className, // Apply user-provided class names
             // Apply placeholderColor class only when placeholder is shown
             showPlaceholder && placeholderColor
@@ -153,4 +170,4 @@ export const EditableText = ({
       )}
     </div>
   )
-}
+})

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
@@ -6,7 +6,7 @@ import { getMarkRange } from '@tiptap/core'
 import type { Editor } from '@tiptap/react'
 import { EditorContent } from '@tiptap/react'
 import type { CSSProperties } from 'react'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { InlinePickerPopover } from '../inline-picker'
 import {
   type ArticleLinkEditMode,
@@ -24,6 +24,8 @@ interface KBArticleEditorProps {
   onChange: (content: { json: JSONContent; html: string }) => void
   /** Knowledge base id — scopes the article-link picker to a single KB by default. */
   knowledgeBaseId?: string
+  /** Fired once when the underlying Tiptap editor instance is ready. */
+  onReady?: (editor: Editor) => void
 }
 
 interface LinkPopoverState {
@@ -43,6 +45,7 @@ export function KBArticleEditor({
   initialContent,
   onChange,
   knowledgeBaseId,
+  onReady,
 }: KBArticleEditorProps) {
   const { editor, gutterCharWidth, slashCommand } = useKBArticleEditor({
     initialContent,
@@ -50,6 +53,12 @@ export function KBArticleEditor({
   })
   const [linkPopover, setLinkPopover] = useState<LinkPopoverState | null>(null)
   const [linkMenu, setLinkMenu] = useState<LinkMenuState | null>(null)
+
+  useEffect(() => {
+    if (editor && !editor.isDestroyed) {
+      onReady?.(editor)
+    }
+  }, [editor, onReady])
 
   // Clicks on chrome around the contenteditable (padding, empty area below
   // the last block) should still focus the editor at end — matches the

--- a/apps/web/src/components/kb/ui/editor/article-cover-strip.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-cover-strip.tsx
@@ -44,52 +44,20 @@ export function ArticleCoverStrip({ article, knowledgeBaseId }: ArticleCoverStri
     autoStart: true,
     fileExtensions: ['.png', '.jpg', '.jpeg', '.webp'],
     sessionMetadata: {
-      role: 'ARTICLE_COVER',
+      role: 'COVER',
       knowledgeBaseId,
       articleId: article.id,
       title: `article-cover-${article.id}`,
     },
-    onChange: (files) => {
-      console.log('[cover] onChange', files)
-    },
-    onExistingFilesAdded: (files) => {
-      console.log('[cover] onExistingFilesAdded', files)
-      const f = files?.[0]
-      console.log('[cover] existing file:', {
-        url: f?.url,
-        serverFileId: f?.serverFileId,
-        id: f?.id,
-      })
-      if (!f?.url) return
-      void updateArticleCover(article.id, {
-        coverImage: f.url,
-        coverImageId: f.serverFileId ?? f.id ?? null,
-      })
-    },
     onUploadComplete: (files) => {
-      console.log('[cover] onUploadComplete', files)
       const f = files?.[0]
-      console.log('[cover] uploaded file:', {
-        url: f?.url,
-        serverFileId: f?.serverFileId,
-        id: f?.id,
-      })
-      if (!f?.url) {
-        console.warn('[cover] upload completed but no url on file')
-        return
-      }
-      console.log('[cover] persisting cover', {
-        articleId: article.id,
-        coverImage: f.url,
-        coverImageId: f.serverFileId ?? null,
-      })
+      if (!f?.url) return
       void updateArticleCover(article.id, {
         coverImage: f.url,
         coverImageId: f.serverFileId ?? null,
       })
     },
     onError: (error) => {
-      console.error('[cover] onError', error)
       toastError({ title: 'Failed to upload cover', description: error })
     },
   })
@@ -150,7 +118,7 @@ export function ArticleCoverStrip({ article, knowledgeBaseId }: ArticleCoverStri
     return (
       <>
         <div className='page-block-openapi:ml-0 mx-auto flex w-full max-w-(--block-wrapper-max-width) flex-wrap items-center gap-2 pt-4'>
-          <FileSelectPicker fileSelect={fileSelect}>
+          <FileSelectPicker fileSelect={fileSelect} hideBrowseExisting>
             <Button
               type='button'
               variant='ghost'
@@ -174,7 +142,7 @@ export function ArticleCoverStrip({ article, knowledgeBaseId }: ArticleCoverStri
       <div className='page-block-openapi:ml-0 group relative mx-auto w-full max-w-(--block-wrapper-max-width) pt-4'>
         <img src={coverImage} alt='' className='aspect-[1200/630] w-full rounded-md object-cover' />
         <div className='absolute right-2 bottom-2 flex flex-wrap items-center gap-1.5 rounded-md bg-background/80 p-1 opacity-0 backdrop-blur-sm transition-opacity group-hover:opacity-100 focus-within:opacity-100'>
-          <FileSelectPicker fileSelect={fileSelect}>
+          <FileSelectPicker fileSelect={fileSelect} hideBrowseExisting>
             <Button type='button' variant='ghost' size='sm'>
               Replace
             </Button>

--- a/apps/web/src/components/kb/ui/editor/article-editor-top.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor-top.tsx
@@ -4,8 +4,8 @@
 import { IconPicker } from '@auxx/ui/components/icon-picker'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { Smile } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { EditableText } from '~/components/editor/editable-text'
+import { useEffect, useRef, useState } from 'react'
+import { EditableText, type EditableTextHandle } from '~/components/editor/editable-text'
 import { useArticleContent } from '../../hooks/use-article-content'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
 import type { ArticleMeta } from '../../store/article-store'
@@ -15,13 +15,16 @@ interface ArticleEditorTopProps {
   article: ArticleMeta
   knowledgeBaseId: string
   onUpdateMetadata?: (changes: { title?: string; description?: string }) => void
+  onAdvanceToContent?: () => void
 }
 
 export function ArticleEditorTop({
   article,
   knowledgeBaseId,
   onUpdateMetadata,
+  onAdvanceToContent,
 }: ArticleEditorTopProps) {
+  const descriptionRef = useRef<EditableTextHandle>(null)
   const { updateArticleDraft } = useArticleMutations(knowledgeBaseId)
   // article.emoji on the store mirrors the *published* revision for published
   // articles. The editor edits the draft, so source the icon from the draft
@@ -72,14 +75,17 @@ export function ArticleEditorTop({
                   </div>
                   <div className='relative flex h-full w-full items-center overflow-hidden text-2xl font-semibold lg:text-4xl'>
                     <EditableText
-                      className='leading-snug focus:ring-0'
+                      className='leading-snug focus:ring-0 py-0'
                       containerClassName='w-full'
                       initialText={article.title}
                       placeholderColor='text-muted-foreground'
                       placeholder='Title goes here'
-                      onSave={(newTitle) => {
+                      onSave={(newTitle, { reason }) => {
                         if (onUpdateMetadata && newTitle !== article.title) {
                           onUpdateMetadata({ title: newTitle })
+                        }
+                        if (reason === 'enter') {
+                          descriptionRef.current?.enterEdit()
                         }
                       }}
                     />
@@ -90,13 +96,17 @@ export function ArticleEditorTop({
                 <div className='flex flex-1 items-center justify-start'>
                   <div className='mt-2 max-h-[2.5rem] flex-1 overflow-y-scroll text-muted-foreground'>
                     <EditableText
+                      ref={descriptionRef}
                       placeholder='Add a description...'
                       placeholderColor='text-muted-foreground'
                       className='leading-snug focus:ring-0'
                       initialText={article.description || ''}
-                      onSave={(newDescription) => {
+                      onSave={(newDescription, { reason }) => {
                         if (onUpdateMetadata && newDescription !== article.description) {
                           onUpdateMetadata({ description: newDescription })
+                        }
+                        if (reason === 'enter') {
+                          onAdvanceToContent?.()
                         }
                       }}
                     />

--- a/apps/web/src/components/kb/ui/editor/article-editor.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor.tsx
@@ -3,6 +3,7 @@
 
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import type { JSONContent } from '@tiptap/core'
+import type { Editor } from '@tiptap/react'
 import { useCallback, useEffect, useRef } from 'react'
 import { useDebounceCallback } from 'usehooks-ts'
 import { KBArticleEditor } from '~/components/editor/kb-article'
@@ -32,6 +33,15 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
   const { updateArticleDraft, updateArticleContent } = useArticleMutations(knowledgeBaseId)
 
   const lastSavedHash = useRef<string | null>(null)
+  const bodyEditorRef = useRef<Editor | null>(null)
+
+  const focusBodyEditor = useCallback(() => {
+    bodyEditorRef.current?.commands.focus('start')
+  }, [])
+
+  const handleBodyEditorReady = useCallback((editor: Editor) => {
+    bodyEditorRef.current = editor
+  }, [])
 
   // Seed the saved hash on first content load so we don't immediately re-save.
   useEffect(() => {
@@ -73,6 +83,7 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
                 article={article}
                 knowledgeBaseId={knowledgeBaseId}
                 onUpdateMetadata={handleMetadataUpdate}
+                onAdvanceToContent={focusBodyEditor}
               />
               <div className='relative flex min-h-0 min-w-0 flex-1 flex-col items-stretch'>
                 {!isContentLoading && (
@@ -80,6 +91,7 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
                     initialContent={draftContentJson ?? emptyContent}
                     onChange={debouncedPersist}
                     knowledgeBaseId={knowledgeBaseId}
+                    onReady={handleBodyEditorReady}
                   />
                 )}
               </div>

--- a/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
@@ -84,6 +84,7 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath, mode }: KBFulls
     previewDescription,
     previewTitle,
     previewEmoji,
+    previewCoverImage,
     hasPublishedVersion,
     fellBackToDraft,
   } = useArticleContent(articleId, knowledgeBaseId, mode)
@@ -246,6 +247,7 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath, mode }: KBFulls
               title={previewTitle ?? activeArticle?.title}
               emoji={previewEmoji ?? activeArticle?.emoji}
               description={previewDescription ?? activeArticle?.description}
+              coverImage={previewCoverImage ?? activeArticle?.coverImage}
               parent={parent}
               resolveAuxxHref={(id) => `/preview/kb/${knowledgeBaseId}/r/${id}`}
               copyMenu={

--- a/apps/web/src/components/pickers/file-select-picker.tsx
+++ b/apps/web/src/components/pickers/file-select-picker.tsx
@@ -55,6 +55,9 @@ export interface FileSelectPickerProps {
   side?: 'top' | 'right' | 'bottom' | 'left'
   sideOffset?: number
 
+  // Hide "Browse Existing" — restrict picker to fresh uploads only
+  hideBrowseExisting?: boolean
+
   // Display
   children: React.ReactNode
 }
@@ -141,6 +144,7 @@ function FileSelectPickerContent({
   align = 'start',
   side,
   sideOffset,
+  hideBrowseExisting,
   children,
 }: FileSelectPickerContentProps) {
   return (
@@ -176,17 +180,19 @@ function FileSelectPickerContent({
             Choose Files
           </Button>
 
-          <FileSelectPickerButton
-            open={fileSelect.pickerOpen}
-            onOpenChange={(open) => (open ? fileSelect.openPicker() : fileSelect.closePicker())}
-            onFilesSelected={(files) => fileSelect.addExistingFiles(files)}
-            allowMultiple={allowMultiple}
-            variant='outline'
-            size='sm'
-            className='flex-1'>
-            <Files />
-            Browse Existing
-          </FileSelectPickerButton>
+          {!hideBrowseExisting && (
+            <FileSelectPickerButton
+              open={fileSelect.pickerOpen}
+              onOpenChange={(open) => (open ? fileSelect.openPicker() : fileSelect.closePicker())}
+              onFilesSelected={(files) => fileSelect.addExistingFiles(files)}
+              allowMultiple={allowMultiple}
+              variant='outline'
+              size='sm'
+              className='flex-1'>
+              <Files />
+              Browse Existing
+            </FileSelectPickerButton>
+          )}
         </div>
 
         <Command>

--- a/packages/lib/src/files/upload/processors/entity-processors.ts
+++ b/packages/lib/src/files/upload/processors/entity-processors.ts
@@ -311,7 +311,9 @@ export class ArticleProcessor extends BaseAttachmentProcessor {
   ]
   protected readonly assetKind: AssetKind = 'INLINE_IMAGE'
   /**
-   * Override processConfig for article-specific validation and policies
+   * Override processConfig for article-specific validation and policies.
+   * Cover uploads are forced PUBLIC so the resulting CDN URL is durable
+   * (OG image crawlers cache for hours/days; presigned URLs would 403).
    */
   async processConfig(init: UploadInitConfig): Promise<ProcessorConfigResult> {
     const base = await super.processConfig(init)
@@ -321,6 +323,17 @@ export class ArticleProcessor extends BaseAttachmentProcessor {
       throw new Error(
         `File size exceeds maximum allowed for article attachments (${this.maxFileSize / 1024 / 1024}MB)`
       )
+    }
+    if (init.metadata?.role === 'COVER') {
+      const { getBucketForVisibility } = await import('../util')
+      return {
+        config: Object.freeze({
+          ...base.config,
+          visibility: 'PUBLIC',
+          bucket: getBucketForVisibility('PUBLIC'),
+        }),
+        warnings,
+      }
     }
     return {
       config: base.config,
@@ -352,6 +365,10 @@ export class ArticleProcessor extends BaseAttachmentProcessor {
     if (session.metadata?.role === 'COVER') return 'THUMBNAIL'
     if (session.metadata?.role === 'THUMBNAIL') return 'THUMBNAIL'
     return this.assetKind
+  }
+  protected isAssetPrivate(session: PresignedUploadSession): boolean {
+    if (session.metadata?.role === 'COVER') return false
+    return super.isAssetPrivate(session)
   }
 }
 // ============= Workflow Run Processor =============

--- a/packages/ui/src/components/kb/article/kb-article-renderer.module.css
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.module.css
@@ -64,19 +64,37 @@
 
 .header {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
+  flex-direction: column;
+  gap: 0.25em;
   margin: 1.5em 0 0;
   padding-bottom: 2.5em;
 }
 
-.headerMain {
+/* The header already owns its spacing — collapse the first content block's
+   top margin so a leading heading doesn't add to it. */
+.header + * {
+  margin-top: 0;
+}
+
+.headerTopRow {
   display: flex;
-  flex-direction: column;
-  gap: 0.25em;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 1.75rem;
+  margin-bottom: 0.25em;
+}
+
+.headerParent {
   min-width: 0;
   flex: 1;
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
 }
 
 .headerDescription {

--- a/packages/ui/src/components/kb/article/kb-article-renderer.tsx
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.tsx
@@ -71,40 +71,42 @@ export function KBArticleRenderer({
       {coverImage ? <img src={coverImage} alt='' className={styles.cover} /> : null}
       {parent || title || description || updatedAt ? (
         <header className={styles.header}>
-          <div className={styles.headerMain}>
-            {parent?.href ? (
-              <Link href={parent.href} prefetch={false} className={styles.parentLink}>
-                {parent.emoji ? (
-                  <EntityIcon iconId={parent.emoji} variant='bare' size='xs' />
-                ) : null}
-                {parent.title}
-              </Link>
-            ) : parent ? (
-              <span className={styles.parentText}>
-                {parent.emoji ? (
-                  <EntityIcon iconId={parent.emoji} variant='bare' size='xs' />
-                ) : null}
-                {parent.title}
-              </span>
-            ) : null}
-            {title ? (
-              <h1 className={styles.h1}>
-                <span className='inline-flex flex-row items-center'>
-                  {emoji ? <EntityIcon iconId={emoji} variant='bare' size='xl' /> : null}
-                  <span>{title}</span>
+          <div className={styles.headerTopRow}>
+            <div className={styles.headerParent}>
+              {parent?.href ? (
+                <Link href={parent.href} prefetch={false} className={styles.parentLink}>
+                  {parent.emoji ? (
+                    <EntityIcon iconId={parent.emoji} variant='bare' size='xs' />
+                  ) : null}
+                  {parent.title}
+                </Link>
+              ) : parent ? (
+                <span className={styles.parentText}>
+                  {parent.emoji ? (
+                    <EntityIcon iconId={parent.emoji} variant='bare' size='xs' />
+                  ) : null}
+                  {parent.title}
                 </span>
-              </h1>
-            ) : null}
-            {description ? <p className={styles.headerDescription}>{description}</p> : null}
-            {updatedAt ? (
-              <p className={styles.headerUpdatedAt}>Last updated {formatRelative(updatedAt)}</p>
-            ) : null}
+              ) : null}
+            </div>
+            <div className={styles.headerActions}>
+              {copyMenu}
+              <KBTableOfContentsDrawer headings={headings} className='@kb-lg:hidden' />
+              {tocToggle}
+            </div>
           </div>
-          <div className='flex items-center gap-2'>
-            {copyMenu}
-            <KBTableOfContentsDrawer headings={headings} className='@kb-lg:hidden' />
-            {tocToggle}
-          </div>
+          {title ? (
+            <h1 className={styles.h1}>
+              <span className='inline-flex flex-row items-center'>
+                {emoji ? <EntityIcon iconId={emoji} variant='bare' size='xl' /> : null}
+                <span>{title}</span>
+              </span>
+            </h1>
+          ) : null}
+          {description ? <p className={styles.headerDescription}>{description}</p> : null}
+          {updatedAt ? (
+            <p className={styles.headerUpdatedAt}>Last updated {formatRelative(updatedAt)}</p>
+          ) : null}
         </header>
       ) : null}
       {doc?.content?.map((node, idx) => {


### PR DESCRIPTION
## Summary
- `EditableText` exposes a `forwardRef` handle (`enterEdit`) and reports the save reason (`enter` vs `blur`); article editor wires Enter-on-title → focus description and Enter-on-description → focus body editor.
- Article cover uploads now force `PUBLIC` visibility so the resulting CDN URL is durable for OG crawlers; the picker hides Browse Existing for cover slots.
- KB article renderer header restructured: parent + actions on a top row, then title / description / updated timestamp below.
- Fullscreen preview threads through `previewCoverImage`.
- Dockerfiles pin `pnpm@10.17.0` and `turbo@2.5.2` via corepack instead of unpinned global installs.

## Test plan
- [ ] Create/edit a KB article: Enter on title moves into description; Enter on description moves into body editor.
- [ ] Upload a cover image, confirm it persists, the URL is public, and the picker no longer shows "Browse Existing".
- [ ] Public preview shows the cover image and updated header layout (actions on top row).
- [ ] Container builds (`build`, `docs`, `homepage`, `kb`, `lambda`) succeed with the pinned pnpm/turbo versions.