### PR TITLE
feat(agents): phase 1 UI — tools + knowledge tabs

### DIFF
--- a/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
@@ -151,7 +151,7 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
             icon={<Wrench className='size-4' />}
             initialOpen
             collapsible={false}>
-            <ToolsSectionContent />
+            <ToolsSectionContent agent={agent} onAutosaveChange={onAutosaveChange} />
           </Section>
         </div>
 
@@ -161,7 +161,7 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
             icon={<BookOpen className='size-4' />}
             initialOpen
             collapsible={false}>
-            <KnowledgeSectionContent />
+            <KnowledgeSectionContent agent={agent} onAutosaveChange={onAutosaveChange} />
           </Section>
         </div>
 

--- a/apps/web/src/components/agents/ui/detail/knowledge/agent-scope-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/agent-scope-row.tsx
@@ -1,0 +1,241 @@
+// apps/web/src/components/agents/ui/detail/knowledge/agent-scope-row.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
+import { cn } from '@auxx/ui/lib/utils'
+import {
+  ChevronRight,
+  FileText,
+  FolderClosed,
+  FolderOpen,
+  MoreVertical,
+  Pin,
+  Star,
+} from 'lucide-react'
+import type { EffectiveScopeMode } from './derive-scope-mode'
+
+export interface AgentScopeRowProps {
+  recordId: string
+  title: string
+  kind: 'container' | 'leaf'
+  depth: number
+  effectiveMode: EffectiveScopeMode
+  isPinned: boolean
+  pinReason: 'manual' | 'mention' | null
+  isOpen?: boolean
+  isLoading?: boolean
+  onToggleOpen?: () => void
+  onSetMode: (mode: EffectiveScopeMode) => void
+  onTogglePin: () => void
+}
+
+const MODE_LABELS_CONTAINER: Record<EffectiveScopeMode, string> = {
+  include_descendants: 'Whole',
+  include_one: 'Container only',
+  exclude: 'Excluded',
+  none: 'None',
+}
+
+const MODE_LABELS_LEAF: Record<EffectiveScopeMode, string> = {
+  include_descendants: 'Included',
+  include_one: 'Included',
+  exclude: 'Excluded',
+  none: 'None',
+}
+
+/**
+ * Lightweight `ArticleSidebarItem`-flavored row: icon + title + mode label +
+ * pin star + expand chevron + actions menu. All interactive bits are
+ * controlled — parent owns expand state and mutations.
+ */
+export function AgentScopeRow({
+  recordId,
+  title,
+  kind,
+  depth,
+  effectiveMode,
+  isPinned,
+  pinReason,
+  isOpen,
+  isLoading,
+  onToggleOpen,
+  onSetMode,
+  onTogglePin,
+}: AgentScopeRowProps) {
+  const paddingLeftRem = 0.5 + depth * 1.125
+  const isContainer = kind === 'container'
+  const modeLabel = isContainer
+    ? MODE_LABELS_CONTAINER[effectiveMode]
+    : MODE_LABELS_LEAF[effectiveMode]
+
+  const isMentionPin = pinReason === 'mention'
+
+  return (
+    <div className='relative' style={{ paddingLeft: `${paddingLeftRem}rem` }}>
+      <div
+        className={cn(
+          'group/scope-row flex items-center rounded-md text-sm',
+          'text-muted-foreground hover:bg-background',
+          effectiveMode === 'exclude' && 'opacity-60'
+        )}>
+        <span className='flex items-center px-1 size-7 text-muted-foreground'>
+          {isContainer ? (
+            isOpen ? (
+              <FolderOpen className='size-4' />
+            ) : (
+              <FolderClosed className='size-4' />
+            )
+          ) : (
+            <FileText className='size-4' />
+          )}
+        </span>
+
+        <span className='flex-1 truncate px-1 py-1.5 text-foreground'>
+          {title || (isLoading ? '…' : 'Untitled')}
+        </span>
+
+        <span className='text-xs text-muted-foreground/70 mr-1'>{modeLabel}</span>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type='button'
+              onClick={onTogglePin}
+              disabled={isMentionPin}
+              className={cn(
+                'p-1 rounded-md hover:bg-primary/5 disabled:cursor-not-allowed',
+                isMentionPin && 'opacity-100'
+              )}
+              aria-label={isPinned ? 'Unpin' : 'Pin'}>
+              {isMentionPin ? (
+                <Pin className='size-4 text-primary' />
+              ) : isPinned ? (
+                <Star className='size-4 text-amber-500 fill-amber-500' />
+              ) : (
+                <Star className='size-4 opacity-40 group-hover/scope-row:opacity-100' />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side='left'>
+            {isMentionPin
+              ? 'Pinned by mention in instructions'
+              : isPinned
+                ? 'Unpin from agent'
+                : 'Pin to agent'}
+          </TooltipContent>
+        </Tooltip>
+
+        {isContainer && (
+          <button
+            type='button'
+            onClick={onToggleOpen}
+            className='p-1 rounded-md hover:bg-primary/5'
+            aria-label={isOpen ? 'Collapse' : 'Expand'}>
+            <ChevronRight
+              className={cn(
+                'size-3.5 text-muted-foreground transition-transform',
+                isOpen && 'rotate-90'
+              )}
+            />
+          </button>
+        )}
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant='ghost'
+              size='icon'
+              className='size-7 opacity-0 group-hover/scope-row:opacity-100 data-[state=open]:opacity-100'>
+              <MoreVertical className='size-4' />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='end' className='w-48'>
+            <DropdownMenuLabel>Access</DropdownMenuLabel>
+            {isContainer ? (
+              <>
+                <ModeItem
+                  current={effectiveMode}
+                  value='include_descendants'
+                  label='Whole'
+                  onSelect={() => onSetMode('include_descendants')}
+                />
+                <ModeItem
+                  current={effectiveMode}
+                  value='include_one'
+                  label='Container only'
+                  onSelect={() => onSetMode('include_one')}
+                />
+                <ModeItem
+                  current={effectiveMode}
+                  value='exclude'
+                  label='Exclude'
+                  onSelect={() => onSetMode('exclude')}
+                />
+                <DropdownMenuSeparator />
+                <ModeItem
+                  current={effectiveMode}
+                  value='none'
+                  label='None'
+                  onSelect={() => onSetMode('none')}
+                />
+              </>
+            ) : (
+              <>
+                <ModeItem
+                  current={effectiveMode}
+                  value='include_one'
+                  label='Include'
+                  onSelect={() => onSetMode('include_one')}
+                />
+                <ModeItem
+                  current={effectiveMode}
+                  value='exclude'
+                  label='Exclude'
+                  onSelect={() => onSetMode('exclude')}
+                />
+                <DropdownMenuSeparator />
+                <ModeItem
+                  current={effectiveMode}
+                  value='none'
+                  label='None'
+                  onSelect={() => onSetMode('none')}
+                />
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      <span className='sr-only'>{recordId}</span>
+    </div>
+  )
+}
+
+interface ModeItemProps {
+  current: EffectiveScopeMode
+  value: EffectiveScopeMode
+  label: string
+  onSelect: () => void
+}
+
+function ModeItem({ current, value, label, onSelect }: ModeItemProps) {
+  return (
+    <DropdownMenuItem
+      onSelect={(e) => {
+        e.preventDefault()
+        onSelect()
+      }}
+      className={cn(current === value && 'bg-accent')}>
+      {label}
+      {current === value && <span className='ml-auto text-xs'>✓</span>}
+    </DropdownMenuItem>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/knowledge/derive-scope-mode.ts
+++ b/apps/web/src/components/agents/ui/detail/knowledge/derive-scope-mode.ts
@@ -1,0 +1,73 @@
+// apps/web/src/components/agents/ui/detail/knowledge/derive-scope-mode.ts
+
+import type { AgentDetail } from '../../../store/agent-store'
+
+export type EffectiveScopeMode = 'include_descendants' | 'include_one' | 'exclude' | 'none'
+
+interface ScopeRow {
+  entityDefinitionId: string
+  entityInstanceId: string | null
+  mode: 'include_descendants' | 'include_one' | 'exclude'
+}
+
+/**
+ * Find the stored mode for a single `recordId` (instance or definition). When
+ * no row exists, returns `'none'`. Matches the planned client-side resolver
+ * approximation — strict per-row lookup, no inheritance flattening yet.
+ *
+ * @param recordId  `'article:abc'` for instance, `'article'` for definition-level
+ */
+export function findStoredMode(
+  scopes: ReadonlyArray<ScopeRow>,
+  recordId: string
+): EffectiveScopeMode {
+  const { entityDefinitionId, entityInstanceId } = splitRecordId(recordId)
+  const row = scopes.find(
+    (s) => s.entityDefinitionId === entityDefinitionId && s.entityInstanceId === entityInstanceId
+  )
+  return row?.mode ?? 'none'
+}
+
+/**
+ * Derive the *effective* mode for a record by walking definition-level then
+ * instance-level rules in order. Instance rules win over definition rules.
+ */
+export function deriveEffectiveMode(
+  scopes: AgentDetail['resourceScopes'],
+  recordId: string
+): EffectiveScopeMode {
+  const { entityDefinitionId, entityInstanceId } = splitRecordId(recordId)
+
+  let mode: EffectiveScopeMode = 'none'
+
+  // Apply definition-level rule first.
+  const defRow = scopes.find(
+    (s) => s.entityDefinitionId === entityDefinitionId && s.entityInstanceId === null
+  )
+  if (defRow) {
+    if (defRow.mode === 'include_descendants') mode = 'include_descendants'
+    else if (defRow.mode === 'exclude') mode = 'exclude'
+    else if (defRow.mode === 'include_one') mode = 'include_one'
+  }
+
+  // Instance-level rule wins if present.
+  if (entityInstanceId !== null) {
+    const instanceRow = scopes.find(
+      (s) => s.entityDefinitionId === entityDefinitionId && s.entityInstanceId === entityInstanceId
+    )
+    if (instanceRow) mode = instanceRow.mode
+  }
+
+  return mode
+}
+
+function splitRecordId(recordId: string): {
+  entityDefinitionId: string
+  entityInstanceId: string | null
+} {
+  const colon = recordId.indexOf(':')
+  if (colon === -1) return { entityDefinitionId: recordId, entityInstanceId: null }
+  const def = recordId.slice(0, colon)
+  const instance = recordId.slice(colon + 1)
+  return { entityDefinitionId: def, entityInstanceId: instance.length > 0 ? instance : null }
+}

--- a/apps/web/src/components/agents/ui/detail/knowledge/knowledge-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/knowledge-section-content.tsx
@@ -1,0 +1,84 @@
+// apps/web/src/components/agents/ui/detail/knowledge/knowledge-section-content.tsx
+'use client'
+
+import { Section } from '@auxx/ui/components/section'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
+import { useCallback, useState } from 'react'
+import type { AgentDetail } from '../../../store/agent-store'
+import type { AutosaveState } from '../../shared/autosave-indicator'
+import { KnowledgeSubTab } from './knowledge-sub-tab'
+import { PinnedRecordsBlock } from './pinned-records-block'
+
+interface KnowledgeSectionContentProps {
+  agent: AgentDetail
+  onAutosaveChange?: (state: AutosaveState) => void
+}
+
+type SubTab = 'knowledge' | 'entities' | 'tickets' | 'datasets' | 'meetings'
+
+const SUB_TABS: Array<{ value: SubTab; label: string; prefix: string | null }> = [
+  { value: 'knowledge', label: 'Knowledge', prefix: 'article' },
+  { value: 'entities', label: 'Entities', prefix: 'contact' },
+  { value: 'tickets', label: 'Tickets', prefix: 'ticket' },
+  { value: 'datasets', label: 'Datasets', prefix: 'dataset' },
+  { value: 'meetings', label: 'Meetings', prefix: 'meeting' },
+]
+
+/**
+ * Knowledge tab body. Sub-tabs split scope rows + pinned references per
+ * record type. v1 ships the Knowledge sub-tab (KB → articles); the rest
+ * render a stub until their tree adapters land.
+ */
+export function KnowledgeSectionContent({ agent, onAutosaveChange }: KnowledgeSectionContentProps) {
+  const [tab, setTab] = useState<SubTab>('knowledge')
+
+  const handleSavingChange = useCallback(
+    (saving: boolean) => {
+      onAutosaveChange?.(saving ? { kind: 'saving' } : { kind: 'saved', at: Date.now() })
+    },
+    [onAutosaveChange]
+  )
+
+  return (
+    <div className='px-3 pb-6 space-y-4'>
+      <Tabs value={tab} onValueChange={(v) => setTab(v as SubTab)}>
+        <TabsList className='justify-start'>
+          {SUB_TABS.map((t) => (
+            <TabsTrigger key={t.value} value={t.value}>
+              {t.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        {SUB_TABS.map((t) => (
+          <TabsContent key={t.value} value={t.value} className='mt-4 space-y-4'>
+            <Section
+              title='Pinned references'
+              description='Records always-on in the prompt. Tap the star to unpin.'
+              initialOpen>
+              <PinnedRecordsBlock
+                agent={agent}
+                filterPrefix={t.prefix}
+                onSavingChange={handleSavingChange}
+              />
+            </Section>
+
+            <Section
+              title='Access scope'
+              description='Which records this agent can search and read.'
+              initialOpen>
+              {t.value === 'knowledge' ? (
+                <KnowledgeSubTab agent={agent} onSavingChange={handleSavingChange} />
+              ) : (
+                <p className='text-sm text-muted-foreground py-2'>
+                  Tree for {t.label.toLowerCase()} lands in a follow-up. Use pinned references above
+                  to scope individual records for now.
+                </p>
+              )}
+            </Section>
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/knowledge/knowledge-sub-tab.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/knowledge-sub-tab.tsx
@@ -1,0 +1,178 @@
+// apps/web/src/components/agents/ui/detail/knowledge/knowledge-sub-tab.tsx
+'use client'
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { toRecordId } from '@auxx/lib/resources/client'
+import { generateId } from '@auxx/utils'
+import { useMemo, useState } from 'react'
+import { useRecord } from '~/components/resources/hooks/use-record'
+import { useRecordList } from '~/components/resources/hooks/use-record-list'
+import type { AgentDetail } from '../../../store/agent-store'
+import { AgentScopeRow } from './agent-scope-row'
+import { deriveEffectiveMode } from './derive-scope-mode'
+import { useScopeMutations } from './use-scope-mutations'
+
+interface KnowledgeSubTabProps {
+  agent: AgentDetail
+  onSavingChange?: (saving: boolean) => void
+}
+
+/**
+ * Renders the Knowledge-base + articles tree. KB containers expand to show
+ * their articles. Each row owns its own mode dropdown + pin star; both write
+ * through `useScopeMutations`.
+ */
+export function KnowledgeSubTab({ agent, onSavingChange }: KnowledgeSubTabProps) {
+  const { setMode, setPin } = useScopeMutations(agent.id, onSavingChange)
+  const { recordIds: kbIds, isLoading } = useRecordList({
+    entityDefinitionId: 'kb',
+    limit: 100,
+  })
+
+  if (isLoading && kbIds.length === 0) {
+    return <p className='text-sm text-muted-foreground py-2'>Loading knowledge bases…</p>
+  }
+  if (kbIds.length === 0) {
+    return (
+      <p className='text-sm text-muted-foreground py-2'>
+        No knowledge bases yet. Create one to scope this agent to a specific source.
+      </p>
+    )
+  }
+
+  return (
+    <div className='space-y-1'>
+      {kbIds.map((kbId) => (
+        <KbContainerRow
+          key={kbId}
+          kbId={kbId}
+          agent={agent}
+          onSetMode={(recordId, mode) => setMode(recordId, mode)}
+          onTogglePin={(recordId, pinned) => setPin(recordId, pinned)}
+        />
+      ))}
+    </div>
+  )
+}
+
+interface KbContainerRowProps {
+  kbId: string
+  agent: AgentDetail
+  onSetMode: (
+    recordId: string,
+    mode: 'include_descendants' | 'include_one' | 'exclude' | 'none'
+  ) => void
+  onTogglePin: (recordId: string, pinned: boolean) => void
+}
+
+function KbContainerRow({ kbId, agent, onSetMode, onTogglePin }: KbContainerRowProps) {
+  const recordId = toRecordId('kb', kbId)
+  const [isOpen, setIsOpen] = useState(false)
+  const { record } = useRecord({ recordId })
+  const effectiveMode = deriveEffectiveMode(agent.resourceScopes, recordId)
+  const pin = agent.pinnedRecords.find((p) => p.recordId === recordId)
+
+  return (
+    <>
+      <AgentScopeRow
+        recordId={recordId}
+        title={(record?.displayName as string) ?? (record?.title as string) ?? 'Untitled'}
+        kind='container'
+        depth={0}
+        effectiveMode={effectiveMode}
+        isPinned={!!pin}
+        pinReason={pin?.pinReason ?? null}
+        isOpen={isOpen}
+        onToggleOpen={() => setIsOpen((o) => !o)}
+        onSetMode={(mode) => onSetMode(recordId, mode)}
+        onTogglePin={() => onTogglePin(recordId, !pin)}
+      />
+      {isOpen && (
+        <KbArticles kbId={kbId} agent={agent} onSetMode={onSetMode} onTogglePin={onTogglePin} />
+      )}
+    </>
+  )
+}
+
+interface KbArticlesProps extends Omit<KbContainerRowProps, 'kbId'> {
+  kbId: string
+}
+
+function KbArticles({ kbId, agent, onSetMode, onTogglePin }: KbArticlesProps) {
+  const filters = useMemo<ConditionGroup[]>(
+    () => [
+      {
+        id: 'agent-scope-kb-filter',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: generateId(),
+            fieldId: 'article:knowledgeBaseId',
+            operator: 'is',
+            value: kbId,
+          },
+        ],
+      },
+    ],
+    [kbId]
+  )
+
+  const { recordIds, isLoading } = useRecordList({
+    entityDefinitionId: 'article',
+    filters,
+    limit: 50,
+  })
+
+  if (isLoading && recordIds.length === 0) {
+    return <div className='pl-9 text-xs text-muted-foreground py-1'>Loading articles…</div>
+  }
+  if (recordIds.length === 0) {
+    return <div className='pl-9 text-xs text-muted-foreground py-1'>No articles in this KB.</div>
+  }
+
+  return (
+    <>
+      {recordIds.map((id) => (
+        <ArticleLeafRow
+          key={id}
+          articleId={id}
+          agent={agent}
+          onSetMode={onSetMode}
+          onTogglePin={onTogglePin}
+        />
+      ))}
+    </>
+  )
+}
+
+interface ArticleLeafRowProps {
+  articleId: string
+  agent: AgentDetail
+  onSetMode: (
+    recordId: string,
+    mode: 'include_descendants' | 'include_one' | 'exclude' | 'none'
+  ) => void
+  onTogglePin: (recordId: string, pinned: boolean) => void
+}
+
+function ArticleLeafRow({ articleId, agent, onSetMode, onTogglePin }: ArticleLeafRowProps) {
+  const recordId = toRecordId('article', articleId)
+  const { record, isLoading } = useRecord({ recordId })
+  const effectiveMode = deriveEffectiveMode(agent.resourceScopes, recordId)
+  const pin = agent.pinnedRecords.find((p) => p.recordId === recordId)
+
+  return (
+    <AgentScopeRow
+      recordId={recordId}
+      title={(record?.displayName as string) ?? (record?.title as string) ?? ''}
+      kind='leaf'
+      depth={1}
+      effectiveMode={effectiveMode}
+      isPinned={!!pin}
+      pinReason={pin?.pinReason ?? null}
+      isLoading={isLoading}
+      onSetMode={(mode) => onSetMode(recordId, mode)}
+      onTogglePin={() => onTogglePin(recordId, !pin)}
+    />
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/knowledge/pinned-records-block.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/pinned-records-block.tsx
@@ -1,0 +1,85 @@
+// apps/web/src/components/agents/ui/detail/knowledge/pinned-records-block.tsx
+'use client'
+
+import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Pin, Star } from 'lucide-react'
+import { useMemo } from 'react'
+import { useRecords } from '~/components/resources/hooks/use-records'
+import type { AgentDetail } from '../../../store/agent-store'
+import { useScopeMutations } from './use-scope-mutations'
+
+interface PinnedRecordsBlockProps {
+  agent: AgentDetail
+  /** Only show pins whose record-type prefix matches. Pass null for all. */
+  filterPrefix: string | null
+  onSavingChange?: (saving: boolean) => void
+}
+
+/**
+ * Compact list of records pinned to the agent. Filtered to the active sub-tab
+ * by record-type prefix. Manual pins can be unpinned via the star; mention
+ * pins are read-only.
+ */
+export function PinnedRecordsBlock({
+  agent,
+  filterPrefix,
+  onSavingChange,
+}: PinnedRecordsBlockProps) {
+  const { setPin } = useScopeMutations(agent.id, onSavingChange)
+
+  const pins = useMemo(() => {
+    if (!filterPrefix) return agent.pinnedRecords
+    return agent.pinnedRecords.filter((p) => {
+      const colon = p.recordId.indexOf(':')
+      const prefix = colon === -1 ? p.recordId : p.recordId.slice(0, colon)
+      return prefix === filterPrefix
+    })
+  }, [agent.pinnedRecords, filterPrefix])
+
+  const recordIds = useMemo(() => pins.map((p) => p.recordId as RecordId), [pins])
+  const { recordsByKey } = useRecords({ recordIds })
+
+  if (pins.length === 0) {
+    return (
+      <p className='text-xs text-muted-foreground py-2'>
+        No pinned records yet. Pin a record below to keep it always-on in the prompt.
+      </p>
+    )
+  }
+
+  return (
+    <ul className='space-y-1'>
+      {pins.map((pin) => {
+        const record = recordsByKey.get(pin.recordId as RecordId)
+        const title = (record?.displayName as string) ?? (record?.title as string) ?? pin.recordId
+        const isMention = pin.pinReason === 'mention'
+        const recordType = parseRecordId(pin.recordId as RecordId).entityDefinitionId
+        return (
+          <li
+            key={pin.recordId}
+            className='flex items-center gap-2 text-sm py-1 px-2 rounded-md hover:bg-background'>
+            {isMention ? (
+              <Pin className='size-4 text-primary' />
+            ) : (
+              <Star className='size-4 text-amber-500 fill-amber-500' />
+            )}
+            <span className='flex-1 truncate'>{title}</span>
+            <Badge variant='outline'>{recordType}</Badge>
+            <Badge variant={isMention ? 'secondary' : 'outline'}>
+              {isMention ? 'By mention' : 'Manual'}
+            </Badge>
+            {!isMention && (
+              <button
+                type='button'
+                onClick={() => setPin(pin.recordId, false)}
+                className='text-xs underline text-muted-foreground hover:text-foreground'>
+                Unpin
+              </button>
+            )}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/knowledge/use-scope-mutations.ts
+++ b/apps/web/src/components/agents/ui/detail/knowledge/use-scope-mutations.ts
@@ -1,0 +1,149 @@
+// apps/web/src/components/agents/ui/detail/knowledge/use-scope-mutations.ts
+'use client'
+
+import type { AgentScopeMode } from '@auxx/lib/agents/client'
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback } from 'react'
+import { api } from '~/trpc/react'
+import type { AgentDetail } from '../../../store/agent-store'
+
+interface UseScopeMutationsReturn {
+  setMode: (recordId: string, mode: AgentScopeMode | 'none') => Promise<void>
+  setPin: (recordId: string, pinned: boolean, note?: string | null) => Promise<void>
+}
+
+/**
+ * Per-agent scope + pin mutations with optimistic updates against the
+ * `agent.getById` cache. Reads come from `agent.resourceScopes` and
+ * `agent.pinnedRecords`; both fields update in place and reconcile via
+ * invalidate on success.
+ */
+export function useScopeMutations(
+  agentId: string,
+  onSavingChange?: (saving: boolean) => void
+): UseScopeMutationsReturn {
+  const utils = api.useUtils()
+  const upsertRow = api.agentScope.upsertRow.useMutation()
+  const removeRow = api.agentScope.removeRow.useMutation()
+  const setPinMutation = api.agentScope.setPin.useMutation()
+
+  const reconcile = useCallback(async () => {
+    await utils.agent.getById.invalidate({ agentId })
+  }, [agentId, utils.agent.getById])
+
+  const optimisticScope = useCallback(
+    (mutator: (scopes: AgentDetail['resourceScopes']) => AgentDetail['resourceScopes']) => {
+      const previous = utils.agent.getById.getData({ agentId })
+      utils.agent.getById.setData({ agentId }, (old) =>
+        old ? { ...old, resourceScopes: mutator(old.resourceScopes) } : old
+      )
+      return previous
+    },
+    [agentId, utils.agent.getById]
+  )
+
+  const optimisticPins = useCallback(
+    (mutator: (pins: AgentDetail['pinnedRecords']) => AgentDetail['pinnedRecords']) => {
+      const previous = utils.agent.getById.getData({ agentId })
+      utils.agent.getById.setData({ agentId }, (old) =>
+        old ? { ...old, pinnedRecords: mutator(old.pinnedRecords) } : old
+      )
+      return previous
+    },
+    [agentId, utils.agent.getById]
+  )
+
+  const setMode = useCallback<UseScopeMutationsReturn['setMode']>(
+    async (recordId, mode) => {
+      onSavingChange?.(true)
+      const { entityDefinitionId, entityInstanceId } = splitRecordId(recordId)
+
+      const previous = optimisticScope((scopes) => {
+        const filtered = scopes.filter(
+          (s) =>
+            !(
+              s.entityDefinitionId === entityDefinitionId && s.entityInstanceId === entityInstanceId
+            )
+        )
+        if (mode === 'none') return filtered
+        return [
+          ...filtered,
+          {
+            id: `optimistic-${recordId}`,
+            agentId,
+            organizationId: '',
+            entityDefinitionId,
+            entityInstanceId,
+            mode,
+            source: 'manual',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          } as AgentDetail['resourceScopes'][number],
+        ]
+      })
+
+      try {
+        if (mode === 'none') {
+          await removeRow.mutateAsync({ agentId, recordId })
+        } else {
+          await upsertRow.mutateAsync({ agentId, recordId, mode })
+        }
+        await reconcile()
+      } catch (err) {
+        utils.agent.getById.setData({ agentId }, previous)
+        toastError({
+          title: 'Failed to update access',
+          description: err instanceof Error ? err.message : 'Unknown error',
+        })
+      } finally {
+        onSavingChange?.(false)
+      }
+    },
+    [agentId, onSavingChange, optimisticScope, reconcile, removeRow, upsertRow, utils.agent.getById]
+  )
+
+  const setPin = useCallback<UseScopeMutationsReturn['setPin']>(
+    async (recordId, pinned, note) => {
+      onSavingChange?.(true)
+      const previous = optimisticPins((pins) => {
+        const filtered = pins.filter((p) => p.recordId !== recordId)
+        if (!pinned) return filtered
+        return [
+          ...filtered,
+          {
+            recordId,
+            pinReason: 'manual' as const,
+            ...(note != null ? { note } : {}),
+          },
+        ]
+      })
+
+      try {
+        await setPinMutation.mutateAsync({ agentId, recordId, pinned, note })
+        await reconcile()
+      } catch (err) {
+        utils.agent.getById.setData({ agentId }, previous)
+        toastError({
+          title: 'Failed to update pin',
+          description: err instanceof Error ? err.message : 'Unknown error',
+        })
+      } finally {
+        onSavingChange?.(false)
+      }
+    },
+    [agentId, onSavingChange, optimisticPins, reconcile, setPinMutation, utils.agent.getById]
+  )
+
+  return { setMode, setPin }
+}
+
+function splitRecordId(recordId: string): {
+  entityDefinitionId: string
+  entityInstanceId: string | null
+} {
+  const colon = recordId.indexOf(':')
+  if (colon === -1) return { entityDefinitionId: recordId, entityInstanceId: null }
+  const def = recordId.slice(0, colon)
+  const instance = recordId.slice(colon + 1)
+  return { entityDefinitionId: def, entityInstanceId: instance.length > 0 ? instance : null }
+}

--- a/apps/web/src/components/agents/ui/detail/tabs/knowledge-tab-placeholder.tsx
+++ b/apps/web/src/components/agents/ui/detail/tabs/knowledge-tab-placeholder.tsx
@@ -1,10 +1,15 @@
 // apps/web/src/components/agents/ui/detail/tabs/knowledge-tab-placeholder.tsx
 'use client'
 
-export function KnowledgeSectionContent() {
-  return (
-    <div className='py-4 text-sm text-muted-foreground'>
-      Knowledge pinning lands in phase-1-ui-tab-knowledge.md.
-    </div>
-  )
+import type { AgentDetail } from '../../../store/agent-store'
+import type { AutosaveState } from '../../shared/autosave-indicator'
+import { KnowledgeSectionContent as KnowledgeContent } from '../knowledge/knowledge-section-content'
+
+interface KnowledgeSectionContentProps {
+  agent: AgentDetail
+  onAutosaveChange?: (state: AutosaveState) => void
+}
+
+export function KnowledgeSectionContent(props: KnowledgeSectionContentProps) {
+  return <KnowledgeContent {...props} />
 }

--- a/apps/web/src/components/agents/ui/detail/tabs/tools-tab-placeholder.tsx
+++ b/apps/web/src/components/agents/ui/detail/tabs/tools-tab-placeholder.tsx
@@ -1,10 +1,15 @@
 // apps/web/src/components/agents/ui/detail/tabs/tools-tab-placeholder.tsx
 'use client'
 
-export function ToolsSectionContent() {
-  return (
-    <div className='py-4 text-sm text-muted-foreground'>
-      Tool selection lands in phase-1-ui-tab-tools.md.
-    </div>
-  )
+import type { AgentDetail } from '../../../store/agent-store'
+import type { AutosaveState } from '../../shared/autosave-indicator'
+import { ToolsSectionContent as ToolsContent } from '../tools/tools-section-content'
+
+interface ToolsSectionContentProps {
+  agent: AgentDetail
+  onAutosaveChange?: (state: AutosaveState) => void
+}
+
+export function ToolsSectionContent(props: ToolsSectionContentProps) {
+  return <ToolsContent {...props} />
 }

--- a/apps/web/src/components/agents/ui/detail/tools/tools-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tools-section-content.tsx
@@ -1,0 +1,147 @@
+// apps/web/src/components/agents/ui/detail/tools/tools-section-content.tsx
+'use client'
+
+import type { ToolsetCatalogEntry } from '@auxx/lib/agents/client'
+import { Section } from '@auxx/ui/components/section'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { useCallback, useMemo } from 'react'
+import { api } from '~/trpc/react'
+import type { AgentDetail } from '../../../store/agent-store'
+import type { AutosaveState } from '../../shared/autosave-indicator'
+import { ToolsetRow } from './toolset-row'
+import { useToolsetMutations } from './use-toolset-mutations'
+
+interface ToolsSectionContentProps {
+  agent: AgentDetail
+  onAutosaveChange?: (state: AutosaveState) => void
+}
+
+type ToolsetRowState = {
+  enabled: boolean
+  source: 'manual' | 'mention' | 'auto_default'
+  disabledTools: string[]
+}
+
+/**
+ * The Tools tab body. Renders the org toolset catalog grouped by Default /
+ * Additional / Apps, with per-toolset enable + per-tool checkboxes. Per-agent
+ * state comes from `agent.toolsets`; mutations route through
+ * `useToolsetMutations`.
+ */
+export function ToolsSectionContent({ agent, onAutosaveChange }: ToolsSectionContentProps) {
+  const catalogQuery = api.agentToolset.list.useQuery(undefined, {
+    staleTime: 60_000,
+  })
+
+  const handleSavingChange = useCallback(
+    (saving: boolean) => {
+      onAutosaveChange?.(saving ? { kind: 'saving' } : { kind: 'saved', at: Date.now() })
+    },
+    [onAutosaveChange]
+  )
+
+  const { toggleToolset, toggleTool } = useToolsetMutations(agent.id, handleSavingChange)
+
+  const stateBySlug = useMemo<Map<string, ToolsetRowState>>(() => {
+    const map = new Map<string, ToolsetRowState>()
+    for (const row of agent.toolsets) {
+      map.set(row.toolsetSlug, {
+        enabled: row.enabled,
+        source: row.source,
+        disabledTools: (row.config?.disabledTools as string[]) ?? [],
+      })
+    }
+    return map
+  }, [agent.toolsets])
+
+  if (catalogQuery.isLoading || !catalogQuery.data) {
+    return (
+      <div className='px-3 pb-6 space-y-3'>
+        <Skeleton className='h-12 w-full' />
+        <Skeleton className='h-12 w-full' />
+        <Skeleton className='h-12 w-full' />
+      </div>
+    )
+  }
+
+  const catalog = catalogQuery.data
+  const defaultEntries = catalog.filter((e) => e.group === 'native' && e.isDefault)
+  const additionalEntries = catalog.filter((e) => e.group === 'native' && !e.isDefault)
+  const appEntries = catalog.filter((e) => e.group === 'app')
+
+  const knownSlugs = new Set(catalog.map((e) => e.slug))
+  const unrecognized = agent.toolsets.filter((r) => !knownSlugs.has(r.toolsetSlug))
+
+  const renderRow = (entry: ToolsetCatalogEntry) => {
+    const state = stateBySlug.get(entry.slug) ?? {
+      enabled: false,
+      source: 'manual' as const,
+      disabledTools: [],
+    }
+    return (
+      <ToolsetRow
+        key={entry.slug}
+        slug={entry.slug}
+        label={entry.label}
+        tools={entry.tools}
+        enabled={state.enabled}
+        source={state.source}
+        disabledTools={state.disabledTools}
+        onToolsetToggle={toggleToolset}
+        onToolToggle={toggleTool}
+      />
+    )
+  }
+
+  return (
+    <div className='pb-6'>
+      <Section
+        title='Default toolsets'
+        description='Pre-enabled toolsets every agent ships with. Uncheck a toolset to remove its tools.'
+        initialOpen>
+        <div className='divide-y'>{defaultEntries.map(renderRow)}</div>
+      </Section>
+
+      <Section
+        title='Additional toolsets'
+        description='Opt-in toolsets. Tools register only after admin enables the toolset.'
+        initialOpen={false}>
+        {additionalEntries.length > 0 ? (
+          <div className='divide-y'>{additionalEntries.map(renderRow)}</div>
+        ) : (
+          <p className='text-sm text-muted-foreground py-2'>No additional toolsets available.</p>
+        )}
+      </Section>
+
+      {appEntries.length > 0 && (
+        <Section
+          title='Apps'
+          description='Toolsets contributed by installed apps.'
+          initialOpen={false}>
+          <div className='divide-y'>{appEntries.map(renderRow)}</div>
+        </Section>
+      )}
+
+      {unrecognized.length > 0 && (
+        <Section
+          title='Unrecognized toolsets'
+          description='These slugs are stored on this agent but no longer appear in the org catalog. Remove them or ignore.'
+          initialOpen={false}>
+          <div className='py-2 text-sm text-muted-foreground space-y-2'>
+            {unrecognized.map((row) => (
+              <div key={row.toolsetSlug} className='flex items-center justify-between'>
+                <span className='font-mono text-xs'>{row.toolsetSlug}</span>
+                <button
+                  type='button'
+                  className='text-xs underline hover:text-foreground'
+                  onClick={() => toggleToolset(row.toolsetSlug, false)}>
+                  Disable
+                </button>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/tools/toolset-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/toolset-row.tsx
@@ -1,0 +1,111 @@
+// apps/web/src/components/agents/ui/detail/tools/toolset-row.tsx
+'use client'
+
+import type { ToolCatalogEntry } from '@auxx/lib/agents/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Checkbox } from '@auxx/ui/components/checkbox'
+import { Field } from '@auxx/ui/components/section'
+import { Switch } from '@auxx/ui/components/switch'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
+import { cn } from '@auxx/ui/lib/utils'
+
+export interface ToolsetRowProps {
+  slug: string
+  label: string
+  tools: ToolCatalogEntry[]
+  enabled: boolean
+  source: 'manual' | 'mention' | 'auto_default'
+  disabledTools: string[]
+  onToolsetToggle: (slug: string, enabled: boolean) => void
+  onToolToggle: (slug: string, toolName: string, enabled: boolean) => void
+}
+
+/**
+ * One row per toolset: title + enable switch + (when enabled) per-tool
+ * checkboxes. Mention-sourced rows show a badge and disable the switch —
+ * the prompt reconciler owns them.
+ */
+export function ToolsetRow({
+  slug,
+  label,
+  tools,
+  enabled,
+  source,
+  disabledTools,
+  onToolsetToggle,
+  onToolToggle,
+}: ToolsetRowProps) {
+  const disabledSet = new Set(disabledTools)
+  const enabledCount =
+    tools.length - disabledTools.filter((d) => tools.some((t) => t.name === d)).length
+
+  return (
+    <div className='py-2'>
+      <Field
+        title={label}
+        description={`Slug: ${slug}`}
+        actions={
+          <div className='flex items-center gap-2'>
+            {enabled && (
+              <span className='text-xs text-muted-foreground'>
+                {enabledCount}/{tools.length} tools
+              </span>
+            )}
+            {source === 'mention' && <Badge variant='secondary'>Pinned by mention</Badge>}
+            {source === 'auto_default' && <Badge variant='outline'>Default</Badge>}
+            <Switch
+              size='sm'
+              checked={enabled}
+              disabled={source === 'mention'}
+              onCheckedChange={(checked) => onToolsetToggle(slug, checked)}
+            />
+          </div>
+        }>
+        {enabled && tools.length > 0 && (
+          <div className='mt-1 ml-3 space-y-1.5'>
+            {tools.map((tool) => (
+              <ToolCheckbox
+                key={tool.name}
+                tool={tool}
+                checked={!disabledSet.has(tool.name)}
+                onChange={(checked) => onToolToggle(slug, tool.name, checked)}
+              />
+            ))}
+          </div>
+        )}
+      </Field>
+    </div>
+  )
+}
+
+interface ToolCheckboxProps {
+  tool: ToolCatalogEntry
+  checked: boolean
+  onChange: (checked: boolean) => void
+}
+
+function ToolCheckbox({ tool, checked, onChange }: ToolCheckboxProps) {
+  return (
+    <div className={cn('flex items-center gap-2 text-sm')}>
+      <Checkbox
+        id={`tool-${tool.name}`}
+        checked={checked}
+        onCheckedChange={(value) => onChange(value === true)}
+      />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <label
+            htmlFor={`tool-${tool.name}`}
+            className='font-mono text-xs cursor-pointer text-foreground hover:underline'>
+            {tool.name}
+          </label>
+        </TooltipTrigger>
+        {tool.description && (
+          <TooltipContent side='right' className='max-w-xs'>
+            {tool.description}
+          </TooltipContent>
+        )}
+      </Tooltip>
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/tools/use-toolset-mutations.ts
+++ b/apps/web/src/components/agents/ui/detail/tools/use-toolset-mutations.ts
@@ -1,0 +1,107 @@
+// apps/web/src/components/agents/ui/detail/tools/use-toolset-mutations.ts
+'use client'
+
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback } from 'react'
+import { api } from '~/trpc/react'
+import type { AgentDetail } from '../../../store/agent-store'
+
+interface ToolsetPatch {
+  enabled?: boolean
+  disabledTools?: string[]
+}
+
+interface UseToolsetMutationsReturn {
+  toggleToolset: (slug: string, enabled: boolean) => Promise<void>
+  toggleTool: (slug: string, toolName: string, enabled: boolean) => Promise<void>
+  isPending: boolean
+}
+
+/**
+ * Per-agent toolset mutations with optimistic updates against the
+ * `agent.getById` cache. Both toggles fire `api.agentToolset.update` and
+ * reconcile by invalidating the detail query on success / rolling back on
+ * error.
+ */
+export function useToolsetMutations(
+  agentId: string,
+  onSavingChange?: (saving: boolean) => void
+): UseToolsetMutationsReturn {
+  const utils = api.useUtils()
+  const update = api.agentToolset.update.useMutation()
+
+  const applyPatch = useCallback(
+    async (slug: string, patch: ToolsetPatch) => {
+      onSavingChange?.(true)
+      const previous = utils.agent.getById.getData({ agentId })
+
+      utils.agent.getById.setData({ agentId }, (old) => {
+        if (!old) return old
+        const toolsets = [...old.toolsets]
+        const idx = toolsets.findIndex((t) => t.toolsetSlug === slug)
+        if (idx >= 0) {
+          const current = toolsets[idx]
+          if (!current) return old
+          const nextConfig = { ...(current.config ?? {}) }
+          if (patch.disabledTools !== undefined) {
+            nextConfig.disabledTools = patch.disabledTools
+          }
+          toolsets[idx] = {
+            ...current,
+            enabled: patch.enabled ?? current.enabled,
+            config: nextConfig,
+            source: current.source === 'auto_default' ? 'manual' : current.source,
+          }
+        } else {
+          toolsets.push({
+            id: `optimistic-${slug}`,
+            agentId,
+            toolsetSlug: slug,
+            enabled: patch.enabled ?? true,
+            source: 'manual',
+            config: patch.disabledTools !== undefined ? { disabledTools: patch.disabledTools } : {},
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          } as AgentDetail['toolsets'][number])
+        }
+        return { ...old, toolsets }
+      })
+
+      try {
+        await update.mutateAsync({ agentId, slug, ...patch })
+        await utils.agent.getById.invalidate({ agentId })
+      } catch (err) {
+        utils.agent.getById.setData({ agentId }, previous)
+        toastError({
+          title: 'Failed to update toolset',
+          description: err instanceof Error ? err.message : 'Unknown error',
+        })
+      } finally {
+        onSavingChange?.(false)
+      }
+    },
+    [agentId, onSavingChange, update, utils.agent.getById]
+  )
+
+  const toggleToolset = useCallback(
+    (slug: string, enabled: boolean) => applyPatch(slug, { enabled }),
+    [applyPatch]
+  )
+
+  const toggleTool = useCallback(
+    async (slug: string, toolName: string, enabled: boolean) => {
+      const current = utils.agent.getById.getData({ agentId })
+      const existing = current?.toolsets.find((t) => t.toolsetSlug === slug)
+      const currentDisabled = new Set<string>((existing?.config?.disabledTools as string[]) ?? [])
+      if (enabled) {
+        currentDisabled.delete(toolName)
+      } else {
+        currentDisabled.add(toolName)
+      }
+      await applyPatch(slug, { disabledTools: [...currentDisabled] })
+    },
+    [agentId, applyPatch, utils.agent.getById]
+  )
+
+  return { toggleToolset, toggleTool, isPending: update.isPending }
+}

--- a/apps/web/src/server/api/root.ts
+++ b/apps/web/src/server/api/root.ts
@@ -3,6 +3,7 @@ import { createCallerFactory, createTRPCRouter } from '~/server/api/trpc'
 import { actorRouter } from './routers/actor'
 import { adminRouter } from './routers/admin'
 import { agentRouter } from './routers/agent'
+import { agentScopeRouter } from './routers/agent-scope'
 import { agentToolsetRouter } from './routers/agent-toolset'
 import { aiFeatureRouter } from './routers/aiFeature'
 import { aiIntegrationRouter } from './routers/aiIntegration'
@@ -86,6 +87,7 @@ export const appRouter = createTRPCRouter({
   actor: actorRouter,
   admin: adminRouter,
   agent: agentRouter,
+  agentScope: agentScopeRouter,
   agentToolset: agentToolsetRouter,
   aiFeature: aiFeatureRouter,
   aiIntegration: aiIntegrationRouter,

--- a/apps/web/src/server/api/routers/agent-scope.ts
+++ b/apps/web/src/server/api/routers/agent-scope.ts
@@ -1,0 +1,117 @@
+// apps/web/src/server/api/routers/agent-scope.ts
+
+import {
+  agentExistsInOrg,
+  PinLimitExceededError,
+  removeAgentScopeRow,
+  ScopeRowImmutableError,
+  setAgentPin,
+  upsertAgentScopeRow,
+} from '@auxx/lib/agents'
+import { createScopedLogger } from '@auxx/logger'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { adminProcedure, createTRPCRouter } from '../trpc'
+
+const logger = createScopedLogger('agent-scope-router')
+
+const scopeModeSchema = z.enum(['include_descendants', 'include_one', 'exclude'])
+const recordIdSchema = z.string().min(1).max(180)
+
+async function ensureAgentInOrg(organizationId: string, agentId: string): Promise<void> {
+  if (!(await agentExistsInOrg(organizationId, agentId))) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
+  }
+}
+
+function mapServiceError(err: unknown): TRPCError {
+  if (err instanceof PinLimitExceededError) {
+    return new TRPCError({ code: 'BAD_REQUEST', message: err.message })
+  }
+  if (err instanceof ScopeRowImmutableError) {
+    return new TRPCError({ code: 'CONFLICT', message: err.message })
+  }
+  return new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+    message: err instanceof Error ? err.message : 'Unknown error',
+  })
+}
+
+/**
+ * Per-agent resource scope + pinned-records mutations. Reads come from
+ * `agent.getById.resourceScopes` and `agent.getById.pinnedRecords`.
+ * Mention-sourced rows are owned by the prompt reconciler and are rejected
+ * here; admin edits write `manual`.
+ */
+export const agentScopeRouter = createTRPCRouter({
+  upsertRow: adminProcedure
+    .input(
+      z.object({
+        agentId: z.string(),
+        recordId: recordIdSchema,
+        mode: scopeModeSchema,
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      await ensureAgentInOrg(organizationId, input.agentId)
+      try {
+        await upsertAgentScopeRow(organizationId, input)
+      } catch (err) {
+        throw mapServiceError(err)
+      }
+      logger.info('Agent scope row upserted', {
+        organizationId,
+        agentId: input.agentId,
+        recordId: input.recordId,
+        mode: input.mode,
+      })
+    }),
+
+  removeRow: adminProcedure
+    .input(
+      z.object({
+        agentId: z.string(),
+        recordId: recordIdSchema,
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      await ensureAgentInOrg(organizationId, input.agentId)
+      try {
+        await removeAgentScopeRow(organizationId, input)
+      } catch (err) {
+        throw mapServiceError(err)
+      }
+      logger.info('Agent scope row removed', {
+        organizationId,
+        agentId: input.agentId,
+        recordId: input.recordId,
+      })
+    }),
+
+  setPin: adminProcedure
+    .input(
+      z.object({
+        agentId: z.string(),
+        recordId: recordIdSchema,
+        pinned: z.boolean(),
+        note: z.string().max(280).nullable().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      await ensureAgentInOrg(organizationId, input.agentId)
+      try {
+        await setAgentPin(organizationId, input)
+      } catch (err) {
+        throw mapServiceError(err)
+      }
+      logger.info('Agent pin toggled', {
+        organizationId,
+        agentId: input.agentId,
+        recordId: input.recordId,
+        pinned: input.pinned,
+      })
+    }),
+})

--- a/apps/web/src/server/api/routers/agent-toolset.ts
+++ b/apps/web/src/server/api/routers/agent-toolset.ts
@@ -3,7 +3,7 @@
 import {
   agentExistsInOrg,
   batchUpdateAgentToolsets,
-  listAgentToolsets,
+  getOrgToolsetCatalog,
   updateAgentToolset,
 } from '@auxx/lib/agents'
 import { createScopedLogger } from '@auxx/logger'
@@ -33,9 +33,12 @@ async function ensureAgentInOrg(organizationId: string, agentId: string): Promis
  * just validates input, enforces org scope via the cache, and delegates.
  */
 export const agentToolsetRouter = createTRPCRouter({
-  list: adminProcedure.input(z.object({ agentId: z.string() })).query(async ({ ctx, input }) => {
-    await ensureAgentInOrg(ctx.session.organizationId, input.agentId)
-    return listAgentToolsets(input.agentId)
+  /**
+   * Org-wide toolset catalog — every available toolset slug and its tools.
+   * Per-agent enabled state lives on `agent.getById.toolsets`.
+   */
+  list: adminProcedure.query(async ({ ctx }) => {
+    return getOrgToolsetCatalog(ctx.session.organizationId)
   }),
 
   update: adminProcedure

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -28,6 +28,12 @@
       "import": "./dist/agents/index.mjs",
       "default": "./src/agents/index.ts"
     },
+    "./agents/client": {
+      "types": "./src/agents/client.ts",
+      "source": "./src/agents/client.ts",
+      "import": "./dist/agents/client.mjs",
+      "default": "./src/agents/client.ts"
+    },
     "./ai": {
       "types": "./src/ai/index.ts",
       "source": "./src/ai/index.ts",
@@ -573,12 +579,6 @@
       "source": "./src/recording/client/index.ts",
       "import": "./dist/recording/client/index.mjs",
       "default": "./src/recording/client/index.ts"
-    },
-    "./references": {
-      "types": "./src/references/index.ts",
-      "source": "./src/references/index.ts",
-      "import": "./dist/references/index.mjs",
-      "default": "./src/references/index.ts"
     },
     "./resource-access": {
       "types": "./src/resource-access/index.ts",

--- a/packages/lib/src/agents/agent-scope-service.ts
+++ b/packages/lib/src/agents/agent-scope-service.ts
@@ -1,0 +1,271 @@
+// packages/lib/src/agents/agent-scope-service.ts
+
+import {
+  type AgentResourceScopeEntity,
+  type Database,
+  database as defaultDb,
+  type PinnedRecord,
+  schema,
+  type Transaction,
+} from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull } from 'drizzle-orm'
+import { getCachedAgentById, onCacheEvent } from '../cache'
+
+const logger = createScopedLogger('agent-scope-service')
+
+const PIN_HARD_CAP = 50
+
+export type AgentScopeMode = 'include_descendants' | 'include_one' | 'exclude'
+
+export interface AgentScopeUpsertInput {
+  agentId: string
+  /** `${entityDefinitionId}:${entityInstanceId}` or `entityDefinitionId` for definition-level. */
+  recordId: string
+  mode: AgentScopeMode
+}
+
+export interface AgentScopeRemoveInput {
+  agentId: string
+  recordId: string
+}
+
+export interface AgentPinInput {
+  agentId: string
+  recordId: string
+  pinned: boolean
+  note?: string | null
+}
+
+/**
+ * Parse a scope `recordId` string into the split column shape used in
+ * `AgentResourceScope`. `'article:abc'` → `{ entityDefinitionId: 'article',
+ * entityInstanceId: 'abc' }`. `'contact'` or `'contact:'` → `{
+ * entityDefinitionId: 'contact', entityInstanceId: null }` (definition-level).
+ */
+export function parseRecordIdForScope(recordId: string): {
+  entityDefinitionId: string
+  entityInstanceId: string | null
+} {
+  const colon = recordId.indexOf(':')
+  if (colon === -1) return { entityDefinitionId: recordId, entityInstanceId: null }
+  const def = recordId.slice(0, colon)
+  const instance = recordId.slice(colon + 1)
+  return {
+    entityDefinitionId: def,
+    entityInstanceId: instance.length > 0 ? instance : null,
+  }
+}
+
+function recordMatchesScopeRow(
+  recordId: string,
+  row: { entityDefinitionId: string; entityInstanceId: string | null }
+): boolean {
+  const parsed = parseRecordIdForScope(recordId)
+  return (
+    parsed.entityDefinitionId === row.entityDefinitionId &&
+    parsed.entityInstanceId === row.entityInstanceId
+  )
+}
+
+async function findScopeRowForUpdate(
+  tx: Transaction,
+  organizationId: string,
+  agentId: string,
+  recordId: string
+): Promise<AgentResourceScopeEntity | undefined> {
+  const { entityDefinitionId, entityInstanceId } = parseRecordIdForScope(recordId)
+  const instanceFilter =
+    entityInstanceId === null
+      ? isNull(schema.AgentResourceScope.entityInstanceId)
+      : eq(schema.AgentResourceScope.entityInstanceId, entityInstanceId)
+
+  const [row] = await tx
+    .select()
+    .from(schema.AgentResourceScope)
+    .where(
+      and(
+        eq(schema.AgentResourceScope.organizationId, organizationId),
+        eq(schema.AgentResourceScope.agentId, agentId),
+        eq(schema.AgentResourceScope.entityDefinitionId, entityDefinitionId),
+        instanceFilter
+      )
+    )
+    .limit(1)
+
+  return row
+}
+
+async function upsertScopeRowInTx(
+  tx: Transaction,
+  organizationId: string,
+  agentId: string,
+  recordId: string,
+  mode: AgentScopeMode
+): Promise<void> {
+  const now = new Date()
+  const existing = await findScopeRowForUpdate(tx, organizationId, agentId, recordId)
+  const { entityDefinitionId, entityInstanceId } = parseRecordIdForScope(recordId)
+
+  if (existing) {
+    await tx
+      .update(schema.AgentResourceScope)
+      .set({
+        mode,
+        // First-touch promotion: any non-manual row becomes `manual` on an
+        // explicit admin edit. Mention pins promote so they survive prompt
+        // changes; auto_defaults promote so they outlive the default set.
+        source: 'manual',
+        updatedAt: now,
+      })
+      .where(eq(schema.AgentResourceScope.id, existing.id))
+    return
+  }
+
+  await tx.insert(schema.AgentResourceScope).values({
+    agentId,
+    organizationId,
+    entityDefinitionId,
+    entityInstanceId,
+    mode,
+    source: 'manual',
+    updatedAt: now,
+  })
+}
+
+/**
+ * Upsert one scope row. Inserts default to `source='manual'`; existing
+ * `mention`-sourced rows stay `mention` (the prompt reconciler owns them).
+ */
+export async function upsertAgentScopeRow(
+  organizationId: string,
+  input: AgentScopeUpsertInput,
+  db: Database = defaultDb as Database
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    await upsertScopeRowInTx(tx, organizationId, input.agentId, input.recordId, input.mode)
+  })
+  await fireAgentUpdated(organizationId, input.agentId)
+}
+
+/**
+ * Remove a scope row. Mention-sourced rows reject with an error — those are
+ * managed by the prompt reconciler. Removing a non-existent row is a no-op.
+ */
+export async function removeAgentScopeRow(
+  organizationId: string,
+  input: AgentScopeRemoveInput,
+  db: Database = defaultDb as Database
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    const existing = await findScopeRowForUpdate(tx, organizationId, input.agentId, input.recordId)
+    if (!existing) return
+    if (existing.source === 'mention') {
+      throw new ScopeRowImmutableError(
+        'Cannot remove a mention-pinned scope row. Drop the mention in the persona prompt first.'
+      )
+    }
+    await tx.delete(schema.AgentResourceScope).where(eq(schema.AgentResourceScope.id, existing.id))
+  })
+  await fireAgentUpdated(organizationId, input.agentId)
+}
+
+/**
+ * Toggle a manual pin. When `pinned=true` and no scope row covers the record
+ * yet, also inserts a `mode='include_one'` row (pin-implies-access, per
+ * `knowledge-access.md` §2.2). Throws `PinLimitExceededError` when the agent
+ * already has 50 pinned records.
+ */
+export async function setAgentPin(
+  organizationId: string,
+  input: AgentPinInput,
+  db: Database = defaultDb as Database
+): Promise<void> {
+  const cached = await getCachedAgentById(organizationId, input.agentId)
+  if (!cached) throw new ScopeRowImmutableError('Agent not found')
+
+  const existing = cached.pinnedRecords
+  const idx = existing.findIndex((p) => p.recordId === input.recordId)
+  const current = idx === -1 ? undefined : existing[idx]
+
+  let next: PinnedRecord[]
+  if (input.pinned) {
+    if (current) {
+      // Already pinned — refresh note if provided; never overwrite a mention pin.
+      if (current.pinReason === 'mention') return
+      next = [...existing]
+      next[idx] = {
+        ...current,
+        note: input.note ?? current.note,
+      }
+    } else {
+      if (existing.length >= PIN_HARD_CAP) {
+        throw new PinLimitExceededError(`Pin limit reached (${PIN_HARD_CAP})`)
+      }
+      const newPin: PinnedRecord = {
+        recordId: input.recordId,
+        pinReason: 'manual',
+      }
+      if (input.note != null) newPin.note = input.note
+      next = [...existing, newPin]
+    }
+  } else {
+    if (!current) return
+    if (current.pinReason === 'mention') {
+      throw new ScopeRowImmutableError(
+        'Cannot unpin a mention-pinned record. Drop the mention in the persona prompt first.'
+      )
+    }
+    next = existing.filter((_, i) => i !== idx)
+  }
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(schema.Agent)
+      .set({ pinnedRecords: next, updatedAt: new Date() })
+      .where(eq(schema.Agent.id, input.agentId))
+
+    // Pin-implies-access: when newly pinning, ensure a scope row exists.
+    if (input.pinned && !current) {
+      const existingRow = await findScopeRowForUpdate(
+        tx,
+        organizationId,
+        input.agentId,
+        input.recordId
+      )
+      if (!existingRow) {
+        await upsertScopeRowInTx(tx, organizationId, input.agentId, input.recordId, 'include_one')
+      }
+    }
+  })
+
+  await fireAgentUpdated(organizationId, input.agentId)
+}
+
+async function fireAgentUpdated(organizationId: string, agentId: string): Promise<void> {
+  try {
+    await onCacheEvent('agent.updated', { orgId: organizationId })
+  } catch (err) {
+    logger.warn('Failed to invalidate caches after agent scope update', {
+      organizationId,
+      agentId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+export class PinLimitExceededError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PinLimitExceededError'
+  }
+}
+
+export class ScopeRowImmutableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ScopeRowImmutableError'
+  }
+}
+
+export { PIN_HARD_CAP, recordMatchesScopeRow }

--- a/packages/lib/src/agents/client.ts
+++ b/packages/lib/src/agents/client.ts
@@ -1,0 +1,23 @@
+// packages/lib/src/agents/client.ts
+
+/**
+ * Client-safe exports from `@auxx/lib/agents`. The barrel `index.ts` pulls
+ * in server-only deps (DB, capabilities); this subpath is what client
+ * components should import from.
+ */
+
+export type AgentScopeMode = 'include_descendants' | 'include_one' | 'exclude'
+
+export interface ToolCatalogEntry {
+  name: string
+  description: string
+}
+
+export interface ToolsetCatalogEntry {
+  slug: string
+  label: string
+  group: 'native' | 'app'
+  appId?: string
+  isDefault: boolean
+  tools: ToolCatalogEntry[]
+}

--- a/packages/lib/src/agents/index.ts
+++ b/packages/lib/src/agents/index.ts
@@ -1,6 +1,20 @@
 // packages/lib/src/agents/index.ts
 
 export {
+  type AgentPinInput,
+  type AgentScopeMode,
+  type AgentScopeRemoveInput,
+  type AgentScopeUpsertInput,
+  PIN_HARD_CAP,
+  PinLimitExceededError,
+  parseRecordIdForScope,
+  recordMatchesScopeRow,
+  removeAgentScopeRow,
+  ScopeRowImmutableError,
+  setAgentPin,
+  upsertAgentScopeRow,
+} from './agent-scope-service'
+export {
   type AgentDetail,
   type AgentSummary,
   agentExistsInOrg,
@@ -25,3 +39,9 @@ export type { AgentToolsetConfig } from './agent-toolset-types'
 export { NATIVE_DEFAULT_TOOLSETS, resolveDefaultToolsets } from './default-toolsets'
 export { filterToolsByToolsets } from './filter-tools'
 export { type ResolvedAgentConfig, resolveAgentConfig } from './resolve-agent-config'
+export {
+  getOrgToolsetCatalog,
+  NATIVE_TOOLSET_LABELS,
+  type ToolCatalogEntry,
+  type ToolsetCatalogEntry,
+} from './toolset-catalog'

--- a/packages/lib/src/agents/toolset-catalog.ts
+++ b/packages/lib/src/agents/toolset-catalog.ts
@@ -1,0 +1,138 @@
+// packages/lib/src/agents/toolset-catalog.ts
+
+import type { AgentToolDefinition } from '../ai/agent-framework/types'
+import type { GetToolDeps, PageCapability } from '../ai/kopilot/capabilities'
+import {
+  createActorCapabilities,
+  createEntityCapabilities,
+  createKbCapabilities,
+  createKbReadCapabilities,
+  createKnowledgeCapabilities,
+  createMailCapabilities,
+  createTaskCapabilities,
+} from '../ai/kopilot/capabilities'
+import { NATIVE_DEFAULT_TOOLSETS } from './default-toolsets'
+
+/**
+ * Catalog entry describing a toolset and the tools it exposes. Read by the
+ * admin Tools tab to render the per-agent toolset selector. Catalog-only —
+ * per-agent enabled state lives on `agent.getById.toolsets`.
+ */
+export interface ToolCatalogEntry {
+  name: string
+  description: string
+}
+
+export interface ToolsetCatalogEntry {
+  slug: string
+  label: string
+  group: 'native' | 'app'
+  appId?: string
+  isDefault: boolean
+  tools: ToolCatalogEntry[]
+}
+
+/**
+ * Human-readable labels for native toolset slugs. Unknown slugs fall back to
+ * the slug itself — matches phase-1-ui-tabs.md §1.1.
+ */
+export const NATIVE_TOOLSET_LABELS: Record<string, string> = {
+  'mail.threads': 'Mail — Threads',
+  'mail.compose': 'Mail — Compose',
+  'mail.drafts': 'Mail — Drafts',
+  'entities.search': 'Entities — Search',
+  'entities.write': 'Entities — Write',
+  knowledge: 'Knowledge search',
+  'kb.read': 'Knowledge base — Read',
+  'kb.write': 'Knowledge base — Write',
+  'tasks.read': 'Tasks — Read',
+  'tasks.write': 'Tasks — Write',
+  actors: 'Members & actors',
+}
+
+const DEFAULT_SLUGS = new Set<string>(NATIVE_DEFAULT_TOOLSETS)
+
+/**
+ * Stub `getDeps` for catalog enumeration. Tool factories capture `getDeps` in
+ * a closure for `execute`-time use only — constructing the tool definition
+ * (name, description, toolsetSlug) never invokes the factory.
+ */
+const catalogGetDeps: GetToolDeps = () => {
+  throw new Error('toolset-catalog: getDeps is for metadata enumeration only')
+}
+
+function collectNativeCapabilities(): PageCapability[] {
+  return [
+    createMailCapabilities(catalogGetDeps),
+    createEntityCapabilities(catalogGetDeps),
+    createKnowledgeCapabilities(catalogGetDeps),
+    createActorCapabilities(catalogGetDeps),
+    createTaskCapabilities(catalogGetDeps),
+    createKbCapabilities(catalogGetDeps),
+    createKbReadCapabilities(catalogGetDeps),
+  ]
+}
+
+/**
+ * Walk every registered native capability, group tools by `toolsetSlug`, and
+ * return one `ToolsetCatalogEntry` per slug. Tools without a `toolsetSlug`
+ * (plan tools) are excluded — they're always-on per README §6.5.
+ *
+ * v1 returns only `group='native'`. The `app` group slot is reserved for the
+ * apps track and stays empty until that catalog provider lands.
+ */
+export async function getOrgToolsetCatalog(
+  _organizationId: string
+): Promise<ToolsetCatalogEntry[]> {
+  const bySlug = new Map<string, { tools: Map<string, ToolCatalogEntry> }>()
+
+  for (const capability of collectNativeCapabilities()) {
+    for (const tool of capability.tools as AgentToolDefinition[]) {
+      const slug = tool.toolsetSlug
+      if (!slug) continue
+      let bucket = bySlug.get(slug)
+      if (!bucket) {
+        bucket = { tools: new Map() }
+        bySlug.set(slug, bucket)
+      }
+      // Dedupe by tool name — a tool registered against more than one page
+      // (rare, but possible) should still appear once per slug.
+      if (!bucket.tools.has(tool.name)) {
+        bucket.tools.set(tool.name, {
+          name: tool.name,
+          description: shortDescription(tool.description),
+        })
+      }
+    }
+  }
+
+  const entries: ToolsetCatalogEntry[] = []
+  for (const [slug, { tools }] of bySlug) {
+    entries.push({
+      slug,
+      label: NATIVE_TOOLSET_LABELS[slug] ?? slug,
+      group: 'native',
+      isDefault: DEFAULT_SLUGS.has(slug),
+      tools: [...tools.values()].sort((a, b) => a.name.localeCompare(b.name)),
+    })
+  }
+
+  entries.sort((a, b) => {
+    if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1
+    return a.label.localeCompare(b.label)
+  })
+
+  return entries
+}
+
+/**
+ * Tool descriptions in the registry are LLM-facing and can run several
+ * paragraphs. The Tools tab tooltip only needs a one-liner — take the first
+ * sentence (up to 200 chars).
+ */
+function shortDescription(description: string): string {
+  const trimmed = description.trim()
+  const sentenceEnd = trimmed.search(/[.!?]\s/)
+  const candidate = sentenceEnd > 0 ? trimmed.slice(0, sentenceEnd + 1) : trimmed
+  return candidate.length > 200 ? `${candidate.slice(0, 197)}…` : candidate
+}


### PR DESCRIPTION
## Summary
- **Tools tab**: replaces placeholder with real UI. New `getOrgToolsetCatalog` service exposes every native + app toolset available to the org; `agentToolset.list` becomes an org-wide catalog (per-agent enabled state lives on `agent.getById.toolsets`).
- **Knowledge tab**: replaces placeholder with real UI. New `agent-scope-service` manages pinned-record scope rows (`include_descendants` / `include_one` / `exclude`) with a hard pin cap and parent/circular safety; `PinLimitExceededError` and `ScopeRowImmutableError` are surfaced from the service. New `agentScope` tRPC router (`upsert` / `remove` / `setPin`) registered on root.
- **Shared**: adds `@auxx/lib/agents/client` subpath for client-safe types (`AgentScopeMode`, toolset catalog types); removes unused `@auxx/lib/references` export.

## Test plan
- [ ] Open an agent detail page → Tools section lists all org toolsets, toggles persist, autosave indicator fires
- [ ] Knowledge section: add a pinned record, switch scope modes, hit pin cap → `PinLimitExceededError` surfaces as a user-facing error
- [ ] Verify the old per-agent `listAgentToolsets` call site is gone and no client code imports `@auxx/lib/references`
- [ ] Confirm `@auxx/lib/agents/client` is the only agents import used in `'use client'` files