### PR TITLE
feat(editor): shared slash-commands module + persona bubble menu

### DIFF
--- a/apps/web/src/components/agents/ui/detail/prompt/persona-editor-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/prompt/persona-editor-content.tsx
@@ -1,52 +1,203 @@
 // apps/web/src/components/agents/ui/detail/prompt/persona-editor-content.tsx
 'use client'
 
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@auxx/ui/components/input-group'
+import { Popover, PopoverAnchor, PopoverContentDialogAware } from '@auxx/ui/components/popover'
+import type { JSONContent } from '@tiptap/core'
 import type { Editor } from '@tiptap/react'
 import { EditorContent } from '@tiptap/react'
-import { memo, useRef } from 'react'
-import { type ActivePickerState, InlinePickerPopover } from '~/components/editor/inline-picker'
-import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
+import { Link as LinkIcon } from 'lucide-react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import {
-  ReferencePickerContent,
-  type ReferencePickerHandle,
-} from '~/components/pickers/reference-picker/reference-picker-content'
-import CollapseWrap from '~/components/workflow/ui/collapse-wrap'
+  EditorBubbleMenu,
+  InlineMarksSection,
+  KBBlockSection,
+  LinkButton,
+  TurnIntoSection,
+} from '~/components/editor/bubble-menu'
+import {
+  InlinePickerPopover,
+  useActivePicker,
+  useSlashCommand,
+} from '~/components/editor/inline-picker'
+import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
+import { useRichTextEditor } from '~/components/editor/rich-text/use-rich-text-editor'
+import { BasicSlashCommandPicker } from '~/components/editor/slash-commands/basic-slash-command-picker'
+import type { ReferencePickerHandle } from '~/components/pickers/reference-picker/reference-picker-content'
+import { ReferencePickerContent } from '~/components/pickers/reference-picker/reference-picker-content'
+import styles from './persona-editor.module.css'
 
 interface PersonaEditorContentProps {
-  editor: Editor | null
-  isExpanded: boolean
-  collapsedMinHeight: number
-  isCollapsed: boolean
-  setCollapsed: (collapsed: boolean) => void
-  activePicker: ActivePickerState | null
-  referencePickerRef: React.RefObject<ReferencePickerHandle | null>
+  /** Snapshot read on mount. Subsequent `agent.prompt` changes don't re-init the editor. */
+  initialContent: JSONContent[] | null
+  onChange: (content: { json: JSONContent; html: string }) => void
   /**
-   * Tabs the picker exposes — must match the `referenceTabs` passed to the
-   * paired `useRichTextEditor` so digit shortcuts and Tab cycling stay in
-   * sync with the visible strip.
+   * Fired with the new editor on mount and `null` on unmount. The parent
+   * uses this to drive header widgets (character count, copy) and to keep
+   * focus state in sync with whichever editor is currently active.
    */
+  onEditorReady: (editor: Editor | null) => void
+  onFocusChange: (focused: boolean) => void
+  /** Called on focus — parent uses this to expand the collapsed card. */
+  onUserActivity?: () => void
+  /** Shared across instances so the same picker handle can drive arrow keys. */
+  referencePickerRef: React.RefObject<ReferencePickerHandle | null>
   referenceTabs?: ReferenceTab[]
 }
 
+interface LinkPopoverState {
+  rect: DOMRect
+  range: { from: number; to: number }
+  initialHref: string
+  selectedText: string
+}
+
+/**
+ * Owns a single TipTap editor instance. The parent (`PersonaEditor`)
+ * mounts one of these in the card and a separate one in the expanded
+ * dialog — never both at once. Each mount creates a fresh editor from
+ * `initialContent`; the parent keeps the latest doc in state so the
+ * next mount picks up where the previous left off.
+ *
+ * This mirrors the workflow `PromptEditor` pattern. Trying to share one
+ * editor instance across two render locations breaks TipTap (its
+ * `EditorContent` calls `flushSync` from `componentDidMount`, which
+ * fires again when React reparents the subtree).
+ */
 export const PersonaEditorContent = memo(function PersonaEditorContent({
-  editor,
-  isExpanded,
-  collapsedMinHeight,
-  isCollapsed,
-  setCollapsed,
-  activePicker,
+  initialContent,
+  onChange,
+  onEditorReady,
+  onFocusChange,
+  onUserActivity,
   referencePickerRef,
   referenceTabs,
 }: PersonaEditorContentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
+  const [linkPopover, setLinkPopover] = useState<LinkPopoverState | null>(null)
 
-  const editorNode = (
-    <div ref={containerRef} className='relative flex-1 min-h-0 flex w-full'>
+  const slashCommand = useSlashCommand()
+
+  const onPickerEnter = useCallback(
+    () => referencePickerRef.current?.confirmHighlighted() ?? false,
+    [referencePickerRef]
+  )
+  const onPickerArrowVertical = useCallback(
+    (dir: 1 | -1) => referencePickerRef.current?.moveHighlight(dir) ?? false,
+    [referencePickerRef]
+  )
+
+  const { editor } = useRichTextEditor({
+    initialContent,
+    onChange,
+    slashCommand,
+    enableReferencePicker: true,
+    onPickerEnter,
+    onPickerArrowVertical,
+    referenceTabs,
+  })
+
+  const activePicker = useActivePicker(editor)
+
+  // Surface the editor instance to the parent so header widgets (character
+  // count, copy button) track whichever instance is currently mounted.
+  useEffect(() => {
+    onEditorReady(editor)
+    return () => onEditorReady(null)
+  }, [editor, onEditorReady])
+
+  useEffect(() => {
+    if (!editor) return
+    const onFocusEvt = () => {
+      onFocusChange(true)
+      onUserActivity?.()
+    }
+    const onBlurEvt = () => onFocusChange(false)
+    editor.on('focus', onFocusEvt)
+    editor.on('blur', onBlurEvt)
+    return () => {
+      editor.off('focus', onFocusEvt)
+      editor.off('blur', onBlurEvt)
+    }
+  }, [editor, onFocusChange, onUserActivity])
+
+  const handlePersonaLinkRequest = useCallback(() => {
+    if (!editor) return
+    const { from, to } = editor.state.selection
+    if (from === to) return
+    const selectedText = editor.state.doc.textBetween(from, to, ' ')
+    const linkType = editor.schema.marks.link
+    const existing = linkType ? editor.getAttributes('link') : null
+    const existingHref = typeof existing?.href === 'string' ? existing.href : ''
+    const start = editor.view.coordsAtPos(from)
+    const end = editor.view.coordsAtPos(to)
+    const rect = new DOMRect(
+      Math.min(start.left, end.left),
+      Math.min(start.top, end.top),
+      Math.max(1, Math.max(start.right, end.right) - Math.min(start.left, end.left)),
+      Math.max(1, Math.max(start.bottom, end.bottom) - Math.min(start.top, end.top))
+    )
+    setLinkPopover({
+      rect,
+      range: { from, to },
+      initialHref: existingHref,
+      selectedText,
+    })
+  }, [editor])
+
+  const handleApplyLink = useCallback(
+    (href: string) => {
+      if (!editor || !linkPopover) return
+      const trimmed = href.trim()
+      if (!trimmed) return
+      const mark = { type: 'link', attrs: { href: trimmed, target: '_blank' } }
+      const text = linkPopover.selectedText || trimmed
+      const node = { type: 'text', text, marks: [mark] }
+      editor
+        .chain()
+        .focus()
+        .insertContentAt(linkPopover.range, node)
+        // Strip the stored link mark so the next typed character isn't linked.
+        .command(({ tr }) => {
+          tr.removeStoredMark(editor.schema.marks.link)
+          return true
+        })
+        .run()
+      setLinkPopover(null)
+    },
+    [editor, linkPopover]
+  )
+
+  return (
+    <div ref={containerRef} className={`${styles.editor} relative flex-1 min-h-0 flex w-full`}>
       <EditorContent
         editor={editor}
         className='prose prose-sm max-w-none dark:prose-invert w-full [&_.ProseMirror]:outline-none [&_.ProseMirror]:focus:outline-none [&_.ProseMirror-focused]:outline-none focus:outline-none'
       />
+      <EditorBubbleMenu
+        editor={editor}
+        renderBlockSection={({ editor }) => <KBBlockSection editor={editor} />}
+        renderTurnInto={({ editor }) => <TurnIntoSection editor={editor} />}
+        renderInlineMarks={({ editor }) => <InlineMarksSection editor={editor} />}
+        renderLink={({ editor }) => (
+          <LinkButton editor={editor} onRequest={handlePersonaLinkRequest} />
+        )}
+      />
+      <InlinePickerPopover
+        state={slashCommand.suggestionState}
+        onClose={slashCommand.closePicker}
+        width={288}>
+        <BasicSlashCommandPicker
+          query={slashCommand.suggestionState.query}
+          onExecute={slashCommand.executeCommand}
+          onClose={slashCommand.closePicker}
+        />
+      </InlinePickerPopover>
       <InlinePickerPopover
         state={{
           isOpen: !!activePicker,
@@ -75,31 +226,75 @@ export const PersonaEditorContent = memo(function PersonaEditorContent({
           tabs={referenceTabs}
         />
       </InlinePickerPopover>
+      <PersonaLinkPopover
+        open={linkPopover !== null}
+        anchorRect={linkPopover?.rect ?? null}
+        initialHref={linkPopover?.initialHref ?? ''}
+        onApply={handleApplyLink}
+        onClose={() => setLinkPopover(null)}
+      />
     </div>
   )
+})
 
-  if (isExpanded) {
-    return (
-      <div className='h-full pb-0'>
-        <ScrollArea
-          className='relative h-full min-h-0 px-3 flex-1 flex'
-          fadeClassName=''
-          allowScrollChaining
-          scrollbarClassName='w-1 mr-0.5 data-[hovering]:opacity-0 hover:!opacity-100'>
-          {editorNode}
-        </ScrollArea>
-      </div>
-    )
-  }
+// Minimal URL-only link popover for persona — no internal article search,
+// admins either paste a URL or cancel. Modeled on `ArticleLinkPopover` for
+// the virtual-anchor + dialog-aware portal behavior.
+function PersonaLinkPopover({
+  open,
+  anchorRect,
+  initialHref,
+  onApply,
+  onClose,
+}: {
+  open: boolean
+  anchorRect: DOMRect | null
+  initialHref: string
+  onApply: (href: string) => void
+  onClose: () => void
+}) {
+  const virtualRef = useRef<{ getBoundingClientRect: () => DOMRect }>({
+    getBoundingClientRect: () => anchorRect ?? new DOMRect(),
+  })
+  virtualRef.current.getBoundingClientRect = () => anchorRect ?? new DOMRect()
+
+  const [draft, setDraft] = useState(initialHref)
+
+  useEffect(() => {
+    if (open) setDraft(initialHref)
+  }, [open, initialHref])
 
   return (
-    <CollapseWrap
-      minHeight={collapsedMinHeight}
-      isCollapsed={isCollapsed}
-      onCollapsedChange={setCollapsed}
-      className='px-3'
-      gradientClassName='from-primary-200/30 dark:from-primary-200/30'>
-      <div className='relative flex w-full'>{editorNode}</div>
-    </CollapseWrap>
+    <Popover open={open} onOpenChange={(o) => !o && onClose()}>
+      <PopoverAnchor virtualRef={virtualRef} />
+      <PopoverContentDialogAware side='bottom' align='start' sideOffset={6} className='w-80 p-2'>
+        <InputGroup>
+          <InputGroupAddon align='inline-start'>
+            <LinkIcon />
+          </InputGroupAddon>
+          <InputGroupInput
+            autoFocus
+            placeholder='https://example.com'
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                onApply(draft)
+              }
+              if (e.key === 'Escape') {
+                e.preventDefault()
+                onClose()
+              }
+            }}
+          />
+          <InputGroupAddon align='inline-end'>
+            <InputGroupButton size='xs' onClick={() => onApply(draft)} disabled={!draft.trim()}>
+              Apply
+            </InputGroupButton>
+          </InputGroupAddon>
+        </InputGroup>
+      </PopoverContentDialogAware>
+    </Popover>
   )
-})
+}

--- a/apps/web/src/components/agents/ui/detail/prompt/persona-editor.module.css
+++ b/apps/web/src/components/agents/ui/detail/prompt/persona-editor.module.css
@@ -1,0 +1,41 @@
+/* apps/web/src/components/agents/ui/detail/prompt/persona-editor.module.css */
+
+/*
+ * Persona-editor density overrides. The block renderer
+ * (`components/editor/kb-article/block-node-view.module.css`) reads
+ * `--editor-*` variables with inline defaults; setting them here
+ * retones the persona editor without forking the renderer.
+ */
+
+.editor {
+  /* Headings — section-label scale, not article-heading scale */
+  --editor-h1-font-size: 16px;
+  --editor-h1-line-height: 22px;
+  --editor-h1-margin-top: 0.75rem;
+  --editor-h1-margin-bottom: 0.25rem;
+
+  --editor-h2-font-size: 14px;
+  --editor-h2-line-height: 20px;
+  --editor-h2-margin-top: 0.625rem;
+  --editor-h2-margin-bottom: 0.25rem;
+
+  --editor-h3-font-size: 13px;
+  --editor-h3-line-height: 18px;
+  --editor-h3-margin-top: 0.5rem;
+  --editor-h3-margin-bottom: 0.125rem;
+
+  /* Pull blocks left — persona card has no left rail to fill. Zero the
+     KB-style negative margin and shrink the gutter so the content column
+     sits flush against the card padding. */
+  --editor-gutter-min-width: 0px;
+  --editor-gutter-margin-right: 0.375rem;
+  --editor-gutter-pull-left: 0;
+
+  /* Tighter indent step — narrow column */
+  --editor-indent-step: 1rem;
+  --editor-indicator-offset: 1.25rem;
+
+  /* Compact indicators */
+  --editor-indicator-size: 1.25rem;
+  --editor-indicator-font-size: 0.8125rem;
+}

--- a/apps/web/src/components/agents/ui/detail/prompt/persona-editor.tsx
+++ b/apps/web/src/components/agents/ui/detail/prompt/persona-editor.tsx
@@ -2,14 +2,16 @@
 'use client'
 
 import { Dialog, DialogContent, DialogTitle } from '@auxx/ui/components/dialog'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { VisuallyHidden } from '@auxx/ui/components/visually-hidden'
 import { cn } from '@auxx/ui/lib/utils'
 import type { JSONContent } from '@tiptap/core'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { DEFAULT_TABS, useActivePicker } from '~/components/editor/inline-picker'
+import type { Editor } from '@tiptap/react'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { DEFAULT_TABS } from '~/components/editor/inline-picker'
 import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
-import { useRichTextEditor } from '~/components/editor/rich-text/use-rich-text-editor'
 import type { ReferencePickerHandle } from '~/components/pickers/reference-picker/reference-picker-content'
+import CollapseWrap from '~/components/workflow/ui/collapse-wrap'
 import { useAgentAutosave } from '../../../hooks/use-agent-autosave'
 import type { AgentDetail } from '../../../store/agent-store'
 import type { AutosaveState } from '../../shared/autosave-indicator'
@@ -42,10 +44,19 @@ function readPromptContent(
 /**
  * Persona prompt editor for the agent detail page. Visual structure mirrors
  * the workflow `PromptEditor` (focus-gradient border, header with copy +
- * expand actions, resizable content, expand-to-dialog). Mounts
- * `useRichTextEditor` with the inline `@`-mention picker so admins can drop
- * references to records, actors, threads, and KB articles inline in the
- * persona doc.
+ * expand actions, resizable content, expand-to-dialog).
+ *
+ * Two-editor pattern: the card and the expanded dialog each mount their own
+ * `PersonaEditorContent` (with its own `useRichTextEditor` call). Only one
+ * is mounted at a time — toggling `isExpanded` unmounts one and mounts the
+ * other. `currentDocRef` holds the live document so the next editor inits
+ * from where the previous left off (the autosave debounce window is too
+ * long to rely on `agent.prompt` for cross-mount handoff).
+ *
+ * A single editor instance does not work here — TipTap's `EditorContent`
+ * runs `flushSync` in `componentDidMount`, which React re-fires whenever
+ * the subtree's host changes (portal target swap or simple reparenting),
+ * leaving the view DOM in a broken state.
  */
 export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
   const referencePickerRef = useRef<ReferencePickerHandle | null>(null)
@@ -56,19 +67,19 @@ export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
   const [isCollapsed, setCollapsed] = useState(true)
   const [isCopied, setIsCopied] = useState(false)
 
+  // The doc each child editor reads on mount. We keep it in a ref so live
+  // edits don't cause `PersonaEditorContent` to re-render with a new prop
+  // (TipTap's `useEditor` reads `initialContent` once, but changing the
+  // prop identity would still re-render the wrapper unnecessarily).
   const initialContent = useMemo(() => readPromptContent(agent.prompt), [agent.prompt])
+  const currentDocRef = useRef<JSONContent[] | null>(initialContent)
 
-  const onPickerEnter = useCallback(
-    () => referencePickerRef.current?.confirmHighlighted() ?? false,
-    []
-  )
-  const onPickerArrowVertical = useCallback(
-    (dir: 1 | -1) => referencePickerRef.current?.moveHighlight(dir) ?? false,
-    []
-  )
+  const [activeEditor, setActiveEditor] = useState<Editor | null>(null)
 
   const handleChange = useCallback(
     ({ json }: { json: JSONContent; html: string }) => {
+      const content = Array.isArray(json.content) ? (json.content as JSONContent[]) : null
+      currentDocRef.current = content
       // 1500ms matches the KB article editor's autosave window. Pairs with
       // the prompt-only fast path in `useAgentMutations.updateAgent` that
       // splices the cache instead of invalidating, so each flush is cheap.
@@ -77,45 +88,27 @@ export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
     [patch]
   )
 
-  const { editor } = useRichTextEditor({
-    initialContent,
-    onChange: handleChange,
-    enableReferencePicker: true,
-    onPickerEnter,
-    onPickerArrowVertical,
-    referenceTabs: PERSONA_REFERENCE_TABS,
-  })
+  const handleEditorReady = useCallback((editor: Editor | null) => {
+    setActiveEditor(editor)
+  }, [])
 
-  const activePicker = useActivePicker(editor)
-
-  useEffect(() => {
-    if (!editor) return
-    const onFocusEvt = () => {
-      setFocused(true)
-      setCollapsed(false)
-    }
-    const onBlurEvt = () => setFocused(false)
-    editor.on('focus', onFocusEvt)
-    editor.on('blur', onBlurEvt)
-    return () => {
-      editor.off('focus', onFocusEvt)
-      editor.off('blur', onBlurEvt)
-    }
-  }, [editor])
+  const handleUserActivity = useCallback(() => {
+    setCollapsed(false)
+  }, [])
 
   const handleCopy = useCallback(() => {
-    if (!editor) return
-    const text = editor.getText()
+    if (!activeEditor) return
+    const text = activeEditor.getText()
     if (navigator.clipboard) {
       navigator.clipboard.writeText(text)
     }
     setIsCopied(true)
     setTimeout(() => setIsCopied(false), 2000)
-  }, [editor])
+  }, [activeEditor])
 
   // Stable element so the memoized header doesn't see a new `countSlot`
   // prop every time PersonaEditor re-renders (focus/blur, autosave state).
-  const countSlot = useMemo(() => <PersonaCharacterCount editor={editor} />, [editor])
+  const countSlot = useMemo(() => <PersonaCharacterCount editor={activeEditor} />, [activeEditor])
 
   const header = (
     <PersonaEditorHeader
@@ -128,30 +121,38 @@ export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
     />
   )
 
-  const content = (
-    <PersonaEditorContent
-      editor={editor}
-      isExpanded={isExpanded}
-      collapsedMinHeight={COLLAPSED_MIN_HEIGHT}
-      isCollapsed={isCollapsed}
-      setCollapsed={setCollapsed}
-      activePicker={activePicker}
-      referencePickerRef={referencePickerRef}
-      referenceTabs={PERSONA_REFERENCE_TABS}
-    />
-  )
-
   return (
     <>
       <div
         className={cn(
           'me-1',
-          isFocused ? 'bg-gradient-to-r from-[#0ba5ec] to-[#155aef]' : 'bg-transparent',
+          isFocused && !isExpanded
+            ? 'bg-gradient-to-r from-[#0ba5ec] to-[#155aef]'
+            : 'bg-transparent',
           '!rounded-[9px] p-0.5'
         )}>
         <div className={cn(isFocused ? 'bg-background' : 'bg-primary-200/30', 'rounded-lg border')}>
           {header}
-          {!isExpanded && content}
+          {!isExpanded && (
+            <CollapseWrap
+              minHeight={COLLAPSED_MIN_HEIGHT}
+              isCollapsed={isCollapsed}
+              onCollapsedChange={setCollapsed}
+              className='px-3'
+              gradientClassName='from-primary-200/30 dark:from-primary-200/30'>
+              <div className='relative flex w-full'>
+                <PersonaEditorContent
+                  initialContent={currentDocRef.current}
+                  onChange={handleChange}
+                  onEditorReady={handleEditorReady}
+                  onFocusChange={setFocused}
+                  onUserActivity={handleUserActivity}
+                  referencePickerRef={referencePickerRef}
+                  referenceTabs={PERSONA_REFERENCE_TABS}
+                />
+              </div>
+            </CollapseWrap>
+          )}
         </div>
       </div>
 
@@ -161,7 +162,25 @@ export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
             <DialogTitle>Persona</DialogTitle>
           </VisuallyHidden>
           <div className='shrink-0 border-b'>{header}</div>
-          <div className='flex-1 min-h-0 overflow-hidden'>{content}</div>
+          <div className='flex-1 min-h-0 overflow-hidden'>
+            <ScrollArea
+              className='relative h-full min-h-0 px-3 flex-1 flex'
+              fadeClassName=''
+              allowScrollChaining
+              scrollbarClassName='w-1 mr-0.5 data-[hovering]:opacity-0 hover:!opacity-100'>
+              {isExpanded && (
+                <PersonaEditorContent
+                  initialContent={currentDocRef.current}
+                  onChange={handleChange}
+                  onEditorReady={handleEditorReady}
+                  onFocusChange={setFocused}
+                  onUserActivity={handleUserActivity}
+                  referencePickerRef={referencePickerRef}
+                  referenceTabs={PERSONA_REFERENCE_TABS}
+                />
+              )}
+            </ScrollArea>
+          </div>
         </DialogContent>
       </Dialog>
     </>

--- a/apps/web/src/components/editor/kb-article/block-node-view.module.css
+++ b/apps/web/src/components/editor/kb-article/block-node-view.module.css
@@ -1,5 +1,32 @@
 /* apps/web/src/components/editor/kb-article/block-node-view.module.css */
 
+/* ============================================
+   Density variables (all optional — defaults inline via `var(name, default)`).
+   Override on an ancestor of `.blockWrapper` (e.g. the editor's outer div)
+   to retheme without forking this file.
+
+   Gutter / left rail:
+     --editor-gutter-min-width      (24px)
+     --editor-gutter-margin-right   (0.75rem)
+   Body text:
+     --editor-text-font-size        (0.875rem)
+     --editor-text-line-height      (24px)
+     --editor-text-letter-spacing   (-0.01em)
+   Headings (h1/h2/h3):
+     --editor-h{1,2,3}-font-size    (24px / 20px / 16px)
+     --editor-h{1,2,3}-line-height  (28px / 24px / 24px)
+     --editor-h{1,2,3}-margin-top   (1.5rem / 1.25rem / 1rem)
+     --editor-h{1,2,3}-margin-bottom (0.5rem / 0.375rem / 0.25rem)
+     --editor-heading-font-weight   (600)
+   Indent / nesting:
+     --editor-indent-step           (1.5rem; multiplied per level)
+     --editor-indicator-offset      (1.75rem; placeholder offset past indicator)
+   Indicators (bullet/number/todo):
+     --editor-indicator-size        (1.5rem)
+     --editor-indicator-font-size   (0.875rem)
+     --editor-todo-checkbox-size    (14px)
+   ============================================ */
+
 .blockWrapper {
   position: relative;
   overflow: visible;
@@ -35,9 +62,9 @@
 
 .lineGutter {
   flex-shrink: 0;
-  min-width: var(--gutter-min-width, 24px);
+  min-width: var(--editor-gutter-min-width, 24px);
   padding: 0 0.25rem;
-  margin-right: 0.75rem;
+  margin-right: var(--editor-gutter-margin-right, 0.75rem);
   user-select: none;
   display: flex;
   align-items: flex-start;
@@ -175,9 +202,9 @@
 .blockContent {
   flex: 1 1 0%;
   min-width: 0;
-  line-height: 24px;
-  font-size: 0.875rem;
-  letter-spacing: -0.01em;
+  line-height: var(--editor-text-line-height, 24px);
+  font-size: var(--editor-text-font-size, 0.875rem);
+  letter-spacing: var(--editor-text-letter-spacing, -0.01em);
   color: var(--color-foreground);
   overflow-wrap: break-word;
   word-break: break-word;
@@ -262,8 +289,8 @@
    ============================================ */
 
 .blockContainer--heading1 {
-  margin-top: 1.5rem;
-  margin-bottom: 0.5rem;
+  margin-top: var(--editor-h1-margin-top, 1.5rem);
+  margin-bottom: var(--editor-h1-margin-bottom, 0.5rem);
 }
 
 .blockContainer--heading1:first-child {
@@ -271,16 +298,16 @@
 }
 
 .blockContent--heading1 {
-  font-size: 24px;
-  font-weight: 600;
+  font-size: var(--editor-h1-font-size, 24px);
+  font-weight: var(--editor-heading-font-weight, 600);
   color: var(--color-foreground);
-  line-height: 28px;
-  letter-spacing: -0.01em;
+  line-height: var(--editor-h1-line-height, 28px);
+  letter-spacing: var(--editor-h1-letter-spacing, -0.01em);
 }
 
 .blockContainer--heading2 {
-  margin-top: 1.25rem;
-  margin-bottom: 0.375rem;
+  margin-top: var(--editor-h2-margin-top, 1.25rem);
+  margin-bottom: var(--editor-h2-margin-bottom, 0.375rem);
 }
 
 .blockContainer--heading2:first-child {
@@ -288,16 +315,16 @@
 }
 
 .blockContent--heading2 {
-  font-size: 20px;
-  font-weight: 600;
+  font-size: var(--editor-h2-font-size, 20px);
+  font-weight: var(--editor-heading-font-weight, 600);
   color: var(--color-foreground);
-  line-height: 24px;
-  letter-spacing: -0.015em;
+  line-height: var(--editor-h2-line-height, 24px);
+  letter-spacing: var(--editor-h2-letter-spacing, -0.015em);
 }
 
 .blockContainer--heading3 {
-  margin-top: 1rem;
-  margin-bottom: 0.25rem;
+  margin-top: var(--editor-h3-margin-top, 1rem);
+  margin-bottom: var(--editor-h3-margin-bottom, 0.25rem);
 }
 
 .blockContainer--heading3:first-child {
@@ -305,11 +332,11 @@
 }
 
 .blockContent--heading3 {
-  font-size: 16px;
-  font-weight: 600;
+  font-size: var(--editor-h3-font-size, 16px);
+  font-weight: var(--editor-heading-font-weight, 600);
   color: var(--color-foreground);
-  line-height: 24px;
-  letter-spacing: -0.015em;
+  line-height: var(--editor-h3-line-height, 24px);
+  letter-spacing: var(--editor-h3-letter-spacing, -0.015em);
 }
 
 /* ============================================
@@ -324,41 +351,41 @@
 }
 
 .blockWrapper[data-indent-level='2'] .blockContentWrapper {
-  padding-left: 1.5rem;
+  padding-left: calc(var(--editor-indent-step, 1.5rem) * 1);
 }
 .blockWrapper[data-indent-level='2'] {
-  --indent-offset: 1.5rem;
+  --editor-indent-offset: calc(var(--editor-indent-step, 1.5rem) * 1);
 }
 
 .blockWrapper[data-indent-level='3'] .blockContentWrapper {
-  padding-left: 3rem;
+  padding-left: calc(var(--editor-indent-step, 1.5rem) * 2);
 }
 .blockWrapper[data-indent-level='3'] {
-  --indent-offset: 3rem;
+  --editor-indent-offset: calc(var(--editor-indent-step, 1.5rem) * 2);
 }
 
 .blockWrapper[data-indent-level='4'] .blockContentWrapper {
-  padding-left: 4.5rem;
+  padding-left: calc(var(--editor-indent-step, 1.5rem) * 3);
 }
 .blockWrapper[data-indent-level='4'] {
-  --indent-offset: 4.5rem;
+  --editor-indent-offset: calc(var(--editor-indent-step, 1.5rem) * 3);
 }
 
 .blockWrapper[data-indent-level='5'] .blockContentWrapper {
-  padding-left: 6rem;
+  padding-left: calc(var(--editor-indent-step, 1.5rem) * 4);
 }
 .blockWrapper[data-indent-level='5'] {
-  --indent-offset: 6rem;
+  --editor-indent-offset: calc(var(--editor-indent-step, 1.5rem) * 4);
 }
 
 /* Bullet & number indicators */
 .bulletIndicator,
 .numberIndicator {
   flex-shrink: 0;
-  width: 1.5rem;
-  height: 1.5rem;
-  line-height: 24px;
-  font-size: 0.875rem;
+  width: var(--editor-indicator-size, 1.5rem);
+  height: var(--editor-indicator-size, 1.5rem);
+  line-height: var(--editor-text-line-height, 24px);
+  font-size: var(--editor-indicator-font-size, 0.875rem);
   color: var(--color-muted-foreground);
   user-select: none;
   display: flex;
@@ -372,16 +399,16 @@
 
 .todoCheckbox {
   padding: 0.3125rem;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: var(--editor-indicator-size, 1.5rem);
+  height: var(--editor-indicator-size, 1.5rem);
   display: flex;
   cursor: pointer;
   position: relative;
 }
 
 .todoCheckbox input[type='checkbox'] {
-  width: 14px;
-  height: 14px;
+  width: var(--editor-todo-checkbox-size, 14px);
+  height: var(--editor-todo-checkbox-size, 14px);
   cursor: pointer;
   border-radius: 4px;
   appearance: none;
@@ -441,9 +468,9 @@
 }
 
 .blockContent--quote {
-  font-size: 0.875rem;
-  line-height: 24px;
-  letter-spacing: -0.01em;
+  font-size: var(--editor-text-font-size, 0.875rem);
+  line-height: var(--editor-text-line-height, 24px);
+  letter-spacing: var(--editor-text-letter-spacing, -0.01em);
   color: var(--color-muted-foreground);
   font-style: normal;
 }
@@ -501,13 +528,13 @@
 .placeholder {
   position: absolute;
   top: 0;
-  left: var(--indent-offset, 0px);
+  left: var(--editor-indent-offset, 0px);
   pointer-events: none;
   user-select: none;
   color: var(--color-muted-foreground);
-  line-height: 24px;
-  font-size: 0.875rem;
-  letter-spacing: -0.01em;
+  line-height: var(--editor-text-line-height, 24px);
+  font-size: var(--editor-text-font-size, 0.875rem);
+  letter-spacing: var(--editor-text-letter-spacing, -0.01em);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -520,7 +547,7 @@
 .numberIndicator ~ .placeholder,
 .todoCheckbox ~ .placeholder,
 .quoteBar ~ .placeholder {
-  left: calc(var(--indent-offset, 0px) + 1.75rem);
+  left: calc(var(--editor-indent-offset, 0px) + var(--editor-indicator-offset, 1.75rem));
 }
 
 /* Hide placeholder while dragging blocks. */

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.module.css
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.module.css
@@ -57,8 +57,12 @@
      padding. We intentionally leave the gutter's margin-right (0.75rem) in
      positive space — that becomes the visual breathing room between the
      numbers and the content column, and lines the content up with the title
-     above. */
-  margin-left: calc(var(--gutter-min-width, 24px) * -1);
+     above. Persona/other consumers can zero this out via
+     `--editor-gutter-pull-left: 0` without also resetting the gutter width. */
+  margin-left: var(
+    --editor-gutter-pull-left,
+    calc(var(--editor-gutter-min-width, 24px) * -1)
+  );
 }
 
 .editorContainer {

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
@@ -229,7 +229,9 @@ export function KBArticleEditor({
         className={styles.editorWrapper}
         onMouseDown={handleWrapperMouseDown}
         onContextMenu={handleContextMenu}
-        style={{ '--gutter-min-width': `calc(${gutterCharWidth}ch + 1rem)` } as CSSProperties}>
+        style={
+          { '--editor-gutter-min-width': `calc(${gutterCharWidth}ch + 1rem)` } as CSSProperties
+        }>
         <div className={styles.editorContainer}>
           <EditorContent editor={editor} className={styles.editorContent} />
         </div>

--- a/apps/web/src/components/editor/kb-article/kb-slash-command-picker.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-slash-command-picker.tsx
@@ -2,13 +2,7 @@
 'use client'
 
 import {
-  Command,
   CommandBreadcrumb,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
   CommandNavigation,
   useCommandNavigation,
 } from '@auxx/ui/components/command'
@@ -16,9 +10,18 @@ import { EntityIcon } from '@auxx/ui/components/icons'
 import { generateId } from '@auxx/utils'
 import { TextSelection } from '@tiptap/pm/state'
 import type { Editor } from '@tiptap/react'
-import { ChevronRight } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { PlaceholderPickerContent } from '~/components/editor/placeholders/placeholder-picker-content'
+import {
+  BASIC_BLOCK_COMMANDS,
+  type BlockCommandDef,
+  runBlockCommand,
+} from '~/components/editor/slash-commands/block-commands'
+import {
+  type SlashCommandItem,
+  SlashCommandPicker,
+  type SlashCommandSection,
+} from '~/components/editor/slash-commands/slash-command-picker'
 import { api } from '~/trpc/react'
 
 type Range = { from: number; to: number }
@@ -35,147 +38,9 @@ interface KBSlashCommandPickerProps {
   editor?: Editor | null
 }
 
-interface BlockCommandSpec {
-  blockType:
-    | 'text'
-    | 'heading'
-    | 'bulletListItem'
-    | 'numberedListItem'
-    | 'todoListItem'
-    | 'quote'
-    | 'codeBlock'
-    | 'divider'
-    | 'callout'
-    | 'embed'
-  level?: number | null
-  checked?: boolean
-  calloutVariant?: 'info' | 'tip' | 'warn' | 'error' | 'success'
-}
+// --- KB-only block commands -----------------------------------------------
 
-interface CommandItemDef {
-  id: string
-  title: string
-  description: string
-  keywords: string[]
-  iconId: string
-  drillDown?: boolean
-  spec?: BlockCommandSpec
-  custom?: (editor: Editor, range: Range) => void
-}
-
-const BASE_COMMANDS: CommandItemDef[] = [
-  {
-    id: 'snippet',
-    title: 'Insert snippet',
-    description: 'Search and insert reusable content',
-    keywords: ['template', 'canned', 'saved', 'reusable'],
-    iconId: 'folder',
-    drillDown: true,
-  },
-  {
-    id: 'placeholder',
-    title: 'Insert placeholder',
-    description: 'Insert a dynamic field value',
-    keywords: ['variable', 'token', 'dynamic', 'merge', 'field'],
-    iconId: 'braces',
-    drillDown: true,
-  },
-  {
-    id: 'article-link',
-    title: 'Link to article',
-    description: 'Insert a link to another KB article',
-    keywords: ['link', 'article', 'reference', 'href', 'url'],
-    iconId: 'link',
-  },
-  {
-    id: 'text',
-    title: 'Text',
-    description: 'Plain text block',
-    keywords: ['p', 'paragraph'],
-    iconId: 'text',
-    spec: { blockType: 'text', level: null },
-  },
-  {
-    id: 'h1',
-    title: 'Heading 1',
-    description: 'Big section heading',
-    keywords: ['h1', 'title', 'large'],
-    iconId: 'heading-1',
-    spec: { blockType: 'heading', level: 1 },
-  },
-  {
-    id: 'h2',
-    title: 'Heading 2',
-    description: 'Medium section heading',
-    keywords: ['h2', 'subtitle'],
-    iconId: 'heading-2',
-    spec: { blockType: 'heading', level: 2 },
-  },
-  {
-    id: 'h3',
-    title: 'Heading 3',
-    description: 'Small section heading',
-    keywords: ['h3', 'subheading'],
-    iconId: 'heading-3',
-    spec: { blockType: 'heading', level: 3 },
-  },
-  {
-    id: 'bullet',
-    title: 'Bullet list',
-    description: 'Create a bullet list',
-    keywords: ['ul', 'unordered', 'bullets', 'points'],
-    iconId: 'list',
-    spec: { blockType: 'bulletListItem', level: 1 },
-  },
-  {
-    id: 'numbered',
-    title: 'Numbered list',
-    description: 'Create a numbered list',
-    keywords: ['ol', 'ordered', 'numbers', 'steps'],
-    iconId: 'list-ordered',
-    spec: { blockType: 'numberedListItem', level: 1 },
-  },
-  {
-    id: 'todo',
-    title: 'To-do list',
-    description: 'Track tasks with checkboxes',
-    keywords: ['todo', 'task', 'check', 'checkbox'],
-    iconId: 'check-square',
-    spec: { blockType: 'todoListItem', checked: false },
-  },
-  {
-    id: 'quote',
-    title: 'Quote',
-    description: 'Capture a quote',
-    keywords: ['blockquote', 'cite'],
-    iconId: 'quote',
-    spec: { blockType: 'quote' },
-  },
-  {
-    id: 'code',
-    title: 'Code',
-    description: 'Capture a code block',
-    keywords: ['codeblock', 'code'],
-    iconId: 'code',
-    spec: { blockType: 'codeBlock' },
-  },
-  {
-    id: 'divider',
-    title: 'Divider',
-    description: 'Visual separator',
-    keywords: ['hr', 'horizontal', 'rule', 'line'],
-    iconId: 'minus',
-    custom: (editor, range) => {
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .updateAttributes('block', { blockType: 'divider', level: null, checked: false })
-        .splitBlock()
-        .updateAttributes('block', { blockType: 'text', level: null, checked: false })
-        .run()
-    },
-  },
+const KB_BLOCK_COMMANDS: BlockCommandDef[] = [
   {
     id: 'image',
     title: 'Image',
@@ -359,6 +224,36 @@ const BASE_COMMANDS: CommandItemDef[] = [
   },
 ]
 
+// --- KB-only tool items ---------------------------------------------------
+
+const TOOL_COMMANDS: SlashCommandItem[] = [
+  {
+    id: 'snippet',
+    title: 'Insert snippet',
+    description: 'Search and insert reusable content',
+    keywords: ['template', 'canned', 'saved', 'reusable'],
+    iconId: 'folder',
+    drillDown: true,
+  },
+  {
+    id: 'placeholder',
+    title: 'Insert placeholder',
+    description: 'Insert a dynamic field value',
+    keywords: ['variable', 'token', 'dynamic', 'merge', 'field'],
+    iconId: 'braces',
+    drillDown: true,
+  },
+  {
+    id: 'article-link',
+    title: 'Link to article',
+    description: 'Insert a link to another KB article',
+    keywords: ['link', 'article', 'reference', 'href', 'url'],
+    iconId: 'link',
+  },
+]
+
+const TOOL_IDS = new Set(TOOL_COMMANDS.map((t) => t.id))
+
 function makeEmptyPanelJSON(label: string) {
   return {
     type: 'panel' as const,
@@ -408,6 +303,13 @@ interface SlashCommandNavItem {
   id: string
   label: string
   type: 'snippets' | 'folder'
+}
+
+// Snippet-mode items reuse `SlashCommandItem` plus a `kind` tag so the
+// section's `onSelect` / `onArrowRight` can dispatch without scanning data.
+interface SnippetItem extends SlashCommandItem {
+  kind: 'folder' | 'snippet'
+  folderCount?: number
 }
 
 export function KBSlashCommandPicker(props: KBSlashCommandPickerProps) {
@@ -464,7 +366,6 @@ function KBSlashCommandPickerContent({
   onEnterPlaceholderMode: () => void
 }) {
   const { push, pop, isAtRoot, current, stack } = useCommandNavigation<SlashCommandNavItem>()
-  const inputRef = useRef<HTMLInputElement>(null)
 
   const isInSnippets = stack.length > 0
   const currentFolderId = current?.type === 'folder' ? current.id : null
@@ -484,6 +385,10 @@ function KBSlashCommandPickerContent({
   })
   const allFolders = foldersData?.folders ?? []
 
+  // Mirror the external query into the local controlled input *only at root*.
+  // While drilled into a snippets folder the input doubles as a folder
+  // search field and we don't want the picker plugin (which still receives
+  // typed characters from outside the input) to clobber it.
   useEffect(() => {
     if (isAtRoot) setSearchQuery(query)
   }, [query, isAtRoot, setSearchQuery])
@@ -510,257 +415,230 @@ function KBSlashCommandPickerContent({
     [allFolders, currentFolderId, q]
   )
 
+  // Root-level snippet *search* (cross-folder hits when typing at root) —
+  // rendered as its own section below the suggestions group.
   const rootSnippetResults = useMemo(() => {
     if (!isAtRoot || !q) return []
     return allSnippets.filter((s) => s.title.toLowerCase().includes(q))
   }, [isAtRoot, allSnippets, q])
 
-  const filteredCommands = useMemo(() => {
+  // Build the merged default-mode "Suggestions" list — tools first, then
+  // basic blocks, then KB-only blocks. Preserves the pre-refactor ordering
+  // and rendering as a single CommandGroup.
+  const suggestionItems: SlashCommandItem[] = useMemo(() => {
     if (isInSnippets) return []
-    let base = onLinkArticle ? BASE_COMMANDS : BASE_COMMANDS.filter((c) => c.id !== 'article-link')
-    // Q1b: containers (tabs/accordion/table) cannot be nested inside a panel.
-    // ProseMirror's schema enforces this structurally; filtering here
-    // just keeps the menu clean.
+    const tools = onLinkArticle
+      ? TOOL_COMMANDS
+      : TOOL_COMMANDS.filter((c) => c.id !== 'article-link')
+    let blocks: BlockCommandDef[] = [...BASIC_BLOCK_COMMANDS, ...KB_BLOCK_COMMANDS]
+    // Containers can't nest inside a panel — ProseMirror's schema would
+    // reject the insert, but hiding from the menu keeps it tidy.
     if (editor && selectionIsInsidePanel(editor)) {
-      base = base.filter((c) => !PANEL_RESTRICTED_COMMAND_IDS.has(c.id))
+      blocks = blocks.filter((c) => !PANEL_RESTRICTED_COMMAND_IDS.has(c.id))
     }
-    // Cells reject containers structurally (containerBlock is not in the
-    // `block` group that cells accept) and cards are visually awkward in a
-    // table cell — hide both from the slash menu inside cells.
+    // Cells reject containers structurally and visually push cards around;
+    // hide both inside cells.
     if (editor && selectionIsInsideTableCell(editor)) {
-      base = base.filter((c) => !CELL_RESTRICTED_COMMAND_IDS.has(c.id))
+      blocks = blocks.filter((c) => !CELL_RESTRICTED_COMMAND_IDS.has(c.id))
     }
-    return base.filter(
-      (item) =>
-        item.title.toLowerCase().includes(q) ||
-        item.description.toLowerCase().includes(q) ||
-        item.keywords.some((kw) => kw.includes(q))
-    )
-  }, [isInSnippets, q, onLinkArticle, editor])
+    return [...tools, ...blocks]
+  }, [isInSnippets, onLinkArticle, editor])
 
-  const runBlockSpec = useCallback(
-    (spec: BlockCommandSpec) => {
-      onExecute((editor, range) => {
-        const attrs: Record<string, unknown> = {
-          blockType: spec.blockType,
-          level: spec.level ?? null,
-        }
-        if (spec.blockType === 'todoListItem') attrs.checked = spec.checked ?? false
-        if (spec.blockType === 'callout') attrs.calloutVariant = spec.calloutVariant ?? 'info'
-        editor.chain().focus().deleteRange(range).updateAttributes('block', attrs).run()
-      })
+  const enterSnippetsDrillDown = useCallback(() => {
+    push({ id: 'snippets', label: 'Snippets', type: 'snippets' })
+    setSearchQuery('')
+  }, [push, setSearchQuery])
+
+  const enterFolder = useCallback(
+    (id: string, label: string) => {
+      push({ id, label, type: 'folder' })
+      setSearchQuery('')
     },
-    [onExecute]
+    [push, setSearchQuery]
   )
 
-  const handleSelect = useCallback(
-    (itemId: string) => {
-      if (itemId === 'snippet') {
-        push({ id: 'snippets', label: 'Snippets', type: 'snippets' })
-        setSearchQuery('')
+  const insertSnippet = useCallback(
+    (snippetId: string) => {
+      const snippet = allSnippets.find((s) => s.id === snippetId)
+      if (!snippet) return
+      onExecute((editor, range) => {
+        editor
+          .chain()
+          .focus()
+          .deleteRange(range)
+          .insertContent(snippet.contentHtml || snippet.content, {
+            parseOptions: { preserveWhitespace: 'full' },
+          })
+          .run()
+      })
+      incrementUsage.mutate({ id: snippet.id })
+    },
+    [allSnippets, onExecute, incrementUsage]
+  )
+
+  const handleSuggestionSelect = useCallback(
+    (item: SlashCommandItem) => {
+      if (item.id === 'snippet') {
+        enterSnippetsDrillDown()
         return
       }
-      if (itemId === 'placeholder') {
+      if (item.id === 'placeholder') {
         onEnterPlaceholderMode()
         return
       }
-      if (itemId === 'article-link' && onLinkArticle) {
+      if (item.id === 'article-link' && onLinkArticle) {
         onExecute((editor, range) => {
           editor.chain().focus().deleteRange(range).run()
           onLinkArticle(editor, range.from)
         })
         return
       }
-
-      const cmd = BASE_COMMANDS.find((c) => c.id === itemId)
-      if (cmd) {
-        if (cmd.custom) {
-          onExecute(cmd.custom)
-          return
-        }
-        if (cmd.spec) {
-          runBlockSpec(cmd.spec)
-          return
-        }
-      }
-
-      const snippet = allSnippets.find((s) => s.id === itemId)
-      if (snippet) {
-        onExecute((editor, range) => {
-          editor
-            .chain()
-            .focus()
-            .deleteRange(range)
-            .insertContent(snippet.contentHtml || snippet.content, {
-              parseOptions: { preserveWhitespace: 'full' },
-            })
-            .run()
-        })
-        incrementUsage.mutate({ id: snippet.id })
-      }
+      // Anything left is a block command.
+      if (TOOL_IDS.has(item.id)) return
+      onExecute(runBlockCommand(item as BlockCommandDef))
     },
-    [
-      allSnippets,
-      onExecute,
-      runBlockSpec,
-      incrementUsage,
-      push,
-      setSearchQuery,
-      onEnterPlaceholderMode,
-    ]
+    [enterSnippetsDrillDown, onEnterPlaceholderMode, onLinkArticle, onExecute]
   )
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        e.stopPropagation()
-        onClose()
-        return
+  const handleSuggestionArrowRight = useCallback(
+    (item: SlashCommandItem) => {
+      if (item.id === 'snippet') {
+        enterSnippetsDrillDown()
+        return true
       }
-      if ((e.key === 'Backspace' || e.key === 'ArrowLeft') && !searchQuery) {
-        if (!isAtRoot) {
-          e.preventDefault()
-          pop()
-          return
-        }
-        if (e.key === 'Backspace') {
-          e.preventDefault()
-          onClose()
-          return
-        }
+      if (item.id === 'placeholder') {
+        onEnterPlaceholderMode()
+        return true
       }
-      if (e.key === 'ArrowRight') {
-        const selected = (e.currentTarget as HTMLElement).querySelector<HTMLElement>(
-          '[cmdk-item][data-selected="true"]'
-        )
-        const value = selected?.getAttribute('data-value')
-        if (!value) return
+      return false
+    },
+    [enterSnippetsDrillDown, onEnterPlaceholderMode]
+  )
 
-        if (isAtRoot && value.toLowerCase() === 'insert snippet') {
-          e.preventDefault()
-          push({ id: 'snippets', label: 'Snippets', type: 'snippets' })
-          setSearchQuery('')
-          return
-        }
-        if (isAtRoot && value.toLowerCase() === 'insert placeholder') {
-          e.preventDefault()
-          onEnterPlaceholderMode()
-          return
-        }
-        if (isInSnippets) {
-          const folder = currentFolders.find((f) => f.name.toLowerCase() === value.toLowerCase())
-          if (folder) {
-            e.preventDefault()
-            push({ id: folder.id, label: folder.name, type: 'folder' })
-            setSearchQuery('')
+  const sections: SlashCommandSection<SlashCommandItem>[] = useMemo(() => {
+    if (isInSnippets) {
+      const snippetItems: SnippetItem[] = [
+        ...currentFolders.map<SnippetItem>((f) => ({
+          id: `folder-${f.id}`,
+          title: f.name,
+          drillDown: true,
+          kind: 'folder',
+          folderCount: f._count.snippets,
+        })),
+        ...currentSnippets.map<SnippetItem>((s) => ({
+          id: `snippet-${s.id}`,
+          title: s.title,
+          kind: 'snippet',
+        })),
+      ]
+      const snippetsSection: SlashCommandSection<SnippetItem> = {
+        id: 'snippets',
+        heading: current?.type === 'folder' ? current.label : 'Snippets',
+        items: snippetItems,
+        onSelect: (item) => {
+          if (item.kind === 'folder') {
+            const folderId = item.id.replace(/^folder-/, '')
+            enterFolder(folderId, item.title)
+            return
           }
-        }
+          insertSnippet(item.id.replace(/^snippet-/, ''))
+        },
+        onArrowRight: (item) => {
+          if (item.kind === 'folder') {
+            const folderId = item.id.replace(/^folder-/, '')
+            enterFolder(folderId, item.title)
+            return true
+          }
+          return false
+        },
+        itemValue: (item) => item.id,
+        renderItem: (item) => (
+          <div className='flex items-center gap-2'>
+            <EntityIcon
+              iconId={item.kind === 'folder' ? 'folder' : 'file-text'}
+              size='xs'
+              className='text-muted-foreground'
+            />
+            <span>{item.title}</span>
+            {item.kind === 'folder' && item.folderCount !== undefined && item.folderCount > 0 && (
+              <span className='text-muted-foreground text-xs'>{item.folderCount}</span>
+            )}
+          </div>
+        ),
       }
-    },
-    [
-      isAtRoot,
-      isInSnippets,
-      searchQuery,
-      onClose,
-      pop,
-      push,
-      setSearchQuery,
-      currentFolders,
-      onEnterPlaceholderMode,
-    ]
-  )
+      return [snippetsSection as unknown as SlashCommandSection<SlashCommandItem>]
+    }
+
+    const suggestionsSection: SlashCommandSection<SlashCommandItem> = {
+      id: 'suggestions',
+      heading: 'Suggestions',
+      items: suggestionItems,
+      onSelect: handleSuggestionSelect,
+      onArrowRight: handleSuggestionArrowRight,
+    }
+
+    const out: SlashCommandSection<SlashCommandItem>[] = [suggestionsSection]
+
+    if (rootSnippetResults.length > 0) {
+      const rootSnippetsSection: SlashCommandSection<SnippetItem> = {
+        id: 'root-snippets',
+        heading: 'Snippets',
+        items: rootSnippetResults.map<SnippetItem>((s) => ({
+          id: `snippet-${s.id}`,
+          title: s.title,
+          kind: 'snippet',
+        })),
+        onSelect: (item) => insertSnippet(item.id.replace(/^snippet-/, '')),
+        itemValue: (item) => item.id,
+        renderItem: (item) => (
+          <div className='flex items-center gap-2'>
+            <EntityIcon iconId='file-text' size='xs' className='text-muted-foreground' />
+            <span>{item.title}</span>
+          </div>
+        ),
+      }
+      out.push(rootSnippetsSection as unknown as SlashCommandSection<SlashCommandItem>)
+    }
+
+    return out
+  }, [
+    isInSnippets,
+    currentFolders,
+    currentSnippets,
+    current,
+    suggestionItems,
+    handleSuggestionSelect,
+    handleSuggestionArrowRight,
+    rootSnippetResults,
+    enterFolder,
+    insertSnippet,
+  ])
+
+  const onBackspaceEmpty = useCallback(() => {
+    if (isAtRoot) return false
+    pop()
+    return true
+  }, [isAtRoot, pop])
+
+  const onArrowLeftEmpty = useCallback(() => {
+    if (isAtRoot) return false
+    pop()
+    return true
+  }, [isAtRoot, pop])
 
   return (
-    <Command className='w-72 overflow-hidden' shouldFilter={false} onKeyDown={handleKeyDown}>
-      <CommandBreadcrumb rootLabel='Commands' />
-      <CommandInput
-        ref={inputRef}
-        placeholder={isInSnippets ? 'Search snippets...' : 'Type a command or search...'}
-        value={searchQuery}
-        onValueChange={setSearchQuery}
-      />
-      <CommandList>
-        {snippetsLoading && <CommandEmpty>Loading...</CommandEmpty>}
-        {!snippetsLoading &&
-          !isInSnippets &&
-          filteredCommands.length === 0 &&
-          rootSnippetResults.length === 0 && <CommandEmpty>No results found.</CommandEmpty>}
-        {!snippetsLoading &&
-          isInSnippets &&
-          currentFolders.length === 0 &&
-          currentSnippets.length === 0 && <CommandEmpty>No snippets found.</CommandEmpty>}
-
-        {!isInSnippets && filteredCommands.length > 0 && (
-          <CommandGroup heading='Suggestions'>
-            {filteredCommands.map((item) => (
-              <CommandItem
-                key={item.id}
-                onSelect={() => handleSelect(item.id)}
-                value={item.title}
-                className='flex items-center justify-between'>
-                <div className='flex items-center gap-2'>
-                  <EntityIcon iconId={item.iconId} size='xs' className='text-muted-foreground' />
-                  <span>{item.title}</span>
-                </div>
-                {item.drillDown && <ChevronRight className='size-4 opacity-50' />}
-              </CommandItem>
-            ))}
-          </CommandGroup>
-        )}
-
-        {!isInSnippets && rootSnippetResults.length > 0 && (
-          <CommandGroup heading='Snippets'>
-            {rootSnippetResults.map((snippet) => (
-              <CommandItem
-                key={snippet.id}
-                value={`snippet-${snippet.id}`}
-                onSelect={() => handleSelect(snippet.id)}>
-                <div className='flex items-center gap-2'>
-                  <EntityIcon iconId='file-text' size='xs' className='text-muted-foreground' />
-                  <span>{snippet.title}</span>
-                </div>
-              </CommandItem>
-            ))}
-          </CommandGroup>
-        )}
-
-        {isInSnippets && (
-          <CommandGroup heading={current?.type === 'folder' ? current.label : 'Snippets'}>
-            {currentFolders.map((folder) => (
-              <CommandItem
-                key={folder.id}
-                value={folder.name}
-                onSelect={() => {
-                  push({ id: folder.id, label: folder.name, type: 'folder' })
-                  setSearchQuery('')
-                }}
-                className='flex items-center justify-between'>
-                <div className='flex items-center gap-2'>
-                  <EntityIcon iconId='folder' size='xs' className='text-muted-foreground' />
-                  <span>{folder.name}</span>
-                  {folder._count.snippets > 0 && (
-                    <span className='text-muted-foreground text-xs'>{folder._count.snippets}</span>
-                  )}
-                </div>
-                <ChevronRight className='size-4 opacity-50' />
-              </CommandItem>
-            ))}
-
-            {currentSnippets.map((snippet) => (
-              <CommandItem
-                key={snippet.id}
-                value={`snippet-${snippet.id}`}
-                onSelect={() => handleSelect(snippet.id)}>
-                <div className='flex items-center gap-2'>
-                  <EntityIcon iconId='file-text' size='xs' className='text-muted-foreground' />
-                  <span>{snippet.title}</span>
-                </div>
-              </CommandItem>
-            ))}
-          </CommandGroup>
-        )}
-      </CommandList>
-    </Command>
+    <SlashCommandPicker
+      query={query}
+      searchQuery={searchQuery}
+      setSearchQuery={setSearchQuery}
+      onClose={onClose}
+      sections={sections}
+      header={<CommandBreadcrumb rootLabel='Commands' />}
+      placeholder={isInSnippets ? 'Search snippets...' : 'Type a command or search...'}
+      emptyMessage={isInSnippets ? 'No snippets found.' : 'No results found.'}
+      onBackspaceEmpty={onBackspaceEmpty}
+      onArrowLeftEmpty={onArrowLeftEmpty}
+      loading={snippetsLoading}
+    />
   )
 }

--- a/apps/web/src/components/editor/slash-commands/basic-slash-command-picker.tsx
+++ b/apps/web/src/components/editor/slash-commands/basic-slash-command-picker.tsx
@@ -1,0 +1,60 @@
+// apps/web/src/components/editor/slash-commands/basic-slash-command-picker.tsx
+'use client'
+
+import type { Editor } from '@tiptap/react'
+import { useEffect, useMemo, useState } from 'react'
+import { BASIC_BLOCK_COMMANDS, type BlockCommandDef, runBlockCommand } from './block-commands'
+import {
+  type SlashCommandItem,
+  SlashCommandPicker,
+  type SlashCommandSection,
+} from './slash-command-picker'
+
+type Range = { from: number; to: number }
+
+interface BasicSlashCommandPickerProps {
+  query: string
+  onExecute: (command: (editor: Editor, range: Range) => void) => void
+  onClose: () => void
+}
+
+/**
+ * Slim slash menu used by surfaces that only need basic block commands —
+ * no snippets, placeholders, or article links. Persona editor uses this;
+ * future agent-trigger / workflow-prompt editors can mount it too.
+ */
+export function BasicSlashCommandPicker({
+  query,
+  onExecute,
+  onClose,
+}: BasicSlashCommandPickerProps) {
+  const [searchQuery, setSearchQuery] = useState(query)
+
+  // Mirror the external query into the controlled input so typing past the
+  // trigger keeps the input in sync with the suggestion plugin.
+  useEffect(() => {
+    setSearchQuery(query)
+  }, [query])
+
+  const sections: SlashCommandSection<SlashCommandItem>[] = useMemo(
+    () => [
+      {
+        id: 'blocks',
+        heading: 'Blocks',
+        items: BASIC_BLOCK_COMMANDS,
+        onSelect: (item) => onExecute(runBlockCommand(item as BlockCommandDef)),
+      },
+    ],
+    [onExecute]
+  )
+
+  return (
+    <SlashCommandPicker
+      query={query}
+      searchQuery={searchQuery}
+      setSearchQuery={setSearchQuery}
+      onClose={onClose}
+      sections={sections}
+    />
+  )
+}

--- a/apps/web/src/components/editor/slash-commands/block-commands.ts
+++ b/apps/web/src/components/editor/slash-commands/block-commands.ts
@@ -1,0 +1,141 @@
+// apps/web/src/components/editor/slash-commands/block-commands.ts
+
+import type { Editor } from '@tiptap/react'
+import type { SlashCommandItem } from './slash-command-picker'
+
+export type SlashRange = { from: number; to: number }
+
+export interface BlockCommandSpec {
+  blockType:
+    | 'text'
+    | 'heading'
+    | 'bulletListItem'
+    | 'numberedListItem'
+    | 'todoListItem'
+    | 'quote'
+    | 'codeBlock'
+    | 'callout'
+    | 'embed'
+  level?: number | null
+  checked?: boolean
+  calloutVariant?: 'info' | 'tip' | 'warn' | 'error' | 'success'
+}
+
+export interface BlockCommandDef extends SlashCommandItem {
+  /** Simple attr-swap action. Mutually exclusive with `custom`. */
+  spec?: BlockCommandSpec
+  /** Free-form action — used when the insert is more than an attr swap
+   *  (divider, image, table, etc.). */
+  custom?: (editor: Editor, range: SlashRange) => void
+}
+
+/** Basic block set shared by every slash-menu surface. */
+export const BASIC_BLOCK_COMMANDS: BlockCommandDef[] = [
+  {
+    id: 'text',
+    title: 'Text',
+    description: 'Plain text block',
+    keywords: ['p', 'paragraph'],
+    iconId: 'text',
+    spec: { blockType: 'text', level: null },
+  },
+  {
+    id: 'h1',
+    title: 'Heading 1',
+    description: 'Big section heading',
+    keywords: ['h1', 'title', 'large'],
+    iconId: 'heading-1',
+    spec: { blockType: 'heading', level: 1 },
+  },
+  {
+    id: 'h2',
+    title: 'Heading 2',
+    description: 'Medium section heading',
+    keywords: ['h2', 'subtitle'],
+    iconId: 'heading-2',
+    spec: { blockType: 'heading', level: 2 },
+  },
+  {
+    id: 'h3',
+    title: 'Heading 3',
+    description: 'Small section heading',
+    keywords: ['h3', 'subheading'],
+    iconId: 'heading-3',
+    spec: { blockType: 'heading', level: 3 },
+  },
+  {
+    id: 'bullet',
+    title: 'Bullet list',
+    description: 'Create a bullet list',
+    keywords: ['ul', 'unordered', 'bullets', 'points'],
+    iconId: 'list',
+    spec: { blockType: 'bulletListItem', level: 1 },
+  },
+  {
+    id: 'numbered',
+    title: 'Numbered list',
+    description: 'Create a numbered list',
+    keywords: ['ol', 'ordered', 'numbers', 'steps'],
+    iconId: 'list-ordered',
+    spec: { blockType: 'numberedListItem', level: 1 },
+  },
+  {
+    id: 'todo',
+    title: 'To-do list',
+    description: 'Track tasks with checkboxes',
+    keywords: ['todo', 'task', 'check', 'checkbox'],
+    iconId: 'check-square',
+    spec: { blockType: 'todoListItem', checked: false },
+  },
+  {
+    id: 'quote',
+    title: 'Quote',
+    description: 'Capture a quote',
+    keywords: ['blockquote', 'cite'],
+    iconId: 'quote',
+    spec: { blockType: 'quote' },
+  },
+  {
+    id: 'code',
+    title: 'Code',
+    description: 'Capture a code block',
+    keywords: ['codeblock', 'code'],
+    iconId: 'code',
+    spec: { blockType: 'codeBlock' },
+  },
+  {
+    id: 'divider',
+    title: 'Divider',
+    description: 'Visual separator',
+    keywords: ['hr', 'horizontal', 'rule', 'line'],
+    iconId: 'minus',
+    custom: (editor, range) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .updateAttributes('block', { blockType: 'divider', level: null, checked: false })
+        .splitBlock()
+        .updateAttributes('block', { blockType: 'text', level: null, checked: false })
+        .run()
+    },
+  },
+]
+
+/** Turn a `BlockCommandDef` into the executor `executeCommand` expects. */
+export function runBlockCommand(def: BlockCommandDef): (editor: Editor, range: SlashRange) => void {
+  if (def.custom) return def.custom
+  if (!def.spec) {
+    throw new Error(`block command "${def.id}" has neither spec nor custom`)
+  }
+  const spec = def.spec
+  return (editor, range) => {
+    const attrs: Record<string, unknown> = {
+      blockType: spec.blockType,
+      level: spec.level ?? null,
+    }
+    if (spec.blockType === 'todoListItem') attrs.checked = spec.checked ?? false
+    if (spec.blockType === 'callout') attrs.calloutVariant = spec.calloutVariant ?? 'info'
+    editor.chain().focus().deleteRange(range).updateAttributes('block', attrs).run()
+  }
+}

--- a/apps/web/src/components/editor/slash-commands/slash-command-picker.tsx
+++ b/apps/web/src/components/editor/slash-commands/slash-command-picker.tsx
@@ -1,0 +1,214 @@
+// apps/web/src/components/editor/slash-commands/slash-command-picker.tsx
+'use client'
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@auxx/ui/components/command'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { ChevronRight } from 'lucide-react'
+import { useCallback, useMemo, useRef } from 'react'
+
+/** Minimal shape every slash-menu item satisfies. Sections can extend it. */
+export interface SlashCommandItem {
+  id: string
+  title: string
+  description?: string
+  keywords?: string[]
+  iconId?: string
+  /** Renders a chevron and is the cue for ArrowRight to trigger
+   *  `onArrowRight`. The shell never owns *what* drill-down does. */
+  drillDown?: boolean
+}
+
+export interface SlashCommandSection<TItem extends SlashCommandItem = SlashCommandItem> {
+  id: string
+  heading?: string
+  items: TItem[]
+  onSelect: (item: TItem) => void
+  /** Return `true` to consume the ArrowRight event. */
+  onArrowRight?: (item: TItem) => boolean
+  /** Override the default `iconId + title + drillDown chevron` row. */
+  renderItem?: (item: TItem) => React.ReactNode
+  /** cmdk value override — defaults to `item.title`. Use a stable, unique
+   *  value for items whose titles may collide with each other (e.g. user
+   *  snippet titles colliding with command titles). */
+  itemValue?: (item: TItem) => string
+}
+
+export interface SlashCommandPickerProps {
+  /** External query coming from the suggestion plugin. The shell does not
+   *  read this — it's part of the contract so composers can sync their
+   *  controlled `searchQuery` when they choose to. */
+  query: string
+  searchQuery: string
+  setSearchQuery: (q: string) => void
+  onClose: () => void
+  sections: SlashCommandSection<SlashCommandItem>[]
+  /** Slot above the search input — KB passes `<CommandBreadcrumb>` here. */
+  header?: React.ReactNode
+  placeholder?: string
+  /** Overrides the default "No results found." */
+  emptyMessage?: string
+  /** Called when Backspace fires at empty input. Return `true` if consumed;
+   *  if not consumed, the shell closes the picker. */
+  onBackspaceEmpty?: () => boolean
+  /** Called when ArrowLeft fires at empty input. Return `true` if consumed;
+   *  if not consumed, the shell does nothing (ArrowLeft is a no-op by
+   *  default). */
+  onArrowLeftEmpty?: () => boolean
+  /** Suppress the "No results" / sections render — composer is still loading. */
+  loading?: boolean
+}
+
+const DEFAULT_PLACEHOLDER = 'Type a command or search...'
+const DEFAULT_EMPTY = 'No results found.'
+
+function defaultMatches(item: SlashCommandItem, q: string): boolean {
+  if (!q) return true
+  if (item.title.toLowerCase().includes(q)) return true
+  if (item.description?.toLowerCase().includes(q)) return true
+  if (item.keywords?.some((kw) => kw.toLowerCase().includes(q))) return true
+  return false
+}
+
+/**
+ * Generic slash-menu shell. Knows nothing about snippets / placeholders /
+ * article-links — sections own click + ArrowRight behavior, the shell only
+ * owns the chrome (input, list, keyboard handling, filtering, empty state).
+ */
+export function SlashCommandPicker({
+  searchQuery,
+  setSearchQuery,
+  onClose,
+  sections,
+  header,
+  placeholder = DEFAULT_PLACEHOLDER,
+  emptyMessage = DEFAULT_EMPTY,
+  onBackspaceEmpty,
+  onArrowLeftEmpty,
+  loading = false,
+}: SlashCommandPickerProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const q = searchQuery.toLowerCase()
+
+  const filteredSections = useMemo(
+    () =>
+      sections.map((section) => ({
+        section,
+        items: section.items.filter((item) => defaultMatches(item, q)),
+      })),
+    [sections, q]
+  )
+
+  const allEmpty = filteredSections.every(({ items }) => items.length === 0)
+
+  // Maps the currently selected cmdk `data-value` back to the originating
+  // section + item so `onArrowRight` can dispatch without each section having
+  // to scan its own items.
+  const itemLookup = useMemo(() => {
+    const map = new Map<string, { section: SlashCommandSection; item: SlashCommandItem }>()
+    for (const { section, items } of filteredSections) {
+      for (const item of items) {
+        const value = section.itemValue?.(item) ?? item.title
+        map.set(value.toLowerCase(), { section, item })
+      }
+    }
+    return map
+  }, [filteredSections])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        onClose()
+        return
+      }
+      if (e.key === 'Backspace' && !searchQuery) {
+        if (onBackspaceEmpty?.()) {
+          e.preventDefault()
+          return
+        }
+        e.preventDefault()
+        onClose()
+        return
+      }
+      if (e.key === 'ArrowLeft' && !searchQuery) {
+        if (onArrowLeftEmpty?.()) {
+          e.preventDefault()
+        }
+        return
+      }
+      if (e.key === 'ArrowRight') {
+        const selected = (e.currentTarget as HTMLElement).querySelector<HTMLElement>(
+          '[cmdk-item][data-selected="true"]'
+        )
+        const value = selected?.getAttribute('data-value')
+        if (!value) return
+        const entry = itemLookup.get(value.toLowerCase())
+        if (!entry) return
+        if (entry.section.onArrowRight?.(entry.item)) {
+          e.preventDefault()
+        }
+      }
+    },
+    [searchQuery, onBackspaceEmpty, onArrowLeftEmpty, onClose, itemLookup]
+  )
+
+  return (
+    <Command className='w-72 overflow-hidden' shouldFilter={false} onKeyDown={handleKeyDown}>
+      {header}
+      <CommandInput
+        ref={inputRef}
+        placeholder={placeholder}
+        value={searchQuery}
+        onValueChange={setSearchQuery}
+      />
+      <CommandList>
+        {loading && <CommandEmpty>Loading...</CommandEmpty>}
+        {!loading && allEmpty && <CommandEmpty>{emptyMessage}</CommandEmpty>}
+        {!loading &&
+          filteredSections.map(({ section, items }) => {
+            if (items.length === 0) return null
+            return (
+              <CommandGroup key={section.id} heading={section.heading}>
+                {items.map((item) => {
+                  const value = section.itemValue?.(item) ?? item.title
+                  return (
+                    <CommandItem
+                      key={item.id}
+                      value={value}
+                      onSelect={() => section.onSelect(item)}
+                      className='flex items-center justify-between'>
+                      {section.renderItem ? (
+                        section.renderItem(item)
+                      ) : (
+                        <DefaultItemContent item={item} />
+                      )}
+                      {item.drillDown && <ChevronRight className='size-4 opacity-50' />}
+                    </CommandItem>
+                  )
+                })}
+              </CommandGroup>
+            )
+          })}
+      </CommandList>
+    </Command>
+  )
+}
+
+function DefaultItemContent({ item }: { item: SlashCommandItem }) {
+  return (
+    <div className='flex items-center gap-2'>
+      {item.iconId && (
+        <EntityIcon iconId={item.iconId} size='xs' className='text-muted-foreground' />
+      )}
+      <span>{item.title}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Extract slash-command pickers into a shared `apps/web/src/components/editor/slash-commands/` module (basic picker + KB block commands + reusable picker shell), so the persona editor and KB editor share the same building blocks.
- Persona editor gets a bubble menu (turn-into / inline marks / link popover / KB block section) and slash-driven block commands, plus a two-editor (card + expanded dialog) pattern with a shared `currentDocRef` so the doc survives across mounts.
- Parameterize KB editor CSS via `--editor-*` custom properties (gutter, text, headings, indent, indicators) so downstream pages can retheme without forking the stylesheet. Renames `--gutter-min-width` → `--editor-gutter-min-width`.

## Test plan
- [ ] Persona editor: focus expands the card; typing autosaves at the 1500ms window; expanding to dialog and back preserves the in-flight document.
- [ ] Persona editor: `/` opens slash picker; block commands (heading, list, callout, etc.) insert correctly; `@` opens reference picker with the expected tabs.
- [ ] Persona editor: bubble menu — bold/italic/etc., turn-into, and link popover (with edit + unlink) work on a selection.
- [ ] KB article editor: slash picker still works (snippets, placeholders, block commands); gutter width still adjusts to line count.
- [ ] KB article editor: visual regression check — no layout shift from the CSS-var rename.