### PR TITLE
feat(kb): draft/published envelopes, originator-tagged resync, shared editor sync

### DIFF
--- a/apps/web/src/components/editor/bubble-menu/bubble-menu.tsx
+++ b/apps/web/src/components/editor/bubble-menu/bubble-menu.tsx
@@ -85,7 +85,7 @@ export function EditorBubbleMenu({
               e.preventDefault()
             }}
             className={cn(
-              'flex w-auto flex-row items-center gap-0.5 rounded-2xl px-0 p-1',
+              'flex w-auto flex-row items-center rounded-2xl p-0.5',
               'border border-foreground/15 bg-popover shadow-md backdrop-blur',
               // Round whichever button ends up flush with the popover edges.
               // CSS :first-child / :last-child resolve against the actually-
@@ -119,7 +119,7 @@ export function BubbleSection({ children }: { children?: React.ReactNode }) {
   const hasContent = childArray.some((c) => c != null && c !== false)
   if (!hasContent) return null
   return (
-    <div className='flex items-center gap-0.5 border-r border-foreground/10 px-1 last:border-r-0 first:pl-0 last:pr-0'>
+    <div className='flex items-center gap-0.5 border-r border-foreground/10 px-0.5 last:border-r-0 first:pl-0 last:pr-0'>
       {children}
     </div>
   )

--- a/apps/web/src/components/editor/bubble-menu/sections/align.tsx
+++ b/apps/web/src/components/editor/bubble-menu/sections/align.tsx
@@ -32,8 +32,15 @@ export function AlignSection({ editor }: AlignSectionProps) {
   const current = useEditorState({
     editor,
     selector: ({ editor }): Align => {
-      for (const opt of OPTIONS) {
-        if (editor.isActive({ textAlign: opt.id })) return opt.id
+      // Read the actual textAlign attribute on the current block. Falling
+      // back to scanning isActive() across every option made the dropdown
+      // pick whichever option happened to match a non-default value first,
+      // which surfaced as "always Right" once any block in the doc carried
+      // textAlign: 'right'.
+      const attrs = editor.getAttributes('block') as { textAlign?: string | null }
+      const value = attrs.textAlign
+      if (value === 'left' || value === 'center' || value === 'right' || value === 'justify') {
+        return value
       }
       return 'left'
     },

--- a/apps/web/src/components/editor/bubble-menu/ui/bubble-toggle-button.tsx
+++ b/apps/web/src/components/editor/bubble-menu/ui/bubble-toggle-button.tsx
@@ -24,7 +24,7 @@ export const BubbleToggleButton = forwardRef<HTMLButtonElement, BubbleToggleButt
           rest.onMouseDown?.(e)
         }}
         className={cn(
-          'inline-flex h-7 min-w-7 items-center justify-center gap-1 rounded-md px-1.5 text-xs',
+          'inline-flex h-6 min-w-7 items-center justify-center gap-1 rounded-md px-1 text-xs',
           'text-foreground/70 transition-colors',
           'hover:bg-foreground/10 hover:text-foreground',
           'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',

--- a/apps/web/src/components/editor/inline-picker/hooks/use-external-content-sync.ts
+++ b/apps/web/src/components/editor/inline-picker/hooks/use-external-content-sync.ts
@@ -1,0 +1,154 @@
+// apps/web/src/components/editor/inline-picker/hooks/use-external-content-sync.ts
+'use client'
+
+import type { Editor } from '@tiptap/react'
+import { type RefObject, useEffect, useRef } from 'react'
+
+interface UseExternalContentSyncArgs<TContent> {
+  editor: Editor | null
+  /** The doc that should be on screen according to the server. */
+  incoming: TContent
+  /** Picker open state — defer sync while open, flush on close. */
+  isPickerOpen: boolean
+  /** How to set the editor content. Editor-specific (HTML vs JSON). */
+  applyContent: (editor: Editor, content: TContent) => void
+  /**
+   * Canonical key for `content`. Must be stable across semantically-equal
+   * docs — for JSON, this means a key-order-insensitive stringify, otherwise
+   * the same doc round-tripping through the DB (which reorders JSONB keys)
+   * compares unequal and the hook re-applies on every save echo.
+   */
+  canonicalKey: (content: TContent) => string
+}
+
+export interface ExternalContentSyncHandle {
+  /**
+   * Call from `onUpdate` (after the change has been propagated to the
+   * parent) with the canonical key of the doc we just sent out — this
+   * becomes the `lastAppliedKey`, so an inbound echo of the same doc is a
+   * no-op.
+   */
+  markLocalEdit: (key: string) => void
+}
+
+/**
+ * Gate that prevents the editor's content-sync effect from clobbering the
+ * live document when the server echoes back content we just sent. The hook
+ * owns:
+ *
+ * - A `lastAppliedKey` ref updated on every inbound apply and on every
+ *   outbound local edit (via the returned handle).
+ * - A `pending` ref that stashes incoming content while a slash/inline
+ *   picker is open and flushes it the moment the picker closes.
+ *
+ * Same shape applies to every TipTap editor that gets fed content from
+ * outside its own `onUpdate` (queries, SSE, AI tools).
+ */
+export function useExternalContentSync<TContent>({
+  editor,
+  incoming,
+  isPickerOpen,
+  applyContent,
+  canonicalKey,
+}: UseExternalContentSyncArgs<TContent>): RefObject<ExternalContentSyncHandle> {
+  const lastAppliedKeyRef = useRef<string | null>(null)
+  const pendingRef = useRef<TContent | null>(null)
+  const handleRef = useRef<ExternalContentSyncHandle>({
+    markLocalEdit: (key) => {
+      lastAppliedKeyRef.current = key
+      // A local edit supersedes anything stashed while the picker is open —
+      // flushing the stash on picker-close would otherwise clobber the fresh
+      // edit (e.g. slash-command insertions while a save is in flight).
+      pendingRef.current = null
+    },
+  })
+
+  // Read picker state without depending on it — otherwise the inbound effect
+  // re-runs when the picker closes after a slash command and re-applies the
+  // stale `incoming` doc on top of the freshly-executed edit. Picker close
+  // is handled by the dedicated flush effect below.
+  const isPickerOpenRef = useRef(isPickerOpen)
+  useEffect(() => {
+    isPickerOpenRef.current = isPickerOpen
+  }, [isPickerOpen])
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return
+    const key = canonicalKey(incoming)
+    if (key === lastAppliedKeyRef.current) return
+    if (isPickerOpenRef.current) {
+      pendingRef.current = incoming
+      return
+    }
+    applyContent(editor, incoming)
+    lastAppliedKeyRef.current = key
+    pendingRef.current = null
+  }, [editor, incoming, applyContent, canonicalKey])
+
+  const prevOpen = useRef(false)
+  useEffect(() => {
+    if (prevOpen.current && !isPickerOpen && editor && pendingRef.current) {
+      const pending = pendingRef.current
+      const key = canonicalKey(pending)
+      if (key !== lastAppliedKeyRef.current) {
+        applyContent(editor, pending)
+        lastAppliedKeyRef.current = key
+      }
+      pendingRef.current = null
+    }
+    prevOpen.current = isPickerOpen
+  }, [isPickerOpen, editor, applyContent, canonicalKey])
+
+  return handleRef
+}
+
+/**
+ * Imperative variant for editors that push content without a single
+ * `incoming` prop driving an effect (AI tools, template inserts). Wraps
+ * `editor.commands.setContent` with the same `lastAppliedKey` guard so
+ * duplicate writes from external sources no-op, and so `onUpdate` callers
+ * can stamp the freshly-edited key via `markLocalEdit`.
+ */
+export interface ContentApplier<TContent> {
+  apply: (content: TContent) => void
+  markLocalEdit: (key: string) => void
+}
+
+export function makeContentApplier<TContent>(
+  editor: Editor | null,
+  applyContent: (editor: Editor, content: TContent) => void,
+  canonicalKey: (content: TContent) => string
+): ContentApplier<TContent> {
+  let lastAppliedKey: string | null = null
+  return {
+    apply: (content) => {
+      if (!editor || editor.isDestroyed) return
+      const key = canonicalKey(content)
+      if (key === lastAppliedKey) return
+      applyContent(editor, content)
+      lastAppliedKey = key
+    },
+    markLocalEdit: (key) => {
+      lastAppliedKey = key
+    },
+  }
+}
+
+/**
+ * Stable, key-order-insensitive stringify for use as a canonical key in
+ * `useExternalContentSync` / `makeContentApplier`. Required because the
+ * server round-trips `contentJson` through a JSONB column, which doesn't
+ * preserve insertion order — plain `JSON.stringify` returns different
+ * strings for the same logical doc and breaks the inbound-skip path.
+ */
+export function stableStringify(value: unknown): string {
+  if (value === null || value === undefined) return JSON.stringify(value ?? null)
+  if (typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`
+  }
+  const entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`)
+  return `{${entries.join(',')}}`
+}

--- a/apps/web/src/components/editor/inline-picker/index.ts
+++ b/apps/web/src/components/editor/inline-picker/index.ts
@@ -5,6 +5,13 @@ export { createInlineNodeView } from './core/inline-node-view'
 // Core factories
 export { createInlinePickerExtension } from './core/inline-picker-extension'
 // Hooks
+export {
+  type ContentApplier,
+  type ExternalContentSyncHandle,
+  makeContentApplier,
+  stableStringify,
+  useExternalContentSync,
+} from './hooks/use-external-content-sync'
 export { useInlinePicker } from './hooks/use-inline-picker'
 export { useMentionEditor } from './hooks/use-mention-editor'
 export { useRecordLinkEditor } from './hooks/use-record-link-editor'

--- a/apps/web/src/components/editor/kb-article/use-kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/use-kb-article-editor.tsx
@@ -13,9 +13,15 @@ import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
 import { useEditor, useEditorState } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Table, TableCell, TableHeader, TableRow } from '../extensions/table'
-import { createPlaceholderNode, PlaceholderBadge, useSlashCommand } from '../inline-picker'
+import {
+  createPlaceholderNode,
+  PlaceholderBadge,
+  stableStringify,
+  useExternalContentSync,
+  useSlashCommand,
+} from '../inline-picker'
 import { Accordion } from './accordion-node'
 import { Block } from './block-node'
 import { MarkdownInputRules } from './markdown-input-rules'
@@ -82,6 +88,10 @@ export function useKBArticleEditor({ initialContent, onChange }: UseKBArticleEdi
     onChangeRef.current = onChange
   }, [onChange])
 
+  const externalSyncRef = useRef<{ markLocalEdit: (key: string) => void }>({
+    markLocalEdit: () => {},
+  })
+
   const editor = useEditor(
     {
       immediatelyRender: false,
@@ -138,7 +148,9 @@ export function useKBArticleEditor({ initialContent, onChange }: UseKBArticleEdi
         // Defer one tick so Suggestion plugin's onStart can mark isOpenRef
         // before we propagate the change.
         setTimeout(() => {
-          if (!slashCommand.isOpenRef.current) onChangeRef.current({ json, html })
+          if (slashCommand.isOpenRef.current) return
+          externalSyncRef.current.markLocalEdit(stableStringify(json))
+          onChangeRef.current({ json, html })
         }, 0)
       },
     },
@@ -151,23 +163,38 @@ export function useKBArticleEditor({ initialContent, onChange }: UseKBArticleEdi
       editor ? Math.max(2, String(editor.state.doc.content.childCount).length) : 2,
   })
 
-  // Sync external content changes (e.g. autosave response landing while user is idle).
-  useEffect(() => {
-    if (!editor || editor.isDestroyed) return
-    const incomingContent = normalizedInitialContent
-    const current = JSON.stringify(editor.getJSON())
-    const incoming = JSON.stringify(incomingContent)
-    if (current === incoming) return
-    const { from, to } = editor.state.selection
-    editor.commands.setContent(incomingContent, false)
+  const applyContent = useCallback((instance: NonNullable<typeof editor>, content: JSONContent) => {
+    // Skip when the editor is already at the incoming doc — happens on
+    // mount because `useEditor` initialized it with the same content, and
+    // a redundant `setContent` here triggers TipTap's React node views to
+    // flushSync mid-commit ("flushSync was called from inside a lifecycle
+    // method" warning). Uses stableStringify so server-side JSONB key
+    // reordering doesn't make a same-content doc look different.
+    if (stableStringify(instance.getJSON()) === stableStringify(content)) return
+    const { from, to } = instance.state.selection
+    instance.commands.setContent(content, false)
     try {
-      editor.commands.setTextSelection({ from, to })
+      instance.commands.setTextSelection({ from, to })
     } catch {
-      editor.commands.focus('end')
+      instance.commands.focus('end')
     }
-  }, [normalizedInitialContent, editor])
+  }, [])
 
-  // Flush deferred onChange when slash picker closes.
+  const canonicalKey = useCallback((content: JSONContent) => stableStringify(content), [])
+
+  const syncHandle = useExternalContentSync<JSONContent>({
+    editor,
+    incoming: normalizedInitialContent,
+    isPickerOpen: slashCommand.suggestionState.isOpen,
+    applyContent,
+    canonicalKey,
+  })
+
+  // Wire the imperative handle into the editor's onUpdate closure.
+  externalSyncRef.current = syncHandle.current
+
+  // Flush deferred onChange when slash picker closes — the hook handles
+  // the *inbound* flush; this handles the *outbound* one.
   const prevOpen = useRef(false)
   useEffect(() => {
     if (prevOpen.current && !slashCommand.suggestionState.isOpen && editor) {

--- a/apps/web/src/components/editor/tiptap-editor.tsx
+++ b/apps/web/src/components/editor/tiptap-editor.tsx
@@ -10,14 +10,19 @@ import Placeholder from '@tiptap/extension-placeholder'
 import TextAlign from '@tiptap/extension-text-align'
 import TextStyle from '@tiptap/extension-text-style'
 import Underline from '@tiptap/extension-underline'
-import { EditorContent, useEditor } from '@tiptap/react'
+import { type Editor, EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import '~/styles/prosemirror.css'
 import { useEditorContext } from './editor-context'
 import { FontSize } from './extensions'
 import { Indent } from './extensions/indent'
-import { createPlaceholderNode, InlinePickerPopover, PlaceholderBadge } from './inline-picker'
+import {
+  createPlaceholderNode,
+  InlinePickerPopover,
+  PlaceholderBadge,
+  useExternalContentSync,
+} from './inline-picker'
 import { useSlashCommand } from './inline-picker/hooks/use-slash-command'
 import { SlashCommandPicker } from './slash-command-picker'
 
@@ -41,6 +46,9 @@ const TiptapEditor = ({
 }: TiptapEditorProps) => {
   const { setEditor } = useEditorContext()
   const slashCommand = useSlashCommand()
+  const externalSyncRef = useRef<{ markLocalEdit: (key: string) => void }>({
+    markLocalEdit: () => {},
+  })
 
   const placeholderNodeExtension = useMemo(
     () => createPlaceholderNode((badgeProps) => <PlaceholderBadge {...badgeProps} />),
@@ -97,32 +105,40 @@ const TiptapEditor = ({
         // before deciding whether to propagate the change.
         const html = editor.getHTML()
         setTimeout(() => {
-          if (!slashCommand.isOpenRef.current) {
-            onChange(html)
-          }
+          if (slashCommand.isOpenRef.current) return
+          externalSyncRef.current.markLocalEdit(html)
+          onChange(html)
         }, 0)
       },
     },
     []
   )
 
-  // Synchronize external content changes
-  useEffect(() => {
-    if (!editorInstance || editorInstance.isDestroyed) return
-
-    const editorHTML = editorInstance.getHTML()
-    if (content !== editorHTML) {
-      const { from, to } = editorInstance.state.selection
-      editorInstance.commands.setContent(content, false)
-      try {
-        editorInstance.commands.setTextSelection({ from, to })
-      } catch {
-        editorInstance.commands.focus('end')
-      }
+  const applyContent = useCallback((instance: Editor, next: string) => {
+    // Skip when the editor already matches — useEditor initialized with
+    // the same HTML, so a redundant setContent here would trigger
+    // TipTap's React adapters to flushSync during commit.
+    if (instance.getHTML() === next) return
+    const { from, to } = instance.state.selection
+    instance.commands.setContent(next, false)
+    try {
+      instance.commands.setTextSelection({ from, to })
+    } catch {
+      instance.commands.focus('end')
     }
-  }, [content, editorInstance])
+  }, [])
+  const canonicalKey = useCallback((html: string) => html, [])
 
-  // Flush deferred content change when slash command picker closes
+  const syncHandle = useExternalContentSync<string>({
+    editor: editorInstance,
+    incoming: content,
+    isPickerOpen: slashCommand.suggestionState.isOpen,
+    applyContent,
+    canonicalKey,
+  })
+  externalSyncRef.current = syncHandle.current
+
+  // Flush deferred outbound onChange when the slash picker closes.
   const prevSlashOpen = useRef(false)
   useEffect(() => {
     if (prevSlashOpen.current && !slashCommand.suggestionState.isOpen && editorInstance) {

--- a/apps/web/src/components/editor/utils/client-session-id.ts
+++ b/apps/web/src/components/editor/utils/client-session-id.ts
@@ -1,0 +1,15 @@
+// apps/web/src/components/editor/utils/client-session-id.ts
+import { generateId } from '@auxx/utils'
+
+let cached: string | null = null
+
+/**
+ * Stable per-tab id used to tag outgoing realtime-relevant mutations so the
+ * originating tab can drop its own server-side echo (kb-article-resync).
+ * Module scope — each tab gets a fresh id at boot, not shared via storage.
+ */
+export function getClientSessionId(): string {
+  if (cached) return cached
+  cached = generateId()
+  return cached
+}

--- a/apps/web/src/components/kb/hooks/use-article-content.ts
+++ b/apps/web/src/components/kb/hooks/use-article-content.ts
@@ -17,46 +17,37 @@ interface UseArticleContentResult {
   /** Draft revision content (what the editor writes to). */
   draftContent: string | null
   draftContentJson: ArticleNodeJSON[] | null
-  draftTitle: string | null
-  draftDescription: string | null
-  draftExcerpt: string | null
-  draftEmoji: string | null
-  draftCoverImage: string | null
-  /** MediaAsset id linked to the draft cover (FK), or null. */
-  draftCoverImageId: string | null
-  /** Last published version (null if never published). */
-  publishedTitle: string | null
+  /** Stable hash of the draft contentJson — used by the editor to dedupe inbound syncs. */
+  draftContentHash: string | null
+  /** Last published version's content body (null if never published). */
   publishedContent: string | null
   publishedContentJson: ArticleNodeJSON[] | null
-  publishedCoverImage: string | null
-  hasPublishedVersion: boolean
-  /** Revision id of the currently-live version (matches an ArticleRevision.id). */
-  publishedRevisionId: string | null
-  hasUnpublishedChanges: boolean
   /** What the preview should render for the resolved mode. */
-  previewTitle: string | null
-  previewDescription: string | null
-  previewExcerpt: string | null
-  previewEmoji: string | null
   previewContent: string | null
   previewContentJson: ArticleNodeJSON[] | null
-  previewCoverImage: string | null
-  /** Resolved version number when mode is `'live'` or historical; null otherwise. */
+  /**
+   * Historical-mode-only metadata snapshot. Populated when `mode` is
+   * `{ versionNumber }` from the secondary version query.
+   */
+  historicalTitle: string | null
+  historicalDescription: string | null
+  historicalExcerpt: string | null
+  historicalEmoji: string | null
+  historicalCoverImage: string | null
+  /** Resolved version number when mode is historical; null otherwise. */
   previewVersionNumber: number | null
-  /** True when mode === 'live' but the article has no published revision. */
-  fellBackToDraft: boolean
   isLoading: boolean
 }
 
 /**
  * Fetch an article's heavy content (HTML + JSON) directly from the server.
- * Content is intentionally not stored in the article store — only metadata is.
+ * Lightweight metadata (title/emoji/cover/description) lives on the article
+ * store — read it from there, or compose it for the active preview mode with
+ * `resolvePreviewMeta(article, mode)`. This hook is purely about content
+ * slices and the historical-version snapshot.
  *
- * Returns the draft (what the editor mutates), the published revision (used
- * to power "discard draft" preview comparisons in the settings dialog), and
- * a resolved preview slice for the requested `mode`. Historical versions
- * are fetched as a separate cache cell keyed by `versionNumber` and treated
- * as immutable (`staleTime: Infinity`).
+ * Historical versions are fetched as a separate cache cell keyed by
+ * `versionNumber` and treated as immutable (`staleTime: Infinity`).
  */
 export function useArticleContent(
   id: string | null | undefined,
@@ -86,62 +77,39 @@ export function useArticleContent(
   const data = baseQuery.data
   const draftContent = data?.content ?? null
   const draftContentJson = (data?.contentJson as ArticleNodeJSON[] | null | undefined) ?? null
-  const draftTitle = data?.title ?? null
-  const draftDescription = data?.description ?? null
-  const draftExcerpt = data?.excerpt ?? null
-  const draftEmoji = data?.emoji ?? null
-  const draftCoverImage = data?.coverImage ?? null
-  const draftCoverImageId = data?.coverImageId ?? null
-  const publishedTitle = data?.publishedTitle ?? null
+  const draftContentHash = data?.draftContentHash ?? null
   const publishedContent = data?.publishedContent ?? null
   const publishedContentJson =
     (data?.publishedContentJson as ArticleNodeJSON[] | null | undefined) ?? null
-  const publishedCoverImage = data?.publishedCoverImage ?? null
   const hasPublishedVersion = !!data?.hasPublishedVersion
-  const publishedRevisionId = data?.publishedRevisionId ?? null
 
-  let previewTitle: string | null = draftTitle
-  let previewDescription: string | null = draftDescription
-  let previewExcerpt: string | null = draftExcerpt
-  let previewEmoji: string | null = draftEmoji
   let previewContent: string | null = draftContent
   let previewContentJson: ArticleNodeJSON[] | null = draftContentJson
-  // In historical mode the version query is separate from the base query, so
-  // it lags one render behind when the user switches versions. Defaulting to
-  // the draft cover here causes a flicker where the draft image flashes
-  // before the version's image takes over — start at null instead.
-  let previewCoverImage: string | null = isHistorical ? null : draftCoverImage
+  let historicalTitle: string | null = null
+  let historicalDescription: string | null = null
+  let historicalExcerpt: string | null = null
+  let historicalEmoji: string | null = null
+  let historicalCoverImage: string | null = null
   let previewVersionNumber: number | null = null
-  let fellBackToDraft = false
 
   if (mode === 'live') {
     if (hasPublishedVersion) {
-      previewTitle = publishedTitle
-      // The base query only returns published content + title — fall back to
-      // draft fields for description/excerpt/emoji since they're not in the
-      // editor view's published payload. Acceptable: the body is what
-      // changes between versions; metadata diffs are rare.
       previewContent = publishedContent
       previewContentJson = publishedContentJson
-      previewCoverImage = publishedCoverImage
-      // versionNumber for the live revision isn't returned by the base query
-      // either; the picker pulls it from getArticleVersions when needed.
-    } else {
-      fellBackToDraft = true
     }
   } else if (isHistorical) {
     const v = versionQuery.data
     if (v) {
-      previewTitle = v.selectedTitle ?? draftTitle
-      previewDescription = v.selectedDescription ?? draftDescription
-      previewExcerpt = v.selectedExcerpt ?? draftExcerpt
-      previewEmoji = v.selectedEmoji ?? draftEmoji
       previewContent = v.selectedContent ?? draftContent
       previewContentJson =
         (v.selectedContentJson as ArticleNodeJSON[] | null | undefined) ?? draftContentJson
+      historicalTitle = v.selectedTitle ?? null
+      historicalDescription = v.selectedDescription ?? null
+      historicalExcerpt = v.selectedExcerpt ?? null
+      historicalEmoji = v.selectedEmoji ?? null
       // No draft fallback for cover — if the historical snapshot has no cover,
       // show no cover. Inheriting from the draft would misrepresent the version.
-      previewCoverImage = v.selectedCoverImage ?? null
+      historicalCoverImage = v.selectedCoverImage ?? null
       previewVersionNumber = v.selectedVersionNumber ?? requestedVersion ?? null
     }
   }
@@ -149,28 +117,17 @@ export function useArticleContent(
   return {
     draftContent,
     draftContentJson,
-    draftTitle,
-    draftDescription,
-    draftExcerpt,
-    draftEmoji,
-    draftCoverImage,
-    draftCoverImageId,
-    publishedTitle,
+    draftContentHash,
     publishedContent,
     publishedContentJson,
-    publishedCoverImage,
-    hasPublishedVersion,
-    publishedRevisionId,
-    hasUnpublishedChanges: !!data?.hasUnpublishedChanges,
-    previewTitle,
-    previewDescription,
-    previewExcerpt,
-    previewEmoji,
     previewContent,
     previewContentJson,
-    previewCoverImage,
+    historicalTitle,
+    historicalDescription,
+    historicalExcerpt,
+    historicalEmoji,
+    historicalCoverImage,
     previewVersionNumber,
-    fellBackToDraft,
     isLoading: baseQuery.isLoading || (isHistorical && versionQuery.isLoading),
   }
 }

--- a/apps/web/src/components/kb/hooks/use-article-mutations.ts
+++ b/apps/web/src/components/kb/hooks/use-article-mutations.ts
@@ -7,34 +7,11 @@ import type { ArticleNodeJSON } from '@auxx/ui/components/kb'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { generateId } from '@auxx/utils'
 import { useCallback } from 'react'
+import { getClientSessionId } from '~/components/editor/utils/client-session-id'
 import { useAnalytics } from '~/hooks/use-analytics'
 import { api } from '~/trpc/react'
 import { type ArticleMeta, getArticleStoreState } from '../store/article-store'
-
-/** Normalize a server article (from tRPC) into ArticleMeta. */
-function normalizeServerArticle(server: any): ArticleMeta {
-  return {
-    id: server.id,
-    knowledgeBaseId: server.knowledgeBaseId,
-    title: server.title ?? '',
-    slug: server.slug ?? '',
-    emoji: server.emoji ?? null,
-    parentId: server.parentId ?? null,
-    articleKind: (server.articleKind ?? ArticleKind.page) as ArticleKindType,
-    sortOrder: server.sortOrder ?? 'a0',
-    isPublished: !!server.isPublished,
-    aiEnabled: server.aiEnabled ?? true,
-    status: (server.status ?? ArticleStatus.DRAFT) as ArticleMeta['status'],
-    description: server.description ?? null,
-    excerpt: server.excerpt ?? null,
-    coverImage: server.coverImage ?? null,
-    hasUnpublishedChanges: !!server.hasUnpublishedChanges,
-    publishedAt: server.publishedAt ? new Date(server.publishedAt) : null,
-    publishedRevisionId: server.publishedRevisionId ?? null,
-    draftRevisionId: server.draftRevisionId ?? null,
-    tagIds: (server.tagIds ?? []) as ArticleMeta['tagIds'],
-  }
-}
+import { normalizeServerArticle } from '../store/normalize-server-article'
 
 interface CreateArticleInput {
   parentId?: string | null
@@ -109,25 +86,35 @@ export function useArticleMutations(knowledgeBaseId: string): UseArticleMutation
     async (input = {}) => {
       const tempId = `temp_${generateId()}`
       const store = getArticleStoreState()
+      const optimisticDraft: ArticleMeta['draft'] = {
+        title: input.title ?? 'Untitled',
+        description: input.description ?? null,
+        excerpt: input.excerpt ?? null,
+        emoji: input.emoji ?? null,
+        coverImage: null,
+        coverImageId: null,
+      }
       const optimisticArticle: ArticleMeta = {
         id: tempId,
         knowledgeBaseId,
-        title: input.title ?? 'Untitled',
+        title: optimisticDraft.title,
         slug: input.slug ?? 'untitled',
-        emoji: input.emoji ?? null,
+        emoji: optimisticDraft.emoji,
         parentId: input.parentId ?? null,
         articleKind: input.articleKind ?? ArticleKind.page,
         sortOrder: 'zz',
         isPublished: false,
         aiEnabled: true,
         status: ArticleStatus.DRAFT,
-        description: input.description ?? null,
-        excerpt: input.excerpt ?? null,
+        description: optimisticDraft.description,
+        excerpt: optimisticDraft.excerpt,
         coverImage: null,
         hasUnpublishedChanges: false,
         publishedAt: null,
         publishedRevisionId: null,
         draftRevisionId: null,
+        draft: optimisticDraft,
+        published: null,
         tagIds: [],
       }
       store.addOptimisticArticle(tempId, optimisticArticle)
@@ -166,23 +153,27 @@ export function useArticleMutations(knowledgeBaseId: string): UseArticleMutation
   const updateArticleDraft = useCallback<UseArticleMutationsResult['updateArticleDraft']>(
     async (id, fields) => {
       const store = getArticleStoreState()
-      // Sidebar shows draft fields when the article isn't yet published.
-      // For published articles we leave the sidebar showing the live title.
-      const current = store.articles.get(id)
-      const showInSidebar = current && !current.isPublished
-      if (showInSidebar) store.setArticleOptimistic(id, fields)
+      // Sidebar always reflects the draft — patchDraft mirrors fields onto
+      // both the draft envelope and the top-level display copy so the
+      // sidebar entry updates immediately, published or not.
+      store.patchDraft(id, fields)
       try {
-        const server = await updateDraftMutation.mutateAsync({ id, data: fields, knowledgeBaseId })
-        const normalized = normalizeServerArticle(server)
-        if (showInSidebar) store.confirmUpdate(id, normalized)
-        else store.applyArticleMetadataFromServer(id, normalized)
-        // The article-list response carries the *published* revision's
-        // metadata for published articles, so the store can't see draft-only
-        // edits (title/emoji/description). The editor reads those from
-        // getArticleById — invalidate so a remount picks up fresh draft data.
-        utils.kb.getArticleById.invalidate({ id, knowledgeBaseId })
+        const server = await updateDraftMutation.mutateAsync({
+          id,
+          data: fields,
+          knowledgeBaseId,
+          originatorSessionId: getClientSessionId(),
+        })
+        store.confirmUpdate(id, normalizeServerArticle(server))
+        // Push the authoritative metadata directly into the editor query
+        // cache so a remount sees the new draft fields. Avoiding invalidate
+        // here means we don't trigger a refetch that would clobber the live
+        // editor's content with stale-by-a-roundtrip JSON.
+        utils.kb.getArticleById.setData({ id, knowledgeBaseId }, (prev) =>
+          prev ? { ...prev, ...server } : prev
+        )
       } catch (error) {
-        if (showInSidebar) store.rollbackUpdate(id)
+        store.rollbackUpdate(id)
         toastError({
           title: "Couldn't update article",
           description: error instanceof Error ? error.message : 'Unknown error occurred',
@@ -194,19 +185,25 @@ export function useArticleMutations(knowledgeBaseId: string): UseArticleMutation
 
   const updateArticleCover = useCallback<UseArticleMutationsResult['updateArticleCover']>(
     async (id, data) => {
-      // Drive the editor's <img> off the getArticleById query cache directly:
-      // clearing coverImage there avoids a published-revision fallback flicker
-      // while the server resolves the new draft URL. The article-store
-      // coverImage column is filled from the server response.
-      utils.kb.getArticleById.setData({ id, knowledgeBaseId }, (prev) =>
-        prev ? { ...prev, coverImage: null, coverImageId: data.coverImageId } : prev
-      )
+      const store = getArticleStoreState()
+      // Optimistically clear the draft cover so the slot collapses while the
+      // server resolves a freshly signed URL for the new asset id.
+      store.patchDraft(id, { coverImage: null, coverImageId: data.coverImageId })
       try {
-        const server = await updateDraftMutation.mutateAsync({ id, data, knowledgeBaseId })
-        getArticleStoreState().applyArticleMetadataFromServer(id, normalizeServerArticle(server))
-        utils.kb.getArticleById.invalidate({ id, knowledgeBaseId })
+        const server = await updateDraftMutation.mutateAsync({
+          id,
+          data,
+          knowledgeBaseId,
+          originatorSessionId: getClientSessionId(),
+        })
+        store.confirmUpdate(id, normalizeServerArticle(server))
+        // Splice the authoritative metadata back into the editor query so a
+        // remount sees the new cover URL without a refetch.
+        utils.kb.getArticleById.setData({ id, knowledgeBaseId }, (prev) =>
+          prev ? { ...prev, ...server } : prev
+        )
       } catch (error) {
-        utils.kb.getArticleById.invalidate({ id, knowledgeBaseId })
+        store.rollbackUpdate(id)
         toastError({
           title: 'Failed to update cover',
           description: error instanceof Error ? error.message : 'Unknown error occurred',
@@ -250,10 +247,17 @@ export function useArticleMutations(knowledgeBaseId: string): UseArticleMutation
           id,
           data,
           knowledgeBaseId,
+          originatorSessionId: getClientSessionId(),
         })
         // Reflect the server's authoritative metadata (e.g. hasUnpublishedChanges)
         // so the sidebar/status pills don't fight a concurrent publish.
         getArticleStoreState().applyArticleMetadataFromServer(id, normalizeServerArticle(server))
+        // Splice the metadata back into the editor query so a remount sees
+        // fresh fields without a refetch. Content fields stay as-is — the
+        // live editor is already authoritative for those.
+        utils.kb.getArticleById.setData({ id, knowledgeBaseId }, (prev) =>
+          prev ? { ...prev, ...server } : prev
+        )
       } catch (error) {
         toastError({
           title: 'Failed to save article',
@@ -261,7 +265,7 @@ export function useArticleMutations(knowledgeBaseId: string): UseArticleMutation
         })
       }
     },
-    [knowledgeBaseId, updateDraftMutation]
+    [knowledgeBaseId, updateDraftMutation, utils.kb.getArticleById]
   )
 
   const deleteArticle = useCallback<UseArticleMutationsResult['deleteArticle']>(

--- a/apps/web/src/components/kb/hooks/use-kb-article-channel.ts
+++ b/apps/web/src/components/kb/hooks/use-kb-article-channel.ts
@@ -4,6 +4,7 @@
 import type { KbArticleEvent } from '@auxx/lib/kb'
 import { createScopedLogger } from '@auxx/logger'
 import { useCallback, useMemo, useState } from 'react'
+import { getClientSessionId } from '~/components/editor/utils/client-session-id'
 import { useSSE } from '~/hooks/use-sse'
 import { api } from '~/trpc/react'
 
@@ -54,7 +55,16 @@ export function useKbArticleChannel({
 
       if (eventType === 'kb-article-resync') {
         if (!articleId || !knowledgeBaseId) return
+        const evt = event as Extract<KbArticleEvent, { type: 'kb-article-resync' }>
+        // The originating tab applied this content optimistically via
+        // setData. Refetching here would clobber any keystrokes the user
+        // typed between save-fired and resync-arrived — drop our own echo.
+        if (evt.originatorSessionId === getClientSessionId()) return
         void utils.kb.getArticleById.invalidate({ id: articleId, knowledgeBaseId })
+        // Refresh the list so the article store picks up any draft metadata
+        // changes (title, emoji, cover) the other tab made — these don't
+        // travel on the realtime event, only the content body does.
+        void utils.kb.getArticles.invalidate({ knowledgeBaseId })
         return
       }
 
@@ -75,7 +85,7 @@ export function useKbArticleChannel({
 
       logger.debug('Unhandled KB article event', { eventType })
     },
-    [articleId, knowledgeBaseId, utils.kb.getArticleById]
+    [articleId, knowledgeBaseId, utils.kb.getArticleById, utils.kb.getArticles]
   )
 
   useSSE(config, onEvent)

--- a/apps/web/src/components/kb/providers/knowledge-base-provider.tsx
+++ b/apps/web/src/components/kb/providers/knowledge-base-provider.tsx
@@ -1,43 +1,17 @@
 // apps/web/src/components/kb/providers/knowledge-base-provider.tsx
 'use client'
 
-import { ArticleKind } from '@auxx/database/enums'
-import type { ArticleKind as ArticleKindType } from '@auxx/database/types'
 import type React from 'react'
 import { useEffect } from 'react'
 import { useTagHierarchy } from '~/components/tags/hooks/use-tag-hierarchy'
 import { api } from '~/trpc/react'
-import { type ArticleMeta, getArticleStoreState } from '../store/article-store'
+import { getArticleStoreState } from '../store/article-store'
 import { getKnowledgeBaseStoreState, type KnowledgeBase } from '../store/knowledge-base-store'
+import { normalizeServerArticle } from '../store/normalize-server-article'
 
 interface KnowledgeBaseProviderProps {
   knowledgeBaseId: string
   children: React.ReactNode
-}
-
-/** Normalize a server article (from tRPC) into ArticleMeta. */
-function normalize(server: any): ArticleMeta {
-  return {
-    id: server.id,
-    knowledgeBaseId: server.knowledgeBaseId,
-    title: server.title ?? '',
-    slug: server.slug ?? '',
-    emoji: server.emoji ?? null,
-    parentId: server.parentId ?? null,
-    articleKind: (server.articleKind ?? ArticleKind.page) as ArticleKindType,
-    sortOrder: server.sortOrder ?? 'a0',
-    isPublished: !!server.isPublished,
-    aiEnabled: server.aiEnabled ?? true,
-    status: server.status,
-    description: server.description ?? null,
-    excerpt: server.excerpt ?? null,
-    coverImage: server.coverImage ?? null,
-    hasUnpublishedChanges: !!server.hasUnpublishedChanges,
-    publishedAt: server.publishedAt ? new Date(server.publishedAt) : null,
-    publishedRevisionId: server.publishedRevisionId ?? null,
-    draftRevisionId: server.draftRevisionId ?? null,
-    tagIds: (server.tagIds ?? []) as ArticleMeta['tagIds'],
-  }
 }
 
 /**
@@ -77,7 +51,7 @@ export function KnowledgeBaseProvider({ knowledgeBaseId, children }: KnowledgeBa
     if (articlesQuery.data) {
       getArticleStoreState().setArticles(
         knowledgeBaseId,
-        (articlesQuery.data as any[]).map(normalize)
+        (articlesQuery.data as any[]).map(normalizeServerArticle)
       )
     }
   }, [articlesQuery.data, knowledgeBaseId])

--- a/apps/web/src/components/kb/store/article-store.ts
+++ b/apps/web/src/components/kb/store/article-store.ts
@@ -9,12 +9,25 @@ import { subscribeWithSelector } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
 
 /**
+ * Lightweight metadata for one revision (draft or published). Mirrors
+ * `ArticleRevisionMeta` from kb-service so the server payload maps 1:1.
+ */
+export interface ArticleRevisionMeta {
+  title: string
+  description: string | null
+  excerpt: string | null
+  emoji: string | null
+  coverImage: string | null
+  coverImageId: string | null
+}
+
+/**
  * ArticleMeta — flat metadata for an article. Content/contentJson are NOT stored
  * here; the editor fetches them directly per-article via tRPC.
  *
- * title/emoji/description/excerpt come from the joined revision row:
- *   - published revision when the article has been published at least once
- *   - draft revision otherwise
+ * Top-level display fields (title/emoji/description/excerpt/coverImage) mirror
+ * `draft.*` — the sidebar reflects the current working state. Consumers that
+ * need the published copy specifically read it off `published`.
  */
 export interface ArticleMeta {
   id: string
@@ -35,6 +48,8 @@ export interface ArticleMeta {
   publishedAt: Date | null
   publishedRevisionId: string | null
   draftRevisionId: string | null
+  draft: ArticleRevisionMeta
+  published: ArticleRevisionMeta | null
   /** Tag RecordIds applied to this article. Empty array if untagged. */
   tagIds: RecordId[]
 }
@@ -89,6 +104,13 @@ interface ArticleStoreState {
   applyArticleMetadataFromServer: (id: string, fields: Partial<ArticleMeta>) => void
 
   setArticleOptimistic: (id: string, updates: Partial<ArticleMeta>) => void
+  /**
+   * Optimistically patch the draft revision envelope and mirror the patched
+   * fields onto the top-level display copy. Mutations that write to the draft
+   * (title/emoji/coverImage/description/excerpt) should go through this
+   * helper so the sidebar entry and the editor reads stay in sync.
+   */
+  patchDraft: (id: string, fields: Partial<ArticleRevisionMeta>) => void
   confirmUpdate: (id: string, server?: ArticleMeta) => void
   rollbackUpdate: (id: string) => void
 
@@ -239,6 +261,21 @@ export const useArticleStore = create<ArticleStoreState>()(
             original: existing?.original ?? server,
           }
         })
+      },
+
+      patchDraft: (id, fields) => {
+        const server = get().articles.get(id) ?? get().optimisticNewArticles[id]
+        if (!server) return
+        const nextDraft: ArticleRevisionMeta = { ...server.draft, ...fields }
+        // Mirror the patched fields onto the top-level display copy so
+        // the sidebar entry updates without waiting for a server roundtrip.
+        const mirrored: Partial<ArticleMeta> = { draft: nextDraft }
+        if (fields.title !== undefined) mirrored.title = nextDraft.title
+        if (fields.emoji !== undefined) mirrored.emoji = nextDraft.emoji
+        if (fields.description !== undefined) mirrored.description = nextDraft.description
+        if (fields.excerpt !== undefined) mirrored.excerpt = nextDraft.excerpt
+        if (fields.coverImage !== undefined) mirrored.coverImage = nextDraft.coverImage
+        get().setArticleOptimistic(id, mirrored)
       },
 
       confirmUpdate: (id, server) => {

--- a/apps/web/src/components/kb/store/normalize-server-article.ts
+++ b/apps/web/src/components/kb/store/normalize-server-article.ts
@@ -1,0 +1,51 @@
+// apps/web/src/components/kb/store/normalize-server-article.ts
+import { ArticleKind, ArticleStatus } from '@auxx/database/enums'
+import type { ArticleKind as ArticleKindType } from '@auxx/database/types'
+import type { ArticleMeta } from './article-store'
+
+/**
+ * Convert a raw tRPC response into a strict {@link ArticleMeta}. Owns every
+ * field-level translation the store relies on: Date coercion, nullable
+ * defaults, draft/published envelope synthesis for cached responses that
+ * predate the envelope rollout, and mirroring `draft.*` onto the top-level
+ * display fields so the sidebar reflects the current working state.
+ *
+ * Every server → store handoff (initial hydration, mutation responses,
+ * cross-tab resync) must go through this — the store trusts its writers to
+ * hand it a fully-shaped value, so a missing field here surfaces as a
+ * runtime crash in a component reading `article.draft.emoji`.
+ */
+export function normalizeServerArticle(server: any): ArticleMeta {
+  const draft: ArticleMeta['draft'] = server.draft ?? {
+    title: server.title ?? '',
+    description: server.description ?? null,
+    excerpt: server.excerpt ?? null,
+    emoji: server.emoji ?? null,
+    coverImage: server.coverImage ?? null,
+    coverImageId: server.coverImageId ?? null,
+  }
+  const published: ArticleMeta['published'] = server.published ?? null
+  return {
+    id: server.id,
+    knowledgeBaseId: server.knowledgeBaseId,
+    title: draft.title,
+    slug: server.slug ?? '',
+    emoji: draft.emoji,
+    parentId: server.parentId ?? null,
+    articleKind: (server.articleKind ?? ArticleKind.page) as ArticleKindType,
+    sortOrder: server.sortOrder ?? 'a0',
+    isPublished: !!server.isPublished,
+    aiEnabled: server.aiEnabled ?? true,
+    status: (server.status ?? ArticleStatus.DRAFT) as ArticleMeta['status'],
+    description: draft.description,
+    excerpt: draft.excerpt,
+    coverImage: draft.coverImage,
+    hasUnpublishedChanges: !!server.hasUnpublishedChanges,
+    publishedAt: server.publishedAt ? new Date(server.publishedAt) : null,
+    publishedRevisionId: server.publishedRevisionId ?? null,
+    draftRevisionId: server.draftRevisionId ?? null,
+    draft,
+    published,
+    tagIds: (server.tagIds ?? []) as ArticleMeta['tagIds'],
+  }
+}

--- a/apps/web/src/components/kb/ui/editor/article-cover-strip.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-cover-strip.tsx
@@ -4,14 +4,13 @@
 import { Button } from '@auxx/ui/components/button'
 import { toastError } from '@auxx/ui/components/toast'
 import { ImagePlus, Tags } from 'lucide-react'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useFileSelect } from '~/components/file-select'
 import { FileSelectPicker } from '~/components/pickers/file-select-picker'
 import { useResource } from '~/components/resources/hooks'
 import { RecordTagChip } from '~/components/tags/ui/record-tag-chip'
 import { TagPicker } from '~/components/tags/ui/tag-picker'
 import { useConfirm } from '~/hooks/use-confirm'
-import { useArticleContent } from '../../hooks/use-article-content'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
 import { useArticleTags } from '../../hooks/use-article-tags'
 import type { ArticleMeta } from '../../store/article-store'
@@ -25,20 +24,17 @@ const HIDDEN_KINDS = new Set(['link', 'tab', 'header'])
 
 export function ArticleCoverStrip({ article, knowledgeBaseId }: ArticleCoverStripProps) {
   const { updateArticleCover } = useArticleMutations(knowledgeBaseId)
-  const { draftCoverImage } = useArticleContent(article.id, knowledgeBaseId)
   const [confirm, ConfirmDialog] = useConfirm()
-
   const [tagsOpen, setTagsOpen] = useState(false)
   const tagsButtonRef = useRef<HTMLButtonElement>(null)
   const { selectedTags, handleTagChange } = useArticleTags(article.id)
   const { resource: tagResource } = useResource('tag')
   const tagEntityDefId = tagResource?.entityDefinitionId
 
-  // Server resolves a fresh URL on every read, keyed off coverImageId. The
-  // store's stringly-typed `article.coverImage` is no longer a valid fallback
-  // (it can hold an expired presigned URL), so we drive purely off the
-  // getArticleById-derived draftCoverImage.
-  const coverImage = draftCoverImage
+  // The store's `draft.coverImage` is the freshly resolved URL for the
+  // article's draft cover — read it synchronously so there's no async
+  // flash between the editor-row and cover-row states.
+  const coverImage = article.draft.coverImage
 
   const fileSelect = useFileSelect({
     entityType: 'ARTICLE',
@@ -62,7 +58,6 @@ export function ArticleCoverStrip({ article, knowledgeBaseId }: ArticleCoverStri
       toastError({ title: 'Failed to upload cover', description: error })
     },
   })
-
   if (HIDDEN_KINDS.has(article.articleKind)) return null
 
   const handleRemove = async () => {
@@ -141,7 +136,7 @@ export function ArticleCoverStrip({ article, knowledgeBaseId }: ArticleCoverStri
   return (
     <>
       <div className='page-block-openapi:ml-0 group relative mx-auto w-full max-w-(--block-wrapper-max-width) pt-4'>
-        <img src={coverImage} alt='' className='aspect-[1200/630] w-full rounded-md object-cover' />
+        <CoverImage src={coverImage} />
         <div className='absolute right-2 bottom-2 flex flex-wrap items-center gap-1.5 rounded-md bg-background/80 p-1 opacity-0 backdrop-blur-sm transition-opacity group-hover:opacity-100 focus-within:opacity-100'>
           <FileSelectPicker fileSelect={fileSelect} hideBrowseExisting>
             <Button type='button' variant='ghost' size='sm'>
@@ -158,5 +153,22 @@ export function ArticleCoverStrip({ article, knowledgeBaseId }: ArticleCoverStri
       {tagPicker}
       <ConfirmDialog />
     </>
+  )
+}
+
+function CoverImage({ src }: { src: string }) {
+  const [loaded, setLoaded] = useState(false)
+  useEffect(() => {
+    setLoaded(false)
+  }, [src])
+  return (
+    <div className='relative aspect-[1200/630] w-full overflow-hidden rounded-md bg-muted'>
+      <img
+        src={src}
+        alt=''
+        onLoad={() => setLoaded(true)}
+        className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-500 ${loaded ? 'opacity-100' : 'opacity-0'}`}
+      />
+    </div>
   )
 }

--- a/apps/web/src/components/kb/ui/editor/article-editor-top.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor-top.tsx
@@ -6,7 +6,6 @@ import { EntityIcon } from '@auxx/ui/components/icons'
 import { Smile } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { EditableText, type EditableTextHandle } from '~/components/editor/editable-text'
-import { useArticleContent } from '../../hooks/use-article-content'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
 import type { ArticleMeta } from '../../store/article-store'
 import { ArticleCoverStrip } from './article-cover-strip'
@@ -26,18 +25,13 @@ export function ArticleEditorTop({
 }: ArticleEditorTopProps) {
   const descriptionRef = useRef<EditableTextHandle>(null)
   const { updateArticleDraft } = useArticleMutations(knowledgeBaseId)
-  // article.emoji on the store mirrors the *published* revision for published
-  // articles. The editor edits the draft, so source the icon from the draft
-  // revision via getArticleById instead — falls back to article.emoji while
-  // the query loads.
-  const { draftEmoji, draftCoverImage } = useArticleContent(article.id, knowledgeBaseId)
-  const effectiveEmoji = draftEmoji ?? article.emoji
-  const hasCover = !!draftCoverImage
+  const draftEmoji = article.draft.emoji
+  const hasCover = !!article.draft.coverImage
 
-  const [pickedEmoji, setPickedEmoji] = useState<string | null>(effectiveEmoji)
+  const [pickedEmoji, setPickedEmoji] = useState<string | null>(draftEmoji)
   useEffect(() => {
-    setPickedEmoji(effectiveEmoji)
-  }, [article.id, effectiveEmoji])
+    setPickedEmoji(draftEmoji)
+  }, [article.id, draftEmoji])
 
   const handleEmojiChange = (emoji: string) => {
     setPickedEmoji(emoji)

--- a/apps/web/src/components/kb/ui/editor/article-editor.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor.tsx
@@ -4,7 +4,7 @@
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import type { JSONContent } from '@tiptap/core'
 import type { Editor } from '@tiptap/react'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useRef } from 'react'
 import { useDebounceCallback } from 'usehooks-ts'
 import { KBArticleEditor } from '~/components/editor/kb-article'
 import { KopilotContext } from '~/components/kopilot/context/kopilot-context'
@@ -30,14 +30,13 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
     knowledgeBaseId
   )
   const { updateArticleDraft, updateArticleContent } = useArticleMutations(knowledgeBaseId)
-  // Cross-tab sync + Kopilot lock signal. Manual edits in another tab
-  // emit `kb-article-resync` which invalidates the article-content query
-  // and the editor's existing sync effect picks up the new doc. The
-  // `locked` flag flips while Kopilot holds a write turn so the editor
-  // goes read-only.
+  // Cross-tab sync + Kopilot lock signal. Self-originated resyncs are
+  // dropped server-side by session id; cross-tab edits invalidate the
+  // article-content query and the editor's `useExternalContentSync` hook
+  // picks up the new doc. The `locked` flag flips while Kopilot holds a
+  // write turn so the editor goes read-only.
   const { locked } = useKbArticleChannel({ articleId: article.id, knowledgeBaseId })
 
-  const lastSavedHash = useRef<string | null>(null)
   const bodyEditorRef = useRef<Editor | null>(null)
 
   const focusBodyEditor = useCallback(() => {
@@ -48,19 +47,9 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
     bodyEditorRef.current = editor
   }, [])
 
-  // Seed the saved hash on first content load so we don't immediately re-save.
-  useEffect(() => {
-    if (lastSavedHash.current === null && draftContentJson != null) {
-      lastSavedHash.current = JSON.stringify(draftContentJson)
-    }
-  }, [draftContentJson])
-
   const persist = useCallback(
     async (payload: { json: JSONContent; html: string }) => {
       const body = (payload.json.content ?? []) as JSONContent[]
-      const hash = JSON.stringify(body)
-      if (hash === lastSavedHash.current) return
-      lastSavedHash.current = hash
       await updateArticleContent(article.id, {
         content: payload.html,
         contentJson: body,

--- a/apps/web/src/components/kb/ui/editor/container-article-placeholder.tsx
+++ b/apps/web/src/components/kb/ui/editor/container-article-placeholder.tsx
@@ -17,11 +17,13 @@ import { getFullSlugPath } from '@auxx/ui/components/kb/utils'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { ExternalLink, FileText, FolderClosed, Heading, Link2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useMemo } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { useArticleList } from '../../hooks/use-article-list'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
 import type { ArticleMeta } from '../../store/article-store'
 import { usePendingInsertStore } from '../../store/pending-insert-store'
+import { ArticleEditorHeader } from './article-editor-header'
+import { ArticleEditorTop } from './article-editor-top'
 
 interface ContainerArticlePlaceholderProps {
   article: ArticleMeta
@@ -49,11 +51,12 @@ const HEADER_OPTIONS: QuickCreateOption[] = [
 
 /**
  * Rendered in the right pane when the URL resolves to a structural
- * container (`tab`, `header`, or `link`) — these kinds have no body of
- * their own, so we show an empty-state with quick-create actions for
- * the children the container can legally hold instead of mounting the
- * Tiptap article editor. Categories keep their normal editor since
- * they carry both a body and children.
+ * container (`tab`, `header`, or `link`). Reuses the article editor's
+ * header + top blocks so the surface matches a real article — same
+ * page-settings cluster, same icon/title/description chrome — then
+ * swaps the body for a quick-create Command list (tab/header) or an
+ * Open-link CTA (link). `ArticleCoverStrip` self-gates for these
+ * kinds, so the cover slot is hidden automatically.
  */
 export function ContainerArticlePlaceholder({
   article,
@@ -61,8 +64,10 @@ export function ContainerArticlePlaceholder({
 }: ContainerArticlePlaceholderProps) {
   const router = useRouter()
   const articles = useArticleList(knowledgeBaseId)
-  const { isCreating } = useArticleMutations(knowledgeBaseId)
+  const { isCreating, updateArticleDraft } = useArticleMutations(knowledgeBaseId)
   const setPending = usePendingInsertStore((s) => s.setPending)
+  const commandWrapperRef = useRef<HTMLDivElement>(null)
+  const linkButtonRef = useRef<HTMLAnchorElement>(null)
 
   const children = useMemo(
     () =>
@@ -71,9 +76,15 @@ export function ContainerArticlePlaceholder({
         .sort((a, b) => (a.sortOrder < b.sortOrder ? -1 : a.sortOrder > b.sortOrder ? 1 : 0)),
     [articles, article.id]
   )
-  const childCount = children.length
 
   const basePath = `/app/kb/${knowledgeBaseId}`
+  const isLink = article.articleKind === ArticleKind.link
+  const options =
+    article.articleKind === ArticleKind.tab
+      ? TAB_OPTIONS
+      : article.articleKind === ArticleKind.header
+        ? HEADER_OPTIONS
+        : null
 
   const handleOpenChild = (child: ArticleMeta) => {
     if (child.articleKind === ArticleKind.link) {
@@ -101,114 +112,105 @@ export function ContainerArticlePlaceholder({
     return <FileText className='size-4 text-muted-foreground' />
   }
 
-  const kindLabel =
-    article.articleKind === ArticleKind.tab
-      ? 'Tab'
-      : article.articleKind === ArticleKind.header
-        ? 'Section header'
-        : 'Link'
+  const handleMetadataUpdate = useCallback(
+    async (changes: { title?: string; description?: string }) => {
+      await updateArticleDraft(article.id, changes)
+    },
+    [article.id, updateArticleDraft]
+  )
 
-  const subtitle =
-    article.articleKind === ArticleKind.link
-      ? 'External link'
-      : `${kindLabel} · ${childCount} ${childCount === 1 ? 'item' : 'items'} inside`
-
-  const hasCustomIcon = !!article.emoji && !!getIcon(article.emoji)
-  const fallbackIcon =
-    article.articleKind === ArticleKind.link ? (
-      <Link2 className='size-7 text-muted-foreground' />
-    ) : article.articleKind === ArticleKind.header ? (
-      <Heading className='size-7 text-muted-foreground' />
-    ) : (
-      <FolderClosed className='size-7 text-muted-foreground' />
-    )
-
-  const linkUrl =
-    article.articleKind === ArticleKind.link &&
-    article.slug &&
-    /^[a-z][a-z0-9+.-]*:/i.test(article.slug)
-      ? article.slug
-      : null
+  const focusContent = useCallback(() => {
+    if (isLink) {
+      linkButtonRef.current?.focus()
+      return
+    }
+    const first = commandWrapperRef.current?.querySelector<HTMLElement>('[cmdk-item]')
+    first?.focus()
+  }, [isLink])
 
   const handleCreate = (kind: ArticleKindType) => {
-    // No `adjacentTo` / `position` → ArticleTreeSection treats this as an
-    // append, putting the new child at the bottom of the container.
     setPending({ articleKind: kind, parentId: article.id })
   }
 
-  const options =
-    article.articleKind === ArticleKind.tab
-      ? TAB_OPTIONS
-      : article.articleKind === ArticleKind.header
-        ? HEADER_OPTIONS
-        : null
+  const linkUrl =
+    isLink && article.slug && /^[a-z][a-z0-9+.-]*:/i.test(article.slug) ? article.slug : null
 
   return (
     <div className='flex min-h-0 flex-1 flex-col'>
+      <ArticleEditorHeader article={article} knowledgeBaseId={knowledgeBaseId} />
       <ScrollArea className='flex-1'>
-        <div className='mx-auto flex w-full max-w-md flex-col items-center px-7 py-16 text-center'>
-          <div className='mb-4'>
-            {hasCustomIcon ? (
-              <EntityIcon iconId={article.emoji as string} variant='bare' size='lg' />
-            ) : (
-              fallbackIcon
-            )}
-          </div>
-          <h1 className='text-2xl font-semibold'>{article.title || 'Untitled'}</h1>
-          <p className='mt-1 text-sm text-muted-foreground'>{subtitle}</p>
-
-          {article.articleKind === ArticleKind.link ? (
-            <div className='mt-8 w-full'>
-              {linkUrl ? (
-                <Button asChild variant='outline' className='w-full'>
-                  <a href={linkUrl} target='_blank' rel='noopener noreferrer'>
-                    <ExternalLink /> Open link
-                  </a>
-                </Button>
-              ) : (
-                <p className='text-sm text-muted-foreground'>
-                  This link doesn't have a URL yet. Set one from the sidebar.
-                </p>
-              )}
-            </div>
-          ) : options ? (
-            <div className='mt-8 w-full text-left'>
-              <Command className='rounded-md border bg-background'>
-                <CommandList>
-                  <CommandGroup>
-                    <CommandGroupLabel>Add to this {kindLabel.toLowerCase()}</CommandGroupLabel>
-                    {options.map(({ kind, label, Icon }) => (
-                      <CommandItem
-                        key={kind}
-                        value={`create-${kind}`}
-                        disabled={isCreating}
-                        onSelect={() => handleCreate(kind)}>
-                        <Icon className='size-4 text-muted-foreground' />
-                        <span>{label}</span>
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                  {children.length > 0 && (
-                    <>
-                      <CommandSeparator />
+        <div className='flex min-h-min flex-1 flex-col'>
+          <div className='relative mx-auto flex h-full w-full max-w-3xl flex-1 flex-col px-7'>
+            <div className='flex min-h-0 flex-1 flex-col pb-10'>
+              <div aria-hidden className='h-11 pt-4' />
+              <ArticleEditorTop
+                article={article}
+                knowledgeBaseId={knowledgeBaseId}
+                onUpdateMetadata={handleMetadataUpdate}
+                onAdvanceToContent={focusContent}
+              />
+              {isLink ? (
+                <div className='mx-auto mt-4 w-full max-w-md'>
+                  {linkUrl ? (
+                    <Button asChild variant='outline' className='w-full'>
+                      <a
+                        ref={linkButtonRef}
+                        href={linkUrl}
+                        target='_blank'
+                        rel='noopener noreferrer'>
+                        <ExternalLink /> Open link
+                      </a>
+                    </Button>
+                  ) : (
+                    <p className='text-center text-muted-foreground text-sm'>
+                      This link doesn't have a URL yet. Set one from page settings.
+                    </p>
+                  )}
+                </div>
+              ) : options ? (
+                <div ref={commandWrapperRef} className='mt-4 w-full text-left'>
+                  <Command className='overflow-hidden rounded-xl border'>
+                    <CommandList>
                       <CommandGroup>
-                        <CommandGroupLabel>Inside</CommandGroupLabel>
-                        {children.map((child) => (
+                        <CommandGroupLabel>
+                          {article.articleKind === ArticleKind.tab
+                            ? 'Add to this tab'
+                            : 'Add to this section header'}
+                        </CommandGroupLabel>
+                        {options.map(({ kind, label, Icon }) => (
                           <CommandItem
-                            key={child.id}
-                            value={`open-${child.id}`}
-                            onSelect={() => handleOpenChild(child)}>
-                            {childIcon(child)}
-                            <span className='truncate'>{child.title || 'Untitled'}</span>
+                            key={kind}
+                            value={`create-${kind}`}
+                            disabled={isCreating}
+                            onSelect={() => handleCreate(kind)}>
+                            <Icon className='size-4 text-muted-foreground' />
+                            <span>{label}</span>
                           </CommandItem>
                         ))}
                       </CommandGroup>
-                    </>
-                  )}
-                </CommandList>
-              </Command>
+                      {children.length > 0 && (
+                        <>
+                          <CommandSeparator />
+                          <CommandGroup>
+                            <CommandGroupLabel>Inside</CommandGroupLabel>
+                            {children.map((child) => (
+                              <CommandItem
+                                key={child.id}
+                                value={`open-${child.id}`}
+                                onSelect={() => handleOpenChild(child)}>
+                                {childIcon(child)}
+                                <span className='truncate'>{child.title || 'Untitled'}</span>
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </>
+                      )}
+                    </CommandList>
+                  </Command>
+                </div>
+              ) : null}
             </div>
-          ) : null}
+          </div>
         </div>
       </ScrollArea>
     </div>

--- a/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-fullscreen-preview.tsx
@@ -27,6 +27,7 @@ import { useKnowledgeBase } from '../../hooks/use-knowledge-base'
 import { ArticleMarkdownCopy } from './article-markdown-copy'
 import { mapKBForPreview } from './map-kb-for-preview'
 import { PreviewVersionPicker } from './preview-version-picker'
+import { resolvePreviewMeta } from './resolve-preview-meta'
 
 interface KBFullscreenPreviewProps {
   knowledgeBaseId: string
@@ -81,15 +82,35 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath, mode }: KBFulls
   const articleId = activeArticle?.id ?? null
   const {
     previewContentJson,
-    previewDescription,
-    previewTitle,
-    previewEmoji,
-    previewCoverImage,
-    hasPublishedVersion,
-    publishedRevisionId,
-    hasUnpublishedChanges,
-    fellBackToDraft,
+    historicalTitle,
+    historicalDescription,
+    historicalEmoji,
+    historicalCoverImage,
   } = useArticleContent(articleId, knowledgeBaseId, mode)
+
+  const isHistorical = typeof mode === 'object' && mode !== null
+  // Draft/live metadata is synchronous off the store envelopes; historical
+  // metadata comes from the version snapshot returned by useArticleContent.
+  const draftLiveMeta =
+    !isHistorical && activeArticle
+      ? resolvePreviewMeta(activeArticle, mode as 'draft' | 'live')
+      : null
+  const hasPublishedVersion = !!activeArticle?.published
+  const publishedRevisionId = activeArticle?.publishedRevisionId ?? null
+  const hasUnpublishedChanges = !!activeArticle?.hasUnpublishedChanges
+  const fellBackToDraft = draftLiveMeta?.fellBackToDraft ?? false
+  const previewTitle = isHistorical
+    ? (historicalTitle ?? activeArticle?.title ?? null)
+    : (draftLiveMeta?.title ?? null)
+  const previewEmoji = isHistorical
+    ? (historicalEmoji ?? activeArticle?.emoji ?? null)
+    : (draftLiveMeta?.emoji ?? null)
+  const previewDescription = isHistorical
+    ? (historicalDescription ?? activeArticle?.description ?? null)
+    : (draftLiveMeta?.description ?? null)
+  const previewCoverImage = isHistorical
+    ? historicalCoverImage
+    : (draftLiveMeta?.coverImage ?? null)
 
   // Versions list — used to label the live banner with vN and to map a
   // historical versionNumber to a revision id for "Restore as draft".
@@ -244,16 +265,16 @@ export function KBFullscreenPreview({ knowledgeBaseId, slugPath, mode }: KBFulls
           <div className='flex min-w-0 flex-1 flex-col'>
             <KBArticleWithToc
               doc={docJson}
-              title={previewTitle ?? activeArticle?.title}
-              emoji={previewEmoji ?? activeArticle?.emoji}
-              description={previewDescription ?? activeArticle?.description}
-              coverImage={previewCoverImage}
+              title={previewTitle ?? undefined}
+              emoji={previewEmoji ?? undefined}
+              description={previewDescription ?? undefined}
+              coverImage={previewCoverImage ?? undefined}
               parent={parent}
               resolveAuxxHref={(id) => `/preview/kb/${knowledgeBaseId}/r/${id}`}
               copyMenu={
                 <ArticleMarkdownCopy
                   doc={docJson}
-                  title={previewTitle ?? activeArticle?.title}
+                  title={previewTitle ?? undefined}
                   markdownHref={markdownHref}
                 />
               }

--- a/apps/web/src/components/kb/ui/preview/kb-preview-topbar.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview-topbar.tsx
@@ -24,7 +24,7 @@ import {
 } from 'lucide-react'
 import { useKbPublicUrl } from '~/components/kb/hooks/use-kb-public-url'
 import { api } from '~/trpc/react'
-import { useArticleContent } from '../../hooks/use-article-content'
+import { useArticleStore } from '../../store/article-store'
 import { type Device, type Theme, usePreview } from './preview-context'
 import { PreviewVersionPicker } from './preview-version-picker'
 
@@ -62,10 +62,12 @@ export function KBPreviewTopBar({ kbId, activeSlugPath, articleId }: KBPreviewTo
       ? `/${activeSlugPath.map(encodeURIComponent).join('/')}`
       : ''
   const publicUrl = useKbPublicUrl(kb?.slug)
-  const { hasPublishedVersion, publishedRevisionId, hasUnpublishedChanges } = useArticleContent(
-    articleId ?? null,
-    kbId
-  )
+  // Read version metadata straight off the article store — no async dep,
+  // so the version picker reflects the latest mutation immediately.
+  const article = useArticleStore((s) => (articleId ? s.articles.get(articleId) : undefined))
+  const hasPublishedVersion = !!article?.published
+  const publishedRevisionId = article?.publishedRevisionId ?? null
+  const hasUnpublishedChanges = !!article?.hasUnpublishedChanges
 
   const isPublished = kb?.publishStatus === 'PUBLISHED'
   const isUnlisted = kb?.publishStatus === 'UNLISTED'

--- a/apps/web/src/components/kb/ui/preview/kb-preview.tsx
+++ b/apps/web/src/components/kb/ui/preview/kb-preview.tsx
@@ -20,6 +20,7 @@ import { PreviewProvider, usePreview } from './preview-context'
 import { DesktopPreviewFrame, MobilePreviewFrame } from './preview-frames'
 import { useKBPreviewHint } from './preview-hint-context'
 import { PreviewHintOverlay } from './preview-hint-overlay'
+import { resolvePreviewMeta } from './resolve-preview-meta'
 
 interface KBPreviewProps {
   knowledgeBase: KnowledgeBase
@@ -59,12 +60,39 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
   useEffect(() => {
     setPreviewMode('draft')
   }, [articleId, setPreviewMode])
-  const { previewContentJson, previewDescription, previewTitle, previewEmoji, previewCoverImage } =
-    useArticleContent(articleId, kbId, previewMode)
+  const {
+    previewContentJson,
+    historicalTitle,
+    historicalDescription,
+    historicalEmoji,
+    historicalCoverImage,
+  } = useArticleContent(articleId, kbId, previewMode)
 
   const publicUrl = useKbPublicUrl(knowledgeBase?.slug)
 
   if (!knowledgeBase) return null
+
+  const isHistorical = typeof previewMode === 'object' && previewMode !== null
+  // Draft/live metadata is synchronous off the store envelopes; historical
+  // metadata comes from the version snapshot returned by useArticleContent.
+  const metaFromStore =
+    !isHistorical && activeArticle
+      ? resolvePreviewMeta(activeArticle, previewMode as 'draft' | 'live')
+      : null
+  const previewTitle = isHistorical
+    ? (historicalTitle ?? activeArticle?.title ?? null)
+    : (metaFromStore?.title ?? null)
+  const previewEmoji = isHistorical
+    ? (historicalEmoji ?? activeArticle?.emoji ?? null)
+    : (metaFromStore?.emoji ?? null)
+  const previewDescription = isHistorical
+    ? (historicalDescription ?? activeArticle?.description ?? null)
+    : (metaFromStore?.description ?? null)
+  // Historical mode shows no cover until the version snapshot lands —
+  // inheriting from the draft would misrepresent the version.
+  const previewCoverImage = isHistorical
+    ? historicalCoverImage
+    : (metaFromStore?.coverImage ?? null)
 
   const docJson: DocJSON | null = previewContentJson
     ? { type: 'doc', content: previewContentJson }
@@ -97,18 +125,10 @@ function KBPreviewInner({ kbId, activeSlugPath }: { kbId: string; activeSlugPath
           <div className='flex min-w-0 flex-1 flex-col'>
             <KBArticleWithToc
               doc={docJson}
-              title={
-                previewTitle ??
-                activeArticle?.title ??
-                articles.find((a) => a.id === articleId)?.title
-              }
-              emoji={
-                previewEmoji ??
-                activeArticle?.emoji ??
-                articles.find((a) => a.id === articleId)?.emoji
-              }
-              description={previewDescription ?? activeArticle?.description}
-              coverImage={previewCoverImage}
+              title={previewTitle ?? undefined}
+              emoji={previewEmoji ?? undefined}
+              description={previewDescription ?? undefined}
+              coverImage={previewCoverImage ?? undefined}
               parent={parent}
               resolveAuxxHref={(id) => `/preview/kb/${kbId}/r/${id}`}
             />

--- a/apps/web/src/components/kb/ui/preview/resolve-preview-meta.ts
+++ b/apps/web/src/components/kb/ui/preview/resolve-preview-meta.ts
@@ -1,0 +1,58 @@
+// apps/web/src/components/kb/ui/preview/resolve-preview-meta.ts
+
+import type { PreviewMode } from '../../hooks/use-article-content'
+import type { ArticleMeta, ArticleRevisionMeta } from '../../store/article-store'
+
+export interface ResolvedPreviewMeta {
+  title: string
+  description: string | null
+  excerpt: string | null
+  emoji: string | null
+  coverImage: string | null
+  /** True when mode === 'live' but the article has no published revision. */
+  fellBackToDraft: boolean
+}
+
+/**
+ * Pure resolver for draft/live preview metadata. Reads synchronously off the
+ * article store envelopes — no async dependency, so flipping the topbar's
+ * "Live" toggle swaps title/emoji/cover without waiting on a query.
+ *
+ * Historical (`{ versionNumber }`) mode is intentionally not handled here:
+ * its metadata lives behind an async `getArticleById(..., versionNumber)`
+ * query and `useArticleContent` returns it through a separate slot.
+ */
+export function resolvePreviewMeta(
+  article: ArticleMeta,
+  mode: Extract<PreviewMode, 'draft' | 'live'>
+): ResolvedPreviewMeta {
+  if (mode === 'live') {
+    const pub: ArticleRevisionMeta | null = article.published
+    if (pub) {
+      return {
+        title: pub.title,
+        description: pub.description,
+        excerpt: pub.excerpt,
+        emoji: pub.emoji,
+        coverImage: pub.coverImage,
+        fellBackToDraft: false,
+      }
+    }
+    return {
+      title: article.draft.title,
+      description: article.draft.description,
+      excerpt: article.draft.excerpt,
+      emoji: article.draft.emoji,
+      coverImage: article.draft.coverImage,
+      fellBackToDraft: true,
+    }
+  }
+  return {
+    title: article.draft.title,
+    description: article.draft.description,
+    excerpt: article.draft.excerpt,
+    emoji: article.draft.emoji,
+    coverImage: article.draft.coverImage,
+    fellBackToDraft: false,
+  }
+}

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -24,6 +24,7 @@ import { flushSync } from 'react-dom'
 import { useDropzone } from 'react-dropzone'
 import { EditorToolbar } from '~/components/editor/editor-button'
 import { EditorProvider, useEditorContext } from '~/components/editor/editor-context'
+import { type ContentApplier, makeContentApplier } from '~/components/editor/inline-picker'
 import { useFileSelect } from '~/components/file-select/hooks/use-file-select'
 import { useCountUpdates } from '~/components/mail/hooks'
 import { useComposeStore } from '~/components/mail/store/compose-store'
@@ -515,11 +516,31 @@ function ReplyComposeEditorComponent({
     }))
     setIsDraftSaved(false)
   }, [])
+  // Imperative content writes (AI tools, undo/redo) route through this
+  // applier so a duplicate write is a no-op. The handler below stamps the
+  // applier with every user edit so subsequent imperative writes of the
+  // same HTML short-circuit.
+  const contentApplier = useMemo<ContentApplier<string | object>>(
+    () =>
+      makeContentApplier<string | object>(
+        editor,
+        (e, content) => {
+          e.commands.setContent(content as Parameters<typeof e.commands.setContent>[0])
+        },
+        (content) => (typeof content === 'string' ? content : JSON.stringify(content))
+      ),
+    [editor]
+  )
+
   // Handlers
-  const handleContentChange = useCallback((newContent: string) => {
-    setContent((prev) => (prev === newContent ? prev : newContent))
-    setIsDraftSaved(false)
-  }, [])
+  const handleContentChange = useCallback(
+    (newContent: string) => {
+      setContent((prev) => (prev === newContent ? prev : newContent))
+      contentApplier.markLocalEdit(newContent)
+      setIsDraftSaved(false)
+    },
+    [contentApplier]
+  )
   const handleSubjectChange = useCallback(
     (subject: string) => {
       setState((prev) => ({ ...prev, subject }))
@@ -608,15 +629,16 @@ function ReplyComposeEditorComponent({
   const processAI = api.aiFeature.compose.useMutation({
     onSuccess: (response) => {
       if (!editor) return
-      // Apply new content based on format
+      // Apply new content based on format — routed through the applier so a
+      // duplicate write (same HTML as the user already has) no-ops.
       if (response.format === OUTPUT_FORMAT.EDITOR) {
         const tiptapContent = JSON.parse(response.content)
-        editor.commands.setContent(tiptapContent)
+        contentApplier.apply(tiptapContent)
       } else if (response.format === OUTPUT_FORMAT.HTML) {
-        editor.commands.setContent(response.content)
+        contentApplier.apply(response.content)
       } else {
         // Plain text - wrap in paragraph
-        editor.commands.setContent(`<p>${response.content}</p>`)
+        contentApplier.apply(`<p>${response.content}</p>`)
       }
       // Sync React content state — setContent doesn't emit onUpdate by default
       handleContentChange(editor.getHTML())

--- a/apps/web/src/server/api/routers/kb.ts
+++ b/apps/web/src/server/api/routers/kb.ts
@@ -275,6 +275,7 @@ export const knowledgeBaseRouter = createTRPCRouter({
         id: z.string(),
         data: articleDraftFieldsSchema,
         knowledgeBaseId: z.string().optional(),
+        originatorSessionId: z.string().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -282,7 +283,8 @@ export const knowledgeBaseRouter = createTRPCRouter({
         input.id,
         input.data as Parameters<ReturnType<typeof getKBService>['updateArticleDraft']>[1],
         ctx.session.user.id,
-        input.knowledgeBaseId
+        input.knowledgeBaseId,
+        { originatorSessionId: input.originatorSessionId }
       )
     }),
 

--- a/packages/lib/src/kb/kb-service.ts
+++ b/packages/lib/src/kb/kb-service.ts
@@ -31,6 +31,20 @@ const logger = createScopedLogger('kb-service')
 
 // ─── Public shapes (flattened) ───────────────────────────────────────────
 
+/**
+ * Lightweight metadata for a single revision (draft or published).
+ * Keeps cover URLs resolved server-side so consumers don't need a follow-up
+ * roundtrip per id.
+ */
+export interface ArticleRevisionMeta {
+  title: string
+  description: string | null
+  excerpt: string | null
+  emoji: string | null
+  coverImage: string | null
+  coverImageId: string | null
+}
+
 export interface ArticleListItem {
   id: string
   knowledgeBaseId: string
@@ -46,12 +60,20 @@ export interface ArticleListItem {
   publishedAt: Date | null
   publishedRevisionId: string | null
   draftRevisionId: string | null
-  // From the joined revision (published if exists, else draft)
+  // Display fields — derived from the draft revision (current working state).
   title: string
   emoji: string | null
   description: string | null
   excerpt: string | null
   coverImage: string | null
+  /**
+   * Per-revision envelopes so consumers (editor, preview) can read the
+   * exact revision they need without an extra async fetch. `draft` is
+   * always present (every article has a draft); `published` is null
+   * until the article has been published at least once.
+   */
+  draft: ArticleRevisionMeta
+  published: ArticleRevisionMeta | null
   /** Tag RecordIds (`entityDefinitionId:tagId`) attached to this article. */
   tagIds: RecordId[]
 }
@@ -60,6 +82,8 @@ export interface ArticleEditorView extends ArticleListItem {
   // Always the draft fields, plus the heavy content
   content: string
   contentJson: ArticleNodeJSON[] | null
+  /** Hash of `contentJson` — the editor uses it to dedupe inbound syncs. */
+  draftContentHash: string
   coverImageId: string | null
   hasPublishedVersion: boolean
   publishedTitle: string | null
@@ -74,6 +98,7 @@ export interface ArticleEditorView extends ArticleListItem {
   selectedEmoji: string | null
   selectedContent: string | null
   selectedContentJson: ArticleNodeJSON[] | null
+  selectedContentHash: string | null
   selectedCoverImage: string | null
   selectedCoverImageId: string | null
 }
@@ -495,8 +520,12 @@ export class KBService {
         this.organizationId
       )
       // Batch-resolve every cover URL in one parallel fan-out so an N-article
-      // KB makes O(unique-asset-count) round-trips, not O(N).
-      const urlMap = await this.resolveCoverUrls(articles.map((a) => this.listCoverImageId(a)))
+      // KB makes O(unique-asset-count) round-trips, not O(N). resolveCoverUrls
+      // de-dupes by id, so passing draft + published per article costs nothing
+      // when they share the same asset (the common case).
+      const urlMap = await this.resolveCoverUrls(
+        articles.flatMap((a) => this.coverIdsForArticle(a))
+      )
       return await Promise.all(
         articles.map((a) =>
           this.flattenForList(a, (tagIdMap.get(a.id) ?? []) as RecordId[], urlMap)
@@ -757,8 +786,12 @@ export class KBService {
     fields: ArticleDraftFields,
     editorId: string,
     knowledgeBaseId?: string,
-    options: { bypassSnapshotClear?: boolean; suppressResyncEvent?: boolean } = {}
-  ): Promise<ArticleListItem> {
+    options: {
+      bypassSnapshotClear?: boolean
+      suppressResyncEvent?: boolean
+      originatorSessionId?: string
+    } = {}
+  ): Promise<ArticleEditorView> {
     try {
       const article = await this.db.query.Article.findFirst({
         where: and(
@@ -840,14 +873,22 @@ export class KBService {
             contentJson: draftJson,
             contentHash: computeArticleJsonHash(draftJson),
             cause: { kind: 'manual' },
+            originatorSessionId: options.originatorSessionId,
           })
         }
       }
 
-      return await this.flattenForList(
-        reloaded ?? { ...updated, publishedRevision: null, draftRevision: null },
-        tagIds
-      )
+      // Return the editor-shaped view (content + contentJson + draftContentHash)
+      // so the client's optimistic `setData` merge can refresh the cached doc.
+      // Without these fields the cache keeps the load-time content, and a
+      // navigate-away-and-back within the query staleTime renders stale content.
+      if (!reloaded) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Article ${id} disappeared during update`,
+        })
+      }
+      return await this.flattenForEditor(reloaded, null, tagIds)
     } catch (error) {
       return this.handleError(error, 'Error updating article draft', { articleId: id })
     }
@@ -980,7 +1021,7 @@ export class KBService {
         this.organizationId
       )
       const urlMap = await this.resolveCoverUrls(
-        reloadedArticles.map((a) => this.listCoverImageId(a))
+        reloadedArticles.flatMap((a) => this.coverIdsForArticle(a))
       )
       return await Promise.all(
         reloadedArticles.map((a) =>
@@ -1565,12 +1606,41 @@ export class KBService {
   // ─── Internal helpers ───────────────────────────────────────────────
 
   /**
-   * Pick the coverImageId to render in list views: prefer the published
-   * revision's link (mirroring the rest of the display fallback), fall back
-   * to the draft. Mirrors {@link flattenForList}'s title/emoji preference.
+   * Cover ids touched by a single article — both draft and published.
+   * Used to prime the batch URL map so a single fan-out resolves every
+   * cover the list payload needs.
    */
-  private listCoverImageId(a: any): string | null {
-    return a.publishedRevision?.coverImageId ?? a.draftRevision?.coverImageId ?? null
+  private coverIdsForArticle(a: any): Array<string | null | undefined> {
+    return [a.draftRevision?.coverImageId, a.publishedRevision?.coverImageId]
+  }
+
+  /**
+   * Build a per-revision envelope (title/emoji/cover…) used by both the
+   * sidebar payload and the editor view so draft and published metadata
+   * stay structurally identical.
+   */
+  private buildRevisionMeta(
+    rev:
+      | {
+          title: string | null
+          description: string | null
+          excerpt: string | null
+          emoji: string | null
+          coverImageId: string | null
+        }
+      | null
+      | undefined,
+    urlMap?: Map<string, string | null>
+  ): ArticleRevisionMeta | null {
+    if (!rev) return null
+    return {
+      title: rev.title ?? '',
+      description: rev.description ?? null,
+      excerpt: rev.excerpt ?? null,
+      emoji: rev.emoji ?? null,
+      coverImageId: rev.coverImageId ?? null,
+      coverImage: rev.coverImageId ? (urlMap?.get(rev.coverImageId) ?? null) : null,
+    }
   }
 
   private async flattenForList(
@@ -1578,11 +1648,19 @@ export class KBService {
     tagIds: RecordId[] = [],
     urlMap?: Map<string, string | null>
   ): Promise<ArticleListItem> {
-    const display = a.publishedRevision ?? a.draftRevision ?? {}
-    const coverImageId = this.listCoverImageId(a)
-    const coverImage = coverImageId
-      ? (urlMap?.get(coverImageId) ?? (await this.resolveCoverUrl(coverImageId)))
-      : null
+    // resolveCoverUrls de-dupes by id, so passing both draft and published
+    // (when present) costs nothing extra for the common case where they
+    // share the same asset.
+    const resolved = urlMap ?? (await this.resolveCoverUrls(this.coverIdsForArticle(a)))
+    const draft = this.buildRevisionMeta(a.draftRevision, resolved) ?? {
+      title: '',
+      description: null,
+      excerpt: null,
+      emoji: null,
+      coverImage: null,
+      coverImageId: null,
+    }
+    const published = this.buildRevisionMeta(a.publishedRevision, resolved)
     return {
       id: a.id,
       knowledgeBaseId: a.knowledgeBaseId,
@@ -1598,11 +1676,14 @@ export class KBService {
       publishedAt: a.publishedAt,
       publishedRevisionId: a.publishedRevisionId,
       draftRevisionId: a.draftRevisionId,
-      title: display.title ?? '',
-      emoji: display.emoji ?? null,
-      description: display.description ?? null,
-      excerpt: display.excerpt ?? null,
-      coverImage,
+      // Sidebar reflects the current working state — always the draft.
+      title: draft.title,
+      emoji: draft.emoji,
+      description: draft.description,
+      excerpt: draft.excerpt,
+      coverImage: draft.coverImage,
+      draft,
+      published,
       tagIds,
     }
   }
@@ -1625,6 +1706,8 @@ export class KBService {
       pub?.coverImageId,
       selected?.coverImageId,
     ])
+    const draftMeta = this.buildRevisionMeta(draft, urlMap)!
+    const publishedMeta = this.buildRevisionMeta(pub, urlMap)
     return {
       id: a.id,
       knowledgeBaseId: a.knowledgeBaseId,
@@ -1640,15 +1723,20 @@ export class KBService {
       publishedAt: a.publishedAt,
       publishedRevisionId: a.publishedRevisionId,
       draftRevisionId: a.draftRevisionId,
-      title: draft.title ?? '',
-      emoji: draft.emoji ?? null,
-      description: draft.description ?? null,
-      excerpt: draft.excerpt ?? null,
-      coverImage: draft.coverImageId ? (urlMap.get(draft.coverImageId) ?? null) : null,
-      coverImageId: draft.coverImageId ?? null,
+      title: draftMeta.title,
+      emoji: draftMeta.emoji,
+      description: draftMeta.description,
+      excerpt: draftMeta.excerpt,
+      coverImage: draftMeta.coverImage,
+      coverImageId: draftMeta.coverImageId,
+      draft: draftMeta,
+      published: publishedMeta,
       tagIds,
       content: draft.content ?? '',
       contentJson: (draft.contentJson as ArticleNodeJSON[] | null) ?? null,
+      draftContentHash: computeArticleJsonHash(
+        (draft.contentJson as ArticleNodeJSON[] | null) ?? null
+      ),
       hasPublishedVersion: !!pub,
       publishedTitle: pub?.title ?? null,
       publishedContent: pub?.content ?? null,
@@ -1661,6 +1749,9 @@ export class KBService {
       selectedEmoji: selected?.emoji ?? null,
       selectedContent: selected?.content ?? null,
       selectedContentJson: (selected?.contentJson as ArticleNodeJSON[] | null) ?? null,
+      selectedContentHash: selected
+        ? computeArticleJsonHash((selected.contentJson as ArticleNodeJSON[] | null) ?? null)
+        : null,
       selectedCoverImage: selected?.coverImageId
         ? (urlMap.get(selected.coverImageId) ?? null)
         : null,

--- a/packages/lib/src/kb/realtime.ts
+++ b/packages/lib/src/kb/realtime.ts
@@ -37,6 +37,8 @@ export type KbArticleEvent =
       contentJson: ArticleNodeJSON[]
       contentHash: string
       cause: { kind: 'kopilot' | 'manual' | 'revert'; turnId?: string }
+      /** Tab that triggered the save — the originating tab drops the echo. */
+      originatorSessionId?: string
     }
   | {
       type: 'kb-article-lock'


### PR DESCRIPTION
## Summary

- **Per-revision metadata envelopes** — `ArticleListItem` / `ArticleEditorView` now carry `draft` and `published` sub-objects (title, emoji, cover, description, excerpt) alongside the flat display fields. The article store mirrors `draft.*` onto its top-level copy so the sidebar always shows the current working state, and preview surfaces resolve draft/live meta synchronously via `resolvePreviewMeta` instead of awaiting `useArticleContent`.
- **Originator-tagged cross-tab resync** — `updateArticleDraft` accepts an `originatorSessionId` (stable per-tab via `getClientSessionId`); the `kb-article-resync` event echoes it back and `useKbArticleChannel` drops self-echoes, so the originating tab keeps any keystrokes it typed between save-fired and SSE-arrived.
- **Shared external-content-sync hook** — extracted `useExternalContentSync` + `makeContentApplier` + `stableStringify` from the KB / TipTap / email editors. One `lastAppliedKey` ref dedupes inbound echoes vs outbound local edits, stashes incoming content while a slash/inline picker is open, and key-order-insensitive stringify keeps JSONB round-trips from triggering spurious reapplies.
- **Container article placeholder polish** — tab / header / link containers reuse `ArticleEditorHeader` + `ArticleEditorTop` so settings cluster, icon, title, description and cover slot match a real article.
- **Bubble menu align fix** — the alignment dropdown read `isActive({ textAlign: opt.id })` in option order, which locked the indicator to "Right" once any block in the doc carried `textAlign: 'right'`. Now reads the block's actual `textAlign` attribute.
- **Article cover fade-in** — `ArticleCoverStrip` fades the `<img>` in on load to avoid the unstyled flash when a freshly-resolved URL swaps in.

## Test plan

- [ ] Open an article in two tabs, type in tab A — tab B updates, caret in tab A doesn't jump
- [ ] Rename / change emoji / change cover on a published article — sidebar entry reflects the draft fields immediately
- [ ] Flip the preview topbar between Draft and Live — title/emoji/cover/description swap with no flicker; "Live" falls back to draft when the article has never been published
- [ ] Open the historical version picker and scrub versions — body + meta switch together, cover starts empty (no draft flash)
- [ ] Open a Tab / Section header / Link container — header chrome matches a real article; quick-create command works; Link shows the "Open link" CTA when the slug is a URL
- [ ] Select text in any block aligned right/center/justify — bubble menu dropdown shows that alignment, not "Right" on every block
- [ ] Hard-paste content into the KB editor while a slash picker is open — content lands once the picker closes; no clobber
- [ ] AI compose in mail reply — clicking the same suggestion twice doesn't double-write; user edits between clicks survive