### PR TITLE
feat(apps): personal + workspace connection scopes, member visibility

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/apps/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/page.tsx
@@ -20,6 +20,7 @@ import { useLayoutEffect, useRef, useState } from 'react'
 import { AppListCard } from '~/components/apps/app-list-card'
 import SettingsPage from '~/components/global/settings-page'
 import { AppIcon } from '~/components/workflow/ui/app-icon'
+import { useUser } from '~/hooks/use-user'
 import { api } from '~/trpc/react'
 
 /** Icon mapping for app categories */
@@ -42,7 +43,8 @@ const SHOW_EMPTY_CATEGORIES = false
  * Displays a list of integrations and provides functionality to manage them
  */
 export default function IntegrationList() {
-  const { data: results } = api.apps.list.useQuery({})
+  const { isAdminOrOwner } = useUser()
+  const { data: results } = api.apps.list.useQuery({}, { enabled: isAdminOrOwner })
   const { data: installedResult } = api.apps.listInstalled.useQuery({
     // type filter is optional - omitting it returns all installations (both dev and production)
   })
@@ -203,10 +205,28 @@ export default function IntegrationList() {
       }
     }
   }, [categoriesToDisplay]) // Re-run when categories change
+  // Members see only the Installed strip (all installed apps, no Browse marketplace).
+  // Their rendering uses installation.app directly because `apps.list` is admin-only.
+  const memberInstalledCards = installed.map((installation) => ({
+    id: installation.app.id,
+    slug: installation.app.slug,
+    title: installation.app.title,
+    description: installation.app.description,
+    avatarUrl: installation.app.avatarUrl,
+    verified: false,
+    isDevelopment: installation.installationType === 'development',
+    isInstalled: true,
+    developerAccount: { title: '' },
+  }))
+
   return (
     <SettingsPage
-      title='Marketplace'
-      description='Manage your external service integrations for email, messaging, and telephony'
+      title={isAdminOrOwner ? 'Marketplace' : 'Apps'}
+      description={
+        isAdminOrOwner
+          ? 'Manage your external service integrations for email, messaging, and telephony'
+          : 'Manage your personal connections to installed apps.'
+      }
       breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Apps' }]}
       button={<></>}>
       <div className='flex flex-col flex-1 p-3 sm:p-6 space-y-8'>
@@ -216,7 +236,7 @@ export default function IntegrationList() {
               <Globe className='size-4' />
               Installed apps
             </div>
-            {hasMoreInstalled && (
+            {isAdminOrOwner && hasMoreInstalled && (
               <Link href='/app/settings/apps/installed'>
                 <Button variant='ghost' size='sm'>
                   View all
@@ -225,21 +245,42 @@ export default function IntegrationList() {
             )}
           </div>
           <div className='w-full @container'>
-            {installedAppsToShow.length > 0 ? (
+            {isAdminOrOwner ? (
+              installedAppsToShow.length > 0 ? (
+                <div className='grid w-full gap-2 @sm:grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3'>
+                  {installedAppsToShow.map(({ app }) => (
+                    <AppListCard
+                      key={app.id}
+                      title={app.title}
+                      description={app.description}
+                      href={`/app/settings/apps/installed/${app.slug}`}
+                      icon={
+                        app.avatarUrl ? <AppIcon iconId={app.avatarUrl} size='sm' /> : undefined
+                      }
+                      subtitle={`By ${app.developerAccount.title}`}
+                      verified={app.verified}
+                      badges={[
+                        ...(app.isDevelopment ? [{ icon: <Code className='size-3' /> }] : []),
+                        ...(app.isInstalled ? [{ label: 'Installed' }] : []),
+                      ]}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div className='border bg-primary-50 w-full p-6 rounded-2xl text-center text-sm text-muted-foreground'>
+                  No apps installed yet
+                </div>
+              )
+            ) : memberInstalledCards.length > 0 ? (
               <div className='grid w-full gap-2 @sm:grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3'>
-                {installedAppsToShow.map(({ app }) => (
+                {memberInstalledCards.map((app) => (
                   <AppListCard
                     key={app.id}
                     title={app.title}
                     description={app.description}
                     href={`/app/settings/apps/installed/${app.slug}`}
                     icon={app.avatarUrl ? <AppIcon iconId={app.avatarUrl} size='sm' /> : undefined}
-                    subtitle={`By ${app.developerAccount.title}`}
-                    verified={app.verified}
-                    badges={[
-                      ...(app.isDevelopment ? [{ icon: <Code className='size-3' /> }] : []),
-                      ...(app.isInstalled ? [{ label: 'Installed' }] : []),
-                    ]}
+                    badges={app.isDevelopment ? [{ icon: <Code className='size-3' /> }] : []}
                   />
                 ))}
               </div>
@@ -250,108 +291,110 @@ export default function IntegrationList() {
             )}
           </div>
         </div>
-        <div className='space-y-6'>
-          <div className='space-y-1'>
-            <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-              <Globe className='size-4' />
-              Browse apps
-            </div>
-            <div className='text-sm text-muted-foreground'>
-              Discover new apps to help you work better
-            </div>
-          </div>
-          <div className='flex flex-col gap-6 justify-start w-full'>
-            <div className='sticky pt-20 -mt-20  top-0'>
-              <div className='grid sm:grid-cols-3 pb-4 sm:pb-0'>
-                <Input
-                  placeholder='Search apps'
-                  className='sm:col-start-2 sm:col-span-2'
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                />
+        {isAdminOrOwner && (
+          <div className='space-y-6'>
+            <div className='space-y-1'>
+              <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
+                <Globe className='size-4' />
+                Browse apps
               </div>
-              <div className='sm:absolute sm:left-0 sm:top-[80px] z-1 pointer-events-none sm:grid sm:grid-cols-3'>
-                <div className='pointer-events-auto '>
-                  <div className='flex flex-row sm:flex-col sm:space-y-1 space-x-2 sm:space-x-0 no-scrollbar overflow-x-auto sm:overflow-x-hidden '>
-                    {categoriesToDisplay.map((category) => {
-                      const IconComponent = iconMap[category.icon as keyof typeof iconMap]
-                      const isActive = activeCategory === category.value
-                      return (
-                        <Button
-                          key={category.value}
-                          variant={isActive ? 'default' : 'outline'}
-                          className='justify-start'
-                          size='sm'
-                          onClick={() => scrollToCategory(category.value)}>
-                          {IconComponent && <IconComponent />}
-                          {category.label}
-                        </Button>
-                      )
-                    })}
+              <div className='text-sm text-muted-foreground'>
+                Discover new apps to help you work better
+              </div>
+            </div>
+            <div className='flex flex-col gap-6 justify-start w-full'>
+              <div className='sticky pt-20 -mt-20  top-0'>
+                <div className='grid sm:grid-cols-3 pb-4 sm:pb-0'>
+                  <Input
+                    placeholder='Search apps'
+                    className='sm:col-start-2 sm:col-span-2'
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                  />
+                </div>
+                <div className='sm:absolute sm:left-0 sm:top-[80px] z-1 pointer-events-none sm:grid sm:grid-cols-3'>
+                  <div className='pointer-events-auto '>
+                    <div className='flex flex-row sm:flex-col sm:space-y-1 space-x-2 sm:space-x-0 no-scrollbar overflow-x-auto sm:overflow-x-hidden '>
+                      {categoriesToDisplay.map((category) => {
+                        const IconComponent = iconMap[category.icon as keyof typeof iconMap]
+                        const isActive = activeCategory === category.value
+                        return (
+                          <Button
+                            key={category.value}
+                            variant={isActive ? 'default' : 'outline'}
+                            className='justify-start'
+                            size='sm'
+                            onClick={() => scrollToCategory(category.value)}>
+                            {IconComponent && <IconComponent />}
+                            {category.label}
+                          </Button>
+                        )
+                      })}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div className='grid  pt-2 w-full sm:grid-cols-3 gap-4'>
-              <div className='flex w-full flex-col justify-start sm:col-start-2 sm:col-end-4 space-y-4 sm:space-y-8'>
-                {filteredApps.length === 0 && searchQuery.trim() ? (
-                  <div className='text-center py-12 text-muted-foreground'>
-                    <div className='text-base font-medium mb-2'>No apps found</div>
-                    <div className='text-sm'>
-                      Try adjusting your search query to find what you're looking for
+              <div className='grid  pt-2 w-full sm:grid-cols-3 gap-4'>
+                <div className='flex w-full flex-col justify-start sm:col-start-2 sm:col-end-4 space-y-4 sm:space-y-8'>
+                  {filteredApps.length === 0 && searchQuery.trim() ? (
+                    <div className='text-center py-12 text-muted-foreground'>
+                      <div className='text-base font-medium mb-2'>No apps found</div>
+                      <div className='text-sm'>
+                        Try adjusting your search query to find what you're looking for
+                      </div>
                     </div>
-                  </div>
-                ) : (
-                  categoriesToDisplay.map((category) => {
-                    const categoryApps = appsByCategory[category.value] || []
-                    const hasCategoryApps = categoryApps.length > 0
+                  ) : (
+                    categoriesToDisplay.map((category) => {
+                      const categoryApps = appsByCategory[category.value] || []
+                      const hasCategoryApps = categoryApps.length > 0
 
-                    return (
-                      <section
-                        key={category.value}
-                        ref={(el) => {
-                          sectionRefs.current[category.value] = el
-                        }}
-                        data-category={category.value}
-                        className='flex flex-col w-full gap-2'>
-                        <div className='text-base font-normal'>{category.label}</div>
-                        {hasCategoryApps ? (
-                          <div className='grid w-full gap-2 sm:grid-cols-2'>
-                            {categoryApps.map((app) => (
-                              <AppListCard
-                                key={app.id}
-                                title={app.title}
-                                description={app.description}
-                                href={`/app/settings/apps/${app.slug}/`}
-                                icon={
-                                  app.avatarUrl ? (
-                                    <AppIcon iconId={app.avatarUrl} size='sm' />
-                                  ) : undefined
-                                }
-                                subtitle={`By ${app.developerAccount.title}`}
-                                verified={app.verified}
-                                badges={[
-                                  ...(app.isDevelopment
-                                    ? [{ icon: <Code className='size-3' /> }]
-                                    : []),
-                                  ...(app.isInstalled ? [{ label: 'Installed' }] : []),
-                                ]}
-                              />
-                            ))}
-                          </div>
-                        ) : (
-                          <div className='text-sm text-muted-foreground h-100'>
-                            No apps in this category yet
-                          </div>
-                        )}
-                      </section>
-                    )
-                  })
-                )}
+                      return (
+                        <section
+                          key={category.value}
+                          ref={(el) => {
+                            sectionRefs.current[category.value] = el
+                          }}
+                          data-category={category.value}
+                          className='flex flex-col w-full gap-2'>
+                          <div className='text-base font-normal'>{category.label}</div>
+                          {hasCategoryApps ? (
+                            <div className='grid w-full gap-2 sm:grid-cols-2'>
+                              {categoryApps.map((app) => (
+                                <AppListCard
+                                  key={app.id}
+                                  title={app.title}
+                                  description={app.description}
+                                  href={`/app/settings/apps/${app.slug}/`}
+                                  icon={
+                                    app.avatarUrl ? (
+                                      <AppIcon iconId={app.avatarUrl} size='sm' />
+                                    ) : undefined
+                                  }
+                                  subtitle={`By ${app.developerAccount.title}`}
+                                  verified={app.verified}
+                                  badges={[
+                                    ...(app.isDevelopment
+                                      ? [{ icon: <Code className='size-3' /> }]
+                                      : []),
+                                    ...(app.isInstalled ? [{ label: 'Installed' }] : []),
+                                  ]}
+                                />
+                              ))}
+                            </div>
+                          ) : (
+                            <div className='text-sm text-muted-foreground h-100'>
+                              No apps in this category yet
+                            </div>
+                          )}
+                        </section>
+                      )
+                    })
+                  )}
+                </div>
               </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     </SettingsPage>
   )

--- a/apps/web/src/components/apps/app-connections.tsx
+++ b/apps/web/src/components/apps/app-connections.tsx
@@ -4,7 +4,7 @@
 
 import type { ConnectionVariable, OAuth2Features } from '@auxx/database'
 import { Button } from '@auxx/ui/components/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@auxx/ui/components/card'
+import { Card, CardContent } from '@auxx/ui/components/card'
 import {
   Dialog,
   DialogContent,
@@ -35,6 +35,8 @@ import {
   Pencil,
   Plus,
   Unplug,
+  User,
+  Users,
   X,
   XCircle,
 } from 'lucide-react'
@@ -42,19 +44,150 @@ import { useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { SecretConnectionDialogContent } from '~/components/apps/app-connection-status'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useUser } from '~/hooks/use-user'
 import type { RouterOutputs } from '~/trpc/react'
 import { api } from '~/trpc/react'
 
+type AppData = RouterOutputs['apps']['getBySlug']
+type ConnectionRow = RouterOutputs['apps']['listConnections'][number]
+type ConnectionDefinition = NonNullable<AppData['installation']['connectionDefinitions']['user']>
+type Scope = 'user' | 'organization'
+
 type Props = {
-  app: RouterOutputs['apps']['getBySlug']
+  app: AppData
   returnTo?: string
+  /** If set, render only the matching section. Otherwise render both (gated on definitions). */
+  scope?: Scope
 }
 
-function AppConnections({ app, returnTo }: Props) {
+function AppConnections({ app, returnTo, scope }: Props) {
   const searchParams = useSearchParams()
   const success = searchParams.get('success') || searchParams.get('oauth_success')
-  const utils = api.useUtils()
+  const { userId, isAdminOrOwner } = useUser()
   const [confirm, ConfirmDialog] = useConfirm()
+
+  const {
+    data: connectionsResult,
+    refetch: refetchConnections,
+    isLoading: isLoadingConnections,
+  } = api.apps.listConnections.useQuery()
+
+  useEffect(() => {
+    if (success === 'true') {
+      void refetchConnections()
+    }
+  }, [success, refetchConnections])
+
+  if (!app.installation.isInstalled) {
+    return (
+      <div className='flex-1 flex-col space-y-6 px-6 py-6'>
+        <div className='border bg-primary-50 w-full p-6 rounded-2xl text-center'>
+          <div className='text-base font-medium mb-2'>App not installed</div>
+          <div className='text-sm text-muted-foreground'>This app needs to be installed first</div>
+        </div>
+      </div>
+    )
+  }
+
+  const { user: userDef, organization: orgDef } = app.installation.connectionDefinitions ?? {}
+  const showPersonal = !!userDef && (scope === undefined || scope === 'user')
+  const showWorkspace = !!orgDef && (scope === undefined || scope === 'organization')
+
+  if (!showPersonal && !showWorkspace) {
+    return (
+      <div className='flex-1 flex-col space-y-6 px-6 py-6'>
+        <div className='border bg-primary-50 w-full p-6 rounded-2xl text-center'>
+          <div className='text-base font-medium mb-2'>No connection required</div>
+          <div className='text-sm text-muted-foreground'>
+            {app.app.title} does not require any external connections
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const allConnections = connectionsResult ?? []
+  const installationId = app.installation.id!
+
+  const personalRows = allConnections.filter(
+    (conn) =>
+      conn.appId === app.app.id &&
+      conn.appInstallationId === installationId &&
+      conn.global === false &&
+      conn.userId === userId
+  )
+  const workspaceRows = allConnections.filter(
+    (conn) =>
+      conn.appId === app.app.id && conn.appInstallationId === installationId && conn.global === true
+  )
+
+  return (
+    <div className='flex-1 flex-col space-y-6 px-6 py-6'>
+      {showPersonal && userDef && (
+        <ConnectionSection
+          app={app}
+          installationId={installationId}
+          definition={userDef}
+          scope='user'
+          rows={personalRows}
+          returnTo={returnTo}
+          canEdit
+          icon={<User className='size-4' />}
+          title='Personal'
+          confirm={confirm}
+          isLoading={isLoadingConnections}
+        />
+      )}
+      {showWorkspace && orgDef && (
+        <ConnectionSection
+          app={app}
+          installationId={installationId}
+          definition={orgDef}
+          scope='organization'
+          rows={workspaceRows}
+          returnTo={returnTo}
+          canEdit={isAdminOrOwner}
+          icon={<Users className='size-4' />}
+          title='Workspace'
+          confirm={confirm}
+          isLoading={isLoadingConnections}
+        />
+      )}
+      <ConfirmDialog />
+    </div>
+  )
+}
+
+export default AppConnections
+
+type ConnectionSectionProps = {
+  app: AppData
+  installationId: string
+  definition: ConnectionDefinition
+  scope: Scope
+  rows: ConnectionRow[]
+  returnTo?: string
+  canEdit: boolean
+  icon: React.ReactNode
+  title: string
+  confirm: ReturnType<typeof useConfirm>[0]
+  isLoading: boolean
+}
+
+function ConnectionSection({
+  app,
+  installationId,
+  definition,
+  scope,
+  rows,
+  returnTo,
+  canEdit,
+  icon,
+  title,
+  confirm,
+  isLoading,
+}: ConnectionSectionProps) {
+  const utils = api.useUtils()
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editLabel, setEditLabel] = useState('')
   const [secretDialogOpen, setSecretDialogOpen] = useState(false)
@@ -64,18 +197,10 @@ function AppConnections({ app, returnTo }: Props) {
   const [variableValues, setVariableValues] = useState<Record<string, string>>({})
   const [reconnectConnectionId, setReconnectConnectionId] = useState<string | null>(null)
 
-  const { data: connectionsResult, refetch: refetchConnections } =
-    api.apps.listConnections.useQuery()
-
-  useEffect(() => {
-    if (success === 'true') {
-      void refetchConnections()
-    }
-  }, [success, refetchConnections])
-
-  const allConnections = connectionsResult ?? []
-  const connectionDefinition = app.installation.connectionDefinition
-  const installationId = app.installation.id!
+  const isOAuth = definition.connectionType === 'oauth2-code'
+  const isSecret = definition.connectionType === 'secret'
+  const connectionVarDefs: ConnectionVariable[] =
+    (definition.oauth2Features as OAuth2Features | null)?.connectionVariables ?? []
 
   const deleteConnection = api.apps.deleteConnection.useMutation({
     onSuccess: () => {
@@ -109,39 +234,10 @@ function AppConnections({ app, returnTo }: Props) {
     },
   })
 
-  if (!app.installation.isInstalled) {
-    return (
-      <div className='flex-1 flex-col space-y-6 px-6 py-6'>
-        <div className='border bg-primary-50 w-full p-6 rounded-2xl text-center'>
-          <div className='text-base font-medium mb-2'>App not installed</div>
-          <div className='text-sm text-muted-foreground'>This app needs to be installed first</div>
-        </div>
-      </div>
-    )
-  }
-
-  if (!connectionDefinition) {
-    return (
-      <div className='flex-1 flex-col space-y-6 px-6 py-6'>
-        <div className='border bg-primary-50 w-full p-6 rounded-2xl text-center'>
-          <div className='text-base font-medium mb-2'>No connection required</div>
-          <div className='text-sm text-muted-foreground'>
-            {app.app.title} does not require any external connections
-          </div>
-        </div>
-      </div>
-    )
-  }
-
-  // Filter connections for this app + installation (org-scoped only)
-  const appConnections = allConnections.filter(
-    (conn) => conn.appId === app.app.id && conn.appInstallationId === installationId && conn.global
-  )
-
-  const connectionType = connectionDefinition.global ? 'organization' : 'user'
-  const isOAuth = connectionDefinition.connectionType === 'oauth2-code'
-  const connectionVarDefs: ConnectionVariable[] =
-    (connectionDefinition.oauth2Features as OAuth2Features | null)?.connectionVariables ?? []
+  const returnToParam = returnTo ? `&returnTo=${encodeURIComponent(returnTo)}` : ''
+  const addConnectionUrl = isOAuth
+    ? `/api/apps/${app.app.slug}/oauth2/authorize?installation=${installationId}&type=${scope}${returnToParam}`
+    : null
 
   const handleAddConnection = () => {
     if (connectionVarDefs.length > 0) {
@@ -159,13 +255,11 @@ function AppConnections({ app, returnTo }: Props) {
       setVariableValues({})
       setVariableDialogOpen(true)
     } else {
-      const returnToParam = returnTo ? `&returnTo=${encodeURIComponent(returnTo)}` : ''
-      window.location.href = `/api/apps/${app.app.slug}/oauth2/authorize?installation=${installationId}&type=${connectionType}&connectionId=${connectionId}${returnToParam}`
+      window.location.href = `/api/apps/${app.app.slug}/oauth2/authorize?installation=${installationId}&type=${scope}&connectionId=${connectionId}${returnToParam}`
     }
   }
 
   const handleVariableSubmit = () => {
-    // Validate required variables
     for (const varDef of connectionVarDefs) {
       if (varDef.required !== false && !variableValues[varDef.key]?.trim()) {
         toastError({
@@ -178,10 +272,8 @@ function AppConnections({ app, returnTo }: Props) {
 
     const params = new URLSearchParams()
     params.set('installation', installationId)
-    params.set('type', connectionType)
-    if (reconnectConnectionId) {
-      params.set('connectionId', reconnectConnectionId)
-    }
+    params.set('type', scope)
+    if (reconnectConnectionId) params.set('connectionId', reconnectConnectionId)
     if (returnTo) params.set('returnTo', returnTo)
     for (const [key, value] of Object.entries(variableValues)) {
       if (value) params.set(`var_${key}`, value)
@@ -218,7 +310,7 @@ function AppConnections({ app, returnTo }: Props) {
       appId: app.app.id,
       installationId: installationId,
       appName: app.app.title,
-      connectionType,
+      connectionType: scope,
       secret: secret.trim(),
     })
   }
@@ -228,51 +320,38 @@ function AppConnections({ app, returnTo }: Props) {
     setEditLabel(currentLabel || '')
   }
 
-  // Build "Add Connection" URL (new flow — no connectionId)
-  const returnToParam = returnTo ? `&returnTo=${encodeURIComponent(returnTo)}` : ''
-  const addConnectionUrl = isOAuth
-    ? `/api/apps/${app.app.slug}/oauth2/authorize?installation=${installationId}&type=${connectionType}${returnToParam}`
-    : null
-
-  const StatusIcon = ({ status }: { status: string }) => {
-    if (status === 'connected') return <CheckCircle className='h-4 w-4 text-green-500' />
-    if (status === 'expired') return <Clock className='h-4 w-4 text-yellow-500' />
-    return <XCircle className='h-4 w-4 text-gray-400' />
+  const showAddButton = canEdit && (isOAuth || isSecret)
+  const onAddClick = () => {
+    if (isOAuth) handleAddConnection()
+    else if (isSecret) setSecretDialogOpen(true)
   }
 
   return (
-    <div className='flex-1 flex-col space-y-6 px-6 py-6'>
+    <div className='space-y-2'>
+      <div className='flex items-end justify-between'>
+        <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
+          {icon}
+          {title}
+        </div>
+        {showAddButton && (
+          <Button variant='outline' size='sm' onClick={onAddClick}>
+            <Plus />
+            Add Connection
+          </Button>
+        )}
+      </div>
       <Card>
-        <CardHeader className='flex-row items-center justify-between'>
-          <div>
-            <CardTitle>Connections</CardTitle>
-            <CardDescription>
-              Manage connections for {app.app.title}. Each connection can be used by different
-              workflows.
-            </CardDescription>
-          </div>
-          {addConnectionUrl ? (
-            <Button variant='outline' size='sm' onClick={handleAddConnection}>
-              <Plus />
-              Add Connection
-            </Button>
-          ) : (
-            connectionDefinition.connectionType === 'secret' && (
-              <Button variant='outline' size='sm' onClick={() => setSecretDialogOpen(true)}>
-                <Plus />
-                Add Connection
-              </Button>
-            )
-          )}
-        </CardHeader>
-        <CardContent>
-          {appConnections.length === 0 ? (
+        <CardContent className='space-y-3 pt-3'>
+          {isLoading ? (
+            <div className='text-sm text-muted-foreground py-4 text-center'>Loading…</div>
+          ) : rows.length === 0 ? (
             <div className='text-sm text-muted-foreground py-4 text-center'>
-              No connections yet. Add a connection to get started.
+              No connections yet.
+              {canEdit ? ' Add a connection to get started.' : ' Ask an admin to connect.'}
             </div>
           ) : (
             <div className='divide-y'>
-              {appConnections.map((conn) => (
+              {rows.map((conn) => (
                 <div
                   key={conn.id}
                   className='flex items-center justify-between py-3 first:pt-0 last:pb-0'>
@@ -328,32 +407,34 @@ function AppConnections({ app, returnTo }: Props) {
                       </div>
                     </div>
                   </div>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant='ghost' size='icon-sm'>
-                        <MoreHorizontal />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align='end'>
-                      <DropdownMenuItem onClick={() => handleStartEdit(conn.id, conn.label)}>
-                        <Pencil />
-                        Rename
-                      </DropdownMenuItem>
-                      {(conn.connectionStatus === 'expired' ||
-                        conn.connectionStatus === 'connected') &&
-                        isOAuth && (
-                          <DropdownMenuItem onClick={() => handleReconnect(conn.id)}>
-                            Reconnect
-                          </DropdownMenuItem>
-                        )}
-                      <DropdownMenuItem
-                        variant='destructive'
-                        onClick={() => handleDisconnect(conn.id, conn.label)}>
-                        <Unplug />
-                        Disconnect
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                  {canEdit && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant='ghost' size='icon-sm'>
+                          <MoreHorizontal />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align='end'>
+                        <DropdownMenuItem onClick={() => handleStartEdit(conn.id, conn.label)}>
+                          <Pencil />
+                          Rename
+                        </DropdownMenuItem>
+                        {(conn.connectionStatus === 'expired' ||
+                          conn.connectionStatus === 'connected') &&
+                          isOAuth && (
+                            <DropdownMenuItem onClick={() => handleReconnect(conn.id)}>
+                              Reconnect
+                            </DropdownMenuItem>
+                          )}
+                        <DropdownMenuItem
+                          variant='destructive'
+                          onClick={() => handleDisconnect(conn.id, conn.label)}>
+                          <Unplug />
+                          Disconnect
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
                 </div>
               ))}
             </div>
@@ -364,7 +445,7 @@ function AppConnections({ app, returnTo }: Props) {
         <DialogContent>
           <SecretConnectionDialogContent
             connectionLabel={app.app.title}
-            connectionType={connectionType}
+            connectionType={scope}
             secret={secret}
             setSecret={setSecret}
             showSecret={showSecret}
@@ -410,9 +491,12 @@ function AppConnections({ app, returnTo }: Props) {
           </div>
         </DialogContent>
       </Dialog>
-      <ConfirmDialog />
     </div>
   )
 }
 
-export default AppConnections
+function StatusIcon({ status }: { status: string }) {
+  if (status === 'connected') return <CheckCircle className='h-4 w-4 text-green-500' />
+  if (status === 'expired') return <Clock className='h-4 w-4 text-yellow-500' />
+  return <XCircle className='h-4 w-4 text-gray-400' />
+}

--- a/apps/web/src/components/apps/app-settings-dialog.tsx
+++ b/apps/web/src/components/apps/app-settings-dialog.tsx
@@ -17,6 +17,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/ta
 import { toastError } from '@auxx/ui/components/toast'
 import { Code, Globe, LucideGitGraph, Mail } from 'lucide-react'
 import { type ReactNode, Suspense, useMemo, useState } from 'react'
+import { useUser } from '~/hooks/use-user'
 import { useExtensionsContext } from '~/providers/extensions/extensions-context'
 import { api } from '~/trpc/react'
 import AppConnections from './app-connections'
@@ -44,6 +45,7 @@ export function AppSettingsDialog({
 }: AppSettingsDialogProps) {
   const [open, setOpen] = useState(false)
   const [activeTab, setActiveTab] = useState('about')
+  const { isAdminOrOwner } = useUser()
 
   const { appInstallations } = useExtensionsContext()
 
@@ -58,7 +60,9 @@ export function AppSettingsDialog({
 
   if (!installation) return null
 
-  const hasConnectionDefinition = !!installation.connectionDefinition
+  const hasConnectionDefinition = !!(
+    installation.connectionDefinitions?.user || installation.connectionDefinitions?.organization
+  )
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -90,9 +94,11 @@ export function AppSettingsDialog({
                 Connections
               </TabsTrigger>
             )}
-            <TabsTrigger value='settings' variant='outline' size='sm'>
-              Settings
-            </TabsTrigger>
+            {isAdminOrOwner && (
+              <TabsTrigger value='settings' variant='outline' size='sm'>
+                Settings
+              </TabsTrigger>
+            )}
           </TabsList>
 
           <div className='flex-1 overflow-y-auto'>
@@ -106,13 +112,15 @@ export function AppSettingsDialog({
               </TabsContent>
             )}
 
-            <TabsContent value='settings' className='mt-0'>
-              <SettingsTab
-                appSlug={appSlug}
-                installationType={installationType}
-                active={activeTab === 'settings'}
-              />
-            </TabsContent>
+            {isAdminOrOwner && (
+              <TabsContent value='settings' className='mt-0'>
+                <SettingsTab
+                  appSlug={appSlug}
+                  installationType={installationType}
+                  active={activeTab === 'settings'}
+                />
+              </TabsContent>
+            )}
           </div>
         </Tabs>
       </DialogContent>

--- a/apps/web/src/components/apps/installed-app-tabs.tsx
+++ b/apps/web/src/components/apps/installed-app-tabs.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useSelectedLayoutSegment } from 'next/navigation'
 // apps/web/src/components/apps/installed-app-tabs.tsx
 import type React from 'react'
+import { useUser } from '~/hooks/use-user'
 
 /**
  * Props for InstalledAppTabs component
@@ -19,6 +20,7 @@ type Props = {
  */
 export function InstalledAppTabs({ slug, children }: Props) {
   const segment = useSelectedLayoutSegment()
+  const { isAdminOrOwner } = useUser()
 
   const tabs = [
     { label: 'About', value: 'about', href: `/app/settings/apps/installed/${slug}/about` },
@@ -27,11 +29,15 @@ export function InstalledAppTabs({ slug, children }: Props) {
       value: 'connections',
       href: `/app/settings/apps/installed/${slug}/connections`,
     },
-    {
-      label: 'Settings',
-      value: 'settings',
-      href: `/app/settings/apps/installed/${slug}/settings`,
-    },
+    ...(isAdminOrOwner
+      ? [
+          {
+            label: 'Settings',
+            value: 'settings',
+            href: `/app/settings/apps/installed/${slug}/settings`,
+          },
+        ]
+      : []),
   ]
 
   const activeTab = segment || 'about'

--- a/apps/web/src/components/workflow/nodes/shared/base/base-panel.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/base/base-panel.tsx
@@ -103,7 +103,9 @@ function AppSettingsTrigger({
   const { appInstallations, appConnections } = useExtensionsContext()
 
   const installation = appInstallations.find((i) => i.app.id === appId)
-  const hasConnectionDef = !!installation?.connectionDefinition
+  const hasConnectionDef = !!(
+    installation?.connectionDefinitions?.user || installation?.connectionDefinitions?.organization
+  )
 
   const connection = appConnections.find((c) => c.appId === appId)
   const status = connection?.connectionStatus ?? 'not_connected'

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -207,12 +207,12 @@ export const SETTINGS_MENU: SidebarProps[] = [
       },
     ],
   },
-  // Channels
+  // Channels — header is member-visible so Apps is reachable. Per-item admin
+  // gates below still keep the admin-only entries hidden from members.
   {
     id: 'channels',
     label: 'Channels',
     type: 'header',
-    access: 'ADMIN',
     items: [
       {
         id: 'settings-channels',

--- a/apps/web/src/providers/extensions/extensions-provider.tsx
+++ b/apps/web/src/providers/extensions/extensions-provider.tsx
@@ -148,7 +148,10 @@ export function ExtensionsProvider({ children }: ExtensionsProviderProps) {
                       appTitle={installation.app.title}
                       organizationId={organizationId}
                       clientBundleSha={installation.currentDeployment!.clientBundleSha}
-                      connectionDefinition={installation.connectionDefinition}
+                      connectionDefinition={
+                        installation.connectionDefinitions?.user ??
+                        installation.connectionDefinitions?.organization
+                      }
                     />
 
                     {/* 2. Set up data handlers for this extension (Plan 4) */}

--- a/packages/lib/src/apps/get-app-details.ts
+++ b/packages/lib/src/apps/get-app-details.ts
@@ -51,7 +51,10 @@ export interface AppWithStatusOutput {
     installationType?: 'development' | 'production'
     installedAt?: Date
     currentDeploymentId?: string
-    connectionDefinition?: ConnectionDefinitionSummary
+    connectionDefinitions: {
+      user?: ConnectionDefinitionSummary
+      organization?: ConnectionDefinitionSummary
+    }
   }
   availableDeployments: Array<{
     id: string
@@ -132,17 +135,16 @@ export async function getAppWithInstallationStatus(
     columns: { title: true, logoUrl: true },
   })
 
-  // Fetch connection definition if app is installed
-  let connectionDefinition: ConnectionDefinitionSummary | undefined
+  // Fetch connection definitions (both scopes) if app is installed
+  const connectionDefinitions: AppWithStatusOutput['installation']['connectionDefinitions'] = {}
   if (installation) {
-    const userConnDef = await getAppConnectionDefinition(cachedApp.id, false)
-    if (userConnDef.isOk()) {
-      connectionDefinition = userConnDef.value
-    } else {
-      const orgConnDef = await getAppConnectionDefinition(cachedApp.id, true)
-      if (orgConnDef.isOk()) {
-        connectionDefinition = orgConnDef.value
-      }
+    const [userConnDef, orgConnDef] = await Promise.all([
+      getAppConnectionDefinition(cachedApp.id, false),
+      getAppConnectionDefinition(cachedApp.id, true),
+    ])
+    if (userConnDef.isOk() && userConnDef.value) connectionDefinitions.user = userConnDef.value
+    if (orgConnDef.isOk() && orgConnDef.value) {
+      connectionDefinitions.organization = orgConnDef.value
     }
   }
 
@@ -182,7 +184,7 @@ export async function getAppWithInstallationStatus(
           | undefined,
         installedAt: installation?.installedAt,
         currentDeploymentId: installation?.currentDeploymentId ?? undefined,
-        connectionDefinition,
+        connectionDefinitions,
       },
       availableDeployments: deployments.map((d) => ({
         id: d.id,

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -169,12 +169,24 @@ export interface CachedInstalledApp {
     createdAt: string // ISO string — rehydrate to Date before returning
   } | null
 
-  /** Full ConnectionDefinitionSummary shape including oauth2Features */
-  connectionDefinition?: {
-    label: string | null
-    global: boolean | null
-    connectionType: string
-    oauth2Features: Record<string, unknown> | null
+  /**
+   * Connection definitions split by scope. Either, both, or neither may be
+   * present per app. Each entry mirrors `ConnectionDefinitionSummary`
+   * (including oauth2Features).
+   */
+  connectionDefinitions: {
+    user?: {
+      label: string | null
+      global: boolean | null
+      connectionType: string
+      oauth2Features: Record<string, unknown> | null
+    }
+    organization?: {
+      label: string | null
+      global: boolean | null
+      connectionType: string
+      oauth2Features: Record<string, unknown> | null
+    }
   }
 
   /**
@@ -278,7 +290,8 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   integrations: { prefix: 'org:integrations', ttlSeconds: ONE_DAY },
   overages: { prefix: 'org:overages', ttlSeconds: 900 },
   orgSettings: { prefix: 'org:settings', ttlSeconds: ONE_DAY },
-  installedApps: { prefix: 'org:installed-apps', ttlSeconds: 900 },
+  // v2: connectionDefinition (singular) → connectionDefinitions (pair). Bump on shape changes.
+  installedApps: { prefix: 'org:installed-apps:v2', ttlSeconds: 900 },
   workflowApps: { prefix: 'org:workflow-apps', ttlSeconds: ONE_DAY },
 
   // AI provider data (15-min TTL)

--- a/packages/lib/src/cache/providers/installed-apps-provider.ts
+++ b/packages/lib/src/cache/providers/installed-apps-provider.ts
@@ -71,14 +71,16 @@ export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
       orgConnByAppId.set(row.appId, { present: true, expiresAt: row.expiresAt })
     }
 
-    // Index by appId (prefer user-scoped over org-scoped, matching getInstalledApps logic)
-    const connDefMap = new Map<string, (typeof connectionDefs)[0]>()
+    // Index by appId, keeping both scopes. global === false → user, global === true → organization.
+    const connDefsByAppId = new Map<
+      string,
+      { user?: (typeof connectionDefs)[0]; organization?: (typeof connectionDefs)[0] }
+    >()
     for (const def of connectionDefs) {
-      const existing = connDefMap.get(def.appId)
-      // Prefer non-global (user-scoped) — same priority as getInstalledApps
-      if (!existing || (existing.global && !def.global)) {
-        connDefMap.set(def.appId, def)
-      }
+      const existing = connDefsByAppId.get(def.appId) ?? {}
+      if (def.global) existing.organization = def
+      else existing.user = def
+      connDefsByAppId.set(def.appId, existing)
     }
 
     // 3. Build serializable output
@@ -105,14 +107,20 @@ export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
             createdAt: inst.currentDeployment.createdAt.toISOString(),
           }
         : null,
-      connectionDefinition: (() => {
-        const def = connDefMap.get(inst.app.id)
-        if (!def) return undefined
+      connectionDefinitions: (() => {
+        const defs = connDefsByAppId.get(inst.app.id) ?? {}
+        const toCached = (def: (typeof connectionDefs)[0] | undefined) =>
+          def
+            ? {
+                label: def.label,
+                global: def.global,
+                connectionType: def.connectionType,
+                oauth2Features: def.oauth2Features as Record<string, unknown> | null,
+              }
+            : undefined
         return {
-          label: def.label,
-          global: def.global,
-          connectionType: def.connectionType,
-          oauth2Features: def.oauth2Features as Record<string, unknown> | null,
+          user: toCached(defs.user),
+          organization: toCached(defs.organization),
         }
       })(),
       aiTools: inst.currentDeployment?.aiTools?.tools ?? undefined,

--- a/packages/services/src/app-connections/list-app-connections.ts
+++ b/packages/services/src/app-connections/list-app-connections.ts
@@ -136,6 +136,7 @@ export async function listAppConnections(organizationId: string, userId?: string
       connectedAt: cred.createdAt,
       expiresAt,
       global: !cred.userId, // If no userId, it's organization-scoped
+      userId: cred.userId,
     }
   })
 

--- a/packages/services/src/app-connections/types.ts
+++ b/packages/services/src/app-connections/types.ts
@@ -87,6 +87,7 @@ export type ConnectionDefinitionSummary = UnwrapOk<ReturnType<typeof getAppConne
  * @property {Date} [connectedAt] - Timestamp when the connection was created.
  * @property {Date} [expiresAt] - Timestamp when the connection expires (for OAuth2 connections).
  * @property {boolean} global - Whether this is an organization-scoped (true) or user-scoped (false) connection.
+ * @property {string | null} userId - The user id this connection belongs to (null for org-scoped rows).
  */
 export interface AppConnection {
   id: string
@@ -99,6 +100,7 @@ export interface AppConnection {
   connectedAt?: Date
   expiresAt?: Date
   global: boolean
+  userId: string | null
 }
 
 /**

--- a/packages/services/src/app-installations/get-installed-apps.ts
+++ b/packages/services/src/app-installations/get-installed-apps.ts
@@ -45,8 +45,11 @@ export interface InstalledApp {
     createdAt: Date
   } | null
 
-  // Connection definition
-  connectionDefinition?: ConnectionDefinitionSummary
+  // Connection definitions, split by scope. Either, both, or neither may be present.
+  connectionDefinitions: {
+    user?: ConnectionDefinitionSummary
+    organization?: ConnectionDefinitionSummary
+  }
 }
 
 /**
@@ -101,20 +104,14 @@ export async function getInstalledApps(input: GetInstalledAppsInput) {
   const installations: InstalledApp[] = []
 
   for (const installation of installationsResult.value) {
-    // Get connection definition for this app
-    let connectionDefinition: ConnectionDefinitionSummary | undefined
+    const [userConnDefResult, orgConnDefResult] = await Promise.all([
+      getAppConnectionDefinition(installation.app.id, false),
+      getAppConnectionDefinition(installation.app.id, true),
+    ])
 
-    // Try user-scoped connection first
-    const userConnDefResult = await getAppConnectionDefinition(installation.app.id, false)
-
-    if (userConnDefResult.isOk() && userConnDefResult.value) {
-      connectionDefinition = userConnDefResult.value
-    } else {
-      // Try organization-scoped
-      const organizationConnDefResult = await getAppConnectionDefinition(installation.app.id, true)
-      if (organizationConnDefResult.isOk() && organizationConnDefResult.value) {
-        connectionDefinition = organizationConnDefResult.value
-      }
+    const connectionDefinitions: InstalledApp['connectionDefinitions'] = {
+      user: userConnDefResult.isOk() ? (userConnDefResult.value ?? undefined) : undefined,
+      organization: orgConnDefResult.isOk() ? (orgConnDefResult.value ?? undefined) : undefined,
     }
 
     installations.push({
@@ -139,7 +136,7 @@ export async function getInstalledApps(input: GetInstalledAppsInput) {
             createdAt: installation.currentDeployment.createdAt,
           }
         : null,
-      connectionDefinition,
+      connectionDefinitions,
     })
   }
 

--- a/scripts/dev-add-gog-calendar-user-def.ts
+++ b/scripts/dev-add-gog-calendar-user-def.ts
@@ -1,0 +1,61 @@
+// scripts/dev-add-gog-calendar-user-def.ts
+// One-shot dev helper: add a user-scope ConnectionDefinition for gog-calendar
+// so the Personal section can be exercised end-to-end. Safe to re-run.
+
+import { database, schema } from '@auxx/database'
+import { createId } from '@paralleldrive/cuid2'
+import { and, eq } from 'drizzle-orm'
+
+async function main() {
+  const orgDef = await database.query.ConnectionDefinition.findFirst({
+    where: (cd, { and, eq }) => and(eq(cd.appId, 'txa68azxnw7s7jwicn0nekr5'), eq(cd.global, true)),
+  })
+  if (!orgDef) throw new Error('gog-calendar org-scope definition not found')
+
+  const existingUser = await database.query.ConnectionDefinition.findFirst({
+    where: (cd, { and, eq }) => and(eq(cd.appId, orgDef.appId), eq(cd.global, false)),
+  })
+  if (existingUser) {
+    console.log('user-scope definition already exists:', existingUser.id)
+    return
+  }
+
+  const [inserted] = await database
+    .insert(schema.ConnectionDefinition)
+    .values({
+      id: createId(),
+      appId: orgDef.appId,
+      developerAccountId: orgDef.developerAccountId,
+      major: orgDef.major,
+      connectionType: orgDef.connectionType,
+      label: 'Personal Google Calendar',
+      description: 'Connect your personal Google Calendar.',
+      global: false,
+      oauth2AuthorizeUrl: orgDef.oauth2AuthorizeUrl,
+      oauth2AccessTokenUrl: orgDef.oauth2AccessTokenUrl,
+      oauth2Scopes: orgDef.oauth2Scopes,
+      oauth2ClientId: orgDef.oauth2ClientId,
+      oauth2ClientSecret: orgDef.oauth2ClientSecret,
+      oauth2TokenRequestAuthMethod: orgDef.oauth2TokenRequestAuthMethod,
+      oauth2RefreshTokenIntervalSeconds: orgDef.oauth2RefreshTokenIntervalSeconds,
+      oauth2Features: {
+        ...(orgDef.oauth2Features ?? {}),
+        additionalAuthorizeParams: {
+          ...((orgDef.oauth2Features ?? {}).additionalAuthorizeParams ?? {}),
+          prompt: 'consent',
+          access_type: 'offline',
+        },
+      },
+      createdById: orgDef.createdById,
+    })
+    .returning()
+
+  console.log('inserted user-scope definition for gog-calendar:', inserted.id)
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })


### PR DESCRIPTION
## Summary
- Split `connectionDefinition` into `connectionDefinitions: { user, organization }` end-to-end (services, cache provider, `get-app-details`, extensions provider, UI consumers) so an app can expose both scopes simultaneously.
- Reworked `AppConnections` into Personal + Workspace sections; Personal is editable by any member, Workspace stays admin-or-owner. `listAppConnections` now returns `userId` so the UI can scope rows.
- Made the `/app/settings/apps` page member-visible: members see an Installed strip only; Marketplace/Browse, Settings tab, and View-all stay gated. Channels sidebar header is no longer admin-only so members can reach Apps.
- Bumped installed-apps cache prefix to `v2` to invalidate the old singular shape.
- Added `scripts/dev-add-gog-calendar-user-def.ts` one-shot helper to seed a user-scoped ConnectionDefinition for gog-calendar in dev.

## Test plan
- [ ] Admin sees Marketplace title, Browse apps section, View all, and Settings tab
- [ ] Non-admin member sees Apps title with Installed strip only — no Browse, no View all, no Settings tab
- [ ] App with both user and org connection defs renders Personal + Workspace sections
- [ ] App with only org def renders Workspace only; app with only user def renders Personal only
- [ ] Member can add/rename/disconnect Personal connections but cannot touch Workspace connections
- [ ] OAuth and secret connection flows still work for both scopes
- [ ] Cache invalidation: bumping to `v2` prefix doesn't break existing orgs (cold-fill on first request)