### PR TITLE
feat(kb-admin): article status dots + breadcrumb KB switcher

### DIFF
--- a/apps/web/src/components/kb/ui/articles/articles-view.tsx
+++ b/apps/web/src/components/kb/ui/articles/articles-view.tsx
@@ -19,11 +19,12 @@ import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dro
 import {
   MainPage,
   MainPageBreadcrumb,
+  MainPageBreadcrumbDropdown,
   MainPageBreadcrumbItem,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { toastError } from '@auxx/ui/components/toast'
-import { Archive, FileText, Globe, GlobeLock, Plus, Trash2 } from 'lucide-react'
+import { Archive, Book, FileText, Globe, GlobeLock, Plus, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { CellSelectionConfig } from '~/components/dynamic-table'
@@ -51,6 +52,7 @@ import {
   KnowledgeBaseDialog,
   type KnowledgeBaseFormValues,
 } from '../dialogs/kb-knowledge-base-dialog'
+import { KBSwitcherDropdownContent } from '../sidebar/kb-switcher'
 
 /** The resource slug + (system) tableId for articles. */
 const ARTICLE_SLUG = 'article'
@@ -427,7 +429,18 @@ export function ArticlesView() {
             </Button>
           }>
           <MainPageBreadcrumb>
-            <MainPageBreadcrumbItem title='Knowledge Base' href='/app/kb' last />
+            <MainPageBreadcrumbItem
+              title='Knowledge Bases'
+              href='/app/kb'
+              className='hidden sm:inline-flex'
+            />
+            <MainPageBreadcrumbDropdown
+              label='Open a knowledge base'
+              icon={<Book className='size-3.5' />}
+              last
+              contentClassName='w-72'>
+              <KBSwitcherDropdownContent />
+            </MainPageBreadcrumbDropdown>
           </MainPageBreadcrumb>
         </MainPageHeader>
         <DynamicResourceView<ArticleRow>

--- a/apps/web/src/components/kb/ui/editor/article-publish-cluster.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-publish-cluster.tsx
@@ -52,12 +52,12 @@ export function ArticlePublishCluster({ article, knowledgeBaseId }: ArticlePubli
   const noun = kindNoun(article.articleKind)
 
   const dotClass = isArchived
-    ? 'bg-muted-foreground'
+    ? 'bg-red-500'
     : isPublished
       ? hasUnsaved
         ? 'bg-amber-500'
         : 'bg-emerald-500'
-      : 'bg-muted-foreground'
+      : 'bg-slate-400'
   const pillLabel = isArchived ? 'Archived' : isPublished ? 'Live' : 'Draft'
 
   const handlePublishChanges = async () => {

--- a/apps/web/src/components/kb/ui/sidebar/article-sidebar-item.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/article-sidebar-item.tsx
@@ -44,6 +44,7 @@ import {
 } from 'lucide-react'
 import { usePathname, useRouter } from 'next/navigation'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { Tooltip } from '~/components/global/tooltip'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { useArticleList } from '../../hooks/use-article-list'
@@ -54,6 +55,45 @@ import { usePendingInsertStore } from '../../store/pending-insert-store'
 import { ArticleSettingsDialog } from '../editor/article-settings-dialog'
 import { ArticleInsertLine } from './article-insert-line'
 import { RenameInput } from './rename-input'
+
+function StatusDot({
+  isPublished,
+  hasUnpublishedChanges,
+  isArchived,
+  withTooltip = true,
+}: {
+  isPublished: boolean
+  hasUnpublishedChanges: boolean
+  isArchived: boolean
+  withTooltip?: boolean
+}) {
+  const { color, label } = isArchived
+    ? { color: 'bg-red-500', label: 'Archived' }
+    : !isPublished
+      ? { color: 'bg-slate-400', label: 'Draft' }
+      : hasUnpublishedChanges
+        ? { color: 'bg-amber-500', label: 'Unpublished changes' }
+        : { color: 'bg-emerald-500', label: 'Live' }
+
+  if (!withTooltip) {
+    return (
+      <span
+        className={cn('ml-1.5 inline-block size-1.5 shrink-0 rounded-full', color)}
+        aria-label={label}
+      />
+    )
+  }
+
+  return (
+    <Tooltip content={label}>
+      <span
+        className='ml-0.5 inline-flex shrink-0 cursor-default items-center justify-center p-1.5'
+        aria-label={label}>
+        <span className={cn('inline-block size-1.5 rounded-full', color)} />
+      </span>
+    </Tooltip>
+  )
+}
 
 interface ArticleSidebarItemProps {
   article: ArticleTreeNode
@@ -469,10 +509,11 @@ export function ArticleSidebarItem({
                   {displayName || (isHeader ? 'Untitled' : '')}
                 </span>
               )}
-              {article.hasUnpublishedChanges && article.isPublished && (
-                <span
-                  className='ml-1.5 inline-block size-1.5 shrink-0 rounded-full bg-amber-500'
-                  title='Unsaved changes'
+              {!isHeader && !isLink && (
+                <StatusDot
+                  isPublished={article.isPublished}
+                  hasUnpublishedChanges={article.hasUnpublishedChanges}
+                  isArchived={isArchived}
                 />
               )}
               {!isHeader && isCategory && (
@@ -625,10 +666,12 @@ export function ArticleSidebarItemPreview({
       <span className={cn('truncate', isCategory && 'font-medium text-foreground')}>
         {article.title || 'Untitled'}
       </span>
-      {article.hasUnpublishedChanges && article.isPublished && (
-        <span
-          className='ml-1.5 inline-block size-1.5 shrink-0 rounded-full bg-amber-500'
-          title='Unsaved changes'
+      {!isLinkPreview && (
+        <StatusDot
+          isPublished={article.isPublished}
+          hasUnpublishedChanges={article.hasUnpublishedChanges}
+          isArchived={isArchived}
+          withTooltip={false}
         />
       )}
       {isArchived ? (


### PR DESCRIPTION
## Summary

- **Sidebar status dots:** extract `StatusDot` and render it on every article — live / draft / archived / unpublished-changes — with a tooltip in the live tree and bare in the drag preview. Previously only unpublished-changes-on-published-articles showed an amber dot, so drafts and archived were visually indistinguishable from live ones.
- **Publish cluster colors:** align with the new sidebar palette — archived = `red-500`, draft = `slate-400` (was `muted-foreground` for both).
- **Articles list breadcrumb:** add `MainPageBreadcrumbDropdown` with `KBSwitcherDropdownContent` so users can switch KBs from the top crumb instead of bouncing back to `/app/kb`.

## Test plan

- [ ] Sidebar tree: each article shows a dot — live (green), unpublished changes (amber), draft (slate), archived (red). Hover → tooltip shows the label.
- [ ] Drag preview: dot still renders without tooltip wrapper.
- [ ] Headers and link articles: no dot (status not meaningful).
- [ ] Publish cluster pill matches the sidebar dot color in each state.
- [ ] `/app/kb/...` articles view: breadcrumb shows `Knowledge Bases` (hidden on mobile) + dropdown trigger labeled "Open a knowledge base" with the KB switcher inside.