### PR TITLE
feat(agents): persona editor with shared rich-text + inline references

### DIFF
--- a/apps/web/src/components/agents/hooks/use-agent-autosave.ts
+++ b/apps/web/src/components/agents/hooks/use-agent-autosave.ts
@@ -1,0 +1,96 @@
+// apps/web/src/components/agents/hooks/use-agent-autosave.ts
+'use client'
+
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { AutosaveState } from '../ui/shared/autosave-indicator'
+import { useAgentMutations } from './use-agent-mutations'
+
+interface AgentUpdatePatch {
+  name?: string
+  description?: string | null
+  modelId?: string | null
+  mentionable?: boolean
+  prompt?: Record<string, unknown>
+}
+
+interface UseAgentAutosaveOptions {
+  /** Notified whenever the autosave state changes (saving / saved / idle). Hoist into the page header. */
+  onStateChange?: (state: AutosaveState) => void
+}
+
+interface UseAgentAutosaveReturn {
+  /** Current autosave state — exposes to inline indicators (otherwise use onStateChange). */
+  state: AutosaveState
+  /** Debounced field patch — coalesces consecutive calls within `debounceMs`. */
+  patch: (input: AgentUpdatePatch, opts?: { debounceMs?: number }) => void
+  /** Flush any queued patch immediately. */
+  flush: () => Promise<void>
+}
+
+/**
+ * Debounced patch wrapper around `api.agent.update`. Field-level callers
+ * pass a partial; the hook coalesces concurrent calls within `debounceMs`
+ * (default 600ms) and fires one mutation per flush.
+ *
+ * The `state` value drives the page-header `AutosaveIndicator`. The hook
+ * keeps the state local but also calls `onStateChange` for parents that
+ * want to hoist a single indicator (matches phase-1-ui-tabs.md §2.1).
+ */
+export function useAgentAutosave(
+  agentId: string,
+  { onStateChange }: UseAgentAutosaveOptions = {}
+): UseAgentAutosaveReturn {
+  const { updateAgent } = useAgentMutations()
+  const [state, setState] = useState<AutosaveState>({ kind: 'idle' })
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const queuedPatchRef = useRef<AgentUpdatePatch | null>(null)
+  const onStateChangeRef = useRef(onStateChange)
+  onStateChangeRef.current = onStateChange
+
+  const setStateAndNotify = useCallback((next: AutosaveState) => {
+    setState(next)
+    onStateChangeRef.current?.(next)
+  }, [])
+
+  const flush = useCallback(async () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = null
+    const patch = queuedPatchRef.current
+    queuedPatchRef.current = null
+    if (!patch) return
+    setStateAndNotify({ kind: 'saving' })
+    try {
+      const ok = await updateAgent(agentId, patch)
+      if (ok) {
+        setStateAndNotify({ kind: 'saved', at: Date.now() })
+      } else {
+        setStateAndNotify({ kind: 'idle' })
+      }
+    } catch (err) {
+      setStateAndNotify({ kind: 'idle' })
+      toastError({ title: 'Save failed', description: (err as Error).message })
+    }
+  }, [agentId, updateAgent, setStateAndNotify])
+
+  const patch = useCallback(
+    (input: AgentUpdatePatch, opts?: { debounceMs?: number }) => {
+      queuedPatchRef.current = { ...queuedPatchRef.current, ...input }
+      if (timerRef.current) clearTimeout(timerRef.current)
+      const ms = opts?.debounceMs ?? 600
+      timerRef.current = setTimeout(() => {
+        void flush()
+      }, ms)
+    },
+    [flush]
+  )
+
+  // Flush any pending patch on unmount so a fast tab-away doesn't drop edits.
+  useEffect(() => {
+    return () => {
+      if (queuedPatchRef.current) void flush()
+    }
+  }, [flush])
+
+  return { state, patch, flush }
+}

--- a/apps/web/src/components/agents/hooks/use-agent-mutations.ts
+++ b/apps/web/src/components/agents/hooks/use-agent-mutations.ts
@@ -18,6 +18,8 @@ interface UpdateAgentInput {
   modelId?: string | null
   mentionable?: boolean
   archivedAt?: Date | null
+  /** Persona Tiptap doc (`{ type: 'doc', content: [...] }`). */
+  prompt?: Record<string, unknown>
 }
 
 interface UseAgentMutationsResult {

--- a/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
@@ -8,6 +8,7 @@ import { useQueryState } from 'nuqs'
 import { useCallback, useEffect, useRef } from 'react'
 import { AGENT_TABS, type AgentTab, DEFAULT_AGENT_TAB } from '../../constant'
 import type { AgentDetail } from '../../store/agent-store'
+import type { AutosaveState } from '../shared/autosave-indicator'
 import { AgentHero } from './agent-hero'
 import { KnowledgeSectionContent } from './tabs/knowledge-tab-placeholder'
 import { PromptSectionContent } from './tabs/prompt-tab-placeholder'
@@ -30,6 +31,8 @@ const STICKY_OFFSET = 56
 
 interface AgentDetailTabsProps {
   agent: AgentDetail
+  /** Lifted autosave state — feeds the page-header `AutosaveIndicator`. */
+  onAutosaveChange?: (state: AutosaveState) => void
 }
 
 /**
@@ -37,7 +40,7 @@ interface AgentDetailTabsProps {
  * tab strip on top. Clicking a tab scrolls the matching section into view;
  * scrolling updates the active tab.
  */
-export function AgentDetailTabs({ agent }: AgentDetailTabsProps) {
+export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProps) {
   const [tab, setTab] = useQueryState('tab', { defaultValue: DEFAULT_AGENT_TAB })
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const sectionRefs = useRef<Record<AgentTab, HTMLDivElement | null>>({
@@ -138,7 +141,7 @@ export function AgentDetailTabs({ agent }: AgentDetailTabsProps) {
             icon={<FileText className='size-4' />}
             initialOpen
             collapsible={false}>
-            <PromptSectionContent />
+            <PromptSectionContent agent={agent} onAutosaveChange={onAutosaveChange} />
           </Section>
         </div>
 

--- a/apps/web/src/components/agents/ui/detail/agent-detail-view.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-view.tsx
@@ -72,7 +72,7 @@ export function AgentDetailView({ agent }: AgentDetailViewProps) {
               ]
             : []
         }>
-        <AgentDetailTabs agent={agent} />
+        <AgentDetailTabs agent={agent} onAutosaveChange={setAutosave} />
       </MainPageContent>
     </MainPage>
   )

--- a/apps/web/src/components/agents/ui/detail/prompt/persona-editor.tsx
+++ b/apps/web/src/components/agents/ui/detail/prompt/persona-editor.tsx
@@ -1,0 +1,106 @@
+// apps/web/src/components/agents/ui/detail/prompt/persona-editor.tsx
+'use client'
+
+import type { JSONContent } from '@tiptap/core'
+import { EditorContent } from '@tiptap/react'
+import { useCallback, useMemo, useRef } from 'react'
+import { InlinePickerPopover, useActivePicker } from '~/components/editor/inline-picker'
+import { useRichTextEditor } from '~/components/editor/rich-text/use-rich-text-editor'
+import {
+  ReferencePickerContent,
+  type ReferencePickerHandle,
+} from '~/components/pickers/reference-picker/reference-picker-content'
+import { useAgentAutosave } from '../../../hooks/use-agent-autosave'
+import type { AgentDetail } from '../../../store/agent-store'
+import type { AutosaveState } from '../../shared/autosave-indicator'
+
+interface PersonaEditorProps {
+  agent: AgentDetail
+  /** Lifted autosave state — used by the page-header indicator. */
+  onAutosaveChange?: (state: AutosaveState) => void
+}
+
+function readPromptContent(
+  prompt: Record<string, unknown> | null | undefined
+): JSONContent[] | null {
+  if (!prompt) return null
+  const content = (prompt as { content?: unknown }).content
+  if (!Array.isArray(content)) return null
+  return content as JSONContent[]
+}
+
+/**
+ * Persona prompt editor for the agent detail page. Mounts `useRichTextEditor`
+ * with the inline `@`-mention picker so admins can drop references to records,
+ * actors, threads, and KB articles inline in the persona doc.
+ */
+export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const referencePickerRef = useRef<ReferencePickerHandle | null>(null)
+  const { patch } = useAgentAutosave(agent.id, { onStateChange: onAutosaveChange })
+
+  const initialContent = useMemo(() => readPromptContent(agent.prompt), [agent.prompt])
+
+  const onPickerEnter = useCallback(
+    () => referencePickerRef.current?.confirmHighlighted() ?? false,
+    []
+  )
+  const onPickerArrowVertical = useCallback(
+    (dir: 1 | -1) => referencePickerRef.current?.moveHighlight(dir) ?? false,
+    []
+  )
+
+  const handleChange = useCallback(
+    ({ json }: { json: JSONContent; html: string }) => {
+      patch({ prompt: json as Record<string, unknown> }, { debounceMs: 800 })
+    },
+    [patch]
+  )
+
+  const { editor } = useRichTextEditor({
+    initialContent,
+    onChange: handleChange,
+    enableReferencePicker: true,
+    onPickerEnter,
+    onPickerArrowVertical,
+  })
+
+  const activePicker = useActivePicker(editor)
+
+  return (
+    <div ref={wrapperRef} className='relative'>
+      <EditorContent
+        editor={editor}
+        className='prose prose-sm max-w-none dark:prose-invert focus:outline-none'
+      />
+      <InlinePickerPopover
+        state={{
+          isOpen: !!activePicker,
+          query: activePicker?.query ?? '',
+          range: null,
+          clientRect: activePicker?.clientRect ?? null,
+        }}
+        containerRef={wrapperRef}
+        width={360}
+        side='bottom'
+        align='start'
+        autoFocus={false}
+        onInteractOutside={(e) => {
+          // Clicking the chip itself must not close the picker.
+          const target = e.target as HTMLElement | null
+          if (target?.closest('[data-type="reference-picker"]')) {
+            e.preventDefault()
+          }
+        }}
+        onClose={() => editor?.commands.closeReferencePicker({ keepText: true })}>
+        <ReferencePickerContent
+          ref={referencePickerRef}
+          tab={activePicker?.tab ?? 'people'}
+          query={activePicker?.query ?? ''}
+          onSelect={(id) => editor?.commands.confirmReferencePicker(id)}
+          onTabChange={(tab) => editor?.commands.setReferencePickerTab(tab)}
+        />
+      </InlinePickerPopover>
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/tabs/prompt-tab-placeholder.tsx
+++ b/apps/web/src/components/agents/ui/detail/tabs/prompt-tab-placeholder.tsx
@@ -1,10 +1,19 @@
 // apps/web/src/components/agents/ui/detail/tabs/prompt-tab-placeholder.tsx
 'use client'
 
-export function PromptSectionContent() {
+import type { AgentDetail } from '../../../store/agent-store'
+import type { AutosaveState } from '../../shared/autosave-indicator'
+import { PersonaEditor } from '../prompt/persona-editor'
+
+interface PromptSectionContentProps {
+  agent: AgentDetail
+  onAutosaveChange?: (state: AutosaveState) => void
+}
+
+export function PromptSectionContent({ agent, onAutosaveChange }: PromptSectionContentProps) {
   return (
-    <div className='py-4 text-sm text-muted-foreground'>
-      Prompt editor lands in phase-1-ui-tab-prompt.md.
+    <div className='px-3 pb-6'>
+      <PersonaEditor agent={agent} onAutosaveChange={onAutosaveChange} />
     </div>
   )
 }

--- a/apps/web/src/components/editor/inline-picker/hooks/use-reference-picker-editor.tsx
+++ b/apps/web/src/components/editor/inline-picker/hooks/use-reference-picker-editor.tsx
@@ -2,18 +2,12 @@
 
 'use client'
 
-import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
-import type { ActorId } from '@auxx/types/actor'
-import { cn } from '@auxx/ui/lib/utils'
+import type { RecordId } from '@auxx/lib/resources/client'
 import Placeholder from '@tiptap/extension-placeholder'
 import { type Editor, type JSONContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { useCallback } from 'react'
-import { ActorBadge } from '~/components/resources/ui/actor-badge'
-import { RecordBadge } from '~/components/resources/ui/record-badge'
-import { ThreadBadge } from '~/components/threads/ui/thread-badge'
-import { createInlineNode } from '../core/inline-node'
-import { ReferencePickerNode } from '../nodes/reference-picker-node'
+import { useCallback, useMemo } from 'react'
+import { buildReferencePickerExtensions } from '../../rich-text/reference-picker-extensions'
 
 interface UseReferencePickerEditorOptions {
   initialContent?: string
@@ -29,42 +23,16 @@ interface UseReferencePickerEditorOptions {
   onPickerArrowVertical?: (direction: 1 | -1) => boolean
 }
 
-const referenceBadgeRing = 'transition-all inline-flex'
-
-function renderReferenceBadge({ id, selected }: { id: string; selected: boolean }) {
-  const ring = cn(referenceBadgeRing, selected && 'ring-2 ring-primary ring-offset-1')
-  if (id.startsWith('user:') || id.startsWith('group:')) {
-    return <ActorBadge actorId={id as ActorId} className={ring} />
-  }
-  if (id.startsWith('thread:') || id.startsWith('draft:')) {
-    try {
-      const { entityInstanceId } = parseRecordId(id as RecordId)
-      return <ThreadBadge threadId={entityInstanceId} className={ring} />
-    } catch {
-      return <RecordBadge recordId={id as RecordId} className={ring} />
-    }
-  }
-  return <RecordBadge recordId={id as RecordId} className={ring} />
-}
-
-const referenceBadgeNode = createInlineNode(
-  {
-    type: 'reference',
-    serialize: (id) => `@[${id}]`,
-    pastePattern: {
-      pattern: /@\[([^\]]+)\]/,
-      getId: (match) => match[1]!,
-    },
-  },
-  renderReferenceBadge
-)
-
 /**
  * Editor hook for the inline-node-based `@` picker.
  *
  * The chip node (`referencePicker`) is transient — it represents an open
  * picker. On confirm it collapses into the `reference` badge node, which is
  * the persisted form.
+ *
+ * This is the Kopilot-composer-style mount. For full rich-text editors
+ * (KB articles, agent persona) use `useRichTextEditor`, which mounts the
+ * same picker extensions alongside the article block set.
  */
 export function useReferencePickerEditor(options: UseReferencePickerEditorOptions = {}) {
   const {
@@ -79,6 +47,11 @@ export function useReferencePickerEditor(options: UseReferencePickerEditorOption
     onPickerArrowVertical,
   } = options
 
+  const referencePickerExtensions = useMemo(
+    () => buildReferencePickerExtensions({ onPickerEnter, onPickerArrowVertical }),
+    [onPickerEnter, onPickerArrowVertical]
+  )
+
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -90,11 +63,7 @@ export function useReferencePickerEditor(options: UseReferencePickerEditorOption
         orderedList: false,
         listItem: false,
       }),
-      referenceBadgeNode,
-      ReferencePickerNode.configure({
-        onEnter: onPickerEnter,
-        onArrowVertical: onPickerArrowVertical,
-      }),
+      ...referencePickerExtensions,
       ...(placeholder ? [Placeholder.configure({ placeholder, showOnlyWhenEditable: true })] : []),
       ...(extensions as []),
     ],

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
@@ -6,7 +6,11 @@ import { getMarkRange } from '@tiptap/core'
 import type { Editor } from '@tiptap/react'
 import { EditorContent } from '@tiptap/react'
 import type { CSSProperties } from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  ReferencePickerContent,
+  type ReferencePickerHandle,
+} from '~/components/pickers/reference-picker/reference-picker-content'
 import {
   AISlotPlaceholder,
   AlignSection,
@@ -18,7 +22,7 @@ import {
   MoreMenuSection,
   TurnIntoSection,
 } from '../bubble-menu'
-import { InlinePickerPopover } from '../inline-picker'
+import { InlinePickerPopover, useActivePicker } from '../inline-picker'
 import {
   type ArticleLinkEditMode,
   type ArticleLinkPick,
@@ -61,10 +65,24 @@ export function KBArticleEditor({
   onReady,
   readOnly,
 }: KBArticleEditorProps) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const referencePickerRef = useRef<ReferencePickerHandle | null>(null)
+  const onPickerEnter = useCallback(
+    () => referencePickerRef.current?.confirmHighlighted() ?? false,
+    []
+  )
+  const onPickerArrowVertical = useCallback(
+    (dir: 1 | -1) => referencePickerRef.current?.moveHighlight(dir) ?? false,
+    []
+  )
+
   const { editor, gutterCharWidth, slashCommand } = useKBArticleEditor({
     initialContent,
     onChange,
+    onPickerEnter,
+    onPickerArrowVertical,
   })
+  const activePicker = useActivePicker(editor)
   const [linkPopover, setLinkPopover] = useState<LinkPopoverState | null>(null)
   const [linkMenu, setLinkMenu] = useState<LinkMenuState | null>(null)
 
@@ -207,6 +225,7 @@ export function KBArticleEditor({
   return (
     <KBEditorContextProvider knowledgeBaseId={knowledgeBaseId}>
       <div
+        ref={wrapperRef}
         className={styles.editorWrapper}
         onMouseDown={handleWrapperMouseDown}
         onContextMenu={handleContextMenu}
@@ -237,6 +256,37 @@ export function KBArticleEditor({
             onClose={slashCommand.closePicker}
             onLinkArticle={handleLinkArticle}
             editor={editor}
+          />
+        </InlinePickerPopover>
+        <InlinePickerPopover
+          state={{
+            isOpen: !!activePicker,
+            query: activePicker?.query ?? '',
+            range: null,
+            clientRect: activePicker?.clientRect ?? null,
+          }}
+          containerRef={wrapperRef}
+          width={360}
+          side='bottom'
+          align='start'
+          autoFocus={false}
+          onInteractOutside={(e) => {
+            // Clicking the chip itself must not close the picker — the user
+            // is editing the query inline. Without this, Radix sees the click
+            // as outside the popover and triggers onClose, collapsing the
+            // chip to plain `@<query>` text.
+            const target = e.target as HTMLElement | null
+            if (target?.closest('[data-type="reference-picker"]')) {
+              e.preventDefault()
+            }
+          }}
+          onClose={() => editor?.commands.closeReferencePicker({ keepText: true })}>
+          <ReferencePickerContent
+            ref={referencePickerRef}
+            tab={activePicker?.tab ?? 'people'}
+            query={activePicker?.query ?? ''}
+            onSelect={(id) => editor?.commands.confirmReferencePicker(id)}
+            onTabChange={(tab) => editor?.commands.setReferencePickerTab(tab)}
           />
         </InlinePickerPopover>
         <ArticleLinkPopover

--- a/apps/web/src/components/editor/kb-article/use-kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/use-kb-article-editor.tsx
@@ -2,206 +2,39 @@
 'use client'
 
 import type { JSONContent } from '@tiptap/core'
-import { Extension, Node } from '@tiptap/core'
-import Color from '@tiptap/extension-color'
-import Highlight from '@tiptap/extension-highlight'
-import Link from '@tiptap/extension-link'
-import TextAlign from '@tiptap/extension-text-align'
-import TextStyle from '@tiptap/extension-text-style'
-import Underline from '@tiptap/extension-underline'
-import { Plugin, PluginKey } from '@tiptap/pm/state'
-import { Decoration, DecorationSet } from '@tiptap/pm/view'
-import { useEditor, useEditorState } from '@tiptap/react'
-import StarterKit from '@tiptap/starter-kit'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
-import { Table, TableCell, TableHeader, TableRow } from '../extensions/table'
-import {
-  createPlaceholderNode,
-  PlaceholderBadge,
-  stableStringify,
-  useExternalContentSync,
-  useSlashCommand,
-} from '../inline-picker'
-import { Accordion } from './accordion-node'
-import { Block } from './block-node'
-import { MarkdownInputRules } from './markdown-input-rules'
-import { MarkdownPaste } from './markdown-paste'
-import { migrateLegacyContent } from './migrate-legacy-content'
-import { Panel } from './panel-node'
-import { Tabs } from './tabs-node'
-
-const Doc = Node.create({
-  name: 'doc',
-  topNode: true,
-  // PM resolves a bare `block` token to the NODE named `block` (which we have),
-  // not the group. So we have to list `table` explicitly even though it's in
-  // `group: 'block'` — node-name resolution takes precedence over group.
-  content: '(block | containerBlock | table)+',
-})
-
-const FocusClasses = Extension.create({
-  name: 'focus-classes',
-  addProseMirrorPlugins() {
-    return [
-      new Plugin({
-        key: new PluginKey('focus-classes'),
-        props: {
-          decorations: ({ doc, selection }) => {
-            const decorations: Decoration[] = []
-            doc.descendants((node, pos) => {
-              if (node.isBlock && pos <= selection.from && pos + node.nodeSize >= selection.to) {
-                decorations.push(Decoration.node(pos, pos + node.nodeSize, { class: 'has-focus' }))
-              }
-              return true
-            })
-            return DecorationSet.create(doc, decorations)
-          },
-        },
-      }),
-    ]
-  },
-})
-
-const emptyBody: JSONContent[] = [{ type: 'block', attrs: { blockType: 'text' }, content: [] }]
+import { useSlashCommand } from '../inline-picker'
+import { useRichTextEditor } from '../rich-text/use-rich-text-editor'
 
 interface UseKBArticleEditorOptions {
   initialContent: JSONContent[] | null
   onChange: (content: { json: JSONContent; html: string }) => void
+  /** Forwarded to the inline `@`-mention picker chip — typically delegates to the popover's keyboard handle. */
+  onPickerEnter?: () => boolean
+  onPickerArrowVertical?: (direction: 1 | -1) => boolean
 }
 
-export function useKBArticleEditor({ initialContent, onChange }: UseKBArticleEditorOptions) {
+/**
+ * Thin shim over `useRichTextEditor` that wires the KB-specific slash
+ * command picker and exposes its state for the consumer to mount the
+ * picker popover. The `@`-mention picker is enabled by default; the
+ * consumer mounts that popover via `useActivePicker(editor)`.
+ */
+export function useKBArticleEditor({
+  initialContent,
+  onChange,
+  onPickerEnter,
+  onPickerArrowVertical,
+}: UseKBArticleEditorOptions) {
   const slashCommand = useSlashCommand()
 
-  const normalizedInitialContent = useMemo<JSONContent>(() => {
-    const migrated = migrateLegacyContent(initialContent)
-    const content = migrated && migrated.length > 0 ? migrated : emptyBody
-    return { type: 'doc', content }
-  }, [initialContent])
-
-  const placeholderNodeExtension = useMemo(
-    () => createPlaceholderNode((p) => <PlaceholderBadge {...p} />),
-    []
-  )
-
-  const onChangeRef = useRef(onChange)
-  useEffect(() => {
-    onChangeRef.current = onChange
-  }, [onChange])
-
-  const externalSyncRef = useRef<{ markLocalEdit: (key: string) => void }>({
-    markLocalEdit: () => {},
+  const { editor, gutterCharWidth } = useRichTextEditor({
+    initialContent,
+    onChange,
+    slashCommand,
+    enableReferencePicker: true,
+    onPickerEnter,
+    onPickerArrowVertical,
   })
 
-  const editor = useEditor(
-    {
-      immediatelyRender: false,
-      extensions: [
-        Doc,
-        StarterKit.configure({
-          document: false,
-          heading: false,
-          paragraph: false,
-          bulletList: false,
-          orderedList: false,
-          listItem: false,
-          blockquote: false,
-          codeBlock: false,
-          horizontalRule: false,
-          history: undefined,
-          // Marks stay enabled (bold, italic, strike, code).
-        }),
-        Block,
-        Panel,
-        Tabs,
-        Accordion,
-        MarkdownInputRules,
-        MarkdownPaste,
-        // Column resizing is disabled in the KB editor — the React NodeView
-        // (TableNodeView) owns the table chrome and column resize is a
-        // follow-up. Reorder + add/remove are handled via table-helpers.ts.
-        Table,
-        TableRow,
-        TableHeader,
-        TableCell,
-        Underline,
-        TextStyle,
-        Color,
-        TextAlign.configure({ types: ['block'] }),
-        Highlight.configure({ multicolor: true }),
-        Link.configure({ openOnClick: false, autolink: true, defaultProtocol: 'https' }),
-        FocusClasses,
-        // Placeholder is rendered as a real DOM sibling inside BlockNodeView,
-        // not via the Placeholder extension's CSS pseudo-element (which would
-        // overlap the line gutter). See block-node-view.tsx `showPlaceholder`.
-        slashCommand.slashCommandExtension,
-        placeholderNodeExtension,
-      ],
-      content: normalizedInitialContent,
-      shouldRerenderOnTransaction: false,
-      onCreate: ({ editor }) => slashCommand.setEditor(editor),
-      onDestroy: () => slashCommand.setEditor(null),
-      onUpdate: ({ editor, transaction }) => {
-        if (!transaction.docChanged) return
-        if (slashCommand.isOpenRef.current) return
-        const json = editor.getJSON()
-        const html = editor.getHTML()
-        // Defer one tick so Suggestion plugin's onStart can mark isOpenRef
-        // before we propagate the change.
-        setTimeout(() => {
-          if (slashCommand.isOpenRef.current) return
-          externalSyncRef.current.markLocalEdit(stableStringify(json))
-          onChangeRef.current({ json, html })
-        }, 0)
-      },
-    },
-    []
-  )
-
-  const gutterCharWidth = useEditorState({
-    editor,
-    selector: ({ editor }) =>
-      editor ? Math.max(2, String(editor.state.doc.content.childCount).length) : 2,
-  })
-
-  const applyContent = useCallback((instance: NonNullable<typeof editor>, content: JSONContent) => {
-    // Skip when the editor is already at the incoming doc — happens on
-    // mount because `useEditor` initialized it with the same content, and
-    // a redundant `setContent` here triggers TipTap's React node views to
-    // flushSync mid-commit ("flushSync was called from inside a lifecycle
-    // method" warning). Uses stableStringify so server-side JSONB key
-    // reordering doesn't make a same-content doc look different.
-    if (stableStringify(instance.getJSON()) === stableStringify(content)) return
-    const { from, to } = instance.state.selection
-    instance.commands.setContent(content, false)
-    try {
-      instance.commands.setTextSelection({ from, to })
-    } catch {
-      instance.commands.focus('end')
-    }
-  }, [])
-
-  const canonicalKey = useCallback((content: JSONContent) => stableStringify(content), [])
-
-  const syncHandle = useExternalContentSync<JSONContent>({
-    editor,
-    incoming: normalizedInitialContent,
-    isPickerOpen: slashCommand.suggestionState.isOpen,
-    applyContent,
-    canonicalKey,
-  })
-
-  // Wire the imperative handle into the editor's onUpdate closure.
-  externalSyncRef.current = syncHandle.current
-
-  // Flush deferred onChange when slash picker closes — the hook handles
-  // the *inbound* flush; this handles the *outbound* one.
-  const prevOpen = useRef(false)
-  useEffect(() => {
-    if (prevOpen.current && !slashCommand.suggestionState.isOpen && editor) {
-      onChangeRef.current({ json: editor.getJSON(), html: editor.getHTML() })
-    }
-    prevOpen.current = slashCommand.suggestionState.isOpen
-  }, [slashCommand.suggestionState.isOpen, editor])
-
-  return { editor, gutterCharWidth: gutterCharWidth ?? 2, slashCommand }
+  return { editor, gutterCharWidth, slashCommand }
 }

--- a/apps/web/src/components/editor/rich-text/index.ts
+++ b/apps/web/src/components/editor/rich-text/index.ts
@@ -1,0 +1,8 @@
+// apps/web/src/components/editor/rich-text/index.ts
+
+export {
+  type BuildReferencePickerExtensionsOptions,
+  buildReferencePickerExtensions,
+} from './reference-picker-extensions'
+export { renderReferenceBadge } from './render-reference-badge'
+export { type UseRichTextEditorOptions, useRichTextEditor } from './use-rich-text-editor'

--- a/apps/web/src/components/editor/rich-text/reference-picker-extensions.ts
+++ b/apps/web/src/components/editor/rich-text/reference-picker-extensions.ts
@@ -1,0 +1,56 @@
+// apps/web/src/components/editor/rich-text/reference-picker-extensions.ts
+
+import { createInlineNode } from '../inline-picker/core/inline-node'
+import { ReferencePickerNode } from '../inline-picker/nodes/reference-picker-node'
+import { renderReferenceBadge } from './render-reference-badge'
+
+export interface BuildReferencePickerExtensionsOptions {
+  /** Called when Enter is pressed inside the open picker chip. */
+  onPickerEnter?: () => boolean
+  /** Called when ArrowUp/Down is pressed inside the open picker chip. */
+  onPickerArrowVertical?: (direction: 1 | -1) => boolean
+}
+
+/**
+ * The committed inline badge node — id-prefix disambiguates kind
+ * (`article:`, `agent:`, `user:`, …). One TipTap node, one badge renderer,
+ * shared by every surface that mounts `@`-mentions.
+ *
+ * `serialize` is the plain-text fallback (renderText / clipboard copy as
+ * text). Markdown export goes through `blocksToMd` separately and resolves
+ * to `[Title](id)`; this stays as the legacy `@[id]` form so Kopilot
+ * composer behavior is unchanged.
+ *
+ * `pastePattern` accepts BOTH the legacy `@[id]` form and the markdown
+ * `[reference](id)` form so docs round-trip cleanly between the composer
+ * and the article editor.
+ */
+const referenceBadgeNode = createInlineNode(
+  {
+    type: 'reference',
+    serialize: (id) => `@[${id}]`,
+    pastePattern: {
+      pattern: /(?:@\[([^\]]+)\])|(?:\[reference\]\(([^)]+)\))/,
+      getId: (match) => (match[1] ?? match[2])!,
+    },
+  },
+  renderReferenceBadge
+)
+
+/**
+ * Build the TipTap extensions for the inline `@`-mention picker. Returns
+ * `[referenceBadgeNode, ReferencePickerNode]` configured with the caller's
+ * keyboard callbacks. Mount this in any rich-text editor that wants
+ * `@`-mentions.
+ */
+export function buildReferencePickerExtensions(
+  options: BuildReferencePickerExtensionsOptions = {}
+) {
+  return [
+    referenceBadgeNode,
+    ReferencePickerNode.configure({
+      onEnter: options.onPickerEnter,
+      onArrowVertical: options.onPickerArrowVertical,
+    }),
+  ]
+}

--- a/apps/web/src/components/editor/rich-text/render-reference-badge.tsx
+++ b/apps/web/src/components/editor/rich-text/render-reference-badge.tsx
@@ -1,0 +1,33 @@
+// apps/web/src/components/editor/rich-text/render-reference-badge.tsx
+
+'use client'
+
+import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
+import type { ActorId } from '@auxx/types/actor'
+import { cn } from '@auxx/ui/lib/utils'
+import { ActorBadge } from '~/components/resources/ui/actor-badge'
+import { RecordBadge } from '~/components/resources/ui/record-badge'
+import { ThreadBadge } from '~/components/threads/ui/thread-badge'
+
+const referenceBadgeRing = 'transition-all inline-flex'
+
+/**
+ * id-prefix → badge renderer for the inline `reference` node. Used by every
+ * editor that mounts the reference picker (Kopilot composer, KB article
+ * editor, agent persona editor).
+ */
+export function renderReferenceBadge({ id, selected }: { id: string; selected: boolean }) {
+  const ring = cn(referenceBadgeRing, selected && 'ring-2 ring-primary ring-offset-1')
+  if (id.startsWith('user:') || id.startsWith('group:')) {
+    return <ActorBadge actorId={id as ActorId} className={ring} />
+  }
+  if (id.startsWith('thread:') || id.startsWith('draft:')) {
+    try {
+      const { entityInstanceId } = parseRecordId(id as RecordId)
+      return <ThreadBadge threadId={entityInstanceId} className={ring} />
+    } catch {
+      return <RecordBadge recordId={id as RecordId} className={ring} />
+    }
+  }
+  return <RecordBadge recordId={id as RecordId} className={ring} />
+}

--- a/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
+++ b/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
@@ -1,0 +1,256 @@
+// apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
+
+'use client'
+
+import type { JSONContent } from '@tiptap/core'
+import { Extension, Node } from '@tiptap/core'
+import Color from '@tiptap/extension-color'
+import Highlight from '@tiptap/extension-highlight'
+import Link from '@tiptap/extension-link'
+import TextAlign from '@tiptap/extension-text-align'
+import TextStyle from '@tiptap/extension-text-style'
+import Underline from '@tiptap/extension-underline'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+import { useEditor, useEditorState } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { Table, TableCell, TableHeader, TableRow } from '../extensions/table'
+import {
+  createPlaceholderNode,
+  PlaceholderBadge,
+  stableStringify,
+  useExternalContentSync,
+  type useSlashCommand,
+} from '../inline-picker'
+import { Accordion } from '../kb-article/accordion-node'
+import { Block } from '../kb-article/block-node'
+import { MarkdownInputRules } from '../kb-article/markdown-input-rules'
+import { MarkdownPaste } from '../kb-article/markdown-paste'
+import { migrateLegacyContent } from '../kb-article/migrate-legacy-content'
+import { Panel } from '../kb-article/panel-node'
+import { Tabs } from '../kb-article/tabs-node'
+import { buildReferencePickerExtensions } from './reference-picker-extensions'
+
+const Doc = Node.create({
+  name: 'doc',
+  topNode: true,
+  // PM resolves a bare `block` token to the NODE named `block` (which we have),
+  // not the group. So we have to list `table` explicitly even though it's in
+  // `group: 'block'` — node-name resolution takes precedence over group.
+  content: '(block | containerBlock | table)+',
+})
+
+const FocusClasses = Extension.create({
+  name: 'focus-classes',
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('focus-classes'),
+        props: {
+          decorations: ({ doc, selection }) => {
+            const decorations: Decoration[] = []
+            doc.descendants((node, pos) => {
+              if (node.isBlock && pos <= selection.from && pos + node.nodeSize >= selection.to) {
+                decorations.push(Decoration.node(pos, pos + node.nodeSize, { class: 'has-focus' }))
+              }
+              return true
+            })
+            return DecorationSet.create(doc, decorations)
+          },
+        },
+      }),
+    ]
+  },
+})
+
+const emptyBody: JSONContent[] = [{ type: 'block', attrs: { blockType: 'text' }, content: [] }]
+
+export interface UseRichTextEditorOptions {
+  initialContent: JSONContent[] | null
+  onChange: (content: { json: JSONContent; html: string }) => void
+  /**
+   * Optional slash-command bundle from `useSlashCommand()`. When set, mounts
+   * the slash extension and wires open-state guards into onUpdate so typing
+   * inside the slash picker doesn't fire onChange.
+   */
+  slashCommand?: ReturnType<typeof useSlashCommand>
+  /**
+   * Default `true`. When set, mounts the `@`-mention picker extensions
+   * (referenceBadgeNode + ReferencePickerNode). The consumer mounts the
+   * popover separately via `useActivePicker(editor)` + `InlinePickerPopover`.
+   */
+  enableReferencePicker?: boolean
+  /** Forwarded to the reference picker chip. */
+  onPickerEnter?: () => boolean
+  /** Forwarded to the reference picker chip. */
+  onPickerArrowVertical?: (direction: 1 | -1) => boolean
+}
+
+/**
+ * Generic rich-text editor hook for the KB block schema. Used by:
+ * - `useKBArticleEditor` (thin shim — adds KB-specific picker / link popover)
+ * - `PersonaEditor` (agent persona prompt, no slash menu)
+ *
+ * Mounts the full block set (StarterKit + Block / Panel / Tabs / Accordion /
+ * Table), the markdown input/paste rules, the focus decoration plugin, and —
+ * by default — the inline reference picker. Slash command is opt-in.
+ */
+export function useRichTextEditor({
+  initialContent,
+  onChange,
+  slashCommand,
+  enableReferencePicker = true,
+  onPickerEnter,
+  onPickerArrowVertical,
+}: UseRichTextEditorOptions) {
+  const normalizedInitialContent = useMemo<JSONContent>(() => {
+    const migrated = migrateLegacyContent(initialContent)
+    const content = migrated && migrated.length > 0 ? migrated : emptyBody
+    return { type: 'doc', content }
+  }, [initialContent])
+
+  const placeholderNodeExtension = useMemo(
+    () => createPlaceholderNode((p) => <PlaceholderBadge {...p} />),
+    []
+  )
+
+  const referencePickerExtensions = useMemo(
+    () =>
+      enableReferencePicker
+        ? buildReferencePickerExtensions({ onPickerEnter, onPickerArrowVertical })
+        : [],
+    [enableReferencePicker, onPickerEnter, onPickerArrowVertical]
+  )
+
+  const onChangeRef = useRef(onChange)
+  useEffect(() => {
+    onChangeRef.current = onChange
+  }, [onChange])
+
+  const externalSyncRef = useRef<{ markLocalEdit: (key: string) => void }>({
+    markLocalEdit: () => {},
+  })
+
+  const slashCommandRef = useRef(slashCommand)
+  slashCommandRef.current = slashCommand
+
+  const editor = useEditor(
+    {
+      immediatelyRender: false,
+      extensions: [
+        Doc,
+        StarterKit.configure({
+          document: false,
+          heading: false,
+          paragraph: false,
+          bulletList: false,
+          orderedList: false,
+          listItem: false,
+          blockquote: false,
+          codeBlock: false,
+          horizontalRule: false,
+          history: undefined,
+          // Marks stay enabled (bold, italic, strike, code).
+        }),
+        Block,
+        Panel,
+        Tabs,
+        Accordion,
+        MarkdownInputRules,
+        MarkdownPaste,
+        // Column resizing is disabled — the React NodeView (TableNodeView)
+        // owns the table chrome and column resize is a follow-up. Reorder +
+        // add/remove are handled via table-helpers.ts.
+        Table,
+        TableRow,
+        TableHeader,
+        TableCell,
+        Underline,
+        TextStyle,
+        Color,
+        TextAlign.configure({ types: ['block'] }),
+        Highlight.configure({ multicolor: true }),
+        Link.configure({ openOnClick: false, autolink: true, defaultProtocol: 'https' }),
+        FocusClasses,
+        // Placeholder renders as a real DOM sibling inside BlockNodeView, not
+        // via the Placeholder extension's CSS pseudo-element (which would
+        // overlap the line gutter). See block-node-view.tsx `showPlaceholder`.
+        ...(slashCommand ? [slashCommand.slashCommandExtension] : []),
+        ...referencePickerExtensions,
+        placeholderNodeExtension,
+      ],
+      content: normalizedInitialContent,
+      shouldRerenderOnTransaction: false,
+      onCreate: ({ editor }) => {
+        slashCommandRef.current?.setEditor(editor)
+      },
+      onDestroy: () => {
+        slashCommandRef.current?.setEditor(null)
+      },
+      onUpdate: ({ editor, transaction }) => {
+        if (!transaction.docChanged) return
+        if (slashCommandRef.current?.isOpenRef.current) return
+        const json = editor.getJSON()
+        const html = editor.getHTML()
+        // Defer one tick so Suggestion plugin's onStart can mark isOpenRef
+        // before we propagate the change.
+        setTimeout(() => {
+          if (slashCommandRef.current?.isOpenRef.current) return
+          externalSyncRef.current.markLocalEdit(stableStringify(json))
+          onChangeRef.current({ json, html })
+        }, 0)
+      },
+    },
+    []
+  )
+
+  const gutterCharWidth = useEditorState({
+    editor,
+    selector: ({ editor }) =>
+      editor ? Math.max(2, String(editor.state.doc.content.childCount).length) : 2,
+  })
+
+  const applyContent = useCallback((instance: NonNullable<typeof editor>, content: JSONContent) => {
+    // Skip when the editor is already at the incoming doc — happens on
+    // mount because `useEditor` initialized it with the same content, and
+    // a redundant `setContent` here triggers TipTap's React node views to
+    // flushSync mid-commit ("flushSync was called from inside a lifecycle
+    // method" warning). Uses stableStringify so server-side JSONB key
+    // reordering doesn't make a same-content doc look different.
+    if (stableStringify(instance.getJSON()) === stableStringify(content)) return
+    const { from, to } = instance.state.selection
+    instance.commands.setContent(content, false)
+    try {
+      instance.commands.setTextSelection({ from, to })
+    } catch {
+      instance.commands.focus('end')
+    }
+  }, [])
+
+  const canonicalKey = useCallback((content: JSONContent) => stableStringify(content), [])
+
+  const syncHandle = useExternalContentSync<JSONContent>({
+    editor,
+    incoming: normalizedInitialContent,
+    isPickerOpen: slashCommand?.suggestionState.isOpen ?? false,
+    applyContent,
+    canonicalKey,
+  })
+
+  // Wire the imperative handle into the editor's onUpdate closure.
+  externalSyncRef.current = syncHandle.current
+
+  // Flush deferred onChange when the slash picker closes — the hook handles
+  // the *inbound* flush; this handles the *outbound* one.
+  const prevOpen = useRef(false)
+  useEffect(() => {
+    const isOpen = slashCommand?.suggestionState.isOpen ?? false
+    if (prevOpen.current && !isOpen && editor) {
+      onChangeRef.current({ json: editor.getJSON(), html: editor.getHTML() })
+    }
+    prevOpen.current = isOpen
+  }, [slashCommand?.suggestionState.isOpen, editor])
+
+  return { editor, gutterCharWidth: gutterCharWidth ?? 2 }
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -574,6 +574,12 @@
       "import": "./dist/recording/client/index.mjs",
       "default": "./src/recording/client/index.ts"
     },
+    "./references": {
+      "types": "./src/references/index.ts",
+      "source": "./src/references/index.ts",
+      "import": "./dist/references/index.mjs",
+      "default": "./src/references/index.ts"
+    },
     "./resource-access": {
       "types": "./src/resource-access/index.ts",
       "source": "./src/resource-access/index.ts",

--- a/packages/lib/src/ai/kopilot/blocks/tiptap-to-plain-text.ts
+++ b/packages/lib/src/ai/kopilot/blocks/tiptap-to-plain-text.ts
@@ -1,10 +1,23 @@
 // packages/lib/src/ai/kopilot/blocks/tiptap-to-plain-text.ts
 
+interface TiptapToPlainTextOptions {
+  /**
+   * Optional resolver for inline `reference` nodes. Receives the `RecordId`
+   * and returns the markdown text to inline (typically `[Title](recordId)`).
+   * When unset, references render as `[reference](id)` — the same form used
+   * by `blocksToMd`, so a re-paste round-trips.
+   */
+  references?: (id: string) => string
+}
+
 /**
  * Naive walker that flattens a Tiptap JSON document into plain text. Text
  * nodes are concatenated with single spaces inside a block; block-level
  * nodes (paragraph, heading, list-item, code-block, etc.) are joined with
  * newlines.
+ *
+ * Inline `reference` nodes flow through the optional `references` resolver
+ * — see `references/preresolve.ts` for the title-fetching pipeline.
  *
  * Phase 1: chip rendering for `agent` / `record` / `tool` mention nodes is
  * out of scope — they collapse to their `label` attr (or empty string) for
@@ -14,9 +27,9 @@
  * Tolerant of malformed input: anything that's not the expected shape
  * yields an empty string rather than throwing.
  */
-export function tiptapDocToPlainText(doc: unknown): string {
+export function tiptapDocToPlainText(doc: unknown, options: TiptapToPlainTextOptions = {}): string {
   if (!doc || typeof doc !== 'object') return ''
-  return walkNode(doc as TiptapNode).trim()
+  return walkNode(doc as TiptapNode, options).trim()
 }
 
 interface TiptapNode {
@@ -36,17 +49,25 @@ const BLOCK_TYPES = new Set([
   'blockquote',
   'codeBlock',
   'horizontalRule',
+  // KB block schema — `Doc -> block -> inline`. Each `block` is a block-
+  // level container that should join its siblings with newlines.
+  'block',
 ])
 
-function walkNode(node: TiptapNode): string {
+function walkNode(node: TiptapNode, options: TiptapToPlainTextOptions): string {
   if (typeof node.text === 'string') return node.text
   if (node.type === 'mention' || node.type === 'mentionRecord' || node.type === 'mentionAgent') {
     const label = (node.attrs?.label as string | undefined) ?? ''
     return label
   }
+  if (node.type === 'reference') {
+    const id = typeof node.attrs?.id === 'string' ? (node.attrs.id as string) : ''
+    if (!id) return ''
+    return options.references ? options.references(id) : `[reference](${id})`
+  }
   if (Array.isArray(node.content)) {
     const isBlock = !node.type || BLOCK_TYPES.has(node.type)
-    const parts = node.content.map(walkNode).filter((s) => s.length > 0)
+    const parts = node.content.map((child) => walkNode(child, options)).filter((s) => s.length > 0)
     return isBlock ? parts.join('\n') : parts.join(' ')
   }
   return ''

--- a/packages/lib/src/kb/markdown/blocks-to-md.ts
+++ b/packages/lib/src/kb/markdown/blocks-to-md.ts
@@ -26,12 +26,18 @@ import { CALLOUT_VARIANTS } from './types'
 export interface BlocksToMdOptions {
   /** How to render placeholder inline nodes. `'literal'` writes `{{id}}`. */
   placeholders?: 'literal' | ((id: string) => string)
+  /**
+   * Optional resolver for inline `reference` nodes. Receives the `RecordId`
+   * and returns the markdown to emit (typically `[Title](recordId)`). When
+   * unset, references render as `[reference](id)`.
+   */
+  references?: (id: string) => string
 }
 
 export function blocksToMd(doc: DocJSON | null | undefined, opts: BlocksToMdOptions = {}): string {
   if (!doc || doc.type !== 'doc' || !Array.isArray(doc.content)) return ''
   const placeholders = opts.placeholders ?? 'literal'
-  const ctx = { placeholders }
+  const ctx: RenderCtx = { placeholders, references: opts.references }
 
   const lines = renderNodes(doc.content, ctx)
 
@@ -70,6 +76,7 @@ function renderArticleNode(node: ArticleNodeJSON, ctx: RenderCtx): string[] {
 
 interface RenderCtx {
   placeholders: 'literal' | ((id: string) => string)
+  references?: (id: string) => string
 }
 
 function renderBlock(block: BlockJSON, ctx: RenderCtx): string[] {

--- a/packages/lib/src/kb/markdown/inline.ts
+++ b/packages/lib/src/kb/markdown/inline.ts
@@ -17,6 +17,13 @@ const MARK_ORDER: MarkJSON['type'][] = [
 
 interface SerializeOpts {
   placeholders: 'literal' | ((id: string) => string)
+  /**
+   * Optional resolver for inline `reference` nodes. Receives the `RecordId`
+   * (e.g. `'article:abc'`, `'agent:abc'`, `'user:abc'`) and returns the
+   * markdown to emit. When unset, references render as `[reference](id)` —
+   * round-trippable via the inline-node paste rule.
+   */
+  references?: (id: string) => string
 }
 
 export function inlineToMd(content: InlineJSON[] | undefined, opts: SerializeOpts): string {
@@ -26,6 +33,12 @@ export function inlineToMd(content: InlineJSON[] | undefined, opts: SerializeOpt
     if (node.type === 'placeholder') {
       const id = typeof node.attrs?.id === 'string' ? (node.attrs.id as string) : ''
       out += renderPlaceholder(id, opts)
+      continue
+    }
+    if (node.type === 'reference') {
+      const id = typeof node.attrs?.id === 'string' ? (node.attrs.id as string) : ''
+      if (!id) continue
+      out += renderReference(id, opts)
       continue
     }
     if (node.type === 'hardBreak') {
@@ -40,6 +53,11 @@ export function inlineToMd(content: InlineJSON[] | undefined, opts: SerializeOpt
 function renderPlaceholder(id: string, opts: SerializeOpts): string {
   if (typeof opts.placeholders === 'function') return opts.placeholders(id)
   return `{{${id}}}`
+}
+
+function renderReference(id: string, opts: SerializeOpts): string {
+  if (typeof opts.references === 'function') return opts.references(id)
+  return `[reference](${id})`
 }
 
 function renderTextNode(node: InlineJSON): string {

--- a/packages/lib/src/kb/markdown/types.ts
+++ b/packages/lib/src/kb/markdown/types.ts
@@ -64,7 +64,7 @@ export interface MarkJSON {
 }
 
 export interface InlineJSON {
-  type: 'text' | 'placeholder' | 'hardBreak'
+  type: 'text' | 'placeholder' | 'hardBreak' | 'reference'
   text?: string
   marks?: MarkJSON[]
   attrs?: Record<string, unknown>

--- a/packages/lib/src/references/__tests__/preresolve.test.ts
+++ b/packages/lib/src/references/__tests__/preresolve.test.ts
@@ -1,0 +1,81 @@
+// packages/lib/src/references/__tests__/preresolve.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { RecordId } from '../../resources/client'
+import { collectReferenceIds, preresolveReferences } from '../preresolve'
+
+const docWith = (...refs: string[]) => ({
+  type: 'doc',
+  content: [
+    {
+      type: 'block',
+      attrs: { blockType: 'text' },
+      content: [
+        { type: 'text', text: 'See ' },
+        ...refs.map((id) => ({ type: 'reference', attrs: { id } })),
+        { type: 'text', text: ' for details.' },
+      ],
+    },
+  ],
+})
+
+describe('collectReferenceIds', () => {
+  it('returns [] for non-objects, empty docs, and unknown shapes', () => {
+    expect(collectReferenceIds(null)).toEqual([])
+    expect(collectReferenceIds(undefined)).toEqual([])
+    expect(collectReferenceIds('hello')).toEqual([])
+    expect(collectReferenceIds({})).toEqual([])
+    expect(collectReferenceIds({ type: 'doc', content: [] })).toEqual([])
+  })
+
+  it('collects reference ids in document order, de-duped', () => {
+    const doc = docWith('article:a', 'agent:x', 'article:a', 'user:u')
+    expect(collectReferenceIds(doc)).toEqual(['article:a', 'agent:x', 'user:u'])
+  })
+
+  it('ignores reference nodes with no id', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'block',
+          attrs: { blockType: 'text' },
+          content: [
+            { type: 'reference', attrs: {} },
+            { type: 'reference' },
+            { type: 'reference', attrs: { id: 'article:b' } },
+          ],
+        },
+      ],
+    }
+    expect(collectReferenceIds(doc)).toEqual(['article:b'])
+  })
+})
+
+describe('preresolveReferences', () => {
+  it('skips the title fetch when there are no references', async () => {
+    let called = false
+    const out = await preresolveReferences({ type: 'doc', content: [] }, async () => {
+      called = true
+      return new Map()
+    })
+    expect(called).toBe(false)
+    expect(out.recordIds).toEqual([])
+    expect(out.titles.size).toBe(0)
+  })
+
+  it('renders resolved titles as markdown links and falls back to [reference](id)', async () => {
+    const doc = docWith('article:a', 'agent:x')
+    const out = await preresolveReferences(
+      doc,
+      async (ids) =>
+        new Map(ids.map((id) => [id, id === ('article:a' as RecordId) ? 'Refunds' : '']))
+    )
+    expect(out.recordIds).toEqual(['article:a', 'agent:x'])
+    expect(out.render('article:a')).toBe('[Refunds](article:a)')
+    // Empty title → bare form so the LLM still sees the id.
+    expect(out.render('agent:x')).toBe('[reference](agent:x)')
+    // Unknown id → bare form.
+    expect(out.render('thread:z')).toBe('[reference](thread:z)')
+  })
+})

--- a/packages/lib/src/references/index.ts
+++ b/packages/lib/src/references/index.ts
@@ -1,0 +1,7 @@
+// packages/lib/src/references/index.ts
+
+export {
+  collectReferenceIds,
+  type PreresolvedReferences,
+  preresolveReferences,
+} from './preresolve'

--- a/packages/lib/src/references/preresolve.ts
+++ b/packages/lib/src/references/preresolve.ts
@@ -1,0 +1,73 @@
+// packages/lib/src/references/preresolve.ts
+
+import type { RecordId } from '../resources/client'
+
+interface TiptapNode {
+  type?: string
+  attrs?: Record<string, unknown>
+  content?: TiptapNode[]
+}
+
+/**
+ * Walk a Tiptap doc and collect every inline `reference` node's `RecordId`,
+ * de-duplicated and in document order. Tolerant of malformed input —
+ * unrecognized shapes yield an empty array.
+ */
+export function collectReferenceIds(doc: unknown): RecordId[] {
+  if (!doc || typeof doc !== 'object') return []
+  const seen = new Set<string>()
+  const out: RecordId[] = []
+  walk(doc as TiptapNode, (id) => {
+    if (seen.has(id)) return
+    seen.add(id)
+    out.push(id as RecordId)
+  })
+  return out
+}
+
+function walk(node: TiptapNode, visit: (id: string) => void): void {
+  if (node.type === 'reference') {
+    const id = typeof node.attrs?.id === 'string' ? (node.attrs.id as string) : ''
+    if (id) visit(id)
+    return
+  }
+  if (Array.isArray(node.content)) {
+    for (const child of node.content) walk(child, visit)
+  }
+}
+
+export interface PreresolvedReferences {
+  /** De-duped record ids in document order. */
+  recordIds: RecordId[]
+  /** Title map keyed by record id. Missing entries fall back to bare ids. */
+  titles: Map<RecordId, string>
+  /**
+   * Inline renderer to pass into `tiptapDocToPlainText({ references })` or
+   * `blocksToMd({ references })`. Returns `[Title](id)` when a title is
+   * resolved, `[reference](id)` otherwise.
+   */
+  render: (id: string) => string
+}
+
+/**
+ * Walk the doc, fetch titles for each unique reference in one batch, and
+ * return an inline renderer the caller hands to `tiptapDocToPlainText` /
+ * `blocksToMd`. The `resolveTitles` callback is supplied by the caller
+ * because record-title shape varies per resource (agent.name vs
+ * article.title vs contact.firstName/lastName etc.) — keeping the lookup
+ * pluggable avoids dragging the resource layer into this module.
+ */
+export async function preresolveReferences(
+  doc: unknown,
+  resolveTitles: (recordIds: RecordId[]) => Promise<Map<RecordId, string>>
+): Promise<PreresolvedReferences> {
+  const recordIds = collectReferenceIds(doc)
+  const titles =
+    recordIds.length === 0 ? new Map<RecordId, string>() : await resolveTitles(recordIds)
+  const render = (id: string): string => {
+    const title = titles.get(id as RecordId)
+    if (title && title.length > 0) return `[${title}](${id})`
+    return `[reference](${id})`
+  }
+  return { recordIds, titles, render }
+}


### PR DESCRIPTION
## Summary
- Extracts a shared `useRichTextEditor` from the KB article editor and mounts the reference picker in both KB articles and the new agent persona editor.
- Adds the persona prompt tab (`PersonaEditor` + `useAgentAutosave`), with autosave state lifted to the page-header indicator.
- Teaches KB markdown (`blocksToMd`, `inlineToMd`) and the kopilot `tiptapDocToPlainText` walker about inline `reference` nodes, with an optional resolver for `[Title](recordId)`.
- Introduces `@auxx/lib/references` (preresolve pipeline) for fetching reference titles before serialization.

## Test plan
- [ ] Open an agent detail → Prompt tab → type/edit content → confirm autosave indicator transitions and persists on reload.
- [ ] Use `@` mention picker inside the persona editor — pick a person/record/thread and confirm the chip renders and round-trips on reload.
- [ ] Confirm KB article editor still mounts the reference picker and slash command behave the same.
- [ ] Verify references serialize to `[Title](recordId)` markdown when a resolver is provided, and `[reference](id)` otherwise.
- [ ] Kopilot turn including a reference renders the resolved title in the plain-text prompt.