### PR TITLE
feat(agents): tool-select dialog with popular curation

### DIFF
--- a/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
@@ -20,6 +20,7 @@ import type { AutosaveState } from '../shared/autosave-indicator'
 import { AgentHero } from './agent-hero'
 import { KnowledgeSectionContent } from './knowledge/knowledge-section-content'
 import { PersonaEditor } from './prompt/persona-editor'
+import { ToolSelectDialog } from './tools/tool-select-dialog'
 import { ToolsSectionContent } from './tools/tools-section-content'
 import { TriggersSectionContent } from './triggers/triggers-section-content'
 
@@ -166,14 +167,7 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
         </div>
 
         <div ref={assignRef('tools')}>
-          <Section
-            title='Tools'
-            icon={<Wrench className='size-4' />}
-            className='[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
-            initialOpen
-            collapsible={false}>
-            <ToolsSectionContent agent={agent} onAutosaveChange={onAutosaveChange} />
-          </Section>
+          <ToolsSection agent={agent} onAutosaveChange={onAutosaveChange} />
         </div>
 
         <div ref={assignRef('knowledge')}>
@@ -227,5 +221,63 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
         <div className='h-[40vh]' />
       </ScrollArea>
     </div>
+  )
+}
+
+interface ToolsSectionProps {
+  agent: AgentDetail
+  onAutosaveChange?: (state: AutosaveState) => void
+}
+
+/**
+ * Tools tab wrapper. Owns the `ToolSelectDialog` state so the "Add tools"
+ * trigger can sit in `<Section actions>` while the dialog renders alongside
+ * the installed-tools list.
+ */
+function ToolsSection({ agent, onAutosaveChange }: ToolsSectionProps) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [pendingAppId, setPendingAppId] = useState<string | null>(null)
+  return (
+    <>
+      <Section
+        title='Tools'
+        icon={<Wrench className='size-4' />}
+        className='[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
+        initialOpen
+        collapsible={false}
+        actions={
+          <Button
+            size='xs'
+            variant='ghost'
+            onClick={() => {
+              setPendingAppId(null)
+              setDialogOpen(true)
+            }}>
+            <Plus />
+            Add tools
+          </Button>
+        }>
+        <ToolsSectionContent
+          agent={agent}
+          onAutosaveChange={onAutosaveChange}
+          onAddToApp={(appId) => {
+            setPendingAppId(appId)
+            setDialogOpen(true)
+          }}
+        />
+      </Section>
+      <ToolSelectDialog
+        agent={agent}
+        open={dialogOpen}
+        onOpenChange={(next) => {
+          setDialogOpen(next)
+          if (!next) setPendingAppId(null)
+        }}
+        initialAppId={pendingAppId ?? undefined}
+        onSavingChange={(saving) =>
+          onAutosaveChange?.(saving ? { kind: 'saving' } : { kind: 'saved', at: Date.now() })
+        }
+      />
+    </>
   )
 }

--- a/apps/web/src/components/agents/ui/detail/tools/catalog-node-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/catalog-node-row.tsx
@@ -2,10 +2,11 @@
 'use client'
 
 import type { CatalogNode, CatalogToolsetNode } from '@auxx/lib/agents/client'
+import { Button } from '@auxx/ui/components/button'
 import { Switch } from '@auxx/ui/components/switch'
 import { TreeRow } from '@auxx/ui/components/tree-row'
 import { pluralize } from '@auxx/utils/strings'
-import { Lock } from 'lucide-react'
+import { Lock, Plus } from 'lucide-react'
 import { Tooltip } from '~/components/global/tooltip'
 import { AppIcon } from '~/components/workflow/ui/app-icon'
 import { ToolsetRow } from './toolset-row'
@@ -14,6 +15,15 @@ export type ToolsetRowState = {
   enabled: boolean
   source: 'manual' | 'mention' | 'auto_default'
 }
+
+/**
+ * `'editor'` shows cascading Switches on containers and per-toolset Switches
+ * on leaves — used by the Tool-Select dialog when we want a one-step add/remove
+ * surface. `'installed'` shows a `{n} tools` chip on containers (no cascade
+ * Switch) and a Trash button on leaves — used by the installed-tools section
+ * where the Add-tools dialog is the source of additions.
+ */
+export type CatalogNodeVariant = 'editor' | 'installed'
 
 interface CatalogNodeRowProps {
   node: CatalogNode
@@ -26,8 +36,19 @@ interface CatalogNodeRowProps {
   /** Presence = collapsed. Stable Set instance — child reads `.has()`. */
   collapsed: Set<string>
   onToggleCollapsed: (id: string) => void
-  onCascadeToggle: (node: CatalogNode, nextEnabled: boolean) => void
-  onLeafToggle: (slug: string, enabled: boolean) => void
+  variant?: CatalogNodeVariant
+  /** Required when `variant === 'editor'`. */
+  onCascadeToggle?: (node: CatalogNode, nextEnabled: boolean) => void
+  /** Required when `variant === 'editor'`. */
+  onLeafToggle?: (slug: string, enabled: boolean) => void
+  /** Required when `variant === 'installed'`. */
+  onLeafRemove?: (slug: string) => void
+  /**
+   * Optional — when supplied + `variant === 'installed'`, app-kind rows render
+   * an "Add" button next to their tools count that invokes this with the app's
+   * node id.
+   */
+  onAddToApp?: (appId: string) => void
 }
 
 /**
@@ -45,8 +66,11 @@ export function CatalogNodeRow({
   stateBySlug,
   collapsed,
   onToggleCollapsed,
+  variant = 'editor',
   onCascadeToggle,
   onLeafToggle,
+  onLeafRemove,
+  onAddToApp,
 }: CatalogNodeRowProps) {
   const iconId = node.iconId ?? inheritedIconId
   const color = node.color ?? inheritedColor
@@ -64,7 +88,9 @@ export function CatalogNodeRow({
         toolCount={node.tools.length}
         enabled={state.enabled}
         source={state.source}
+        variant={variant}
         onToolsetToggle={onLeafToggle}
+        onToolsetRemove={onLeafRemove}
       />
     )
   }
@@ -81,15 +107,22 @@ export function CatalogNodeRow({
       isOpen={isOpen}
       onToggleOpen={() => onToggleCollapsed(node.id)}
       actions={
-        <ContainerActions
-          stats={stats}
-          onToggle={(next) => onCascadeToggle(node, next)}
-          lockedMessage={
-            node.kind === 'app'
-              ? 'Locked — every toolset in this app is referenced in instructions.'
-              : 'Locked — every toolset in this sub-group is referenced in instructions.'
-          }
-        />
+        variant === 'editor' ? (
+          <ContainerEditorActions
+            stats={stats}
+            onToggle={(next) => onCascadeToggle?.(node, next)}
+            lockedMessage={
+              node.kind === 'app'
+                ? 'Locked — every toolset in this app is referenced in instructions.'
+                : 'Locked — every toolset in this sub-group is referenced in instructions.'
+            }
+          />
+        ) : (
+          <ContainerInstalledStats
+            stats={stats}
+            onAdd={node.kind === 'app' && onAddToApp ? () => onAddToApp(node.id) : undefined}
+          />
+        )
       }>
       {node.children.map((child) => (
         <CatalogNodeRow
@@ -101,8 +134,11 @@ export function CatalogNodeRow({
           stateBySlug={stateBySlug}
           collapsed={collapsed}
           onToggleCollapsed={onToggleCollapsed}
+          variant={variant}
           onCascadeToggle={onCascadeToggle}
           onLeafToggle={onLeafToggle}
+          onLeafRemove={onLeafRemove}
+          onAddToApp={onAddToApp}
         />
       ))}
     </TreeRow>
@@ -160,7 +196,52 @@ export function collectToggleable(
   return targets
 }
 
-function ContainerActions({
+/**
+ * Predicate: this toolset is "installed" — either explicitly enabled, or
+ * mention-locked (effectively pinned by the prompt; the user should still see
+ * it in the installed surface so they understand why it's active).
+ */
+function isInstalledLeaf(node: CatalogToolsetNode, stateBySlug: Map<string, ToolsetRowState>) {
+  const state = stateBySlug.get(node.slug)
+  if (!state) return false
+  return state.enabled || state.source === 'mention'
+}
+
+/**
+ * Walk the tree and return a copy with non-installed leaves dropped and
+ * containers whose children all got dropped removed. Used by the installed
+ * tools section to keep the App → SubGroup → Toolset hierarchy but only show
+ * installed leaves.
+ */
+export function pruneToInstalled(
+  nodes: CatalogNode[],
+  stateBySlug: Map<string, ToolsetRowState>
+): CatalogNode[] {
+  const result: CatalogNode[] = []
+  for (const node of nodes) {
+    const pruned = pruneNode(node, stateBySlug)
+    if (pruned) result.push(pruned)
+  }
+  return result
+}
+
+function pruneNode(
+  node: CatalogNode,
+  stateBySlug: Map<string, ToolsetRowState>
+): CatalogNode | null {
+  if (node.kind === 'toolset') {
+    return isInstalledLeaf(node, stateBySlug) ? node : null
+  }
+  const children: CatalogNode[] = []
+  for (const child of node.children) {
+    const kept = pruneNode(child, stateBySlug)
+    if (kept) children.push(kept)
+  }
+  if (children.length === 0) return null
+  return { ...node, children }
+}
+
+function ContainerEditorActions({
   stats,
   onToggle,
   lockedMessage,
@@ -199,6 +280,38 @@ function ContainerActions({
         </Tooltip>
       ) : (
         groupSwitch
+      )}
+    </div>
+  )
+}
+
+function ContainerInstalledStats({ stats, onAdd }: { stats: ContainerStats; onAdd?: () => void }) {
+  return (
+    <div className='flex items-center gap-2'>
+      <span className='text-xs text-muted-foreground'>
+        {stats.enabled} {pluralize(stats.enabled, 'tool')}
+      </span>
+      {stats.locked > 0 && (
+        <Tooltip
+          side='left'
+          content={`${stats.locked} locked by ${pluralize(stats.locked, 'mention')} in instructions.`}>
+          <span className='inline-flex items-center gap-0.5 text-[11px] text-muted-foreground'>
+            <Lock className='size-3' />
+            {stats.locked}
+          </span>
+        </Tooltip>
+      )}
+      {onAdd && (
+        <Button
+          size='icon-xs'
+          variant='ghost'
+          aria-label='Add tools to this app'
+          onClick={(e) => {
+            e.stopPropagation()
+            onAdd()
+          }}>
+          <Plus />
+        </Button>
       )}
     </div>
   )

--- a/apps/web/src/components/agents/ui/detail/tools/tool-select-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tool-select-dialog.tsx
@@ -1,0 +1,492 @@
+// apps/web/src/components/agents/ui/detail/tools/tool-select-dialog.tsx
+'use client'
+
+import type { CatalogContainerNode, CatalogNode } from '@auxx/lib/agents/client'
+import { flattenCatalogToToolsets } from '@auxx/lib/agents/client'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Separator } from '@auxx/ui/components/separator'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
+import { pluralize } from '@auxx/utils/strings'
+import { ChevronLeft } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { api } from '~/trpc/react'
+import type { AgentDetail } from '../../../store/agent-store'
+import { ToolSelectRow, toolCountBadge } from './tool-select-row'
+import { useToolsetMutations } from './use-toolset-mutations'
+
+interface ToolSelectDialogProps {
+  agent: AgentDetail
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Optional save-state hook — wires the agent autosave indicator. */
+  onSavingChange?: (saving: boolean) => void
+  /**
+   * When set + the dialog is opened, jumps straight to the App-detail view
+   * for this app id. The Back button still returns to the Apps list.
+   */
+  initialAppId?: string
+}
+
+type ViewMode = 'list' | 'app-detail'
+type ListTab = 'all' | 'apps'
+
+interface InstalledState {
+  enabled: boolean
+  source: 'manual' | 'mention' | 'auto_default'
+}
+
+/**
+ * Multi-view dialog used to add toolsets to an agent. Three surfaces:
+ *
+ *  - List / All: flat picker grouped into Popular + All tools.
+ *  - List / Apps: one row per app, navigates to App-detail on click.
+ *  - App-detail: leaves of the selected app with an "Add all tools" button.
+ *
+ * Clicking a row toggles its enabled flag via `useToolsetMutations` — the
+ * dialog stays open so the user can add several toolsets in a row.
+ */
+export function ToolSelectDialog({
+  agent,
+  open,
+  onOpenChange,
+  onSavingChange,
+  initialAppId,
+}: ToolSelectDialogProps) {
+  const catalogQuery = api.agentToolset.list.useQuery(undefined, { staleTime: 60_000 })
+  const { toggleToolset, toggleToolsets } = useToolsetMutations(
+    agent.id,
+    agent.slug,
+    onSavingChange
+  )
+
+  const [viewMode, setViewMode] = useState<ViewMode>('list')
+  const [tab, setTab] = useState<ListTab>('all')
+  const [selectedAppId, setSelectedAppId] = useState<string | null>(null)
+  const [search, setSearch] = useState('')
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  // On open: jump to App-detail when `initialAppId` is provided, else show the list.
+  // On close: reset to the default view.
+  useEffect(() => {
+    if (open) {
+      if (initialAppId) {
+        setViewMode('app-detail')
+        setSelectedAppId(initialAppId)
+      } else {
+        setViewMode('list')
+        setTab('all')
+        setSelectedAppId(null)
+      }
+      setSearch('')
+    } else {
+      setViewMode('list')
+      setTab('all')
+      setSelectedAppId(null)
+      setSearch('')
+    }
+    // Only react to `open` flips — `initialAppId` is read at open time.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: see comment above
+  }, [open])
+
+  const installedState = useMemo<Map<string, InstalledState>>(() => {
+    const map = new Map<string, InstalledState>()
+    for (const row of agent.toolsets) {
+      map.set(row.slug, { enabled: row.enabled, source: row.source })
+    }
+    return map
+  }, [agent.toolsets])
+
+  const catalog = catalogQuery.data
+  const flat = useMemo(() => (catalog ? flattenCatalogToToolsets(catalog) : []), [catalog])
+
+  const selectedApp = useMemo(() => {
+    if (!catalog || !selectedAppId) return null
+    return catalog.find((root) => root.id === selectedAppId) ?? null
+  }, [catalog, selectedAppId])
+
+  function isInstalled(slug: string): boolean {
+    const state = installedState.get(slug)
+    if (!state) return false
+    return state.enabled || state.source === 'mention'
+  }
+
+  function sourceOf(slug: string): InstalledState['source'] | undefined {
+    return installedState.get(slug)?.source
+  }
+
+  const handleToolsetClick = (slug: string) => {
+    const installed = isInstalled(slug)
+    const source = sourceOf(slug)
+    // Locked rows: clicking is a no-op (the row still shows the green check).
+    if (installed && source && source !== 'manual') return
+    void toggleToolset(slug, !installed)
+  }
+
+  const handleRemove = (slug: string) => {
+    const source = sourceOf(slug)
+    if (source && source !== 'manual') return
+    void toggleToolset(slug, false)
+  }
+
+  const handleOpenApp = (appNode: CatalogContainerNode) => {
+    setSelectedAppId(appNode.id)
+    setViewMode('app-detail')
+    setSearch('')
+  }
+
+  const handleBack = () => {
+    setViewMode('list')
+    setTab('apps')
+    setSelectedAppId(null)
+    setSearch('')
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className='h-dvh sm:h-[600px]'
+        innerClassName='p-0'
+        position='tc'
+        size='lg'
+        onOpenAutoFocus={(e) => {
+          e.preventDefault()
+          searchInputRef.current?.focus()
+        }}>
+        <div className='flex flex-1 flex-col min-h-0'>
+          {viewMode === 'list' ? (
+            <ListView
+              tab={tab}
+              onTabChange={setTab}
+              search={search}
+              onSearchChange={setSearch}
+              searchInputRef={searchInputRef}
+              catalog={catalog}
+              flat={flat}
+              isLoading={catalogQuery.isLoading}
+              isInstalled={isInstalled}
+              sourceOf={sourceOf}
+              onToggle={handleToolsetClick}
+              onRemove={handleRemove}
+              onOpenApp={handleOpenApp}
+            />
+          ) : selectedApp ? (
+            <AppDetailView
+              app={selectedApp}
+              onBack={handleBack}
+              isInstalled={isInstalled}
+              sourceOf={sourceOf}
+              onToggle={handleToolsetClick}
+              onRemove={handleRemove}
+              onAddAll={(slugs) => {
+                if (slugs.length === 0) return
+                void toggleToolsets(slugs.map((slug) => ({ slug, enabled: true })))
+              }}
+            />
+          ) : (
+            <div className='flex flex-1 items-center justify-center p-8'>
+              <Skeleton className='h-12 w-full max-w-sm rounded-lg' />
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface ListViewProps {
+  tab: ListTab
+  onTabChange: (tab: ListTab) => void
+  search: string
+  onSearchChange: (q: string) => void
+  searchInputRef: React.RefObject<HTMLInputElement>
+  catalog: CatalogNode[] | undefined
+  flat: ReturnType<typeof flattenCatalogToToolsets>
+  isLoading: boolean
+  isInstalled: (slug: string) => boolean
+  sourceOf: (slug: string) => InstalledState['source'] | undefined
+  onToggle: (slug: string) => void
+  onRemove: (slug: string) => void
+  onOpenApp: (appNode: CatalogContainerNode) => void
+}
+
+function ListView({
+  tab,
+  onTabChange,
+  search,
+  onSearchChange,
+  searchInputRef,
+  catalog,
+  flat,
+  isLoading,
+  isInstalled,
+  sourceOf,
+  onToggle,
+  onRemove,
+  onOpenApp,
+}: ListViewProps) {
+  const filteredFlat = useMemo(() => {
+    if (!search.trim()) return flat
+    const q = search.trim().toLowerCase()
+    return flat.filter(
+      (e) =>
+        e.label.toLowerCase().includes(q) ||
+        e.fullLabel.toLowerCase().includes(q) ||
+        e.description.toLowerCase().includes(q) ||
+        e.path.join(' ').toLowerCase().includes(q)
+    )
+  }, [flat, search])
+
+  const popular = filteredFlat.filter((e) => e.isPopular)
+  const all = filteredFlat
+
+  const apps = useMemo<CatalogContainerNode[]>(() => {
+    if (!catalog) return []
+    const roots = catalog.filter((n): n is CatalogContainerNode => n.kind !== 'toolset')
+    if (!search.trim()) return roots
+    const q = search.trim().toLowerCase()
+    return roots.filter((r) => r.label.toLowerCase().includes(q))
+  }, [catalog, search])
+
+  return (
+    <>
+      <DialogHeader className='mb-0 flex h-10 flex-row items-center justify-between border-b px-3'>
+        <div>
+          <Button variant='ghost' size='sm'>
+            Add tools
+          </Button>
+          <DialogTitle className='sr-only'>Add tools</DialogTitle>
+          <DialogDescription className='sr-only'>
+            Browse the toolset catalog and add tools to this agent.
+          </DialogDescription>
+        </div>
+      </DialogHeader>
+
+      <div className='flex items-center justify-between gap-2 border-b px-3 py-2'>
+        <Tabs value={tab} onValueChange={(v) => onTabChange(v as ListTab)}>
+          <TabsList>
+            <TabsTrigger value='all'>All</TabsTrigger>
+            <TabsTrigger value='apps'>Apps</TabsTrigger>
+          </TabsList>
+        </Tabs>
+        <div className='flex-1 max-w-xs'>
+          <InputSearch
+            ref={searchInputRef}
+            placeholder='Search tools...'
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            onClear={() => onSearchChange('')}
+          />
+        </div>
+      </div>
+
+      <ScrollArea className='flex-1' scrollbarClassName='w-1!'>
+        <div className='py-3 px-3'>
+          {isLoading ? (
+            <div className='space-y-2'>
+              {[0, 1, 2].map((i) => (
+                <Skeleton key={i} className='h-12 w-full rounded-lg' />
+              ))}
+            </div>
+          ) : tab === 'all' ? (
+            filteredFlat.length === 0 ? (
+              <EmptySearchResult search={search} />
+            ) : (
+              <div className='space-y-4'>
+                {popular.length > 0 && (
+                  <Section title='Popular tools'>
+                    <div className='grid grid-cols-1 gap-1 sm:grid-cols-2'>
+                      {popular.map((entry) => (
+                        <ToolSelectRow
+                          key={entry.slug}
+                          id={entry.slug}
+                          iconId={entry.iconId}
+                          color={entry.color || null}
+                          label={entry.fullLabel}
+                          description={entry.description || undefined}
+                          badge={toolCountBadge(entry.tools.length) ?? undefined}
+                          toolNames={entry.tools.map((t) => t.displayName)}
+                          installed={isInstalled(entry.slug)}
+                          source={sourceOf(entry.slug)}
+                          onSelect={() => onToggle(entry.slug)}
+                          onRemove={() => onRemove(entry.slug)}
+                        />
+                      ))}
+                    </div>
+                  </Section>
+                )}
+                {all.length > 0 && (
+                  <Section title='All tools'>
+                    {all.map((entry) => (
+                      <ToolSelectRow
+                        key={entry.slug}
+                        id={entry.slug}
+                        iconId={entry.iconId}
+                        color={entry.color || null}
+                        label={entry.fullLabel}
+                        description={entry.description || undefined}
+                        badge={toolCountBadge(entry.tools.length) ?? undefined}
+                        toolNames={entry.tools.map((t) => t.displayName)}
+                        installed={isInstalled(entry.slug)}
+                        source={sourceOf(entry.slug)}
+                        onSelect={() => onToggle(entry.slug)}
+                        onRemove={() => onRemove(entry.slug)}
+                      />
+                    ))}
+                  </Section>
+                )}
+              </div>
+            )
+          ) : apps.length === 0 ? (
+            <EmptySearchResult search={search} />
+          ) : (
+            <div className='space-y-1'>
+              {apps.map((appNode) => {
+                const counts = countLeaves(appNode, isInstalled)
+                return (
+                  <ToolSelectRow
+                    key={appNode.id}
+                    id={appNode.id}
+                    iconId={appNode.iconId ?? 'package'}
+                    color={appNode.color}
+                    label={appNode.label}
+                    subtitle={`${counts.installed}/${counts.total} ${pluralize(counts.total, 'tool')} installed`}
+                    installed={false}
+                    onSelect={() => onOpenApp(appNode)}
+                  />
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+    </>
+  )
+}
+
+interface AppDetailViewProps {
+  app: CatalogContainerNode
+  onBack: () => void
+  isInstalled: (slug: string) => boolean
+  sourceOf: (slug: string) => InstalledState['source'] | undefined
+  onToggle: (slug: string) => void
+  onRemove: (slug: string) => void
+  onAddAll: (slugs: string[]) => void
+}
+
+function AppDetailView({
+  app,
+  onBack,
+  isInstalled,
+  sourceOf,
+  onToggle,
+  onRemove,
+  onAddAll,
+}: AppDetailViewProps) {
+  const leaves = useMemo(() => flattenCatalogToToolsets([app]), [app])
+  const installedCount = leaves.reduce((n, l) => (isInstalled(l.slug) ? n + 1 : n), 0)
+  const total = leaves.length
+  const allInstalled = installedCount === total && total > 0
+
+  return (
+    <>
+      <DialogHeader className='mb-0 flex h-10 flex-row items-center border-b px-3'>
+        <div className='flex items-center gap-1'>
+          <Button variant='ghost' size='sm' onClick={onBack}>
+            <ChevronLeft />
+            Back
+          </Button>
+          <Separator orientation='vertical' className='h-5' />
+          <Button variant='ghost' size='sm'>
+            {app.label}
+          </Button>
+          <DialogTitle className='sr-only'>{app.label}</DialogTitle>
+          <DialogDescription className='sr-only'>
+            Toolsets exposed by {app.label}.
+          </DialogDescription>
+        </div>
+      </DialogHeader>
+
+      <div className='flex items-center justify-between border-b ps-3 pe-2 py-1'>
+        <span className='text-xs text-muted-foreground'>
+          {installedCount}/{total} {pluralize(total, 'tool')} installed
+        </span>
+        <Button
+          size='sm'
+          variant='ghost'
+          disabled={allInstalled}
+          onClick={() => onAddAll(leaves.map((l) => l.slug))}>
+          {allInstalled ? 'All installed' : 'Add all tools'}
+        </Button>
+      </div>
+
+      <ScrollArea className='flex-1' scrollbarClassName='w-1!'>
+        <div className='p-3'>
+          {leaves.map((entry) => (
+            <ToolSelectRow
+              key={entry.slug}
+              id={entry.slug}
+              iconId={entry.iconId}
+              color={entry.color || null}
+              label={entry.fullLabel}
+              description={entry.description || undefined}
+              badge={toolCountBadge(entry.tools.length) ?? undefined}
+              toolNames={entry.tools.map((t) => t.displayName)}
+              installed={isInstalled(entry.slug)}
+              source={sourceOf(entry.slug)}
+              onSelect={() => onToggle(entry.slug)}
+              onRemove={() => onRemove(entry.slug)}
+            />
+          ))}
+        </div>
+      </ScrollArea>
+    </>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h3 className='mb-1 px-2 text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+        {title}
+      </h3>
+      <div className=''>{children}</div>
+    </div>
+  )
+}
+
+function EmptySearchResult({ search }: { search: string }) {
+  return (
+    <div className='flex flex-col items-center justify-center py-12 text-center'>
+      <p className='text-sm text-muted-foreground'>
+        {search.trim() ? `No tools match "${search}".` : 'No tools available.'}
+      </p>
+    </div>
+  )
+}
+
+function countLeaves(
+  node: CatalogNode,
+  isInstalled: (slug: string) => boolean
+): { total: number; installed: number } {
+  if (node.kind === 'toolset') {
+    return { total: 1, installed: isInstalled(node.slug) ? 1 : 0 }
+  }
+  let total = 0
+  let installed = 0
+  for (const child of node.children) {
+    const sub = countLeaves(child, isInstalled)
+    total += sub.total
+    installed += sub.installed
+  }
+  return { total, installed }
+}

--- a/apps/web/src/components/agents/ui/detail/tools/tool-select-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tool-select-row.tsx
@@ -1,0 +1,150 @@
+// apps/web/src/components/agents/ui/detail/tools/tool-select-row.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { pluralize } from '@auxx/utils/strings'
+import { Check, Trash2 } from 'lucide-react'
+import { Tooltip } from '~/components/global/tooltip'
+import { AppIcon } from '~/components/workflow/ui/app-icon'
+
+export interface ToolSelectRowProps {
+  /** Either a toolset slug or an app id — opaque to the row. */
+  id: string
+  iconId: string
+  color: string | null
+  label: string
+  description?: string
+  /** Right-side badge label, e.g. `'3 tools'`. */
+  badge?: string
+  /** Tool display names shown in the badge tooltip. */
+  toolNames?: string[]
+  /** Subtitle line shown below the label — used by the Apps tab to show installed counts. */
+  subtitle?: string
+  installed: boolean
+  /**
+   * Source of the installed state, when known. `'manual'` = removable;
+   * `'mention'` / `'auto_default'` = locked (trash disabled with tooltip).
+   */
+  source?: 'manual' | 'mention' | 'auto_default'
+  /**
+   * Click handler for the row body. Toggles add/remove for toolsets; opens
+   * the app-detail view for apps.
+   */
+  onSelect: () => void
+  /**
+   * Optional inline remove handler. When supplied + `installed === true` +
+   * the row is removable, renders a hover trash button that fires this
+   * instead of `onSelect`.
+   */
+  onRemove?: () => void
+}
+
+/**
+ * Row used inside the Tool-Select dialog (All tab + App-detail tab). Avatar
+ * spans two lines, title + description on the right, optional badge on the
+ * far right. When `installed`, a green check overlays the avatar and a
+ * hover-only trash button appears (or a disabled trash with tooltip when
+ * `source` indicates the row is locked).
+ */
+export function ToolSelectRow({
+  iconId,
+  color,
+  label,
+  description,
+  badge,
+  toolNames,
+  subtitle,
+  installed,
+  source,
+  onSelect,
+  onRemove,
+}: ToolSelectRowProps) {
+  const removable = source === undefined || source === 'manual'
+  const lockedTooltip =
+    source === 'mention'
+      ? 'Locked — referenced in instructions. Remove the @-mention to unlock.'
+      : 'Default toolset — always available.'
+
+  return (
+    <button
+      type='button'
+      onClick={onSelect}
+      className='group flex w-full items-center gap-3 rounded-lg px-1 py-1 text-left hover:bg-primary-100/80'>
+      <div className='relative shrink-0'>
+        <AppIcon
+          iconId={iconId}
+          color={color ?? undefined}
+          size='lg'
+          className='border border-foreground/5'
+        />
+        {installed && (
+          <span className='absolute -top-0.5 -right-0.5 inline-flex size-2.5 items-center justify-center rounded-full bg-green-500 ring-1 ring-background'>
+            <Check className='size-2 text-white' />
+          </span>
+        )}
+      </div>
+
+      <div className='flex min-w-0 flex-1 flex-col'>
+        <div className='flex items-center gap-2'>
+          <span className='truncate text-sm font-medium'>{label}</span>
+          {badge &&
+            (toolNames && toolNames.length > 0 ? (
+              <Tooltip
+                side='top'
+                contentComponent={
+                  <div className='flex max-w-xs flex-col gap-0.5 py-0 text-xs'>
+                    {toolNames.map((name) => (
+                      <span key={name}>{name}</span>
+                    ))}
+                  </div>
+                }>
+                <Badge variant='purple' size='xs' className='text-[10px]'>
+                  {badge}
+                </Badge>
+              </Tooltip>
+            ) : (
+              <Badge variant='purple' size='xs' className='text-[10px]'>
+                {badge}
+              </Badge>
+            ))}
+        </div>
+        {description && (
+          <span className='truncate text-xs text-muted-foreground'>{description}</span>
+        )}
+        {!description && subtitle && (
+          <span className='text-xs text-muted-foreground'>{subtitle}</span>
+        )}
+      </div>
+
+      {installed &&
+        onRemove &&
+        (removable ? (
+          <span
+            role='button'
+            tabIndex={-1}
+            aria-label='Remove toolset'
+            onClick={(e) => {
+              e.stopPropagation()
+              onRemove()
+            }}
+            className='ml-2 inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100'>
+            <Trash2 className='size-3.5' />
+          </span>
+        ) : (
+          <Tooltip side='left' content={lockedTooltip}>
+            <span
+              aria-label='Toolset locked'
+              className='ml-2 inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 opacity-0 group-hover:opacity-100'>
+              <Trash2 className='size-3.5' />
+            </span>
+          </Tooltip>
+        ))}
+    </button>
+  )
+}
+
+/** Build the `{n} tools` badge string. Returns `null` for rows with one or zero tools. */
+export function toolCountBadge(toolCount: number): string | null {
+  if (toolCount < 2) return null
+  return `${toolCount} ${pluralize(toolCount, 'tool')}`
+}

--- a/apps/web/src/components/agents/ui/detail/tools/tools-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tools-section-content.tsx
@@ -2,26 +2,36 @@
 'use client'
 
 import type { CatalogNode } from '@auxx/lib/agents/client'
+import { EmptySection } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
+import { Wrench } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { api } from '~/trpc/react'
 import type { AgentDetail } from '../../../store/agent-store'
 import type { AutosaveState } from '../../shared/autosave-indicator'
-import { CatalogNodeRow, collectToggleable, type ToolsetRowState } from './catalog-node-row'
+import { CatalogNodeRow, pruneToInstalled, type ToolsetRowState } from './catalog-node-row'
 import { useToolsetMutations } from './use-toolset-mutations'
 
 interface ToolsSectionContentProps {
   agent: AgentDetail
   onAutosaveChange?: (state: AutosaveState) => void
+  /** Invoked when a top-level app row's "Add" button is clicked. */
+  onAddToApp?: (appId: string) => void
 }
 
 /**
- * The Tools tab body. Renders the org catalog tree as a recursive `TreeRow`:
- * App → (optional Sub-group) → Toolset. Switches cascade — toggling an app
- * row toggles every toolset under it (respecting mention locks); same for
- * sub-group rows. See `plans/kopilot/agents/tools/recursive-catalog-node.md`.
+ * Tools tab body — renders only the toolsets currently installed on the
+ * agent, as a pruned App → SubGroup → Toolset tree. The catalog browser and
+ * the "Add tools" trigger live one level up in `ToolsSection`
+ * (`agent-detail-tabs.tsx`); this component intentionally has no header so
+ * the action sits inside `<Section actions>`. See
+ * `plans/kopilot/agents/tools/tool-select-dialog.md`.
  */
-export function ToolsSectionContent({ agent, onAutosaveChange }: ToolsSectionContentProps) {
+export function ToolsSectionContent({
+  agent,
+  onAutosaveChange,
+  onAddToApp,
+}: ToolsSectionContentProps) {
   const catalogQuery = api.agentToolset.list.useQuery(undefined, {
     staleTime: 60_000,
   })
@@ -33,11 +43,7 @@ export function ToolsSectionContent({ agent, onAutosaveChange }: ToolsSectionCon
     [onAutosaveChange]
   )
 
-  const { toggleToolset, toggleToolsets } = useToolsetMutations(
-    agent.id,
-    agent.slug,
-    handleSavingChange
-  )
+  const { toggleToolset } = useToolsetMutations(agent.id, agent.slug, handleSavingChange)
 
   const stateBySlug = useMemo<Map<string, ToolsetRowState>>(() => {
     const map = new Map<string, ToolsetRowState>()
@@ -47,25 +53,47 @@ export function ToolsSectionContent({ agent, onAutosaveChange }: ToolsSectionCon
     return map
   }, [agent.toolsets])
 
-  // One Set for every container id in the tree; presence = collapsed.
-  // Defaults to empty (everything expanded — matches the pre-refactor UX).
-  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set())
+  const installedTree = useMemo(
+    () => (catalogQuery.data ? pruneToInstalled(catalogQuery.data, stateBySlug) : []),
+    [catalogQuery.data, stateBySlug]
+  )
 
-  const toggleCollapsed = useCallback((id: string) => {
-    setCollapsed((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }, [])
+  // Default = every container id collapsed. Derived synchronously from
+  // `installedTree` so the first render is already in the closed state — no
+  // open/close flash. Once the user toggles a row, `collapsed` becomes their
+  // explicit set and stays that way.
+  const defaultCollapsed = useMemo(() => {
+    const ids = new Set<string>()
+    const walk = (n: CatalogNode) => {
+      if (n.kind === 'toolset') return
+      ids.add(n.id)
+      n.children.forEach(walk)
+    }
+    installedTree.forEach(walk)
+    return ids
+  }, [installedTree])
 
-  const onCascadeToggle = useCallback(
-    (node: CatalogNode, nextEnabled: boolean) => {
-      const targets = collectToggleable(node, stateBySlug, nextEnabled)
-      if (targets.length > 0) void toggleToolsets(targets)
+  const [collapsedOverride, setCollapsedOverride] = useState<Set<string> | null>(null)
+  const collapsed = collapsedOverride ?? defaultCollapsed
+
+  const toggleCollapsed = useCallback(
+    (id: string) => {
+      setCollapsedOverride((prev) => {
+        const base = prev ?? defaultCollapsed
+        const next = new Set(base)
+        if (next.has(id)) next.delete(id)
+        else next.add(id)
+        return next
+      })
     },
-    [stateBySlug, toggleToolsets]
+    [defaultCollapsed]
+  )
+
+  const handleRemove = useCallback(
+    (slug: string) => {
+      void toggleToolset(slug, false)
+    },
+    [toggleToolset]
   )
 
   if (catalogQuery.isLoading || !catalogQuery.data) {
@@ -83,9 +111,21 @@ export function ToolsSectionContent({ agent, onAutosaveChange }: ToolsSectionCon
     )
   }
 
+  if (installedTree.length === 0) {
+    return (
+      <div className='px-3 py-2'>
+        <EmptySection
+          icon={<Wrench className='size-5' />}
+          title='No tools yet'
+          description='Add tools to give this agent capabilities.'
+        />
+      </div>
+    )
+  }
+
   return (
     <div className='flex flex-col pe-4'>
-      {catalogQuery.data.map((root) => (
+      {installedTree.map((root) => (
         <CatalogNodeRow
           key={root.id}
           node={root}
@@ -95,8 +135,9 @@ export function ToolsSectionContent({ agent, onAutosaveChange }: ToolsSectionCon
           stateBySlug={stateBySlug}
           collapsed={collapsed}
           onToggleCollapsed={toggleCollapsed}
-          onCascadeToggle={onCascadeToggle}
-          onLeafToggle={toggleToolset}
+          variant='installed'
+          onLeafRemove={handleRemove}
+          onAddToApp={onAddToApp}
         />
       ))}
     </div>

--- a/apps/web/src/components/agents/ui/detail/tools/toolset-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/toolset-row.tsx
@@ -1,9 +1,10 @@
 // apps/web/src/components/agents/ui/detail/tools/toolset-row.tsx
 'use client'
 
+import { Button } from '@auxx/ui/components/button'
 import { Switch } from '@auxx/ui/components/switch'
 import { TreeRow } from '@auxx/ui/components/tree-row'
-import { Lock } from 'lucide-react'
+import { Lock, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 import { AppIcon } from '~/components/workflow/ui/app-icon'
@@ -20,14 +21,24 @@ export interface ToolsetRowProps {
   enabled: boolean
   source: 'manual' | 'mention' | 'auto_default'
   depth?: number
-  onToolsetToggle: (slug: string, enabled: boolean) => void
+  /**
+   * `'editor'` renders a `<Switch>` (the catalog-browsing surface).
+   * `'installed'` renders a `<Trash2>` button — used by the installed-tools
+   * section where the dialog handles add/remove and rows only need a removal
+   * action. Mention-locked and auto_default rows show a disabled trash with a
+   * tooltip explaining the lock.
+   */
+  variant?: 'editor' | 'installed'
+  onToolsetToggle?: (slug: string, enabled: boolean) => void
+  onToolsetRemove?: (slug: string) => void
 }
 
 /**
  * One toolset rendered as a single-line TreeRow: icon + short label + tool
- * count + source badge + Switch. The toolset is the atomic unit of control —
- * there are no per-tool sub-rows. Mention-sourced rows show a badge and
- * disable the switch.
+ * count + source badge + action. Mention/auto_default rows are locked: the
+ * editor variant disables the Switch, the installed variant disables the
+ * Trash. The toolset is the atomic unit of control — there are no per-tool
+ * sub-rows.
  */
 export function ToolsetRow({
   slug,
@@ -39,7 +50,9 @@ export function ToolsetRow({
   enabled,
   source,
   depth = 0,
+  variant = 'editor',
   onToolsetToggle,
+  onToolsetRemove,
 }: ToolsetRowProps) {
   // Local state for instant switch feedback. Syncs back to server truth when
   // the parent prop changes (after optimistic update + cache reconciliation).
@@ -50,6 +63,10 @@ export function ToolsetRow({
 
   const isMention = source === 'mention'
   const isAutoDefault = source === 'auto_default'
+  const removable = source === 'manual'
+  const lockedTooltip = isMention
+    ? 'Locked — referenced in instructions. Remove the @-mention to unlock.'
+    : 'Default toolset — always available.'
 
   return (
     <TreeRow
@@ -62,12 +79,12 @@ export function ToolsetRow({
           <span className='text-xs text-muted-foreground'>
             {toolCount} {toolCount === 1 ? 'tool' : 'tools'}
           </span>
-          {isAutoDefault && (
+          {isAutoDefault && variant === 'editor' && (
             <span className='text-[10px] uppercase tracking-wide text-muted-foreground/70'>
               default
             </span>
           )}
-          {isMention && (
+          {isMention && variant === 'editor' && (
             <Tooltip
               side='left'
               content='Referenced in instructions. Remove the @-mention to unlock.'>
@@ -78,7 +95,31 @@ export function ToolsetRow({
               </span>
             </Tooltip>
           )}
-          {isMention ? (
+          {variant === 'installed' ? (
+            removable ? (
+              <Button
+                variant='ghost'
+                size='icon'
+                className='size-7 text-muted-foreground hover:text-destructive'
+                onClick={() => onToolsetRemove?.(slug)}
+                aria-label='Remove toolset'>
+                <Trash2 className='size-3.5' />
+              </Button>
+            ) : (
+              <Tooltip side='left' content={lockedTooltip}>
+                <span className='inline-flex opacity-60'>
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    className='size-7'
+                    disabled
+                    aria-label='Toolset locked'>
+                    <Trash2 className='size-3.5' />
+                  </Button>
+                </span>
+              </Tooltip>
+            )
+          ) : isMention ? (
             <Tooltip side='left' content='Locked — referenced in instructions.'>
               <span className='inline-flex opacity-60'>
                 <Switch size='xs' checked={localEnabled} disabled />
@@ -90,7 +131,7 @@ export function ToolsetRow({
               checked={localEnabled}
               onCheckedChange={(checked) => {
                 setLocalEnabled(checked)
-                onToolsetToggle(slug, checked)
+                onToolsetToggle?.(slug, checked)
               }}
             />
           )}

--- a/packages/lib/src/agents/builtin-app.ts
+++ b/packages/lib/src/agents/builtin-app.ts
@@ -28,6 +28,12 @@ export interface BuiltinToolsetMeta {
   iconId: string
   color: string
   isDefault: boolean
+  /**
+   * Curated for the Tool-Select dialog's "Popular tools" group. Independent of
+   * `isDefault` (which controls auto-enable for new agents) so the curation
+   * set can grow beyond the auto-enable set.
+   */
+  isPopular: boolean
   /** One-line tooltip copy shown on the leaf row's help icon. */
   description: string
   /**
@@ -48,6 +54,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'mails',
     color: 'blue',
     isDefault: true,
+    isPopular: true,
     description: 'Read mail threads, list inbox folders, and search across messages.',
     subGroupIconId: 'mails',
     subGroupColor: 'blue',
@@ -60,6 +67,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'send',
     color: 'blue',
     isDefault: true,
+    isPopular: true,
     description: 'Send new mail and reply to existing threads on behalf of the user.',
     subGroupIconId: null,
     subGroupColor: null,
@@ -72,6 +80,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'file-text',
     color: 'blue',
     isDefault: false,
+    isPopular: true,
     description: 'Create, update, and discard draft messages.',
     subGroupIconId: null,
     subGroupColor: null,
@@ -84,6 +93,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'search',
     color: 'purple',
     isDefault: true,
+    isPopular: true,
     description: 'Search and list entity records across every domain.',
     subGroupIconId: 'database',
     subGroupColor: 'purple',
@@ -96,6 +106,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'edit',
     color: 'purple',
     isDefault: true,
+    isPopular: false,
     description: 'Create, update, and annotate entity records.',
     subGroupIconId: null,
     subGroupColor: null,
@@ -108,6 +119,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'search',
     color: 'teal',
     isDefault: true,
+    isPopular: false,
     description: 'Read ticket comments and look up activity threads.',
     subGroupIconId: 'message-square',
     subGroupColor: 'teal',
@@ -120,6 +132,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'message-square',
     color: 'teal',
     isDefault: true,
+    isPopular: true,
     description: 'Post comments, reply to threads, and mention teammates.',
     subGroupIconId: null,
     subGroupColor: null,
@@ -132,6 +145,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'book-open',
     color: 'orange',
     isDefault: true,
+    isPopular: true,
     description: 'Search the knowledge base and retrieve published articles.',
     subGroupIconId: 'book-open',
     subGroupColor: 'orange',
@@ -144,6 +158,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'edit',
     color: 'orange',
     isDefault: false,
+    isPopular: false,
     description: 'Author, update, and publish knowledge-base articles.',
     subGroupIconId: null,
     subGroupColor: null,
@@ -156,6 +171,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'search',
     color: 'green',
     isDefault: false,
+    isPopular: false,
     description: 'Search and list tasks across assignees and queues.',
     subGroupIconId: 'list-checks',
     subGroupColor: 'green',
@@ -168,6 +184,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'check-circle',
     color: 'green',
     isDefault: false,
+    isPopular: true,
     description: 'Create, update, and resolve tasks.',
     subGroupIconId: null,
     subGroupColor: null,
@@ -180,6 +197,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'help-circle',
     color: 'gray',
     isDefault: true,
+    isPopular: false,
     description: 'Search internal product docs and runbooks.',
     subGroupIconId: 'help-circle',
     subGroupColor: 'gray',
@@ -192,6 +210,7 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<BuiltinToolsetMeta> = [
     iconId: 'users',
     color: 'pink',
     isDefault: true,
+    isPopular: false,
     description: 'Look up workspace members, teams, and bot actors.',
     subGroupIconId: null,
     subGroupColor: null,

--- a/packages/lib/src/agents/client.ts
+++ b/packages/lib/src/agents/client.ts
@@ -44,6 +44,8 @@ export interface CatalogToolsetNode extends CatalogNodeBase {
   /** One-line tooltip copy shown on the leaf row's help icon. */
   description: string
   isDefault: boolean
+  /** Curated for the Tool-Select dialog's "Popular tools" group. */
+  isPopular: boolean
   tools: ToolCatalogEntry[]
 }
 
@@ -66,6 +68,9 @@ export interface FlatToolsetCatalogEntry {
   color: string
   /** Ordered ancestor labels, top-down. */
   path: string[]
+  isDefault: boolean
+  /** Curated for the Tool-Select dialog's "Popular tools" group. */
+  isPopular: boolean
   tools: ToolCatalogEntry[]
 }
 
@@ -95,6 +100,8 @@ export function flattenCatalogToToolsets(roots: CatalogNode[]): FlatToolsetCatal
         iconId,
         color,
         path: pathLabels,
+        isDefault: node.isDefault,
+        isPopular: node.isPopular,
         tools: node.tools,
       })
       return

--- a/packages/lib/src/agents/toolset-catalog.ts
+++ b/packages/lib/src/agents/toolset-catalog.ts
@@ -101,6 +101,8 @@ export interface CatalogToolsetNode extends CatalogNodeBase {
   /** One-line tooltip copy shown on the leaf row's help icon. */
   description: string
   isDefault: boolean
+  /** Curated for the Tool-Select dialog's "Popular tools" group. */
+  isPopular: boolean
   tools: ToolCatalogEntry[]
 }
 
@@ -183,6 +185,7 @@ interface ToolsetInput {
   iconId: string | null
   color: string | null
   isDefault: boolean
+  isPopular: boolean
   description: string
   subGroup: string | null
   /** Sub-group header icon; first non-null across same-subGroup rows wins. */
@@ -230,6 +233,7 @@ async function buildOrgCatalogTree(organizationId: string): Promise<CatalogNode[
         iconId: meta.iconId,
         color: meta.color,
         isDefault: meta.isDefault,
+        isPopular: meta.isPopular,
         description: meta.description,
         subGroup: meta.subGroup,
         subGroupIconId: meta.subGroupIconId,
@@ -277,6 +281,9 @@ async function buildOrgCatalogTree(organizationId: string): Promise<CatalogNode[
           iconId: ts.iconKey ?? null,
           color: null,
           isDefault: ts.isDefault,
+          // SDK doesn't expose `isPopular` yet — third-party toolsets default
+          // to false. Deferred to a future SDK-side iteration.
+          isPopular: false,
           description: ts.description ?? '',
           subGroup: ts.subGroup ?? null,
           // App-side sub-group icon/color stays inherited from the app row.
@@ -367,6 +374,7 @@ function toToolsetNode(ts: ToolsetInput): CatalogToolsetNode {
     color: ts.color,
     description: ts.description,
     isDefault: ts.isDefault,
+    isPopular: ts.isPopular,
     tools: [...ts.tools].sort((a, b) => a.name.localeCompare(b.name)),
   }
 }


### PR DESCRIPTION
## Summary
- Splits the Tools tab into an installed-tools surface (pruned App → SubGroup → Toolset tree with trash + per-app Add) and a dedicated Add-tools dialog
- Adds an `isPopular` flag on builtin toolsets to drive a curated "Popular tools" group in the dialog
- Introduces a `variant` prop on `CatalogNodeRow`/`ToolsetRow` so the same tree renders as either an editor (switches) or installed list (trash)

## Test plan
- [ ] Open an agent's Tools tab — installed tree starts collapsed, shows only enabled/mention-locked toolsets
- [ ] Empty agent (no tools) shows the empty state with the Add-tools CTA
- [ ] "Add tools" opens the dialog; "Popular tools" group lists curated toolsets
- [ ] Per-app Add button in installed list opens the dialog scoped to that app
- [ ] Mention-locked toolsets render a disabled trash with tooltip; auto_default toolsets the same
- [ ] Removing a toolset from the installed list reflects in the catalog state