### PR TITLE
feat(kopilot): smooth streaming text + partial-JSON block rendering

### DIFF
--- a/apps/web/src/components/agents/ui/detail/tools/catalog-node-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/catalog-node-row.tsx
@@ -224,8 +224,8 @@ function ContainerInstalledStats({
   const allRemovable = stats.total > 0 && stats.removable === stats.total
   const lockedTooltip =
     stats.lockKind === 'mention'
-      ? 'Locked — referenced in instructions. Remove the @-mention to unlock.'
-      : 'Default toolset — always available.'
+      ? "This tool is referenced in your agent's prompt. To remove it, first edit your prompt."
+      : 'Required'
 
   return (
     <div className='flex items-center'>

--- a/apps/web/src/components/agents/ui/detail/tools/tool-select-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tool-select-row.tsx
@@ -62,8 +62,8 @@ export function ToolSelectRow({
   const removable = source === undefined || source === 'manual'
   const lockedTooltip =
     source === 'mention'
-      ? 'Locked — referenced in instructions. Remove the @-mention to unlock.'
-      : 'Default toolset — always available.'
+      ? "This tool is referenced in your agent's prompt. To remove it, first edit your prompt."
+      : 'Required'
 
   return (
     <button

--- a/apps/web/src/components/agents/ui/detail/tools/toolset-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/toolset-row.tsx
@@ -38,8 +38,8 @@ export function ToolsetRow({
   const tooltip = removable
     ? 'Remove toolset'
     : source === 'mention'
-      ? 'Locked — referenced in instructions. Remove the @-mention to unlock.'
-      : 'Default toolset — always available.'
+      ? "This tool is referenced in your agent's prompt. To remove it, first edit your prompt."
+      : 'Required'
 
   return (
     <TreeRow

--- a/apps/web/src/components/kopilot/hooks/use-smooth-stream.ts
+++ b/apps/web/src/components/kopilot/hooks/use-smooth-stream.ts
@@ -1,0 +1,176 @@
+// apps/web/src/components/kopilot/hooks/use-smooth-stream.ts
+
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+export interface SmoothStreamResult {
+  /** Substring of raw that should currently be displayed. */
+  displayed: string
+  /** Absolute word count of the displayed prefix (for stable keys). */
+  displayedWordCount: number
+}
+
+interface SmoothStreamOpts {
+  isStreaming?: boolean
+  /** Baseline characters-per-second drip rate. Default 100. */
+  cps?: number
+}
+
+const BACKLOG_K = 4
+const CPS_CAP = 600
+
+/**
+ * Drips `raw` out at an adaptive characters-per-second rate, smoothing model
+ * bursts into a continuous reveal. Returns the substring currently revealed
+ * plus its word count for stable per-word keys.
+ */
+export function useSmoothStream(raw: string, opts?: SmoothStreamOpts): SmoothStreamResult {
+  const isStreaming = opts?.isStreaming ?? true
+  const baseline = opts?.cps ?? 100
+
+  const cursorRef = useRef(0)
+  const lastTickRef = useRef<number | null>(null)
+  const rafRef = useRef<number | null>(null)
+  const rawRef = useRef(raw)
+  const isStreamingRef = useRef(isStreaming)
+  const baselineRef = useRef(baseline)
+
+  const [displayed, setDisplayed] = useState('')
+  const [displayedWordCount, setDisplayedWordCount] = useState(0)
+
+  rawRef.current = raw
+  isStreamingRef.current = isStreaming
+  baselineRef.current = baseline
+
+  // Reset on new message (raw shrunk or cleared).
+  useEffect(() => {
+    if (raw.length < cursorRef.current) {
+      cursorRef.current = 0
+      lastTickRef.current = null
+      setDisplayed('')
+      setDisplayedWordCount(0)
+    }
+  }, [raw])
+
+  // Poke the rAF loop awake whenever there's new backlog.
+  useEffect(() => {
+    if (rafRef.current !== null) return
+    if (cursorRef.current >= raw.length) return
+
+    const tick = (now: number) => {
+      const last = lastTickRef.current ?? now
+      const dt = Math.max(0, (now - last) / 1000)
+      lastTickRef.current = now
+
+      const total = rawRef.current.length
+      const backlog = total - cursorRef.current
+
+      if (backlog <= 0) {
+        rafRef.current = null
+        lastTickRef.current = null
+        return
+      }
+
+      // When the upstream is done but we still have backlog, drain at cap.
+      const cps = isStreamingRef.current
+        ? Math.min(CPS_CAP, baselineRef.current + BACKLOG_K * backlog)
+        : CPS_CAP
+      const advance = Math.max(1, Math.floor(cps * dt))
+      const next = Math.min(total, cursorRef.current + advance)
+      cursorRef.current = next
+
+      const slice = rawRef.current.slice(0, next)
+      setDisplayed(slice)
+      setDisplayedWordCount(countWords(slice))
+
+      rafRef.current = requestAnimationFrame(tick)
+    }
+
+    rafRef.current = requestAnimationFrame(tick)
+  }, [raw])
+
+  // Cancel on unmount.
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
+    }
+  }, [])
+
+  return { displayed, displayedWordCount }
+}
+
+function countWords(s: string): number {
+  if (!s) return 0
+  const m = s.match(/\S+/g)
+  return m ? m.length : 0
+}
+
+export interface StreamSplit {
+  prefix: string
+  tail: string
+  /** Absolute word count of prefix. Used for stable tail keys. */
+  prefixWordCount: number
+}
+
+interface SplitOpts {
+  tailWords?: number
+}
+
+/**
+ * Split the currently-displayed string into a stable markdown prefix and a
+ * trailing window of up to `tailWords` words for per-word animation. Holds the
+ * tail empty while inside an unclosed ```auxx:` fence so partial JSON stays in
+ * the prefix where the code-block renderer can show a partial card.
+ */
+export function splitAtHorizon(displayed: string, opts?: SplitOpts): StreamSplit {
+  const tailWords = opts?.tailWords ?? 12
+
+  if (hasOpenAuxxFence(displayed)) {
+    return { prefix: displayed, tail: '', prefixWordCount: countWords(displayed) }
+  }
+
+  const wordPositions: number[] = []
+  const re = /\S+/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(displayed)) !== null) {
+    wordPositions.push(m.index)
+  }
+
+  const total = wordPositions.length
+  if (total <= tailWords) {
+    return { prefix: '', tail: displayed, prefixWordCount: 0 }
+  }
+
+  const splitIdx = total - tailWords
+  const splitAt = wordPositions[splitIdx]!
+  return {
+    prefix: displayed.slice(0, splitAt),
+    tail: displayed.slice(splitAt),
+    prefixWordCount: splitIdx,
+  }
+}
+
+/**
+ * Detect whether the displayed string contains an opened (but not yet closed)
+ * ```auxx:<type> fenced block.
+ */
+function hasOpenAuxxFence(s: string): boolean {
+  const fenceRe = /```/g
+  let openedAuxx = false
+  let m: RegExpExecArray | null
+  while ((m = fenceRe.exec(s)) !== null) {
+    if (!openedAuxx) {
+      const after = s.slice(m.index + 3)
+      const nl = after.indexOf('\n')
+      const info = (nl === -1 ? after : after.slice(0, nl)).trim()
+      if (info.startsWith('auxx:')) openedAuxx = true
+    } else {
+      openedAuxx = false
+    }
+  }
+  return openedAuxx
+}

--- a/apps/web/src/components/kopilot/ui/blocks/block-schemas.ts
+++ b/apps/web/src/components/kopilot/ui/blocks/block-schemas.ts
@@ -155,9 +155,21 @@ export const tableColumnSchema = z.object({
   align: z.enum(['left', 'center', 'right']).optional(),
 })
 
+/**
+ * `columns` / `rows` are optional so the schema also accepts the best-effort
+ * output of the partial-JSON parser during streaming — the renderer defaults
+ * both to `[]` and grows the table as more data arrives.
+ *
+ * `.catch()` on each element keeps a single malformed cell/column from
+ * rejecting the whole table: the offending entry is coerced to a blank
+ * placeholder so the rest of the table renders progressively.
+ */
+const tableColumnPartialSafe = tableColumnSchema.catch({ label: '' })
+const tableCellPartialSafe = tableCellSchema.catch({ text: '' })
+
 export const tableBlockSchema = z.object({
-  columns: z.array(tableColumnSchema),
-  rows: z.array(z.array(tableCellSchema)),
+  columns: z.array(tableColumnPartialSafe).optional(),
+  rows: z.array(z.array(tableCellPartialSafe)).optional(),
 })
 
 /** Registry of block type → Zod schema */

--- a/apps/web/src/components/kopilot/ui/blocks/entity-card-item.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/entity-card-item.tsx
@@ -109,7 +109,7 @@ export function EntityCardItem({ recordId, snapshot, selectable }: EntityCardIte
 
 function EntityCardItemSkeleton() {
   return (
-    <div className='flex items-center gap-3 rounded-lg bg-background p-3 shadow-sm ring-1 ring-border'>
+    <div className='flex items-center gap-3 rounded-2xl bg-background p-1 shadow-sm ring-1 ring-border'>
       <Skeleton className='size-8 rounded-full' />
       <div className='min-w-0 flex-1 space-y-1.5'>
         <Skeleton className='h-4 w-32' />

--- a/apps/web/src/components/kopilot/ui/blocks/table-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/table-block.tsx
@@ -208,7 +208,10 @@ function ExpandButton({
 }
 
 export function TableBlock({ data }: BlockRendererProps<TableBlockData>) {
-  const { columns, rows } = data
+  // Default to empty arrays so partial streaming data (or a partial-JSON parse
+  // result without `columns`/`rows`) renders an empty table instead of crashing.
+  const columns = data.columns ?? []
+  const rows = data.rows ?? []
   const [isExpanded, setIsExpanded] = useState(false)
 
   return (

--- a/apps/web/src/components/kopilot/ui/blocks/task-item-skeleton.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/task-item-skeleton.tsx
@@ -3,10 +3,21 @@
 'use client'
 
 import { Badge } from '@auxx/ui/components/badge'
+import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
 import { format } from 'date-fns'
 import { Check, CircleDashed } from 'lucide-react'
 import type { TaskSnapshotData } from './block-schemas'
+
+/**
+ * Shared wrapper classes — must mirror TaskItem (apps/web/src/components/tasks/ui/task-item.tsx)
+ * so loading / snapshot / live rows all occupy the same vertical footprint.
+ */
+const TASK_ROW_WRAPPER = cn(
+  'relative flex gap-2 ps-1 pe-2 py-1.5',
+  'bg-illustration ring-border-illustration rounded-xl border border-transparent',
+  'shadow shadow-black/10 ring-1'
+)
 
 interface TaskItemSkeletonProps {
   snapshot: TaskSnapshotData
@@ -21,33 +32,71 @@ interface TaskItemSkeletonProps {
 export function TaskItemSkeleton({ snapshot, isDeleted }: TaskItemSkeletonProps) {
   const isCompleted = !!snapshot.completedAt
   return (
-    <div className='flex items-start gap-2 px-2 py-2 text-sm'>
+    <div className={cn(TASK_ROW_WRAPPER, (isCompleted || isDeleted) && 'opacity-60')}>
       {isCompleted ? (
-        <Check className='mt-0.5 size-4 shrink-0 text-muted-foreground' />
+        <Check className='mt-1 size-4 shrink-0 text-muted-foreground' />
       ) : (
-        <CircleDashed className='mt-0.5 size-4 shrink-0 text-muted-foreground' />
+        <CircleDashed className='mt-1 size-4 shrink-0 text-muted-foreground' />
       )}
       <div className='min-w-0 flex-1'>
-        <div className='flex items-center gap-2'>
+        <div className='flex items-start justify-between gap-2'>
           <span
             className={cn(
-              'truncate',
-              isCompleted && 'text-muted-foreground line-through',
+              'flex-1 truncate text-sm leading-6',
+              isCompleted && 'line-through text-muted-foreground',
               isDeleted && 'text-muted-foreground'
             )}>
             {snapshot.title}
           </span>
-          {isDeleted && (
-            <Badge variant='outline' className='shrink-0 text-[10px] uppercase'>
-              Deleted
-            </Badge>
+          {snapshot.deadline && (
+            <span className='flex-shrink-0 text-xs leading-6 text-muted-foreground'>
+              {format(new Date(snapshot.deadline), 'MMM d, yyyy')}
+            </span>
           )}
         </div>
-        {snapshot.deadline && (
-          <div className='mt-0.5 text-xs text-muted-foreground'>
-            {format(new Date(snapshot.deadline), 'MMM d, yyyy')}
+        {isDeleted && (
+          <div className='mt-0.5'>
+            <Badge variant='outline' className='text-[10px] uppercase'>
+              Deleted
+            </Badge>
           </div>
         )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Pure loading placeholder — same outer dimensions as TaskItem, no content.
+ * Used when neither a live task nor a snapshot is available yet.
+ */
+export function TaskRowLoading() {
+  return (
+    <div className={TASK_ROW_WRAPPER}>
+      <CircleDashed className='mt-1 size-4 shrink-0 text-muted-foreground/40' />
+      <div className='min-w-0 flex-1'>
+        <div className='flex items-center justify-between gap-2'>
+          <Skeleton className='my-1 h-4 w-2/3' />
+          <Skeleton className='my-1 h-3 w-16 shrink-0' />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Row-shaped placeholder for tasks the server confirmed do not exist.
+ * Same outer chrome as TaskItem so the list does not reflow.
+ */
+export function TaskRowUnavailable({ taskId }: { taskId: string }) {
+  return (
+    <div className={cn(TASK_ROW_WRAPPER, 'opacity-60')}>
+      <CircleDashed className='mt-1 size-4 shrink-0 text-muted-foreground' />
+      <div className='min-w-0 flex-1'>
+        <div className='flex items-center gap-2 text-sm leading-6 text-muted-foreground'>
+          <span className='shrink-0'>Task unavailable</span>
+          <span className='truncate font-mono text-[10px] opacity-70'>{taskId}</span>
+        </div>
       </div>
     </div>
   )

--- a/apps/web/src/components/kopilot/ui/blocks/task-list-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/task-list-block.tsx
@@ -13,7 +13,7 @@ import { TaskItem } from '~/components/tasks/ui/task-item'
 import { BlockCard } from './block-card'
 import type { BlockRendererProps } from './block-registry'
 import type { TaskListData } from './block-schemas'
-import { TaskItemSkeleton } from './task-item-skeleton'
+import { TaskItemSkeleton, TaskRowLoading, TaskRowUnavailable } from './task-item-skeleton'
 
 export function TaskListBlock({ data, skipEntrance }: BlockRendererProps<TaskListData>) {
   const router = useRouter()
@@ -63,11 +63,9 @@ export function TaskListBlock({ data, skipEntrance }: BlockRendererProps<TaskLis
                 ) : snap ? (
                   <TaskItemSkeleton snapshot={snap} isDeleted={isDeleted} />
                 ) : isDeleted ? (
-                  <div className='px-2 py-2 text-xs text-muted-foreground'>
-                    Task unavailable — <span className='font-mono'>{taskId}</span>
-                  </div>
+                  <TaskRowUnavailable taskId={taskId} />
                 ) : (
-                  <div className='px-2 py-2 text-xs text-muted-foreground'>Loading…</div>
+                  <TaskRowLoading />
                 )}
               </motion.div>
             )

--- a/apps/web/src/components/kopilot/ui/blocks/thread-list-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/thread-list-block.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { Badge } from '@auxx/ui/components/badge'
+import { Skeleton } from '@auxx/ui/components/skeleton'
 import { formatDistanceToNowStrict } from 'date-fns'
 import { Mail } from 'lucide-react'
 import { motion } from 'motion/react'
@@ -71,15 +72,11 @@ function ThreadListRow({ threadId, snapshot }: ThreadListRowProps) {
   const showDeleted = !thread && !!snapshot && isNotFound
 
   if (!thread && !snapshot && isLoading) {
-    return <div className='px-2 py-2 text-xs text-muted-foreground'>Loading…</div>
+    return <ThreadRowSkeleton />
   }
 
   if (!thread && !snapshot && isNotFound) {
-    return (
-      <div className='px-2 py-2 text-xs text-muted-foreground'>
-        Thread unavailable — <span className='font-mono'>{threadId}</span>
-      </div>
-    )
+    return <ThreadRowUnavailable threadId={threadId} />
   }
 
   return (
@@ -125,5 +122,40 @@ function ThreadListRow({ threadId, snapshot }: ThreadListRowProps) {
         </div>
       </div>
     </button>
+  )
+}
+
+/**
+ * Loading placeholder — matches ThreadListRow's wrapper so the list does not
+ * reflow when threads hydrate.
+ */
+function ThreadRowSkeleton() {
+  return (
+    <div className='flex w-full items-start gap-3 px-2 py-2 text-sm'>
+      <span className='mt-1.5 size-2 shrink-0 rounded-full bg-muted' />
+      <div className='min-w-0 flex-1'>
+        <Skeleton className='my-0.5 h-4 w-2/3' />
+        <Skeleton className='mt-1 h-3 w-1/3' />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Same row footprint as the loaded thread, used when the server confirms the
+ * thread no longer exists. Disabled visual treatment to match the deleted
+ * branch in the live button.
+ */
+function ThreadRowUnavailable({ threadId }: { threadId: string }) {
+  return (
+    <div className='flex w-full items-start gap-3 px-2 py-2 text-sm text-muted-foreground'>
+      <span className='mt-1.5 size-2 shrink-0 rounded-full bg-transparent' />
+      <div className='min-w-0 flex-1'>
+        <div className='flex items-center gap-2'>
+          <span className='truncate'>Thread unavailable</span>
+        </div>
+        <div className='mt-0.5 truncate font-mono text-[10px] opacity-70'>{threadId}</div>
+      </div>
+    </div>
   )
 }

--- a/apps/web/src/components/kopilot/ui/messages/assistant-message.tsx
+++ b/apps/web/src/components/kopilot/ui/messages/assistant-message.tsx
@@ -8,11 +8,13 @@ import { Tooltip } from '~/components/global/tooltip'
 import type { KopilotMessage, LinkSnapshot, ThinkingGroup } from '../../stores/kopilot-store'
 import { useKopilotStore } from '../../stores/kopilot-store'
 import '../../styles/kopilot-prose.css'
+import { parse as partialJsonParse } from '../../utils/partial-json'
 import { AuxxBlock } from '../blocks/auxx-block'
 import { REFERENCE_BLOCK_TYPES } from '../blocks/block-schemas'
 import { SparkleIcon } from '../sparkle-icon'
 import { AuxxInlineLink } from './auxx-inline-link'
 import { MessageActions } from './message-actions'
+import { StreamingText } from './streaming-text'
 import { ThinkingSteps } from './thinking-steps'
 
 const REFERENCE_BLOCK_SET = new Set<string>(REFERENCE_BLOCK_TYPES)
@@ -52,22 +54,25 @@ function buildMarkdownComponents(
 
       const raw = String(children ?? '').trim()
       if (!raw) {
-        return (
-          <pre className='not-prose'>
-            <code>{String(children ?? '')}</code>
-          </pre>
-        )
+        // Render the block shell with empty data so the chrome appears as soon
+        // as the fence opens, instead of flashing a code-block placeholder.
+        return <AuxxBlock type={auxxType} data={{}} />
       }
       let data: unknown
       try {
         data = JSON.parse(raw)
       } catch {
-        // Keep the fence visible as code while streaming / if JSON is malformed
-        return (
-          <pre className='not-prose'>
-            <code>{String(children ?? '')}</code>
-          </pre>
-        )
+        // Streaming / malformed: best-effort parse so users see the table fill
+        // in row-by-row instead of raw JSON.
+        try {
+          data = partialJsonParse(raw)
+        } catch {
+          return (
+            <pre className='not-prose'>
+              <code>{String(children ?? '')}</code>
+            </pre>
+          )
+        }
       }
       return <AuxxBlock type={auxxType} data={data} />
     },
@@ -150,12 +155,21 @@ export function AssistantMessage({
           </Tooltip>
         ) : (
           <div className='kopilot-prose'>
-            <Markdown
-              remarkPlugins={[remarkGfm]}
-              components={markdownComponents}
-              urlTransform={auxxUrlTransform}>
-              {isStreaming ? `${content}\u258C` : content}
-            </Markdown>
+            {isStreaming ? (
+              <StreamingText
+                raw={content}
+                isStreaming
+                markdownComponents={markdownComponents}
+                urlTransform={auxxUrlTransform}
+              />
+            ) : (
+              <Markdown
+                remarkPlugins={[remarkGfm]}
+                components={markdownComponents}
+                urlTransform={auxxUrlTransform}>
+                {content}
+              </Markdown>
+            )}
           </div>
         )}
         {!isStreaming && message && !message.error && (

--- a/apps/web/src/components/kopilot/ui/messages/streaming-text.tsx
+++ b/apps/web/src/components/kopilot/ui/messages/streaming-text.tsx
@@ -1,0 +1,57 @@
+// apps/web/src/components/kopilot/ui/messages/streaming-text.tsx
+
+'use client'
+
+import { motion, useReducedMotion } from 'motion/react'
+import { useMemo } from 'react'
+import Markdown, { type Components, type UrlTransform } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { splitAtHorizon, useSmoothStream } from '../../hooks/use-smooth-stream'
+
+interface Props {
+  raw: string
+  isStreaming: boolean
+  markdownComponents: Components
+  urlTransform: UrlTransform
+}
+
+export function StreamingText({ raw, isStreaming, markdownComponents, urlTransform }: Props) {
+  const reduced = useReducedMotion()
+  const { displayed } = useSmoothStream(raw, { isStreaming })
+  const { prefix, tail, prefixWordCount } = useMemo(() => splitAtHorizon(displayed), [displayed])
+  // Split keeps whitespace as alternating tokens so word indices are derivable:
+  // word at even position 2k, whitespace at 2k+1.
+  const tailTokens = useMemo(() => tail.split(/(\s+)/), [tail])
+
+  return (
+    <div>
+      <Markdown
+        remarkPlugins={[remarkGfm]}
+        components={markdownComponents}
+        urlTransform={urlTransform}>
+        {prefix}
+      </Markdown>
+      <span aria-hidden>
+        {tailTokens.map((tok, i) => {
+          if (!tok) return null
+          if (/^\s+$/.test(tok)) {
+            return <span key={`s-${prefixWordCount}-${i}`}>{tok}</span>
+          }
+          const wordIndex = prefixWordCount + Math.floor(i / 2)
+          return reduced ? (
+            <span key={wordIndex}>{tok}</span>
+          ) : (
+            <motion.span
+              key={wordIndex}
+              initial={{ opacity: 0, filter: 'blur(3px)' }}
+              animate={{ opacity: 1, filter: 'blur(0px)' }}
+              transition={{ duration: 0.35, ease: 'easeOut' }}
+              className='will-change-[filter,opacity]'>
+              {tok}
+            </motion.span>
+          )
+        })}
+      </span>
+    </div>
+  )
+}

--- a/apps/web/src/components/kopilot/utils/partial-json.ts
+++ b/apps/web/src/components/kopilot/utils/partial-json.ts
@@ -1,0 +1,433 @@
+// apps/web/src/components/kopilot/utils/partial-json.ts
+
+/**
+ * Lenient JSON parser used to render kopilot blocks (most importantly the
+ * `auxx:table` fence) while their JSON is still streaming in. Unlike
+ * `JSON.parse`, it returns a best-effort value for truncated input — open
+ * strings/arrays/objects produce the partial collected so far instead of
+ * throwing. Strict input still goes through native `JSON.parse` (called
+ * first), so this is a pure fallback path.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* biome-ignore-all lint/suspicious/noExplicitAny: parser intentionally untyped */
+
+type Error = unknown
+
+let logError = console.error
+
+export function setErrorLogger(logger: (message: string, data?: any) => void): void {
+  logError = logger
+}
+
+export function disableErrorLogging(): void {
+  logError = () => {
+    /* do not output to console */
+  }
+}
+
+export function enableErrorLogging(): void {
+  logError = console.error
+}
+
+export function stripComments(text: string): string {
+  const buffer: string[] = []
+
+  let in_string = false
+  let string_char = ''
+  let string_escaped = false
+
+  let in_inline_comment = false
+
+  let in_block_comment = false
+  let saw_star = false
+
+  let in_html_comment = false
+  let saw_hyphen = 0
+
+  for (const char of text) {
+    if (in_string) {
+      if (string_escaped) {
+        string_escaped = false
+        buffer.push(char)
+        continue
+      }
+
+      if (char === '\\') {
+        string_escaped = true
+        buffer.push(char)
+        continue
+      }
+
+      if (char === string_char) {
+        in_string = false
+        buffer.push(char)
+        continue
+      }
+
+      buffer.push(char)
+      continue
+    }
+
+    if (in_inline_comment) {
+      if (char === '\n') {
+        in_inline_comment = false
+        continue
+      }
+      continue
+    }
+
+    const buffer_length = buffer.length
+    const last_char = buffer_length === 0 ? '' : buffer[buffer_length - 1]
+
+    if (in_block_comment) {
+      if (char === '*') {
+        saw_star = true
+        continue
+      }
+      if (saw_star && char === '/') {
+        in_block_comment = false
+        continue
+      }
+      saw_star = false
+      continue
+    }
+
+    if (in_html_comment) {
+      if (char === '-') {
+        saw_hyphen++
+        continue
+      }
+      if (saw_hyphen >= 2 && char === '>') {
+        in_html_comment = false
+        continue
+      }
+      saw_hyphen = 0
+      continue
+    }
+
+    if (last_char === '/' && char === '/') {
+      buffer.pop()
+      in_inline_comment = true
+      continue
+    }
+
+    if (last_char === '/' && char === '*') {
+      buffer.pop()
+      in_block_comment = true
+      saw_star = false
+      continue
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      in_string = true
+      string_char = char
+      string_escaped = false
+      buffer.push(char)
+      continue
+    }
+
+    if (
+      buffer_length >= 4 &&
+      char === '-' &&
+      buffer[buffer_length - 1] === '-' &&
+      buffer[buffer_length - 2] === '!' &&
+      buffer[buffer_length - 3] === '<'
+    ) {
+      in_html_comment = true
+      buffer.pop()
+      buffer.pop()
+      buffer.pop()
+      continue
+    }
+
+    buffer.push(char)
+  }
+  return buffer.join('')
+}
+
+export function parse(s: string | undefined | null): any {
+  if (s === undefined) {
+    return undefined
+  }
+  if (s === null) {
+    return null
+  }
+  if (s === '') {
+    return ''
+  }
+  s = stripComments(s)
+  s = s.replace(/\\+$/, (match) => (match.length % 2 === 0 ? match : match.slice(0, -1)))
+  try {
+    return JSON.parse(s)
+  } catch (e) {
+    const [data, reminding] =
+      s.trimStart()[0] === ':' ? parseAny(s, e) : parseAny(s, e, parseStringWithoutQuote)
+    parse.lastParseReminding = reminding
+    if (parse.onExtraToken && reminding.length > 0) {
+      const trimmedReminding = reminding.trimEnd()
+      parse.lastParseReminding = trimmedReminding
+      if (trimmedReminding.length > 0) {
+        parse.onExtraToken(s, data, trimmedReminding)
+      }
+    }
+    return data
+  }
+}
+
+export namespace parse {
+  export let lastParseReminding: string | undefined
+  export const onExtraToken: (text: string, data: any, reminding: string) => void = (
+    text,
+    data,
+    reminding
+  ) => {
+    logError('parsed json with extra tokens:', { text, data, reminding })
+  }
+}
+
+function parseAny(s: string, e: Error, fallback?: Parser<any>): ParseResult<any> {
+  const parser = parsers[s[0]] || fallback
+  if (!parser) {
+    logError(`no parser registered for ${JSON.stringify(s[0])}:`, { s })
+    throw e
+  }
+  return parser(s, e)
+}
+
+function parseStringCasual(s: string, e: Error, delimiters?: string[]): ParseResult<string> {
+  if (s[0] === '"') {
+    return parseString(s)
+  }
+  if (s[0] === "'") {
+    return parseSingleQuoteString(s)
+  }
+  if (s[0] === '`') {
+    return parseBacktickString(s)
+  }
+  return parseStringWithoutQuote(s, e, delimiters)
+}
+
+type Code = string
+type Parser<T> = (s: Code, e: Error) => ParseResult<T>
+type ParseResult<T> = [T, Code]
+
+const parsers: Record<string, Parser<any>> = {}
+
+function skipSpace(s: string): string {
+  return s.trimStart()
+}
+
+function parseSpace(s: string, e: Error) {
+  s = skipSpace(s)
+  return parseAny(s, e)
+}
+
+parsers[' '] = parseSpace
+parsers['\r'] = parseSpace
+parsers['\n'] = parseSpace
+parsers['\t'] = parseSpace
+
+function parseArray(s: string, e: Error): ParseResult<any[]> {
+  s = s.substring(1) // skip starting '['
+  const acc: any[] = []
+  s = skipSpace(s)
+  while (s.length > 0) {
+    if (s[0] === ']') {
+      s = s.substring(1) // skip ending ']'
+      break
+    }
+    const res = parseAny(s, e, (s, e) => parseStringWithoutQuote(s, e, [',', ']']))
+    acc.push(res[0])
+    s = res[1]
+    s = skipSpace(s)
+    if (s[0] === ',') {
+      s = s.substring(1)
+      s = skipSpace(s)
+    }
+  }
+  return [acc, s]
+}
+
+parsers['['] = parseArray
+
+function parseNumber(s: string): ParseResult<number | string> {
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i]
+    if (parsers[c] === parseNumber) {
+      continue
+    }
+    const num = s.substring(0, i)
+    s = s.substring(i)
+    return [numToStr(num), s]
+  }
+  return [numToStr(s), '']
+}
+
+for (const c of '0123456789.-'.slice()) {
+  parsers[c] = parseNumber
+}
+
+function numToStr(s: string) {
+  if (s === '-') {
+    return -0
+  }
+  const num = +s
+  if (Number.isNaN(num)) {
+    return s
+  }
+  return num
+}
+
+function parseString(s: string): ParseResult<string> {
+  for (let i = 1; i < s.length; i++) {
+    const c = s[i]
+    if (c === '\\') {
+      i++
+      continue
+    }
+    if (c === '"') {
+      const str = fixEscapedCharacters(s.substring(0, i + 1))
+      s = s.substring(i + 1)
+      return [JSON.parse(str), s]
+    }
+  }
+  return [JSON.parse(`${fixEscapedCharacters(s)}"`), '']
+}
+
+parsers['"'] = parseString
+
+function fixEscapedCharacters(s: string): string {
+  return s.replace(/\n/g, '\\n').replace(/\t/g, '\\t').replace(/\r/g, '\\r')
+}
+
+function parseSingleQuoteString(s: string): ParseResult<string> {
+  for (let i = 1; i < s.length; i++) {
+    const c = s[i]
+    if (c === '\\') {
+      i++
+      continue
+    }
+    if (c === "'") {
+      const str = fixEscapedCharacters(s.substring(0, i + 1))
+      s = s.substring(i + 1)
+      return [JSON.parse(`"${str.slice(1, -1)}"`), s]
+    }
+  }
+  return [JSON.parse(`"${fixEscapedCharacters(s.slice(1))}"`), '']
+}
+
+parsers["'"] = parseSingleQuoteString
+
+function parseBacktickString(s: string): ParseResult<string> {
+  const buffer: string[] = []
+  let is_escaped = false
+  let escape_count = 0
+  for (let i = 1; i < s.length; i++) {
+    const c = s[i]
+    if (is_escaped) {
+      buffer.push(c)
+      is_escaped = false
+      continue
+    }
+    if (c === '\\') {
+      is_escaped = true
+      escape_count++
+      continue
+    }
+    if (c === '`') {
+      const str = buffer.join('')
+      s = s.substring(str.length + escape_count + 2)
+      return [str, s]
+    }
+    buffer.push(c)
+  }
+  return [buffer.join(''), s.slice(1)]
+}
+
+parsers['`'] = parseBacktickString
+
+function parseStringWithoutQuote(
+  s: string,
+  _e: Error,
+  delimiters: string[] = [' ']
+): ParseResult<string> {
+  const index = Math.min(
+    ...delimiters.map((delimiter) => {
+      const i = s.indexOf(delimiter)
+      return i === -1 ? s.length : i
+    })
+  )
+  const value = s.substring(0, index).trim()
+  const rest = s.substring(index)
+  return [value, rest]
+}
+
+function parseObject(s: string, e: Error): ParseResult<object> {
+  s = s.substring(1) // skip starting '{'
+  const acc: any = {}
+  s = skipSpace(s)
+  while (s.length > 0) {
+    if (s[0] === '}') {
+      s = s.substring(1) // skip ending '}'
+      break
+    }
+
+    const keyRes = parseStringCasual(s, e, [':', '}'])
+    const key = keyRes[0]
+    s = keyRes[1]
+
+    s = skipSpace(s)
+    if (s[0] !== ':') {
+      acc[key] = undefined
+      break
+    }
+    s = s.substring(1) // skip ':'
+    s = skipSpace(s)
+
+    if (s.length === 0) {
+      acc[key] = undefined
+      break
+    }
+    const valueRes = parseAny(s, e)
+    acc[key] = valueRes[0]
+    s = valueRes[1]
+    s = skipSpace(s)
+
+    if (s[0] === ',') {
+      s = s.substring(1)
+      s = skipSpace(s)
+    }
+  }
+  return [acc, s]
+}
+
+parsers['{'] = parseObject
+
+function parseToken<T>(s: string, tokenStr: string, tokenVal: T, e: Error): ParseResult<T> {
+  for (let i = tokenStr.length; i >= 1; i--) {
+    if (s.startsWith(tokenStr.slice(0, i))) {
+      return [tokenVal, s.slice(i)]
+    }
+  }
+  /* istanbul ignore next */
+  const prefix = JSON.stringify(s.slice(0, tokenStr.length))
+  logError(`unknown token starting with ${prefix}:`, { s })
+  throw e
+}
+
+function parseTrue(s: string, e: Error): ParseResult<true> {
+  return parseToken(s, 'true', true, e)
+}
+
+function parseFalse(s: string, e: Error): ParseResult<false> {
+  return parseToken(s, 'false', false, e)
+}
+
+function parseNull(s: string, e: Error): ParseResult<null> {
+  return parseToken(s, 'null', null, e)
+}
+
+parsers['t'] = parseTrue
+parsers['f'] = parseFalse
+parsers['n'] = parseNull


### PR DESCRIPTION
## Summary
- Smooth assistant text reveal: rAF-driven character cursor (`useSmoothStream`) drips raw stream output, and a trailing word window blurs in via motion — model bursts feel continuous instead of chunky.
- Partial-JSON parsing for `auxx:` fences while streaming: `table-block` schema now accepts optional `columns`/`rows` and recovers from malformed cells, so tables fill in row-by-row instead of flashing a raw code block.
- Row-shaped loading and unavailable placeholders for task and thread list blocks — same outer chrome as the live rows, no reflow on hydrate.
- Side change: rewrote agent installed-tool tooltips into user-facing copy ("This tool is referenced in your agent's prompt…", "Required").

## Test plan
- [ ] Open a kopilot thread, send a message that produces a long markdown reply — confirm text drips smoothly without choppy bursts and the trailing words blur in.
- [ ] Send a prompt that produces an `auxx:table` block — confirm the table grows row-by-row mid-stream and doesn't flash raw JSON.
- [ ] Send an `auxx:task-list` / `auxx:thread-list` block — confirm loading and unavailable rows occupy the same footprint as the loaded rows (no reflow).
- [ ] Open the agent detail tools tree — hover a mention-locked tool and a required toolset, confirm new tooltip copy.
- [ ] Toggle "Reduce motion" in the OS — confirm streaming words appear without the blur/opacity animation.