### PR TITLE
feat(kopilot): lambda streaming response probe (spike)

### DIFF
--- a/apps/lambda/build.sh
+++ b/apps/lambda/build.sh
@@ -35,6 +35,7 @@ deno compile \
   --allow-env \
   --allow-read \
   --allow-write=/tmp \
+  --allow-sys \
   --output "$DIST_DIR/bootstrap" \
   "$BUILD_DIR/src/lambda-runtime.ts"
 

--- a/apps/lambda/src/dev-server.ts
+++ b/apps/lambda/src/dev-server.ts
@@ -13,6 +13,7 @@
 
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts'
 import { handler } from './index.ts'
+import { streamingProbe } from './test-handlers/streaming-probe.ts'
 import type { LambdaEvent } from './types.ts'
 
 const PORT = parseInt(Deno.env.get('PORT') || '3008', 10)
@@ -29,6 +30,42 @@ async function handleRequest(req: Request): Promise<Response> {
     return new Response(JSON.stringify({ status: 'ok', port: PORT }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  // SPIKE: streaming response probe — yields SSE events for cadence testing.
+  // See plans/kopilot/apps/lambda-streaming-spike.md
+  if (url.pathname === '/stream-probe' && req.method === 'POST') {
+    let opts: { steps?: number; intervalMs?: number } = {}
+    try {
+      const text = await req.text()
+      if (text) opts = JSON.parse(text)
+    } catch {
+      // empty/invalid body → defaults
+    }
+
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        try {
+          for await (const ev of streamingProbe(opts)) {
+            const chunk = `event: ${ev.event}\ndata: ${JSON.stringify(ev.data)}\n\n`
+            controller.enqueue(encoder.encode(chunk))
+          }
+        } finally {
+          controller.close()
+        }
+      },
+    })
+
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache, no-transform',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      },
     })
   }
 

--- a/apps/lambda/src/test-handlers/streaming-probe.ts
+++ b/apps/lambda/src/test-handlers/streaming-probe.ts
@@ -1,0 +1,45 @@
+// apps/lambda/src/test-handlers/streaming-probe.ts
+
+/**
+ * Streaming probe handler — yields 3 progress events at 500ms intervals
+ * followed by a result event. Used only by the lambda-streaming spike to
+ * verify that chunks arrive at the caller on cadence (not buffered).
+ *
+ * SPIKE: see plans/kopilot/apps/lambda-streaming-spike.md
+ * Delete this file (and the streaming-probe branch in lambda-runtime.ts)
+ * once the spike verdict is in.
+ */
+
+import type { StreamEvent } from '../runtime/stream-response.ts'
+
+export async function* streamingProbe(opts: {
+  steps?: number
+  intervalMs?: number
+}): AsyncGenerator<StreamEvent> {
+  const steps = opts.steps ?? 3
+  const intervalMs = opts.intervalMs ?? 500
+  const startedAt = Date.now()
+
+  for (let i = 1; i <= steps; i++) {
+    yield {
+      event: 'progress',
+      data: {
+        step: i,
+        total: steps,
+        elapsedMs: Date.now() - startedAt,
+        emittedAt: Date.now(),
+      },
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+
+  yield {
+    event: 'result',
+    data: {
+      ok: true,
+      steps,
+      totalElapsedMs: Date.now() - startedAt,
+      emittedAt: Date.now(),
+    },
+  }
+}

--- a/apps/web/src/app/api/kopilot/_spike-stream/route.ts
+++ b/apps/web/src/app/api/kopilot/_spike-stream/route.ts
@@ -1,0 +1,95 @@
+// apps/web/src/app/api/kopilot/_spike-stream/route.ts
+
+/**
+ * SPIKE: Lambda response-streaming end-to-end test route.
+ *
+ * Calls the lambda `streaming-probe` handler via `invokeLambdaExecutorStreaming`
+ * and forwards each event as SSE to the browser. Used to verify that AWS
+ * Lambda `RESPONSE_STREAM` mode delivers chunks on cadence (not buffered) all
+ * the way through Function URL → Node fetch → Next.js SSE → browser.
+ *
+ * Delete this route once the spike verdict is in.
+ * See plans/kopilot/apps/lambda-streaming-spike.md
+ */
+
+import { invokeLambdaExecutorStreaming } from '@auxx/services/lambda-execution'
+import type { NextRequest } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function POST(request: NextRequest) {
+  if (process.env.NODE_ENV === 'production') {
+    return new Response('Spike route disabled in production', { status: 404 })
+  }
+
+  let body: { steps?: number; intervalMs?: number } = {}
+  try {
+    body = await request.json()
+  } catch {
+    // empty body is fine — use defaults
+  }
+
+  const encoder = new TextEncoder()
+  const startedAt = Date.now()
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = (event: string, data: unknown) => {
+        try {
+          controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`))
+        } catch {
+          // ignore — controller might be closed
+        }
+      }
+
+      send('spike-start', { startedAt, payload: body })
+
+      const result = await invokeLambdaExecutorStreaming({
+        payload: { type: 'streaming-probe', steps: body.steps, intervalMs: body.intervalMs },
+        caller: 'kopilot-spike',
+        onEvent: (ev) => {
+          send('lambda-event', {
+            event: ev.event,
+            data: ev.data,
+            forwardedAt: Date.now(),
+            elapsedSinceStart: Date.now() - startedAt,
+          })
+        },
+      })
+
+      if (result.isErr()) {
+        send('spike-error', { error: result.error })
+      } else {
+        send('spike-complete', {
+          ttfbMs: result.value.ttfbMs,
+          totalDurationMs: result.value.totalDurationMs,
+          eventCount: result.value.eventCount,
+          finalResult: result.value.finalResult,
+        })
+      }
+
+      try {
+        controller.close()
+      } catch {
+        // already closed
+      }
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}
+
+export async function GET() {
+  return new Response(
+    'POST { "steps"?: number, "intervalMs"?: number } to this route to run the lambda streaming spike. See plans/kopilot/apps/lambda-streaming-spike.md',
+    { status: 200, headers: { 'Content-Type': 'text/plain' } }
+  )
+}

--- a/packages/services/src/lambda-execution/index.ts
+++ b/packages/services/src/lambda-execution/index.ts
@@ -6,4 +6,10 @@ export type {
   LambdaExecutionResult,
 } from './invoke-lambda-executor'
 export { invokeLambdaExecutor } from './invoke-lambda-executor'
+export {
+  invokeLambdaExecutorStreaming,
+  type StreamEvent,
+  type StreamingInvocationError,
+  type StreamingInvocationResult,
+} from './invoke-lambda-executor-streaming'
 export { prepareLambdaContext } from './prepare-lambda-context'

--- a/packages/services/src/lambda-execution/invoke-lambda-executor-streaming.ts
+++ b/packages/services/src/lambda-execution/invoke-lambda-executor-streaming.ts
@@ -1,0 +1,165 @@
+// packages/services/src/lambda-execution/invoke-lambda-executor-streaming.ts
+
+/**
+ * SPIKE: streaming-aware lambda invocation.
+ *
+ * Mirrors `invokeLambdaExecutor` but reads the response body as a chunked
+ * SSE stream and forwards each event via `onEvent`. Used to verify that
+ * AWS Lambda `RESPONSE_STREAM` mode delivers chunks on cadence end-to-end.
+ *
+ * See plans/kopilot/apps/lambda-streaming-spike.md
+ */
+
+import { INTERNAL_LAMBDA_URL } from '@auxx/config/server'
+import { signInboundRequest } from '@auxx/credentials/lambda-auth'
+import type { Result } from 'neverthrow'
+import { err, ok } from 'neverthrow'
+
+export interface StreamEvent {
+  event: string
+  data: unknown
+  /** Timestamp (ms) when this event was received by the caller — for cadence measurement */
+  receivedAt: number
+}
+
+export interface StreamingInvocationResult {
+  /** The terminal `result` event's data, if one was emitted */
+  finalResult: unknown
+  /** Total events received (including `result`) */
+  eventCount: number
+  /** Total wall-clock duration from fetch start to stream end */
+  totalDurationMs: number
+  /** Time from fetch start to first chunk arriving */
+  ttfbMs: number
+}
+
+export interface StreamingInvocationError {
+  code: string
+  message: string
+  statusCode: number
+}
+
+/**
+ * Parse SSE frames (`event:`, `data:`) from a buffered string.
+ * Returns parsed events and the leftover (incomplete) frame.
+ */
+function parseSseFrames(buffer: string): {
+  events: Array<{ event: string; data: unknown }>
+  leftover: string
+} {
+  const events: Array<{ event: string; data: unknown }> = []
+  const frames = buffer.split('\n\n')
+  const leftover = frames.pop() ?? ''
+
+  for (const frame of frames) {
+    if (!frame.trim()) continue
+    let eventName = 'message'
+    let dataLine = ''
+    for (const line of frame.split('\n')) {
+      if (line.startsWith('event:')) eventName = line.slice(6).trim()
+      else if (line.startsWith('data:')) dataLine += line.slice(5).trim()
+    }
+    if (!dataLine) continue
+    try {
+      events.push({ event: eventName, data: JSON.parse(dataLine) })
+    } catch {
+      events.push({ event: eventName, data: dataLine })
+    }
+  }
+
+  return { events, leftover }
+}
+
+export async function invokeLambdaExecutorStreaming(params: {
+  payload: any
+  caller: string
+  /** Optional path on the lambda-server (default `/stream-probe` for the spike). */
+  path?: string
+  lambdaUrl?: string
+  onEvent: (ev: StreamEvent) => void
+}): Promise<Result<StreamingInvocationResult, StreamingInvocationError>> {
+  const {
+    payload,
+    caller,
+    path = '/stream-probe',
+    lambdaUrl = INTERNAL_LAMBDA_URL,
+    onEvent,
+  } = params
+
+  try {
+    const body = JSON.stringify(payload)
+    const secret = process.env.LAMBDA_INVOKE_SECRET
+    const authHeaders = secret ? signInboundRequest({ body, caller, secret }) : {}
+
+    // lambdaUrl may be `https://host` or `https://host/`; join cleanly with path
+    const base = lambdaUrl.replace(/\/$/, '')
+    const targetUrl = `${base}${path.startsWith('/') ? path : `/${path}`}`
+
+    const startedAt = Date.now()
+    const response = await fetch(targetUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+        ...authHeaders,
+      },
+      body,
+    })
+
+    if (!response.ok || !response.body) {
+      return err({
+        code: 'STREAM_INVOCATION_FAILED',
+        message: `Lambda returned ${response.status}`,
+        statusCode: response.status,
+      })
+    }
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    let ttfbMs: number | null = null
+    let eventCount = 0
+    let finalResult: unknown = null
+
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (ttfbMs === null) ttfbMs = Date.now() - startedAt
+
+      buffer += decoder.decode(value, { stream: true })
+      const { events, leftover } = parseSseFrames(buffer)
+      buffer = leftover
+
+      for (const ev of events) {
+        eventCount += 1
+        const wrapped: StreamEvent = { ...ev, receivedAt: Date.now() }
+        onEvent(wrapped)
+        if (ev.event === 'result') finalResult = ev.data
+      }
+    }
+
+    // Flush any trailing frame
+    if (buffer.trim()) {
+      const { events } = parseSseFrames(`${buffer}\n\n`)
+      for (const ev of events) {
+        eventCount += 1
+        onEvent({ ...ev, receivedAt: Date.now() })
+        if (ev.event === 'result') finalResult = ev.data
+      }
+    }
+
+    return ok({
+      finalResult,
+      eventCount,
+      totalDurationMs: Date.now() - startedAt,
+      ttfbMs: ttfbMs ?? -1,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return err({
+      code: 'STREAM_INVOCATION_ERROR',
+      message: `Failed to stream from Lambda: ${message}`,
+      statusCode: 500,
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- Exploratory plumbing for SSE-style streaming from the Railway-hosted `apps/lambda` to a Next route
- Adds `/stream-probe` dev endpoint in `apps/lambda/src/dev-server.ts` emitting cadence events from `test-handlers/streaming-probe.ts`
- New `invokeLambdaExecutorStreaming` export in `@auxx/services/lambda-execution`
- Next route at `apps/web/src/app/api/kopilot/_spike-stream/route.ts` for end-to-end timing
- `--allow-sys` added to the deno compile step in `build.sh`

Tracking doc: `plans/kopilot/apps/lambda-streaming-spike.md`. The `_spike-stream` underscore prefix marks the route as throwaway exploratory code.

## Test plan
- [ ] POST to `/stream-probe` on the local lambda dev server returns an SSE stream with the expected cadence
- [ ] GET `/api/kopilot/_spike-stream` from the web app proxies the stream and measures end-to-end timing
- [ ] `apps/lambda/build.sh` still produces a working bootstrap binary with `--allow-sys`