### PR TITLE
feat(kb): editor bubble menu, list-style attr, container placeholders, live badge

### DIFF
--- a/apps/web/src/components/editor/bubble-menu/bubble-menu-context.ts
+++ b/apps/web/src/components/editor/bubble-menu/bubble-menu-context.ts
@@ -1,0 +1,13 @@
+// apps/web/src/components/editor/bubble-menu/bubble-menu-context.ts
+'use client'
+
+import { createContext, useContext } from 'react'
+
+/** Registered by the bubble menu shell. Sections call this when their own
+ *  dropdown/popover opens/closes so the parent bubble stays mounted across
+ *  the focus transition. */
+export const BubbleSubPopoverContext = createContext<(open: boolean) => void>(() => {})
+
+export function useBubbleSubPopover(): (open: boolean) => void {
+  return useContext(BubbleSubPopoverContext)
+}

--- a/apps/web/src/components/editor/bubble-menu/bubble-menu.tsx
+++ b/apps/web/src/components/editor/bubble-menu/bubble-menu.tsx
@@ -1,0 +1,126 @@
+// apps/web/src/components/editor/bubble-menu/bubble-menu.tsx
+'use client'
+
+import { Popover, PopoverAnchor, PopoverContentDialogAware } from '@auxx/ui/components/popover'
+import { TooltipProvider } from '@auxx/ui/components/tooltip'
+import { cn } from '@auxx/ui/lib/utils'
+import type { Editor } from '@tiptap/react'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { BubbleSubPopoverContext } from './bubble-menu-context'
+import { type BubbleMenuRange, useBubbleMenuState } from './use-bubble-menu-state'
+
+export interface EditorBubbleMenuContext {
+  editor: Editor
+  range: BubbleMenuRange
+  rect: DOMRect
+}
+
+interface EditorBubbleMenuProps {
+  editor: Editor | null
+  shouldShow?: (ctx: { editor: Editor; from: number; to: number }) => boolean
+  /** Block-aware controls (Section 1). The renderer is expected to return
+   *  null when the selection spans multiple blocks. */
+  renderBlockSection?: (ctx: EditorBubbleMenuContext) => React.ReactNode
+  renderAISlot?: (ctx: EditorBubbleMenuContext) => React.ReactNode
+  renderTurnInto?: (ctx: EditorBubbleMenuContext) => React.ReactNode
+  renderInlineMarks?: (ctx: EditorBubbleMenuContext) => React.ReactNode
+  renderColor?: (ctx: EditorBubbleMenuContext) => React.ReactNode
+  renderAlign?: (ctx: EditorBubbleMenuContext) => React.ReactNode
+  renderLink?: (ctx: EditorBubbleMenuContext) => React.ReactNode
+  renderMore?: (ctx: EditorBubbleMenuContext) => React.ReactNode
+  className?: string
+}
+
+export function EditorBubbleMenu({
+  editor,
+  shouldShow,
+  renderBlockSection,
+  renderAISlot,
+  renderTurnInto,
+  renderInlineMarks,
+  renderColor,
+  renderAlign,
+  renderLink,
+  renderMore,
+  className,
+}: EditorBubbleMenuProps) {
+  // Track open sub-popovers (color picker, turn-into menu, etc.) so the
+  // bubble stays mounted while they're open and steal focus from the editor.
+  const [subPopoverCount, setSubPopoverCount] = useState(0)
+  const trackSubPopover = useCallback((open: boolean) => {
+    setSubPopoverCount((n) => Math.max(0, open ? n + 1 : n - 1))
+  }, [])
+
+  const state = useBubbleMenuState({
+    editor,
+    shouldShow,
+    forceOpen: subPopoverCount > 0,
+  })
+
+  const virtualRef = useRef<{ getBoundingClientRect: () => DOMRect }>({
+    getBoundingClientRect: () => state.rect ?? new DOMRect(),
+  })
+  virtualRef.current.getBoundingClientRect = () => state.rect ?? new DOMRect()
+
+  const ctx = useMemo<EditorBubbleMenuContext | null>(
+    () => (editor && state.rect ? { editor, range: state.range, rect: state.rect } : null),
+    [editor, state.range, state.rect]
+  )
+
+  if (!editor || !ctx) return null
+
+  return (
+    <BubbleSubPopoverContext.Provider value={trackSubPopover}>
+      <TooltipProvider delayDuration={350}>
+        <Popover open={state.open} onOpenChange={() => {}}>
+          <PopoverAnchor virtualRef={virtualRef} />
+          <PopoverContentDialogAware
+            side='top'
+            align='start'
+            sideOffset={8}
+            collisionPadding={8}
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            onCloseAutoFocus={(e) => e.preventDefault()}
+            onMouseDown={(e) => {
+              e.preventDefault()
+            }}
+            className={cn(
+              'flex w-auto flex-row items-center gap-0.5 rounded-2xl px-0 p-1',
+              'border border-foreground/15 bg-popover shadow-md backdrop-blur',
+              // Round whichever button ends up flush with the popover edges.
+              // CSS :first-child / :last-child resolve against the actually-
+              // rendered DOM, so this works even when some sections return null.
+              '[&>:first-child>:first-child]:rounded-l-2xl',
+              '[&>:last-child>:last-child]:rounded-r-2xl',
+              className
+            )}>
+            {renderBlockSection?.(ctx)}
+            {renderAISlot?.(ctx)}
+            {renderTurnInto?.(ctx)}
+            {renderInlineMarks?.(ctx)}
+            <BubbleSection>
+              {renderColor?.(ctx)}
+              {renderAlign?.(ctx)}
+              {renderLink?.(ctx)}
+              {renderMore?.(ctx)}
+            </BubbleSection>
+          </PopoverContentDialogAware>
+        </Popover>
+      </TooltipProvider>
+    </BubbleSubPopoverContext.Provider>
+  )
+}
+
+export function BubbleSection({ children }: { children?: React.ReactNode }) {
+  // React treats `null`/`false`/`undefined` as no children but they still
+  // count for the `hasContent` heuristic below. Use a manual check that
+  // walks the array.
+  const childArray = Array.isArray(children) ? children : [children]
+  const hasContent = childArray.some((c) => c != null && c !== false)
+  if (!hasContent) return null
+  return (
+    <div className='flex items-center gap-0.5 border-r border-foreground/10 px-1 last:border-r-0 first:pl-0 last:pr-0'>
+      {children}
+    </div>
+  )
+}

--- a/apps/web/src/components/editor/bubble-menu/index.ts
+++ b/apps/web/src/components/editor/bubble-menu/index.ts
@@ -1,0 +1,13 @@
+// apps/web/src/components/editor/bubble-menu/index.ts
+
+export { BubbleSection, EditorBubbleMenu, type EditorBubbleMenuContext } from './bubble-menu'
+export { useBubbleSubPopover } from './bubble-menu-context'
+export { KBBlockSection } from './kb/kb-block-section'
+export { AISlotPlaceholder } from './sections/ai-slot'
+export { AlignSection } from './sections/align'
+export { ColorPickerSection } from './sections/color-picker'
+export { InlineMarksSection } from './sections/inline-marks'
+export { LinkButton } from './sections/link-button'
+export { MoreMenuSection } from './sections/more-menu'
+export { TurnIntoSection } from './sections/turn-into'
+export { type BubbleMenuRange, useBubbleMenuState } from './use-bubble-menu-state'

--- a/apps/web/src/components/editor/bubble-menu/kb/kb-block-section.tsx
+++ b/apps/web/src/components/editor/bubble-menu/kb/kb-block-section.tsx
@@ -1,0 +1,363 @@
+// apps/web/src/components/editor/bubble-menu/kb/kb-block-section.tsx
+'use client'
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import type { CalloutVariant } from '@auxx/ui/components/kb/article'
+import { CalloutIcon } from '@auxx/ui/components/kb/article'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
+import type { Editor } from '@tiptap/react'
+import { useEditorState } from '@tiptap/react'
+import {
+  AlignCenter,
+  AlignLeft,
+  AlignRight,
+  ChevronDown,
+  type LucideIcon,
+  Square,
+} from 'lucide-react'
+import type React from 'react'
+import { BubbleSection } from '../bubble-menu'
+import { useBubbleSubPopover } from '../bubble-menu-context'
+import { BubbleToggleButton } from '../ui/bubble-toggle-button'
+
+interface KBBlockSectionProps {
+  editor: Editor
+}
+
+interface BlockSelectionInfo {
+  /** Position of the single `block` node containing the selection; null if
+   *  multi-block or no block ancestor. */
+  pos: number | null
+  blockType: string | null
+  attrs: Record<string, unknown> | null
+}
+
+function findContainingBlock(editor: Editor): BlockSelectionInfo {
+  const { from, to } = editor.state.selection
+  let firstPos: number | null = null
+  let firstType: string | null = null
+  let firstAttrs: Record<string, unknown> | null = null
+  let count = 0
+  editor.state.doc.nodesBetween(from, to, (node, pos) => {
+    if (node.type.name === 'block') {
+      count++
+      if (count === 1) {
+        firstPos = pos
+        firstType = String(node.attrs.blockType ?? 'text')
+        firstAttrs = { ...node.attrs }
+      }
+      return false
+    }
+    return true
+  })
+  if (count !== 1) return { pos: null, blockType: null, attrs: null }
+  return { pos: firstPos, blockType: firstType, attrs: firstAttrs }
+}
+
+export function KBBlockSection({ editor }: KBBlockSectionProps) {
+  const info = useEditorState({
+    editor,
+    selector: ({ editor }) => findContainingBlock(editor),
+    equalityFn: (a, b) =>
+      a.pos === b.pos &&
+      a.blockType === b.blockType &&
+      JSON.stringify(a.attrs) === JSON.stringify(b.attrs),
+  })
+
+  if (!info.pos || !info.blockType || !info.attrs) return null
+
+  const update = (patch: Record<string, unknown>) => {
+    const pos = info.pos
+    if (pos == null) return
+    editor
+      .chain()
+      .focus()
+      .command(({ tr, state }) => {
+        const node = state.doc.nodeAt(pos)
+        if (!node || node.type.name !== 'block') return false
+        tr.setNodeMarkup(pos, undefined, { ...node.attrs, ...patch })
+        return true
+      })
+      .run()
+  }
+
+  let control: React.ReactNode = null
+  switch (info.blockType) {
+    case 'bulletListItem':
+      control = (
+        <BulletListStyleDropdown
+          current={(info.attrs.listStyle as string | null) ?? 'disc'}
+          onChange={(v) => update({ listStyle: v })}
+        />
+      )
+      break
+    case 'numberedListItem':
+      control = (
+        <NumberedListStyleDropdown
+          current={(info.attrs.listStyle as string | null) ?? '1'}
+          onChange={(v) => update({ listStyle: v })}
+        />
+      )
+      break
+    case 'callout':
+      control = (
+        <CalloutVariantDropdown
+          current={(info.attrs.calloutVariant as CalloutVariant) ?? 'info'}
+          onChange={(v) => update({ calloutVariant: v })}
+        />
+      )
+      break
+    case 'image':
+      control = (
+        <ImageAlignDropdown
+          current={(info.attrs.imageAlign as 'left' | 'center' | 'right') ?? 'center'}
+          onChange={(v) => update({ imageAlign: v })}
+        />
+      )
+      break
+    case 'embed':
+      control = (
+        <EmbedAspectDropdown
+          current={(info.attrs.embedAspect as string) ?? '16:9'}
+          onChange={(v) => update({ embedAspect: v })}
+        />
+      )
+      break
+  }
+
+  if (!control) return null
+  return <BubbleSection>{control}</BubbleSection>
+}
+
+const BULLET_OPTIONS: { id: string; label: string; glyph: string }[] = [
+  { id: 'disc', label: 'Disc', glyph: '•' },
+  { id: 'circle', label: 'Circle', glyph: '◦' },
+  { id: 'square', label: 'Square', glyph: '▪' },
+]
+
+function BulletListStyleDropdown({
+  current,
+  onChange,
+}: {
+  current: string
+  onChange: (v: string) => void
+}) {
+  const onOpenChange = useBubbleSubPopover()
+  const active = BULLET_OPTIONS.find((o) => o.id === current) ?? BULLET_OPTIONS[0]
+  return (
+    <DropdownMenu onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <BubbleToggleButton aria-label='Bullet style' className='gap-1 px-2'>
+              <span className='text-sm leading-none'>{active.glyph}</span>
+              <ChevronDown className='size-3 opacity-60' />
+            </BubbleToggleButton>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>List style</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align='start'>
+        <DropdownMenuLabel className='text-xs'>Bullet style</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {BULLET_OPTIONS.map((o) => (
+          <DropdownMenuCheckboxItem
+            key={o.id}
+            checked={current === o.id}
+            onSelect={(e) => {
+              e.preventDefault()
+              onChange(o.id)
+            }}>
+            <span className='mr-2 inline-block w-3 text-center'>{o.glyph}</span>
+            {o.label}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+const NUMBERED_OPTIONS: { id: string; label: string; sample: string }[] = [
+  { id: '1', label: 'Decimal', sample: '1.' },
+  { id: 'a', label: 'Lower alpha', sample: 'a.' },
+  { id: 'A', label: 'Upper alpha', sample: 'A.' },
+  { id: 'i', label: 'Lower roman', sample: 'i.' },
+  { id: 'I', label: 'Upper roman', sample: 'I.' },
+]
+
+function NumberedListStyleDropdown({
+  current,
+  onChange,
+}: {
+  current: string
+  onChange: (v: string) => void
+}) {
+  const onOpenChange = useBubbleSubPopover()
+  const active = NUMBERED_OPTIONS.find((o) => o.id === current) ?? NUMBERED_OPTIONS[0]
+  return (
+    <DropdownMenu onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <BubbleToggleButton aria-label='Numbering style' className='gap-1 px-2'>
+              <span className='text-xs leading-none'>{active.sample}</span>
+              <ChevronDown className='size-3 opacity-60' />
+            </BubbleToggleButton>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>List style</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align='start'>
+        <DropdownMenuLabel className='text-xs'>Numbering style</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {NUMBERED_OPTIONS.map((o) => (
+          <DropdownMenuCheckboxItem
+            key={o.id}
+            checked={current === o.id}
+            onSelect={(e) => {
+              e.preventDefault()
+              onChange(o.id)
+            }}>
+            <span className='mr-2 inline-block w-6 text-left tabular-nums'>{o.sample}</span>
+            {o.label}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+const CALLOUT_VARIANTS: { id: CalloutVariant; label: string }[] = [
+  { id: 'info', label: 'Info' },
+  { id: 'tip', label: 'Tip' },
+  { id: 'warn', label: 'Warning' },
+  { id: 'error', label: 'Error' },
+  { id: 'success', label: 'Success' },
+]
+
+function CalloutVariantDropdown({
+  current,
+  onChange,
+}: {
+  current: CalloutVariant
+  onChange: (v: CalloutVariant) => void
+}) {
+  const onOpenChange = useBubbleSubPopover()
+  return (
+    <DropdownMenu onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <BubbleToggleButton aria-label='Callout variant' className='gap-1 px-2'>
+              <CalloutIcon variant={current} size={14} />
+              <ChevronDown className='size-3 opacity-60' />
+            </BubbleToggleButton>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Callout variant</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align='start'>
+        {CALLOUT_VARIANTS.map((v) => (
+          <DropdownMenuItem
+            key={v.id}
+            onSelect={() => onChange(v.id)}
+            className='flex items-center gap-2'>
+            <CalloutIcon variant={v.id} size={14} /> {v.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+const IMAGE_ALIGN_OPTIONS: {
+  id: 'left' | 'center' | 'right'
+  label: string
+  Icon: LucideIcon
+}[] = [
+  { id: 'left', label: 'Left', Icon: AlignLeft },
+  { id: 'center', label: 'Center', Icon: AlignCenter },
+  { id: 'right', label: 'Right', Icon: AlignRight },
+]
+
+function ImageAlignDropdown({
+  current,
+  onChange,
+}: {
+  current: 'left' | 'center' | 'right'
+  onChange: (v: 'left' | 'center' | 'right') => void
+}) {
+  const onOpenChange = useBubbleSubPopover()
+  const ActiveIcon = IMAGE_ALIGN_OPTIONS.find((o) => o.id === current)?.Icon ?? AlignCenter
+  return (
+    <DropdownMenu onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <BubbleToggleButton aria-label='Image alignment' className='gap-1 px-1.5'>
+              <ActiveIcon />
+              <ChevronDown className='size-3 opacity-60' />
+            </BubbleToggleButton>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Image alignment</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align='start'>
+        {IMAGE_ALIGN_OPTIONS.map((o) => (
+          <DropdownMenuItem
+            key={o.id}
+            onSelect={() => onChange(o.id)}
+            className='flex items-center gap-2'>
+            <o.Icon className='size-3.5 text-muted-foreground' /> {o.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+const EMBED_ASPECTS = ['16:9', '4:3', '1:1'] as const
+
+function EmbedAspectDropdown({
+  current,
+  onChange,
+}: {
+  current: string
+  onChange: (v: string) => void
+}) {
+  const onOpenChange = useBubbleSubPopover()
+  return (
+    <DropdownMenu onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <BubbleToggleButton aria-label='Embed aspect ratio' className='gap-1 px-2'>
+              <Square />
+              <span className='text-xs leading-none'>{current}</span>
+              <ChevronDown className='size-3 opacity-60' />
+            </BubbleToggleButton>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Aspect ratio</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align='start'>
+        {EMBED_ASPECTS.map((a) => (
+          <DropdownMenuItem
+            key={a}
+            onSelect={() => onChange(a)}
+            className='flex items-center gap-2'>
+            {a}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/src/components/editor/bubble-menu/sections/ai-slot.tsx
+++ b/apps/web/src/components/editor/bubble-menu/sections/ai-slot.tsx
@@ -1,0 +1,31 @@
+// apps/web/src/components/editor/bubble-menu/sections/ai-slot.tsx
+'use client'
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
+import { Sparkles } from 'lucide-react'
+import { BubbleSection } from '../bubble-menu'
+import { BubbleToggleButton } from '../ui/bubble-toggle-button'
+
+interface AISlotPlaceholderProps {
+  onClick?: () => void
+}
+
+/** Placeholder AI button — real behavior wired in a follow-up. */
+export function AISlotPlaceholder({ onClick }: AISlotPlaceholderProps) {
+  return (
+    <BubbleSection>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <BubbleToggleButton
+            aria-label='Ask AI'
+            className='gap-1 px-2 text-primary'
+            onClick={onClick}>
+            <Sparkles />
+            <span className='text-xs font-medium'>AI</span>
+          </BubbleToggleButton>
+        </TooltipTrigger>
+        <TooltipContent>Ask AI (coming soon)</TooltipContent>
+      </Tooltip>
+    </BubbleSection>
+  )
+}

--- a/apps/web/src/components/editor/bubble-menu/sections/align.tsx
+++ b/apps/web/src/components/editor/bubble-menu/sections/align.tsx
@@ -1,0 +1,70 @@
+// apps/web/src/components/editor/bubble-menu/sections/align.tsx
+'use client'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
+import type { Editor } from '@tiptap/react'
+import { useEditorState } from '@tiptap/react'
+import { AlignCenter, AlignJustify, AlignLeft, AlignRight, ChevronDown } from 'lucide-react'
+import { useBubbleSubPopover } from '../bubble-menu-context'
+import { BubbleToggleButton } from '../ui/bubble-toggle-button'
+
+type Align = 'left' | 'center' | 'right' | 'justify'
+
+const OPTIONS: { id: Align; label: string; Icon: typeof AlignLeft }[] = [
+  { id: 'left', label: 'Align left', Icon: AlignLeft },
+  { id: 'center', label: 'Align center', Icon: AlignCenter },
+  { id: 'right', label: 'Align right', Icon: AlignRight },
+  { id: 'justify', label: 'Justify', Icon: AlignJustify },
+]
+
+interface AlignSectionProps {
+  editor: Editor
+}
+
+export function AlignSection({ editor }: AlignSectionProps) {
+  const onOpenChange = useBubbleSubPopover()
+  const current = useEditorState({
+    editor,
+    selector: ({ editor }): Align => {
+      for (const opt of OPTIONS) {
+        if (editor.isActive({ textAlign: opt.id })) return opt.id
+      }
+      return 'left'
+    },
+  })
+
+  const ActiveIcon = OPTIONS.find((o) => o.id === current)?.Icon ?? AlignLeft
+
+  return (
+    <DropdownMenu onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <BubbleToggleButton aria-label='Text alignment' className='gap-0.5 px-1.5'>
+              <ActiveIcon />
+              <ChevronDown className='size-3 opacity-60' />
+            </BubbleToggleButton>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Alignment</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align='start' className='w-40'>
+        {OPTIONS.map((o) => (
+          <DropdownMenuItem
+            key={o.id}
+            onSelect={() => editor.chain().focus().setTextAlign(o.id).run()}
+            className='flex items-center gap-2'>
+            <o.Icon className='size-3.5 text-muted-foreground' />
+            <span>{o.label}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/src/components/editor/bubble-menu/sections/color-picker.tsx
+++ b/apps/web/src/components/editor/bubble-menu/sections/color-picker.tsx
@@ -1,0 +1,168 @@
+// apps/web/src/components/editor/bubble-menu/sections/color-picker.tsx
+'use client'
+
+import { Popover, PopoverContentDialogAware, PopoverTrigger } from '@auxx/ui/components/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
+import { cn } from '@auxx/ui/lib/utils'
+import type { Editor } from '@tiptap/react'
+import { useEditorState } from '@tiptap/react'
+import { Check, ChevronDown } from 'lucide-react'
+import { useBubbleSubPopover } from '../bubble-menu-context'
+import { BubbleToggleButton } from '../ui/bubble-toggle-button'
+
+interface ColorSwatch {
+  id: string
+  label: string
+  textVar: string
+  bgVar: string
+}
+
+const SWATCHES: ColorSwatch[] = [
+  { id: 'default', label: 'Default', textVar: '', bgVar: '' },
+  { id: 'red', label: 'Red', textVar: 'var(--kb-text-red)', bgVar: 'var(--kb-bg-red)' },
+  {
+    id: 'orange',
+    label: 'Orange',
+    textVar: 'var(--kb-text-orange)',
+    bgVar: 'var(--kb-bg-orange)',
+  },
+  {
+    id: 'yellow',
+    label: 'Yellow',
+    textVar: 'var(--kb-text-yellow)',
+    bgVar: 'var(--kb-bg-yellow)',
+  },
+  { id: 'green', label: 'Green', textVar: 'var(--kb-text-green)', bgVar: 'var(--kb-bg-green)' },
+  { id: 'teal', label: 'Teal', textVar: 'var(--kb-text-teal)', bgVar: 'var(--kb-bg-teal)' },
+  { id: 'blue', label: 'Blue', textVar: 'var(--kb-text-blue)', bgVar: 'var(--kb-bg-blue)' },
+  {
+    id: 'purple',
+    label: 'Purple',
+    textVar: 'var(--kb-text-purple)',
+    bgVar: 'var(--kb-bg-purple)',
+  },
+  { id: 'pink', label: 'Pink', textVar: 'var(--kb-text-pink)', bgVar: 'var(--kb-bg-pink)' },
+]
+
+interface ColorPickerSectionProps {
+  editor: Editor
+}
+
+export function ColorPickerSection({ editor }: ColorPickerSectionProps) {
+  const onOpenChange = useBubbleSubPopover()
+  const state = useEditorState({
+    editor,
+    selector: ({ editor }) => ({
+      activeColor: editor.getAttributes('textStyle').color as string | undefined,
+      activeHighlight: editor.getAttributes('highlight').color as string | undefined,
+    }),
+  })
+
+  const applyText = (swatch: ColorSwatch) => {
+    if (!swatch.textVar) {
+      editor.chain().focus().unsetColor().run()
+      return
+    }
+    editor.chain().focus().setColor(swatch.textVar).run()
+  }
+
+  const applyHighlight = (swatch: ColorSwatch) => {
+    if (!swatch.bgVar) {
+      editor.chain().focus().unsetHighlight().run()
+      return
+    }
+    editor.chain().focus().setHighlight({ color: swatch.bgVar }).run()
+  }
+
+  return (
+    <Popover onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <BubbleToggleButton
+              aria-label='Text and highlight color'
+              className='gap-0.5 px-1.5'
+              active={!!state.activeColor || !!state.activeHighlight}>
+              <span
+                className='flex size-4 items-center justify-center rounded-sm text-[11px] font-semibold leading-none'
+                style={{
+                  color: state.activeColor || 'currentColor',
+                  background: state.activeHighlight || 'transparent',
+                }}>
+                A
+              </span>
+              <ChevronDown className='size-3 opacity-60' />
+            </BubbleToggleButton>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Text color</TooltipContent>
+      </Tooltip>
+      <PopoverContentDialogAware
+        align='start'
+        sideOffset={8}
+        className='w-56 p-2'
+        onMouseDown={(e) => e.preventDefault()}>
+        <div className='text-muted-foreground mb-1 px-1 text-[11px] font-medium uppercase tracking-wide'>
+          Text
+        </div>
+        <div className='grid grid-cols-9 gap-1'>
+          {SWATCHES.map((s) => (
+            <SwatchButton
+              key={s.id}
+              label={s.label}
+              swatchStyle={{ color: s.textVar || 'inherit' }}
+              isActive={s.textVar ? state.activeColor === s.textVar : !state.activeColor}
+              onClick={() => applyText(s)}>
+              A
+            </SwatchButton>
+          ))}
+        </div>
+        <div className='text-muted-foreground mt-3 mb-1 px-1 text-[11px] font-medium uppercase tracking-wide'>
+          Highlight
+        </div>
+        <div className='grid grid-cols-9 gap-1'>
+          {SWATCHES.map((s) => (
+            <SwatchButton
+              key={s.id}
+              label={s.label}
+              swatchStyle={{
+                background: s.bgVar || 'transparent',
+                border: s.id === 'default' ? '1px dashed var(--border)' : undefined,
+              }}
+              isActive={s.bgVar ? state.activeHighlight === s.bgVar : !state.activeHighlight}
+              onClick={() => applyHighlight(s)}
+            />
+          ))}
+        </div>
+      </PopoverContentDialogAware>
+    </Popover>
+  )
+}
+
+interface SwatchButtonProps {
+  label: string
+  swatchStyle: React.CSSProperties
+  isActive: boolean
+  onClick: () => void
+  children?: React.ReactNode
+}
+
+function SwatchButton({ label, swatchStyle, isActive, onClick, children }: SwatchButtonProps) {
+  return (
+    <button
+      type='button'
+      aria-label={label}
+      title={label}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className={cn(
+        'relative flex size-5 items-center justify-center rounded-sm text-[11px] font-semibold leading-none',
+        'border border-foreground/10 transition-colors hover:border-foreground/40',
+        isActive && 'ring-2 ring-ring ring-offset-1 ring-offset-popover'
+      )}
+      style={swatchStyle}>
+      {children}
+      {isActive && !children && <Check className='size-3 text-foreground/80' strokeWidth={3} />}
+    </button>
+  )
+}

--- a/apps/web/src/components/editor/bubble-menu/sections/inline-marks.tsx
+++ b/apps/web/src/components/editor/bubble-menu/sections/inline-marks.tsx
@@ -1,0 +1,92 @@
+// apps/web/src/components/editor/bubble-menu/sections/inline-marks.tsx
+'use client'
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
+import type { Editor } from '@tiptap/react'
+import { useEditorState } from '@tiptap/react'
+import { Bold, Code, Italic, Strikethrough, Underline as UnderlineIcon } from 'lucide-react'
+import { BubbleSection } from '../bubble-menu'
+import { BubbleToggleButton } from '../ui/bubble-toggle-button'
+
+interface InlineMarksSectionProps {
+  editor: Editor
+}
+
+export function InlineMarksSection({ editor }: InlineMarksSectionProps) {
+  const state = useEditorState({
+    editor,
+    selector: ({ editor }) => ({
+      bold: editor.isActive('bold'),
+      italic: editor.isActive('italic'),
+      underline: editor.isActive('underline'),
+      strike: editor.isActive('strike'),
+      code: editor.isActive('code'),
+    }),
+  })
+
+  return (
+    <BubbleSection>
+      <MarkButton
+        label='Bold'
+        shortcut='⌘B'
+        active={state.bold}
+        onClick={() => editor.chain().focus().toggleBold().run()}>
+        <Bold />
+      </MarkButton>
+      <MarkButton
+        label='Italic'
+        shortcut='⌘I'
+        active={state.italic}
+        onClick={() => editor.chain().focus().toggleItalic().run()}>
+        <Italic />
+      </MarkButton>
+      <MarkButton
+        label='Underline'
+        shortcut='⌘U'
+        active={state.underline}
+        onClick={() => editor.chain().focus().toggleUnderline().run()}>
+        <UnderlineIcon />
+      </MarkButton>
+      <MarkButton
+        label='Strikethrough'
+        shortcut='⌘⇧S'
+        active={state.strike}
+        onClick={() => editor.chain().focus().toggleStrike().run()}>
+        <Strikethrough />
+      </MarkButton>
+      <MarkButton
+        label='Inline code'
+        shortcut='⌘E'
+        active={state.code}
+        onClick={() => editor.chain().focus().toggleCode().run()}>
+        <Code />
+      </MarkButton>
+    </BubbleSection>
+  )
+}
+
+interface MarkButtonProps {
+  label: string
+  shortcut?: string
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}
+
+function MarkButton({ label, shortcut, active, onClick, children }: MarkButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <BubbleToggleButton aria-label={label} active={active} onClick={onClick}>
+          {children}
+        </BubbleToggleButton>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span className='flex items-center gap-1.5'>
+          {label}
+          {shortcut && <span className='text-muted-foreground'>{shortcut}</span>}
+        </span>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/web/src/components/editor/bubble-menu/sections/link-button.tsx
+++ b/apps/web/src/components/editor/bubble-menu/sections/link-button.tsx
@@ -1,0 +1,31 @@
+// apps/web/src/components/editor/bubble-menu/sections/link-button.tsx
+'use client'
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
+import type { Editor } from '@tiptap/react'
+import { useEditorState } from '@tiptap/react'
+import { Link as LinkIcon } from 'lucide-react'
+import { BubbleToggleButton } from '../ui/bubble-toggle-button'
+
+interface LinkButtonProps {
+  editor: Editor
+  onRequest: () => void
+}
+
+export function LinkButton({ editor, onRequest }: LinkButtonProps) {
+  const active = useEditorState({
+    editor,
+    selector: ({ editor }) => editor.isActive('link'),
+  })
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <BubbleToggleButton aria-label='Add link' active={active} onClick={onRequest}>
+          <LinkIcon />
+        </BubbleToggleButton>
+      </TooltipTrigger>
+      <TooltipContent>Link</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/web/src/components/editor/bubble-menu/sections/more-menu.tsx
+++ b/apps/web/src/components/editor/bubble-menu/sections/more-menu.tsx
@@ -1,0 +1,44 @@
+// apps/web/src/components/editor/bubble-menu/sections/more-menu.tsx
+'use client'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
+import type { Editor } from '@tiptap/react'
+import { Eraser, MoreHorizontal } from 'lucide-react'
+import { useBubbleSubPopover } from '../bubble-menu-context'
+import { BubbleToggleButton } from '../ui/bubble-toggle-button'
+
+interface MoreMenuSectionProps {
+  editor: Editor
+}
+
+export function MoreMenuSection({ editor }: MoreMenuSectionProps) {
+  const onOpenChange = useBubbleSubPopover()
+  return (
+    <DropdownMenu onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <BubbleToggleButton aria-label='More options'>
+              <MoreHorizontal />
+            </BubbleToggleButton>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>More</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align='end' className='w-44'>
+        <DropdownMenuItem
+          onSelect={() => editor.chain().focus().unsetAllMarks().run()}
+          className='flex items-center gap-2'>
+          <Eraser className='size-3.5 text-muted-foreground' />
+          <span>Clear formatting</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/src/components/editor/bubble-menu/sections/turn-into.tsx
+++ b/apps/web/src/components/editor/bubble-menu/sections/turn-into.tsx
@@ -1,0 +1,190 @@
+// apps/web/src/components/editor/bubble-menu/sections/turn-into.tsx
+'use client'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import type { Editor } from '@tiptap/react'
+import { useEditorState } from '@tiptap/react'
+import { ChevronDown } from 'lucide-react'
+import { BubbleSection } from '../bubble-menu'
+import { useBubbleSubPopover } from '../bubble-menu-context'
+import { BubbleToggleButton } from '../ui/bubble-toggle-button'
+
+interface TurnIntoOption {
+  id: string
+  label: string
+  iconId: string
+  blockType: string
+  level?: number | null
+  calloutVariant?: 'info' | 'tip' | 'warn' | 'error' | 'success'
+  checked?: boolean
+}
+
+/** Subset of the slash menu — in-place block transforms only. */
+const TURN_INTO_OPTIONS: TurnIntoOption[] = [
+  { id: 'text', label: 'Text', iconId: 'text', blockType: 'text', level: null },
+  { id: 'h1', label: 'Heading 1', iconId: 'heading-1', blockType: 'heading', level: 1 },
+  { id: 'h2', label: 'Heading 2', iconId: 'heading-2', blockType: 'heading', level: 2 },
+  { id: 'h3', label: 'Heading 3', iconId: 'heading-3', blockType: 'heading', level: 3 },
+  { id: 'bullet', label: 'Bullet list', iconId: 'list', blockType: 'bulletListItem', level: 1 },
+  {
+    id: 'numbered',
+    label: 'Numbered list',
+    iconId: 'list-ordered',
+    blockType: 'numberedListItem',
+    level: 1,
+  },
+  {
+    id: 'todo',
+    label: 'To-do list',
+    iconId: 'check-square',
+    blockType: 'todoListItem',
+    checked: false,
+  },
+  { id: 'quote', label: 'Quote', iconId: 'quote', blockType: 'quote' },
+  { id: 'code', label: 'Code', iconId: 'code', blockType: 'codeBlock' },
+  {
+    id: 'callout-info',
+    label: 'Info callout',
+    iconId: 'info',
+    blockType: 'callout',
+    calloutVariant: 'info',
+  },
+  {
+    id: 'callout-tip',
+    label: 'Tip callout',
+    iconId: 'lightbulb',
+    blockType: 'callout',
+    calloutVariant: 'tip',
+  },
+  {
+    id: 'callout-warn',
+    label: 'Warning callout',
+    iconId: 'alert-triangle',
+    blockType: 'callout',
+    calloutVariant: 'warn',
+  },
+  {
+    id: 'callout-error',
+    label: 'Error callout',
+    iconId: 'x-circle',
+    blockType: 'callout',
+    calloutVariant: 'error',
+  },
+  {
+    id: 'callout-success',
+    label: 'Success callout',
+    iconId: 'check-circle',
+    blockType: 'callout',
+    calloutVariant: 'success',
+  },
+  { id: 'divider', label: 'Divider', iconId: 'minus', blockType: 'divider', level: null },
+]
+
+interface TurnIntoSectionProps {
+  editor: Editor
+}
+
+interface SelectionBlocks {
+  /** All `block` node positions touched by the current selection. */
+  positions: number[]
+  /** Shared blockType across all blocks in selection, or null if mixed. */
+  sharedType: string | null
+  /** Shared blockType label for the trigger. */
+  label: string
+}
+
+function findSelectionBlocks(editor: Editor): SelectionBlocks {
+  const { from, to } = editor.state.selection
+  const positions: number[] = []
+  const types = new Set<string>()
+  editor.state.doc.nodesBetween(from, to, (node, pos) => {
+    if (node.type.name === 'block') {
+      positions.push(pos)
+      types.add(String(node.attrs.blockType ?? 'text'))
+      return false
+    }
+    return true
+  })
+  const sharedType = types.size === 1 ? (types.values().next().value ?? null) : null
+  return {
+    positions,
+    sharedType,
+    label: sharedType ? labelForBlockType(sharedType, editor, positions[0]) : 'Mixed',
+  }
+}
+
+function labelForBlockType(blockType: string, editor: Editor, pos?: number): string {
+  if (blockType === 'heading' && typeof pos === 'number') {
+    const level = editor.state.doc.nodeAt(pos)?.attrs.level ?? 1
+    return `Heading ${level}`
+  }
+  const opt = TURN_INTO_OPTIONS.find(
+    (o) => o.blockType === blockType && o.calloutVariant === undefined
+  )
+  return opt?.label ?? blockType
+}
+
+export function TurnIntoSection({ editor }: TurnIntoSectionProps) {
+  const onOpenChange = useBubbleSubPopover()
+  const selection = useEditorState({
+    editor,
+    selector: ({ editor }) => findSelectionBlocks(editor),
+    equalityFn: (a, b) =>
+      a.sharedType === b.sharedType &&
+      a.positions.length === b.positions.length &&
+      a.positions.every((p, i) => p === b.positions[i]),
+  })
+
+  // Hide entirely if the selection has no convertible blocks (e.g. only
+  // crossed table cells, or no shared type to derive a label from).
+  if (selection.positions.length === 0) return null
+
+  const apply = (option: TurnIntoOption) => {
+    const chain = editor.chain().focus()
+    for (const pos of selection.positions) {
+      const attrs: Record<string, unknown> = {
+        blockType: option.blockType,
+        level: option.level ?? null,
+      }
+      if (option.blockType === 'todoListItem') attrs.checked = option.checked ?? false
+      if (option.blockType === 'callout') attrs.calloutVariant = option.calloutVariant ?? 'info'
+      chain.command(({ tr, state }) => {
+        const node = state.doc.nodeAt(pos)
+        if (!node || node.type.name !== 'block') return false
+        tr.setNodeMarkup(pos, undefined, { ...node.attrs, ...attrs })
+        return true
+      })
+    }
+    chain.run()
+  }
+
+  return (
+    <BubbleSection>
+      <DropdownMenu onOpenChange={onOpenChange}>
+        <DropdownMenuTrigger asChild>
+          <BubbleToggleButton aria-label='Turn into' className='gap-1 px-2'>
+            <span className='max-w-24 truncate'>{selection.label}</span>
+            <ChevronDown className='size-3 opacity-60' />
+          </BubbleToggleButton>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align='start' className='max-h-72 w-48 overflow-y-auto'>
+          {TURN_INTO_OPTIONS.map((opt) => (
+            <DropdownMenuItem
+              key={opt.id}
+              onSelect={() => apply(opt)}
+              className='flex items-center gap-2'>
+              <EntityIcon iconId={opt.iconId} size='xs' className='text-muted-foreground' />
+              <span>{opt.label}</span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </BubbleSection>
+  )
+}

--- a/apps/web/src/components/editor/bubble-menu/ui/bubble-toggle-button.tsx
+++ b/apps/web/src/components/editor/bubble-menu/ui/bubble-toggle-button.tsx
@@ -1,0 +1,41 @@
+// apps/web/src/components/editor/bubble-menu/ui/bubble-toggle-button.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import type { ButtonHTMLAttributes } from 'react'
+import { forwardRef } from 'react'
+
+interface BubbleToggleButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  active?: boolean
+}
+
+/** Single, dense toggle button used inside the bubble menu. */
+export const BubbleToggleButton = forwardRef<HTMLButtonElement, BubbleToggleButtonProps>(
+  function BubbleToggleButton({ className, active, type, children, ...rest }, ref) {
+    return (
+      <button
+        ref={ref}
+        type={type ?? 'button'}
+        data-state={active ? 'on' : 'off'}
+        // Stop mousedown from blurring the editor — the bubble must stay open
+        // while the user clicks its buttons.
+        onMouseDown={(e) => {
+          e.preventDefault()
+          rest.onMouseDown?.(e)
+        }}
+        className={cn(
+          'inline-flex h-7 min-w-7 items-center justify-center gap-1 rounded-md px-1.5 text-xs',
+          'text-foreground/70 transition-colors',
+          'hover:bg-foreground/10 hover:text-foreground',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+          'data-[state=on]:bg-primary/15 data-[state=on]:text-primary data-[state=on]:ring-1 data-[state=on]:ring-primary/30',
+          'disabled:pointer-events-none disabled:opacity-50',
+          '[&>svg]:size-3.5 [&>svg]:shrink-0',
+          className
+        )}
+        {...rest}>
+        {children}
+      </button>
+    )
+  }
+)

--- a/apps/web/src/components/editor/bubble-menu/use-bubble-menu-state.ts
+++ b/apps/web/src/components/editor/bubble-menu/use-bubble-menu-state.ts
@@ -1,0 +1,128 @@
+// apps/web/src/components/editor/bubble-menu/use-bubble-menu-state.ts
+'use client'
+
+import type { Editor } from '@tiptap/react'
+import { useEffect, useState } from 'react'
+
+export interface BubbleMenuRange {
+  from: number
+  to: number
+}
+
+export interface BubbleMenuState {
+  open: boolean
+  rect: DOMRect | null
+  range: BubbleMenuRange
+}
+
+interface UseBubbleMenuStateOptions {
+  editor: Editor | null
+  shouldShow?: (ctx: { editor: Editor; from: number; to: number }) => boolean
+  /** When `true`, the menu stays mounted even if the selection collapses or
+   *  the editor loses focus — used while a nested popover (color picker, turn
+   *  into menu) is open and steals focus from the editor. */
+  forceOpen?: boolean
+}
+
+const EMPTY_RECT = new DOMRect()
+
+function computeSelectionRect(editor: Editor): DOMRect | null {
+  const domSel = typeof window !== 'undefined' ? window.getSelection() : null
+  if (domSel && domSel.rangeCount > 0 && !domSel.isCollapsed) {
+    const r = domSel.getRangeAt(0).getBoundingClientRect()
+    if (r.width > 0 || r.height > 0) return r
+  }
+  // Fallback to PM coords — covers cases where the DOM selection is empty
+  // (e.g. the editor was just programmatically updated).
+  try {
+    const { from, to } = editor.state.selection
+    if (from === to) return null
+    const start = editor.view.coordsAtPos(from)
+    const end = editor.view.coordsAtPos(to)
+    const left = Math.min(start.left, end.left)
+    const top = Math.min(start.top, end.top)
+    const right = Math.max(start.right, end.right)
+    const bottom = Math.max(start.bottom, end.bottom)
+    return new DOMRect(left, top, right - left, bottom - top)
+  } catch {
+    return null
+  }
+}
+
+function defaultShouldShow(ctx: { editor: Editor; from: number; to: number }): boolean {
+  const { editor, from, to } = ctx
+  if (from === to) return false
+  if (!editor.isEditable) return false
+  // Hide entirely inside a codeBlock — Tiptap's `isActive('block', { blockType })`
+  // checks the wrapping `block` node's attrs.
+  if (editor.isActive('block', { blockType: 'codeBlock' })) return false
+  return true
+}
+
+export function useBubbleMenuState({
+  editor,
+  shouldShow = defaultShouldShow,
+  forceOpen = false,
+}: UseBubbleMenuStateOptions): BubbleMenuState {
+  const [state, setState] = useState<BubbleMenuState>({
+    open: false,
+    rect: null,
+    range: { from: 0, to: 0 },
+  })
+
+  useEffect(() => {
+    if (!editor) return
+
+    let rafId: number | null = null
+
+    const compute = () => {
+      rafId = null
+      if (editor.isDestroyed) return
+      const { from, to } = editor.state.selection
+      const ok = shouldShow({ editor, from, to })
+      if (!ok) {
+        setState((prev) => (prev.open ? { ...prev, open: false } : prev))
+        return
+      }
+      const rect = computeSelectionRect(editor)
+      if (!rect) {
+        setState((prev) => (prev.open ? { ...prev, open: false } : prev))
+        return
+      }
+      setState({ open: true, rect, range: { from, to } })
+    }
+
+    const schedule = () => {
+      if (rafId !== null) return
+      rafId = window.requestAnimationFrame(compute)
+    }
+
+    editor.on('selectionUpdate', schedule)
+    editor.on('transaction', schedule)
+    editor.on('blur', schedule)
+    editor.on('focus', schedule)
+
+    // Reposition on viewport changes too.
+    window.addEventListener('scroll', schedule, true)
+    window.addEventListener('resize', schedule)
+
+    schedule()
+
+    return () => {
+      if (rafId !== null) window.cancelAnimationFrame(rafId)
+      editor.off('selectionUpdate', schedule)
+      editor.off('transaction', schedule)
+      editor.off('blur', schedule)
+      editor.off('focus', schedule)
+      window.removeEventListener('scroll', schedule, true)
+      window.removeEventListener('resize', schedule)
+    }
+  }, [editor, shouldShow])
+
+  if (forceOpen && state.rect) {
+    return { ...state, open: true }
+  }
+  // Avoid returning a null rect downstream — keeps Radix happy when the menu
+  // is transitioning closed.
+  return state.rect ? state : { ...state, rect: EMPTY_RECT }
+}

--- a/apps/web/src/components/editor/kb-article/block-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/block-node-view.tsx
@@ -20,6 +20,7 @@ import { parseEmbedUrl } from '@auxx/ui/components/kb/utils'
 import type { NodeViewProps } from '@tiptap/react'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import { Check, ChevronDown } from 'lucide-react'
+import type React from 'react'
 import { useState } from 'react'
 import styles from './block-node-view.module.css'
 import { CardsBlockView } from './cards-block-view'
@@ -52,9 +53,33 @@ const CODE_LANGUAGES = [
 
 const EMBED_ASPECTS: EmbedAspect[] = ['16:9', '4:3', '1:1']
 
-function formatBullet(depth: number): string {
-  const bullets = ['•', '◦', '▪']
-  return bullets[depth % bullets.length] ?? '•'
+type BulletListStyle = 'disc' | 'circle' | 'square'
+type NumberedListStyle = '1' | 'a' | 'A' | 'i' | 'I'
+
+const BULLET_GLYPHS: Record<BulletListStyle, string> = {
+  disc: '•',
+  circle: '◦',
+  square: '▪',
+}
+
+function formatBullet(depth: number, override: BulletListStyle | null): string {
+  if (override) return BULLET_GLYPHS[override]
+  // Default cycle by depth — preserves prior behavior for blocks without a
+  // chosen listStyle.
+  const cycle: BulletListStyle[] = ['disc', 'circle', 'square']
+  return BULLET_GLYPHS[cycle[depth % cycle.length] ?? 'disc']
+}
+
+function toAlpha(n: number, upper: boolean): string {
+  // 1 → a, 2 → b, ..., 26 → z, 27 → aa
+  let value = n
+  let result = ''
+  while (value > 0) {
+    const rem = (value - 1) % 26
+    result = String.fromCharCode((upper ? 65 : 97) + rem) + result
+    value = Math.floor((value - 1) / 26)
+  }
+  return result || (upper ? 'A' : 'a')
 }
 
 function toRoman(n: number): string {
@@ -84,11 +109,25 @@ function toRoman(n: number): string {
   return result
 }
 
-function formatNumber(index: number, depth: number): string {
+function formatNumber(index: number, depth: number, override: NumberedListStyle | null): string {
+  if (override === '1') return `${index}.`
+  if (override === 'a') return `${toAlpha(index, false)}.`
+  if (override === 'A') return `${toAlpha(index, true)}.`
+  if (override === 'i') return `${toRoman(index)}.`
+  if (override === 'I') return `${toRoman(index).toUpperCase()}.`
+  // Default cycle by depth.
   const level = depth % 3
   if (level === 0) return `${index}.`
-  if (level === 1) return `${String.fromCharCode(96 + index)}.`
+  if (level === 1) return `${toAlpha(index, false)}.`
   return `${toRoman(index)}.`
+}
+
+function isBulletStyle(v: unknown): v is BulletListStyle {
+  return v === 'disc' || v === 'circle' || v === 'square'
+}
+
+function isNumberedStyle(v: unknown): v is NumberedListStyle {
+  return v === '1' || v === 'a' || v === 'A' || v === 'i' || v === 'I'
 }
 
 export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeViewProps) {
@@ -103,6 +142,8 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
     codeLanguage,
     embedUrl,
     embedAspect,
+    listStyle,
+    textAlign,
   } = node.attrs as {
     blockType?: string
     level?: number | null
@@ -115,7 +156,12 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
     embedUrl?: string | null
     embedProvider?: EmbedProvider
     embedAspect?: EmbedAspect
+    listStyle?: string | null
+    textAlign?: string | null
   }
+
+  const bulletOverride = isBulletStyle(listStyle) ? listStyle : null
+  const numberedOverride = isNumberedStyle(listStyle) ? listStyle : null
 
   const [embedDraft, setEmbedDraft] = useState('')
   const [embedError, setEmbedError] = useState<string | null>(null)
@@ -275,16 +321,21 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
           <div className={`${styles.lineNumber} text-xs tabular-nums`}>{lineNumber ?? ''}</div>
         </div>
 
-        <div className={contentWrapperClasses} data-content-wrapper>
+        <div
+          className={contentWrapperClasses}
+          data-content-wrapper
+          style={
+            textAlign ? { textAlign: textAlign as React.CSSProperties['textAlign'] } : undefined
+          }>
           {blockType === 'bulletListItem' && (
             <span className={styles.bulletIndicator} contentEditable={false}>
-              {formatBullet(indentLevel)}
+              {formatBullet(indentLevel, bulletOverride)}
             </span>
           )}
 
           {blockType === 'numberedListItem' && (
             <span className={styles.numberIndicator} contentEditable={false}>
-              {formatNumber(numberedIndex, indentLevel)}
+              {formatNumber(numberedIndex, indentLevel, numberedOverride)}
             </span>
           )}
 

--- a/apps/web/src/components/editor/kb-article/block-node.ts
+++ b/apps/web/src/components/editor/kb-article/block-node.ts
@@ -169,6 +169,14 @@ export const Block = Node.create({
             ? { 'data-cards': JSON.stringify(attrs.cards) }
             : {},
       },
+      // Marker style for list items. `disc | circle | square` for bullets,
+      // `1 | a | A | i | I` for numbered. `null` = use the default. Honored
+      // by BlockNodeView when it renders the bullet/number glyph.
+      listStyle: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-list-style'),
+        renderHTML: (attrs) => (attrs.listStyle ? { 'data-list-style': attrs.listStyle } : {}),
+      },
     }
   },
 

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.module.css
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.module.css
@@ -1,5 +1,50 @@
 /* apps/web/src/components/editor/kb-article/kb-article-editor.module.css */
 
+/* ============================================
+   KB inline color palette — referenced by the
+   bubble menu color picker via CSS variables,
+   so light/dark mode resolve at render time.
+   Text colors (foreground) and highlight colors
+   (background) live in :root so the inline
+   `style="color: var(--kb-text-red)"` marks
+   produced by Tiptap's Color extension resolve
+   everywhere the article renders.
+   ============================================ */
+
+:global(:root) {
+  --kb-text-default: inherit;
+  --kb-text-red: oklch(0.55 0.18 25);
+  --kb-text-orange: oklch(0.62 0.16 60);
+  --kb-text-yellow: oklch(0.7 0.13 90);
+  --kb-text-green: oklch(0.55 0.14 145);
+  --kb-text-teal: oklch(0.6 0.1 195);
+  --kb-text-blue: oklch(0.55 0.16 245);
+  --kb-text-purple: oklch(0.5 0.18 295);
+  --kb-text-pink: oklch(0.6 0.18 350);
+
+  --kb-bg-default: transparent;
+  --kb-bg-red: color-mix(in oklab, var(--kb-text-red) 18%, transparent);
+  --kb-bg-orange: color-mix(in oklab, var(--kb-text-orange) 22%, transparent);
+  --kb-bg-yellow: color-mix(in oklab, var(--kb-text-yellow) 28%, transparent);
+  --kb-bg-green: color-mix(in oklab, var(--kb-text-green) 18%, transparent);
+  --kb-bg-teal: color-mix(in oklab, var(--kb-text-teal) 22%, transparent);
+  --kb-bg-blue: color-mix(in oklab, var(--kb-text-blue) 18%, transparent);
+  --kb-bg-purple: color-mix(in oklab, var(--kb-text-purple) 18%, transparent);
+  --kb-bg-pink: color-mix(in oklab, var(--kb-text-pink) 22%, transparent);
+}
+
+:global(.dark) {
+  --kb-text-red: oklch(0.72 0.18 25);
+  --kb-text-orange: oklch(0.75 0.15 60);
+  --kb-text-yellow: oklch(0.85 0.13 90);
+  --kb-text-green: oklch(0.72 0.14 145);
+  --kb-text-teal: oklch(0.75 0.1 195);
+  --kb-text-blue: oklch(0.72 0.15 245);
+  --kb-text-purple: oklch(0.7 0.17 295);
+  --kb-text-pink: oklch(0.75 0.16 350);
+}
+
+
 .editorWrapper {
   position: relative;
   z-index: 1;

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
@@ -7,6 +7,17 @@ import type { Editor } from '@tiptap/react'
 import { EditorContent } from '@tiptap/react'
 import type { CSSProperties } from 'react'
 import { useCallback, useEffect, useState } from 'react'
+import {
+  AISlotPlaceholder,
+  AlignSection,
+  ColorPickerSection,
+  EditorBubbleMenu,
+  InlineMarksSection,
+  KBBlockSection,
+  LinkButton,
+  MoreMenuSection,
+  TurnIntoSection,
+} from '../bubble-menu'
 import { InlinePickerPopover } from '../inline-picker'
 import {
   type ArticleLinkEditMode,
@@ -118,6 +129,29 @@ export function KBArticleEditor({
     setLinkPopover({ rect })
   }, [])
 
+  const handleBubbleLinkRequest = useCallback(() => {
+    if (!editor) return
+    const { from, to } = editor.state.selection
+    if (from === to) return
+    const selectedText = editor.state.doc.textBetween(from, to, ' ')
+    const linkType = editor.schema.marks.link
+    const existing = linkType ? editor.getAttributes('link') : null
+    const existingHref = typeof existing?.href === 'string' ? existing.href : ''
+    const start = editor.view.coordsAtPos(from)
+    const end = editor.view.coordsAtPos(to)
+    const rect = new DOMRect(
+      Math.min(start.left, end.left),
+      Math.min(start.top, end.top),
+      Math.max(1, Math.max(start.right, end.right) - Math.min(start.left, end.left)),
+      Math.max(1, Math.max(start.bottom, end.bottom) - Math.min(start.top, end.top))
+    )
+    setLinkPopover({
+      rect,
+      range: { from, to },
+      edit: { kind: 'edit', initialHref: existingHref, initialText: selectedText },
+    })
+  }, [editor])
+
   const handlePick = useCallback(
     (pick: ArticleLinkPick) => {
       if (!editor || !linkPopover) return
@@ -180,6 +214,19 @@ export function KBArticleEditor({
         <div className={styles.editorContainer}>
           <EditorContent editor={editor} className={styles.editorContent} />
         </div>
+        <EditorBubbleMenu
+          editor={editor}
+          renderBlockSection={({ editor }) => <KBBlockSection editor={editor} />}
+          renderAISlot={() => <AISlotPlaceholder />}
+          renderTurnInto={({ editor }) => <TurnIntoSection editor={editor} />}
+          renderInlineMarks={({ editor }) => <InlineMarksSection editor={editor} />}
+          renderColor={({ editor }) => <ColorPickerSection editor={editor} />}
+          renderAlign={({ editor }) => <AlignSection editor={editor} />}
+          renderLink={({ editor }) => (
+            <LinkButton editor={editor} onRequest={handleBubbleLinkRequest} />
+          )}
+          renderMore={({ editor }) => <MoreMenuSection editor={editor} />}
+        />
         <InlinePickerPopover
           state={slashCommand.suggestionState}
           onClose={slashCommand.closePicker}

--- a/apps/web/src/components/editor/kb-article/use-kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/use-kb-article-editor.tsx
@@ -3,8 +3,11 @@
 
 import type { JSONContent } from '@tiptap/core'
 import { Extension, Node } from '@tiptap/core'
+import Color from '@tiptap/extension-color'
 import Highlight from '@tiptap/extension-highlight'
 import Link from '@tiptap/extension-link'
+import TextAlign from '@tiptap/extension-text-align'
+import TextStyle from '@tiptap/extension-text-style'
 import Underline from '@tiptap/extension-underline'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
@@ -111,6 +114,9 @@ export function useKBArticleEditor({ initialContent, onChange }: UseKBArticleEdi
         TableHeader,
         TableCell,
         Underline,
+        TextStyle,
+        Color,
+        TextAlign.configure({ types: ['block'] }),
         Highlight.configure({ multicolor: true }),
         Link.configure({ openOnClick: false, autolink: true, defaultProtocol: 'https' }),
         FocusClasses,

--- a/apps/web/src/components/kb/hooks/use-article-content.ts
+++ b/apps/web/src/components/kb/hooks/use-article-content.ts
@@ -30,6 +30,8 @@ interface UseArticleContentResult {
   publishedContentJson: ArticleNodeJSON[] | null
   publishedCoverImage: string | null
   hasPublishedVersion: boolean
+  /** Revision id of the currently-live version (matches an ArticleRevision.id). */
+  publishedRevisionId: string | null
   hasUnpublishedChanges: boolean
   /** What the preview should render for the resolved mode. */
   previewTitle: string | null
@@ -96,6 +98,7 @@ export function useArticleContent(
     (data?.publishedContentJson as ArticleNodeJSON[] | null | undefined) ?? null
   const publishedCoverImage = data?.publishedCoverImage ?? null
   const hasPublishedVersion = !!data?.hasPublishedVersion
+  const publishedRevisionId = data?.publishedRevisionId ?? null
 
   let previewTitle: string | null = draftTitle
   let previewDescription: string | null = draftDescription
@@ -157,6 +160,7 @@ export function useArticleContent(
     publishedContentJson,
     publishedCoverImage,
     hasPublishedVersion,
+    publishedRevisionId,
     hasUnpublishedChanges: !!data?.hasUnpublishedChanges,
     previewTitle,
     previewDescription,

--- a/apps/web/src/components/kb/ui/editor/container-article-placeholder.tsx
+++ b/apps/web/src/components/kb/ui/editor/container-article-placeholder.tsx
@@ -1,0 +1,216 @@
+// apps/web/src/components/kb/ui/editor/container-article-placeholder.tsx
+'use client'
+
+import { ArticleKind } from '@auxx/database/enums'
+import type { ArticleKind as ArticleKindType } from '@auxx/database/types'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Command,
+  CommandGroup,
+  CommandGroupLabel,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@auxx/ui/components/command'
+import { EntityIcon, getIcon } from '@auxx/ui/components/icons'
+import { getFullSlugPath } from '@auxx/ui/components/kb/utils'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { ExternalLink, FileText, FolderClosed, Heading, Link2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useMemo } from 'react'
+import { useArticleList } from '../../hooks/use-article-list'
+import { useArticleMutations } from '../../hooks/use-article-mutations'
+import type { ArticleMeta } from '../../store/article-store'
+import { usePendingInsertStore } from '../../store/pending-insert-store'
+
+interface ContainerArticlePlaceholderProps {
+  article: ArticleMeta
+  knowledgeBaseId: string
+}
+
+interface QuickCreateOption {
+  kind: ArticleKindType
+  label: string
+  Icon: React.ComponentType<{ className?: string }>
+}
+
+const TAB_OPTIONS: QuickCreateOption[] = [
+  { kind: ArticleKind.page, label: 'Page', Icon: FileText },
+  { kind: ArticleKind.category, label: 'Category', Icon: FolderClosed },
+  { kind: ArticleKind.link, label: 'Link', Icon: Link2 },
+  { kind: ArticleKind.header, label: 'Section header', Icon: Heading },
+]
+
+const HEADER_OPTIONS: QuickCreateOption[] = [
+  { kind: ArticleKind.page, label: 'Page', Icon: FileText },
+  { kind: ArticleKind.category, label: 'Category', Icon: FolderClosed },
+  { kind: ArticleKind.link, label: 'Link', Icon: Link2 },
+]
+
+/**
+ * Rendered in the right pane when the URL resolves to a structural
+ * container (`tab`, `header`, or `link`) — these kinds have no body of
+ * their own, so we show an empty-state with quick-create actions for
+ * the children the container can legally hold instead of mounting the
+ * Tiptap article editor. Categories keep their normal editor since
+ * they carry both a body and children.
+ */
+export function ContainerArticlePlaceholder({
+  article,
+  knowledgeBaseId,
+}: ContainerArticlePlaceholderProps) {
+  const router = useRouter()
+  const articles = useArticleList(knowledgeBaseId)
+  const { isCreating } = useArticleMutations(knowledgeBaseId)
+  const setPending = usePendingInsertStore((s) => s.setPending)
+
+  const children = useMemo(
+    () =>
+      articles
+        .filter((a) => a.parentId === article.id)
+        .sort((a, b) => (a.sortOrder < b.sortOrder ? -1 : a.sortOrder > b.sortOrder ? 1 : 0)),
+    [articles, article.id]
+  )
+  const childCount = children.length
+
+  const basePath = `/app/kb/${knowledgeBaseId}`
+
+  const handleOpenChild = (child: ArticleMeta) => {
+    if (child.articleKind === ArticleKind.link) {
+      const url = child.slug && /^[a-z][a-z0-9+.-]*:/i.test(child.slug) ? child.slug : null
+      if (url) window.open(url, '_blank', 'noopener,noreferrer')
+      return
+    }
+    const slug = getFullSlugPath(child, articles)
+    router.push(`${basePath}/editor/~/${slug}?panel=articles`)
+  }
+
+  const childIcon = (child: ArticleMeta) => {
+    if (child.emoji && getIcon(child.emoji)) {
+      return <EntityIcon iconId={child.emoji} variant='bare' size='sm' />
+    }
+    if (child.articleKind === ArticleKind.category) {
+      return <FolderClosed className='size-4 text-muted-foreground' />
+    }
+    if (child.articleKind === ArticleKind.header) {
+      return <Heading className='size-4 text-muted-foreground' />
+    }
+    if (child.articleKind === ArticleKind.link) {
+      return <Link2 className='size-4 text-muted-foreground' />
+    }
+    return <FileText className='size-4 text-muted-foreground' />
+  }
+
+  const kindLabel =
+    article.articleKind === ArticleKind.tab
+      ? 'Tab'
+      : article.articleKind === ArticleKind.header
+        ? 'Section header'
+        : 'Link'
+
+  const subtitle =
+    article.articleKind === ArticleKind.link
+      ? 'External link'
+      : `${kindLabel} · ${childCount} ${childCount === 1 ? 'item' : 'items'} inside`
+
+  const hasCustomIcon = !!article.emoji && !!getIcon(article.emoji)
+  const fallbackIcon =
+    article.articleKind === ArticleKind.link ? (
+      <Link2 className='size-7 text-muted-foreground' />
+    ) : article.articleKind === ArticleKind.header ? (
+      <Heading className='size-7 text-muted-foreground' />
+    ) : (
+      <FolderClosed className='size-7 text-muted-foreground' />
+    )
+
+  const linkUrl =
+    article.articleKind === ArticleKind.link &&
+    article.slug &&
+    /^[a-z][a-z0-9+.-]*:/i.test(article.slug)
+      ? article.slug
+      : null
+
+  const handleCreate = (kind: ArticleKindType) => {
+    // No `adjacentTo` / `position` → ArticleTreeSection treats this as an
+    // append, putting the new child at the bottom of the container.
+    setPending({ articleKind: kind, parentId: article.id })
+  }
+
+  const options =
+    article.articleKind === ArticleKind.tab
+      ? TAB_OPTIONS
+      : article.articleKind === ArticleKind.header
+        ? HEADER_OPTIONS
+        : null
+
+  return (
+    <div className='flex min-h-0 flex-1 flex-col'>
+      <ScrollArea className='flex-1'>
+        <div className='mx-auto flex w-full max-w-md flex-col items-center px-7 py-16 text-center'>
+          <div className='mb-4'>
+            {hasCustomIcon ? (
+              <EntityIcon iconId={article.emoji as string} variant='bare' size='lg' />
+            ) : (
+              fallbackIcon
+            )}
+          </div>
+          <h1 className='text-2xl font-semibold'>{article.title || 'Untitled'}</h1>
+          <p className='mt-1 text-sm text-muted-foreground'>{subtitle}</p>
+
+          {article.articleKind === ArticleKind.link ? (
+            <div className='mt-8 w-full'>
+              {linkUrl ? (
+                <Button asChild variant='outline' className='w-full'>
+                  <a href={linkUrl} target='_blank' rel='noopener noreferrer'>
+                    <ExternalLink /> Open link
+                  </a>
+                </Button>
+              ) : (
+                <p className='text-sm text-muted-foreground'>
+                  This link doesn't have a URL yet. Set one from the sidebar.
+                </p>
+              )}
+            </div>
+          ) : options ? (
+            <div className='mt-8 w-full text-left'>
+              <Command className='rounded-md border bg-background'>
+                <CommandList>
+                  <CommandGroup>
+                    <CommandGroupLabel>Add to this {kindLabel.toLowerCase()}</CommandGroupLabel>
+                    {options.map(({ kind, label, Icon }) => (
+                      <CommandItem
+                        key={kind}
+                        value={`create-${kind}`}
+                        disabled={isCreating}
+                        onSelect={() => handleCreate(kind)}>
+                        <Icon className='size-4 text-muted-foreground' />
+                        <span>{label}</span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                  {children.length > 0 && (
+                    <>
+                      <CommandSeparator />
+                      <CommandGroup>
+                        <CommandGroupLabel>Inside</CommandGroupLabel>
+                        {children.map((child) => (
+                          <CommandItem
+                            key={child.id}
+                            value={`open-${child.id}`}
+                            onSelect={() => handleOpenChild(child)}>
+                            {childIcon(child)}
+                            <span className='truncate'>{child.title || 'Untitled'}</span>
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </>
+                  )}
+                </CommandList>
+              </Command>
+            </div>
+          ) : null}
+        </div>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
 'use client'
 
+import { ArticleKind } from '@auxx/database/enums'
 import { mergeDraftOverLive } from '@auxx/lib/kb/client'
 import { findArticleBySlugPath } from '@auxx/ui/components/kb/utils'
 import { useQueryState } from 'nuqs'
@@ -10,6 +11,7 @@ import { useArticleList, useIsArticleListLoaded } from '../../hooks/use-article-
 import { useKnowledgeBase } from '../../hooks/use-knowledge-base'
 import { KBPreview } from '../preview/kb-preview'
 import { ArticleEditor } from './article-editor'
+import { ContainerArticlePlaceholder } from './container-article-placeholder'
 
 interface KBEditorPageBodyProps {
   knowledgeBaseId: string
@@ -60,6 +62,12 @@ function KBEditorBody({ knowledgeBaseId, slug, hasArticlesLoaded }: KBEditorBody
   if (!hasArticlesLoaded) return <LoadingSpinner />
 
   if (currentArticle) {
+    const kind = currentArticle.articleKind
+    if (kind === ArticleKind.tab || kind === ArticleKind.header || kind === ArticleKind.link) {
+      return (
+        <ContainerArticlePlaceholder article={currentArticle} knowledgeBaseId={knowledgeBaseId} />
+      )
+    }
     return <ArticleEditor article={currentArticle} knowledgeBaseId={knowledgeBaseId} />
   }
 

--- a/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
@@ -86,6 +86,8 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath, mode }: KBFulls
     previewEmoji,
     previewCoverImage,
     hasPublishedVersion,
+    publishedRevisionId,
+    hasUnpublishedChanges,
     fellBackToDraft,
   } = useArticleContent(articleId, knowledgeBaseId, mode)
 
@@ -156,6 +158,8 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath, mode }: KBFulls
             articleId={articleId}
             mode={mode}
             hasPublishedVersion={hasPublishedVersion}
+            publishedRevisionId={publishedRevisionId}
+            hasUnpublishedChanges={hasUnpublishedChanges}
             onModeChange={handleModeChange}
           />
         ) : null}
@@ -187,6 +191,8 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath, mode }: KBFulls
         articleId={articleId}
         mode={mode}
         hasPublishedVersion={hasPublishedVersion}
+        publishedRevisionId={publishedRevisionId}
+        hasUnpublishedChanges={hasUnpublishedChanges}
         onModeChange={handleModeChange}
       />
     ) : null
@@ -208,6 +214,8 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath, mode }: KBFulls
             articleId={articleId}
             mode={mode}
             hasPublishedVersion={hasPublishedVersion}
+            publishedRevisionId={publishedRevisionId}
+            hasUnpublishedChanges={hasUnpublishedChanges}
             onModeChange={handleModeChange}
           />
         ) : null}

--- a/apps/web/src/components/kb/ui/preview/kb-preview-topbar.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview-topbar.tsx
@@ -62,7 +62,10 @@ export function KBPreviewTopBar({ kbId, activeSlugPath, articleId }: KBPreviewTo
       ? `/${activeSlugPath.map(encodeURIComponent).join('/')}`
       : ''
   const publicUrl = useKbPublicUrl(kb?.slug)
-  const { hasPublishedVersion } = useArticleContent(articleId ?? null, kbId)
+  const { hasPublishedVersion, publishedRevisionId, hasUnpublishedChanges } = useArticleContent(
+    articleId ?? null,
+    kbId
+  )
 
   const isPublished = kb?.publishStatus === 'PUBLISHED'
   const isUnlisted = kb?.publishStatus === 'UNLISTED'
@@ -132,6 +135,8 @@ export function KBPreviewTopBar({ kbId, activeSlugPath, articleId }: KBPreviewTo
             articleId={articleId}
             mode={previewMode}
             hasPublishedVersion={hasPublishedVersion}
+            publishedRevisionId={publishedRevisionId}
+            hasUnpublishedChanges={hasUnpublishedChanges}
             onModeChange={setPreviewMode}
           />
         ) : null}

--- a/apps/web/src/components/kb/ui/preview/preview-version-picker.tsx
+++ b/apps/web/src/components/kb/ui/preview/preview-version-picker.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/kb/ui/preview/preview-version-picker.tsx
 'use client'
 
+import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import {
   DropdownMenu,
@@ -26,6 +27,16 @@ interface PreviewVersionPickerProps {
    * Lets parents keep layout stable while waiting for an article id.
    */
   disabled?: boolean
+  /**
+   * ArticleRevision id of the currently-published revision. Used to badge the
+   * matching row in the version history list. Null when never published.
+   */
+  publishedRevisionId?: string | null
+  /**
+   * When false and a published version exists, the Draft entry shows
+   * "Same as live" to signal that publishing would be a no-op.
+   */
+  hasUnpublishedChanges?: boolean
 }
 
 function modeLabel(mode: PreviewMode, activeVersionLabel: string | null): string {
@@ -65,6 +76,8 @@ export function PreviewVersionPicker({
   hasPublishedVersion,
   onModeChange,
   disabled,
+  publishedRevisionId = null,
+  hasUnpublishedChanges = true,
 }: PreviewVersionPickerProps) {
   const [open, setOpen] = useState(false)
   const versionsQuery = api.kb.getArticleVersions.useQuery(
@@ -94,7 +107,9 @@ export function PreviewVersionPicker({
         <DropdownMenuItem onSelect={() => onModeChange('draft')}>
           <Check className={mode === 'draft' ? 'opacity-100' : 'opacity-0'} />
           <span>Draft</span>
-          <span className='ml-auto text-xs text-muted-foreground'>in progress</span>
+          {hasPublishedVersion && !hasUnpublishedChanges ? (
+            <span className='ml-auto text-xs text-muted-foreground'>Same as live</span>
+          ) : null}
         </DropdownMenuItem>
         {hasPublishedVersion ? (
           <DropdownMenuItem onSelect={() => onModeChange('live')}>
@@ -129,6 +144,7 @@ export function PreviewVersionPicker({
         ) : (
           versions.map((v) => {
             const isActive = isHistorical(mode) && mode.versionNumber === v.versionNumber
+            const isLive = publishedRevisionId !== null && v.id === publishedRevisionId
             return (
               <DropdownMenuItem
                 key={v.id}
@@ -138,11 +154,16 @@ export function PreviewVersionPicker({
                   }
                 }}>
                 <Check className={isActive ? 'opacity-100' : 'opacity-0'} />
-                <div className='flex min-w-0 flex-1 flex-col'>
+                <div className='flex min-w-0 flex-1 items-center gap-1.5'>
                   <span className='truncate text-sm'>
                     v{v.versionNumber}
                     {v.label ? ` — ${v.label}` : ''}
                   </span>
+                  {isLive ? (
+                    <Badge variant='green' size='xs'>
+                      Live
+                    </Badge>
+                  ) : null}
                 </div>
                 <span className='ml-2 shrink-0 text-xs text-muted-foreground'>
                   {relativeTime(v.createdAt)}

--- a/apps/web/src/components/kb/ui/sidebar/article-sidebar-item.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/article-sidebar-item.tsx
@@ -136,7 +136,7 @@ export function ArticleSidebarItem({
 
   const basePath = `/app/kb/${knowledgeBaseId}`
   const slugPaths = useMemo(() => getArticleSlugPaths(articles), [articles])
-  const isActive = !isHeader && isArticleActive(article, pathname, basePath, slugPaths)
+  const isActive = isArticleActive(article, pathname, basePath, slugPaths)
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging, over, active } =
     useSortable({
@@ -406,7 +406,7 @@ export function ArticleSidebarItem({
                 if (linkUrl) window.open(linkUrl, '_blank', 'noopener,noreferrer')
                 return
               }
-              if (isHeader || isLink) return
+              if (isLink) return
               if (isRenaming) return
               if (isDragging) {
                 e.preventDefault()
@@ -437,7 +437,8 @@ export function ArticleSidebarItem({
               'focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring',
               !isHeader && 'rounded-md px-2 py-2 text-sm',
               !isHeader && isActive && 'font-medium text-accent-foreground',
-              isHeader && 'cursor-text',
+              isHeader && !isRenaming && 'cursor-pointer',
+              isHeader && isRenaming && 'cursor-text',
               isDragging && 'pointer-events-none'
             )}>
             <div className='flex flex-1 items-center'>
@@ -460,7 +461,10 @@ export function ArticleSidebarItem({
                   className={cn(
                     'truncate',
                     isHeader &&
-                      'text-xs font-semibold uppercase tracking-wide text-muted-foreground'
+                      cn(
+                        'text-xs font-semibold uppercase tracking-wide',
+                        isActive ? 'text-foreground' : 'text-muted-foreground'
+                      )
                   )}>
                   {displayName || (isHeader ? 'Untitled' : '')}
                 </span>

--- a/apps/web/src/components/kb/ui/sidebar/kb-articles-panel.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/kb-articles-panel.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
-import { findFirstNavigableUnder, getFullSlugPath } from '@auxx/ui/components/kb/utils'
+import { getFullSlugPath } from '@auxx/ui/components/kb/utils'
 import { cn } from '@auxx/ui/lib/utils'
 import { DndContext, DragOverlay } from '@dnd-kit/core'
 import { restrictToVerticalAxis, restrictToWindowEdges } from '@dnd-kit/modifiers'
@@ -177,11 +177,10 @@ export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
   const handleTabChange = useCallback(
     (tabId: string) => {
       setPendingTabId(tabId)
-      const firstChild = findFirstNavigableUnder(tabId, articles)
-      if (firstChild) {
-        const slug = getFullSlugPath(firstChild, articles)
-        router.push(`${basePath}/editor/~/${slug}?panel=articles`)
-      }
+      const tab = articles.find((a) => a.id === tabId)
+      if (!tab) return
+      const slug = getFullSlugPath(tab, articles)
+      router.push(`${basePath}/editor/~/${slug}?panel=articles`)
     },
     [articles, basePath, router]
   )


### PR DESCRIPTION
## Summary
- New **editor bubble menu** (`apps/web/src/components/editor/bubble-menu/`) with sections for inline marks, color/highlight picker, text alignment, link, turn-into, AI slot, more menu, and a KB-specific block section. Wired into `KBArticleEditor`.
- Block node gains a `listStyle` attr (`disc | circle | square` for bullets, `1 | a | A | i | I` for numbered). `BlockNodeView` honors it; alphabetic numbering now uses proper base-26 (`aa` after `z`).
- Tiptap extensions added: `Color`, `TextStyle`, `TextAlign` (block-level types).
- KB color palette CSS variables in `:root` / `.dark` for both foreground and highlight, so inline color marks resolve correctly in light/dark mode wherever the article renders.
- Container-kind articles (`tab`, `header`, `link`) render a new `ContainerArticlePlaceholder` instead of opening the article editor.
- Preview version picker badges the live revision with a green **Live** badge and labels the Draft entry as "Same as live" when there are no unpublished changes.
- Sidebar headers behave like other nav items: active state highlights, click navigates (previously inert).
- Tab change in the articles panel navigates to the tab itself rather than its first navigable child.

## Test plan
- [ ] Open a KB article, select text, confirm bubble menu appears with all sections
- [ ] Use color picker, alignment, link, turn-into, inline marks — verify they apply and persist
- [ ] Toggle theme — confirm inline colors and highlights remain legible in both light and dark mode
- [ ] Switch bullet/numbered list to each `listStyle` option; confirm glyphs render and round-trip through save
- [ ] Click a container-kind article (tab/header/link) — verify placeholder renders, no editor mount
- [ ] In preview version picker: confirm the live revision shows the **Live** badge, Draft shows "Same as live" only when there are no unpublished changes
- [ ] Click a header in the sidebar — confirm it becomes active and navigates