### PR TITLE
chore(kb): add /health endpoint for deploy probes

### DIFF
--- a/apps/kb/src/app/health/route.ts
+++ b/apps/kb/src/app/health/route.ts
@@ -1,0 +1,16 @@
+// apps/kb/src/app/health/route.ts
+import { NextResponse } from 'next/server'
+
+export async function GET(): Promise<NextResponse> {
+  return NextResponse.json(
+    {
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+      version: process.env.APP_VERSION || 'dev',
+      sha: process.env.GIT_SHA?.slice(0, 7) || 'local',
+      buildTime: process.env.BUILD_TIME || null,
+      app: 'kb',
+    },
+    { status: 200 }
+  )
+}


### PR DESCRIPTION
## Summary

- New `apps/kb/src/app/health/route.ts` — `GET /health` returns `{ status, timestamp, version, sha, buildTime, app }` JSON, mirroring the convention used by the other apps so Railway / SST health checks can hit kb the same way.
- Reads `APP_VERSION`, `GIT_SHA`, `BUILD_TIME` from env (with `dev` / `local` / `null` fallbacks for local).

## Test plan

- [ ] `curl http://localhost:3002/health` → 200 with the JSON body.
- [ ] In the deployed env, the configured probe path (`/health`) responds 200.