### PR TITLE
feat(kopilot): oneshot query mode + collapsible block cards

### DIFF
--- a/apps/web/src/components/kopilot/ui/blocks/block-card.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/block-card.tsx
@@ -3,8 +3,11 @@
 'use client'
 
 import { cn } from '@auxx/ui/lib/utils'
-import type { ReactNode } from 'react'
+import { Maximize2, Minimize2 } from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+import { type ReactNode, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
+import { ActionButton } from '~/components/workflow/ui/action-button'
 
 const STATUS_CONFIG = {
   pending: { color: 'bg-amber-500', label: 'Pending Approval' },
@@ -49,6 +52,29 @@ interface BlockCardProps {
   'data-slot'?: string
   /** Extra classes for the outer wrapper. Use `[&_[data-slot=block-card-body]]:p-0` etc. to target inner slots. */
   className?: string
+  /** Render a Maximize/Minimize toggle in the header and collapse the body. */
+  collapsible?: boolean
+  /** Initial collapsed state when `collapsible`. Default: false. */
+  defaultCollapsed?: boolean
+  /**
+   * Extra header-right slot — rendered between `secondaryText` and the
+   * built-in collapse toggle. Lets callers add their own icon buttons
+   * (e.g. table-block's expand-to-dialog) without forking the layout.
+   * Use `ActionButton` for visual consistency.
+   */
+  headerActions?: ReactNode
+}
+
+function CollapseToggle({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => void }) {
+  return (
+    <Tooltip content={collapsed ? 'Expand' : 'Collapse'}>
+      <div className='-my-1 -mr-1'>
+        <ActionButton onClick={onToggle}>
+          {collapsed ? <Maximize2 className='size-3.5' /> : <Minimize2 className='size-3.5' />}
+        </ActionButton>
+      </div>
+    </Tooltip>
+  )
 }
 
 export function BlockCard({
@@ -62,28 +88,15 @@ export function BlockCard({
   actions,
   'data-slot': dataSlot,
   className,
+  collapsible,
+  defaultCollapsed = false,
+  headerActions,
 }: BlockCardProps) {
   const showFooter = hasFooter && (actionLabel || (actions && actions.length > 0))
+  const [collapsed, setCollapsed] = useState(defaultCollapsed)
 
-  return (
-    <div
-      data-slot={dataSlot}
-      className={cn(
-        'rounded-3xl bg-card/25 p-2 shadow-lg shadow-black/[.065] ring-1 ring-border-illustration',
-        className
-      )}>
-      {hasHeader && (
-        <div className='flex items-start justify-between px-2 pt-1'>
-          <div className='flex items-center gap-2'>
-            {indicator}
-            {primaryText && (
-              <span className='text-xs font-semibold text-foreground/90'>{primaryText}</span>
-            )}
-          </div>
-          {secondaryText && <div className='text-sm text-foreground/50'>{secondaryText}</div>}
-        </div>
-      )}
-
+  const body = (
+    <>
       {children && (
         <div
           data-slot='block-card-body'
@@ -118,6 +131,50 @@ export function BlockCard({
             ))}
           </div>
         </div>
+      )}
+    </>
+  )
+
+  return (
+    <div
+      data-slot={dataSlot}
+      className={cn(
+        'rounded-3xl bg-card/25 p-2 shadow-lg shadow-black/[.065] ring-1 ring-border-illustration',
+        className
+      )}>
+      {hasHeader && (
+        <div className='flex items-start justify-between px-2 pt-1'>
+          <div className='flex items-center gap-2'>
+            {indicator}
+            {primaryText && (
+              <span className='text-xs font-semibold text-foreground/90'>{primaryText}</span>
+            )}
+          </div>
+          <div className='flex items-center gap-1.5'>
+            {secondaryText && <div className='text-sm text-foreground/50'>{secondaryText}</div>}
+            {headerActions}
+            {collapsible && (
+              <CollapseToggle collapsed={collapsed} onToggle={() => setCollapsed((v) => !v)} />
+            )}
+          </div>
+        </div>
+      )}
+
+      {collapsible ? (
+        <AnimatePresence initial={false}>
+          {!collapsed && (
+            <motion.div
+              initial={{ height: 0, opacity: 0, filter: 'blur(3px)' }}
+              animate={{ height: 'auto', opacity: 1, filter: 'blur(0px)' }}
+              exit={{ height: 0, opacity: 0, filter: 'blur(3px)' }}
+              transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+              style={{ overflow: 'hidden' }}>
+              {body}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      ) : (
+        body
       )}
     </div>
   )

--- a/apps/web/src/components/kopilot/ui/blocks/bulk-update-approval-card.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/bulk-update-approval-card.tsx
@@ -58,7 +58,9 @@ export function BulkUpdateApprovalCard({ args, status, onApprove, onReject }: Ap
             ? 'Rejected'
             : undefined
       }
-      actions={actions}>
+      actions={actions}
+      collapsible={status === 'rejected'}
+      defaultCollapsed={status === 'rejected'}>
       {values.length > 0 && (
         <div className='mb-2 border-b pb-2'>
           {values.map((v) => (

--- a/apps/web/src/components/kopilot/ui/blocks/draft-approval-card.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/draft-approval-card.tsx
@@ -149,7 +149,9 @@ export function DraftApprovalCard({
       secondaryText={secondaryText}
       actionLabel={isPending ? 'Send message?' : undefined}
       hasFooter={actions.length > 0}
-      actions={actions}>
+      actions={actions}
+      collapsible={isRejected}
+      defaultCollapsed={isRejected}>
       <div className='h-40'>
         <ScrollArea
           className='h-full'

--- a/apps/web/src/components/kopilot/ui/blocks/entity-create-approval-card.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/entity-create-approval-card.tsx
@@ -36,7 +36,9 @@ export function EntityCreateApprovalCard({ args, status, onApprove, onReject }: 
       primaryText={`Create ${resource?.label ?? 'Record'}`}
       hasFooter={isPending}
       actionLabel={isPending ? 'Create record?' : undefined}
-      actions={actions}>
+      actions={actions}
+      collapsible={status === 'rejected'}
+      defaultCollapsed={status === 'rejected'}>
       {entries.length > 0 ? (
         <div>
           {entries.map(([key, value]) => (

--- a/apps/web/src/components/kopilot/ui/blocks/entity-update-approval-card.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/entity-update-approval-card.tsx
@@ -32,7 +32,9 @@ export function EntityUpdateApprovalCard({ args, status, onApprove, onReject }: 
       primaryText={`Update ${resource?.label ?? 'Record'}${record?.displayName ? `: ${record.displayName}` : ''}`}
       hasFooter={isPending}
       actionLabel={isPending ? 'Apply changes?' : undefined}
-      actions={actions}>
+      actions={actions}
+      collapsible={status === 'rejected'}
+      defaultCollapsed={status === 'rejected'}>
       <div>
         {Object.entries(values).map(([key, value]) => (
           <KopilotFieldRow

--- a/apps/web/src/components/kopilot/ui/blocks/generic-approval-card.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/generic-approval-card.tsx
@@ -30,7 +30,9 @@ export function GenericApprovalCard({
       primaryText='Approval required'
       secondaryText={<span className='font-mono text-xs'>{toolName}</span>}
       hasFooter={isPending}
-      actions={actions}>
+      actions={actions}
+      collapsible={status === 'rejected'}
+      defaultCollapsed={status === 'rejected'}>
       {argEntries.length > 0 && (
         <div className='space-y-1.5'>
           {argEntries.map(([key, value]) => {

--- a/apps/web/src/components/kopilot/ui/blocks/table-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/table-block.tsx
@@ -192,13 +192,16 @@ function TableContent({ columns, rows }: { columns: TableColumnData[]; rows: Tab
 function ExpandButton({
   isExpanded,
   onExpandChange,
+  insetHeader,
 }: {
   isExpanded: boolean
   onExpandChange: (expanded: boolean) => void
+  /** Pull button into the card's p-2 padding when used in BlockCard headerActions. */
+  insetHeader?: boolean
 }) {
   return (
     <Tooltip content={isExpanded ? 'Close' : 'Expand'}>
-      <div>
+      <div className={insetHeader ? '-my-1 -mr-1' : undefined}>
         <ActionButton onClick={() => onExpandChange(!isExpanded)}>
           {isExpanded ? <Minimize2 className='size-3.5' /> : <Maximize2 className='size-3.5' />}
         </ActionButton>
@@ -221,12 +224,12 @@ export function TableBlock({ data }: BlockRendererProps<TableBlockData>) {
         primaryText='Table'
         hasFooter={false}
         secondaryText={
-          <span className='flex items-center gap-1.5'>
-            <span className='text-xs text-muted-foreground'>
-              {rows.length} {rows.length === 1 ? 'row' : 'rows'}
-            </span>
-            <ExpandButton isExpanded={false} onExpandChange={setIsExpanded} />
+          <span className='text-xs text-muted-foreground'>
+            {rows.length} {rows.length === 1 ? 'row' : 'rows'}
           </span>
+        }
+        headerActions={
+          <ExpandButton isExpanded={false} onExpandChange={setIsExpanded} insetHeader />
         }>
         <ScrollArea
           orientation='horizontal'

--- a/apps/web/src/components/kopilot/ui/blocks/task-create-approval-card.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/task-create-approval-card.tsx
@@ -54,7 +54,9 @@ export function TaskCreateApprovalCard({ args, status, onApprove, onReject }: Ap
       primaryText='Create Task'
       hasFooter={isPending}
       actionLabel={isPending ? 'Create this task?' : undefined}
-      actions={actions}>
+      actions={actions}
+      collapsible={status === 'rejected'}
+      defaultCollapsed={status === 'rejected'}>
       <div className='space-y-2'>
         {/* Title */}
         <div className='flex items-start gap-2'>

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
@@ -9,7 +9,13 @@ import {
   OPERATOR_DEFINITIONS,
   type Operator,
 } from '../../../../../conditions/operator-definitions'
-import { UnifiedCrudHandler } from '../../../../../resources/crud'
+import {
+  countEntityInstances,
+  countSystemResource,
+  isSystemResource,
+  UnifiedCrudHandler,
+} from '../../../../../resources/crud'
+import type { TableId } from '../../../../../resources/registry/field-registry'
 import { getFieldOptions } from '../../../../../resources/registry/option-helpers'
 import type { Resource } from '../../../../../resources/registry/types'
 import { toRecordId } from '../../../../../resources/resource-id'
@@ -172,7 +178,7 @@ Examples:
       const logicalOperator = (args.logicalOperator as 'AND' | 'OR') ?? 'AND'
       const sort = args.sort as { field: string; direction: 'asc' | 'desc' } | undefined
       const countOnly = args.countOnly === true
-      const limit = countOnly ? 0 : Math.min((args.limit as number) || 25, 100)
+      const limit = Math.min((args.limit as number) || 25, 100)
       const offset = Math.max((args.offset as number) || 0, 0)
 
       const warnings: QueryWarning[] = []
@@ -224,30 +230,47 @@ Examples:
 
       // Convert simplified filters → ConditionGroup[]
       const conditionGroup = convertToConditionGroup(validFilters, resource, logicalOperator)
+      const conditionGroups = conditionGroup ? [conditionGroup] : []
 
-      // Build sorting
-      const sorting = sort ? [{ id: sort.field, desc: sort.direction === 'desc' }] : []
-
-      // Query filtered IDs
-      const filtered = await handler.listFiltered({
-        entityDefinitionId: entityDefId,
-        filters: conditionGroup ? [conditionGroup] : [],
-        sorting,
-        limit,
-        cursor: offset > 0 ? { snapshotId: '', offset } : undefined,
-      })
-
-      // Count-only mode — return just the total, skip hydration
+      // Count-only mode — short-circuit: run just `SELECT COUNT(*)`, skip id fetch + hydration.
       if (countOnly) {
+        const total = isSystemResource(entityDefId)
+          ? await countSystemResource({
+              db,
+              tableId: entityDefId as TableId,
+              organizationId: agentDeps.organizationId,
+              filters: conditionGroups,
+            })
+          : await countEntityInstances({
+              db,
+              entityDefinitionId: entityDefId,
+              organizationId: agentDeps.organizationId,
+              filters: conditionGroups,
+            })
+
         return {
           success: true,
           output: {
             entityType: resource.label,
-            total_matching: filtered.total,
+            total_matching: total,
             warnings: warnings.length > 0 ? warnings : undefined,
           },
         }
       }
+
+      // Build sorting
+      const sorting = sort ? [{ id: sort.field, desc: sort.direction === 'desc' }] : []
+
+      // Query filtered IDs — oneshot mode: paged SQL + parallel COUNT(*), no Redis snapshot
+      // (kopilot doesn't benefit from snapshot reuse since each tool call is independent).
+      const filtered = await handler.listFiltered({
+        entityDefinitionId: entityDefId,
+        filters: conditionGroups,
+        sorting,
+        limit,
+        offset,
+        mode: 'oneshot',
+      })
 
       // Hydrate results with display data
       const recordIds = filtered.ids.map((id) => toRecordId(entityDefId, id))

--- a/packages/lib/src/resources/crud/index.ts
+++ b/packages/lib/src/resources/crud/index.ts
@@ -27,12 +27,16 @@ export type {
 } from './unified-handler-queries'
 // Query utilities
 export {
+  countEntityInstances,
+  countSystemResource,
   extractRequiredRelatedEntities,
   getTableSchema,
   isSystemResource,
   listAll,
   queryEntityInstanceIds,
+  queryEntityInstanceIdsPaged,
   querySystemResourceIds,
+  querySystemResourceIdsPaged,
   resolveEntityId,
   resolveEntityIdFromCache,
 } from './unified-handler-queries'

--- a/packages/lib/src/resources/crud/unified-handler-queries.ts
+++ b/packages/lib/src/resources/crud/unified-handler-queries.ts
@@ -12,7 +12,7 @@ import {
   toFieldId,
   toResourceFieldId,
 } from '@auxx/types/field'
-import { and, eq, isNull } from 'drizzle-orm'
+import { and, asc, eq, isNull, type SQL, sql } from 'drizzle-orm'
 import {
   findCachedResource,
   getCachedEntityDefId,
@@ -54,8 +54,18 @@ export interface ListFilteredInput {
   sorting?: Array<{ id: string; desc: boolean }>
   /** Limit per request (default: 100) */
   limit?: number
+  /** Offset for pagination — only honored in oneshot mode */
+  offset?: number
   /** Cursor for pagination */
   cursor?: { snapshotId: string; offset: number }
+  /**
+   * Query mode:
+   * - 'snapshot' (default): cache the full filtered id list and slice. Best for stable
+   *   infinite-scroll UIs where the user pages through a frozen view.
+   * - 'oneshot': run a single paged `SELECT id ... LIMIT n OFFSET m` plus a parallel
+   *   `COUNT(*)`. No Redis. Best for one-shot callers (agents) that don't re-page.
+   */
+  mode?: 'snapshot' | 'oneshot'
 }
 
 /**
@@ -129,6 +139,93 @@ export function extractRequiredRelatedEntities(
   }
 
   return relatedEntityIds
+}
+
+/**
+ * Internal: build the context, WHERE clause, and ORDER BY clauses for an entity-instance
+ * query. Shared between the snapshot path (all-ids fetch) and the oneshot paged/count
+ * helpers so we don't duplicate field resolution + related-entity lookups.
+ */
+async function buildEntityInstanceQueryParts(params: {
+  organizationId: string
+  entityDefinitionId: string
+  filters: ConditionGroup[]
+  sorting: Array<{ id: string; desc: boolean }>
+}): Promise<{
+  whereClause: SQL<unknown> | undefined
+  orderByClauses: SQL<unknown>[] | undefined
+}> {
+  const { organizationId, entityDefinitionId, filters, sorting } = params
+
+  // Get fields for this entity from org cache
+  const fields = await getCachedResourceFields(organizationId, entityDefinitionId)
+
+  // Inject displayName as a virtual field for free-text search (denormalized column).
+  const fieldsWithDisplayName = fields.some((f) => f.key === 'displayName')
+    ? fields
+    : [
+        ...fields,
+        {
+          id: toFieldId('displayName'),
+          key: 'displayName',
+          label: 'Display Name',
+          name: 'Display Name',
+          type: BaseType.STRING,
+          fieldType: 'TEXT' as FieldType,
+          isSystem: true,
+          dbColumn: 'displayName',
+          nullable: true,
+          showInPanel: false,
+          capabilities: {
+            filterable: true,
+            sortable: true,
+            creatable: false,
+            updatable: false,
+            configurable: false,
+          },
+        } satisfies ResourceField,
+      ]
+
+  // Detect required related entities from filters
+  const requiredRelatedEntities = extractRequiredRelatedEntities(filters, fieldsWithDisplayName)
+
+  // Build relatedEntityFields map from org cache
+  const relatedEntityFields: Record<string, ResourceField[]> = {}
+  for (const relatedEntityId of requiredRelatedEntities) {
+    const relatedFields = await getCachedResourceFields(organizationId, relatedEntityId)
+    relatedEntityFields[relatedEntityId] = relatedFields
+  }
+
+  const context: EntityQueryContext = {
+    fields: fieldsWithDisplayName,
+    outerTable: schema.EntityInstance,
+    relatedEntityFields,
+  }
+
+  const whereClause = entityConditionBuilder.buildGroupedQuery(filters, context)
+
+  if (entityConditionBuilder.droppedConditions.length > 0) {
+    logger.warn(
+      `Dropped ${entityConditionBuilder.droppedConditions.length} filter condition(s): ${JSON.stringify(entityConditionBuilder.droppedConditions)}`
+    )
+    if (process.env.NODE_ENV === 'development') {
+      console.error(
+        `[entity-query] Filter conditions dropped:`,
+        entityConditionBuilder.droppedConditions
+      )
+    }
+  }
+
+  const orderByClauses =
+    sorting.length > 0
+      ? entityConditionBuilder.buildOrderBySql(
+          sorting[0].id,
+          sorting[0].desc ? 'desc' : 'asc',
+          context
+        )
+      : undefined
+
+  return { whereClause, orderByClauses }
 }
 
 /**
@@ -294,6 +391,186 @@ export async function querySystemResourceIds(params: {
 
   const results = await query
   return results.map((r) => r.id)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PAGED + COUNT HELPERS (oneshot mode)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Paged variant of {@link queryEntityInstanceIds}: runs `SELECT id ... LIMIT n OFFSET m`
+ * in parallel with `COUNT(*)` using the same WHERE clause. Adds `EntityInstance.id ASC`
+ * as a deterministic tie-break so OFFSET paging is stable when the sort column has ties.
+ *
+ * @returns `ids` (length ≤ limit) and `total` (full match count, independent of limit).
+ */
+export async function queryEntityInstanceIdsPaged(params: {
+  db: Database
+  entityDefinitionId: string
+  organizationId: string
+  filters: ConditionGroup[]
+  sorting: Array<{ id: string; desc: boolean }>
+  limit: number
+  offset: number
+}): Promise<{ ids: string[]; total: number }> {
+  const { db, entityDefinitionId, organizationId, filters, sorting, limit, offset } = params
+
+  const { whereClause, orderByClauses } = await buildEntityInstanceQueryParts({
+    organizationId,
+    entityDefinitionId,
+    filters,
+    sorting,
+  })
+
+  const baseWhere = and(
+    eq(schema.EntityInstance.entityDefinitionId, entityDefinitionId),
+    eq(schema.EntityInstance.organizationId, organizationId),
+    isNull(schema.EntityInstance.archivedAt),
+    whereClause
+  )
+
+  // Deterministic tie-break: append id ASC so OFFSET paging is stable when the
+  // user-chosen sort column has ties. Snapshot path doesn't need this because
+  // the id list is frozen at snapshot-create time.
+  const finalOrderBy = orderByClauses
+    ? [...orderByClauses, asc(schema.EntityInstance.id)]
+    : [asc(schema.EntityInstance.id)]
+
+  const idsQuery = db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(baseWhere)
+    .orderBy(...finalOrderBy)
+    .limit(limit)
+    .offset(offset)
+
+  const countQuery = db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(schema.EntityInstance)
+    .where(baseWhere)
+
+  const [idsResult, countResult] = await Promise.all([idsQuery, countQuery])
+
+  return {
+    ids: idsResult.map((r) => r.id),
+    total: Number(countResult[0]?.count ?? 0),
+  }
+}
+
+/**
+ * Count-only variant for entity instances. Skips the id fetch entirely.
+ */
+export async function countEntityInstances(params: {
+  db: Database
+  entityDefinitionId: string
+  organizationId: string
+  filters: ConditionGroup[]
+}): Promise<number> {
+  const { db, entityDefinitionId, organizationId, filters } = params
+
+  const { whereClause } = await buildEntityInstanceQueryParts({
+    organizationId,
+    entityDefinitionId,
+    filters,
+    sorting: [],
+  })
+
+  const result = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.entityDefinitionId, entityDefinitionId),
+        eq(schema.EntityInstance.organizationId, organizationId),
+        isNull(schema.EntityInstance.archivedAt),
+        whereClause
+      )
+    )
+
+  return Number(result[0]?.count ?? 0)
+}
+
+/**
+ * Paged variant of {@link querySystemResourceIds}: runs `SELECT id ... LIMIT n OFFSET m`
+ * in parallel with `COUNT(*)`. Adds `id ASC` as a deterministic tie-break.
+ */
+export async function querySystemResourceIdsPaged(params: {
+  db: Database
+  tableId: TableId
+  organizationId: string
+  filters: ConditionGroup[]
+  sorting: Array<{ id: string; desc: boolean }>
+  limit: number
+  offset: number
+}): Promise<{ ids: string[]; total: number }> {
+  const { db, tableId, organizationId, filters, sorting, limit, offset } = params
+
+  const tableSchema = getTableSchema(tableId)
+  if (!tableSchema) {
+    throw new Error(`Unknown table: ${tableId}`)
+  }
+
+  const whereClause = systemConditionBuilder.buildGroupedQuery(filters, tableId)
+  const baseWhere = and(eq(tableSchema.organizationId, organizationId), whereClause)
+
+  const orderByClauses =
+    sorting.length > 0
+      ? systemConditionBuilder.buildOrderBySql(
+          sorting[0].id,
+          sorting[0].desc ? 'desc' : 'asc',
+          tableId
+        )
+      : undefined
+
+  const finalOrderBy = orderByClauses
+    ? [...orderByClauses, asc(tableSchema.id)]
+    : [asc(tableSchema.id)]
+
+  const idsQuery = db
+    .select({ id: tableSchema.id })
+    .from(tableSchema)
+    .where(baseWhere)
+    .orderBy(...finalOrderBy)
+    .limit(limit)
+    .offset(offset)
+
+  const countQuery = db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(tableSchema)
+    .where(baseWhere)
+
+  const [idsResult, countResult] = await Promise.all([idsQuery, countQuery])
+
+  return {
+    ids: idsResult.map((r: { id: string }) => r.id),
+    total: Number(countResult[0]?.count ?? 0),
+  }
+}
+
+/**
+ * Count-only variant for system resources. Skips the id fetch entirely.
+ */
+export async function countSystemResource(params: {
+  db: Database
+  tableId: TableId
+  organizationId: string
+  filters: ConditionGroup[]
+}): Promise<number> {
+  const { db, tableId, organizationId, filters } = params
+
+  const tableSchema = getTableSchema(tableId)
+  if (!tableSchema) {
+    throw new Error(`Unknown table: ${tableId}`)
+  }
+
+  const whereClause = systemConditionBuilder.buildGroupedQuery(filters, tableId)
+
+  const result = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(tableSchema)
+    .where(and(eq(tableSchema.organizationId, organizationId), whereClause))
+
+  return Number(result[0]?.count ?? 0)
 }
 
 /**

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -50,7 +50,9 @@ import {
   type ListFilteredResult,
   listAll as listAllQuery,
   queryEntityInstanceIds,
+  queryEntityInstanceIdsPaged,
   querySystemResourceIds,
+  querySystemResourceIdsPaged,
   resolveEntityIdFromCache,
 } from './unified-handler-queries'
 
@@ -620,15 +622,59 @@ export class UnifiedCrudHandler {
     filters?: ConditionGroup[]
     sorting?: Array<{ id: string; desc: boolean }>
     limit?: number
+    /** Pagination offset — honored in oneshot mode (snapshot mode uses cursor.offset). */
+    offset?: number
     cursor?: { snapshotId: string; offset: number }
+    /**
+     * Query mode:
+     * - 'snapshot' (default): cache the full filtered id list, slice for pagination.
+     * - 'oneshot': bypass Redis, run a paged SQL query + parallel COUNT(*). Use for
+     *   one-shot callers (agents) that don't benefit from a stable snapshot.
+     */
+    mode?: 'snapshot' | 'oneshot'
   }): Promise<ListFilteredResult> {
-    const { entityDefinitionId, sorting = [], limit = 100, cursor } = params
+    const { entityDefinitionId, sorting = [], limit = 100, cursor, mode = 'snapshot' } = params
 
     // Resolve valueSource placeholders (e.g. currentUser) before any cache key
     // is computed so snapshots are isolated per viewer.
     const filters = resolveConditionContext(params.filters ?? [], {
       currentUserId: this.userId,
     })
+
+    // Oneshot mode: bypass snapshot, run paged SQL + COUNT in parallel.
+    if (mode === 'oneshot') {
+      const offset = Math.max(params.offset ?? 0, 0)
+
+      const { ids, total } = isSystemResource(entityDefinitionId)
+        ? await querySystemResourceIdsPaged({
+            db: this.db,
+            tableId: entityDefinitionId as TableId,
+            organizationId: this.organizationId,
+            filters: filters as ConditionGroup[],
+            sorting,
+            limit,
+            offset,
+          })
+        : await queryEntityInstanceIdsPaged({
+            db: this.db,
+            entityDefinitionId: isEntityDefinitionType(entityDefinitionId)
+              ? (await this.resolveEntityDefinition(entityDefinitionId)).id
+              : entityDefinitionId,
+            organizationId: this.organizationId,
+            filters: filters as ConditionGroup[],
+            sorting,
+            limit,
+            offset,
+          })
+
+      return {
+        snapshotId: '',
+        ids,
+        total,
+        hasMore: offset + ids.length < total,
+        fromCache: false,
+      }
+    }
 
     // Extract pagination from cursor if provided
     const snapshotId = cursor?.snapshotId


### PR DESCRIPTION
## Summary

- **Backend:** new `oneshot` mode on `UnifiedCrudHandler.listFiltered` that bypasses the Redis snapshot and runs a paged `SELECT id LIMIT/OFFSET` in parallel with `COUNT(*)`. Adds `id ASC` tie-break for stable OFFSET paging. Adds `countEntityInstances` / `countSystemResource` count-only helpers.
- **Kopilot query-records tool:** switches to oneshot mode (each agent call is independent — no snapshot reuse benefit) and short-circuits `countOnly: true` calls to a pure `COUNT(*)`, skipping the id fetch + hydration entirely.
- **Frontend:** `BlockCard` gains `collapsible` + `headerActions` props with an animated toggle. Approval cards (draft, generic, entity create/update, bulk update, task create) default to collapsed when rejected so chat history stays scannable. `table-block` migrates its expand button into `headerActions`.

## Test plan

- [ ] Kopilot query-records returns correct totals + paged ids for entity and system resources
- [ ] Kopilot `countOnly: true` returns just `total_matching` and skips hydration
- [ ] OFFSET paging is stable across calls when sort column has ties
- [ ] Approval cards auto-collapse on rejection and expand via header toggle
- [ ] Table block expand-to-dialog still works from the new `headerActions` slot