### PR TITLE
feat(search): per-model embeddings, weight renormalization, partial-failure signals

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
@@ -133,14 +133,30 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
 
         const trimmed = filtered.slice(0, limit)
 
+        // Hybrid runs vector + text in parallel via Promise.allSettled. If one
+        // side throws (e.g. embedding-model mismatch), results may be missing
+        // semantic matches or exact-text matches — surface that so the agent
+        // can adjust its strategy instead of silently rephrasing forever.
+        const warnings: string[] = []
+        if (response.metrics?.vectorFailed) {
+          warnings.push(
+            `Semantic (vector) search unavailable: ${response.metrics.vectorFailed}. Results are text-only and may miss paraphrased matches.`
+          )
+        }
+        if (response.metrics?.textFailed) {
+          warnings.push(
+            `Keyword (text) search unavailable: ${response.metrics.textFailed}. Results are vector-only.`
+          )
+        }
+
         if (trimmed.length === 0) {
+          const message =
+            warnings.length > 0
+              ? `No matching results. ${warnings.join(' ')}`
+              : 'No matching results. Try rephrasing the query.'
           return {
             success: true,
-            output: {
-              results: [],
-              count: 0,
-              message: 'No matching results. Try rephrasing the query.',
-            },
+            output: { results: [], count: 0, message, ...(warnings.length ? { warnings } : {}) },
           }
         }
 
@@ -191,6 +207,7 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
             count: results.length,
             total: response.total,
             docs: dedupedDocs,
+            ...(warnings.length ? { warnings } : {}),
           },
         }
       } catch (error) {

--- a/packages/lib/src/datasets/search/hybrid-search.ts
+++ b/packages/lib/src/datasets/search/hybrid-search.ts
@@ -118,6 +118,18 @@ export class HybridSearchService {
         totalTime,
         resultsCount: filteredResults.length,
         cacheHit: vectorMetrics?.cacheHit || textMetrics?.cacheHit || false,
+        vectorFailed:
+          vectorResult.status === 'rejected'
+            ? vectorResult.reason instanceof Error
+              ? vectorResult.reason.message
+              : String(vectorResult.reason)
+            : undefined,
+        textFailed:
+          textResult.status === 'rejected'
+            ? textResult.reason instanceof Error
+              ? textResult.reason.message
+              : String(textResult.reason)
+            : undefined,
       }
 
       logger.info('Hybrid search completed', {
@@ -233,18 +245,19 @@ export class HybridSearchService {
     // Use the result that exists, prefer vector result for metadata
     const baseResult = vectorResult || textResult!
 
-    // Calculate combined score
-    let combinedScore = 0
-    let highlights: string[] = []
+    // Re-normalize weights against the sides that actually returned a result.
+    // Without this, a text-only hit gets `0.4 * raw` and looks weak even when
+    // it's a perfect match — and a vector-only hit gets `0.6 * raw`. Keeping
+    // scores on the same scale regardless of which side fires lets downstream
+    // consumers (and the agent) trust the absolute score.
+    const effectiveVW = vectorResult ? vectorWeight : 0
+    const effectiveTW = textResult ? textWeight : 0
+    const totalWeight = effectiveVW + effectiveTW || 1
+    const combinedScore =
+      ((vectorResult?.score ?? 0) * effectiveVW + (textResult?.score ?? 0) * effectiveTW) /
+      totalWeight
 
-    if (vectorResult) {
-      combinedScore += (vectorResult.score || 0) * vectorWeight
-    }
-
-    if (textResult) {
-      combinedScore += (textResult.score || 0) * textWeight
-      highlights = textResult.highlights || []
-    }
+    const highlights = textResult?.highlights ?? []
 
     return {
       ...baseResult,

--- a/packages/lib/src/datasets/search/vector-search.ts
+++ b/packages/lib/src/datasets/search/vector-search.ts
@@ -137,35 +137,66 @@ export class VectorSearchService {
       return []
     }
 
-    // 1. Group datasets by dimension
-    const byDimension = new Map<number, DatasetConfig[]>()
+    // 1. Group datasets by (embeddingModel, vectorDimension). Each group needs
+    //    its own query embedding produced by the matching model — embedding a
+    //    query with the wrong model yields a vector that lives in a different
+    //    semantic space, and asking the wrong model for a dimension it can't
+    //    produce throws (e.g. text-embedding-3-small max 1536 vs requested 3072).
+    const byModelDim = new Map<
+      string,
+      { model: string; dimension: number; datasets: DatasetConfig[] }
+    >()
     for (const dataset of datasetConfigs) {
-      const dim = dataset.vectorDimension || 1536
-      if (!byDimension.has(dim)) {
-        byDimension.set(dim, [])
+      if (!dataset.embeddingModel) {
+        throw new VectorSearchError(
+          `Dataset ${dataset.id} is missing embeddingModel — cannot run vector search`,
+          { datasetId: dataset.id }
+        )
       }
-      byDimension.get(dim)!.push(dataset)
+      if (!dataset.vectorDimension) {
+        throw new VectorSearchError(
+          `Dataset ${dataset.id} is missing vectorDimension — cannot run vector search`,
+          { datasetId: dataset.id }
+        )
+      }
+      const key = `${dataset.embeddingModel}@${dataset.vectorDimension}`
+      const group = byModelDim.get(key)
+      if (group) {
+        group.datasets.push(dataset)
+      } else {
+        byModelDim.set(key, {
+          model: dataset.embeddingModel,
+          dimension: dataset.vectorDimension,
+          datasets: [dataset],
+        })
+      }
     }
 
-    // 2. Generate query embeddings for each unique dimension (parallel)
-    const dimensions = Array.from(byDimension.keys())
+    // 2. One embedding per (model, dimension) pair, in parallel
+    const groups = Array.from(byModelDim.values())
     const embeddingService = new EmbeddingService(db, organizationId, userId)
 
     const embeddings = await Promise.all(
-      dimensions.map((dim) => embeddingService.generateSingle(query, { dimensions: dim }))
+      groups.map((g) =>
+        embeddingService.generateSingle(query, {
+          modelId: g.model,
+          dimensions: g.dimension,
+        })
+      )
     )
-    const embeddingByDim = new Map(dimensions.map((dim, i) => [dim, embeddings[i]]))
 
-    // 3. Search each dimension group in parallel
-    const searchPromises = Array.from(byDimension.entries()).map(async ([dimension, datasets]) => {
-      const datasetIds = datasets.map((d) => d.id)
-      const queryVector = embeddingByDim.get(dimension)!
-
-      return PostgreSQLVectorDB.searchByVectorMultiDataset(queryVector, datasetIds, dimension, {
-        topK: options.maxResults || 20,
-        scoreThreshold: options.similarityThreshold || 0.0,
-        includeMetadata: options.includeMetadata !== false,
-      })
+    // 3. Search each group in parallel against its own pgvector dimension column
+    const searchPromises = groups.map(async (g, i) => {
+      return PostgreSQLVectorDB.searchByVectorMultiDataset(
+        embeddings[i],
+        g.datasets.map((d) => d.id),
+        g.dimension,
+        {
+          topK: options.maxResults || 20,
+          scoreThreshold: options.similarityThreshold || 0.0,
+          includeMetadata: options.includeMetadata !== false,
+        }
+      )
     })
 
     const resultGroups = await Promise.all(searchPromises)

--- a/packages/lib/src/datasets/services/search.service.ts
+++ b/packages/lib/src/datasets/services/search.service.ts
@@ -151,6 +151,7 @@ export class SearchService {
         responseTime,
         hasMore: offset + limit < results.length,
         nextOffset: offset + limit < results.length ? offset + limit : undefined,
+        metrics: performanceMetrics,
       }
 
       logger.info('Search completed', {

--- a/packages/lib/src/datasets/types/search.types.ts
+++ b/packages/lib/src/datasets/types/search.types.ts
@@ -82,6 +82,8 @@ export interface SearchResponse {
   suggestions?: string[]
   hasMore?: boolean
   nextOffset?: number
+  /** Performance + partial-failure signals. Always set for hybrid; optional for single-strategy. */
+  metrics?: SearchPerformanceMetrics
 }
 
 /**
@@ -257,6 +259,10 @@ export interface SearchPerformanceMetrics {
   totalTime: number
   resultsCount: number
   cacheHit: boolean
+  /** When set, vector search threw and only text-side results contributed. */
+  vectorFailed?: string
+  /** When set, full-text search threw and only vector-side results contributed. */
+  textFailed?: string
 }
 
 /**

--- a/scripts/debug-search-knowledge.ts
+++ b/scripts/debug-search-knowledge.ts
@@ -402,4 +402,7 @@ main()
   })
   .finally(async () => {
     await closePools()
+    // SystemUserService opens a Redis client we can't easily close from here.
+    // Force exit so the script terminates instead of hanging on Redis sockets.
+    process.exit(process.exitCode ?? 0)
   })


### PR DESCRIPTION
## Summary
- **vector-search**: Group datasets by `(embeddingModel, vectorDimension)` so each group's query is embedded by its matching model. Previously every group used the default model and only varied dimension, producing vectors in the wrong semantic space and throwing when a model couldn't emit the requested dimension.
- **hybrid-search**: Renormalize vector/text weights against the sides that actually returned a result, so a text-only or vector-only hit isn't artificially scaled down by the missing side's weight.
- **partial-failure signals**: Expose `vectorFailed` / `textFailed` on `SearchPerformanceMetrics` and forward them to the kopilot `search_knowledge` tool as `warnings`, so the agent can adjust strategy instead of silently rephrasing the query.
- **debug-search-knowledge**: Force exit after `closePools()` — `SystemUserService` leaves a Redis client open that we can't reach from here, which hung the script.

## Test plan
- [ ] Search across datasets that use different embedding models (e.g. `text-embedding-3-small` + `text-embedding-3-large`) and confirm both groups return relevant matches
- [ ] Force a vector-side failure (e.g. break an embedding key) and verify the kopilot tool returns a `warnings` entry and still surfaces text-only results
- [ ] Spot-check hybrid scores for vector-only vs hybrid hits — absolute scores should be on the same scale
- [ ] Run `scripts/debug-search-knowledge.ts` and confirm the process exits cleanly