### PR TITLE
chore(infra): kb docker image + recall.ai secrets

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,6 +58,9 @@ jobs:
           - name: docs
             file: apps/docs/Dockerfile
             image: ghcr.io/auxx-ai/docs
+          - name: kb
+            file: apps/kb/Dockerfile
+            image: ghcr.io/auxx-ai/kb
     steps:
       - name: Free disk space
         run: |

--- a/infra/secrets.ts
+++ b/infra/secrets.ts
@@ -52,6 +52,20 @@ export const secretsConfig = {
     description: 'HMAC secret for apps/kb local session cookies',
   },
 
+  // Recall.ai (meeting bot)
+  RECALL_AI_API_KEY: {
+    secret: new sst.Secret('RECALL_AI_API_KEY'),
+    description: 'Recall.ai API key for meeting bot provider',
+  },
+  RECALL_AI_WEBHOOK_SECRET: {
+    secret: new sst.Secret('RECALL_AI_WEBHOOK_SECRET'),
+    description: 'Recall.ai webhook signing secret',
+  },
+  RECALL_AI_REGION: {
+    secret: new sst.Secret('RECALL_AI_REGION'),
+    description: 'Recall.ai API region (e.g. us-west-2)',
+  },
+
   // OAuth - GitHub
   AUTH_GITHUB_ID: {
     secret: new sst.Secret('AUTH_GITHUB_ID'),


### PR DESCRIPTION
## Summary
- Add `kb` app to the release-please docker build matrix, publishing `ghcr.io/auxx-ai/kb`
- Define `RECALL_AI_API_KEY`, `RECALL_AI_WEBHOOK_SECRET`, and `RECALL_AI_REGION` SST secrets for the Recall.ai meeting bot provider

## Test plan
- [ ] release-please workflow builds and pushes the `kb` image on next release
- [ ] `sst secret set` succeeds for the three `RECALL_AI_*` secrets in dev/prod