### PR TITLE
feat(agents): phase 2 admin UI + service-layer refactor

### DIFF
--- a/apps/web/src/app/(protected)/app/agents/[slug]/page.tsx
+++ b/apps/web/src/app/(protected)/app/agents/[slug]/page.tsx
@@ -1,0 +1,97 @@
+// apps/web/src/app/(protected)/app/agents/[slug]/page.tsx
+'use client'
+
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageContent,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { Lock } from 'lucide-react'
+import { useParams } from 'next/navigation'
+import { AgentsProvider } from '~/components/agents'
+import { useAgent } from '~/components/agents/hooks/use-agent'
+import { AgentDetailView } from '~/components/agents/ui/detail/agent-detail-view'
+import { EmptyState } from '~/components/global/empty-state'
+import { useUser } from '~/hooks/use-user'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+
+function AgentDetailLoader({ slug }: { slug: string }) {
+  const { detail, isLoading } = useAgent(slug)
+
+  if (isLoading && !detail) {
+    return (
+      <MainPage>
+        <MainPageHeader>
+          <MainPageBreadcrumb>
+            <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
+            <MainPageBreadcrumbItem title='Agents' href='/app/agents' />
+            <MainPageBreadcrumbItem title='Loading…' last />
+          </MainPageBreadcrumb>
+        </MainPageHeader>
+        <MainPageContent>
+          <div className='p-6 text-sm text-muted-foreground'>Loading agent…</div>
+        </MainPageContent>
+      </MainPage>
+    )
+  }
+
+  if (!detail) {
+    return (
+      <MainPage>
+        <MainPageHeader>
+          <MainPageBreadcrumb>
+            <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
+            <MainPageBreadcrumbItem title='Agents' href='/app/agents' />
+            <MainPageBreadcrumbItem title='Not found' last />
+          </MainPageBreadcrumb>
+        </MainPageHeader>
+        <MainPageContent>
+          <EmptyState
+            title='Agent not found'
+            description='This agent may have been deleted.'
+            button={<div className='h-12' />}
+          />
+        </MainPageContent>
+      </MainPage>
+    )
+  }
+
+  return <AgentDetailView agent={detail} />
+}
+
+export default function AgentDetailPage() {
+  const params = useParams<{ slug: string }>()
+  const slug = params?.slug
+  const { hasAccess } = useFeatureFlags()
+  const { isAdminOrOwner } = useUser()
+
+  if (!hasAccess(FeatureKey.agents) || !isAdminOrOwner) {
+    return (
+      <MainPage>
+        <MainPageHeader>
+          <MainPageBreadcrumb>
+            <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
+            <MainPageBreadcrumbItem title='Agents' last />
+          </MainPageBreadcrumb>
+        </MainPageHeader>
+        <MainPageContent>
+          <EmptyState
+            icon={Lock}
+            title='Agents Not Available'
+            description='Agents are admin-only and require the agents feature on your plan.'
+            button={<div className='h-12' />}
+          />
+        </MainPageContent>
+      </MainPage>
+    )
+  }
+
+  return (
+    <AgentsProvider>
+      <AgentDetailLoader slug={slug ?? ''} />
+    </AgentsProvider>
+  )
+}

--- a/apps/web/src/app/(protected)/app/agents/new/page.tsx
+++ b/apps/web/src/app/(protected)/app/agents/new/page.tsx
@@ -1,0 +1,51 @@
+// apps/web/src/app/(protected)/app/agents/new/page.tsx
+'use client'
+
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageContent,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { Lock } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { AgentsProvider } from '~/components/agents'
+import { AgentDetailNewView } from '~/components/agents/ui/detail/agent-detail-view'
+import { EmptyState } from '~/components/global/empty-state'
+import { useUser } from '~/hooks/use-user'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+
+export default function AgentNewPage() {
+  const router = useRouter()
+  const { hasAccess } = useFeatureFlags()
+  const { isAdminOrOwner } = useUser()
+
+  if (!hasAccess(FeatureKey.agents) || !isAdminOrOwner) {
+    return (
+      <MainPage>
+        <MainPageHeader>
+          <MainPageBreadcrumb>
+            <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
+            <MainPageBreadcrumbItem title='Agents' last />
+          </MainPageBreadcrumb>
+        </MainPageHeader>
+        <MainPageContent>
+          <EmptyState
+            icon={Lock}
+            title='Agents Not Available'
+            description='Agents are admin-only and require the agents feature on your plan.'
+            button={<div className='h-12' />}
+          />
+        </MainPageContent>
+      </MainPage>
+    )
+  }
+
+  return (
+    <AgentsProvider>
+      <AgentDetailNewView onCreated={(slug) => router.replace(`/app/agents/${slug}`)} />
+    </AgentsProvider>
+  )
+}

--- a/apps/web/src/app/(protected)/app/agents/page.tsx
+++ b/apps/web/src/app/(protected)/app/agents/page.tsx
@@ -1,0 +1,49 @@
+// apps/web/src/app/(protected)/app/agents/page.tsx
+'use client'
+
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageContent,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { Lock } from 'lucide-react'
+import { AgentsProvider } from '~/components/agents'
+import { AgentsPageContent } from '~/components/agents/ui/list/agents-page-content'
+import { EmptyState } from '~/components/global/empty-state'
+import { useUser } from '~/hooks/use-user'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+
+export default function AgentsPage() {
+  const { hasAccess } = useFeatureFlags()
+  const { isAdminOrOwner } = useUser()
+
+  if (!hasAccess(FeatureKey.agents) || !isAdminOrOwner) {
+    return (
+      <MainPage>
+        <MainPageHeader>
+          <MainPageBreadcrumb>
+            <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
+            <MainPageBreadcrumbItem title='Agents' last />
+          </MainPageBreadcrumb>
+        </MainPageHeader>
+        <MainPageContent>
+          <EmptyState
+            icon={Lock}
+            title='Agents Not Available'
+            description='Agents are admin-only and require the agents feature on your plan.'
+            button={<div className='h-12' />}
+          />
+        </MainPageContent>
+      </MainPage>
+    )
+  }
+
+  return (
+    <AgentsProvider>
+      <AgentsPageContent />
+    </AgentsProvider>
+  )
+}

--- a/apps/web/src/components/agents/constant.ts
+++ b/apps/web/src/components/agents/constant.ts
@@ -1,0 +1,8 @@
+// apps/web/src/components/agents/constant.ts
+
+/** Default tab on the agent detail page. */
+export const DEFAULT_AGENT_TAB = 'prompt'
+
+/** Tab keys used by the agent detail page. */
+export const AGENT_TABS = ['prompt', 'tools', 'knowledge'] as const
+export type AgentTab = (typeof AGENT_TABS)[number]

--- a/apps/web/src/components/agents/hooks/index.ts
+++ b/apps/web/src/components/agents/hooks/index.ts
@@ -1,0 +1,6 @@
+// apps/web/src/components/agents/hooks/index.ts
+
+export { useAgent } from './use-agent'
+export { useAgentMutations } from './use-agent-mutations'
+export { useAgentSearch } from './use-agent-search'
+export { useAgents } from './use-agents'

--- a/apps/web/src/components/agents/hooks/use-agent-mutations.ts
+++ b/apps/web/src/components/agents/hooks/use-agent-mutations.ts
@@ -1,0 +1,118 @@
+// apps/web/src/components/agents/hooks/use-agent-mutations.ts
+'use client'
+
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback } from 'react'
+import { api } from '~/trpc/react'
+import { getAgentStoreState } from '../store/agent-store'
+
+interface CreateAgentInput {
+  name: string
+  slug: string
+  description?: string | null
+}
+
+interface UpdateAgentInput {
+  name?: string
+  description?: string | null
+  modelId?: string | null
+  mentionable?: boolean
+  archivedAt?: Date | null
+}
+
+interface UseAgentMutationsResult {
+  createAgent: (input: CreateAgentInput) => Promise<{ agentId: string; slug: string } | undefined>
+  updateAgent: (id: string, patch: UpdateAgentInput) => Promise<boolean>
+  archiveAgent: (id: string) => Promise<boolean>
+  unarchiveAgent: (id: string) => Promise<boolean>
+  isCreating: boolean
+  isUpdating: boolean
+}
+
+/**
+ * Optimistic create/update/archive for agents. Pairs with the agents store so
+ * the list, breadcrumb switcher, and detail header all reflect changes
+ * instantly and reconcile on the next list refetch.
+ */
+export function useAgentMutations(): UseAgentMutationsResult {
+  const utils = api.useUtils()
+  const createMutation = api.agent.create.useMutation()
+  const updateMutation = api.agent.update.useMutation()
+
+  const createAgent = useCallback<UseAgentMutationsResult['createAgent']>(
+    async (input) => {
+      try {
+        const result = await createMutation.mutateAsync({
+          name: input.name,
+          slug: input.slug,
+          description: input.description ?? undefined,
+        })
+        await utils.agent.list.invalidate()
+        return { agentId: result.agentId, slug: input.slug }
+      } catch (error) {
+        toastError({
+          title: 'Failed to create agent',
+          description: error instanceof Error ? error.message : 'Unknown error occurred',
+        })
+        return undefined
+      }
+    },
+    [createMutation, utils.agent.list]
+  )
+
+  const updateAgent = useCallback<UseAgentMutationsResult['updateAgent']>(
+    async (id, patch) => {
+      const store = getAgentStoreState()
+      // Only flat scalars belong in the optimistic patch — keep TS happy.
+      const optimistic: Record<string, unknown> = {}
+      if (patch.name !== undefined) optimistic.name = patch.name
+      if (patch.description !== undefined) optimistic.description = patch.description
+      if (patch.modelId !== undefined) optimistic.modelId = patch.modelId
+      if (patch.mentionable !== undefined) optimistic.mentionable = patch.mentionable
+      if (patch.archivedAt !== undefined) {
+        optimistic.archivedAt = patch.archivedAt ? patch.archivedAt.toISOString() : null
+      }
+      store.setAgentOptimistic(id, optimistic as never)
+      try {
+        await updateMutation.mutateAsync({ agentId: id, ...patch })
+        store.confirmAgentUpdate(id)
+        await Promise.all([utils.agent.list.invalidate(), utils.agent.getById.invalidate()])
+        return true
+      } catch (error) {
+        store.rollbackAgentUpdate(id)
+        toastError({
+          title: 'Failed to update agent',
+          description: error instanceof Error ? error.message : 'Unknown error occurred',
+        })
+        return false
+      }
+    },
+    [updateMutation, utils.agent.list, utils.agent.getById]
+  )
+
+  const archiveAgent = useCallback<UseAgentMutationsResult['archiveAgent']>(
+    async (id) => {
+      const store = getAgentStoreState()
+      store.markAgentArchived(id)
+      const ok = await updateAgent(id, { archivedAt: new Date() })
+      if (ok) store.confirmAgentArchive(id)
+      else store.rollbackAgentArchive(id)
+      return ok
+    },
+    [updateAgent]
+  )
+
+  const unarchiveAgent = useCallback<UseAgentMutationsResult['unarchiveAgent']>(
+    async (id) => updateAgent(id, { archivedAt: null }),
+    [updateAgent]
+  )
+
+  return {
+    createAgent,
+    updateAgent,
+    archiveAgent,
+    unarchiveAgent,
+    isCreating: createMutation.isPending,
+    isUpdating: updateMutation.isPending,
+  }
+}

--- a/apps/web/src/components/agents/hooks/use-agent-search.ts
+++ b/apps/web/src/components/agents/hooks/use-agent-search.ts
@@ -1,0 +1,15 @@
+// apps/web/src/components/agents/hooks/use-agent-search.ts
+'use client'
+
+import { useShallow } from 'zustand/shallow'
+import { useAgentStore } from '../store/agent-store'
+
+/** Read/write the in-memory search string used by the list page. */
+export function useAgentSearch(): { search: string; setSearch: (s: string) => void } {
+  return useAgentStore(
+    useShallow((s) => ({
+      search: s.search,
+      setSearch: s.setSearch,
+    }))
+  )
+}

--- a/apps/web/src/components/agents/hooks/use-agent.ts
+++ b/apps/web/src/components/agents/hooks/use-agent.ts
@@ -1,0 +1,37 @@
+// apps/web/src/components/agents/hooks/use-agent.ts
+'use client'
+
+import { useShallow } from 'zustand/shallow'
+import { api } from '~/trpc/react'
+import {
+  type AgentDetail,
+  type AgentListItem,
+  selectEffectiveAgent,
+  useAgentStore,
+} from '../store/agent-store'
+
+/**
+ * Resolve one agent by id or slug. Returns the cached list-row immediately if
+ * it's already in the store, plus the full detail row fetched via
+ * `api.agent.getById` (whose input accepts either id or slug).
+ */
+export function useAgent(idOrSlug: string | null | undefined): {
+  agent: AgentListItem | undefined
+  detail: AgentDetail | undefined
+  isLoading: boolean
+} {
+  const cached = useAgentStore(
+    useShallow((s) => (idOrSlug ? selectEffectiveAgent(s, idOrSlug) : undefined))
+  )
+
+  const { data, isLoading } = api.agent.getById.useQuery(
+    { agentId: idOrSlug ?? '' },
+    { enabled: !!idOrSlug, staleTime: 30 * 1000 }
+  )
+
+  return {
+    agent: cached,
+    detail: data as AgentDetail | undefined,
+    isLoading,
+  }
+}

--- a/apps/web/src/components/agents/hooks/use-agents.ts
+++ b/apps/web/src/components/agents/hooks/use-agents.ts
@@ -1,0 +1,38 @@
+// apps/web/src/components/agents/hooks/use-agents.ts
+'use client'
+
+import { useEffect } from 'react'
+import { useShallow } from 'zustand/shallow'
+import { api } from '~/trpc/react'
+import {
+  type AgentListItem,
+  getAgentStoreState,
+  selectEffectiveAgents,
+  useAgentStore,
+} from '../store/agent-store'
+
+interface UseAgentsResult {
+  agents: AgentListItem[]
+  isLoading: boolean
+  hasLoadedOnce: boolean
+}
+
+/**
+ * Hydrates the agents store from `api.agent.list` and returns the effective
+ * list (server rows merged with any pending optimistic updates).
+ */
+export function useAgents(): UseAgentsResult {
+  const { data, isLoading } = api.agent.list.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  })
+
+  useEffect(() => {
+    const store = getAgentStoreState()
+    store.setLoading(isLoading)
+    if (data) store.setAgents(data as AgentListItem[])
+  }, [data, isLoading])
+
+  const agents = useAgentStore(useShallow(selectEffectiveAgents))
+  const hasLoadedOnce = useAgentStore((s) => s.hasLoadedOnce)
+  return { agents, isLoading, hasLoadedOnce }
+}

--- a/apps/web/src/components/agents/index.ts
+++ b/apps/web/src/components/agents/index.ts
@@ -1,0 +1,6 @@
+// apps/web/src/components/agents/index.ts
+
+export { AGENT_TABS, type AgentTab, DEFAULT_AGENT_TAB } from './constant'
+export { useAgent, useAgentMutations, useAgentSearch, useAgents } from './hooks'
+export { AgentsProvider } from './providers'
+export type { AgentDetail, AgentListItem } from './store'

--- a/apps/web/src/components/agents/providers/agents-provider.tsx
+++ b/apps/web/src/components/agents/providers/agents-provider.tsx
@@ -1,0 +1,14 @@
+// apps/web/src/components/agents/providers/agents-provider.tsx
+'use client'
+
+import { useAgents } from '../hooks/use-agents'
+
+/**
+ * Hydrates the agents Zustand store from `api.agent.list`. Wrap any surface
+ * that reads agents from the store (list page, detail page, breadcrumb
+ * switcher) so the store is populated before children render.
+ */
+export function AgentsProvider({ children }: { children: React.ReactNode }) {
+  useAgents()
+  return <>{children}</>
+}

--- a/apps/web/src/components/agents/providers/index.ts
+++ b/apps/web/src/components/agents/providers/index.ts
@@ -1,0 +1,3 @@
+// apps/web/src/components/agents/providers/index.ts
+
+export { AgentsProvider } from './agents-provider'

--- a/apps/web/src/components/agents/store/agent-store.ts
+++ b/apps/web/src/components/agents/store/agent-store.ts
@@ -1,0 +1,226 @@
+// apps/web/src/components/agents/store/agent-store.ts
+'use client'
+
+import '~/lib/immer-config'
+import { create } from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
+import { immer } from 'zustand/middleware/immer'
+import type { RouterOutputs } from '~/trpc/react'
+
+export type AgentListItem = RouterOutputs['agent']['list'][number]
+export type AgentDetail = RouterOutputs['agent']['getById']
+
+interface PendingAgentUpdate {
+  optimistic: Partial<AgentListItem>
+  original: AgentListItem
+}
+
+interface AgentStoreState {
+  // ─── Server state ──────────────────────────────────────────────────
+  agents: AgentListItem[]
+  agentsById: Record<string, AgentListItem>
+  agentsBySlug: Record<string, AgentListItem>
+  isLoading: boolean
+  hasLoadedOnce: boolean
+
+  // ─── UI state ──────────────────────────────────────────────────────
+  search: string
+
+  // ─── Optimistic state ──────────────────────────────────────────────
+  pendingUpdates: Record<string, PendingAgentUpdate>
+  optimisticNewAgents: Record<string, AgentListItem>
+  optimisticArchived: Set<string>
+
+  // ─── Actions ───────────────────────────────────────────────────────
+  setAgents: (agents: AgentListItem[]) => void
+  applyAgentFromServer: (agent: AgentListItem) => void
+  setLoading: (isLoading: boolean) => void
+  setSearch: (s: string) => void
+
+  setAgentOptimistic: (id: string, updates: Partial<AgentListItem>) => void
+  confirmAgentUpdate: (id: string, server?: AgentListItem) => void
+  rollbackAgentUpdate: (id: string) => void
+
+  addOptimisticAgent: (tempId: string, agent: AgentListItem) => void
+  confirmAgentCreate: (tempId: string, server: AgentListItem) => void
+  rollbackAgentCreate: (tempId: string) => void
+
+  markAgentArchived: (id: string) => void
+  confirmAgentArchive: (id: string) => void
+  rollbackAgentArchive: (id: string) => void
+
+  reset: () => void
+}
+
+export const useAgentStore = create<AgentStoreState>()(
+  subscribeWithSelector(
+    immer((set) => ({
+      agents: [],
+      agentsById: {},
+      agentsBySlug: {},
+      isLoading: false,
+      hasLoadedOnce: false,
+      search: '',
+      pendingUpdates: {},
+      optimisticNewAgents: {},
+      optimisticArchived: new Set<string>(),
+
+      setAgents: (agents) =>
+        set((state) => {
+          state.agents = agents
+          const byId: Record<string, AgentListItem> = {}
+          const bySlug: Record<string, AgentListItem> = {}
+          for (const a of agents) {
+            byId[a.id] = a
+            bySlug[a.slug] = a
+          }
+          state.agentsById = byId
+          state.agentsBySlug = bySlug
+          state.hasLoadedOnce = true
+
+          // Drop pending updates the server has already merged.
+          for (const [id, pending] of Object.entries(state.pendingUpdates)) {
+            const server = byId[id]
+            if (!server) continue
+            const merged = { ...pending.original, ...pending.optimistic } as AgentListItem
+            const matches = (Object.keys(pending.optimistic) as Array<keyof AgentListItem>).every(
+              (k) => server[k] === merged[k]
+            )
+            if (matches) delete state.pendingUpdates[id]
+          }
+          for (const tempId of Object.keys(state.optimisticNewAgents)) {
+            if (byId[tempId]) delete state.optimisticNewAgents[tempId]
+          }
+          for (const id of state.optimisticArchived) {
+            const server = byId[id]
+            if (!server || server.archivedAt) state.optimisticArchived.delete(id)
+          }
+        }),
+
+      applyAgentFromServer: (agent) =>
+        set((state) => {
+          state.agentsById[agent.id] = agent
+          state.agentsBySlug[agent.slug] = agent
+          const idx = state.agents.findIndex((x) => x.id === agent.id)
+          if (idx === -1) state.agents.push(agent)
+          else state.agents[idx] = agent
+          delete state.pendingUpdates[agent.id]
+          state.optimisticArchived.delete(agent.id)
+        }),
+
+      setLoading: (isLoading) =>
+        set((state) => {
+          state.isLoading = isLoading
+        }),
+
+      setSearch: (s) =>
+        set((state) => {
+          state.search = s
+        }),
+
+      setAgentOptimistic: (id, updates) =>
+        set((state) => {
+          const server = state.agentsById[id] ?? state.optimisticNewAgents[id]
+          if (!server) return
+          const existing = state.pendingUpdates[id]
+          state.pendingUpdates[id] = {
+            optimistic: existing ? { ...existing.optimistic, ...updates } : updates,
+            original: existing?.original ?? server,
+          }
+        }),
+
+      confirmAgentUpdate: (id, server) =>
+        set((state) => {
+          delete state.pendingUpdates[id]
+          if (server) {
+            state.agentsById[id] = server
+            state.agentsBySlug[server.slug] = server
+            const idx = state.agents.findIndex((x) => x.id === id)
+            if (idx >= 0) state.agents[idx] = server
+          }
+        }),
+
+      rollbackAgentUpdate: (id) =>
+        set((state) => {
+          delete state.pendingUpdates[id]
+        }),
+
+      addOptimisticAgent: (tempId, agent) =>
+        set((state) => {
+          state.optimisticNewAgents[tempId] = agent
+          state.agents.push(agent)
+        }),
+
+      confirmAgentCreate: (tempId, server) =>
+        set((state) => {
+          delete state.optimisticNewAgents[tempId]
+          state.agentsById[server.id] = server
+          state.agentsBySlug[server.slug] = server
+          const idx = state.agents.findIndex((x) => x.id === tempId)
+          if (idx >= 0) state.agents[idx] = server
+          else state.agents.push(server)
+        }),
+
+      rollbackAgentCreate: (tempId) =>
+        set((state) => {
+          delete state.optimisticNewAgents[tempId]
+          state.agents = state.agents.filter((x) => x.id !== tempId)
+        }),
+
+      markAgentArchived: (id) =>
+        set((state) => {
+          state.optimisticArchived.add(id)
+        }),
+
+      confirmAgentArchive: (id) =>
+        set((state) => {
+          state.optimisticArchived.delete(id)
+        }),
+
+      rollbackAgentArchive: (id) =>
+        set((state) => {
+          state.optimisticArchived.delete(id)
+        }),
+
+      reset: () =>
+        set((state) => {
+          state.agents = []
+          state.agentsById = {}
+          state.agentsBySlug = {}
+          state.isLoading = false
+          state.hasLoadedOnce = false
+          state.search = ''
+          state.pendingUpdates = {}
+          state.optimisticNewAgents = {}
+          state.optimisticArchived.clear()
+        }),
+    }))
+  )
+)
+
+export const getAgentStoreState = () => useAgentStore.getState()
+
+/** Effective list — does NOT remove archived rows; server-side `list` already filters by default. */
+export function selectEffectiveAgents(state: AgentStoreState): AgentListItem[] {
+  return state.agents.map((a) => {
+    const pending = state.pendingUpdates[a.id]
+    return pending ? ({ ...a, ...pending.optimistic } as AgentListItem) : a
+  })
+}
+
+export function selectEffectiveAgent(
+  state: AgentStoreState,
+  idOrSlug: string
+): AgentListItem | undefined {
+  const fromId = state.agentsById[idOrSlug]
+  const fromSlug = state.agentsBySlug[idOrSlug]
+  let a = fromId ?? fromSlug ?? state.optimisticNewAgents[idOrSlug]
+  if (!a) return undefined
+  const pending = state.pendingUpdates[a.id]
+  if (pending) a = { ...a, ...pending.optimistic } as AgentListItem
+  return a
+}
+
+export function selectAgentSearch(state: AgentStoreState): string {
+  return state.search
+}

--- a/apps/web/src/components/agents/store/index.ts
+++ b/apps/web/src/components/agents/store/index.ts
@@ -1,0 +1,11 @@
+// apps/web/src/components/agents/store/index.ts
+
+export {
+  type AgentDetail,
+  type AgentListItem,
+  getAgentStoreState,
+  selectAgentSearch,
+  selectEffectiveAgent,
+  selectEffectiveAgents,
+  useAgentStore,
+} from './agent-store'

--- a/apps/web/src/components/agents/ui/detail/agent-archive-button.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-archive-button.tsx
@@ -1,0 +1,66 @@
+// apps/web/src/components/agents/ui/detail/agent-archive-button.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Archive, ArchiveRestore } from 'lucide-react'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useAgentMutations } from '../../hooks/use-agent-mutations'
+import type { AgentDetail, AgentListItem } from '../../store/agent-store'
+
+interface AgentArchiveButtonProps {
+  agent: Pick<AgentDetail | AgentListItem, 'id' | 'name' | 'archivedAt'>
+  onSavingChange?: (saving: boolean) => void
+  onSaved?: () => void
+}
+
+export function AgentArchiveButton({ agent, onSavingChange, onSaved }: AgentArchiveButtonProps) {
+  const { archiveAgent, unarchiveAgent, isUpdating } = useAgentMutations()
+  const [confirm, ConfirmDialog] = useConfirm()
+  const archived = agent.archivedAt != null
+
+  const handleClick = async () => {
+    if (archived) {
+      onSavingChange?.(true)
+      const ok = await unarchiveAgent(agent.id)
+      onSavingChange?.(false)
+      if (ok) onSaved?.()
+      return
+    }
+    const ok = await confirm({
+      title: 'Archive agent?',
+      description: `"${agent.name}" will stop responding to mentions and triggers.`,
+      confirmText: 'Archive',
+      cancelText: 'Cancel',
+      destructive: false,
+    })
+    if (!ok) return
+    onSavingChange?.(true)
+    const success = await archiveAgent(agent.id)
+    onSavingChange?.(false)
+    if (success) onSaved?.()
+  }
+
+  return (
+    <>
+      <ConfirmDialog />
+      <Button
+        variant='outline'
+        size='sm'
+        onClick={handleClick}
+        loading={isUpdating}
+        loadingText={archived ? 'Unarchiving…' : 'Archiving…'}>
+        {archived ? (
+          <>
+            <ArchiveRestore />
+            Unarchive
+          </>
+        ) : (
+          <>
+            <Archive />
+            Archive
+          </>
+        )}
+      </Button>
+    </>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/agent-breadcrumb-switcher.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-breadcrumb-switcher.tsx
@@ -1,0 +1,22 @@
+// apps/web/src/components/agents/ui/detail/agent-breadcrumb-switcher.tsx
+'use client'
+
+import { MainPageBreadcrumbDropdown } from '@auxx/ui/components/main-page'
+import type { AgentDetail, AgentListItem } from '../../store/agent-store'
+import { AgentAvatar } from '../shared/agent-avatar'
+import { AgentSwitcherDropdownContent } from './agent-switcher-dropdown-content'
+
+interface AgentBreadcrumbSwitcherProps {
+  activeAgent: Pick<AgentDetail | AgentListItem, 'id' | 'name' | 'avatarUrl' | 'slug'>
+}
+
+export function AgentBreadcrumbSwitcher({ activeAgent }: AgentBreadcrumbSwitcherProps) {
+  return (
+    <MainPageBreadcrumbDropdown
+      label={activeAgent.name || activeAgent.slug}
+      icon={<AgentAvatar agent={activeAgent} size={5} className='mr-1' />}
+      last>
+      <AgentSwitcherDropdownContent activeAgentId={activeAgent.id} />
+    </MainPageBreadcrumbDropdown>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
@@ -1,0 +1,170 @@
+// apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
+'use client'
+
+import { Section } from '@auxx/ui/components/section'
+import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
+import { BookOpen, FileText, Wrench } from 'lucide-react'
+import { useQueryState } from 'nuqs'
+import { useCallback, useEffect, useRef } from 'react'
+import { AGENT_TABS, type AgentTab, DEFAULT_AGENT_TAB } from '../../constant'
+import type { AgentDetail } from '../../store/agent-store'
+import { AgentHero } from './agent-hero'
+import { KnowledgeSectionContent } from './tabs/knowledge-tab-placeholder'
+import { PromptSectionContent } from './tabs/prompt-tab-placeholder'
+import { ToolsSectionContent } from './tabs/tools-tab-placeholder'
+
+const SECTION_ICONS: Record<AgentTab, React.ComponentType<{ className?: string }>> = {
+  prompt: FileText,
+  tools: Wrench,
+  knowledge: BookOpen,
+}
+
+const SECTION_LABELS: Record<AgentTab, string> = {
+  prompt: 'Prompt',
+  tools: 'Tools',
+  knowledge: 'Knowledge',
+}
+
+// Sticky tab strip height + small buffer — used as the scroll-spy activation point.
+const STICKY_OFFSET = 56
+
+interface AgentDetailTabsProps {
+  agent: AgentDetail
+}
+
+/**
+ * Renders the agent detail page as a single scrollable column with a sticky
+ * tab strip on top. Clicking a tab scrolls the matching section into view;
+ * scrolling updates the active tab.
+ */
+export function AgentDetailTabs({ agent }: AgentDetailTabsProps) {
+  const [tab, setTab] = useQueryState('tab', { defaultValue: DEFAULT_AGENT_TAB })
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const sectionRefs = useRef<Record<AgentTab, HTMLDivElement | null>>({
+    prompt: null,
+    tools: null,
+    knowledge: null,
+  })
+  const isProgrammaticScrollRef = useRef(false)
+
+  const scrollToSection = useCallback((value: string) => {
+    const target = sectionRefs.current[value as AgentTab]
+    const container = scrollContainerRef.current
+    if (!target || !container) return
+    isProgrammaticScrollRef.current = true
+    const targetRect = target.getBoundingClientRect()
+    const containerRect = container.getBoundingClientRect()
+    container.scrollTo({
+      top: container.scrollTop + (targetRect.top - containerRect.top) - STICKY_OFFSET,
+      behavior: 'smooth',
+    })
+    window.setTimeout(() => {
+      isProgrammaticScrollRef.current = false
+    }, 700)
+  }, [])
+
+  const handleTabChange = useCallback(
+    (value: string) => {
+      setTab(value)
+      scrollToSection(value)
+    },
+    [setTab, scrollToSection]
+  )
+
+  // Scroll-spy: as the user scrolls, switch the active tab to whichever
+  // section is closest to the top of the viewport.
+  useEffect(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+
+    let raf = 0
+    let lastActive: AgentTab | null = (tab as AgentTab) ?? null
+
+    const onScroll = () => {
+      if (isProgrammaticScrollRef.current) return
+      if (raf) cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(() => {
+        const containerRect = container.getBoundingClientRect()
+        const activationY = containerRect.top + STICKY_OFFSET + 8
+        let best: AgentTab | null = null
+        for (const t of AGENT_TABS) {
+          const el = sectionRefs.current[t]
+          if (!el) continue
+          const rect = el.getBoundingClientRect()
+          if (rect.top <= activationY) best = t
+        }
+        if (best && best !== lastActive) {
+          lastActive = best
+          setTab(best)
+        }
+      })
+    }
+
+    container.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      container.removeEventListener('scroll', onScroll)
+      if (raf) cancelAnimationFrame(raf)
+    }
+  }, [setTab, tab])
+
+  const assignRef = (value: AgentTab) => (el: HTMLDivElement | null) => {
+    sectionRefs.current[value] = el
+  }
+
+  return (
+    <div className='flex flex-col flex-1 min-h-0'>
+      <div ref={scrollContainerRef} className='flex-1 overflow-y-auto'>
+        <AgentHero agent={agent} />
+
+        <div className='sticky top-0 z-10 bg-background border-b'>
+          <Tabs value={tab} onValueChange={handleTabChange}>
+            <TabsList className='w-full justify-start rounded-none bg-primary-150 px-2'>
+              {AGENT_TABS.map((value) => {
+                const Icon = SECTION_ICONS[value]
+                return (
+                  <TabsTrigger key={value} value={value} variant='outline'>
+                    <Icon />
+                    {SECTION_LABELS[value]}
+                  </TabsTrigger>
+                )
+              })}
+            </TabsList>
+          </Tabs>
+        </div>
+
+        <div ref={assignRef('prompt')}>
+          <Section
+            title='Prompt'
+            icon={<FileText className='size-4' />}
+            initialOpen
+            collapsible={false}>
+            <PromptSectionContent />
+          </Section>
+        </div>
+
+        <div ref={assignRef('tools')}>
+          <Section
+            title='Tools'
+            icon={<Wrench className='size-4' />}
+            initialOpen
+            collapsible={false}>
+            <ToolsSectionContent />
+          </Section>
+        </div>
+
+        <div ref={assignRef('knowledge')}>
+          <Section
+            title='Knowledge'
+            icon={<BookOpen className='size-4' />}
+            initialOpen
+            collapsible={false}>
+            <KnowledgeSectionContent />
+          </Section>
+        </div>
+
+        {/* Spacer so the last section can scroll up to the activation line. */}
+        <div className='h-[40vh]' />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/agent-detail-view.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-view.tsx
@@ -1,0 +1,133 @@
+// apps/web/src/components/agents/ui/detail/agent-detail-view.tsx
+'use client'
+
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageContent,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { useMedia } from '~/hooks/use-media'
+import { useDockStore } from '~/stores/dock-store'
+import { api } from '~/trpc/react'
+import { useAgentMutations } from '../../hooks/use-agent-mutations'
+import type { AgentDetail } from '../../store/agent-store'
+import { AgentGeneralDialog, type AgentGeneralFormValues } from '../dialogs/agent-general-dialog'
+import { AutosaveIndicator, type AutosaveState } from '../shared/autosave-indicator'
+import { AgentArchiveButton } from './agent-archive-button'
+import { AgentBreadcrumbSwitcher } from './agent-breadcrumb-switcher'
+import { AgentDetailTabs } from './agent-detail-tabs'
+import { AgentDockedChat } from './agent-docked-chat'
+
+interface AgentDetailViewProps {
+  agent: AgentDetail
+}
+
+export function AgentDetailView({ agent }: AgentDetailViewProps) {
+  const isDesktop = useMedia('(min-width: 1024px)')
+  const dockedWidth = useDockStore((state) => state.dockedWidth)
+  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
+  const minWidth = useDockStore((state) => state.minWidth)
+  const maxWidth = useDockStore((state) => state.maxWidth)
+
+  const [autosave, setAutosave] = useState<AutosaveState>({ kind: 'idle' })
+
+  return (
+    <MainPage>
+      <MainPageHeader
+        action={
+          <div className='flex items-center gap-2'>
+            <AutosaveIndicator state={autosave} />
+            <AgentArchiveButton
+              agent={agent}
+              onSavingChange={(saving) =>
+                setAutosave(saving ? { kind: 'saving' } : { kind: 'saved', at: Date.now() })
+              }
+              onSaved={() => setAutosave({ kind: 'saved', at: Date.now() })}
+            />
+          </div>
+        }>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
+          <MainPageBreadcrumbItem title='Agents' href='/app/agents' />
+          <AgentBreadcrumbSwitcher activeAgent={agent} />
+        </MainPageBreadcrumb>
+      </MainPageHeader>
+
+      <MainPageContent
+        dockedPanels={
+          isDesktop
+            ? [
+                {
+                  key: 'agent-chat',
+                  content: <AgentDockedChat agentId={agent.id} />,
+                  width: dockedWidth,
+                  onWidthChange: setDockedWidth,
+                  minWidth,
+                  maxWidth,
+                },
+              ]
+            : []
+        }>
+        <AgentDetailTabs agent={agent} />
+      </MainPageContent>
+    </MainPage>
+  )
+}
+
+interface AgentDetailNewViewProps {
+  onCreated: (slug: string) => void
+}
+
+/**
+ * "New agent" surface — opens the general-edit dialog by default. On submit,
+ * creates the agent and hands off to the parent for navigation. On cancel,
+ * routes back to the list.
+ */
+export function AgentDetailNewView({ onCreated }: AgentDetailNewViewProps) {
+  const router = useRouter()
+  const [open, setOpen] = useState(true)
+  const { createAgent, isCreating } = useAgentMutations()
+  const utils = api.useUtils()
+
+  useEffect(() => {
+    if (!open) router.push('/app/agents')
+  }, [open, router])
+
+  const handleSubmit = async (values: AgentGeneralFormValues) => {
+    const created = await createAgent({
+      name: values.name,
+      slug: values.slug,
+      description: values.description || null,
+    })
+    if (!created) return
+    await utils.agent.list.invalidate()
+    setOpen(false)
+    onCreated(created.slug)
+  }
+
+  return (
+    <MainPage>
+      <MainPageHeader>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
+          <MainPageBreadcrumbItem title='Agents' href='/app/agents' />
+          <MainPageBreadcrumbItem title='New' last />
+        </MainPageBreadcrumb>
+      </MainPageHeader>
+      <MainPageContent>
+        <div className='p-6 text-sm text-muted-foreground'>Creating new agent…</div>
+        <AgentGeneralDialog
+          open={open}
+          onOpenChange={setOpen}
+          mode='create'
+          isSubmitting={isCreating}
+          onSubmit={handleSubmit}
+        />
+      </MainPageContent>
+    </MainPage>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/agent-docked-chat.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-docked-chat.tsx
@@ -1,0 +1,24 @@
+// apps/web/src/components/agents/ui/detail/agent-docked-chat.tsx
+'use client'
+
+import { KopilotChat } from '~/components/kopilot/ui/kopilot-chat'
+
+interface AgentDockedChatProps {
+  agentId: string
+}
+
+/**
+ * Docked Kopilot chat scoped to one agent. New sessions created from this
+ * surface carry `agentId` so the engine resolves the agent's toolset / prompt
+ * config end-to-end (see /api/kopilot/stream + process-agent-job).
+ *
+ * v1 always starts a fresh session — no session history is surfaced. Admins
+ * who want chat history can still visit /app/kopilot directly.
+ */
+export function AgentDockedChat({ agentId }: AgentDockedChatProps) {
+  return (
+    <div className='h-full flex flex-col'>
+      <KopilotChat page='agent-detail' agentId={agentId} initialSessionId={null} />
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/agent-hero.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-hero.tsx
@@ -1,0 +1,71 @@
+// apps/web/src/components/agents/ui/detail/agent-hero.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { Pencil } from 'lucide-react'
+import { useState } from 'react'
+import { useAgentMutations } from '../../hooks/use-agent-mutations'
+import type { AgentDetail } from '../../store/agent-store'
+import { AgentGeneralDialog, type AgentGeneralFormValues } from '../dialogs/agent-general-dialog'
+import { AgentAvatar } from '../shared/agent-avatar'
+
+interface AgentHeroProps {
+  agent: AgentDetail
+}
+
+export function AgentHero({ agent }: AgentHeroProps) {
+  const isArchived = !!agent.archivedAt
+  const [editing, setEditing] = useState(false)
+  const { updateAgent, isUpdating } = useAgentMutations()
+
+  const handleSubmit = async (values: AgentGeneralFormValues) => {
+    const ok = await updateAgent(agent.id, {
+      name: values.name,
+      description: values.description ? values.description : null,
+    })
+    if (ok) setEditing(false)
+  }
+
+  return (
+    <>
+      <div className='flex gap-3 py-2 px-3 flex-row items-center justify-start border-b'>
+        <AgentAvatar agent={agent} size={12} />
+        <div className='flex flex-col align-start flex-1 min-w-0'>
+          <div className='flex items-center gap-2'>
+            <div className='text-lg font-medium text-neutral-900 dark:text-neutral-400 truncate'>
+              {agent.name || 'Untitled'}
+            </div>
+            {isArchived ? (
+              <Badge variant='secondary'>Archived</Badge>
+            ) : (
+              <Badge variant='secondary'>Active</Badge>
+            )}
+          </div>
+          <div className='text-xs text-neutral-500 truncate'>
+            <code className='text-xs'>@{agent.slug}</code>
+            {agent.description ? <span> · {agent.description}</span> : null}
+          </div>
+        </div>
+        <Button variant='outline' size='sm' onClick={() => setEditing(true)}>
+          <Pencil />
+          Edit
+        </Button>
+      </div>
+
+      <AgentGeneralDialog
+        open={editing}
+        onOpenChange={setEditing}
+        mode='edit'
+        lockSlug
+        initialValues={{
+          name: agent.name ?? '',
+          slug: agent.slug,
+          description: agent.description ?? '',
+        }}
+        isSubmitting={isUpdating}
+        onSubmit={handleSubmit}
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/agent-switcher-dropdown-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-switcher-dropdown-content.tsx
@@ -1,0 +1,74 @@
+// apps/web/src/components/agents/ui/detail/agent-switcher-dropdown-content.tsx
+'use client'
+
+import {
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from '@auxx/ui/components/dropdown-menu'
+import { Check, Plus } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useAgents } from '../../hooks/use-agents'
+import { AgentAvatar } from '../shared/agent-avatar'
+
+interface AgentSwitcherDropdownContentProps {
+  activeAgentId: string
+}
+
+/**
+ * Body of the breadcrumb switcher dropdown — shows the active agent in the
+ * header label, every other non-archived agent in the list, and a footer
+ * "+ New agent" entry. Mirrors KBSwitcherDropdownContent at
+ * `apps/web/src/components/kb/ui/sidebar/kb-switcher.tsx`.
+ */
+export function AgentSwitcherDropdownContent({ activeAgentId }: AgentSwitcherDropdownContentProps) {
+  const router = useRouter()
+  const { agents, isLoading } = useAgents()
+
+  const active = agents.find((a) => a.id === activeAgentId)
+  const others = agents.filter((a) => a.id !== activeAgentId && a.archivedAt == null)
+
+  return (
+    <>
+      <DropdownMenuLabel className='p-0 font-normal'>
+        <div className='flex items-center gap-2 px-1 py-1.5 text-left text-sm'>
+          {active ? <AgentAvatar agent={active} size={8} /> : null}
+          <div className='grid flex-1 text-left text-sm leading-tight'>
+            <span className='truncate font-semibold'>
+              {isLoading ? 'Loading…' : active?.name || 'Agent'}
+            </span>
+            <span className='truncate text-xs text-muted-foreground'>
+              {active?.archivedAt ? 'Archived' : 'Active'}
+            </span>
+          </div>
+        </div>
+      </DropdownMenuLabel>
+      <DropdownMenuSeparator />
+      {isLoading ? (
+        <DropdownMenuItem disabled>Loading…</DropdownMenuItem>
+      ) : others.length > 0 ? (
+        others.map((agent) => (
+          <DropdownMenuItem
+            key={agent.id}
+            onSelect={() => router.push(`/app/agents/${agent.slug}`)}
+            className='h-7 cursor-pointer'>
+            <div className='flex items-center justify-between w-full'>
+              <div className='flex items-center gap-2 min-w-0'>
+                <AgentAvatar agent={agent} size={5} />
+                <span className='truncate'>{agent.name || agent.slug}</span>
+              </div>
+              {agent.id === activeAgentId ? <Check className='size-3.5' /> : null}
+            </div>
+          </DropdownMenuItem>
+        ))
+      ) : (
+        <DropdownMenuItem disabled>No other agents</DropdownMenuItem>
+      )}
+      <DropdownMenuSeparator />
+      <DropdownMenuItem onSelect={() => router.push('/app/agents/new')}>
+        <Plus />
+        New agent
+      </DropdownMenuItem>
+    </>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/tabs/knowledge-tab-placeholder.tsx
+++ b/apps/web/src/components/agents/ui/detail/tabs/knowledge-tab-placeholder.tsx
@@ -1,0 +1,10 @@
+// apps/web/src/components/agents/ui/detail/tabs/knowledge-tab-placeholder.tsx
+'use client'
+
+export function KnowledgeSectionContent() {
+  return (
+    <div className='py-4 text-sm text-muted-foreground'>
+      Knowledge pinning lands in phase-1-ui-tab-knowledge.md.
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/tabs/prompt-tab-placeholder.tsx
+++ b/apps/web/src/components/agents/ui/detail/tabs/prompt-tab-placeholder.tsx
@@ -1,0 +1,10 @@
+// apps/web/src/components/agents/ui/detail/tabs/prompt-tab-placeholder.tsx
+'use client'
+
+export function PromptSectionContent() {
+  return (
+    <div className='py-4 text-sm text-muted-foreground'>
+      Prompt editor lands in phase-1-ui-tab-prompt.md.
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/tabs/tools-tab-placeholder.tsx
+++ b/apps/web/src/components/agents/ui/detail/tabs/tools-tab-placeholder.tsx
@@ -1,0 +1,10 @@
+// apps/web/src/components/agents/ui/detail/tabs/tools-tab-placeholder.tsx
+'use client'
+
+export function ToolsSectionContent() {
+  return (
+    <div className='py-4 text-sm text-muted-foreground'>
+      Tool selection lands in phase-1-ui-tab-tools.md.
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/dialogs/agent-general-dialog.tsx
+++ b/apps/web/src/components/agents/ui/dialogs/agent-general-dialog.tsx
@@ -1,0 +1,289 @@
+// apps/web/src/components/agents/ui/dialogs/agent-general-dialog.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@auxx/ui/components/field'
+import { Input } from '@auxx/ui/components/input'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+} from '@auxx/ui/components/input-group'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { Spinner } from '@auxx/ui/components/spinner'
+import { Textarea } from '@auxx/ui/components/textarea'
+import { Check, X } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { useDebouncedCallback } from '~/hooks/use-debounced-value'
+import { api } from '~/trpc/react'
+import { AgentAvatar } from '../shared/agent-avatar'
+
+export interface AgentGeneralFormValues {
+  name: string
+  slug: string
+  description: string
+}
+
+interface AgentGeneralDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  mode: 'create' | 'edit'
+  initialValues?: Partial<AgentGeneralFormValues>
+  /** Lock slug field after create — slugs are immutable post-create in v1. */
+  lockSlug?: boolean
+  isSubmitting?: boolean
+  onSubmit: (values: AgentGeneralFormValues) => Promise<void> | void
+  onCancel?: () => void
+}
+
+const SLUG_REGEX = /^[a-z0-9-]+$/
+
+function toSlug(str: string): string {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60)
+}
+
+export function AgentGeneralDialog({
+  open,
+  onOpenChange,
+  mode,
+  initialValues,
+  lockSlug,
+  isSubmitting,
+  onSubmit,
+  onCancel,
+}: AgentGeneralDialogProps) {
+  const [name, setName] = useState(initialValues?.name ?? '')
+  const [slug, setSlug] = useState(initialValues?.slug ?? '')
+  const [description, setDescription] = useState(initialValues?.description ?? '')
+  const [touchedSlug, setTouchedSlug] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Slug availability state
+  const [slugAvailable, setSlugAvailable] = useState<boolean | null>(null)
+  const [isCheckingSlug, setIsCheckingSlug] = useState(false)
+
+  const utils = api.useUtils()
+
+  useEffect(() => {
+    if (!open) return
+    setName(initialValues?.name ?? '')
+    setSlug(initialValues?.slug ?? '')
+    setDescription(initialValues?.description ?? '')
+    setTouchedSlug(!!initialValues?.slug)
+    setError(null)
+    setSlugAvailable(null)
+    setIsCheckingSlug(false)
+  }, [open, initialValues])
+
+  const checkSlug = useDebouncedCallback(async (slugToCheck: string) => {
+    if (!slugToCheck || !SLUG_REGEX.test(slugToCheck)) {
+      setSlugAvailable(null)
+      setIsCheckingSlug(false)
+      return
+    }
+    try {
+      const result = await utils.agent.checkSlug.fetch({ slug: slugToCheck })
+      setSlugAvailable(result.available)
+    } catch {
+      setSlugAvailable(false)
+    } finally {
+      setIsCheckingSlug(false)
+    }
+  }, 300)
+
+  // Auto-derive slug from name when user hasn't manually edited it (create mode only)
+  useEffect(() => {
+    if (mode !== 'create' || touchedSlug) return
+    const derived = toSlug(name)
+    setSlug(derived)
+    if (derived) {
+      setIsCheckingSlug(true)
+      checkSlug(derived)
+    } else {
+      setSlugAvailable(null)
+    }
+  }, [name, mode, touchedSlug, checkSlug])
+
+  const handleSlugChange = useCallback(
+    (value: string) => {
+      setTouchedSlug(true)
+      const next = toSlug(value)
+      setSlug(next)
+      if (next) {
+        setIsCheckingSlug(true)
+        checkSlug(next)
+      } else {
+        setSlugAvailable(null)
+      }
+    },
+    [checkSlug]
+  )
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    if (!name.trim()) {
+      setError('Name is required')
+      return
+    }
+    if (name.length > 120) {
+      setError('Name must be 120 characters or fewer')
+      return
+    }
+    if (!slug.trim()) {
+      setError('Slug is required')
+      return
+    }
+    if (!SLUG_REGEX.test(slug)) {
+      setError('Slug may only contain lowercase letters, digits, and dashes')
+      return
+    }
+    if (slug.length > 60) {
+      setError('Slug must be 60 characters or fewer')
+      return
+    }
+    if (description.length > 500) {
+      setError('Description must be 500 characters or fewer')
+      return
+    }
+    await onSubmit({ name: name.trim(), slug: slug.trim(), description: description.trim() })
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && onCancel) onCancel()
+    onOpenChange(next)
+  }
+
+  const isCreate = mode === 'create'
+  const slugLocked = !!lockSlug || !isCreate
+  const isValid =
+    name.trim().length > 0 &&
+    slug.trim().length > 0 &&
+    SLUG_REGEX.test(slug) &&
+    (slugLocked || slugAvailable === true)
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent size='sm' position='tc'>
+        <DialogHeader>
+          <DialogTitle>{isCreate ? 'Create agent' : 'Edit agent'}</DialogTitle>
+          <DialogDescription>
+            {isCreate
+              ? 'Give your agent a name and slug. You can refine prompt, tools, and knowledge after.'
+              : 'Update the agent name and description.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <FieldGroup className='gap-4'>
+            <div className='grid grid-cols-[30px_1fr] gap-2 items-end'>
+              <Field>
+                <FieldLabel className='sr-only'>Avatar</FieldLabel>
+                <AgentAvatar agent={{ name, avatarUrl: null }} size={7} />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor='agent-name'>Name</FieldLabel>
+                <Input
+                  id='agent-name'
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder='Sarah'
+                  autoFocus
+                />
+              </Field>
+            </div>
+
+            <Field>
+              <FieldLabel htmlFor='agent-slug'>Slug</FieldLabel>
+              <InputGroup>
+                <InputGroupAddon align='inline-start'>
+                  <InputGroupText>/</InputGroupText>
+                </InputGroupAddon>
+                <InputGroupInput
+                  id='agent-slug'
+                  value={slug}
+                  onChange={(e) => handleSlugChange(e.target.value)}
+                  placeholder='sarah'
+                  disabled={slugLocked}
+                />
+                <InputGroupAddon align='inline-end'>
+                  {!slugLocked && isCheckingSlug ? (
+                    <Spinner />
+                  ) : !slugLocked && slug ? (
+                    slugAvailable === true ? (
+                      <Check className='size-4 text-success' />
+                    ) : slugAvailable === false ? (
+                      <X className='size-4 text-destructive' />
+                    ) : null
+                  ) : null}
+                </InputGroupAddon>
+              </InputGroup>
+              <FieldDescription>
+                {slugLocked
+                  ? 'Slug cannot be changed after creation.'
+                  : 'Used in @mentions and URLs. Lowercase letters, digits, and dashes only.'}
+              </FieldDescription>
+              {slugAvailable === false && !slugLocked && (
+                <FieldError>This slug is already in use.</FieldError>
+              )}
+            </Field>
+
+            <Field>
+              <FieldLabel htmlFor='agent-description'>Description</FieldLabel>
+              <Textarea
+                id='agent-description'
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder='Returns specialist'
+                rows={3}
+              />
+            </Field>
+
+            {error ? <FieldError>{error}</FieldError> : null}
+          </FieldGroup>
+
+          <DialogFooter>
+            <Button
+              type='button'
+              size='sm'
+              variant='ghost'
+              onClick={() => handleOpenChange(false)}
+              disabled={isSubmitting}>
+              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+            </Button>
+            <Button
+              type='submit'
+              size='sm'
+              variant='outline'
+              loading={isSubmitting}
+              loadingText='Saving…'
+              disabled={!isValid || isSubmitting}>
+              {isCreate ? 'Create agent' : 'Save'} <KbdSubmit variant='outline' size='sm' />
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/agents/ui/list/agent-card.tsx
+++ b/apps/web/src/components/agents/ui/list/agent-card.tsx
@@ -1,0 +1,125 @@
+// apps/web/src/components/agents/ui/list/agent-card.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { LastUpdated } from '@auxx/ui/components/last-updated'
+import { Archive, ArchiveRestore, MoreVertical, Pencil } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { Tooltip } from '~/components/global/tooltip'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useAgentMutations } from '../../hooks/use-agent-mutations'
+import type { AgentListItem } from '../../store/agent-store'
+import { AgentAvatar } from '../shared/agent-avatar'
+
+interface AgentCardProps {
+  agent: AgentListItem
+}
+
+export function AgentCard({ agent }: AgentCardProps) {
+  const router = useRouter()
+  const { archiveAgent, unarchiveAgent } = useAgentMutations()
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  const archived = agent.archivedAt != null
+  const statusColor = archived ? 'bg-muted-foreground/40' : 'bg-good-500'
+  const statusLabel = archived ? 'Archived' : 'Active'
+
+  const stop = (e: React.MouseEvent) => e.stopPropagation()
+  const wrap = (fn: () => void | Promise<void>) => (e: React.MouseEvent) => {
+    e.stopPropagation()
+    void fn()
+  }
+
+  const handleNavigate = () => router.push(`/app/agents/${agent.slug}`)
+
+  const handleArchive = async () => {
+    const ok = await confirm({
+      title: 'Archive agent?',
+      description: `"${agent.name}" will stop responding to mentions and triggers.`,
+      confirmText: 'Archive',
+      cancelText: 'Cancel',
+      destructive: false,
+    })
+    if (ok) await archiveAgent(agent.id)
+  }
+
+  return (
+    <>
+      <ConfirmDialog />
+      <button
+        type='button'
+        onClick={handleNavigate}
+        className='text-left rounded-2xl bg-background dark:bg-primary-50 hover:bg-primary-50/50 hover:outline-5 dark:hover:outline-primary-50/50 hover:outline-primary-100 flex flex-col p-3 gap-2 border cursor-pointer group/agent-card relative'>
+        <div className='flex flex-row items-start gap-2 w-full'>
+          <div className='relative shrink-0'>
+            <AgentAvatar agent={agent} size={8} />
+            <Tooltip content={statusLabel}>
+              <div
+                className={`absolute -top-0.5 -right-0.5 size-2.5 rounded-full border-2 border-primary-50 ${statusColor}`}
+              />
+            </Tooltip>
+          </div>
+
+          <div className='flex flex-col flex-1 min-w-0'>
+            <div className='flex flex-row justify-between items-start gap-1'>
+              <p className='text-sm font-semibold line-clamp-1 group-hover/agent-card:text-info'>
+                {agent.name || agent.slug}
+              </p>
+            </div>
+            <LastUpdated
+              timestamp={agent.updatedAt}
+              prefix=''
+              includeSeconds={true}
+              className='text-xs text-muted-foreground'
+            />
+          </div>
+        </div>
+
+        <p className='text-xs text-muted-foreground line-clamp-1 min-h-4'>
+          {agent.description ?? ''}
+        </p>
+
+        <div className='flex items-center justify-between mt-auto gap-2'>
+          <Badge variant='pill' size='sm' className='shrink-0'>
+            {agent.modelId ?? 'Default model'}
+          </Badge>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                className='opacity-0 group-hover/agent-card:opacity-100 duration-300 data-[state=open]:opacity-100! data-[state=open]:bg-muted! transition-opacity rounded-lg'
+                variant='ghost'
+                size='icon-xs'
+                onClick={stop}>
+                <MoreVertical />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end' onClick={stop}>
+              <DropdownMenuItem onClick={wrap(handleNavigate)}>
+                <Pencil />
+                Edit
+              </DropdownMenuItem>
+              {archived ? (
+                <DropdownMenuItem onClick={wrap(() => unarchiveAgent(agent.id))}>
+                  <ArchiveRestore />
+                  Unarchive
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem onClick={wrap(handleArchive)}>
+                  <Archive />
+                  Archive
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </button>
+    </>
+  )
+}

--- a/apps/web/src/components/agents/ui/list/agents-empty-state.tsx
+++ b/apps/web/src/components/agents/ui/list/agents-empty-state.tsx
@@ -1,0 +1,38 @@
+// apps/web/src/components/agents/ui/list/agents-empty-state.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Bot } from 'lucide-react'
+import { EmptyState } from '~/components/global/empty-state'
+import { useAgentSearch } from '../../hooks/use-agent-search'
+import { CreateAgentButton } from './create-agent-button'
+
+interface AgentsEmptyStateProps {
+  /** True when the unfiltered list itself is empty (no agents in org). */
+  isFirstRun: boolean
+}
+
+export function AgentsEmptyState({ isFirstRun }: AgentsEmptyStateProps) {
+  const { setSearch } = useAgentSearch()
+  if (isFirstRun) {
+    return (
+      <EmptyState
+        icon={Bot}
+        title='No agents yet'
+        description='Create an agent to delegate work to AI.'
+        button={<CreateAgentButton />}
+      />
+    )
+  }
+  return (
+    <EmptyState
+      icon={Bot}
+      title='No agents match your search.'
+      button={
+        <Button variant='outline' size='sm' onClick={() => setSearch('')}>
+          Clear
+        </Button>
+      }
+    />
+  )
+}

--- a/apps/web/src/components/agents/ui/list/agents-grid-view.tsx
+++ b/apps/web/src/components/agents/ui/list/agents-grid-view.tsx
@@ -1,0 +1,31 @@
+// apps/web/src/components/agents/ui/list/agents-grid-view.tsx
+'use client'
+
+import { useMemo } from 'react'
+import { useAgentSearch } from '../../hooks/use-agent-search'
+import { useAgents } from '../../hooks/use-agents'
+import { filterAgents } from '../../utils/filter-agents'
+import { AgentCard } from './agent-card'
+import { AgentsEmptyState } from './agents-empty-state'
+
+export function AgentsGridView() {
+  const { agents, hasLoadedOnce } = useAgents()
+  const { search } = useAgentSearch()
+
+  const filtered = useMemo(() => filterAgents(agents, search), [agents, search])
+
+  if (!hasLoadedOnce) {
+    return <div className='p-6 text-sm text-muted-foreground'>Loading agents…</div>
+  }
+  if (filtered.length === 0) {
+    return <AgentsEmptyState isFirstRun={agents.length === 0} />
+  }
+
+  return (
+    <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
+      {filtered.map((agent) => (
+        <AgentCard key={agent.id} agent={agent} />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/list/agents-page-content.tsx
+++ b/apps/web/src/components/agents/ui/list/agents-page-content.tsx
@@ -1,0 +1,38 @@
+// apps/web/src/components/agents/ui/list/agents-page-content.tsx
+'use client'
+
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageContent,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { AgentsGridView } from './agents-grid-view'
+import { AgentsSearchBar } from './agents-search-bar'
+import { CreateAgentButton } from './create-agent-button'
+
+export function AgentsPageContent() {
+  return (
+    <MainPage>
+      <MainPageHeader action={<CreateAgentButton />}>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
+          <MainPageBreadcrumbItem title='Agents' last />
+        </MainPageBreadcrumb>
+      </MainPageHeader>
+
+      <MainPageContent>
+        <ScrollArea className='flex-1 min-h-0 flex flex-col'>
+          <div className='sticky top-0 z-10 backdrop-blur-sm shrink-0 px-3 sm:px-6 pt-3 pb-2'>
+            <AgentsSearchBar />
+          </div>
+          <div className='p-3 sm:p-6 flex-1 flex flex-col min-h-0'>
+            <AgentsGridView />
+          </div>
+        </ScrollArea>
+      </MainPageContent>
+    </MainPage>
+  )
+}

--- a/apps/web/src/components/agents/ui/list/agents-search-bar.tsx
+++ b/apps/web/src/components/agents/ui/list/agents-search-bar.tsx
@@ -1,0 +1,21 @@
+// apps/web/src/components/agents/ui/list/agents-search-bar.tsx
+'use client'
+
+import { Input } from '@auxx/ui/components/input'
+import { Search } from 'lucide-react'
+import { useAgentSearch } from '../../hooks/use-agent-search'
+
+export function AgentsSearchBar() {
+  const { search, setSearch } = useAgentSearch()
+  return (
+    <div className='relative max-w-md'>
+      <Search className='absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground' />
+      <Input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder='Search agents…'
+        className='pl-8'
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/list/create-agent-button.tsx
+++ b/apps/web/src/components/agents/ui/list/create-agent-button.tsx
@@ -1,0 +1,17 @@
+// apps/web/src/components/agents/ui/list/create-agent-button.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Plus } from 'lucide-react'
+import Link from 'next/link'
+
+export function CreateAgentButton() {
+  return (
+    <Button asChild size='sm'>
+      <Link href='/app/agents/new'>
+        <Plus />
+        Create agent
+      </Link>
+    </Button>
+  )
+}

--- a/apps/web/src/components/agents/ui/shared/agent-avatar.tsx
+++ b/apps/web/src/components/agents/ui/shared/agent-avatar.tsx
@@ -1,0 +1,31 @@
+// apps/web/src/components/agents/ui/shared/agent-avatar.tsx
+'use client'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { cn } from '@auxx/ui/lib/utils'
+import { Bot } from 'lucide-react'
+import type { AgentListItem } from '../../store/agent-store'
+
+interface AgentAvatarProps {
+  agent: Pick<AgentListItem, 'name' | 'avatarUrl'>
+  /** Tailwind size scale — applied as `size-{size}`. Default 8 (32px). */
+  size?: 5 | 6 | 7 | 8 | 10 | 12
+  className?: string
+}
+
+/**
+ * Square rounded-xl agent avatar. Falls back to a `<Bot />` icon when the
+ * backing user has no avatar. v1 deliberately avoids emoji rendering — that
+ * lands in the General-tab follow-up.
+ */
+export function AgentAvatar({ agent, size = 8, className }: AgentAvatarProps) {
+  const initial = (agent.name ?? '?').trim().charAt(0).toUpperCase()
+  return (
+    <Avatar className={cn(`size-${size}`, 'rounded-xl border', className)}>
+      {agent.avatarUrl ? <AvatarImage src={agent.avatarUrl} alt={agent.name ?? ''} /> : null}
+      <AvatarFallback className='rounded-xl bg-primary-50 text-primary'>
+        {agent.avatarUrl ? initial : <Bot className='size-4' />}
+      </AvatarFallback>
+    </Avatar>
+  )
+}

--- a/apps/web/src/components/agents/ui/shared/autosave-indicator.tsx
+++ b/apps/web/src/components/agents/ui/shared/autosave-indicator.tsx
@@ -1,0 +1,42 @@
+// apps/web/src/components/agents/ui/shared/autosave-indicator.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { formatDistanceToNow } from 'date-fns'
+import { Check, Loader2 } from 'lucide-react'
+
+export type AutosaveState = { kind: 'idle' } | { kind: 'saving' } | { kind: 'saved'; at: number }
+
+interface AutosaveIndicatorProps {
+  state: AutosaveState
+  className?: string
+}
+
+/**
+ * Header pill that surfaces autosave status. Renders nothing on idle.
+ *
+ * v1 only lights up on archive/unarchive — full debounced field autosave wiring
+ * lands inside the per-tab follow-up plans.
+ */
+export function AutosaveIndicator({ state, className }: AutosaveIndicatorProps) {
+  if (state.kind === 'idle') return null
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-1 text-xs text-muted-foreground px-1.5 py-0.5',
+        className
+      )}>
+      {state.kind === 'saving' ? (
+        <>
+          <Loader2 className='size-3 animate-spin' />
+          <span>Saving…</span>
+        </>
+      ) : (
+        <>
+          <Check className='size-3 text-good-500' />
+          <span>Saved {formatDistanceToNow(state.at, { addSuffix: true })}</span>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/utils/filter-agents.ts
+++ b/apps/web/src/components/agents/utils/filter-agents.ts
@@ -1,0 +1,16 @@
+// apps/web/src/components/agents/utils/filter-agents.ts
+
+import type { AgentListItem } from '../store/agent-store'
+
+/**
+ * Filter the agent list by a free-text query against name + description.
+ * Empty / whitespace-only queries pass everything through.
+ */
+export function filterAgents(agents: AgentListItem[], search: string): AgentListItem[] {
+  const q = search.trim().toLowerCase()
+  if (!q) return agents
+  return agents.filter((a) => {
+    const haystack = `${a.name ?? ''} ${a.description ?? ''}`.toLowerCase()
+    return haystack.includes(q)
+  })
+}

--- a/apps/web/src/components/calls/constants.ts
+++ b/apps/web/src/components/calls/constants.ts
@@ -1,4 +1,4 @@
 // apps/web/src/components/calls/constants.ts
 
 /** Toggle to use mock data instead of real API calls during development. */
-export const USE_MOCK_DATA = true
+export const USE_MOCK_DATA = false

--- a/apps/web/src/components/global/sidebar/nav-main.tsx
+++ b/apps/web/src/components/global/sidebar/nav-main.tsx
@@ -11,6 +11,7 @@ import {
 import { usePathname } from 'next/navigation'
 import type * as React from 'react'
 import type { SidebarProps } from '~/constants/menu'
+import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { CollapsibleSidebarSection } from './collapsible-sidebar-section'
 import { SidebarGroupHeader } from './sidebar-group-header'
@@ -27,6 +28,7 @@ export function NavMain({ menu, itemActions }: Props) {
   const pathname = usePathname()
   const { getGroupOpen, toggleGroup } = useSidebarStateContext()
   const { hasAccess } = useFeatureFlags()
+  const { isAdminOrOwner } = useUser()
   const isOpen = getGroupOpen('configurations')
 
   /** Toggle the Configurations group open/closed state */
@@ -45,12 +47,15 @@ export function NavMain({ menu, itemActions }: Props) {
     return fullUrl
   }
 
-  // Filter items by feature access
+  // Filter items by feature access (and admin-only gates for top-level entries)
   const filteredItems = menu.items
     .filter((item) => !item.featureKey || hasAccess(item.featureKey))
+    .filter((item) => !item.adminOnly || isAdminOrOwner)
     .map((item) => ({
       ...item,
-      items: item.items?.filter((sub) => !sub.featureKey || hasAccess(sub.featureKey)),
+      items: item.items
+        ?.filter((sub) => !sub.featureKey || hasAccess(sub.featureKey))
+        .filter((sub) => !sub.adminOnly || isAdminOrOwner),
     }))
     .filter((item) => !item.items || item.items.length > 0)
 

--- a/apps/web/src/components/kopilot/hooks/use-kopilot-sse.ts
+++ b/apps/web/src/components/kopilot/hooks/use-kopilot-sse.ts
@@ -19,6 +19,8 @@ export interface KopilotRequest {
   inputAmendment?: Record<string, unknown>
   /** Model override in "provider:model" format — omit to use system default */
   modelId?: string
+  /** Target a user-authored agent on session create; ignored on existing sessions. */
+  agentId?: string | null
 }
 
 interface UseKopilotSSEOptions {

--- a/apps/web/src/components/kopilot/ui/kopilot-chat.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-chat.tsx
@@ -27,6 +27,12 @@ export interface KopilotChatProps {
   initialSessionId?: string | null
   /** Class applied to inner content areas (message list, composer) for centering/width constraints */
   contentClassName?: string
+  /**
+   * Target a specific user-authored agent. When set, outgoing requests carry
+   * `agentId` so newly-created sessions are bound to that agent and the engine
+   * resolves its toolset / prompt config. Ignored on existing sessions.
+   */
+  agentId?: string | null
 }
 
 export function KopilotChat({
@@ -34,6 +40,7 @@ export function KopilotChat({
   onSessionChange,
   initialSessionId,
   contentClassName,
+  agentId,
 }: KopilotChatProps) {
   const activeSessionId = useKopilotStore((s) => s.activeSessionId)
   const setEditingMessage = useKopilotStore((s) => s.setEditingMessage)
@@ -103,9 +110,12 @@ export function KopilotChat({
     [activeSessionId, messageMap, setMessageFeedback, rateMessage]
   )
 
-  const handleSend = useCallback((request: KopilotRequest) => {
-    setPendingRequest(request)
-  }, [])
+  const handleSend = useCallback(
+    (request: KopilotRequest) => {
+      setPendingRequest(agentId ? { ...request, agentId } : request)
+    },
+    [agentId]
+  )
 
   const handleSuggestionClick = useCallback(
     (text: string, autoSubmit: boolean) => {
@@ -132,14 +142,18 @@ export function KopilotChat({
         type: 'message',
         page: merged.page ?? page,
         context: merged,
+        ...(agentId ? { agentId } : {}),
       })
     },
-    [addMessage, messages, activeSessionId, page]
+    [addMessage, messages, activeSessionId, page, agentId]
   )
 
-  const handleApprovalAction = useCallback((request: KopilotRequest) => {
-    setPendingRequest(request)
-  }, [])
+  const handleApprovalAction = useCallback(
+    (request: KopilotRequest) => {
+      setPendingRequest(agentId ? { ...request, agentId } : request)
+    },
+    [agentId]
+  )
 
   const handleEditMessage = useCallback(
     (messageId: string) => {
@@ -167,9 +181,10 @@ export function KopilotChat({
         type: 'message',
         page: merged.page ?? page,
         context: merged,
+        ...(agentId ? { agentId } : {}),
       })
     },
-    [messageMap, activeSessionId, page]
+    [messageMap, activeSessionId, page, agentId]
   )
 
   return (

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -50,6 +50,8 @@ export type SidebarProps = {
   cloudOnly?: boolean
   /** Feature key required for this menu item to be visible */
   featureKey?: string
+  /** When true, only admins/owners see this item */
+  adminOnly?: boolean
 } & FieldProps
 
 import type * as React from 'react'
@@ -84,6 +86,14 @@ export const SIDEBAR_MENU: SidebarProps[] = [
     slug: 'kopilot/new',
     icon: <MessagesSquare />,
     featureKey: 'kopilot',
+  },
+  {
+    id: 'agents',
+    label: 'Agents',
+    slug: 'agents',
+    icon: <Bot />,
+    featureKey: 'agents',
+    adminOnly: true,
   },
   {
     id: 'calls',

--- a/apps/web/src/server/api/routers/agent-toolset.ts
+++ b/apps/web/src/server/api/routers/agent-toolset.ts
@@ -1,11 +1,13 @@
 // apps/web/src/server/api/routers/agent-toolset.ts
 
-import { schema } from '@auxx/database'
-import type { AgentToolsetConfig } from '@auxx/lib/agents'
-import { onCacheEvent } from '@auxx/lib/cache'
+import {
+  agentExistsInOrg,
+  batchUpdateAgentToolsets,
+  listAgentToolsets,
+  updateAgentToolset,
+} from '@auxx/lib/agents'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
-import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { adminProcedure, createTRPCRouter } from '../trpc'
 
@@ -17,110 +19,37 @@ const toolsetPatchSchema = z.object({
   disabledTools: z.array(z.string().min(1).max(120)).optional(),
 })
 
-async function applyToolsetPatch(
-  // biome-ignore lint/suspicious/noExplicitAny: drizzle tx
-  tx: any,
-  agentId: string,
-  patch: z.infer<typeof toolsetPatchSchema>
-) {
-  const now = new Date()
-
-  const [existing] = await tx
-    .select({
-      id: schema.AgentToolset.id,
-      config: schema.AgentToolset.config,
-      source: schema.AgentToolset.source,
-    })
-    .from(schema.AgentToolset)
-    .where(
-      and(eq(schema.AgentToolset.agentId, agentId), eq(schema.AgentToolset.toolsetSlug, patch.slug))
-    )
-    .limit(1)
-
-  if (existing) {
-    const nextConfig: AgentToolsetConfig = { ...(existing.config as AgentToolsetConfig) }
-    if (patch.disabledTools !== undefined) {
-      nextConfig.disabledTools = patch.disabledTools
-    }
-    const update: Record<string, unknown> = {
-      updatedAt: now,
-      config: nextConfig,
-    }
-    if (patch.enabled !== undefined) update.enabled = patch.enabled
-    // First-touch promotion: auto_default rows become 'manual' once an admin
-    // actively saves them.
-    if (existing.source === 'auto_default') update.source = 'manual'
-    await tx.update(schema.AgentToolset).set(update).where(eq(schema.AgentToolset.id, existing.id))
-    return
+async function ensureAgentInOrg(organizationId: string, agentId: string): Promise<void> {
+  if (!(await agentExistsInOrg(organizationId, agentId))) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
   }
-
-  const config: AgentToolsetConfig = {}
-  if (patch.disabledTools !== undefined) config.disabledTools = patch.disabledTools
-  await tx.insert(schema.AgentToolset).values({
-    agentId,
-    toolsetSlug: patch.slug,
-    config,
-    source: 'manual',
-    enabled: patch.enabled ?? true,
-    updatedAt: now,
-  })
 }
 
 /**
  * Per-agent toolset CRUD. Mention-sourced rows (`source='mention'`) are
  * managed by the prompt reconciler and not mutable through this router; this
- * router writes `manual` (or promotes `auto_default` → `manual`).
+ * router writes `manual` (or promotes `auto_default` → `manual`). All
+ * persistence lives in `@auxx/lib/agents/agent-toolset-service`; the router
+ * just validates input, enforces org scope via the cache, and delegates.
  */
 export const agentToolsetRouter = createTRPCRouter({
   list: adminProcedure.input(z.object({ agentId: z.string() })).query(async ({ ctx, input }) => {
-    const { organizationId } = ctx.session
-
-    const [agent] = await ctx.db
-      .select({ id: schema.Agent.id })
-      .from(schema.Agent)
-      .where(
-        and(eq(schema.Agent.id, input.agentId), eq(schema.Agent.organizationId, organizationId))
-      )
-      .limit(1)
-    if (!agent) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
-    }
-
-    return ctx.db
-      .select()
-      .from(schema.AgentToolset)
-      .where(eq(schema.AgentToolset.agentId, input.agentId))
+    await ensureAgentInOrg(ctx.session.organizationId, input.agentId)
+    return listAgentToolsets(input.agentId)
   }),
 
   update: adminProcedure
-    .input(
-      toolsetPatchSchema.extend({
-        agentId: z.string(),
-      })
-    )
+    .input(toolsetPatchSchema.extend({ agentId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
+      await ensureAgentInOrg(organizationId, input.agentId)
 
-      const [agent] = await ctx.db
-        .select({ id: schema.Agent.id })
-        .from(schema.Agent)
-        .where(
-          and(eq(schema.Agent.id, input.agentId), eq(schema.Agent.organizationId, organizationId))
-        )
-        .limit(1)
-      if (!agent) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
-      }
-
-      await ctx.db.transaction(async (tx) => {
-        await applyToolsetPatch(tx, input.agentId, {
-          slug: input.slug,
-          enabled: input.enabled,
-          disabledTools: input.disabledTools,
-        })
+      await updateAgentToolset(organizationId, input.agentId, {
+        slug: input.slug,
+        enabled: input.enabled,
+        disabledTools: input.disabledTools,
       })
 
-      await onCacheEvent('agent.updated', { orgId: organizationId })
       logger.info('Agent toolset updated', {
         organizationId,
         agentId: input.agentId,
@@ -137,25 +66,10 @@ export const agentToolsetRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
+      await ensureAgentInOrg(organizationId, input.agentId)
 
-      const [agent] = await ctx.db
-        .select({ id: schema.Agent.id })
-        .from(schema.Agent)
-        .where(
-          and(eq(schema.Agent.id, input.agentId), eq(schema.Agent.organizationId, organizationId))
-        )
-        .limit(1)
-      if (!agent) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
-      }
+      await batchUpdateAgentToolsets(organizationId, input.agentId, input.toolsets)
 
-      await ctx.db.transaction(async (tx) => {
-        for (const patch of input.toolsets) {
-          await applyToolsetPatch(tx, input.agentId, patch)
-        }
-      })
-
-      await onCacheEvent('agent.updated', { orgId: organizationId })
       logger.info('Agent toolsets batch-updated', {
         organizationId,
         agentId: input.agentId,

--- a/apps/web/src/server/api/routers/agent.ts
+++ b/apps/web/src/server/api/routers/agent.ts
@@ -1,14 +1,15 @@
 // apps/web/src/server/api/routers/agent.ts
 
-import { schema } from '@auxx/database'
 import {
+  agentExistsInOrg,
   createAgent as createAgentService,
-  resolveDefaultToolsets,
+  getAgentDetailByIdOrSlug,
+  isAgentSlugTaken,
+  listAgents,
   updateAgent as updateAgentService,
 } from '@auxx/lib/agents'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
-import { and, eq, ne } from 'drizzle-orm'
 import { z } from 'zod'
 import { adminProcedure, createTRPCRouter } from '../trpc'
 
@@ -20,103 +21,32 @@ const promptSchema = z.record(z.string(), z.unknown())
  * Admin-only CRUD for user-authored Kopilot agents. Toolset rows are managed
  * via the sibling `agentToolset.*` router. Archive is driven through `update`
  * (`archivedAt: Date | null`) per plans/kopilot/agents/phase-1-engine-and-api.md
- * §3.2.
+ * §3.2. Reads flow through the org agents cache; writes go through
+ * `@auxx/lib/agents` service functions — no raw SQL lives in this router.
  */
 export const agentRouter = createTRPCRouter({
   list: adminProcedure
     .input(z.object({ includeArchived: z.boolean().optional() }).optional())
-    .query(async ({ ctx, input }) => {
-      const { organizationId } = ctx.session
-      const includeArchived = input?.includeArchived ?? false
-
-      // getCachedAgents already filters out archivedAt; bypass for archived
-      // visibility by reading the raw cache key.
-      const all = await ctx.db
-        .select({
-          id: schema.Agent.id,
-          userId: schema.Agent.userId,
-          name: schema.User.name,
-          slug: schema.Agent.slug,
-          description: schema.Agent.description,
-          avatarAssetId: schema.User.avatarAssetId,
-          mentionable: schema.Agent.mentionable,
-          modelId: schema.Agent.modelId,
-          archivedAt: schema.Agent.archivedAt,
-          createdAt: schema.Agent.createdAt,
-          updatedAt: schema.Agent.updatedAt,
-        })
-        .from(schema.Agent)
-        .innerJoin(schema.User, eq(schema.User.id, schema.Agent.userId))
-        .where(eq(schema.Agent.organizationId, organizationId))
-
-      const rows = includeArchived ? all : all.filter((r) => !r.archivedAt)
-      return rows.map((r) => ({
-        ...r,
-        archivedAt: r.archivedAt ? r.archivedAt.toISOString() : null,
-        createdAt: r.createdAt.toISOString(),
-        updatedAt: r.updatedAt.toISOString(),
-      }))
-    }),
-
-  getById: adminProcedure.input(z.object({ agentId: z.string() })).query(async ({ ctx, input }) => {
-    const { organizationId } = ctx.session
-
-    const [row] = await ctx.db
-      .select({
-        agent: schema.Agent,
-        userName: schema.User.name,
-        avatarAssetId: schema.User.avatarAssetId,
+    .query(({ ctx, input }) =>
+      listAgents(ctx.session.organizationId, {
+        includeArchived: input?.includeArchived ?? false,
       })
-      .from(schema.Agent)
-      .innerJoin(schema.User, eq(schema.User.id, schema.Agent.userId))
-      .where(
-        and(eq(schema.Agent.id, input.agentId), eq(schema.Agent.organizationId, organizationId))
-      )
-      .limit(1)
+    ),
 
-    if (!row) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
-    }
-
-    const { agent } = row
-
-    const toolsets = await ctx.db
-      .select()
-      .from(schema.AgentToolset)
-      .where(eq(schema.AgentToolset.agentId, agent.id))
-
-    const resourceScopes = await ctx.db
-      .select()
-      .from(schema.AgentResourceScope)
-      .where(eq(schema.AgentResourceScope.agentId, agent.id))
-
-    return {
-      id: agent.id,
-      organizationId: agent.organizationId,
-      userId: agent.userId,
-      createdById: agent.createdById,
-      name: row.userName,
-      slug: agent.slug,
-      description: agent.description,
-      avatarAssetId: row.avatarAssetId,
-      prompt: agent.prompt,
-      pinnedRecords: agent.pinnedRecords,
-      mentionable: agent.mentionable,
-      modelId: agent.modelId,
-      archivedAt: agent.archivedAt ? agent.archivedAt.toISOString() : null,
-      createdAt: agent.createdAt.toISOString(),
-      updatedAt: agent.updatedAt.toISOString(),
-      toolsets: toolsets.map((t) => ({
-        id: t.id,
-        slug: t.toolsetSlug,
-        appInstallationId: t.appInstallationId,
-        config: t.config,
-        source: t.source,
-        enabled: t.enabled,
-      })),
-      resourceScopes,
-    }
-  }),
+  /**
+   * Resolve an agent by id or slug. The input field is named `agentId` for
+   * backward compatibility with existing callers, but accepts either form —
+   * the service helper checks both columns against the org agents cache.
+   */
+  getById: adminProcedure
+    .input(z.object({ agentId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const detail = await getAgentDetailByIdOrSlug(ctx.session.organizationId, input.agentId)
+      if (!detail) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
+      }
+      return detail
+    }),
 
   create: adminProcedure
     .input(
@@ -132,10 +62,9 @@ export const agentRouter = createTRPCRouter({
         modelId: z.string().max(120).optional().nullable(),
         mentionable: z.boolean().optional(),
         /**
-         * Initial toolset slugs to enable. When omitted, defaults to
-         * `resolveDefaultToolsets(orgId)` and rows are tagged
-         * `source='auto_default'`. When provided, caller-supplied slugs are
-         * tagged `source='manual'`.
+         * Initial toolset slugs to enable. When omitted, `createAgent`
+         * resolves defaults and tags the rows `source='auto_default'`. When
+         * provided, every slug lands as `source='manual'`.
          */
         toolsetSlugs: z.array(z.string().min(1).max(120)).optional(),
       })
@@ -143,14 +72,7 @@ export const agentRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
 
-      const [conflict] = await ctx.db
-        .select({ id: schema.Agent.id })
-        .from(schema.Agent)
-        .where(
-          and(eq(schema.Agent.organizationId, organizationId), eq(schema.Agent.slug, input.slug))
-        )
-        .limit(1)
-      if (conflict) {
+      if (await isAgentSlugTaken(organizationId, input.slug)) {
         throw new TRPCError({ code: 'CONFLICT', message: 'Slug already in use' })
       }
 
@@ -163,33 +85,17 @@ export const agentRouter = createTRPCRouter({
         prompt: input.prompt,
         modelId: input.modelId ?? null,
         mentionable: input.mentionable ?? true,
+        toolsetSlugs: input.toolsetSlugs,
       })
-
-      const slugs = input.toolsetSlugs ?? (await resolveDefaultToolsets(organizationId))
-      const source: 'manual' | 'auto_default' = input.toolsetSlugs ? 'manual' : 'auto_default'
-      const now = new Date()
-
-      if (slugs.length > 0) {
-        await ctx.db.insert(schema.AgentToolset).values(
-          slugs.map((slug) => ({
-            agentId: created.agentId,
-            toolsetSlug: slug,
-            source,
-            enabled: true,
-            config: {},
-            updatedAt: now,
-          }))
-        )
-      }
 
       logger.info('Agent created', {
         organizationId,
         agentId: created.agentId,
-        toolsetCount: slugs.length,
-        source,
+        toolsetCount: created.toolsetSlugs.length,
+        source: created.toolsetSource,
       })
 
-      return created
+      return { agentId: created.agentId, userId: created.userId }
     }),
 
   update: adminProcedure
@@ -209,12 +115,7 @@ export const agentRouter = createTRPCRouter({
       const { organizationId } = ctx.session
       const { agentId, ...patch } = input
 
-      const [existing] = await ctx.db
-        .select({ id: schema.Agent.id })
-        .from(schema.Agent)
-        .where(and(eq(schema.Agent.id, agentId), eq(schema.Agent.organizationId, organizationId)))
-        .limit(1)
-      if (!existing) {
+      if (!(await agentExistsInOrg(organizationId, agentId))) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
       }
 
@@ -232,20 +133,9 @@ export const agentRouter = createTRPCRouter({
   checkSlug: adminProcedure
     .input(z.object({ slug: z.string().min(1).max(60), excludeAgentId: z.string().optional() }))
     .query(async ({ ctx, input }) => {
-      const { organizationId } = ctx.session
-      const conditions = [
-        eq(schema.Agent.organizationId, organizationId),
-        eq(schema.Agent.slug, input.slug),
-      ]
-      if (input.excludeAgentId) {
-        conditions.push(ne(schema.Agent.id, input.excludeAgentId))
-      }
-      const [row] = await ctx.db
-        .select({ id: schema.Agent.id })
-        .from(schema.Agent)
-        .where(and(...conditions))
-        .limit(1)
-
-      return { available: !row }
+      const taken = await isAgentSlugTaken(ctx.session.organizationId, input.slug, {
+        excludeAgentId: input.excludeAgentId,
+      })
+      return { available: !taken }
     }),
 })

--- a/packages/lib/src/agents/agent-service.ts
+++ b/packages/lib/src/agents/agent-service.ts
@@ -1,9 +1,17 @@
 // packages/lib/src/agents/agent-service.ts
 
-import { type Database, database as defaultDb, schema } from '@auxx/database'
+import {
+  type AgentResourceScopeEntity,
+  type AgentToolsetEntity,
+  type Database,
+  database as defaultDb,
+  type PinnedRecord,
+  schema,
+} from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { eq } from 'drizzle-orm'
-import { onCacheEvent } from '../cache'
+import { and, eq } from 'drizzle-orm'
+import { getAllCachedAgents, getCachedAgentById, getCachedAgents, onCacheEvent } from '../cache'
+import { resolveDefaultToolsets } from './default-toolsets'
 
 const logger = createScopedLogger('agent-service')
 
@@ -18,11 +26,21 @@ export interface CreateAgentInput {
   prompt?: Record<string, unknown>
   modelId?: string | null
   mentionable?: boolean
+  /**
+   * Initial toolset slugs to enable. When omitted, defaults from
+   * `resolveDefaultToolsets(orgId)` are inserted with `source='auto_default'`.
+   * When provided, caller-supplied slugs are inserted with `source='manual'`.
+   */
+  toolsetSlugs?: string[]
 }
 
 export interface CreatedAgent {
   agentId: string
   userId: string
+  /** Toolset slugs inserted alongside the agent. */
+  toolsetSlugs: string[]
+  /** Source applied to the toolset rows (manual vs auto_default). */
+  toolsetSource: 'manual' | 'auto_default'
 }
 
 /**
@@ -64,6 +82,8 @@ export async function createAgent(
   } = input
 
   const now = new Date()
+  const toolsetSource: 'manual' | 'auto_default' = input.toolsetSlugs ? 'manual' : 'auto_default'
+  const toolsetSlugs = input.toolsetSlugs ?? (await resolveDefaultToolsets(organizationId))
 
   const { agentId, userId } = await db.transaction(async (tx) => {
     // 1. Insert the synthetic User. emailVerified: true skips any
@@ -119,6 +139,21 @@ export async function createAgent(
       updatedAt: now,
     })
 
+    // 5. AgentToolset rows. Auto-defaults when caller omitted toolsetSlugs;
+    //    explicit choices land as `manual`.
+    if (toolsetSlugs.length > 0) {
+      await tx.insert(schema.AgentToolset).values(
+        toolsetSlugs.map((toolsetSlug) => ({
+          agentId: agent.id,
+          toolsetSlug,
+          source: toolsetSource,
+          enabled: true,
+          config: {},
+          updatedAt: now,
+        }))
+      )
+    }
+
     return { agentId: agent.id, userId: user.id }
   })
 
@@ -134,7 +169,7 @@ export async function createAgent(
     })
   }
 
-  return { agentId, userId }
+  return { agentId, userId, toolsetSlugs, toolsetSource }
 }
 
 export interface UpdateAgentInput {
@@ -225,4 +260,149 @@ export async function archiveAgent(
   db: Database = defaultDb as Database
 ): Promise<void> {
   await updateAgent(agentId, organizationId, { archivedAt: new Date() }, db)
+}
+
+/**
+ * Summary row for admin listings. Sourced entirely from the org cache.
+ */
+export interface AgentSummary {
+  id: string
+  userId: string
+  createdById: string
+  name: string
+  slug: string
+  description: string | null
+  avatarUrl: string | null
+  mentionable: boolean
+  modelId: string | null
+  archivedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * List agents for the admin UI. Read flows entirely through the org cache;
+ * pass `includeArchived: true` to include soft-deleted rows.
+ */
+export async function listAgents(
+  organizationId: string,
+  options: { includeArchived?: boolean } = {}
+): Promise<AgentSummary[]> {
+  const all = options.includeArchived
+    ? await getAllCachedAgents(organizationId)
+    : await getCachedAgents(organizationId)
+  return all.map(toAgentSummary)
+}
+
+function toAgentSummary(a: {
+  id: string
+  userId: string
+  createdById: string
+  name: string
+  slug: string
+  description: string | null
+  avatarUrl: string | null
+  mentionable: boolean
+  modelId: string | null
+  archivedAt: string | null
+  createdAt: string
+  updatedAt: string
+}): AgentSummary {
+  return {
+    id: a.id,
+    userId: a.userId,
+    createdById: a.createdById,
+    name: a.name,
+    slug: a.slug,
+    description: a.description,
+    avatarUrl: a.avatarUrl,
+    mentionable: a.mentionable,
+    modelId: a.modelId,
+    archivedAt: a.archivedAt,
+    createdAt: a.createdAt,
+    updatedAt: a.updatedAt,
+  }
+}
+
+/**
+ * Full admin-detail view of one agent. Combines the cached agent row with
+ * (uncached) toolset + resource-scope rows read in one DB round trip each.
+ * Returns `null` when the agent does not exist for this org.
+ */
+export interface AgentDetail extends AgentSummary {
+  organizationId: string
+  prompt: Record<string, unknown>
+  pinnedRecords: PinnedRecord[]
+  toolsets: AgentToolsetEntity[]
+  resourceScopes: AgentResourceScopeEntity[]
+}
+
+/**
+ * Resolve an agent by id or slug, returning the full admin-detail view.
+ *
+ * Lookup flows through the org agents cache (which contains every agent in
+ * the org, including archived rows), so a single network roundtrip resolves
+ * either identifier. Returns `null` when neither identifier matches.
+ */
+export async function getAgentDetailByIdOrSlug(
+  organizationId: string,
+  idOrSlug: string,
+  db: Database = defaultDb as Database
+): Promise<AgentDetail | null> {
+  const all = await getAllCachedAgents(organizationId)
+  const match = all.find((a) => a.id === idOrSlug || a.slug === idOrSlug)
+  if (!match) return null
+  return getAgentDetail(organizationId, match.id, db)
+}
+
+export async function getAgentDetail(
+  organizationId: string,
+  agentId: string,
+  db: Database = defaultDb as Database
+): Promise<AgentDetail | null> {
+  const cached = await getCachedAgentById(organizationId, agentId)
+  if (!cached) return null
+
+  const [toolsets, resourceScopes] = await Promise.all([
+    db.select().from(schema.AgentToolset).where(eq(schema.AgentToolset.agentId, agentId)),
+    db
+      .select()
+      .from(schema.AgentResourceScope)
+      .where(
+        and(
+          eq(schema.AgentResourceScope.agentId, agentId),
+          eq(schema.AgentResourceScope.organizationId, organizationId)
+        )
+      ),
+  ])
+
+  return {
+    ...toAgentSummary(cached),
+    organizationId,
+    prompt: cached.prompt,
+    pinnedRecords: cached.pinnedRecords,
+    toolsets,
+    resourceScopes,
+  }
+}
+
+/**
+ * Returns true when an active or archived agent owns the given slug in this
+ * org. Optionally excludes one agent (used by `update`-style slug checks).
+ */
+export async function isAgentSlugTaken(
+  organizationId: string,
+  slug: string,
+  options: { excludeAgentId?: string } = {}
+): Promise<boolean> {
+  const all = await getAllCachedAgents(organizationId)
+  return all.some((a) => a.slug === slug && a.id !== options.excludeAgentId)
+}
+
+/**
+ * Cache-backed existence guard. Use in routers to keep org-scope enforcement
+ * out of raw SQL. Includes archived agents so callers can act on them.
+ */
+export async function agentExistsInOrg(organizationId: string, agentId: string): Promise<boolean> {
+  return (await getCachedAgentById(organizationId, agentId)) !== null
 }

--- a/packages/lib/src/agents/agent-toolset-service.ts
+++ b/packages/lib/src/agents/agent-toolset-service.ts
@@ -1,0 +1,138 @@
+// packages/lib/src/agents/agent-toolset-service.ts
+
+import {
+  type AgentToolsetEntity,
+  type Database,
+  database as defaultDb,
+  schema,
+  type Transaction,
+} from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq } from 'drizzle-orm'
+import { onCacheEvent } from '../cache'
+import type { AgentToolsetConfig } from './agent-toolset-types'
+
+const logger = createScopedLogger('agent-toolset-service')
+
+/**
+ * Patch shape applied to a single `(agentId, toolsetSlug)` row. Both
+ * `enabled` and `disabledTools` are independently optional so callers can
+ * patch just what changed.
+ */
+export interface AgentToolsetPatch {
+  slug: string
+  enabled?: boolean
+  disabledTools?: string[]
+}
+
+/**
+ * List the toolset rows for one agent. Toolsets are not currently cached
+ * (per-agent row count is O(10)); this is a single indexed DB read.
+ */
+export async function listAgentToolsets(
+  agentId: string,
+  db: Database = defaultDb as Database
+): Promise<AgentToolsetEntity[]> {
+  return db.select().from(schema.AgentToolset).where(eq(schema.AgentToolset.agentId, agentId))
+}
+
+/**
+ * Upsert one toolset row inside a caller-provided tx. Newly inserted rows
+ * land with `source='manual'`; existing `auto_default` rows are promoted to
+ * `manual` on first admin save (first-touch promotion).
+ */
+async function applyToolsetPatch(
+  tx: Transaction,
+  agentId: string,
+  patch: AgentToolsetPatch
+): Promise<void> {
+  const now = new Date()
+
+  const [existing] = await tx
+    .select({
+      id: schema.AgentToolset.id,
+      config: schema.AgentToolset.config,
+      source: schema.AgentToolset.source,
+    })
+    .from(schema.AgentToolset)
+    .where(
+      and(eq(schema.AgentToolset.agentId, agentId), eq(schema.AgentToolset.toolsetSlug, patch.slug))
+    )
+    .limit(1)
+
+  if (existing) {
+    const nextConfig: AgentToolsetConfig = { ...(existing.config as AgentToolsetConfig) }
+    if (patch.disabledTools !== undefined) {
+      nextConfig.disabledTools = patch.disabledTools
+    }
+    const update: Record<string, unknown> = { updatedAt: now, config: nextConfig }
+    if (patch.enabled !== undefined) update.enabled = patch.enabled
+    if (existing.source === 'auto_default') update.source = 'manual'
+    await tx.update(schema.AgentToolset).set(update).where(eq(schema.AgentToolset.id, existing.id))
+    return
+  }
+
+  const config: AgentToolsetConfig = {}
+  if (patch.disabledTools !== undefined) config.disabledTools = patch.disabledTools
+  await tx.insert(schema.AgentToolset).values({
+    agentId,
+    toolsetSlug: patch.slug,
+    config,
+    source: 'manual',
+    enabled: patch.enabled ?? true,
+    updatedAt: now,
+  })
+}
+
+/**
+ * Update one toolset row for an agent. Wraps `applyToolsetPatch` in a tx and
+ * emits the `agent.updated` cache event so dependent caches refresh.
+ */
+export async function updateAgentToolset(
+  organizationId: string,
+  agentId: string,
+  patch: AgentToolsetPatch,
+  db: Database = defaultDb as Database
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    await applyToolsetPatch(tx, agentId, patch)
+  })
+
+  try {
+    await onCacheEvent('agent.updated', { orgId: organizationId })
+  } catch (err) {
+    logger.warn('Failed to invalidate caches after toolset update', {
+      organizationId,
+      agentId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+/**
+ * Apply many toolset patches for an agent atomically. Rows not in the patch
+ * list are left untouched — callers send the full set they want to enable,
+ * plus explicit `enabled: false` for ones they unchecked.
+ */
+export async function batchUpdateAgentToolsets(
+  organizationId: string,
+  agentId: string,
+  patches: AgentToolsetPatch[],
+  db: Database = defaultDb as Database
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    for (const patch of patches) {
+      await applyToolsetPatch(tx, agentId, patch)
+    }
+  })
+
+  try {
+    await onCacheEvent('agent.updated', { orgId: organizationId })
+  } catch (err) {
+    logger.warn('Failed to invalidate caches after toolset batch update', {
+      organizationId,
+      agentId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}

--- a/packages/lib/src/agents/index.ts
+++ b/packages/lib/src/agents/index.ts
@@ -1,13 +1,26 @@
 // packages/lib/src/agents/index.ts
 
 export {
+  type AgentDetail,
+  type AgentSummary,
+  agentExistsInOrg,
   archiveAgent,
   type CreateAgentInput,
   type CreatedAgent,
   createAgent,
+  getAgentDetail,
+  getAgentDetailByIdOrSlug,
+  isAgentSlugTaken,
+  listAgents,
   type UpdateAgentInput,
   updateAgent,
 } from './agent-service'
+export {
+  type AgentToolsetPatch,
+  batchUpdateAgentToolsets,
+  listAgentToolsets,
+  updateAgentToolset,
+} from './agent-toolset-service'
 export type { AgentToolsetConfig } from './agent-toolset-types'
 export { NATIVE_DEFAULT_TOOLSETS, resolveDefaultToolsets } from './default-toolsets'
 export { filterToolsByToolsets } from './filter-tools'

--- a/packages/lib/src/cache/index.ts
+++ b/packages/lib/src/cache/index.ts
@@ -47,7 +47,9 @@ export type { CacheEvent } from './invalidation-graph'
 // ── Cache Helpers ──
 export {
   findCachedResource,
+  getAllCachedAgents,
   getAllCachedCustomFields,
+  getCachedAgentById,
   getCachedAgents,
   getCachedAgentsByUserIds,
   getCachedCustomFields,

--- a/packages/lib/src/cache/org-cache-helpers.ts
+++ b/packages/lib/src/cache/org-cache-helpers.ts
@@ -174,6 +174,26 @@ export async function getCachedAgents(orgId: string): Promise<CachedAgent[]> {
 }
 
 /**
+ * Get every cached agent for an organization, including archived rows.
+ * Use when admin tooling needs to surface archived agents.
+ */
+export async function getAllCachedAgents(orgId: string): Promise<CachedAgent[]> {
+  return getOrgCache().get(orgId, 'agents')
+}
+
+/**
+ * Find a single cached agent by id within an org, including archived rows.
+ * Returns null when the agent does not belong to the org or does not exist.
+ */
+export async function getCachedAgentById(
+  orgId: string,
+  agentId: string
+): Promise<CachedAgent | null> {
+  const agents = await getOrgCache().get(orgId, 'agents')
+  return agents.find((a) => a.id === agentId) ?? null
+}
+
+/**
  * Get cached agents matching the given backing-user IDs.
  * Includes archived agents so historical attributions resolve correctly.
  */

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/cache/org-cache-keys.ts
 
+import type { PinnedRecord } from '@auxx/database'
 import type {
   CustomFieldEntity,
   OrganizationMemberInfo,
@@ -94,6 +95,7 @@ export interface DehydratedOrgProfile {
 export interface CachedAgent {
   id: string
   userId: string
+  createdById: string
   name: string
   slug: string
   description: string | null
@@ -101,10 +103,14 @@ export interface CachedAgent {
   mentionable: boolean
   /** Tiptap doc; empty object when no prompt has been authored. */
   prompt: Record<string, unknown>
+  /** Manual + mention-sourced records pinned to this agent. */
+  pinnedRecords: PinnedRecord[]
   /** Per-agent model override in `provider:model` format; null = inherit. */
   modelId: string | null
   /** ISO string when archived; null when active. */
   archivedAt: string | null
+  createdAt: string
+  updatedAt: string
 }
 
 /** Dehydrated group instance for cache (JSON-serializable) */

--- a/packages/lib/src/cache/providers/agents-provider.ts
+++ b/packages/lib/src/cache/providers/agents-provider.ts
@@ -23,12 +23,16 @@ export const agentsProvider: CacheProvider<CachedAgent[]> = {
       .select({
         id: schema.Agent.id,
         userId: schema.Agent.userId,
+        createdById: schema.Agent.createdById,
         slug: schema.Agent.slug,
         description: schema.Agent.description,
         prompt: schema.Agent.prompt,
+        pinnedRecords: schema.Agent.pinnedRecords,
         modelId: schema.Agent.modelId,
         mentionable: schema.Agent.mentionable,
         archivedAt: schema.Agent.archivedAt,
+        createdAt: schema.Agent.createdAt,
+        updatedAt: schema.Agent.updatedAt,
         userName: schema.User.name,
         avatarAssetId: schema.User.avatarAssetId,
       })
@@ -53,14 +57,18 @@ export const agentsProvider: CacheProvider<CachedAgent[]> = {
         return {
           id: row.id,
           userId: row.userId,
+          createdById: row.createdById,
           name: row.userName ?? '',
           slug: row.slug,
           description: row.description ?? null,
           avatarUrl,
           prompt: (row.prompt ?? {}) as Record<string, unknown>,
+          pinnedRecords: row.pinnedRecords ?? [],
           modelId: row.modelId ?? null,
           mentionable: row.mentionable,
           archivedAt: row.archivedAt ? row.archivedAt.toISOString() : null,
+          createdAt: row.createdAt.toISOString(),
+          updatedAt: row.updatedAt.toISOString(),
         }
       })
     )

--- a/packages/lib/src/permissions/types.ts
+++ b/packages/lib/src/permissions/types.ts
@@ -44,6 +44,7 @@ export enum FeatureKey {
   realtimeMail = 'realtimeMail',
   callRecordings = 'callRecordings',
   todayInbox = 'todayInbox',
+  agents = 'agents',
 
   // ── Static limits (count of things, not time-based) ──
   teammates = 'teammates',
@@ -146,6 +147,13 @@ export const FEATURE_REGISTRY: FeatureMetadata[] = [
     type: 'boolean',
     label: 'Today Inbox',
     description: 'AI suggestion bundles for stale records, surfaced in /app/today.',
+    group: 'AI',
+  },
+  {
+    key: FeatureKey.agents,
+    type: 'boolean',
+    label: 'Agents',
+    description: 'User-authored Kopilot agents (CRUD + runtime targeting).',
     group: 'AI',
   },
 

--- a/packages/seed/src/domains/billing.domain.ts
+++ b/packages/seed/src/domains/billing.domain.ts
@@ -113,6 +113,7 @@ const BOOLEAN_GATES = {
     realtimeSync: true,
     callRecordings: false,
     todayInbox: false,
+    agents: true,
   },
   free: {
     knowledgeBase: false,
@@ -130,6 +131,7 @@ const BOOLEAN_GATES = {
     realtimeSync: true,
     callRecordings: false,
     todayInbox: false,
+    agents: true,
   },
   starter: {
     knowledgeBase: false,
@@ -147,6 +149,7 @@ const BOOLEAN_GATES = {
     realtimeSync: true,
     callRecordings: false,
     todayInbox: false,
+    agents: true,
   },
   growth: {
     knowledgeBase: false,
@@ -164,6 +167,7 @@ const BOOLEAN_GATES = {
     realtimeSync: true,
     callRecordings: false,
     todayInbox: false,
+    agents: true,
   },
   enterprise: {
     knowledgeBase: false,
@@ -181,6 +185,7 @@ const BOOLEAN_GATES = {
     realtimeSync: true,
     callRecordings: false,
     todayInbox: false,
+    agents: true,
   },
 } as const
 


### PR DESCRIPTION
## Summary
- New `/app/agents` admin surface — list, new, and `[slug]` detail pages with hero, breadcrumb switcher, tab placeholders (prompt/tools/knowledge), docked chat, archive, search/grid, and create dialog. Backed by a Zustand store, react-query hooks, and provider scaffolding under `apps/web/src/components/agents/`.
- Service-layer refactor: all agent + agent-toolset persistence moves out of tRPC routers into `@auxx/lib/agents` (`listAgents`, `getAgentDetail`, `getAgentDetailByIdOrSlug`, `agentExistsInOrg`, `isAgentSlugTaken`, plus a new `agent-toolset-service` with `listAgentToolsets` / `updateAgentToolset` / `batchUpdateAgentToolsets`). Routers validate input, scope by org via the cache, and delegate — no raw SQL left in `agent.ts` / `agent-toolset.ts`.
- Org agents cache expanded with `createdById`, `pinnedRecords`, `createdAt`, `updatedAt`; new `getAllCachedAgents` (includes archived) and `getCachedAgentById` helpers so the admin detail view can resolve by id-or-slug in one roundtrip.
- Kopilot chat accepts an `agentId` prop and threads it through send / retry / approval requests so new sessions bind to a target agent.
- Sidebar gains an Agents entry with `adminOnly` gating; new `agents` boolean feature flag added to `FEATURE_REGISTRY` and enabled across all billing tiers in `packages/seed`.

## Test plan
- [ ] `/app/agents` list page renders, search filters, empty state shows for orgs with no agents
- [ ] Create-agent dialog → new agent appears in list and resolves at `/app/agents/<slug>`
- [ ] Detail page: breadcrumb switcher, hero edit, archive, docked chat (binds `agentId`)
- [ ] Tabs render placeholders without crashing
- [ ] Toolset list/update/batch-update via tRPC still works (regression — service-layer refactor only)
- [ ] Sidebar Agents entry hidden for non-admins, visible for admin/owner
- [ ] `agents` feature flag honored when toggled off