### PR TITLE
feat(agents): builder kopilot — markdown prompts, triggers tool, server-side setup guard

### DIFF
--- a/apps/web/src/components/agents/ui/detail/knowledge/__tests__/derive-scope-mode.test.ts
+++ b/apps/web/src/components/agents/ui/detail/knowledge/__tests__/derive-scope-mode.test.ts
@@ -1,0 +1,101 @@
+// apps/web/src/components/agents/ui/detail/knowledge/__tests__/derive-scope-mode.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { deriveEffectiveMode } from '../derive-scope-mode'
+
+type AgentScopes = Parameters<typeof deriveEffectiveMode>[0]
+
+function row(
+  entityDefinitionId: string,
+  entityInstanceId: string | null,
+  mode: 'include_descendants' | 'include_one' | 'exclude'
+): AgentScopes[number] {
+  return {
+    id: `r-${entityDefinitionId}-${entityInstanceId ?? 'def'}`,
+    agentId: 'agent-1',
+    organizationId: 'org-1',
+    entityDefinitionId,
+    entityInstanceId,
+    mode,
+    source: 'manual',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as AgentScopes[number]
+}
+
+describe('deriveEffectiveMode', () => {
+  const kbA = 'kb:A'
+  const articleX = 'article:X'
+  const articleY = 'article:Y'
+  const articleParent = 'article:P'
+
+  it('returns none when neither own row nor ancestor exists', () => {
+    expect(deriveEffectiveMode([], articleX, { ancestorRecordIds: [kbA] })).toBe('none')
+  })
+
+  it('inherits include_descendants from KB ancestor when no own row', () => {
+    const scopes = [row('kb', 'A', 'include_descendants')]
+    expect(deriveEffectiveMode(scopes, articleX, { ancestorRecordIds: [kbA] })).toBe(
+      'inherited_include_descendants'
+    )
+  })
+
+  it('inherits exclude from KB ancestor when no own row', () => {
+    const scopes = [row('kb', 'A', 'exclude')]
+    expect(deriveEffectiveMode(scopes, articleX, { ancestorRecordIds: [kbA] })).toBe(
+      'inherited_exclude'
+    )
+  })
+
+  it('own include_one wins over ancestor exclude', () => {
+    const scopes = [row('kb', 'A', 'exclude'), row('article', 'X', 'include_one')]
+    expect(deriveEffectiveMode(scopes, articleX, { ancestorRecordIds: [kbA] })).toBe('include_one')
+  })
+
+  it('own exclude wins over ancestor include_descendants', () => {
+    const scopes = [row('kb', 'A', 'include_descendants'), row('article', 'X', 'exclude')]
+    expect(deriveEffectiveMode(scopes, articleX, { ancestorRecordIds: [kbA] })).toBe('exclude')
+  })
+
+  it('nearest article ancestor exclude wins over no own row', () => {
+    const scopes = [row('article', 'P', 'exclude')]
+    // P is the parent, A is the KB further up.
+    expect(deriveEffectiveMode(scopes, articleY, { ancestorRecordIds: [articleParent, kbA] })).toBe(
+      'inherited_exclude'
+    )
+  })
+
+  it('nearest ancestor include_descendants beats more-distant exclude', () => {
+    const scopes = [row('kb', 'A', 'exclude'), row('article', 'P', 'include_descendants')]
+    expect(deriveEffectiveMode(scopes, articleY, { ancestorRecordIds: [articleParent, kbA] })).toBe(
+      'inherited_include_descendants'
+    )
+  })
+
+  it('ancestor include_one does NOT inherit to descendants', () => {
+    // include_one is "this one record only" — descendants stay none.
+    const scopes = [row('article', 'P', 'include_one')]
+    expect(deriveEffectiveMode(scopes, articleY, { ancestorRecordIds: [articleParent] })).toBe(
+      'none'
+    )
+  })
+
+  it('falls through to definition-level rule when no ancestor matches', () => {
+    const scopes = [row('article', null, 'include_descendants')]
+    expect(deriveEffectiveMode(scopes, articleX, { ancestorRecordIds: [kbA] })).toBe(
+      'inherited_include_descendants'
+    )
+  })
+
+  it('ancestor rule wins over definition-level rule', () => {
+    const scopes = [row('article', null, 'exclude'), row('kb', 'A', 'include_descendants')]
+    expect(deriveEffectiveMode(scopes, articleX, { ancestorRecordIds: [kbA] })).toBe(
+      'inherited_include_descendants'
+    )
+  })
+
+  it('works without ancestors arg (back-compat for depth-0 callers)', () => {
+    const scopes = [row('kb', 'A', 'include_descendants')]
+    expect(deriveEffectiveMode(scopes, kbA)).toBe('include_descendants')
+  })
+})

--- a/apps/web/src/components/agents/ui/detail/knowledge/agent-scope-actions.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/agent-scope-actions.tsx
@@ -19,6 +19,11 @@ export interface AgentScopeActionsProps {
  * Trailing-slot cluster for an agent scope row: include/exclude toggle, pin
  * star, and a trash button to clear the rule. Slots into `TreeRow`'s
  * `actions` prop.
+ *
+ * When `effectiveMode` is an `inherited_*` variant the row has no explicit
+ * stored rule of its own — the include/exclude icon renders without color to
+ * signal that, the trash button hides (nothing to remove), and clicking the
+ * toggle writes a *new* explicit row that overrides the inherited state.
  */
 export function AgentScopeActions({
   kind,
@@ -31,29 +36,54 @@ export function AgentScopeActions({
   const isContainer = kind === 'container'
   const isMentionPin = pinReason === 'mention'
   const includeMode: EffectiveScopeMode = isContainer ? 'include_descendants' : 'include_one'
-  const isExcluded = effectiveMode === 'exclude'
-  const isIncluded = effectiveMode === 'include_descendants' || effectiveMode === 'include_one'
+
+  const isExplicitExcluded = effectiveMode === 'exclude'
+  const isExplicitIncluded =
+    effectiveMode === 'include_descendants' || effectiveMode === 'include_one'
+  const isInheritedIncluded = effectiveMode === 'inherited_include_descendants'
+  const isInheritedExcluded = effectiveMode === 'inherited_exclude'
+
+  const isExcluded = isExplicitExcluded || isInheritedExcluded
+  const isIncluded = isExplicitIncluded || isInheritedIncluded
+  const isInherited = isInheritedIncluded || isInheritedExcluded
+  const hasExplicitRule = isExplicitExcluded || isExplicitIncluded
+
+  const tooltipContent = isInheritedIncluded
+    ? 'Included (inherited) — click to exclude'
+    : isInheritedExcluded
+      ? 'Excluded (inherited) — click to include'
+      : isExplicitIncluded
+        ? 'Included — click to exclude'
+        : isExplicitExcluded
+          ? 'Excluded — click to include'
+          : 'Not set — click to include'
 
   return (
     <>
-      <Tooltip
-        side='left'
-        content={
-          isIncluded
-            ? 'Included — click to exclude'
-            : isExcluded
-              ? 'Excluded — click to include'
-              : 'Not set — click to include'
-        }>
+      <Tooltip side='left' content={tooltipContent}>
         <button
           type='button'
           onClick={() => onSetMode(isIncluded ? 'exclude' : includeMode)}
           className='p-1 rounded-md hover:bg-primary/5'
           aria-label={isIncluded ? 'Exclude' : 'Include'}>
           {isExcluded ? (
-            <Ban className='size-4 text-destructive' />
+            <Ban
+              className={cn(
+                'size-4',
+                hasExplicitRule
+                  ? 'text-destructive'
+                  : 'text-muted-foreground opacity-40 group-hover/tree-row:opacity-100'
+              )}
+            />
           ) : isIncluded ? (
-            <Check className='size-4 text-emerald-600' />
+            <Check
+              className={cn(
+                'size-4',
+                hasExplicitRule
+                  ? 'text-emerald-600'
+                  : 'text-muted-foreground opacity-40 group-hover/tree-row:opacity-100'
+              )}
+            />
           ) : (
             <Check className='size-4 opacity-40 group-hover/tree-row:opacity-100' />
           )}
@@ -88,13 +118,13 @@ export function AgentScopeActions({
         </button>
       </Tooltip>
 
-      <Tooltip side='left' content='Remove rule'>
+      <Tooltip side='left' content={isInherited ? 'Reset to inherited' : 'Remove rule'}>
         <button
           type='button'
           onClick={() => onSetMode('none')}
           className={cn(
             'p-1 rounded-md hover:bg-destructive/10 opacity-0 group-hover/tree-row:opacity-100',
-            effectiveMode === 'none' && 'invisible pointer-events-none'
+            !hasExplicitRule && 'invisible pointer-events-none'
           )}
           aria-label='Remove rule'>
           <Trash2 className='size-4 text-muted-foreground hover:text-destructive' />

--- a/apps/web/src/components/agents/ui/detail/knowledge/derive-scope-mode.ts
+++ b/apps/web/src/components/agents/ui/detail/knowledge/derive-scope-mode.ts
@@ -2,7 +2,21 @@
 
 import type { AgentDetail } from '../../../store/agent-store'
 
-export type EffectiveScopeMode = 'include_descendants' | 'include_one' | 'exclude' | 'none'
+export type EffectiveScopeMode =
+  | 'include_descendants'
+  | 'include_one'
+  | 'exclude'
+  | 'inherited_include_descendants'
+  | 'inherited_exclude'
+  | 'none'
+
+export interface AncestorContext {
+  /**
+   * Ordered nearest-first. Each entry is a recordId string like `'kb:abc'` or
+   * `'article:xyz'`. The closest ancestor with an inheritable rule wins.
+   */
+  ancestorRecordIds: string[]
+}
 
 interface ScopeRow {
   entityDefinitionId: string
@@ -12,8 +26,8 @@ interface ScopeRow {
 
 /**
  * Find the stored mode for a single `recordId` (instance or definition). When
- * no row exists, returns `'none'`. Matches the planned client-side resolver
- * approximation — strict per-row lookup, no inheritance flattening yet.
+ * no row exists, returns `'none'`. Strict per-row lookup — does not walk
+ * ancestors. Use {@link deriveEffectiveMode} when you need inheritance.
  *
  * @param recordId  `'article:abc'` for instance, `'article'` for definition-level
  */
@@ -29,36 +43,36 @@ export function findStoredMode(
 }
 
 /**
- * Derive the *effective* mode for a record by walking definition-level then
- * instance-level rules in order. Instance rules win over definition rules.
+ * Derive the *effective* mode for a record. Order of precedence:
+ *
+ *   1. An explicit row on this exact recordId.
+ *   2. The closest ancestor (nearest-first) whose row is `include_descendants`
+ *      or `exclude` — both flagged as `inherited_*` in the result. `include_one`
+ *      on an ancestor does NOT inherit (it only covers the ancestor itself).
+ *   3. A definition-level row (`entityDefinitionId` with null instance) —
+ *      flagged as inherited.
+ *   4. `'none'`.
  */
 export function deriveEffectiveMode(
   scopes: AgentDetail['resourceScopes'],
-  recordId: string
+  recordId: string,
+  ancestors?: AncestorContext
 ): EffectiveScopeMode {
-  const { entityDefinitionId, entityInstanceId } = splitRecordId(recordId)
+  const own = findStoredMode(scopes, recordId)
+  if (own !== 'none') return own
 
-  let mode: EffectiveScopeMode = 'none'
-
-  // Apply definition-level rule first.
-  const defRow = scopes.find(
-    (s) => s.entityDefinitionId === entityDefinitionId && s.entityInstanceId === null
-  )
-  if (defRow) {
-    if (defRow.mode === 'include_descendants') mode = 'include_descendants'
-    else if (defRow.mode === 'exclude') mode = 'exclude'
-    else if (defRow.mode === 'include_one') mode = 'include_one'
+  for (const ancestorId of ancestors?.ancestorRecordIds ?? []) {
+    const m = findStoredMode(scopes, ancestorId)
+    if (m === 'include_descendants') return 'inherited_include_descendants'
+    if (m === 'exclude') return 'inherited_exclude'
   }
 
-  // Instance-level rule wins if present.
-  if (entityInstanceId !== null) {
-    const instanceRow = scopes.find(
-      (s) => s.entityDefinitionId === entityDefinitionId && s.entityInstanceId === entityInstanceId
-    )
-    if (instanceRow) mode = instanceRow.mode
-  }
+  const { entityDefinitionId } = splitRecordId(recordId)
+  const defMode = findStoredMode(scopes, entityDefinitionId)
+  if (defMode === 'include_descendants') return 'inherited_include_descendants'
+  if (defMode === 'exclude') return 'inherited_exclude'
 
-  return mode
+  return 'none'
 }
 
 function splitRecordId(recordId: string): {

--- a/apps/web/src/components/agents/ui/detail/knowledge/flat-record-list.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/flat-record-list.tsx
@@ -99,7 +99,6 @@ function RecordLeafRow({ recordId, agent, mutations, depth }: RecordLeafRowProps
       icon={<FileText className='size-4' />}
       title={title || (isLoading ? '…' : 'Untitled')}
       depth={depth}
-      dimmed={effectiveMode === 'exclude'}
       actions={
         <AgentScopeActions
           kind='leaf'

--- a/apps/web/src/components/agents/ui/detail/knowledge/kb-branch.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/kb-branch.tsx
@@ -1,15 +1,23 @@
 // apps/web/src/components/agents/ui/detail/knowledge/kb-branch.tsx
 'use client'
 
-import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import type { ArticleTreeNode } from '@auxx/ui/components/kb/utils'
+import { buildArticleTree } from '@auxx/ui/components/kb/utils'
 import { TreeRow } from '@auxx/ui/components/tree-row'
-import { generateId } from '@auxx/utils'
-import { FileText, FolderClosed, FolderOpen, Plus } from 'lucide-react'
+import {
+  ExternalLink,
+  FileText,
+  FolderClosed,
+  FolderOpen,
+  Hash,
+  LayoutPanelTop,
+  Plus,
+} from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { RecordPicker } from '~/components/pickers/record-picker/record-picker'
 import { useRecord } from '~/components/resources/hooks/use-record'
-import { useRecordList } from '~/components/resources/hooks/use-record-list'
+import { api } from '~/trpc/react'
 import type { AgentDetail } from '../../../store/agent-store'
 import { AgentScopeActions } from './agent-scope-actions'
 import { deriveEffectiveMode } from './derive-scope-mode'
@@ -27,7 +35,9 @@ interface KbBranchProps {
  * Body for the `kb` resource branch. Lists the KBs the admin has added (via
  * picker) and lets each expand to its full article tree. Setting "Whole" on
  * a KB still grants the agent access to every article; the per-article rows
- * inside exist so the admin can pin or override individual articles.
+ * inside exist so the admin can pin or override individual articles. Articles
+ * are rendered as the real `parentId` tree (categories, headers, tabs, links)
+ * — same shape as the KB editor sidebar.
  */
 export function KbBranch({ agent, mutations, depth }: KbBranchProps) {
   const addedKbIds = useAddedKbInstanceIds(agent)
@@ -84,7 +94,6 @@ function KbContainerRow({ kbId, agent, mutations, depth }: KbContainerRowProps) 
       expandable
       isOpen={isOpen}
       onToggleOpen={() => setIsOpen((o) => !o)}
-      dimmed={effectiveMode === 'exclude'}
       actions={
         <AgentScopeActions
           kind='container'
@@ -95,7 +104,13 @@ function KbContainerRow({ kbId, agent, mutations, depth }: KbContainerRowProps) 
           onTogglePin={() => mutations.setPin(recordId, !pin)}
         />
       }>
-      <KbArticles kbId={kbId} agent={agent} mutations={mutations} depth={depth + 1} />
+      <KbArticles
+        kbId={kbId}
+        agent={agent}
+        mutations={mutations}
+        depth={depth + 1}
+        kbRecordId={recordId}
+      />
     </TreeRow>
   )
 }
@@ -105,47 +120,41 @@ interface KbArticlesProps {
   agent: AgentDetail
   mutations: ScopeMutations
   depth: number
+  kbRecordId: string
 }
 
-function KbArticles({ kbId, agent, mutations, depth }: KbArticlesProps) {
-  const filters = useMemo<ConditionGroup[]>(
-    () => [
-      {
-        id: 'agent-scope-kb-filter',
-        logicalOperator: 'AND',
-        conditions: [
-          {
-            id: generateId(),
-            fieldId: 'article:knowledgeBaseId',
-            operator: 'is',
-            value: kbId,
-          },
-        ],
-      },
-    ],
-    [kbId]
+type ArticleListItem = NonNullable<ReturnType<typeof api.kb.getArticles.useQuery>['data']>[number]
+
+function KbArticles({ kbId, agent, mutations, depth, kbRecordId }: KbArticlesProps) {
+  const { data: articles, isLoading } = api.kb.getArticles.useQuery(
+    { knowledgeBaseId: kbId, includeUnpublished: true },
+    { staleTime: 5 * 60 * 1000 }
   )
 
-  const { recordIds, isLoading } = useRecordList({
-    entityDefinitionId: 'article',
-    filters,
-    limit: 100,
-  })
+  const tree = useMemo<ArticleTreeNode<ArticleListItem>[]>(() => {
+    if (!articles) return []
+    // Archived articles aren't useful as scope targets — keep them out of
+    // the tree so the agent picker doesn't surface decommissioned content.
+    const visible = articles.filter(
+      (a) => !('archivedAt' in a) || (a as { archivedAt?: Date | null }).archivedAt == null
+    )
+    return buildArticleTree(visible)
+  }, [articles])
 
-  if (isLoading && recordIds.length === 0) {
+  if (isLoading && !articles) {
     return (
       <div
         className='text-xs text-muted-foreground py-1'
-        style={{ paddingLeft: `${0.5 + depth * 1.125}rem` }}>
+        style={{ paddingLeft: `${0.5 + depth * 1.5}rem` }}>
         Loading articles…
       </div>
     )
   }
-  if (recordIds.length === 0) {
+  if (tree.length === 0) {
     return (
       <div
         className='text-xs text-muted-foreground py-1'
-        style={{ paddingLeft: `${0.5 + depth * 1.125}rem` }}>
+        style={{ paddingLeft: `${0.5 + depth * 1.5}rem` }}>
         No articles in this KB.
       </div>
     )
@@ -153,45 +162,97 @@ function KbArticles({ kbId, agent, mutations, depth }: KbArticlesProps) {
 
   return (
     <>
-      {recordIds.map((id) => (
-        <ArticleLeafRow key={id} articleId={id} agent={agent} mutations={mutations} depth={depth} />
+      {tree.map((node) => (
+        <ArticleTreeRow
+          key={node.id}
+          node={node}
+          agent={agent}
+          mutations={mutations}
+          depth={depth}
+          ancestorRecordIds={[kbRecordId]}
+        />
       ))}
     </>
   )
 }
 
-interface ArticleLeafRowProps {
-  articleId: string
+interface ArticleTreeRowProps {
+  node: ArticleTreeNode<ArticleListItem>
   agent: AgentDetail
   mutations: ScopeMutations
   depth: number
+  ancestorRecordIds: string[]
 }
 
-function ArticleLeafRow({ articleId, agent, mutations, depth }: ArticleLeafRowProps) {
-  const recordId = toRecordId('article', articleId)
-  const { record, isLoading } = useRecord({ recordId })
-  const effectiveMode = deriveEffectiveMode(agent.resourceScopes, recordId)
+function ArticleTreeRow({ node, agent, mutations, depth, ancestorRecordIds }: ArticleTreeRowProps) {
+  const recordId = toRecordId('article', node.id)
+  const [isOpen, setIsOpen] = useState(false)
+  const effectiveMode = deriveEffectiveMode(agent.resourceScopes, recordId, {
+    ancestorRecordIds,
+  })
   const pin = agent.pinnedRecords.find((p) => p.recordId === recordId)
-  const title = (record?.displayName as string) ?? (record?.title as string) ?? ''
+  const title = node.title || 'Untitled'
+
+  const hasChildren = node.children.length > 0
+  const kind = node.articleKind
+  const isStructural = kind === 'tab' || kind === 'link'
+  const isContainer = kind === 'category' || kind === 'header' || kind === 'tab'
+
+  const icon = renderArticleIcon(kind, isOpen)
+
+  const childAncestors = useMemo(
+    () => [recordId, ...ancestorRecordIds],
+    [recordId, ancestorRecordIds]
+  )
 
   return (
     <TreeRow
-      icon={<FileText className='size-4' />}
-      title={title || (isLoading ? '…' : 'Untitled')}
+      icon={icon}
+      title={<span className={isStructural ? 'text-muted-foreground/80' : undefined}>{title}</span>}
       depth={depth}
-      dimmed={effectiveMode === 'exclude'}
+      expandable={isContainer && hasChildren}
+      isOpen={isOpen}
+      onToggleOpen={() => setIsOpen((o) => !o)}
       actions={
-        <AgentScopeActions
-          kind='leaf'
-          effectiveMode={effectiveMode}
-          isPinned={!!pin}
-          pinReason={pin?.pinReason ?? null}
-          onSetMode={(mode) => mutations.setMode(recordId, mode)}
-          onTogglePin={() => mutations.setPin(recordId, !pin)}
-        />
-      }
-    />
+        isStructural ? null : (
+          <AgentScopeActions
+            kind={isContainer ? 'container' : 'leaf'}
+            effectiveMode={effectiveMode}
+            isPinned={!!pin}
+            pinReason={pin?.pinReason ?? null}
+            onSetMode={(mode) => mutations.setMode(recordId, mode)}
+            onTogglePin={() => mutations.setPin(recordId, !pin)}
+          />
+        )
+      }>
+      {hasChildren &&
+        node.children.map((child) => (
+          <ArticleTreeRow
+            key={child.id}
+            node={child}
+            agent={agent}
+            mutations={mutations}
+            depth={depth + 1}
+            ancestorRecordIds={childAncestors}
+          />
+        ))}
+    </TreeRow>
   )
+}
+
+function renderArticleIcon(kind: ArticleListItem['articleKind'], isOpen: boolean) {
+  switch (kind) {
+    case 'category':
+      return isOpen ? <FolderOpen className='size-4' /> : <FolderClosed className='size-4' />
+    case 'header':
+      return <Hash className='size-4' />
+    case 'tab':
+      return <LayoutPanelTop className='size-4' />
+    case 'link':
+      return <ExternalLink className='size-4' />
+    default:
+      return <FileText className='size-4' />
+  }
 }
 
 interface AddKbRowProps {

--- a/apps/web/src/components/agents/ui/detail/knowledge/knowledge-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/knowledge-section-content.tsx
@@ -66,7 +66,7 @@ export function KnowledgeSectionContent({ agent, onAutosaveChange }: KnowledgeSe
   }
 
   return (
-    <div className='pe-3'>
+    <div className='pe-4'>
       {orderedTypes.map((resource) => (
         <ResourceTypeBranch
           key={resource.id}

--- a/apps/web/src/components/agents/ui/detail/knowledge/resource-type-branch.tsx
+++ b/apps/web/src/components/agents/ui/detail/knowledge/resource-type-branch.tsx
@@ -59,7 +59,6 @@ export function ResourceTypeBranch({ resource, agent, mutations }: ResourceTypeB
       expandable
       isOpen={isOpen}
       onToggleOpen={() => setIsOpen((o) => !o)}
-      dimmed={effectiveMode === 'exclude'}
       actions={
         <AgentScopeActions
           kind='container'

--- a/apps/web/src/components/agents/ui/detail/prompt/persona-editor-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/prompt/persona-editor-content.tsx
@@ -6,6 +6,7 @@ import type { Editor } from '@tiptap/react'
 import { EditorContent } from '@tiptap/react'
 import { memo, useRef } from 'react'
 import { type ActivePickerState, InlinePickerPopover } from '~/components/editor/inline-picker'
+import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
 import {
   ReferencePickerContent,
   type ReferencePickerHandle,
@@ -20,6 +21,12 @@ interface PersonaEditorContentProps {
   setCollapsed: (collapsed: boolean) => void
   activePicker: ActivePickerState | null
   referencePickerRef: React.RefObject<ReferencePickerHandle | null>
+  /**
+   * Tabs the picker exposes — must match the `referenceTabs` passed to the
+   * paired `useRichTextEditor` so digit shortcuts and Tab cycling stay in
+   * sync with the visible strip.
+   */
+  referenceTabs?: ReferenceTab[]
 }
 
 export const PersonaEditorContent = memo(function PersonaEditorContent({
@@ -30,6 +37,7 @@ export const PersonaEditorContent = memo(function PersonaEditorContent({
   setCollapsed,
   activePicker,
   referencePickerRef,
+  referenceTabs,
 }: PersonaEditorContentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -64,6 +72,7 @@ export const PersonaEditorContent = memo(function PersonaEditorContent({
           query={activePicker?.query ?? ''}
           onSelect={(id) => editor?.commands.confirmReferencePicker(id)}
           onTabChange={(tab) => editor?.commands.setReferencePickerTab(tab)}
+          tabs={referenceTabs}
         />
       </InlinePickerPopover>
     </div>

--- a/apps/web/src/components/agents/ui/detail/prompt/persona-editor.tsx
+++ b/apps/web/src/components/agents/ui/detail/prompt/persona-editor.tsx
@@ -6,7 +6,8 @@ import { VisuallyHidden } from '@auxx/ui/components/visually-hidden'
 import { cn } from '@auxx/ui/lib/utils'
 import type { JSONContent } from '@tiptap/core'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useActivePicker } from '~/components/editor/inline-picker'
+import { DEFAULT_TABS, useActivePicker } from '~/components/editor/inline-picker'
+import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
 import { useRichTextEditor } from '~/components/editor/rich-text/use-rich-text-editor'
 import type { ReferencePickerHandle } from '~/components/pickers/reference-picker/reference-picker-content'
 import { useAgentAutosave } from '../../../hooks/use-agent-autosave'
@@ -23,6 +24,11 @@ interface PersonaEditorProps {
 }
 
 const COLLAPSED_MIN_HEIGHT = 120
+
+// Persona editor is the one surface that opts into the Tools tab — admins
+// reference toolsets they want pinned to the agent's prompt. Customer-facing
+// editors (mail composer, KB articles) stay on `DEFAULT_TABS` by design.
+const PERSONA_REFERENCE_TABS: ReferenceTab[] = [...DEFAULT_TABS, 'tools']
 
 function readPromptContent(
   prompt: Record<string, unknown> | null | undefined
@@ -77,6 +83,7 @@ export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
     enableReferencePicker: true,
     onPickerEnter,
     onPickerArrowVertical,
+    referenceTabs: PERSONA_REFERENCE_TABS,
   })
 
   const activePicker = useActivePicker(editor)
@@ -130,6 +137,7 @@ export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
       setCollapsed={setCollapsed}
       activePicker={activePicker}
       referencePickerRef={referencePickerRef}
+      referenceTabs={PERSONA_REFERENCE_TABS}
     />
   )
 
@@ -137,8 +145,9 @@ export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
     <>
       <div
         className={cn(
+          'me-1',
           isFocused ? 'bg-gradient-to-r from-[#0ba5ec] to-[#155aef]' : 'bg-transparent',
-          '!rounded-[9px] p-0.5 w-full'
+          '!rounded-[9px] p-0.5'
         )}>
         <div className={cn(isFocused ? 'bg-background' : 'bg-primary-200/30', 'rounded-lg border')}>
           {header}

--- a/apps/web/src/components/agents/ui/detail/setup/agent-setup-mode.tsx
+++ b/apps/web/src/components/agents/ui/detail/setup/agent-setup-mode.tsx
@@ -39,7 +39,7 @@ export function AgentSetupMode({ agent }: AgentSetupModeProps) {
 
   const step = deriveSetupStep(agent)
   const completeness = computeCompleteness(agent)
-  console.log({ step, completeness })
+
   return (
     <ScrollArea className='flex-1 min-h-0'>
       <div className='mx-auto flex-1 flex max-w-2xl flex-col items-center justify-between gap-8 px-6 pt-12 pb-6 text-center'>

--- a/apps/web/src/components/agents/ui/detail/setup/derive-setup-step.ts
+++ b/apps/web/src/components/agents/ui/detail/setup/derive-setup-step.ts
@@ -2,7 +2,7 @@
 
 import type { AgentDetail } from '../../../store/agent-store'
 
-export type SetupStep = 'alignment' | 'personalization' | 'onboarding'
+export type SetupStep = 'alignment' | 'onboarding' | 'personalization'
 
 export interface SetupCopy {
   step: SetupStep
@@ -20,19 +20,19 @@ const COPY: Record<SetupStep, SetupCopy> = {
     subtitle: 'Agent Alignment',
     description: 'Learning about your use case and setting objectives.',
   },
-  personalization: {
-    step: 'personalization',
-    index: 2,
-    title: 'Personalization',
-    subtitle: 'Agent Personalization',
-    description: 'Tailoring capabilities to fit your needs.',
-  },
   onboarding: {
     step: 'onboarding',
-    index: 3,
+    index: 2,
     title: 'Onboarding',
     subtitle: 'Agent Onboarding',
-    description: 'Finalizing setup and preparing to assist you.',
+    description: 'Wiring up toolsets, knowledge, and the persona prompt.',
+  },
+  personalization: {
+    step: 'personalization',
+    index: 3,
+    title: 'Personalization',
+    subtitle: 'Agent Personalization',
+    description: 'Finalizing name, avatar, and tone.',
   },
 }
 
@@ -40,23 +40,28 @@ function isEmptyTiptapDoc(doc: Record<string, unknown> | null | undefined): bool
   if (!doc) return true
   const content = (doc as { content?: unknown[] }).content
   if (!content || !Array.isArray(content) || content.length === 0) return true
-  // A Tiptap "doc" with a single empty paragraph is also "empty".
   if (content.length === 1) {
     const node = content[0] as { type?: string; content?: unknown[] }
-    if (node?.type === 'paragraph' && (!node.content || node.content.length === 0)) return true
+    if (!node) return true
+    // Empty Tiptap paragraph or empty KB-block placeholder.
+    if (node.type === 'paragraph' && (!node.content || node.content.length === 0)) return true
+    if (node.type === 'block' && (!node.content || node.content.length === 0)) return true
   }
   return false
 }
 
 /**
- * Derive the current setup step from agent shape. The builder persona's three
- * phases (alignment → personalization → onboarding) line up with prompt /
- * toolsets / wrap-up, so derivation works without a sync channel.
+ * Derive the current setup step from agent shape. Mirrors the persona's
+ * three phases (alignment → onboarding → personalization) — the prompt and
+ * toolsets are the Onboarding deliverable, the name is the Personalization
+ * deliverable.
  */
 export function deriveSetupStep(agent: AgentDetail): SetupCopy {
-  if (isEmptyTiptapDoc(agent.prompt)) return COPY.alignment
-  if ((agent.toolsets ?? []).length === 0) return COPY.personalization
-  return COPY.onboarding
+  if (isEmptyTiptapDoc(agent.prompt) || (agent.toolsets ?? []).length === 0) {
+    return COPY.alignment
+  }
+  if (!agent.name || agent.name.trim() === '') return COPY.onboarding
+  return COPY.personalization
 }
 
 /**

--- a/apps/web/src/components/agents/ui/detail/tools/tools-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tools-section-content.tsx
@@ -4,7 +4,9 @@
 import { NATIVE_GROUP_CATALOG, type ToolsetCatalogEntry } from '@auxx/lib/agents/client'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { Skeleton } from '@auxx/ui/components/skeleton'
+import { Switch } from '@auxx/ui/components/switch'
 import { TreeRow } from '@auxx/ui/components/tree-row'
+import { pluralize } from '@auxx/utils/strings'
 import { useCallback, useMemo, useState } from 'react'
 import { api } from '~/trpc/react'
 import type { AgentDetail } from '../../../store/agent-store'
@@ -47,7 +49,11 @@ export function ToolsSectionContent({ agent, onAutosaveChange }: ToolsSectionCon
     [onAutosaveChange]
   )
 
-  const { toggleToolset } = useToolsetMutations(agent.id, agent.slug, handleSavingChange)
+  const { toggleToolset, toggleToolsets } = useToolsetMutations(
+    agent.id,
+    agent.slug,
+    handleSavingChange
+  )
 
   const stateBySlug = useMemo<Map<string, ToolsetRowState>>(() => {
     const map = new Map<string, ToolsetRowState>()
@@ -83,18 +89,45 @@ export function ToolsSectionContent({ agent, onAutosaveChange }: ToolsSectionCon
     })
   }, [])
 
+  const toggleGroupEnabled = useCallback(
+    async (group: string, entries: ToolsetCatalogEntry[], nextEnabled: boolean) => {
+      const targets = entries.filter((entry) => {
+        const state = stateBySlug.get(entry.slug)
+        const source = state?.source ?? 'manual'
+        if (source === 'mention') return false
+        return (state?.enabled ?? false) !== nextEnabled
+      })
+      if (targets.length === 0) return
+      if (!nextEnabled) {
+        setCollapsed((prev) => {
+          if (prev.has(group)) return prev
+          const next = new Set(prev)
+          next.add(group)
+          return next
+        })
+      }
+      await toggleToolsets(targets.map((entry) => ({ slug: entry.slug, enabled: nextEnabled })))
+    },
+    [stateBySlug, toggleToolsets]
+  )
+
   if (catalogQuery.isLoading || !catalogQuery.data) {
     return (
-      <div className='px-3 pb-6 space-y-3'>
-        <Skeleton className='h-12 w-full' />
-        <Skeleton className='h-12 w-full' />
-        <Skeleton className='h-12 w-full' />
+      <div className='flex flex-col pe-4'>
+        {[0, 1, 2].map((i) => (
+          <div key={i} className='ps-2'>
+            <div className='flex items-center gap-2 px-1 h-9'>
+              <Skeleton className='size-5 rounded-md' />
+              <Skeleton className='h-4 w-32' />
+            </div>
+          </div>
+        ))}
       </div>
     )
   }
 
   return (
-    <div className='flex flex-col pe-3'>
+    <div className='flex flex-col pe-4'>
       {grouped.map(([group, entries]) => {
         const meta = NATIVE_GROUP_CATALOG[group]
         const isOpen = !collapsed.has(group)
@@ -102,6 +135,11 @@ export function ToolsSectionContent({ agent, onAutosaveChange }: ToolsSectionCon
           (acc, e) => acc + (stateBySlug.get(e.slug)?.enabled ? 1 : 0),
           0
         )
+        const toggleableCount = entries.reduce(
+          (acc, e) => acc + ((stateBySlug.get(e.slug)?.source ?? 'manual') !== 'mention' ? 1 : 0),
+          0
+        )
+        const groupEnabled = enabledCount > 0
         return (
           <TreeRow
             key={group}
@@ -113,9 +151,19 @@ export function ToolsSectionContent({ agent, onAutosaveChange }: ToolsSectionCon
             isOpen={isOpen}
             onToggleOpen={() => toggleGroup(group)}
             actions={
-              <span className='text-xs text-muted-foreground'>
-                {enabledCount}/{entries.length}
-              </span>
+              <div className='flex items-center gap-2'>
+                <span className='text-xs text-muted-foreground'>
+                  {enabledCount}/{entries.length} {pluralize(entries.length, 'tool')}
+                </span>
+                <Switch
+                  size='xs'
+                  checked={groupEnabled}
+                  disabled={toggleableCount === 0}
+                  onCheckedChange={(checked) => {
+                    void toggleGroupEnabled(group, entries, checked)
+                  }}
+                />
+              </div>
             }>
             {entries.map((entry) => {
               const state = stateBySlug.get(entry.slug) ?? {

--- a/apps/web/src/components/agents/ui/detail/tools/toolset-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/toolset-row.tsx
@@ -56,7 +56,7 @@ export function ToolsetRow({
           {/* {source === 'mention' && <Badge variant='secondary'>Pinned by mention</Badge>} */}
           {/* {source === 'auto_default' && <Badge variant='outline'>Default</Badge>} */}
           <Switch
-            size='sm'
+            size='xs'
             checked={localEnabled}
             disabled={source === 'mention'}
             onCheckedChange={(checked) => {

--- a/apps/web/src/components/agents/ui/detail/tools/use-toolset-mutations.ts
+++ b/apps/web/src/components/agents/ui/detail/tools/use-toolset-mutations.ts
@@ -8,13 +8,15 @@ import type { AgentDetail } from '../../../store/agent-store'
 
 interface UseToolsetMutationsReturn {
   toggleToolset: (slug: string, enabled: boolean) => Promise<void>
+  toggleToolsets: (changes: Array<{ slug: string; enabled: boolean }>) => Promise<void>
   isPending: boolean
 }
 
 /**
  * Per-agent toolset mutations with optimistic updates against the
- * `agent.getById` cache. Fires `api.agentToolset.update` and reconciles by
- * invalidating the detail query on success / rolling back on error.
+ * `agent.getById` cache. The optimistic write mirrors the server's exact
+ * response (enabled flag + `auto_default → manual` source promotion), so we
+ * don't invalidate on success — only roll back on error.
  *
  * The `agentSlug` param is required because `AgentDetailLoader` subscribes to
  * `agent.getById` by slug (from the URL), so optimistic writes must target
@@ -65,8 +67,6 @@ export function useToolsetMutations(
 
       try {
         await update.mutateAsync({ agentId, slug, enabled })
-        // Invalidate without a key so both slug-keyed and id-keyed entries refetch.
-        await utils.agent.getById.invalidate()
       } catch (err) {
         utils.agent.getById.setData({ agentId: agentSlug }, previous)
         toastError({
@@ -81,5 +81,64 @@ export function useToolsetMutations(
     [agentId, agentSlug, onSavingChange, update, utils.agent.getById]
   )
 
-  return { toggleToolset, isPending: update.isPending }
+  /**
+   * Bulk variant. Applies one combined optimistic write and fires all
+   * mutations in parallel. No invalidate — the optimistic write already
+   * mirrors the server response.
+   */
+  const toggleToolsets = useCallback(
+    async (changes: Array<{ slug: string; enabled: boolean }>) => {
+      if (changes.length === 0) return
+
+      savingTimerRef.current = setTimeout(() => onSavingChange?.(true), 400)
+      const previous = utils.agent.getById.getData({ agentId: agentSlug })
+
+      utils.agent.getById.setData({ agentId: agentSlug }, (old) => {
+        if (!old) return old
+        const toolsets = [...old.toolsets]
+        for (const { slug, enabled } of changes) {
+          const idx = toolsets.findIndex((t) => t.toolsetSlug === slug)
+          if (idx >= 0) {
+            const current = toolsets[idx]
+            if (!current) continue
+            toolsets[idx] = {
+              ...current,
+              enabled,
+              source: current.source === 'auto_default' ? 'manual' : current.source,
+            }
+          } else {
+            toolsets.push({
+              id: `optimistic-${slug}`,
+              agentId,
+              toolsetSlug: slug,
+              enabled,
+              source: 'manual',
+              config: {},
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            } as AgentDetail['toolsets'][number])
+          }
+        }
+        return { ...old, toolsets }
+      })
+
+      try {
+        await Promise.all(
+          changes.map(({ slug, enabled }) => update.mutateAsync({ agentId, slug, enabled }))
+        )
+      } catch (err) {
+        utils.agent.getById.setData({ agentId: agentSlug }, previous)
+        toastError({
+          title: 'Failed to update toolsets',
+          description: err instanceof Error ? err.message : 'Unknown error',
+        })
+      } finally {
+        clearTimeout(savingTimerRef.current)
+        onSavingChange?.(false)
+      }
+    },
+    [agentId, agentSlug, onSavingChange, update, utils.agent.getById]
+  )
+
+  return { toggleToolset, toggleToolsets, isPending: update.isPending }
 }

--- a/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
@@ -94,7 +94,7 @@ export function TriggersSectionContent({
           className='mx-3'
         />
       ) : (
-        <div className='flex flex-col pe-3'>
+        <div className='flex flex-col pe-4'>
           {rows.map((row) => {
             const meta = KIND_META[row.kind as TriggerKind]
             const lastFiredLabel = row.lastFiredAt
@@ -159,7 +159,7 @@ export function TriggersSectionContent({
                       </button>
                     </Tooltip>
                     <Switch
-                      size='sm'
+                      size='xs'
                       className='ml-1'
                       checked={row.enabled}
                       onCheckedChange={(checked) =>

--- a/apps/web/src/components/editor/inline-picker/index.ts
+++ b/apps/web/src/components/editor/inline-picker/index.ts
@@ -25,11 +25,11 @@ export { createPlaceholderNode } from './nodes/placeholder-node'
 export { createPromptNode } from './nodes/prompt-node'
 export { PromptTemplateBadge } from './nodes/prompt-node-view'
 export {
+  DEFAULT_TABS,
   REFERENCE_PICKER_NODE,
   ReferencePickerNode,
   type ReferenceTab,
   TAB_LABEL,
-  TAB_ORDER,
 } from './nodes/reference-picker-node'
 // Types
 export type {

--- a/apps/web/src/components/editor/inline-picker/nodes/reference-picker-node.tsx
+++ b/apps/web/src/components/editor/inline-picker/nodes/reference-picker-node.tsx
@@ -30,23 +30,30 @@ function pickerQueryText(node: import('@tiptap/pm/model').Node): string {
   return node.textContent.replace(/​/g, '')
 }
 
-export type ReferenceTab = 'people' | 'records' | 'messages' | 'articles'
+export type ReferenceTab = 'people' | 'records' | 'messages' | 'articles' | 'tools'
 
-export const TAB_ORDER: ReferenceTab[] = ['people', 'records', 'messages', 'articles']
+/**
+ * Default tab set rendered by `@`-pickers. Opt-in tabs (currently just
+ * `'tools'`) are NOT included here — they ship only in admin-facing surfaces
+ * that explicitly pass `tabs: [...DEFAULT_TABS, 'tools']`. Opt-in defaults
+ * keep tabs like `tools` from accidentally appearing in customer-facing
+ * editors (mail composer, KB articles).
+ */
+export const DEFAULT_TABS: ReferenceTab[] = ['people', 'records', 'messages', 'articles']
 
 export const TAB_LABEL: Record<ReferenceTab, string> = {
   people: 'People',
   records: 'Records',
   messages: 'Messages',
   articles: 'Articles',
+  tools: 'Tools',
 }
 
-/** Digit → tab. `@2foo` switches to Records before search begins. */
-const DIGIT_TAB: Partial<Record<string, ReferenceTab>> = {
-  '1': 'people',
-  '2': 'records',
-  '3': 'messages',
-  '4': 'articles',
+/** Resolve digit (1–9) → tab from the configured tab list. */
+function digitToTab(digit: string, tabs: readonly ReferenceTab[]): ReferenceTab | null {
+  const idx = Number.parseInt(digit, 10)
+  if (!Number.isFinite(idx) || idx < 1 || idx > tabs.length) return null
+  return tabs[idx - 1] ?? null
 }
 
 const pickerPluginKey = new PluginKey('reference-picker-keys')
@@ -64,6 +71,14 @@ interface ReferencePickerOptions {
    * stops the event so it doesn't move the document cursor.
    */
   onArrowVertical?: (direction: 1 | -1) => boolean
+  /**
+   * Tabs this picker exposes. Drives the initial chip tab, digit shortcuts
+   * (1–N), and Tab/Shift+Tab cycling. The popover (`ReferencePickerContent`)
+   * must be passed the same list — they're paired but not auto-synced
+   * because the popover lives in React and this node lives in ProseMirror.
+   * Defaults to `DEFAULT_TABS`.
+   */
+  tabs?: ReferenceTab[]
 }
 
 function findPickerNode(state: import('@tiptap/pm/state').EditorState) {
@@ -191,6 +206,7 @@ export const ReferencePickerNode = Node.create<ReferencePickerOptions>({
     return {
       onEnter: undefined,
       onArrowVertical: undefined,
+      tabs: DEFAULT_TABS,
     }
   },
 
@@ -217,6 +233,7 @@ export const ReferencePickerNode = Node.create<ReferencePickerOptions>({
   },
 
   addInputRules() {
+    const options = this.options
     return [
       new InputRule({
         // `@` at start-of-block or after whitespace. Capture preceding char so
@@ -250,7 +267,8 @@ export const ReferencePickerNode = Node.create<ReferencePickerOptions>({
           // browser produces no `beforeinput` events when the user types →
           // PM never dispatches a textInput transaction → keystrokes are
           // silently dropped (confirmed via diagnostic logs).
-          const node = nodeType.create({ tab: 'people' }, state.schema.text(ZWSP))
+          const initialTab = options.tabs?.[0] ?? 'people'
+          const node = nodeType.create({ tab: initialTab }, state.schema.text(ZWSP))
           tr.replaceRangeWith(atFrom, atTo, node)
           // Place the cursor after the seed ZWSP (inside the chip, offset 2:
           // 1 to enter the chip + 1 to skip the ZWSP).
@@ -493,8 +511,9 @@ export const ReferencePickerNode = Node.create<ReferencePickerOptions>({
               return false
             }
 
-            // --- Digit 1–4: tab quick-access ---
-            const digitTab = DIGIT_TAB[event.key]
+            // --- Digit 1–N: tab quick-access (where N = configured tabs) ---
+            const tabs = options.tabs ?? DEFAULT_TABS
+            const digitTab = digitToTab(event.key, tabs)
             if (digitTab) {
               const canSwitch = isNodeSelected || realQueryLen === 0
               if (canSwitch) {
@@ -514,9 +533,10 @@ export const ReferencePickerNode = Node.create<ReferencePickerOptions>({
             // --- Tab / Shift+Tab: cycle tabs ---
             if (event.key === 'Tab') {
               event.preventDefault()
-              const idx = TAB_ORDER.indexOf((pickerNode.attrs.tab ?? 'people') as ReferenceTab)
+              const currentTab = (pickerNode.attrs.tab ?? tabs[0] ?? 'people') as ReferenceTab
+              const idx = Math.max(0, tabs.indexOf(currentTab))
               const dir = event.shiftKey ? -1 : 1
-              const next = TAB_ORDER[(idx + dir + TAB_ORDER.length) % TAB_ORDER.length]!
+              const next = tabs[(idx + dir + tabs.length) % tabs.length]!
               const tr = state.tr.setNodeMarkup(chipFrom, undefined, {
                 ...pickerNode.attrs,
                 tab: next,

--- a/apps/web/src/components/editor/rich-text/reference-picker-extensions.ts
+++ b/apps/web/src/components/editor/rich-text/reference-picker-extensions.ts
@@ -1,7 +1,10 @@
 // apps/web/src/components/editor/rich-text/reference-picker-extensions.ts
 
 import { createInlineNode } from '../inline-picker/core/inline-node'
-import { ReferencePickerNode } from '../inline-picker/nodes/reference-picker-node'
+import {
+  ReferencePickerNode,
+  type ReferenceTab,
+} from '../inline-picker/nodes/reference-picker-node'
 import { renderReferenceBadge } from './render-reference-badge'
 
 export interface BuildReferencePickerExtensionsOptions {
@@ -9,6 +12,13 @@ export interface BuildReferencePickerExtensionsOptions {
   onPickerEnter?: () => boolean
   /** Called when ArrowUp/Down is pressed inside the open picker chip. */
   onPickerArrowVertical?: (direction: 1 | -1) => boolean
+  /**
+   * Tabs the picker exposes. Defaults to `DEFAULT_TABS`. Pass
+   * `[...DEFAULT_TABS, 'tools']` on admin-facing surfaces (persona editor) to
+   * opt in to the Tools tab. The matching `<ReferencePickerContent>` mount
+   * must be passed the same list.
+   */
+  referenceTabs?: ReferenceTab[]
 }
 
 /**
@@ -51,6 +61,7 @@ export function buildReferencePickerExtensions(
     ReferencePickerNode.configure({
       onEnter: options.onPickerEnter,
       onArrowVertical: options.onPickerArrowVertical,
+      ...(options.referenceTabs ? { tabs: options.referenceTabs } : {}),
     }),
   ]
 }

--- a/apps/web/src/components/editor/rich-text/render-reference-badge.tsx
+++ b/apps/web/src/components/editor/rich-text/render-reference-badge.tsx
@@ -5,6 +5,7 @@
 import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import type { ActorId } from '@auxx/types/actor'
 import { cn } from '@auxx/ui/lib/utils'
+import { ToolsetBadge } from '~/components/pickers/toolset-picker/toolset-badge'
 import { ActorBadge } from '~/components/resources/ui/actor-badge'
 import { RecordBadge } from '~/components/resources/ui/record-badge'
 import { ThreadBadge } from '~/components/threads/ui/thread-badge'
@@ -28,6 +29,11 @@ export function renderReferenceBadge({ id, selected }: { id: string; selected: b
     } catch {
       return <RecordBadge recordId={id as RecordId} className={ring} />
     }
+  }
+  // Admin-surface ids — toolset (and stub tool:<name>) for the persona prompt
+  // Tools tab. Resolved against the org toolset catalog, not the record cache.
+  if (id.startsWith('toolset:')) {
+    return <ToolsetBadge slug={id.slice('toolset:'.length)} className={ring} />
   }
   return <RecordBadge recordId={id as RecordId} className={ring} />
 }

--- a/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
+++ b/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
@@ -23,6 +23,7 @@ import {
   useExternalContentSync,
   type useSlashCommand,
 } from '../inline-picker'
+import type { ReferenceTab } from '../inline-picker/nodes/reference-picker-node'
 import { Accordion } from '../kb-article/accordion-node'
 import { Block } from '../kb-article/block-node'
 import { MarkdownInputRules } from '../kb-article/markdown-input-rules'
@@ -85,6 +86,13 @@ export interface UseRichTextEditorOptions {
   onPickerEnter?: () => boolean
   /** Forwarded to the reference picker chip. */
   onPickerArrowVertical?: (direction: 1 | -1) => boolean
+  /**
+   * Tabs the reference picker exposes. Defaults to `DEFAULT_TABS`. Pass
+   * `[...DEFAULT_TABS, 'tools']` on admin-facing surfaces (persona editor)
+   * to opt into the Tools tab. The matching `<ReferencePickerContent>` mount
+   * must be passed the same list.
+   */
+  referenceTabs?: ReferenceTab[]
 }
 
 /**
@@ -103,6 +111,7 @@ export function useRichTextEditor({
   enableReferencePicker = true,
   onPickerEnter,
   onPickerArrowVertical,
+  referenceTabs,
 }: UseRichTextEditorOptions) {
   const normalizedInitialContent = useMemo<JSONContent>(() => {
     const migrated = migrateLegacyContent(initialContent)
@@ -118,9 +127,13 @@ export function useRichTextEditor({
   const referencePickerExtensions = useMemo(
     () =>
       enableReferencePicker
-        ? buildReferencePickerExtensions({ onPickerEnter, onPickerArrowVertical })
+        ? buildReferencePickerExtensions({
+            onPickerEnter,
+            onPickerArrowVertical,
+            referenceTabs,
+          })
         : [],
-    [enableReferencePicker, onPickerEnter, onPickerArrowVertical]
+    [enableReferencePicker, onPickerEnter, onPickerArrowVertical, referenceTabs]
   )
 
   const onChangeRef = useRef(onChange)

--- a/apps/web/src/components/pickers/record-picker/record-picker-content.tsx
+++ b/apps/web/src/components/pickers/record-picker/record-picker-content.tsx
@@ -185,10 +185,11 @@ export function RecordPickerContent({
     }
   }, [entityDefinitionId, entityDefinitionIds, debouncedSearch, showInput])
 
-  // Search query — in mention mode (input hidden), always fire so the
-  // empty-query state shows recent records instead of blank.
+  // Search query — fire on open (empty query → recent records) when the picker owns its input
+  // or in mention mode (input hidden). Only gate on a typed query when the search box is
+  // controlled externally (e.g. recipient-input shares its own input).
   const { data: searchResults, isLoading: isSearching } = api.record.search.useQuery(searchParams, {
-    enabled: !showInput || debouncedSearch.trim().length > 0,
+    enabled: !showInput || externalSearch === undefined || debouncedSearch.trim().length > 0,
     staleTime: 30_000,
     placeholderData: keepPreviousData,
   })

--- a/apps/web/src/components/pickers/reference-picker/reference-picker-content.tsx
+++ b/apps/web/src/components/pickers/reference-picker/reference-picker-content.tsx
@@ -6,14 +6,15 @@ import type { RecordId } from '@auxx/lib/resources/client'
 import { cn } from '@auxx/ui/lib/utils'
 import { useEffect, useImperativeHandle, useMemo, useRef } from 'react'
 import {
+  DEFAULT_TABS,
   type ReferenceTab,
   TAB_LABEL,
-  TAB_ORDER,
 } from '~/components/editor/inline-picker/nodes/reference-picker-node'
 import { ActorPickerContent } from '../actor-picker/actor-picker-content'
 import { ArticleReferenceList } from '../article-picker/article-reference-list'
 import { RecordPickerContent } from '../record-picker/record-picker-content'
 import { ThreadReferenceList } from '../thread-picker/thread-reference-list'
+import { ToolsetReferenceList } from '../toolset-picker/toolset-reference-list'
 
 export type { ReferenceTab }
 
@@ -37,6 +38,14 @@ export interface ReferencePickerContentProps {
   ref?: React.Ref<ReferencePickerHandle>
   /** Optional className for the outer Command shell */
   className?: string
+  /**
+   * Tabs to render. Defaults to `DEFAULT_TABS` (the four legacy tabs). Pass
+   * `[...DEFAULT_TABS, 'tools']` on admin-facing surfaces (persona editor)
+   * to opt into the tools tab. Must match the `tabs` option passed to the
+   * paired `ReferencePickerNode` so digit shortcuts / Tab cycling stay in
+   * sync with the visible strip.
+   */
+  tabs?: ReferenceTab[]
 }
 
 /**
@@ -51,6 +60,7 @@ export function ReferencePickerContent({
   onTabChange,
   ref,
   className,
+  tabs = DEFAULT_TABS,
 }: ReferencePickerContentProps) {
   const noop = useMemo(() => () => {}, [])
   const containerRef = useRef<HTMLDivElement>(null)
@@ -126,7 +136,7 @@ export function ReferencePickerContent({
   return (
     <div ref={containerRef} className={cn('rounded-lg', className)}>
       <div className='flex items-center gap-0 border-b px-1 shrink-0' role='tablist'>
-        {TAB_ORDER.map((t, idx) => (
+        {tabs.map((t, idx) => (
           <button
             key={t}
             type='button'
@@ -190,6 +200,12 @@ export function ReferencePickerContent({
             onSelectSingle={(id) => onSelect(id)}
             externalSearch={query}
             showInput={false}
+          />
+        )}
+        {tab === 'tools' && (
+          <ToolsetReferenceList
+            externalSearch={query}
+            onSelectSingle={(id) => onSelect(id as unknown as RecordId)}
           />
         )}
       </div>

--- a/apps/web/src/components/pickers/toolset-picker/toolset-badge.tsx
+++ b/apps/web/src/components/pickers/toolset-picker/toolset-badge.tsx
@@ -1,0 +1,50 @@
+// apps/web/src/components/pickers/toolset-picker/toolset-badge.tsx
+
+'use client'
+
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { cn } from '@auxx/ui/lib/utils'
+import { useMemo } from 'react'
+import { api } from '~/trpc/react'
+
+interface ToolsetBadgeProps {
+  slug: string
+  className?: string
+}
+
+/**
+ * Inline pill for a `toolset:<slug>` reference chip. Resolves the slug via
+ * the org toolset catalog (cached client-side, shared with the agents Tools
+ * tab). Falls back to the raw slug if the catalog hasn't loaded or the slug
+ * is no longer in the catalog.
+ */
+export function ToolsetBadge({ slug, className }: ToolsetBadgeProps) {
+  const catalogQuery = api.agentToolset.list.useQuery(undefined, {
+    staleTime: 60_000,
+  })
+  const entry = useMemo(
+    () => catalogQuery.data?.find((e) => e.slug === slug),
+    [catalogQuery.data, slug]
+  )
+
+  const label = entry?.shortLabel ?? entry?.label ?? slug
+  const iconId = entry?.iconId ?? 'wrench'
+  const color = entry?.color ?? 'gray'
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-[5px] bg-neutral-100 px-1 py-0 h-5 text-sm text-neutral-600 ring-1 ring-neutral-300 dark:bg-muted dark:text-neutral-100 dark:ring-neutral-800',
+        className
+      )}
+      data-slot='toolset-badge'>
+      <EntityIcon iconId={iconId} color={color} size='sm' />
+      {catalogQuery.isLoading && !entry ? (
+        <Skeleton className='h-3 w-14 rounded-full' />
+      ) : (
+        <span className='truncate max-w-[160px]'>{label}</span>
+      )}
+    </span>
+  )
+}

--- a/apps/web/src/components/pickers/toolset-picker/toolset-reference-list.tsx
+++ b/apps/web/src/components/pickers/toolset-picker/toolset-reference-list.tsx
@@ -1,0 +1,93 @@
+// apps/web/src/components/pickers/toolset-picker/toolset-reference-list.tsx
+
+'use client'
+
+import type { ToolsetCatalogEntry } from '@auxx/lib/agents'
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandPlaceholder,
+} from '@auxx/ui/components/command'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { cn } from '@auxx/ui/lib/utils'
+import { useMemo } from 'react'
+import { api } from '~/trpc/react'
+
+export interface ToolsetReferenceListProps {
+  /** Search query forwarded from the picker chip. */
+  externalSearch?: string
+  /** Selection callback — receives the chip id (`toolset:<slug>`). */
+  onSelectSingle: (id: string) => void
+  className?: string
+}
+
+/**
+ * Flat single-list search component for the ReferencePicker Tools tab.
+ *
+ * Backed by `api.agentToolset.list` (org-wide toolset catalog). The "Tools"
+ * tab is one of intentionally-coarse granularity: an admin pins a whole
+ * toolset to the persona prompt and the agent gets all of its tools.
+ * Individual tool pinning (`tool:<name>`) is not exposed in v1 — the catalog
+ * has no per-tool selection surface and per-tool gating already lives on the
+ * Tools tab via `disabledTools`.
+ */
+export function ToolsetReferenceList({
+  externalSearch = '',
+  onSelectSingle,
+  className,
+}: ToolsetReferenceListProps) {
+  const catalogQuery = api.agentToolset.list.useQuery(undefined, {
+    staleTime: 60_000,
+  })
+
+  const filtered = useMemo<ToolsetCatalogEntry[]>(() => {
+    const items = catalogQuery.data ?? []
+    const q = externalSearch.trim().toLowerCase()
+    if (!q) return items
+    return items.filter((entry) => {
+      if (entry.slug.toLowerCase().includes(q)) return true
+      if (entry.label.toLowerCase().includes(q)) return true
+      if (entry.shortLabel.toLowerCase().includes(q)) return true
+      return entry.tools.some((t) => t.name.toLowerCase().includes(q))
+    })
+  }, [catalogQuery.data, externalSearch])
+
+  const isLoading = catalogQuery.isLoading
+  const showEmpty = !isLoading && filtered.length === 0 && (catalogQuery.data?.length ?? 0) > 0
+  const showEmptyInitial = !isLoading && (catalogQuery.data?.length ?? 0) === 0
+
+  return (
+    <Command shouldFilter={false} className={cn('rounded-lg', className)}>
+      <CommandList>
+        {isLoading && <CommandPlaceholder>Loading…</CommandPlaceholder>}
+        {showEmpty && <CommandPlaceholder>No toolsets match</CommandPlaceholder>}
+        {showEmptyInitial && <CommandPlaceholder>No toolsets available</CommandPlaceholder>}
+        {filtered.length > 0 && (
+          <CommandGroup aria-label='Toolsets'>
+            {filtered.map((entry) => {
+              const id = `toolset:${entry.slug}`
+              return (
+                <CommandItem
+                  key={entry.slug}
+                  value={id}
+                  onSelect={() => onSelectSingle(id)}
+                  className='flex items-center gap-2'>
+                  <EntityIcon iconId={entry.iconId ?? 'wrench'} color={entry.color} size='sm' />
+                  <div className='flex min-w-0 flex-col'>
+                    <span className='text-sm truncate'>{entry.label}</span>
+                    <span className='text-[10px] text-muted-foreground'>
+                      {entry.tools.length} {entry.tools.length === 1 ? 'tool' : 'tools'} ·{' '}
+                      {entry.parentGroup}
+                    </span>
+                  </div>
+                </CommandItem>
+              )
+            })}
+          </CommandGroup>
+        )}
+      </CommandList>
+    </Command>
+  )
+}

--- a/packages/lib/src/agents/agent-service.ts
+++ b/packages/lib/src/agents/agent-service.ts
@@ -12,6 +12,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { generateId } from '@auxx/utils'
 import { and, eq, isNull } from 'drizzle-orm'
 import { getAllCachedAgents, getCachedAgentById, getCachedAgents, onCacheEvent } from '../cache'
+import { BadRequestError } from '../errors'
 import { resolveDefaultToolsets } from './default-toolsets'
 
 const logger = createScopedLogger('agent-service')
@@ -273,16 +274,38 @@ export async function updateAgent(
 }
 
 /**
- * Mark an agent's chat-driven setup mode as complete. Idempotent — no-ops on
- * an already-completed agent. Flips the rail UI from the setup carousel to
- * the Prompt/Tools/Knowledge tabs. The agent is functionally live throughout
+ * Mark an agent's chat-driven setup mode as complete. Idempotent on
+ * already-completed agents. Flips the rail UI from the setup carousel to the
+ * Prompt/Tools/Knowledge tabs. The agent is functionally live throughout
  * setup; this only gates the UI surface.
+ *
+ * Rejects with `BadRequestError` if the agent does not yet have the minimum
+ * configuration the carousel was meant to enforce: a non-empty persona
+ * prompt, at least one toolset, and a name. Guards both the chat-builder
+ * tool and the rail's "Mark setup complete" escape hatch from shipping a
+ * half-built agent past the carousel.
  */
 export async function completeAgentSetup(
   agentId: string,
   organizationId: string,
   db: Database = defaultDb as Database
 ): Promise<void> {
+  const detail = await getAgentDetail(organizationId, agentId, db)
+  if (!detail) throw new BadRequestError(`Agent not found: ${agentId}`)
+
+  // Already complete — preserve previous idempotent behavior.
+  if (detail.setupCompletedAt) return
+
+  if (isEmptyPromptDoc(detail.prompt)) {
+    throw new BadRequestError('Add a persona prompt before completing setup.')
+  }
+  if ((detail.toolsets ?? []).length === 0) {
+    throw new BadRequestError('Enable at least one toolset before completing setup.')
+  }
+  if (!detail.name || detail.name.trim() === '') {
+    throw new BadRequestError('Give the agent a name before completing setup.')
+  }
+
   const result = await db
     .update(schema.Agent)
     .set({ setupCompletedAt: new Date(), updatedAt: new Date() })
@@ -306,6 +329,27 @@ export async function completeAgentSetup(
       error: err instanceof Error ? err.message : String(err),
     })
   }
+}
+
+/**
+ * True when the prompt doc has no real content. Mirrors the client-side
+ * `isEmptyTiptapDoc` check in `derive-setup-step.ts` and also accepts the
+ * KB block shape (`{ blockType: 'text' }` with an empty `content` array)
+ * the persona editor uses today.
+ */
+function isEmptyPromptDoc(doc: Record<string, unknown> | null | undefined): boolean {
+  if (!doc) return true
+  const content = (doc as { content?: unknown[] }).content
+  if (!Array.isArray(content) || content.length === 0) return true
+  if (content.length === 1) {
+    const node = content[0] as { type?: string; content?: unknown[] }
+    if (!node) return true
+    // Empty Tiptap paragraph.
+    if (node.type === 'paragraph' && (!node.content || node.content.length === 0)) return true
+    // Empty KB-block placeholder (`mdToBlocks` emits this for empty input).
+    if (node.type === 'block' && (!node.content || node.content.length === 0)) return true
+  }
+  return false
 }
 
 /**

--- a/packages/lib/src/ai/agent-framework/query-loop.ts
+++ b/packages/lib/src/ai/agent-framework/query-loop.ts
@@ -25,6 +25,11 @@ import {
 
 const logger = createScopedLogger('agent-query-loop')
 const DEFAULT_MAX_ITERATIONS = 10
+// Number of consecutive iterations in which the same tool fails (and only
+// that tool runs) before we bail out of the turn. Without this, a model
+// stuck on a malformed tool input can burn the full iteration budget
+// silently — see plans/kopilot/agents/builder/builder-failure-diagnosis.md §3.5.
+const SAME_TOOL_FAILURE_LIMIT = 3
 
 /**
  * Core agent query loop — standalone async generator.
@@ -61,6 +66,8 @@ export async function* agentQueryLoop(
   let currentState = state
   let iteration = 0
   let totalToolCallCount = 0
+  let failingToolName: string | null = null
+  let failingToolStreak = 0
 
   /**
    * Per-turn cache of idempotent tool results. Keyed by "toolName::sortedArgsJson".
@@ -546,6 +553,41 @@ export async function* agentQueryLoop(
 
     // Let the agent process intermediate results
     currentState = await agent.processResult(content, toolCalls, currentState, ctx)
+
+    // Same-tool failure streak detector. If every tool call in this iteration
+    // failed AND they all reference the same tool name, track the streak.
+    // Three in a row bails the turn — the model is stuck on a malformed
+    // input (e.g. an empty `{}` to a tool whose schema it can't satisfy).
+    const allFailed = toolResults.results.length > 0 && toolResults.results.every((r) => !r.success)
+    const distinctNames = new Set(toolResults.results.map((r) => r.toolName))
+    if (allFailed && distinctNames.size === 1) {
+      const onlyName = [...distinctNames][0]
+      if (failingToolName === onlyName) {
+        failingToolStreak++
+      } else {
+        failingToolName = onlyName
+        failingToolStreak = 1
+      }
+      if (failingToolStreak >= SAME_TOOL_FAILURE_LIMIT) {
+        const lastError = toolResults.results.find((r) => !r.success)?.error ?? 'unknown error'
+        logger.warn('Same-tool failure streak — aborting turn', {
+          turnId,
+          agent: agent.name,
+          tool: onlyName,
+          streak: failingToolStreak,
+          iteration,
+          lastError,
+        })
+        yield {
+          type: 'turn-error',
+          error: `Tool \`${onlyName}\` failed ${failingToolStreak} times in a row: ${lastError}`,
+        }
+        break
+      }
+    } else {
+      failingToolName = null
+      failingToolStreak = 0
+    }
   }
 
   yield { type: 'agent-completed', agent: agent.name }

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/index.ts
@@ -7,6 +7,7 @@ import { createCompleteAgentSetupTool } from './tools/complete-agent-setup'
 import { createSetAgentPromptTool } from './tools/set-agent-prompt'
 import { createSetAgentResourceScopeTool } from './tools/set-agent-resource-scope'
 import { createSetAgentToolsetsTool } from './tools/set-agent-toolsets'
+import { createSetAgentTriggersTool } from './tools/set-agent-triggers'
 import { createSuggestRepliesTool } from './tools/suggest-replies'
 import { createUpdateAgentIdentityTool } from './tools/update-agent-identity'
 
@@ -35,6 +36,7 @@ export async function createAgentsBuilderCapabilities(
       createSetAgentPromptTool(getDeps),
       createSetAgentToolsetsTool(getDeps),
       createSetAgentResourceScopeTool(getDeps),
+      createSetAgentTriggersTool(getDeps),
       createCompleteAgentSetupTool(getDeps),
     ],
     systemPromptAddition: buildBuilderPersonaPrompt({ catalog }),

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/persona-prompt.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/persona-prompt.ts
@@ -4,10 +4,9 @@ import { BUILDER_AVATAR_POOL } from '../../../../agents/builder-avatars'
 import type { ToolsetCatalogEntry } from '../../../../agents/toolset-catalog'
 
 /**
- * Build the builder persona prompt addition. Three parts:
- * 1. Identity + flow guidance (alignment → personalization → onboarding)
- * 2. Toolset catalog inlined verbatim
- * 3. Discovery + chip rules
+ * Build the builder persona prompt addition. Order matches the user-preferred
+ * flow: substantive config first (toolsets / knowledge / prompt / triggers),
+ * cosmetic finishing pass last (name / avatar / tone).
  */
 export function buildBuilderPersonaPrompt(deps: { catalog: ToolsetCatalogEntry[] }): string {
   const { catalog } = deps
@@ -36,13 +35,16 @@ Most admins fall into one of two flows:
 1. **Fresh agent** (no prompt, no toolsets). Run a three-phase interview using
    \`plan_create\`:
    - **Alignment** — what's the agent's job, in one sentence?
+   - **Onboarding** — toolsets, knowledge scope, persona prompt, triggers (if
+     the admin wants autonomous runs).
    - **Personalization** — name, description, avatar, tone.
-   - **Onboarding** — toolsets, knowledge scope, any starting persona text.
 
-   As the LAST step of Onboarding — once the agent has a real name, a
-   non-empty persona prompt, and at least one toolset enabled — call
+   Once Onboarding has a non-empty persona prompt and at least one toolset
+   enabled — AND Personalization has set a name — call
    \`complete_agent_setup\`. That flips the detail-page rail from the setup
    carousel to the live editing tabs. Do NOT call it earlier; do NOT skip it.
+   The server rejects \`complete_agent_setup\` until prompt + toolsets + name
+   are present, so calling early just wastes a turn.
 
 2. **Existing agent**. Skip the interview entirely. Edit in place; act on the
    admin's explicit request and call setter tools eagerly. Never call
@@ -55,8 +57,6 @@ In either flow:
   admin revise.
 - When you suggest 2–4 next-turn options to the admin, also call
   \`suggest_replies\` so the chips render above the composer.
-- Avatars: pick one slug from the announced pool. Available slugs:
-  ${avatarBlock}.
 
 ## Toolsets you can give the agent
 
@@ -65,15 +65,35 @@ tools):
 
 ${catalogBlock}
 
-## Discovery rule
+## Onboarding details
 
-Before asking the admin "which KB / which records?", call
-\`search_entities\` / \`search_knowledge\` (whichever fits) to inline real
-workspace names. Don't ask blindly.
+- **Knowledge / scope**: before asking the admin "which KB / which records?",
+  call \`search_entities\` / \`search_knowledge\` (whichever fits) to inline
+  real workspace names. Don't ask blindly.
+- **Persona prompt** (\`set_agent_prompt\`): pass the FULL prompt as
+  markdown. Headings, paragraphs, lists, blockquotes, and code fences work.
+  Inline \`@[<RecordId>]\` syntax embeds a reference chip — useful for
+  pinning toolsets (\`@[toolset:mail]\`), articles
+  (\`@[article:<id>]\`), people / agents (\`@[user:<id>]\`), or any other
+  record. The previous prompt is replaced wholesale.
+- **Triggers** (\`set_agent_triggers\`): default to NO triggers (chat-only
+  agent). If the admin wants the agent to run on a schedule or react to
+  record changes, pass the full set of triggers. \`scheduled\` takes
+  \`cron\` or \`everyMinutes/everyHours/everyDays\`; \`event\` takes
+  \`triggerType\` (\`created\` / \`updated\` / \`deleted\`) and
+  \`entityDefinitionSlug\` (apiSlug from \`list_entities\`).
+
+## Personalization details
+
+After Onboarding, set the cosmetic layer via \`update_agent_identity\`:
+
+- **Name** — a concrete, human-friendly label (1–100 chars).
+- **Description** — one-line summary shown to admins.
+- **Avatar** — pick one slug from the curated pool:
+  ${avatarBlock}.
 
 ## What you don't do
 
-- You don't configure triggers in v1 — that capability ships later.
 - You don't switch the agent's model — that's an admin-only setting.
 - You don't archive or delete agents through this chat.
 `

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/complete-agent-setup.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/complete-agent-setup.ts
@@ -41,7 +41,18 @@ finalization signal. No arguments — operates on the agent in session context.`
         }
       }
 
-      await completeAgentSetup(agentRef.id, agentDeps.organizationId)
+      try {
+        await completeAgentSetup(agentRef.id, agentDeps.organizationId)
+      } catch (err) {
+        // Surface server-side preconditions (empty prompt / missing toolset
+        // / missing name) as a tool error so the model can fix the gap
+        // instead of erroring out the turn.
+        return {
+          success: false,
+          output: null,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      }
 
       return {
         success: true,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-prompt.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-prompt.ts
@@ -1,42 +1,47 @@
 // packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-prompt.ts
 
 import { updateAgent } from '../../../../../agents/agent-service'
+import { mdToBlocks } from '../../../../../kb/markdown'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import { findRef } from '../../../context-refs'
 import type { GetToolDeps } from '../../types'
 import { buildAgentRailUpdate } from '../snapshot'
 
-const PROMPT_MAX_BYTES = 64_000
+const MARKDOWN_MAX_BYTES = 20_000
 
 /**
- * Replace the persona prompt document of the agent bound to this builder
- * session. The `doc` argument is a TiptapJSON document — the same shape the
- * Prompt-tab editor writes. Append-style edits are computed client-side by
- * the model and submitted as a full new doc.
+ * Replace the persona prompt of the agent bound to this builder session.
+ *
+ * The model authors markdown; the server expands it into the editor's block
+ * shape (`mdToBlocks`) — same converter the KB write tools use. Wholesale
+ * replace; to edit, fetch the current prompt from the active references,
+ * splice locally, send the full markdown back.
  */
 export function createSetAgentPromptTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'set_agent_prompt',
-    description: `Replace the agent's persona prompt with a new TiptapJSON document.
+    description: `Replace the agent's persona prompt with a markdown document.
 
 The persona prompt is the agent's instructions: tone, role, constraints,
-escalation rules, and any \`@\`-mentions of toolsets / records / KBs that
-seed its knowledge scope. The doc is shown to admins in the Prompt tab.
+escalation rules, and any \`@\`-references to toolsets / records / KB articles
+that seed its knowledge scope. The doc is shown to admins in the Prompt tab.
 
-To append a section, fetch the current doc (it lives in this session's
-active references / agent detail), splice on a new heading + paragraph
-yourself, and pass the FULL resulting document.`,
+Use standard markdown — headings, paragraphs, bullet / numbered lists,
+blockquotes, code fences, dividers. Inline \`@[<RecordId>]\` syntax embeds a
+reference chip (e.g. \`@[toolset:mail]\`, \`@[article:abc123]\`,
+\`@[user:def456]\`). The previous prompt is replaced wholesale.`,
     parameters: {
       type: 'object',
       properties: {
-        doc: {
-          type: 'object',
+        markdown: {
+          type: 'string',
           description:
-            'Full TiptapJSON document — `{ type: "doc", content: [...] }`. The previous prompt is replaced wholesale.',
-          additionalProperties: true,
+            'Full persona prompt as markdown. Headings, paragraphs, lists, blockquotes, code fences, and inline `@[<RecordId>]` references are supported. Replaces the previous prompt wholesale.',
+          minLength: 1,
+          maxLength: MARKDOWN_MAX_BYTES,
         },
       },
-      required: ['doc'],
+      required: ['markdown'],
       additionalProperties: false,
     },
     execute: async (args, agentDeps) => {
@@ -50,41 +55,49 @@ yourself, and pass the FULL resulting document.`,
         }
       }
 
-      const doc = args.doc as Record<string, unknown> | undefined
-      if (!doc || typeof doc !== 'object') {
-        return { success: false, output: null, error: 'doc must be a TiptapJSON object' }
-      }
-      if (doc.type !== 'doc' || !Array.isArray((doc as { content?: unknown }).content)) {
+      const markdown = typeof args.markdown === 'string' ? args.markdown : ''
+      if (!markdown.trim()) {
         return {
           success: false,
           output: null,
-          error: 'doc must be a TiptapJSON document with `type: "doc"` and a `content` array',
+          error: 'markdown must be a non-empty string. Pass the full persona prompt as markdown.',
         }
       }
-
-      const serialized = JSON.stringify(doc)
-      if (serialized.length > PROMPT_MAX_BYTES) {
+      if (markdown.length > MARKDOWN_MAX_BYTES) {
         return {
           success: false,
           output: null,
-          error: `prompt exceeds max ${PROMPT_MAX_BYTES} bytes (got ${serialized.length})`,
+          error: `markdown exceeds max ${MARKDOWN_MAX_BYTES} characters (got ${markdown.length})`,
         }
       }
 
+      let blocks: ReturnType<typeof mdToBlocks>
+      try {
+        blocks = mdToBlocks(markdown)
+      } catch (err) {
+        return {
+          success: false,
+          output: null,
+          error: `Failed to parse markdown: ${err instanceof Error ? err.message : String(err)}`,
+        }
+      }
+
+      const doc = { type: 'doc', content: blocks } as Record<string, unknown>
       await updateAgent(agentRef.id, agentDeps.organizationId, { prompt: doc })
 
       const referenceCount = countReferences(doc)
+      const byteLength = JSON.stringify(doc).length
 
       return {
         success: true,
         output: {
           agentId: agentRef.id,
-          byteLength: serialized.length,
+          byteLength,
           referenceCount,
           ...buildAgentRailUpdate({
             agentId: agentRef.id,
             changed: ['prompt'],
-            summary: `prompt replaced (${serialized.length} bytes, ${referenceCount} refs)`,
+            summary: `prompt replaced (${byteLength} bytes, ${referenceCount} refs)`,
           }),
         },
       }
@@ -93,17 +106,15 @@ yourself, and pass the FULL resulting document.`,
 }
 
 /**
- * Walk the doc and count `@`-mention reference nodes. Mention chips are
- * Tiptap inline nodes with `type: 'reference'` (or similar — the parser
- * tolerates a couple of variants used in the codebase). The exact mention
- * → scope reconciliation lives in the prompt-mentions plan.
+ * Walk the doc and count `reference` inline nodes (the `@[id]` chips). The
+ * exact reference → scope reconciliation lives in the prompt-mentions plan.
  */
 function countReferences(doc: Record<string, unknown>): number {
   let count = 0
   const walk = (node: unknown): void => {
     if (!node || typeof node !== 'object') return
     const n = node as { type?: string; content?: unknown[] }
-    if (n.type === 'reference' || n.type === 'mention') count++
+    if (n.type === 'reference') count++
     if (Array.isArray(n.content)) {
       for (const child of n.content) walk(child)
     }

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-triggers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-triggers.ts
@@ -1,0 +1,300 @@
+// packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-triggers.ts
+
+import {
+  type AgentTriggerInput,
+  AgentTriggerService,
+  type CrudEventTriggerInput,
+  type ScheduledTriggerInput,
+} from '../../../../../agents/agent-trigger-service'
+import { findCachedResource } from '../../../../../cache/org-cache-helpers'
+import { mdToBlocks } from '../../../../../kb/markdown'
+import type { ScheduledTriggerConfig } from '../../../../../workflows/cron-pattern'
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import { findRef } from '../../../context-refs'
+import type { GetToolDeps } from '../../types'
+import { buildAgentRailUpdate } from '../snapshot'
+
+const MAX_TRIGGERS = 10
+const INSTRUCTIONS_MAX = 2000
+const EVENT_TRIGGER_TYPES = ['created', 'updated', 'deleted'] as const
+
+interface ParsedScheduledTrigger {
+  kind: 'scheduled'
+  cron?: string
+  everyMinutes?: number
+  everyHours?: number
+  everyDays?: number
+  timezone?: string
+  instructions?: string
+}
+
+interface ParsedEventTrigger {
+  kind: 'event'
+  triggerType: 'created' | 'updated' | 'deleted'
+  entityDefinitionSlug: string
+  instructions?: string
+}
+
+type ParsedTrigger = ParsedScheduledTrigger | ParsedEventTrigger
+
+/**
+ * Replace the agent's trigger set. Pass the FULL desired list — anything not
+ * in `triggers` is removed (and its BullMQ scheduler is torn down via the
+ * service). v1 covers two kinds:
+ *
+ *  - `scheduled`: cron or `everyN{Minutes,Hours,Days}` shorthand, optional
+ *    timezone, optional per-fire instructions.
+ *  - `event`: CRUD events (created / updated / deleted) for a single entity
+ *    type, referenced by apiSlug / entityType / id.
+ *
+ * `app` and `event-direct` kinds are admin-driven and ship via the rail UI,
+ * not this builder tool.
+ */
+export function createSetAgentTriggersTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'set_agent_triggers',
+    description: `Replace the agent's trigger set with the provided list.
+
+Triggers tell the agent when to run autonomously. Default: no triggers — the
+agent only responds to direct chat. Add triggers when the admin asks the
+agent to react to records or run on a schedule.
+
+Two supported kinds:
+
+- \`scheduled\`: runs on a clock. Pass either \`cron\` (5- or 6-field cron
+  expression) OR one of \`everyMinutes\` / \`everyHours\` / \`everyDays\`.
+  Optional \`timezone\` (IANA name). Use \`instructions\` to tell the agent
+  what to do each fire (e.g. "summarize new replies in the last day").
+- \`event\`: fires when a record is created / updated / deleted. Pass
+  \`triggerType\` and \`entityDefinitionSlug\` (the apiSlug from
+  \`list_entities\` — e.g. \`ticket\`, \`contact\`).
+
+This call REPLACES the full set. To add one trigger to an agent that already
+has two, send all three in the call.`,
+    parameters: {
+      type: 'object',
+      properties: {
+        triggers: {
+          type: 'array',
+          maxItems: MAX_TRIGGERS,
+          description: 'Full desired set of triggers. Empty array removes all triggers.',
+          items: {
+            oneOf: [
+              {
+                type: 'object',
+                properties: {
+                  kind: { const: 'scheduled' },
+                  cron: {
+                    type: 'string',
+                    description:
+                      'BullMQ cron pattern (5- or 6-field). Mutually exclusive with everyN*.',
+                  },
+                  everyMinutes: { type: 'integer', minimum: 1, maximum: 59 },
+                  everyHours: { type: 'integer', minimum: 1, maximum: 23 },
+                  everyDays: { type: 'integer', minimum: 1, maximum: 30 },
+                  timezone: {
+                    type: 'string',
+                    description: 'IANA timezone (e.g. "America/Los_Angeles")',
+                  },
+                  instructions: { type: 'string', maxLength: INSTRUCTIONS_MAX },
+                },
+                required: ['kind'],
+                additionalProperties: false,
+              },
+              {
+                type: 'object',
+                properties: {
+                  kind: { const: 'event' },
+                  triggerType: { type: 'string', enum: EVENT_TRIGGER_TYPES },
+                  entityDefinitionSlug: {
+                    type: 'string',
+                    description:
+                      'apiSlug / entityType / id from `list_entities` (e.g. `ticket`, `contact`).',
+                  },
+                  instructions: { type: 'string', maxLength: INSTRUCTIONS_MAX },
+                },
+                required: ['kind', 'triggerType', 'entityDefinitionSlug'],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+      },
+      required: ['triggers'],
+      additionalProperties: false,
+    },
+    execute: async (args, agentDeps) => {
+      const { sessionContext } = getDeps()
+      const agentRef = findRef(sessionContext, 'agent')
+      if (!agentRef?.id) {
+        return {
+          success: false,
+          output: null,
+          error: 'No agent in session context — this tool only runs on the builder page.',
+        }
+      }
+
+      const rawTriggers = (args.triggers ?? []) as ParsedTrigger[]
+      if (!Array.isArray(rawTriggers)) {
+        return { success: false, output: null, error: 'triggers must be an array' }
+      }
+      if (rawTriggers.length > MAX_TRIGGERS) {
+        return {
+          success: false,
+          output: null,
+          error: `Too many triggers (max ${MAX_TRIGGERS}, got ${rawTriggers.length}).`,
+        }
+      }
+
+      // Resolve each parsed trigger into a typed AgentTriggerInput. Entity
+      // slugs resolve through the org resources cache so the LLM never has
+      // to pass cuid-style ids.
+      const resolved: Array<{ input: AgentTriggerInput; instructions?: string }> = []
+      for (let i = 0; i < rawTriggers.length; i++) {
+        const t = rawTriggers[i]
+        const built = await buildTriggerInput(t, agentDeps.organizationId, i)
+        if ('error' in built) return { success: false, output: null, error: built.error }
+        resolved.push({ input: built.input, instructions: built.instructions })
+      }
+
+      const service = new AgentTriggerService()
+      const existing = await service.listForAgent(agentRef.id, agentDeps.organizationId)
+
+      // Replace-all: tear down existing, recreate. Simpler than diffing; the
+      // service's scheduler upserts handle BullMQ churn.
+      for (const row of existing) {
+        await service.deleteTrigger(row.id, agentDeps.organizationId)
+      }
+
+      const created: string[] = []
+      for (const { input, instructions } of resolved) {
+        const row = await service.createTrigger({
+          agentId: agentRef.id,
+          organizationId: agentDeps.organizationId,
+          createdById: agentDeps.userId,
+          enabled: true,
+          instructions: instructions ? instructionsToDoc(instructions) : null,
+          trigger: input,
+        })
+        created.push(row.id)
+      }
+
+      return {
+        success: true,
+        output: {
+          agentId: agentRef.id,
+          triggerIds: created,
+          removed: existing.length,
+          ...buildAgentRailUpdate({
+            agentId: agentRef.id,
+            changed: ['identity'],
+            summary: `${created.length} trigger${created.length === 1 ? '' : 's'} set (${existing.length} removed)`,
+          }),
+        },
+      }
+    },
+  }
+}
+
+interface BuiltTrigger {
+  input: AgentTriggerInput
+  instructions?: string
+}
+
+async function buildTriggerInput(
+  t: ParsedTrigger,
+  organizationId: string,
+  index: number
+): Promise<BuiltTrigger | { error: string }> {
+  if (!t || typeof t !== 'object' || !('kind' in t)) {
+    return { error: `triggers[${index}]: missing 'kind'` }
+  }
+
+  if (t.kind === 'scheduled') {
+    const config = buildScheduledConfig(t)
+    if ('error' in config) return { error: `triggers[${index}]: ${config.error}` }
+    const input: ScheduledTriggerInput = { kind: 'scheduled', config: config.config }
+    return { input, instructions: t.instructions }
+  }
+
+  if (t.kind === 'event') {
+    if (!EVENT_TRIGGER_TYPES.includes(t.triggerType)) {
+      return {
+        error: `triggers[${index}]: triggerType must be one of ${EVENT_TRIGGER_TYPES.join(', ')}`,
+      }
+    }
+    if (!t.entityDefinitionSlug || typeof t.entityDefinitionSlug !== 'string') {
+      return { error: `triggers[${index}]: entityDefinitionSlug is required for event triggers` }
+    }
+    const resource = await findCachedResource(organizationId, t.entityDefinitionSlug)
+    if (!resource) {
+      return {
+        error: `triggers[${index}]: unknown entityDefinitionSlug "${t.entityDefinitionSlug}". Use the apiSlug from list_entities.`,
+      }
+    }
+    const input: CrudEventTriggerInput = {
+      kind: 'event',
+      triggerType: t.triggerType,
+      entityDefinitionId: resource.id,
+    }
+    return { input, instructions: t.instructions }
+  }
+
+  return { error: `triggers[${index}]: unsupported kind "${(t as { kind: string }).kind}"` }
+}
+
+function buildScheduledConfig(
+  t: ParsedScheduledTrigger
+): { config: ScheduledTriggerConfig } | { error: string } {
+  const { cron, everyMinutes, everyHours, everyDays, timezone } = t
+  const everyCount = [everyMinutes, everyHours, everyDays].filter((v) => v !== undefined).length
+
+  if (cron && everyCount > 0) {
+    return { error: 'pass either cron OR one everyN* field, not both' }
+  }
+  if (!cron && everyCount === 0) {
+    return {
+      error: 'scheduled trigger requires cron or one of everyMinutes / everyHours / everyDays',
+    }
+  }
+  if (everyCount > 1) {
+    return { error: 'pass only one of everyMinutes / everyHours / everyDays' }
+  }
+
+  if (cron) {
+    return {
+      config: { triggerInterval: 'custom', timeBetweenTriggers: {}, customCron: cron, timezone },
+    }
+  }
+  if (everyMinutes !== undefined) {
+    return {
+      config: {
+        triggerInterval: 'minutes',
+        timeBetweenTriggers: { minutes: everyMinutes, isConstant: true },
+        timezone,
+      },
+    }
+  }
+  if (everyHours !== undefined) {
+    return {
+      config: {
+        triggerInterval: 'hours',
+        timeBetweenTriggers: { hours: everyHours, isConstant: true },
+        timezone,
+      },
+    }
+  }
+  // everyDays
+  return {
+    config: {
+      triggerInterval: 'days',
+      timeBetweenTriggers: { days: everyDays, isConstant: true },
+      timezone,
+    },
+  }
+}
+
+/** Wrap a single-line instructions string in the editor's doc shape. */
+function instructionsToDoc(text: string): Record<string, unknown> {
+  return { type: 'doc', content: mdToBlocks(text) }
+}

--- a/packages/lib/src/kb/markdown/__tests__/round-trip.test.ts
+++ b/packages/lib/src/kb/markdown/__tests__/round-trip.test.ts
@@ -240,3 +240,94 @@ describe('round-trip', () => {
     expect(out).toContain('{{first_name}}')
   })
 })
+
+describe('mdToBlocks — inline references', () => {
+  it('parses @[id] into a reference inline node', () => {
+    const doc = mdToDoc('See @[user:abc] for context.')
+    const inline = doc.content[0]?.content ?? []
+    expect(inline).toEqual([
+      { type: 'text', text: 'See ' },
+      { type: 'reference', attrs: { id: 'user:abc' } },
+      { type: 'text', text: ' for context.' },
+    ])
+  })
+
+  it('parses RecordId-shaped [Title](id) links as references', () => {
+    const doc = mdToDoc('Open [Settings](user:abc) to continue.')
+    const inline = doc.content[0]?.content ?? []
+    expect(inline).toEqual([
+      { type: 'text', text: 'Open ' },
+      { type: 'reference', attrs: { id: 'user:abc' } },
+      { type: 'text', text: ' to continue.' },
+    ])
+  })
+
+  it('keeps http(s) links as ordinary link marks', () => {
+    const doc = mdToDoc('[Docs](https://example.com) here.')
+    const inline = doc.content[0]?.content ?? []
+    const link = inline[0] as {
+      type: string
+      marks?: { type: string; attrs?: { href?: string } }[]
+    }
+    expect(link.type).toBe('text')
+    expect(link.marks?.[0]?.type).toBe('link')
+    expect(link.marks?.[0]?.attrs?.href).toBe('https://example.com')
+  })
+
+  it('keeps mailto/tel links as ordinary link marks', () => {
+    const doc = mdToDoc('[email](mailto:a@b.com) [phone](tel:+1-555-0100)')
+    const inline = doc.content[0]?.content ?? []
+    for (const node of inline) {
+      if ((node as { type?: string }).type !== 'text') continue
+      const marks = (node as { marks?: { type: string }[] }).marks ?? []
+      // Reference nodes won't have a `link` mark; ordinary text won't either.
+      // Anything that DOES have a link mark must be the mailto/tel.
+      const link = marks.find((m) => m.type === 'link')
+      if (link) {
+        const href = (link as { attrs?: { href?: string } }).attrs?.href ?? ''
+        expect(/^(mailto|tel):/.test(href)).toBe(true)
+      }
+    }
+    // No reference node leaked in.
+    expect(inline.some((n) => (n as { type?: string }).type === 'reference')).toBe(false)
+  })
+
+  it('round-trips a doc with a reference back to the same node', () => {
+    const original: DocJSON = {
+      type: 'doc',
+      content: [
+        block('text', {}, [
+          text('See '),
+          { type: 'reference', attrs: { id: 'user:abc' } },
+          text(' first.'),
+        ]),
+      ] as never,
+    }
+    const md = blocksToMd(original)
+    const reparsed = mdToDoc(md)
+    const inline = reparsed.content[0]?.content ?? []
+    expect(inline).toEqual([
+      { type: 'text', text: 'See ' },
+      { type: 'reference', attrs: { id: 'user:abc' } },
+      { type: 'text', text: ' first.' },
+    ])
+  })
+
+  it('handles two references in the same paragraph', () => {
+    const doc = mdToDoc('Both @[user:a] and @[toolset:mail] are involved.')
+    const inline = doc.content[0]?.content ?? []
+    expect(inline).toEqual([
+      { type: 'text', text: 'Both ' },
+      { type: 'reference', attrs: { id: 'user:a' } },
+      { type: 'text', text: ' and ' },
+      { type: 'reference', attrs: { id: 'toolset:mail' } },
+      { type: 'text', text: ' are involved.' },
+    ])
+  })
+
+  it('ignores @[…] that does not look like a RecordId', () => {
+    const doc = mdToDoc('Plain @[not a record] should stay text.')
+    const inline = doc.content[0]?.content ?? []
+    expect(inline.some((n) => (n as { type?: string }).type === 'reference')).toBe(false)
+  })
+})

--- a/packages/lib/src/kb/markdown/md-to-blocks.ts
+++ b/packages/lib/src/kb/markdown/md-to-blocks.ts
@@ -30,8 +30,47 @@ import type {
 import { CALLOUT_VARIANTS, EMBED_ASPECTS, EMBED_PROVIDERS, IMAGE_ALIGNS } from './types'
 
 const PLACEHOLDER_RE = /\{\{([a-zA-Z0-9_.-]+)\}\}/g
+const REFERENCE_AT_RE = /@\[([a-zA-Z][a-zA-Z0-9_-]*:[\w.-]+)\]/g
 const IMAGE_ATTR_TRAILER_RE = /^\{([^{}\n]*)\}/
 const HEADING_MAX_LEVEL = 3
+
+// `<entityDefinitionId>:<entityInstanceId>` — matches `RecordId`'s structural
+// shape (the brand in `@auxx/types`). Used to detect link URLs that the LLM
+// (or markdown-paste flow) means as `reference` inline nodes, not real URLs.
+const RECORD_ID_RE = /^[a-zA-Z][a-zA-Z0-9_-]*:[\w.-]+$/
+
+// `@[id]` tokens need to round-trip through remark untouched. Remark-directive
+// treats `:` as the textDirective sigil, so `@[user:abc]` would parse as
+// `@[user` + directive(:abc) + `]`. Pre-substitute references with a Private
+// Use Area token, run remark, then resolve tokens back to reference nodes in
+// `pushTextSplit`. PUA chars (U+E000..U+F8FF) are guaranteed-opaque text.
+const REF_TOKEN_OPEN = ''
+const REF_TOKEN_CLOSE = ''
+const REF_TOKEN_RE = new RegExp(`${REF_TOKEN_OPEN}(\\d+)${REF_TOKEN_CLOSE}`, 'g')
+
+// URL schemes that look RecordId-shaped but are real protocols. Keep in sync
+// with anything else the markdown surface needs to accept verbatim.
+const REAL_URL_SCHEMES = new Set([
+  'http',
+  'https',
+  'mailto',
+  'ftp',
+  'tel',
+  'sms',
+  'data',
+  'blob',
+  'file',
+  'ws',
+  'wss',
+  'chrome',
+  'about',
+])
+
+function isReferenceUrl(url: string): boolean {
+  if (!RECORD_ID_RE.test(url)) return false
+  const scheme = url.slice(0, url.indexOf(':')).toLowerCase()
+  return !REAL_URL_SCHEMES.has(scheme)
+}
 
 const parser = unified().use(remarkParse).use(remarkGfm).use(remarkDirective)
 
@@ -39,7 +78,9 @@ export function mdToBlocks(markdown: string): ArticleNodeJSON[] {
   const cleaned = stripFrontmatter(markdown ?? '')
   if (!cleaned.trim()) return emptyContent()
 
-  const tree = parser.parse(cleaned) as MdastRoot
+  const { source, references } = preExtractReferences(cleaned)
+
+  const tree = parser.parse(source) as MdastRoot
   const ctx: ParseCtx = { nodes: [] }
   // Buffer for consecutive `<details>` HTML siblings so we can merge them
   // into a single accordion block (Q6d).
@@ -74,7 +115,66 @@ export function mdToBlocks(markdown: string): ArticleNodeJSON[] {
   }
   flushDetails()
   if (ctx.nodes.length === 0) return emptyContent()
+  if (references.length > 0) substituteReferences(ctx.nodes, references)
   return ctx.nodes
+}
+
+// ─── reference pre-substitution ──────────────────────────────────────
+
+function preExtractReferences(markdown: string): { source: string; references: string[] } {
+  const references: string[] = []
+  const source = markdown.replace(REFERENCE_AT_RE, (_match, id: string) => {
+    const idx = references.length
+    references.push(id)
+    return `${REF_TOKEN_OPEN}${idx}${REF_TOKEN_CLOSE}`
+  })
+  return { source, references }
+}
+
+function substituteReferences(nodes: ArticleNodeJSON[], pool: string[]): void {
+  for (const node of nodes) {
+    if (node.type === 'block') {
+      node.content = expandReferencesInInline(node.content ?? [], pool)
+    } else if (node.type === 'table') {
+      for (const row of node.content) {
+        for (const cell of row.content) substituteReferences(cell.content, pool)
+      }
+    } else if (node.type === 'tabs' || node.type === 'accordion') {
+      for (const panel of node.content) substituteReferences(panel.content, pool)
+    }
+  }
+}
+
+function expandReferencesInInline(inline: InlineJSON[], pool: string[]): InlineJSON[] {
+  const out: InlineJSON[] = []
+  for (const node of inline) {
+    if (node.type !== 'text' || typeof node.text !== 'string') {
+      out.push(node)
+      continue
+    }
+    if (!node.text.includes(REF_TOKEN_OPEN)) {
+      out.push(node)
+      continue
+    }
+    const marks = node.marks ?? []
+    const re = new RegExp(REF_TOKEN_RE.source, 'g')
+    let lastIndex = 0
+    let match: RegExpExecArray | null = re.exec(node.text)
+    while (match) {
+      if (match.index > lastIndex) {
+        out.push(makeText(node.text.slice(lastIndex, match.index), marks))
+      }
+      const idx = Number.parseInt(match[1], 10)
+      const id = pool[idx]
+      if (id) out.push({ type: 'reference', attrs: { id } })
+      lastIndex = match.index + match[0].length
+      match = re.exec(node.text)
+    }
+    if (lastIndex < node.text.length) {
+      out.push(makeText(node.text.slice(lastIndex), marks))
+    }
+  }
+  return out
 }
 
 interface ParseCtx {
@@ -381,7 +481,16 @@ function walkInline(node: MdastNode, marks: MarkJSON[], out: InlineJSON[]): void
       return
     }
     case 'link': {
-      const linkMark: MarkJSON = { type: 'link', attrs: { href: node.url ?? '' } }
+      const url = node.url ?? ''
+      // Links whose href is a `RecordId` (e.g. `[Settings](user:abc)`) are
+      // collapsed into a single `reference` inline node — the editor renders
+      // a chip and the round-trip from `blocksToMd` already emits this shape.
+      // Real-looking URLs (http(s), mailto, etc.) keep the link mark.
+      if (isReferenceUrl(url)) {
+        out.push({ type: 'reference', attrs: { id: url } })
+        return
+      }
+      const linkMark: MarkJSON = { type: 'link', attrs: { href: url } }
       for (const c of node.children ?? []) walkInline(c, addMark(marks, linkMark), out)
       return
     }
@@ -424,7 +533,10 @@ function walkInline(node: MdastNode, marks: MarkJSON[], out: InlineJSON[]): void
 
 function pushTextSplit(text: string, marks: MarkJSON[], out: InlineJSON[]): void {
   if (!text) return
-  // Split out {{placeholder}} segments.
+  // Split out {{placeholder}} segments. `@[id]` reference tokens are
+  // pre-substituted to PUA markers in `mdToBlocks` and expanded back in a
+  // post-pass (`substituteReferences`) — they pass through here as opaque
+  // text.
   let lastIndex = 0
   const re = new RegExp(PLACEHOLDER_RE.source, 'g')
   let match: RegExpExecArray | null = re.exec(text)

--- a/packages/ui/src/components/tree-row.tsx
+++ b/packages/ui/src/components/tree-row.tsx
@@ -38,8 +38,6 @@ export interface TreeRowProps {
    */
   children?: React.ReactNode
 
-  /** Dimmed/exclude visual state. */
-  dimmed?: boolean
   /** Class for the outer container. */
   className?: string
   /** Class for the single-line row itself. */
@@ -66,7 +64,6 @@ export function TreeRow({
   onToggleOpen,
   onTitleClick,
   children,
-  dimmed,
   className,
   rowClassName,
 }: TreeRowProps) {
@@ -106,7 +103,6 @@ export function TreeRow({
             'group/tree-row flex items-center justify-between rounded-md text-sm px-1',
             'text-muted-foreground hover:bg-background',
             expandable && 'cursor-pointer',
-            dimmed && 'opacity-60',
             rowClassName
           )}
           onClick={expandable ? onToggleOpen : undefined}>


### PR DESCRIPTION
## Summary

- **Markdown persona prompts** — `set_agent_prompt` now takes markdown (parsed via `mdToBlocks`) instead of TiptapJSON. `mdToBlocks` learns `@[recordId]` inline references and collapses RecordId-shaped link URLs into reference nodes (round-trips via `blocksToMd`).
- **`set_agent_triggers` builder tool** — wired into the agents-builder capability set so the LLM can configure scheduled / event triggers in-flow.
- **Server-side setup precondition** — `completeAgentSetup` rejects until prompt + ≥1 toolset + name are present; the tool surfaces the precondition as a tool error so the model can recover within the turn instead of erroring out.
- **Persona prompt re-ordered** — substantive config (toolsets / knowledge / prompt / triggers) before personalization (name / avatar / tone), matching the preferred onboarding flow.
- **Query loop guardrail** — bails the turn after 3 consecutive iterations of the same failing tool (prevents silent budget burn on malformed inputs).
- **Reference picker `tools` tab** — opt-in extra tab (persona editor only) with `ToolsetBadge` + `ToolsetReferenceList`. Tab list, digit shortcuts, and Tab cycling are now configurable; default tabs unchanged for customer-facing surfaces.
- **Knowledge scope inherited state** — rows render `inherited_*` modes distinctly and hide the trash button when no explicit rule exists.

## Test plan

- [ ] Build a fresh agent in chat — verify the model authors the prompt as markdown, including `@[toolset:…]` chips that render as `ToolsetBadge` pills
- [ ] Try `complete_agent_setup` before adding a toolset / prompt / name — model should get a tool error and recover
- [ ] Ask the builder to add a scheduled trigger; confirm it lands via `set_agent_triggers`
- [ ] In the persona editor, type `@` and confirm the Tools tab appears, digit `5` jumps to it, Tab cycles include it
- [ ] In a customer-facing editor (mail composer / KB), confirm `@` picker still shows only the four default tabs
- [ ] Open an agent's knowledge tree with inherited rows — toggle/trash should behave per `inherited_*` rules
- [ ] `pnpm test` for `packages/lib` (covers new round-trip cases) and `apps/web` knowledge tests