### PR TITLE
feat(kb): cacheComponents Suspense fix, no-flash dark mode, 12-step palette

### DIFF
--- a/apps/kb/package.json
+++ b/apps/kb/package.json
@@ -33,6 +33,7 @@
     "@tailwindcss/postcss": "catalog:",
     "@types/node": "catalog:",
     "postcss": "catalog:",
+    "prettier": "^3.8.1",
     "rimraf": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:"

--- a/apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
+++ b/apps/kb/src/app/[orgSlug]/[kbSlug]/layout.tsx
@@ -3,11 +3,9 @@
 import { WEBAPP_URL } from '@auxx/config/urls'
 import { isOrgMember } from '@auxx/lib/cache'
 import { KBLayout } from '@auxx/ui/components/kb'
-import type { KBMode } from '@auxx/ui/components/kb/theme'
 import '@auxx/ui/global.css'
 import type { Metadata } from 'next'
 import { cacheLife, cacheTag } from 'next/cache'
-import { cookies } from 'next/headers'
 import { notFound, redirect } from 'next/navigation'
 import { Suspense } from 'react'
 import { getLocalSession, getLoginUrl } from '~/lib/auth'
@@ -38,47 +36,36 @@ export default async function KBSlugLayout({ params, children }: KBSlugLayoutPro
   const visibility = await getCachedKBVisibility(orgSlug, kbSlug)
   if (!visibility || visibility.publishStatus === 'DRAFT') notFound()
 
-  const mode = await readModeCookie(visibility.id)
-
   if (visibility.visibility === 'PUBLIC') {
     return (
-      <PublicKBLayout orgSlug={orgSlug} kbSlug={kbSlug} mode={mode}>
+      <PublicKBLayout orgSlug={orgSlug} kbSlug={kbSlug}>
         {children}
       </PublicKBLayout>
     )
   }
 
   // INTERNAL: dynamic — auth gate inside Suspense so the cacheComponents
-  // model is satisfied (uncached cookie/membership reads are streamed).
+  // model is satisfied (uncached membership reads are streamed).
   return (
     <Suspense fallback={null}>
       <InternalKBLayoutGate
         orgSlug={orgSlug}
         kbSlug={kbSlug}
         kbId={visibility.id}
-        organizationId={visibility.organizationId}
-        mode={mode}>
+        organizationId={visibility.organizationId}>
         {children}
       </InternalKBLayoutGate>
     </Suspense>
   )
 }
 
-async function readModeCookie(kbId: string): Promise<KBMode | undefined> {
-  const cookieStore = await cookies()
-  const value = cookieStore.get(`kb-mode-${kbId}`)?.value
-  return value === 'dark' ? 'dark' : value === 'light' ? 'light' : undefined
-}
-
 async function PublicKBLayout({
   orgSlug,
   kbSlug,
-  mode,
   children,
 }: {
   orgSlug: string
   kbSlug: string
-  mode?: KBMode
   children: React.ReactNode
 }) {
   'use cache'
@@ -92,12 +79,7 @@ async function PublicKBLayout({
   const searchOrigin = `${basePath}/search.json`
 
   return (
-    <KBLayout
-      kb={kb}
-      articles={articles}
-      basePath={basePath}
-      searchOrigin={searchOrigin}
-      mode={mode}>
+    <KBLayout kb={kb} articles={articles} basePath={basePath} searchOrigin={searchOrigin}>
       {children}
     </KBLayout>
   )
@@ -108,14 +90,12 @@ async function InternalKBLayoutGate({
   kbSlug,
   kbId,
   organizationId,
-  mode,
   children,
 }: {
   orgSlug: string
   kbSlug: string
   kbId: string
   organizationId: string
-  mode?: KBMode
   children: React.ReactNode
 }) {
   const session = await getLocalSession()
@@ -136,12 +116,7 @@ async function InternalKBLayoutGate({
   const searchOrigin = `${basePath}/search.json`
 
   return (
-    <KBLayout
-      kb={kb}
-      articles={articles}
-      basePath={basePath}
-      searchOrigin={searchOrigin}
-      mode={mode}>
+    <KBLayout kb={kb} articles={articles} basePath={basePath} searchOrigin={searchOrigin}>
       {children}
     </KBLayout>
   )

--- a/apps/kb/src/app/layout.tsx
+++ b/apps/kb/src/app/layout.tsx
@@ -7,9 +7,27 @@ export const metadata: Metadata = {
   description: 'Knowledge Base',
 }
 
+// Paint <html> bg to match the KB mode so overscroll, scrollbars, and any
+// area outside the KBThemeProvider div don't flash white in dark mode.
+// `:has()` reactively re-matches when the inline NoFlashModeScript flips
+// `data-kb-mode` on first paint.
+const htmlModeCss = `
+html:has([data-kb-mode='dark']) {
+  background-color: #1d1d1d;
+  color-scheme: dark;
+}
+html:has([data-kb-mode='light']) {
+  background-color: #ffffff;
+  color-scheme: light;
+}
+`
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang='en'>
+    <html lang='en' suppressHydrationWarning>
+      <head>
+        <style dangerouslySetInnerHTML={{ __html: htmlModeCss }} />
+      </head>
       <body style={{ margin: 0 }}>{children}</body>
     </html>
   )

--- a/apps/kb/src/app/page.tsx
+++ b/apps/kb/src/app/page.tsx
@@ -2,8 +2,9 @@
 // Public KB roots are served at /<orgSlug>/<kbSlug>/. The bare root has no
 // useful content; redirect visitors to the marketing site.
 
+import { HOMEPAGE_URL } from '@auxx/config/urls'
 import { redirect } from 'next/navigation'
 
 export default function RootPage() {
-  redirect(process.env.KB_MARKETING_URL ?? 'https://auxx.ai')
+  redirect(HOMEPAGE_URL)
 }

--- a/packages/ui/src/components/kb/theme/kb-theme-provider.tsx
+++ b/packages/ui/src/components/kb/theme/kb-theme-provider.tsx
@@ -20,13 +20,26 @@ export function KBThemeProvider({ kb, mode, children }: KBThemeProviderProps) {
       data-kb-id={kb.id}
       data-kb-mode={initialMode}
       data-kb-theme={theme}
+      suppressHydrationWarning
       className='flex min-h-0 flex-1 flex-col'
       style={{ background: 'var(--kb-page-bg)' }}>
-      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: values are sanitized via buildKBCss */}
       <style dangerouslySetInnerHTML={{ __html: css }} />
+      <NoFlashModeScript kbId={kb.id} />
       {children}
     </div>
   )
+}
+
+/**
+ * Syncs `data-kb-mode` on the host element from the `kb-mode-{id}` cookie
+ * before paint, mirroring `KBModeToggle.applyMode()`. Cached server shells
+ * SSR with `kb.defaultMode`; this script flips the attribute to the user's
+ * stored preference without a flash, so the cached layout can stay one
+ * variant per KB instead of splitting per mode.
+ */
+function NoFlashModeScript({ kbId }: { kbId: string }) {
+  const code = `(function(){try{var id=${JSON.stringify(kbId)};var esc=id.replace(/[-\\/\\\\^$*+?.()|[\\]{}]/g,'\\\\$&');var m=document.cookie.match(new RegExp('(?:^|; )kb-mode-'+esc+'=([^;]*)'));if(!m)return;var v=decodeURIComponent(m[1]);if(v!=='dark'&&v!=='light')return;var el=document.currentScript&&document.currentScript.parentElement;if(el)el.setAttribute('data-kb-mode',v);}catch(_){}})();`
+  return <script dangerouslySetInnerHTML={{ __html: code }} />
 }
 
 function normalizeMode(value: string | null | undefined): KBMode {

--- a/packages/ui/src/components/kb/theme/kb-theme-tokens.ts
+++ b/packages/ui/src/components/kb/theme/kb-theme-tokens.ts
@@ -10,16 +10,178 @@ export interface KBColorPair {
 }
 
 export const KB_TOKEN_DEFAULTS: Record<string, KBColorPair> = {
-  primary: { light: '#2563eb', dark: '#60a5fa' },
+  primary: { light: '#346ddb', dark: '#346ddb' },
   tint: { light: '#dbeafe', dark: '#1e3a8a' },
   info: { light: '#0ea5e9', dark: '#38bdf8' },
   success: { light: '#16a34a', dark: '#4ade80' },
   warning: { light: '#f59e0b', dark: '#fbbf24' },
   danger: { light: '#dc2626', dark: '#f87171' },
-  bg: { light: '#ffffff', dark: '#0a0a0a' },
-  fg: { light: '#0a0a0a', dark: '#ffffff' },
-  muted: { light: '#f4f4f5', dark: '#18181b' },
-  border: { light: '#e4e4e7', dark: '#27272a' },
+  bg: { light: '#ffffff', dark: '#1d1d1d' },
+  fg: { light: '#1d1d1d', dark: '#ffffff' },
+  muted: { light: '#f1f3f5', dark: '#2c2c2c' },
+  border: { light: '#dee2e6', dark: '#393939' },
+}
+
+/**
+ * 12-step color scales for primary + neutral families. Each step is paired
+ * with a `contrast-*` foreground color suitable for text on that step.
+ *
+ * Step semantics (Radix Colors convention):
+ *  1   app background tint
+ *  2   raised surface (cards, header)
+ *  3   subtle component bg (hover for step 1, normal for components)
+ *  4   component bg (hover for step 3, normal for buttons)
+ *  5   component bg pressed
+ *  6   subtle border (dividers)
+ *  7   border (input outlines)
+ *  8   border (hover, focus ring)
+ *  9   solid brand bg (buttons) — derived from `--kb-primary` for primary family
+ * 10   solid hover
+ * 11   low-contrast text (subtle copy, captions)
+ * 12   high-contrast text (headings, body)
+ *
+ * Dark values mirror the reference 'clean dark' palette exactly. Light values
+ * are hand-picked Radix-style blue/slate counterparts that share step 9 with
+ * dark so the brand color renders identically across modes.
+ */
+type Scale12 = readonly [
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+]
+
+interface FamilyScale {
+  light: Scale12
+  dark: Scale12
+  contrastLight: Scale12
+  contrastDark: Scale12
+}
+
+const PRIMARY_SCALE: FamilyScale = {
+  dark: [
+    'rgb(29, 29, 29)', // 1
+    'rgb(32, 35, 39)', // 2
+    'rgb(39, 44, 53)', // 3
+    'rgb(40, 48, 62)', // 4
+    'rgb(43, 54, 72)', // 5
+    'rgb(45, 58, 81)', // 6
+    'rgb(52, 68, 96)', // 7
+    'rgb(59, 78, 112)', // 8
+    'rgb(52, 109, 219)', // 9
+    'rgb(80, 139, 252)', // 10
+    'rgb(167, 193, 239)', // 11
+    'rgb(249, 255, 255)', // 12
+  ],
+  contrastDark: [
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+  ],
+  light: [
+    'rgb(253, 253, 254)', // 1
+    'rgb(245, 248, 255)', // 2
+    'rgb(234, 241, 255)', // 3
+    'rgb(221, 231, 255)', // 4
+    'rgb(207, 221, 255)', // 5
+    'rgb(188, 207, 250)', // 6
+    'rgb(164, 189, 241)', // 7
+    'rgb(128, 162, 232)', // 8
+    'rgb(52, 109, 219)', // 9 — same as dark
+    'rgb(42, 95, 201)', // 10
+    'rgb(46, 93, 182)', // 11
+    'rgb(20, 42, 87)', // 12
+  ],
+  contrastLight: [
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+  ],
+}
+
+const NEUTRAL_SCALE: FamilyScale = {
+  dark: [
+    'rgb(29, 29, 29)', // 1
+    'rgb(34, 34, 34)', // 2
+    'rgb(44, 44, 44)', // 3
+    'rgb(48, 48, 48)', // 4
+    'rgb(53, 53, 53)', // 5
+    'rgb(57, 57, 57)', // 6
+    'rgb(67, 67, 67)', // 7
+    'rgb(78, 78, 78)', // 8
+    'rgb(120, 120, 120)', // 9
+    'rgb(144, 144, 144)', // 10
+    'rgb(192, 192, 192)', // 11
+    'rgb(255, 255, 255)', // 12
+  ],
+  contrastDark: [
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+  ],
+  light: [
+    'rgb(255, 255, 255)', // 1
+    'rgb(248, 249, 250)', // 2
+    'rgb(241, 243, 245)', // 3
+    'rgb(233, 236, 239)', // 4
+    'rgb(222, 226, 230)', // 5
+    'rgb(206, 212, 218)', // 6
+    'rgb(173, 181, 189)', // 7
+    'rgb(134, 142, 150)', // 8
+    'rgb(108, 117, 125)', // 9
+    'rgb(73, 80, 87)', // 10
+    'rgb(52, 58, 64)', // 11
+    'rgb(29, 29, 29)', // 12
+  ],
+  contrastLight: [
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(29, 29, 29)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+    'rgb(255, 255, 255)',
+  ],
 }
 
 export const KB_CORNER_RADIUS: Record<KBCornerStyle, string> = {
@@ -111,20 +273,20 @@ interface ThemeVars {
 const KB_THEME_VARS: Record<KBTheme, Record<KBMode, ThemeVars>> = {
   clean: {
     light: {
-      pageBg: '#ffffff',
-      surfaceBg: '#ffffff',
-      sidebarBg: '#ffffff',
-      contentBg: '#ffffff',
-      surfaceBorder: '#e4e4e7',
+      pageBg: 'var(--kb-neutral-1)',
+      surfaceBg: 'var(--kb-neutral-2)',
+      sidebarBg: 'var(--kb-neutral-1)',
+      contentBg: 'var(--kb-neutral-2)',
+      surfaceBorder: 'var(--kb-neutral-6)',
       borderWeight: '1px',
       headingScale: '1',
     },
     dark: {
-      pageBg: '#0a0a0a',
-      surfaceBg: '#0a0a0a',
-      sidebarBg: '#0a0a0a',
-      contentBg: '#0a0a0a',
-      surfaceBorder: '#27272a',
+      pageBg: 'var(--kb-neutral-1)',
+      surfaceBg: 'var(--kb-neutral-2)',
+      sidebarBg: 'var(--kb-neutral-1)',
+      contentBg: 'var(--kb-neutral-2)',
+      surfaceBorder: 'var(--kb-neutral-6)',
       borderWeight: '1px',
       headingScale: '1',
     },
@@ -218,16 +380,27 @@ function buildModeVars(kb: KBThemeInput, mode: KBMode, theme: KBTheme): string {
     return sanitizeColor(mode === 'light' ? light : dark, fallback)
   }
   const tv = KB_THEME_VARS[theme][mode]
+  const primaryBrand = get('primary', kb.primaryColorLight, kb.primaryColorDark)
   const decls: Array<[string, string]> = [
-    ['--kb-primary', get('primary', kb.primaryColorLight, kb.primaryColorDark)],
+    // 12-step scales (primary + neutral). Step 9 of primary is overridden with
+    // the user-supplied brand color so admin-picked colors still drive the
+    // solid CTA bg; the rest of the scale uses the curated reference values.
+    ...scaleDecls('--kb-primary', PRIMARY_SCALE, mode, { override9: primaryBrand }),
+    ...scaleDecls('--kb-neutral', NEUTRAL_SCALE, mode),
+    // Flat tokens (info/warning/danger/success keep the single-color shape;
+    // tint stays user-supplied for brand-tinted surfaces in the gradient theme).
     ['--kb-tint', get('tint', kb.tintColorLight, kb.tintColorDark)],
     ['--kb-info', get('info', kb.infoColorLight, kb.infoColorDark)],
     ['--kb-success', get('success', kb.successColorLight, kb.successColorDark)],
     ['--kb-warning', get('warning', kb.warningColorLight, kb.warningColorDark)],
     ['--kb-danger', get('danger', kb.dangerColorLight, kb.dangerColorDark)],
-    ['--kb-bg', KB_TOKEN_DEFAULTS.bg[mode]],
-    ['--kb-fg', KB_TOKEN_DEFAULTS.fg[mode]],
-    ['--kb-muted', KB_TOKEN_DEFAULTS.muted[mode]],
+    // Backward-compat aliases — existing components consume these. Resolved
+    // through the scale so the rest of the codebase picks up the new palette
+    // without a sweep.
+    ['--kb-primary', 'var(--kb-primary-9)'],
+    ['--kb-bg', 'var(--kb-neutral-1)'],
+    ['--kb-fg', 'var(--kb-neutral-12)'],
+    ['--kb-muted', 'var(--kb-neutral-3)'],
     ['--kb-border', tv.surfaceBorder],
     ['--kb-page-bg', tv.pageBg],
     ['--kb-surface-bg', tv.surfaceBg],
@@ -237,6 +410,24 @@ function buildModeVars(kb: KBThemeInput, mode: KBMode, theme: KBTheme): string {
     ['--kb-heading-scale', tv.headingScale],
   ]
   return decls.map(([k, v]) => `${k}: ${v};`).join(' ')
+}
+
+function scaleDecls(
+  prefix: string,
+  scale: FamilyScale,
+  mode: KBMode,
+  opts: { override9?: string } = {}
+): Array<[string, string]> {
+  const colors = mode === 'dark' ? scale.dark : scale.light
+  const contrasts = mode === 'dark' ? scale.contrastDark : scale.contrastLight
+  const out: Array<[string, string]> = []
+  for (let i = 0; i < 12; i++) {
+    const step = i + 1
+    const value = step === 9 && opts.override9 ? opts.override9 : colors[i]
+    out.push([`${prefix}-${step}`, value])
+    out.push([`${prefix}-contrast-${step}`, contrasts[i]])
+  }
+  return out
 }
 
 function escapeAttr(value: string): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -803,6 +803,9 @@ importers:
       postcss:
         specifier: 'catalog:'
         version: 8.5.6
+      prettier:
+        specifier: ^3.8.1
+        version: 3.8.1
       rimraf:
         specifier: 'catalog:'
         version: 5.0.10


### PR DESCRIPTION
## Summary

Three related fixes for the public KB app under Next 16 + `cacheComponents`:

- **cacheComponents Suspense violation** — `cookies()` was read at the top of `[orgSlug]/[kbSlug]/layout.tsx` outside any `<Suspense>`, 500'ing every PUBLIC article route. Drop the server-side cookie read; cached layout SSRs with `kb.defaultMode` and a new inline `NoFlashModeScript` inside `KBThemeProvider` flips `data-kb-mode` from the `kb-mode-${id}` cookie before paint (next-themes pattern). `<html>` gets `suppressHydrationWarning` + CSS `:has()` rules so html bg + `color-scheme` match the active mode for overscroll, scrollbars, and pre-paint areas.
- **Prettier compile warning** — `@react-email/render` (transitively via `@auxx/lib/files/server`) soft-imports `prettier` which Next 16 keeps in default `serverExternalPackages`. Add `prettier@^3.8.1` to kb dev deps, matching `apps/web`.
- **12-step primary + neutral palette** — replace single-color `clean`-theme tokens with hand-curated 12-step Radix-style scales, paired with `contrast-*` foregrounds. Dark values mirror the supplied reference palette exactly (`primary-9 = rgb(52,109,219)`, `neutral-1 = rgb(29,29,29)`, etc.). Step 9 of primary is overridden by the user-supplied brand color so admin theming still drives CTAs. Existing `--kb-primary` / `--kb-fg` / `--kb-muted` are aliased to the new scale steps so the 113 existing call sites pick up the new colors with no sweep.

Also: kb root `/` redirect now uses `HOMEPAGE_URL` from `@auxx/config/urls` instead of the hardcoded `https://auxx.ai` fallback, so dev redirects to localhost:3001.

## Test plan

- [ ] Hit `/<orgSlug>/<kbSlug>/...` on a PUBLIC kb in dev → renders 200 (no Suspense error in console).
- [ ] Toggle dark mode via `<KBModeToggle>` → cookie is written, DOM flips. Hard reload → first paint already shows the cookie value (no flash) thanks to the inline script.
- [ ] Compare overscroll / scrollbar bg in dark mode → matches `#1d1d1d`, not white.
- [ ] Console clean of both the `Uncached data was accessed outside of <Suspense>` error and the `Package prettier can't be external` warning.
- [ ] Visual check on the `clean` dark theme: page bg `rgb(29,29,29)`, raised surface `rgb(34,34,34)`, brand blue `#346ddb`. Light theme still readable.
- [ ] Hit private (INTERNAL) kb path → auth gate still works inside `<Suspense>`; no flash; correct mode.
- [ ] Hit kb root `/` in dev → 307 to `http://localhost:3001/` instead of `https://auxx.ai`.