### PR TITLE
feat(kopilot): rename resource: chips to entity: + rich template previews

### DIFF
--- a/apps/web/src/components/editor/kb-article/block-node-view.module.css
+++ b/apps/web/src/components/editor/kb-article/block-node-view.module.css
@@ -100,6 +100,30 @@
   margin-left: 0;
 }
 
+/* Read-only mode — TipTap sets `contenteditable="false"` on the root
+   `.ProseMirror` element when `editor.setEditable(false)` is in effect.
+   Suppress the gutter (line number + drag handle), the selection outline,
+   and the text cursor so the editor reads as a static preview.
+
+   Used by the system-template gallery preview; the same TipTap instance
+   stays mounted so badge rendering and block layout match the customize
+   view byte-for-byte. */
+:global(.ProseMirror[contenteditable='false']) .lineGutter {
+  display: none;
+}
+
+:global(.ProseMirror[contenteditable='false']) .blockContainer {
+  margin-left: 0;
+}
+
+:global(.ProseMirror[contenteditable='false']) .blockWrapper:global(.ProseMirror-selectednode) {
+  outline: none;
+}
+
+:global(.ProseMirror[contenteditable='false']) .blockContent {
+  cursor: default;
+}
+
 /* ============================================
    Line number — subtle, appears on hover/focus
    ============================================ */

--- a/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
+++ b/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
@@ -48,6 +48,12 @@ interface PromptEditorContentProps {
   /** Shared across instances so the same picker handle can drive arrow keys. */
   referencePickerRef: React.RefObject<ReferencePickerHandle | null>
   referenceTabs?: ReferenceTab[]
+  /**
+   * When `false`, mounts the editor in read-only mode — same TipTap
+   * instance, same reference badge rendering, but typing / paste / slash /
+   * `@`-picker are inert. Used by the template gallery preview.
+   */
+  editable?: boolean
 }
 
 interface LinkPopoverState {
@@ -77,6 +83,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
   onUserActivity,
   referencePickerRef,
   referenceTabs,
+  editable = true,
 }: PromptEditorContentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [linkPopover, setLinkPopover] = useState<LinkPopoverState | null>(null)
@@ -100,6 +107,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
     onPickerEnter,
     onPickerArrowVertical,
     referenceTabs,
+    editable,
   })
 
   const activePicker = useActivePicker(editor)

--- a/apps/web/src/components/editor/prompt-editor/prompt-editor.tsx
+++ b/apps/web/src/components/editor/prompt-editor/prompt-editor.tsx
@@ -24,6 +24,12 @@ export interface PromptEditorProps {
   /** Fires on TipTap focus/blur. */
   onFocusChange?: (focused: boolean) => void
   className?: string
+  /**
+   * When `false`, renders the prompt with the same TipTap extensions
+   * (badges, blocks) but disables typing — for read-only previews like
+   * the template gallery detail view.
+   */
+  editable?: boolean
 }
 
 /**
@@ -46,6 +52,7 @@ export function PromptEditor({
   onEditorReady,
   onFocusChange,
   className,
+  editable = true,
 }: PromptEditorProps) {
   const referencePickerRef = useRef<ReferencePickerHandle | null>(null)
   const [, setFocused] = useState(false)
@@ -74,6 +81,7 @@ export function PromptEditor({
         onFocusChange={handleFocusChange}
         referencePickerRef={referencePickerRef}
         referenceTabs={referenceTabs}
+        editable={editable}
       />
     </div>
   )

--- a/apps/web/src/components/editor/rich-text/render-reference-badge.tsx
+++ b/apps/web/src/components/editor/rich-text/render-reference-badge.tsx
@@ -41,8 +41,8 @@ export function renderReferenceBadge({ id, selected }: { id: string; selected: b
   if (id.startsWith('toolset:')) {
     return <ToolsetBadge slug={id.slice('toolset:'.length)} className={ring} />
   }
-  if (id.startsWith('resource:')) {
-    return <ResourceBadge id={id.slice('resource:'.length)} selected={selected} className={ring} />
+  if (id.startsWith('entity:')) {
+    return <ResourceBadge id={id.slice('entity:'.length)} selected={selected} className={ring} />
   }
   if (id.startsWith('field:')) {
     const payload = id.slice('field:'.length)

--- a/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
+++ b/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
@@ -93,6 +93,13 @@ export interface UseRichTextEditorOptions {
    * must be passed the same list.
    */
   referenceTabs?: ReferenceTab[]
+  /**
+   * Forwarded to TipTap's `useEditor({ editable })`. Defaults to `true`.
+   * When `false`, the editor renders its content with the same block / badge
+   * extensions but disables typing — used for read-only previews (system
+   * template gallery, etc.).
+   */
+  editable?: boolean
 }
 
 /**
@@ -112,6 +119,7 @@ export function useRichTextEditor({
   onPickerEnter,
   onPickerArrowVertical,
   referenceTabs,
+  editable = true,
 }: UseRichTextEditorOptions) {
   const normalizedInitialContent = useMemo<JSONContent>(() => {
     const migrated = migrateLegacyContent(initialContent)
@@ -151,6 +159,7 @@ export function useRichTextEditor({
   const editor = useEditor(
     {
       immediatelyRender: false,
+      editable,
       extensions: [
         Doc,
         StarterKit.configure({
@@ -217,6 +226,14 @@ export function useRichTextEditor({
     },
     []
   )
+
+  // `useEditor` is created once with `editable` from the first render. Sync
+  // subsequent toggles via `setEditable` so a "View ↔ Customize" swap on the
+  // same editor instance flips read-only state without remounting.
+  useEffect(() => {
+    if (!editor) return
+    if (editor.isEditable !== editable) editor.setEditable(editable)
+  }, [editor, editable])
 
   const gutterCharWidth = useEditorState({
     editor,

--- a/apps/web/src/components/kopilot/ui/dialogs/prompt-template-dialog.tsx
+++ b/apps/web/src/components/kopilot/ui/dialogs/prompt-template-dialog.tsx
@@ -5,7 +5,6 @@
 import { constants } from '@auxx/config/client'
 import type { DocJSON } from '@auxx/lib/kb/markdown'
 import type { SystemTemplateGalleryItem } from '@auxx/lib/prompt-templates'
-import { docToText } from '@auxx/lib/tiptap'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -374,9 +373,13 @@ export function PromptTemplateDialog({ open, onOpenChange }: PromptTemplateDialo
                           </div>
                         ) : (
                           <div className='rounded-xl border bg-muted/30 p-4'>
-                            <p className='text-sm text-muted-foreground whitespace-pre-wrap leading-relaxed'>
-                              {docToText(selectedTemplate.prompt)}
-                            </p>
+                            <PromptEditor
+                              key={`preview-${selectedTemplate.id}`}
+                              initialContent={selectedTemplate.prompt.content as never}
+                              onChange={() => {}}
+                              editable={false}
+                              referenceTabs={TEMPLATE_REFERENCE_TABS}
+                            />
                           </div>
                         )}
                       </div>

--- a/apps/web/src/components/pickers/resource-picker/resource-reference-list.tsx
+++ b/apps/web/src/components/pickers/resource-picker/resource-reference-list.tsx
@@ -11,15 +11,15 @@ import { ResourceItem } from './resource-item'
 export interface ResourceReferenceListProps {
   /** Search query forwarded from the picker chip. */
   externalSearch?: string
-  /** Selection callback — receives the chip id (`resource:<entityDefinitionId>`). */
+  /** Selection callback — receives the chip id (`entity:<entityDefinitionId>`). */
   onSelectSingle: (id: string) => void
   className?: string
 }
 
 /**
  * Flat single-list search component for the ReferencePicker Resources tab.
- * Backed by the resource store (`useResources`). Selections produce a
- * `resource:<entityDefinitionId>` chip id which the renderer maps to
+ * Backed by the resource store (`useResources`). Selections produce an
+ * `entity:<entityDefinitionId>` chip id which the renderer maps to
  * `ResourceBadge`.
  */
 export function ResourceReferenceList({
@@ -51,7 +51,7 @@ export function ResourceReferenceList({
                 key={resource.id}
                 resource={resource}
                 isSelected={false}
-                onToggle={(id) => onSelectSingle(`resource:${id}`)}
+                onToggle={(id) => onSelectSingle(`entity:${id}`)}
                 multi={false}
               />
             ))}

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/persona-prompt.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/persona-prompt.ts
@@ -63,8 +63,8 @@ Pass the FULL prompt as markdown (headings, lists, fences). Replaces the previou
 
 Other inline refs:
 - \`@[article:<recordId>]\`, \`@[agent:<agentId>]\`, \`@[user:<userId>]\`, \`@[<defId>:<instId>]\`
-- **\`@[resource:<entityDef>]\`** — the entity *type* (e.g. \`@[resource:ticket]\`). Use this in the Capabilities & Scope sentence instead of writing the entity name inline.
-- **\`@[field:<entityDef>:<fieldId>]\`** — a field on a resource (e.g. \`@[field:ticket:status]\`). For relationship traversals use the path form \`@[field:<rootDef>:<rootField>::<targetDef>:<targetField>]\`.
+- **\`@[entity:<entityDef>]\`** — the entity *type* (e.g. \`@[entity:ticket]\`). Use this in the Capabilities & Scope sentence instead of writing the entity name inline.
+- **\`@[field:<entityDef>:<fieldId>]\`** — a field on an entity (e.g. \`@[field:ticket:status]\`). For relationship traversals use the path form \`@[field:<rootDef>:<rootField>::<targetDef>:<targetField>]\`.
 
 **Hard rule — schema chips.** Any sentence that classifies, tags, prioritizes, sorts, routes, or branches by a record value MUST chip the field with \`@[field:…]\` AND use real option ids returned by \`list_entity_fields\` — never invented labels. Prose like "set the status to high" is a bug; rewrite as "set @[field:ticket:status] to the matching option id from \`list_entity_fields\`."
 
@@ -74,12 +74,12 @@ Example shape:
 # Support Triage
 
 ## Capabilities & Scope
-Triage every @[resource:ticket] this workspace receives.
+Triage every @[entity:ticket] this workspace receives.
 
 ## Instructions
 1. Read the thread with @[tool:get_thread_detail].
 2. Look up the sender with @[tool:search_entities].
-3. Identify the @[resource:ticket] for this thread; fetch current values of @[field:ticket:status], @[field:ticket:priority], @[field:ticket:category] with @[tool:get_entity].
+3. Identify the @[entity:ticket] for this thread; fetch current values of @[field:ticket:status], @[field:ticket:priority], @[field:ticket:category] with @[tool:get_entity].
 4. Choose the matching option id — you MUST use one of the option ids returned by @[tool:list_entity_fields] earlier in this turn. Never invent labels.
 5. Apply with @[tool:update_entity], or escalate via @[tool:create_task].
 \`\`\`

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-prompt.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-prompt.ts
@@ -37,10 +37,10 @@ reference chip. Supported ids:
     Use these EAGERLY — referencing a tool by name in the prompt makes the
     chip render in the editor, and the runtime expands it to a backtick-quoted
     tool name when this agent runs.
-  - \`@[resource:<entityDef>]\` — the entity *type* (e.g. \`@[resource:ticket]\`).
+  - \`@[entity:<entityDef>]\` — the entity *type* (e.g. \`@[entity:ticket]\`).
     Use in the Capabilities & Scope sentence instead of writing the entity name
     inline. Validated server-side; unknown entityDefs are rejected.
-  - \`@[field:<entityDef>:<fieldId>]\` — a field on a resource (e.g.
+  - \`@[field:<entityDef>:<fieldId>]\` — a field on an entity (e.g.
     \`@[field:ticket:status]\`). Use whenever the prompt classifies, tags,
     routes, or branches by a record value. Validated server-side; unknown
     fields are rejected.
@@ -56,7 +56,7 @@ The previous prompt is replaced wholesale.`,
         markdown: {
           type: 'string',
           description:
-            'Full persona prompt as markdown. Headings, paragraphs, lists, blockquotes, code fences, and inline `@[<id>]` references (`tool:`, `resource:`, `field:`, `article:`, `agent:`, `user:`, or a raw `<defId>:<instId>` record id) are supported. Replaces the previous prompt wholesale.',
+            'Full persona prompt as markdown. Headings, paragraphs, lists, blockquotes, code fences, and inline `@[<id>]` references (`tool:`, `entity:`, `field:`, `article:`, `agent:`, `user:`, or a raw `<defId>:<instId>` record id) are supported. Replaces the previous prompt wholesale.',
           minLength: 1,
           maxLength: MARKDOWN_MAX_BYTES,
         },
@@ -111,7 +111,7 @@ The previous prompt is replaced wholesale.`,
 
       const doc = { type: 'doc', content: blocks } as Record<string, unknown>
 
-      // Validate schema chips (`resource:` / `field:`) BEFORE persisting so the
+      // Validate schema chips (`entity:` / `field:`) BEFORE persisting so the
       // model sees the failure in the next turn instead of saving a broken
       // prompt the admin can't run. Tools chips are validated by the toolset
       // reconciler — separate path.
@@ -207,11 +207,11 @@ interface SchemaValidationResult {
 }
 
 /**
- * Validate `resource:` / `field:` reference chips against the org's cached
+ * Validate `entity:` / `field:` reference chips against the org's cached
  * schema. Returns:
  *   - `unresolvedReferences`: chip ids that don't resolve (rejection condition)
  *   - `warnings`: non-blocking advisories (e.g. a field-bearing entity is
- *     mentioned in prose with zero `@[resource:…]` chips)
+ *     mentioned in prose with zero `@[entity:…]` chips)
  *
  * Resource lookup matches `findCachedResource` (id / entityType / apiSlug).
  * Field lookup verifies the field exists on its declared entity by `id` or
@@ -223,7 +223,7 @@ async function validateSchemaReferences(
   organizationId: string
 ): Promise<SchemaValidationResult> {
   const ids = collectReferenceIds(doc)
-  const resourceChips = ids.filter((id) => id.startsWith('resource:'))
+  const entityChips = ids.filter((id) => id.startsWith('entity:'))
   const fieldChips = ids.filter((id) => id.startsWith('field:'))
 
   const unresolved: string[] = []
@@ -231,7 +231,7 @@ async function validateSchemaReferences(
 
   // Resolve unique entityDef keys once.
   const entityKeys = new Set<string>()
-  for (const chip of resourceChips) entityKeys.add(chip.slice('resource:'.length))
+  for (const chip of entityChips) entityKeys.add(chip.slice('entity:'.length))
   for (const chip of fieldChips) {
     const payload = chip.slice('field:'.length)
     const head = payload.split('::')[0] ?? payload
@@ -244,8 +244,8 @@ async function validateSchemaReferences(
     resolvedByKey.set(key, await findCachedResource(organizationId, key))
   }
 
-  for (const chip of resourceChips) {
-    const key = chip.slice('resource:'.length)
+  for (const chip of entityChips) {
+    const key = chip.slice('entity:'.length)
     if (!resolvedByKey.get(key)) {
       unresolved.push(chip)
     }
@@ -272,13 +272,13 @@ async function validateSchemaReferences(
     if (!found) unresolved.push(chip)
   }
 
-  // Warning: field-bearing entity mentioned in prose, no @[resource:…] chip.
+  // Warning: field-bearing entity mentioned in prose, no @[entity:…] chip.
   // Match resource labels (and plurals where available) case-insensitively
-  // against the doc's plain text. Skip when a `@[resource:<id>]` chip is
+  // against the doc's plain text. Skip when an `@[entity:<id>]` chip is
   // already present for that entity.
   const chippedEntityKeys = new Set<string>()
-  for (const chip of resourceChips) {
-    const key = chip.slice('resource:'.length)
+  for (const chip of entityChips) {
+    const key = chip.slice('entity:'.length)
     const resolved = resolvedByKey.get(key)
     if (resolved) {
       chippedEntityKeys.add(resolved.id)
@@ -305,7 +305,7 @@ async function validateSchemaReferences(
   }
   if (mentionedWithoutChip.length > 0) {
     warnings.push(
-      `Prose mentions ${mentionedWithoutChip.map((l) => `"${l}"`).join(', ')} but no \`@[resource:…]\` chip is present. Wrap the entity noun with \`@[resource:<apiSlug>]\` so admins can audit scope at a glance.`
+      `Prose mentions ${mentionedWithoutChip.map((l) => `"${l}"`).join(', ')} but no \`@[entity:…]\` chip is present. Wrap the entity noun with \`@[entity:<apiSlug>]\` so admins can audit scope at a glance.`
     )
   }
 
@@ -314,7 +314,7 @@ async function validateSchemaReferences(
   }
 
   const slugList = allResources.map((r) => r.apiSlug).join(', ')
-  const errorMessage = `Rejected — ${unresolved.length} unresolved schema chip(s): ${unresolved.map((c) => `\`${c}\``).join(', ')}. For \`@[resource:<key>]\` chips, key must be one of the apiSlugs: ${slugList}. For \`@[field:<entityDef>:<fieldId>]\` chips, call \`list_entity_fields\` on the entityDef first and use a real field id from the response. Fix and retry.`
+  const errorMessage = `Rejected — ${unresolved.length} unresolved schema chip(s): ${unresolved.map((c) => `\`${c}\``).join(', ')}. For \`@[entity:<key>]\` chips, key must be one of the apiSlugs: ${slugList}. For \`@[field:<entityDef>:<fieldId>]\` chips, call \`list_entity_fields\` on the entityDef first and use a real field id from the response. Fix and retry.`
 
   return { unresolvedReferences: unresolved, warnings, errorMessage }
 }

--- a/packages/lib/src/ai/kopilot/prompts/__tests__/__snapshots__/core-runtime-prompt.snapshot.test.ts.snap
+++ b/packages/lib/src/ai/kopilot/prompts/__tests__/__snapshots__/core-runtime-prompt.snapshot.test.ts.snap
@@ -83,6 +83,14 @@ A \`recordId\` is the literal \`recordId\` from a tool result: \`<entityDefiniti
 
 \`threadId\` and \`taskId\` are single opaque strings (no colon).
 
+**Inline \`@[…]\` chip references are not recordIds.** Prompts and agent personas may contain flattened chips of the form \`[reference](<id>)\` where \`<id>\` is one of:
+
+- \`entity:<entityDefinitionId>\` — a record *type*, not an instance. \`entity:ticket\` means "a ticket record" (whichever one is in context), not a specific ticket id.
+- \`field:<entityDefinitionId>:<fieldId>\` — a field on an entity type (e.g. \`field:ticket:status\`). Use \`list_entity_fields\` to get the real field ids. Path form for relationship traversals: \`field:<rootDef>:<rootField>::<targetDef>:<targetField>\`.
+- \`tool:<name>\` — a tool by name, e.g. \`tool:get_thread_detail\`.
+
+Never pass \`entity:…\`, \`field:…\`, or \`tool:…\` strings where a recordId is expected. Real recordIds have no prefix word — just two opaque segments separated by one colon.
+
 ### Block schemas
 
 #### \`auxx:entity-list\`

--- a/packages/lib/src/ai/kopilot/prompts/sections/block-catalog.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/block-catalog.ts
@@ -52,6 +52,14 @@ A \`recordId\` is the literal \`recordId\` from a tool result: \`<entityDefiniti
 
 \`threadId\` and \`taskId\` are single opaque strings (no colon).
 
+**Inline \`@[…]\` chip references are not recordIds.** Prompts and agent personas may contain flattened chips of the form \`[reference](<id>)\` where \`<id>\` is one of:
+
+- \`entity:<entityDefinitionId>\` — a record *type*, not an instance. \`entity:ticket\` means "a ticket record" (whichever one is in context), not a specific ticket id.
+- \`field:<entityDefinitionId>:<fieldId>\` — a field on an entity type (e.g. \`field:ticket:status\`). Use \`list_entity_fields\` to get the real field ids. Path form for relationship traversals: \`field:<rootDef>:<rootField>::<targetDef>:<targetField>\`.
+- \`tool:<name>\` — a tool by name, e.g. \`tool:get_thread_detail\`.
+
+Never pass \`entity:…\`, \`field:…\`, or \`tool:…\` strings where a recordId is expected. Real recordIds have no prefix word — just two opaque segments separated by one colon.
+
 ### Block schemas
 
 #### \`auxx:entity-list\`

--- a/packages/lib/src/kb/markdown/__tests__/round-trip.test.ts
+++ b/packages/lib/src/kb/markdown/__tests__/round-trip.test.ts
@@ -330,4 +330,66 @@ describe('mdToBlocks — inline references', () => {
     const inline = doc.content[0]?.content ?? []
     expect(inline.some((n) => (n as { type?: string }).type === 'reference')).toBe(false)
   })
+
+  it('parses simple field chips (id contains a second colon)', () => {
+    const doc = mdToDoc('Read @[field:ticket:status] before replying.')
+    const inline = doc.content[0]?.content ?? []
+    expect(inline).toEqual([
+      { type: 'text', text: 'Read ' },
+      { type: 'reference', attrs: { id: 'field:ticket:status' } },
+      { type: 'text', text: ' before replying.' },
+    ])
+  })
+
+  it('parses relationship-path field chips (`::` separator)', () => {
+    const doc = mdToDoc('Look at @[field:ticket:assignee::user:name] for ownership.')
+    const inline = doc.content[0]?.content ?? []
+    expect(inline).toEqual([
+      { type: 'text', text: 'Look at ' },
+      { type: 'reference', attrs: { id: 'field:ticket:assignee::user:name' } },
+      { type: 'text', text: ' for ownership.' },
+    ])
+  })
+
+  it('round-trips a field-chip reference through blocksToMd/mdToBlocks', () => {
+    const original: DocJSON = {
+      type: 'doc',
+      content: [
+        block('text', {}, [
+          text('Set '),
+          { type: 'reference', attrs: { id: 'field:ticket:status' } },
+          text(' to closed.'),
+        ]),
+      ] as never,
+    }
+    const md = blocksToMd(original)
+    const reparsed = mdToDoc(md)
+    const inline = reparsed.content[0]?.content ?? []
+    expect(inline).toEqual([
+      { type: 'text', text: 'Set ' },
+      { type: 'reference', attrs: { id: 'field:ticket:status' } },
+      { type: 'text', text: ' to closed.' },
+    ])
+  })
+
+  it('round-trips a path-form field chip through blocksToMd/mdToBlocks', () => {
+    const original: DocJSON = {
+      type: 'doc',
+      content: [
+        block('text', {}, [
+          text('Owner is '),
+          { type: 'reference', attrs: { id: 'field:ticket:assignee::user:name' } },
+          text('.'),
+        ]),
+      ] as never,
+    }
+    const md = blocksToMd(original)
+    const reparsed = mdToDoc(md)
+    const inline = reparsed.content[0]?.content ?? []
+    expect(inline).toEqual([
+      { type: 'text', text: 'Owner is ' },
+      { type: 'reference', attrs: { id: 'field:ticket:assignee::user:name' } },
+      { type: 'text', text: '.' },
+    ])
+  })
 })

--- a/packages/lib/src/kb/markdown/md-to-blocks.ts
+++ b/packages/lib/src/kb/markdown/md-to-blocks.ts
@@ -30,14 +30,22 @@ import type {
 import { CALLOUT_VARIANTS, EMBED_ASPECTS, EMBED_PROVIDERS, IMAGE_ALIGNS } from './types'
 
 const PLACEHOLDER_RE = /\{\{([a-zA-Z0-9_.-]+)\}\}/g
-const REFERENCE_AT_RE = /@\[([a-zA-Z][a-zA-Z0-9_-]*:[\w.-]+)\]/g
+// The id half allows `:` so field chips parse as a single reference:
+//   `@[field:ticket:status]`                           → simple field
+//   `@[field:ticket:assignee::user:name]`              → relationship path (`::` separator)
+// Without `:` in the id char class the parser stops at the second colon and
+// silently drops the chip — see plans/kopilot/templates/template-overhaul-with-references.md §3.2.
+const REFERENCE_AT_RE = /@\[([a-zA-Z][a-zA-Z0-9_-]*:[\w.:-]+)\]/g
 const IMAGE_ATTR_TRAILER_RE = /^\{([^{}\n]*)\}/
 const HEADING_MAX_LEVEL = 3
 
 // `<entityDefinitionId>:<entityInstanceId>` — matches `RecordId`'s structural
 // shape (the brand in `@auxx/types`). Used to detect link URLs that the LLM
 // (or markdown-paste flow) means as `reference` inline nodes, not real URLs.
-const RECORD_ID_RE = /^[a-zA-Z][a-zA-Z0-9_-]*:[\w.-]+$/
+// The id half includes `:` so multi-colon chip ids (field chips like
+// `field:ticket:status` and path chips like `field:ticket:assignee::user:name`)
+// resolve as references when written in `[Foo](id)` paste form.
+const RECORD_ID_RE = /^[a-zA-Z][a-zA-Z0-9_-]*:[\w.:-]+$/
 
 // `@[id]` tokens need to round-trip through remark untouched. Remark-directive
 // treats `:` as the textDirective sigil, so `@[user:abc]` would parse as

--- a/packages/lib/src/prompt-templates/__tests__/__snapshots__/flatten.test.ts.snap
+++ b/packages/lib/src/prompt-templates/__tests__/__snapshots__/flatten.test.ts.snap
@@ -1,0 +1,334 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`prompt template flatten snapshots > flattens "account-research" stably 1`] = `
+"Context
+You are researching a specific 
+[Entity: company](entity:company)
+ using public web sources. Start with 
+[Tool: search_knowledge](tool:search_knowledge)
+ for any internal notes the org has already captured on the account, then fall back to public sources — the company's official website, trustworthy business websites, recent news from reputable publications.
+Task
+Produce a company research brief that includes:
+Snapshot: what the company does in 1-2 sentences
+Firmographics: Industry / Category, HQ location, company size, funding status
+GTM motion: PLG, sales-led, or enterprise
+Recent news: max 4-5 bullet points summarizing meaningful announcements in the last 90 days such as product launches, funding, acquisitions, leadership changes, layoffs, or regulatory updates
+Key figureheads: 4-5 bullet points on executive roles
+Competitive landscape: 1-2 sentences on their main competitors
+Constraints
+Use the following output structure:
+Be concise and actionable, avoid long paragraphs
+If information is missing, write "Unknown"
+When there are conflicting signals, prioritize the most recent information
+If the company name is ambiguous, state the ambiguity and list the top 3 likely matches
+If the company record doesn't have a domain, or the user doesn't provide one, try to find it using external web search
+If there is no relevant company name or company record in context, ask the user to confirm what the relevant company is before proceeding."
+`;
+
+exports[`prompt template flatten snapshots > flattens "deal-brief" stably 1`] = `
+"Context
+You are preparing a report for an AE about a specific 
+[Entity: deal](entity:deal)
+. Use 
+[Tool: get_entity](tool:get_entity)
+ to pull the deal record and its associated 
+[Entity: company](entity:company)
+, 
+[Tool: list_notes](tool:list_notes)
+ for sales notes, and 
+[Tool: get_entity_history](tool:get_entity_history)
+ for stage history. Linked records may include 
+[Entity: meeting](entity:meeting)
+ recordings, emails, people, workspaces, and users. The customer context may be incomplete. You must only use what is supported by the available data and call out any gaps.
+Task
+Create a deal report for the selected deal record that includes:
+Company overview: what the company does (from record data or from running web research), relevant firmographics
+Deal summary: current stage, deal value, expected closing date, blockers (feature gaps, stakeholder alignment, security/legal, pricing, competition), and next steps
+Constraints
+Use the following output structure:
+Be concise and actionable, avoid long paragraphs
+If information is missing, write "Unknown"
+When there are conflicting signals, prioritize the most recent information
+If there is no relevant deal record in context, ask the user to confirm what is the relevant company or deal record before proceeding."
+`;
+
+exports[`prompt template flatten snapshots > flattens "draft-reply" stably 1`] = `
+"Context
+You are a customer support agent drafting a reply to a customer. Use 
+[Tool: get_thread_detail](tool:get_thread_detail)
+ to review the 
+[Entity: ticket](entity:ticket)
+ conversation (including prior agent replies for tone matching), 
+[Tool: get_entity](tool:get_entity)
+ to pull the linked 
+[Entity: contact](entity:contact)
+ (and any domain records the org has installed), and 
+[Tool: search_knowledge](tool:search_knowledge)
+ for relevant policy or product articles. Match the tone and style of previous agent responses in the thread.
+Task
+Draft a reply to the customer that includes:
+Acknowledgment of their concern or question
+A clear, direct answer or update on their issue
+Any specific actions you've taken or will take
+A concrete next step or resolution
+Constraints
+Use the following output structure:
+Be professional, empathetic, and concise — avoid filler phrases like "I understand your frustration"
+Match the tone of previous agent responses in the conversation
+If the issue requires information you don't have, say what's needed and who needs to provide it
+If there is no relevant ticket conversation in context, ask the user to confirm which conversation to reply to before proceeding."
+`;
+
+exports[`prompt template flatten snapshots > flattens "escalation-assessment" stably 1`] = `
+"Context
+You are a support team lead reviewing a 
+[Entity: ticket](entity:ticket)
+ to determine whether it should be escalated. Use 
+[Tool: get_thread_detail](tool:get_thread_detail)
+ for the conversation, 
+[Tool: list_notes](tool:list_notes)
+ for internal notes, and 
+[Tool: get_entity_history](tool:get_entity_history)
+ for the history of actions taken so far. The ticket may have a linked 
+[Entity: contact](entity:contact)
+ plus whatever domain records the org has installed.
+Task
+Produce an escalation assessment that includes:
+Summary: 1-2 sentences on what the issue is
+Severity signals: list the factors that suggest escalation may be needed — customer sentiment, issue complexity, time since first contact, repeat contacts, revenue impact, or failed resolution attempts
+Recommendation: escalate or continue handling at current level, with clear reasoning
+Suggested next step: if escalating, who should handle it and what they need to know; if not escalating, what the agent should do next
+Constraints
+Use the following output structure:
+Be concise and actionable, avoid long paragraphs
+If information is missing, write "Unknown"
+When there are conflicting signals, prioritize the most recent information
+If there is no relevant ticket conversation in context, ask the user to confirm which ticket to assess before proceeding."
+`;
+
+exports[`prompt template flatten snapshots > flattens "extract-action-items" stably 1`] = `
+"Context
+You are reviewing a conversation to identify all outstanding action items. Use 
+[Tool: get_thread_detail](tool:get_thread_detail)
+ for the message history and 
+[Tool: list_notes](tool:list_notes)
+ for internal notes. When attributing items, reference the 
+[Entity: contact](entity:contact)
+ for each owner where possible.
+Task
+Extract all action items from the conversation:
+For each item, include: what needs to be done, who is responsible (by name or role), and any deadline or urgency mentioned
+Group items by owner when possible
+Flag any items that appear urgent or time-sensitive
+Note any items where the owner is unclear
+Constraints
+Use the following output structure:
+Format as a numbered checklist
+Be specific — "Follow up with customer" is too vague; "Send tracking number to customer for order #1234" is actionable
+Only extract items that are explicitly stated or clearly implied — don't invent tasks
+If the conversation contains no action items, say so explicitly
+If there is no relevant conversation in context, ask the user to confirm which conversation to review before proceeding."
+`;
+
+exports[`prompt template flatten snapshots > flattens "order-status-lookup" stably 1`] = `
+"Context
+You are a support agent looking up a customer's 
+[Entity: order](entity:order)
+. Use 
+[Tool: search_entities](tool:search_entities)
+ to find the order by number or by the linked 
+[Entity: contact](entity:contact)
+, and 
+[Tool: get_entity](tool:get_entity)
+ to fetch the order's fields — order details, fulfillment status, tracking information, and payment status. The customer may have referenced an order number, or it may be linked to the current 
+[Entity: ticket](entity:ticket)
+.
+Task
+Produce an order status update that includes:
+Order number and date placed
+Items ordered: product names and quantities
+Payment status: paid, partially refunded, refunded, or pending
+Fulfillment status: unfulfilled, partially fulfilled, fulfilled, or delivered
+Tracking: carrier, tracking number, and last known status (if available)
+Estimated delivery date (if available)
+Constraints
+Use the following output structure:
+Be concise and factual — this is a status report, not a customer-facing message
+If information is missing, write "Unknown"
+If multiple orders exist for this customer, summarize the most recent one and note how many others exist
+If there is no relevant order data in context, ask the user to confirm the order number or customer before proceeding."
+`;
+
+exports[`prompt template flatten snapshots > flattens "refund-policy-response" stably 1`] = `
+"Context
+You are a support agent handling a refund-related inquiry. Use 
+[Tool: get_thread_detail](tool:get_thread_detail)
+ for the 
+[Entity: ticket](entity:ticket)
+ conversation, 
+[Tool: search_entities](tool:search_entities)
+ / 
+[Tool: get_entity](tool:get_entity)
+ for the customer's 
+[Entity: order](entity:order)
+ data, and 
+[Tool: search_knowledge](tool:search_knowledge)
+ for the refund or return policy. The customer may be requesting a refund, asking about eligibility, or disputing a previous refund decision.
+Task
+Draft a customer-facing response that includes:
+Whether the customer qualifies for a refund based on the available policy and order details
+The specific policy criteria that apply to their situation
+If eligible: the refund process, expected timeline, and refund method
+If not eligible: a clear explanation of why, and any alternatives (store credit, exchange, partial refund)
+Constraints
+Use the following output structure:
+Be empathetic but direct — don't over-apologize or use filler
+Cite the specific policy reason, not just "per our policy"
+If no refund policy is available in context, note this and draft a general response asking the customer to allow time for review
+If order details are missing, ask the user to confirm the order before proceeding."
+`;
+
+exports[`prompt template flatten snapshots > flattens "sales-coach" stably 1`] = `
+"Context
+You are coaching an AE based on a specific sales call they ran. Use 
+[Tool: get_transcript](tool:get_transcript)
+ for the call transcript and 
+[Tool: get_thread_detail](tool:get_thread_detail)
+ for any linked email threads. Linked records may include a 
+[Entity: meeting](entity:meeting)
+ and the participant's 
+[Entity: contact](entity:contact)
+. The customer context may be incomplete. You must only use what is supported by the available data and call out any gaps.
+Task
+Create a post-call coaching summary that includes:
+Call overview: 1 sentence on what the meeting was about, the meeting objective (if included or inferable), and the outcome (what progress was made, purchase decision reached or not, next step secured or not)
+What went well: what the AE did effectively (discovery, positioning, objection handling, next steps, building rapport)
+What to improve: 3-5 coaching opportunities, prioritized by impact on deal progression. For each improvement, list what happened, why it matters, and what to do differently next time.
+Constraints
+Use the following output structure:
+Be concise and actionable, avoid long paragraphs
+If information is missing, write "Unknown"
+When there are conflicting signals, prioritize the most recent information
+If there is no relevant call recording in context, ask the user to confirm what is the relevant call recording or meeting before proceeding."
+`;
+
+exports[`prompt template flatten snapshots > flattens "sentiment-analysis" stably 1`] = `
+"Context
+You are a customer experience analyst reviewing a support conversation. Use 
+[Tool: get_thread_detail](tool:get_thread_detail)
+ to read the 
+[Entity: ticket](entity:ticket)
+ conversation — sentiment is a function of the customer's words, not metadata. The 
+[Entity: contact](entity:contact)
+ context may include order history and previous interactions.
+Task
+Produce a sentiment analysis that includes:
+Current sentiment: rate as frustrated, dissatisfied, neutral, satisfied, or positive — with a 1-sentence explanation
+Sentiment trajectory: is it improving, stable, or deteriorating over the course of the conversation?
+Emotional triggers: list the specific moments or statements that shifted sentiment (max 3-4 bullet points)
+Recommended tone: what tone and approach the next response should take, with a brief example phrase
+Constraints
+Use the following output structure:
+Be concise and actionable, avoid long paragraphs
+Base your assessment only on what the customer actually said — don't infer emotions that aren't supported by the text
+If the conversation is too short to assess trajectory, note that explicitly
+If there is no relevant conversation in context, ask the user to confirm which conversation to analyze before proceeding."
+`;
+
+exports[`prompt template flatten snapshots > flattens "shipping-inquiry" stably 1`] = `
+"Context
+You are a support agent handling a shipping-related question or concern. Use 
+[Tool: get_thread_detail](tool:get_thread_detail)
+ for the 
+[Entity: ticket](entity:ticket)
+ conversation, and 
+[Tool: search_entities](tool:search_entities)
+ / 
+[Tool: get_entity](tool:get_entity)
+ to pull the customer's 
+[Entity: order](entity:order)
+ with its fulfillment and tracking data. The customer may be asking about delivery timing, reporting a missing package, or inquiring about shipping options.
+Task
+Draft a customer-facing response that addresses their shipping concern:
+Current fulfillment and tracking status
+Carrier and tracking number (if available)
+Expected delivery timeline based on shipping method and destination
+If there's a delay or issue: acknowledge it, explain what's known, and offer a concrete next step (reshipment, refund, investigation)
+Constraints
+Use the following output structure:
+Be concise and helpful — lead with the status, then explain
+If tracking shows delivered but the customer says they didn't receive it, recommend specific next steps (check with neighbors, wait 24-48 hours, file a carrier claim)
+If no order or tracking data is available in context, ask the user to confirm the order before proceeding."
+`;
+
+exports[`prompt template flatten snapshots > flattens "summarize-thread" stably 1`] = `
+"Context
+You are reviewing a conversation thread. Use 
+[Tool: get_thread_detail](tool:get_thread_detail)
+ to read the full message list and 
+[Tool: list_notes](tool:list_notes)
+ for internal notes. Linked records may include a 
+[Entity: ticket](entity:ticket)
+ or a 
+[Entity: contact](entity:contact)
+ participant. The thread may be a support ticket, an internal discussion, or a customer interaction.
+Task
+Create a thread summary that includes:
+Overview: what the conversation is about in 1-2 sentences
+Key points: the most important things discussed (max 5 bullet points)
+Decisions made: any agreements, approvals, or conclusions reached
+Outstanding items: anything unresolved or still needing follow-up, with who owns each item
+Constraints
+Use the following output structure:
+Be concise and actionable, avoid long paragraphs
+If information is missing, write "Unknown"
+Attribute action items to specific people when possible
+If the thread is very short (1-2 messages), note that the summary may be incomplete
+If there is no relevant conversation in context, ask the user to confirm which thread to summarize before proceeding."
+`;
+
+exports[`prompt template flatten snapshots > flattens "summarize-ticket" stably 1`] = `
+"Context
+You are a support operations analyst reviewing a customer support 
+[Entity: ticket](entity:ticket)
+. Use 
+[Tool: get_thread_detail](tool:get_thread_detail)
+ for the conversation, 
+[Tool: list_notes](tool:list_notes)
+ for internal notes, and 
+[Tool: get_entity_history](tool:get_entity_history)
+ for the timeline of edits. The ticket may also have a linked 
+[Entity: contact](entity:contact)
+ and other records installed by the org's domain seeds (e.g. orders, deals).
+Task
+Create a ticket summary that includes:
+Issue: what the customer contacted about in 1-2 sentences
+Timeline: key events in chronological order (max 5 bullet points)
+Actions taken: what the support team has done so far
+Current status: where things stand right now — resolved, waiting on customer, waiting on internal team, or unresolved
+Next step: the single most important thing that needs to happen next
+Constraints
+Use the following output structure:
+Be concise and actionable, avoid long paragraphs
+If information is missing, write "Unknown"
+When there are conflicting signals, prioritize the most recent information
+If there is no relevant ticket conversation in context, ask the user to confirm which ticket to summarize before proceeding."
+`;
+
+exports[`prompt template flatten snapshots > flattens "translate-message" stably 1`] = `
+"Context
+You are a support agent handling a message in a language other than English. Use 
+[Tool: get_thread_detail](tool:get_thread_detail)
+ to read the prior messages — the conversation drives the language detection. The customer has written in their preferred language and expects a response in the same language.
+Task
+Provide:
+Detected language: identify what language the customer is writing in
+English translation: translate the customer's most recent message into English
+Draft reply: write a response in the customer's language that addresses their message, matching the same level of formality
+Constraints
+Use the following output structure:
+Clearly label each section: "Detected Language", "English Translation", "Draft Reply"
+Preserve the customer's meaning accurately — don't paraphrase or soften their tone in translation
+If the language is ambiguous (e.g., could be Portuguese or Spanish), state the ambiguity and translate in the most likely language
+If the message is already in English, note that and offer to translate the draft reply into a specified language instead."
+`;

--- a/packages/lib/src/prompt-templates/__tests__/chip-catalog.test.ts
+++ b/packages/lib/src/prompt-templates/__tests__/chip-catalog.test.ts
@@ -1,0 +1,58 @@
+// packages/lib/src/prompt-templates/__tests__/chip-catalog.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { DocJSON, InlineJSON } from '../../kb/markdown'
+import { resolveTemplateChip } from '../template-chip-catalog'
+import { listPromptTemplates } from '../template-registry'
+
+/**
+ * Walk a compiled template's `DocJSON` and collect every inline `reference`
+ * id. We only care about the block schema (`type: 'block'`, `content: InlineJSON[]`)
+ * — system templates don't use tabs/accordion/table containers today.
+ */
+function collectChipIds(doc: DocJSON): string[] {
+  const ids: string[] = []
+  for (const node of doc.content ?? []) {
+    if (node?.type !== 'block') continue
+    walkInline(node.content as InlineJSON[] | undefined, ids)
+  }
+  return ids
+}
+
+function walkInline(inline: InlineJSON[] | undefined, out: string[]): void {
+  if (!inline) return
+  for (const node of inline) {
+    if (node.type === 'reference') {
+      const id = node.attrs?.id
+      if (typeof id === 'string') out.push(id)
+    }
+  }
+}
+
+describe('template chip catalog', () => {
+  const templates = listPromptTemplates()
+
+  it('every template chip resolves against the catalog', () => {
+    const unresolved: { template: string; chipId: string; reason: string }[] = []
+    for (const t of templates) {
+      for (const chipId of collectChipIds(t.prompt)) {
+        const r = resolveTemplateChip(chipId)
+        if (!r.ok) unresolved.push({ template: t.id, chipId, reason: r.reason })
+      }
+    }
+    expect(unresolved).toEqual([])
+  })
+
+  it('at least one chip per non-content-only template', () => {
+    // Content-only templates (translation, sentiment) per plan §8.1 may stay
+    // chip-light. Everything else should have at least one chip.
+    const CONTENT_ONLY = new Set(['translate-message'])
+    const missing: string[] = []
+    for (const t of templates) {
+      if (CONTENT_ONLY.has(t.id)) continue
+      const ids = collectChipIds(t.prompt)
+      if (ids.length === 0) missing.push(t.id)
+    }
+    expect(missing).toEqual([])
+  })
+})

--- a/packages/lib/src/prompt-templates/__tests__/flatten.test.ts
+++ b/packages/lib/src/prompt-templates/__tests__/flatten.test.ts
@@ -1,0 +1,30 @@
+// packages/lib/src/prompt-templates/__tests__/flatten.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { docToText } from '../../tiptap/doc-to-text'
+import { listPromptTemplates } from '../template-registry'
+
+/**
+ * Stub label resolver for the flatten snapshot. Mirrors what the runtime
+ * `resolvePromptBadges` produces conceptually — `[<Kind>: <name>](id)` —
+ * without depending on a live tool / EntityDefinition lookup. The snapshot
+ * locks the *shape* the model sees so a chip id rename surfaces in CI.
+ */
+function stubResolveReference(id: string): string {
+  const colon = id.indexOf(':')
+  if (colon <= 0) return `[reference](${id})`
+  const prefix = id.slice(0, colon)
+  const rest = id.slice(colon + 1)
+  if (prefix === 'tool') return `[Tool: ${rest}](${id})`
+  if (prefix === 'entity') return `[Entity: ${rest}](${id})`
+  return `[reference](${id})`
+}
+
+describe('prompt template flatten snapshots', () => {
+  for (const template of listPromptTemplates()) {
+    it(`flattens "${template.id}" stably`, () => {
+      const flattened = docToText(template.prompt, { references: stubResolveReference })
+      expect(flattened).toMatchSnapshot()
+    })
+  }
+})

--- a/packages/lib/src/prompt-templates/template-chip-catalog.ts
+++ b/packages/lib/src/prompt-templates/template-chip-catalog.ts
@@ -1,0 +1,101 @@
+// packages/lib/src/prompt-templates/template-chip-catalog.ts
+
+import { ENTITY_DEFINITION_TYPES, type EntityDefinitionType } from '@auxx/types/resource'
+
+/**
+ * Audit table for every `@[...]` chip id referenced from a system prompt
+ * template. The boot-time test (`__tests__/chip-catalog.test.ts`) walks each
+ * compiled template's `DocJSON`, finds every inline `reference` node, and
+ * asserts the id resolves via {@link resolveTemplateChip}.
+ *
+ * If a contributor adds a new chip to a `.md` template that isn't in here,
+ * the test fails — forcing the audit to stay in sync with the source files.
+ *
+ * The catalog is intentionally a flat constant table rather than a runtime
+ * lookup against the live tool / EntityDefinition tables: the system
+ * templates ship in the binary and need to validate at module-eval, before
+ * any DB connection exists.
+ *
+ * See: plans/kopilot/templates/template-overhaul-with-references.md §5
+ */
+
+/**
+ * Tools referenced by chip id in system templates. The chip id is
+ * `tool:<name>`. The names below must match the `name` field on a real
+ * `AgentToolDefinition` in
+ * `packages/lib/src/ai/kopilot/capabilities/**\/tools/*.ts`.
+ *
+ * If a tool is renamed, this list and any `.md` referencing it both have to
+ * be updated.
+ */
+export const KNOWN_TOOL_NAMES = new Set<string>([
+  'get_thread_detail',
+  'list_notes',
+  'get_entity',
+  'get_entity_history',
+  'search_entities',
+  'search_knowledge',
+  'get_transcript',
+])
+
+/**
+ * `entity:<entityDefinitionId>` chip ids that are guaranteed to resolve in
+ * any org. These are system types from `ENTITY_DEFINITION_TYPES`.
+ */
+export const SYSTEM_ENTITY_IDS: Set<string> = new Set(ENTITY_DEFINITION_TYPES)
+
+/**
+ * `entity:<entityDefinitionId>` chip ids that exist only after a
+ * `@auxx/seed` domain pack has been installed for the org (e.g. Shopify
+ * orders, sales pipeline deals).
+ *
+ * Per Q2 of the templates-v2 plan: these aren't on the system type guard,
+ * but the runtime EntityDefinition row resolves them once the seed is
+ * applied. If the org hasn't installed the seed, the reference resolver
+ * logs a miss and the chip flattens to `[reference](missing:entity:order)`
+ * in the rendered prompt — visible drift instead of silent degradation.
+ */
+export const SEED_ENTITY_IDS = new Set<string>(['order', 'deal'])
+
+export type ChipKind =
+  | { ok: true; kind: 'tool'; name: string }
+  | { ok: true; kind: 'entity:system'; entityDefinitionId: EntityDefinitionType }
+  | { ok: true; kind: 'entity:seed'; entityDefinitionId: string }
+  | { ok: false; reason: string }
+
+/**
+ * Resolve a chip id from a system template to a known catalog entry, or
+ * return a structured failure with the reason.
+ */
+export function resolveTemplateChip(chipId: string): ChipKind {
+  const colon = chipId.indexOf(':')
+  if (colon <= 0) return { ok: false, reason: `chip id "${chipId}" missing prefix` }
+  const prefix = chipId.slice(0, colon)
+  const rest = chipId.slice(colon + 1)
+
+  if (prefix === 'tool') {
+    if (KNOWN_TOOL_NAMES.has(rest)) return { ok: true, kind: 'tool', name: rest }
+    return {
+      ok: false,
+      reason: `unknown tool name "${rest}" — add it to KNOWN_TOOL_NAMES or fix the chip`,
+    }
+  }
+
+  if (prefix === 'entity') {
+    if (SYSTEM_ENTITY_IDS.has(rest)) {
+      return { ok: true, kind: 'entity:system', entityDefinitionId: rest as EntityDefinitionType }
+    }
+    if (SEED_ENTITY_IDS.has(rest)) {
+      return { ok: true, kind: 'entity:seed', entityDefinitionId: rest }
+    }
+    return {
+      ok: false,
+      reason: `unknown entity "${rest}" — not in ENTITY_DEFINITION_TYPES or SEED_ENTITY_IDS`,
+    }
+  }
+
+  return {
+    ok: false,
+    reason: `unsupported chip prefix "${prefix}" in system template — only tool / entity are vetted`,
+  }
+}

--- a/packages/lib/src/prompt-templates/templates/account-research.md
+++ b/packages/lib/src/prompt-templates/templates/account-research.md
@@ -9,7 +9,7 @@ iconColor: blue
 
 **Context**
 
-You are researching a specific company using public web sources. You have access to publicly available information which can include the company's official website, trustworthy business websites, recent news from reputable publications.
+You are researching a specific @[entity:company] using public web sources. Start with @[tool:search_knowledge] for any internal notes the org has already captured on the account, then fall back to public sources — the company's official website, trustworthy business websites, recent news from reputable publications.
 
 **Task**
 

--- a/packages/lib/src/prompt-templates/templates/deal-brief.md
+++ b/packages/lib/src/prompt-templates/templates/deal-brief.md
@@ -9,7 +9,7 @@ iconColor: amber
 
 **Context**
 
-You are preparing a report for an AE about a specific deal. You have access to the relevant deal record, associated company record, meeting history, call recordings, notes, emails, and other records like people, workspaces, users. The customer context may be incomplete. You must only use what is supported by the available data and call out any gaps.
+You are preparing a report for an AE about a specific @[entity:deal]. Use @[tool:get_entity] to pull the deal record and its associated @[entity:company], @[tool:list_notes] for sales notes, and @[tool:get_entity_history] for stage history. Linked records may include @[entity:meeting] recordings, emails, people, workspaces, and users. The customer context may be incomplete. You must only use what is supported by the available data and call out any gaps.
 
 **Task**
 

--- a/packages/lib/src/prompt-templates/templates/draft-reply.md
+++ b/packages/lib/src/prompt-templates/templates/draft-reply.md
@@ -9,7 +9,7 @@ iconColor: purple
 
 **Context**
 
-You are a customer support agent drafting a reply to a customer. You have access to the full ticket conversation, any linked orders, customer profile, and knowledge base articles. You should match the tone and style of previous agent responses in the thread.
+You are a customer support agent drafting a reply to a customer. Use @[tool:get_thread_detail] to review the @[entity:ticket] conversation (including prior agent replies for tone matching), @[tool:get_entity] to pull the linked @[entity:contact] (and any domain records the org has installed), and @[tool:search_knowledge] for relevant policy or product articles. Match the tone and style of previous agent responses in the thread.
 
 **Task**
 

--- a/packages/lib/src/prompt-templates/templates/escalation-assessment.md
+++ b/packages/lib/src/prompt-templates/templates/escalation-assessment.md
@@ -9,7 +9,7 @@ iconColor: amber
 
 **Context**
 
-You are a support team lead reviewing a ticket to determine whether it should be escalated. You have access to the full ticket conversation, customer profile, any linked orders, and the history of actions taken so far.
+You are a support team lead reviewing a @[entity:ticket] to determine whether it should be escalated. Use @[tool:get_thread_detail] for the conversation, @[tool:list_notes] for internal notes, and @[tool:get_entity_history] for the history of actions taken so far. The ticket may have a linked @[entity:contact] plus whatever domain records the org has installed.
 
 **Task**
 

--- a/packages/lib/src/prompt-templates/templates/extract-action-items.md
+++ b/packages/lib/src/prompt-templates/templates/extract-action-items.md
@@ -9,7 +9,7 @@ iconColor: orange
 
 **Context**
 
-You are reviewing a conversation to identify all outstanding action items. You have access to the full conversation thread, including all messages between participants and any internal notes.
+You are reviewing a conversation to identify all outstanding action items. Use @[tool:get_thread_detail] for the message history and @[tool:list_notes] for internal notes. When attributing items, reference the @[entity:contact] for each owner where possible.
 
 **Task**
 

--- a/packages/lib/src/prompt-templates/templates/order-status-lookup.md
+++ b/packages/lib/src/prompt-templates/templates/order-status-lookup.md
@@ -9,7 +9,7 @@ iconColor: green
 
 **Context**
 
-You are a support agent looking up a customer's order. You have access to the Shopify order data, including order details, fulfillment status, tracking information, and payment status. The customer may have referenced an order number, or it may be linked to the current ticket.
+You are a support agent looking up a customer's @[entity:order]. Use @[tool:search_entities] to find the order by number or by the linked @[entity:contact], and @[tool:get_entity] to fetch the order's fields — order details, fulfillment status, tracking information, and payment status. The customer may have referenced an order number, or it may be linked to the current @[entity:ticket].
 
 **Task**
 

--- a/packages/lib/src/prompt-templates/templates/refund-policy-response.md
+++ b/packages/lib/src/prompt-templates/templates/refund-policy-response.md
@@ -9,7 +9,7 @@ iconColor: pink
 
 **Context**
 
-You are a support agent handling a refund-related inquiry. You have access to the ticket conversation, the customer's order data, and any available refund or return policy from the knowledge base. The customer may be requesting a refund, asking about eligibility, or disputing a previous refund decision.
+You are a support agent handling a refund-related inquiry. Use @[tool:get_thread_detail] for the @[entity:ticket] conversation, @[tool:search_entities] / @[tool:get_entity] for the customer's @[entity:order] data, and @[tool:search_knowledge] for the refund or return policy. The customer may be requesting a refund, asking about eligibility, or disputing a previous refund decision.
 
 **Task**
 

--- a/packages/lib/src/prompt-templates/templates/sales-coach.md
+++ b/packages/lib/src/prompt-templates/templates/sales-coach.md
@@ -9,7 +9,7 @@ iconColor: purple
 
 **Context**
 
-You are coaching an AE based on a specific sales call they ran. You have access to the call transcript, any linked meeting notes, emails, participant records, and company records. The customer context may be incomplete. You must only use what is supported by the available data and call out any gaps.
+You are coaching an AE based on a specific sales call they ran. Use @[tool:get_transcript] for the call transcript and @[tool:get_thread_detail] for any linked email threads. Linked records may include a @[entity:meeting] and the participant's @[entity:contact]. The customer context may be incomplete. You must only use what is supported by the available data and call out any gaps.
 
 **Task**
 

--- a/packages/lib/src/prompt-templates/templates/sentiment-analysis.md
+++ b/packages/lib/src/prompt-templates/templates/sentiment-analysis.md
@@ -9,7 +9,7 @@ iconColor: red
 
 **Context**
 
-You are a customer experience analyst reviewing a support conversation. You have access to the full ticket conversation, including all customer messages and agent responses. The customer context may include order history and previous interactions.
+You are a customer experience analyst reviewing a support conversation. Use @[tool:get_thread_detail] to read the @[entity:ticket] conversation — sentiment is a function of the customer's words, not metadata. The @[entity:contact] context may include order history and previous interactions.
 
 **Task**
 

--- a/packages/lib/src/prompt-templates/templates/shipping-inquiry.md
+++ b/packages/lib/src/prompt-templates/templates/shipping-inquiry.md
@@ -9,7 +9,7 @@ iconColor: teal
 
 **Context**
 
-You are a support agent handling a shipping-related question or concern. You have access to the ticket conversation, the customer's order and fulfillment data from Shopify, including tracking information if available. The customer may be asking about delivery timing, reporting a missing package, or inquiring about shipping options.
+You are a support agent handling a shipping-related question or concern. Use @[tool:get_thread_detail] for the @[entity:ticket] conversation, and @[tool:search_entities] / @[tool:get_entity] to pull the customer's @[entity:order] with its fulfillment and tracking data. The customer may be asking about delivery timing, reporting a missing package, or inquiring about shipping options.
 
 **Task**
 

--- a/packages/lib/src/prompt-templates/templates/summarize-thread.md
+++ b/packages/lib/src/prompt-templates/templates/summarize-thread.md
@@ -9,7 +9,7 @@ iconColor: indigo
 
 **Context**
 
-You are reviewing a conversation thread. You have access to all messages in the thread, including any internal notes, linked records, and participant information. The thread may be a support ticket, an internal discussion, or a customer interaction.
+You are reviewing a conversation thread. Use @[tool:get_thread_detail] to read the full message list and @[tool:list_notes] for internal notes. Linked records may include a @[entity:ticket] or a @[entity:contact] participant. The thread may be a support ticket, an internal discussion, or a customer interaction.
 
 **Task**
 

--- a/packages/lib/src/prompt-templates/templates/summarize-ticket.md
+++ b/packages/lib/src/prompt-templates/templates/summarize-ticket.md
@@ -9,7 +9,7 @@ iconColor: blue
 
 **Context**
 
-You are a support operations analyst reviewing a customer support ticket. You have access to the full ticket conversation, including all messages between the customer and support agents, any internal notes, and linked records such as orders or customer profiles.
+You are a support operations analyst reviewing a customer support @[entity:ticket]. Use @[tool:get_thread_detail] for the conversation, @[tool:list_notes] for internal notes, and @[tool:get_entity_history] for the timeline of edits. The ticket may also have a linked @[entity:contact] and other records installed by the org's domain seeds (e.g. orders, deals).
 
 **Task**
 

--- a/packages/lib/src/prompt-templates/templates/translate-message.md
+++ b/packages/lib/src/prompt-templates/templates/translate-message.md
@@ -9,7 +9,7 @@ iconColor: teal
 
 **Context**
 
-You are a support agent handling a message in a language other than English. You have access to the ticket conversation and any linked records. The customer has written in their preferred language and expects a response in the same language.
+You are a support agent handling a message in a language other than English. Use @[tool:get_thread_detail] to read the prior messages — the conversation drives the language detection. The customer has written in their preferred language and expects a response in the same language.
 
 **Task**
 


### PR DESCRIPTION
## Summary

- Renames the `resource:` reference-chip prefix to `entity:` everywhere it appears — persona-prompt instructions, the agents-builder `set_agent_prompt` schema validation, the resource picker, the badge renderer, and all 13 system templates — so the chip name lines up with the schema and runtime tools.
- Adds an `editable` prop to `PromptEditor` / `useRichTextEditor` (forwarded to TipTap's `setEditable`) and uses it for the template-gallery preview, so the read-only preview renders chips and block layouts identical to the customize view instead of falling back to `docToText`. Supporting CSS hides the gutter and selection outline when `contenteditable="false"`.
- System templates now lead with `@[tool:…]` and `@[entity:…]` chips (e.g. `draft-reply`, `summarize-ticket`, `account-research`) and ship with a `template-chip-catalog.ts` + boot-time `chip-catalog.test.ts` that fail the build if a template references an unknown tool or entity id.
- Fixes `mdToBlocks` regex so multi-colon chip ids (`field:ticket:status`, path-form `field:ticket:assignee::user:name`) parse as a single reference instead of being silently truncated at the second colon. Adds round-trip tests.
- Adds a chip-vs-recordId clarification to the block-catalog runtime prompt (and snapshot).

## Test plan

- [ ] `pnpm test --filter @auxx/lib -- prompt-templates` — chip catalog + flatten tests pass
- [ ] `pnpm test --filter @auxx/lib -- kb/markdown` — round-trip tests cover field-chip and path-chip parsing
- [ ] `pnpm test --filter @auxx/lib -- ai/kopilot/prompts` — runtime-prompt snapshot updated
- [ ] Open the prompt template gallery in `apps/web` and confirm the preview renders chips/blocks (not raw text)
- [ ] Create/edit an agent persona and confirm `@[entity:ticket]` chips still validate and render