### PR TITLE
feat(agents): dm trigger kind + Chat tab + composer sender picker

### DIFF
--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -1,7 +1,7 @@
 // apps/web/src/app/api/kopilot/stream/route.ts
 
 import { database as db } from '@auxx/database'
-import { filterToolsByToolsets, resolveAgentConfig } from '@auxx/lib/agents'
+import { buildDmTriggerContext, filterToolsByToolsets, resolveAgentConfig } from '@auxx/lib/agents'
 import { type UsageTrackingRequest, UsageTrackingService } from '@auxx/lib/ai'
 import {
   AgentEngine,
@@ -14,6 +14,7 @@ import {
   subscribeToAgentEvents,
   withAgentRunLog,
 } from '@auxx/lib/ai/agent-framework'
+import type { TriggerContext } from '@auxx/lib/ai/kopilot'
 import {
   createActorCapabilities,
   createAgentsBuilderCapabilities,
@@ -32,7 +33,10 @@ import {
 } from '@auxx/lib/ai/kopilot'
 import { createToolDepsFactory } from '@auxx/lib/ai/kopilot/capabilities'
 import { getModelCreditMultiplier } from '@auxx/lib/ai/quota'
+import { getCachedAgentById } from '@auxx/lib/cache'
+import { ForbiddenError } from '@auxx/lib/errors'
 import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
+import { docToText } from '@auxx/lib/tiptap'
 import { createScopedLogger } from '@auxx/logger'
 import {
   createSession,
@@ -52,6 +56,21 @@ interface SessionRefLike {
   kind?: string
   id?: string
   origin?: string
+}
+
+/**
+ * Convert the DM trigger's Tiptap instructions doc into plain text for the
+ * system prompt. Mirrors the worker-path conversion in
+ * `process-agent-job.ts:resolveTriggerContext` but kept inline to avoid
+ * pulling the heavier reference-resolver dependency on every DM send.
+ */
+function renderDmInstructions(instructions: Record<string, unknown> | null): string | null {
+  if (!instructions) return null
+  if (typeof instructions === 'string') {
+    return instructions.length > 0 ? instructions : null
+  }
+  const text = docToText(instructions, {})
+  return text.length > 0 ? text : null
 }
 
 /**
@@ -93,6 +112,13 @@ interface KopilotStreamRequest {
    * Ignored when sessionId is provided (existing session keeps its type).
    */
   sessionType?: 'kopilot' | 'builder'
+  /**
+   * Trigger discriminator for the run. 'dm' means the request originated
+   * from the agent Chat tab or the composer sender picker; the route
+   * resolves the agent's `dm` AgentTrigger gating (enabled? instructions?)
+   * and layers the DM trigger-instructions slot into the system prompt.
+   */
+  triggerKind?: 'dm'
 }
 
 /**
@@ -194,6 +220,11 @@ export async function POST(request: NextRequest) {
         let storedModelId: string | null = null
         let sessionAgentId: string | null = null
         let sessionType: 'kopilot' | 'builder' = 'kopilot'
+        let resolvedPage: string | undefined = page
+        // Computed when body.triggerKind === 'dm'. Threaded to the engine so the
+        // system prompt's trigger-instructions slot renders. Gate is re-run on
+        // every send so disabling DM mid-thread surfaces a 403.
+        let inProcessTriggerContext: TriggerContext | undefined
 
         if (sessionId) {
           const sessionResult = await getSessionById({ sessionId, organizationId })
@@ -211,12 +242,50 @@ export async function POST(request: NextRequest) {
           const placeholderTitle = message.slice(0, 100)
           sessionAgentId = body.agentId ?? null
           sessionType = body.sessionType ?? 'kopilot'
+
+          // DM sessions get tagged with the dm AgentTrigger + a triggerContext
+          // payload so the worker path (`resolveTriggerContext`) can recover
+          // the DM kind on subsequent sends without re-reading the agent.
+          let createAgentTriggerId: string | null = null
+          let createTriggerContext: Record<string, unknown> | null = null
+          if (body.triggerKind === 'dm' && sessionAgentId) {
+            const cachedAgent = await getCachedAgentById(organizationId, sessionAgentId)
+            if (!cachedAgent) {
+              send({ type: 'turn-error', error: 'Agent not found', code: 'not_found' })
+              cleanup()
+              return
+            }
+            try {
+              const dm = buildDmTriggerContext({ agent: cachedAgent })
+              createAgentTriggerId = dm.triggerContext.triggerId
+              createTriggerContext = {
+                kind: dm.triggerContext.kind,
+                firedAt: dm.triggerContext.firedAt,
+              }
+              inProcessTriggerContext = {
+                kind: 'dm',
+                instructions: renderDmInstructions(dm.triggerInstructions),
+                payload: { firedAt: dm.triggerContext.firedAt },
+              }
+              resolvedPage = 'agents.dm'
+            } catch (err) {
+              if (err instanceof ForbiddenError) {
+                send({ type: 'turn-error', error: err.message, code: 'forbidden' })
+                cleanup()
+                return
+              }
+              throw err
+            }
+          }
+
           const createResult = await createSession({
             organizationId,
             userId,
             type: sessionType,
             title: placeholderTitle,
             agentId: sessionAgentId,
+            agentTriggerId: createAgentTriggerId,
+            triggerContext: createTriggerContext,
           })
           if (createResult.isErr()) {
             send({ type: 'error', error: createResult.error.message })
@@ -232,6 +301,33 @@ export async function POST(request: NextRequest) {
             title: placeholderTitle,
             createdAt: createResult.value.createdAt.toISOString(),
           })
+        }
+
+        // Existing-session DM gate: re-resolve the cached agent on every send
+        // so disabling DM mid-thread surfaces a fresh 403, not a stale OK.
+        if (body.triggerKind === 'dm' && sessionAgentId && !inProcessTriggerContext) {
+          const cachedAgent = await getCachedAgentById(organizationId, sessionAgentId)
+          if (!cachedAgent) {
+            send({ type: 'turn-error', error: 'Agent not found', code: 'not_found' })
+            cleanup()
+            return
+          }
+          try {
+            const dm = buildDmTriggerContext({ agent: cachedAgent })
+            inProcessTriggerContext = {
+              kind: 'dm',
+              instructions: renderDmInstructions(dm.triggerInstructions),
+              payload: { firedAt: dm.triggerContext.firedAt },
+            }
+            resolvedPage = 'agents.dm'
+          } catch (err) {
+            if (err instanceof ForbiddenError) {
+              send({ type: 'turn-error', error: err.message, code: 'forbidden' })
+              cleanup()
+              return
+            }
+            throw err
+          }
         }
 
         logger.info('Kopilot turn context', {
@@ -255,13 +351,14 @@ export async function POST(request: NextRequest) {
                 userId,
                 message,
                 type,
-                page,
+                page: resolvedPage,
                 context,
                 approvalAction: body.approvalAction,
                 inputAmendment: body.inputAmendment,
                 modelId: body.modelId,
                 agentId: sessionAgentId,
                 sessionType,
+                triggerKind: body.triggerKind,
                 send,
                 cleanup,
                 request,
@@ -273,13 +370,14 @@ export async function POST(request: NextRequest) {
                 userId,
                 message,
                 type,
-                page,
+                page: resolvedPage,
                 context,
                 approvalAction: body.approvalAction,
                 inputAmendment: body.inputAmendment,
                 modelId: body.modelId,
                 agentId: sessionAgentId,
                 sessionType,
+                triggerContext: inProcessTriggerContext,
                 savedMessages,
                 savedDomainState,
                 storedModelId,
@@ -378,6 +476,7 @@ async function runInProcessPath(params: {
   modelId?: string
   agentId: string | null
   sessionType: 'kopilot' | 'builder'
+  triggerContext?: TriggerContext
   savedMessages: Record<string, unknown>[]
   savedDomainState: Record<string, unknown>
   storedModelId: string | null
@@ -398,6 +497,7 @@ async function runInProcessPath(params: {
     modelId,
     agentId,
     sessionType,
+    triggerContext,
     savedMessages,
     savedDomainState,
     storedModelId,
@@ -544,6 +644,7 @@ async function runInProcessPath(params: {
     defaultProvider,
     maxIterations: 30,
     agentConfig,
+    triggerContext,
   })
 
   // Create LLM adapter
@@ -697,6 +798,13 @@ async function runWorkerPath(params: {
   modelId?: string
   agentId: string | null
   sessionType: 'kopilot' | 'builder'
+  /**
+   * Set when the request originated from the agent Chat tab or composer
+   * sender picker. The worker re-resolves the trigger context from the
+   * session's `agentTriggerId` (set at session-create time for DM); this
+   * field is forwarded mainly for downstream analytics / future routing.
+   */
+  triggerKind?: 'dm'
   send: (event: AgentEvent | { type: string; [key: string]: unknown }) => void
   cleanup: () => void
   request: NextRequest
@@ -741,7 +849,10 @@ async function runWorkerPath(params: {
     resolveCompletion()
   })
 
-  // 2. Enqueue the job
+  // 2. Enqueue the job. The worker reads `agentTriggerId` off the session
+  // row (set at session-create time for DM), so the job payload doesn't
+  // need to carry the trigger id explicitly — `triggerKind` is forwarded
+  // for analytics and future routing only.
   await enqueueAgentJob({
     sessionId,
     organizationId,
@@ -755,6 +866,7 @@ async function runWorkerPath(params: {
     inputAmendment: params.inputAmendment,
     modelId: params.modelId,
     agentId: params.agentId,
+    triggerKind: params.triggerKind,
   })
 
   // 3. Wait for terminal event or disconnect

--- a/apps/web/src/components/agents/ui/detail/agent-docked-chat.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-docked-chat.tsx
@@ -2,7 +2,10 @@
 'use client'
 
 import { agentTemplates } from '@auxx/lib/agents/client'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
+import { MessageSquareOff, Settings2 } from 'lucide-react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useEffect, useState } from 'react'
 import { KopilotContext } from '~/components/kopilot/context'
 import { KopilotChatProvider } from '~/components/kopilot/options'
@@ -15,54 +18,90 @@ interface AgentDockedChatProps {
   agentId: string
 }
 
+type Panel = 'build' | 'chat'
+const PANELS: readonly Panel[] = ['build', 'chat'] as const
+
 /**
- * Docked Kopilot chat scoped to one agent. The session is bound to
- * `(userId, agentId, type='builder')` — each admin gets their own persistent
- * builder thread per agent. On mount we look up the most recent builder
- * session and load it; if none exists, the chat starts fresh and the first
- * message creates a new builder-tagged session.
+ * Docked Kopilot chat scoped to one agent. Two tabs:
+ * - **Build** — the agent builder thread (session `(userId, agentId,
+ *   type='builder')`, builder persona + tools). This is the configuration
+ *   surface.
+ * - **Chat** — a direct-message thread with the agent itself (session
+ *   `(userId, agentId, type='kopilot')` plus `triggerKind='dm'` so the
+ *   DM AgentTrigger gates the run and layers in DM trigger-instructions).
  *
- * Fresh agents (no prompt body, no enabled toolsets) get two seed-prompt
- * chips in the empty state — the builder persona expects the admin to either
- * pick one or describe what they want, and these chips make the first turn
- * trivial. Populated agents hide the chips entirely; the chat reads as edit-
- * in-place.
+ * Default tab follows `setupCompletedAt`: agents that finished setup land
+ * on Chat (first instinct is to test); agents mid-setup land on Build.
+ * The current panel is persisted in `?panel=` so a refresh round-trips.
  *
- * If the URL carries `?template=<id>`, the templated prompt is submitted
- * directly as the first user turn (no chip rendered). The capture is frozen
- * at mount so the param-strip can't change the message after the chat has
- * already dispatched it.
+ * Build-tab specifics (preserved from the pre-tabs implementation):
+ * fresh agents get two seed-prompt suggestion chips, and a templated
+ * prompt (`?template=<id>`) is auto-submitted as the first user turn.
  */
 export function AgentDockedChat({ agentId }: AgentDockedChatProps) {
+  const { agent, detail } = useAgent(agentId)
+
+  const isFreshAgent = detail?.setupCompletedAt == null
+  const defaultPanel: Panel = isFreshAgent ? 'build' : 'chat'
+
+  const [panel, setPanel] = useQueryState(
+    'panel',
+    parseAsStringLiteral(PANELS).withDefault(defaultPanel)
+  )
+
+  return (
+    <Tabs
+      value={panel}
+      onValueChange={(v) => setPanel(v as Panel)}
+      className='flex h-full flex-col'>
+      <TabsList variant='outline'>
+        <TabsTrigger value='build' variant='outline'>
+          Build
+        </TabsTrigger>
+        <TabsTrigger value='chat' variant='outline'>
+          Chat
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value='build' className='flex-1 overflow-hidden'>
+        <BuildPanel agentId={agentId} isFreshAgent={isFreshAgent} agentName={agent?.name ?? null} />
+      </TabsContent>
+      <TabsContent value='chat' className='flex-1 overflow-hidden'>
+        <ChatPanel
+          agentId={agentId}
+          agentName={agent?.name ?? null}
+          agentDescription={detail?.description ?? null}
+          isFreshAgent={isFreshAgent}
+          onJumpToBuild={() => setPanel('build')}
+        />
+      </TabsContent>
+    </Tabs>
+  )
+}
+
+// ── Build tab ──────────────────────────────────────────────────────────────
+
+interface BuildPanelProps {
+  agentId: string
+  isFreshAgent: boolean
+  agentName: string | null
+}
+
+function BuildPanel({ agentId, isFreshAgent, agentName }: BuildPanelProps) {
   const { data, isLoading } = api.kopilot.listSessions.useQuery(
     { type: 'builder', agentId, limit: 1 },
     { staleTime: 30_000 }
   )
-  const { agent, detail } = useAgent(agentId)
 
   const searchParams = useSearchParams()
   const router = useRouter()
   const pathname = usePathname()
 
-  // Show seed-prompt chips while the agent is mid-setup — drafts created
-  // through the new "Create agent" button start with auto-default toolsets
-  // (which used to defeat the fresh-agent check), but `setupCompletedAt`
-  // null is the authoritative signal that the admin hasn't finished
-  // chatting through the build yet.
-  const isFreshAgent = detail?.setupCompletedAt == null
-
-  // Freeze the template at first render. Subsequent param changes are
-  // ignored, so the param-strip effect below can't yank the suggestion
-  // before autoSubmit runs. Stale ids resolve to null → falls through to
-  // the default chips silently.
   const [capturedTemplate] = useState(() => {
     const templateId = searchParams.get('template')
     if (!templateId) return null
     return agentTemplates.find((t) => t.id === templateId) ?? null
   })
 
-  // Strip `?template=<id>` after capture so a refresh doesn't fire the
-  // prompt twice. Runs once on mount.
   useEffect(() => {
     if (searchParams.get('template')) {
       router.replace(pathname, { scroll: false })
@@ -79,6 +118,7 @@ export function AgentDockedChat({ agentId }: AgentDockedChatProps) {
       options={{
         allowModelPicker: false,
         allowSlashCommands: false,
+        allowSenderPicker: false,
         hideSuggestions: !isFreshAgent,
         emptyStateDescription: isFreshAgent
           ? 'Tell me what this agent should do, or pick one below.'
@@ -87,7 +127,7 @@ export function AgentDockedChat({ agentId }: AgentDockedChatProps) {
       <KopilotContext
         page='agents.builder'
         activeAgentId={agentId}
-        activeAgentLabel={agent?.name ?? 'Untitled agent'}
+        activeAgentLabel={agentName ?? 'Untitled agent'}
       />
       {isFreshAgent && !hasTemplate && (
         <>
@@ -115,5 +155,119 @@ export function AgentDockedChat({ agentId }: AgentDockedChatProps) {
         />
       </div>
     </KopilotChatProvider>
+  )
+}
+
+// ── Chat tab ───────────────────────────────────────────────────────────────
+
+interface ChatPanelProps {
+  agentId: string
+  agentName: string | null
+  agentDescription: string | null
+  isFreshAgent: boolean
+  onJumpToBuild: () => void
+}
+
+function ChatPanel({
+  agentId,
+  agentName,
+  agentDescription,
+  isFreshAgent,
+  onJumpToBuild,
+}: ChatPanelProps) {
+  // The DM session is a kopilot session bound to (user, agent). One rolling
+  // thread per pair in v1; "Start new chat" lands later.
+  const sessionsQuery = api.kopilot.listSessions.useQuery(
+    { type: 'kopilot', agentId, limit: 1 },
+    { staleTime: 30_000, enabled: !isFreshAgent }
+  )
+  const triggersQuery = api.agentTrigger.list.useQuery(
+    { agentId },
+    { staleTime: 30_000, enabled: !isFreshAgent }
+  )
+
+  if (isFreshAgent) {
+    return (
+      <EmptyChatState
+        icon={<Settings2 className='size-6' />}
+        title='Save your agent first'
+        description='Complete setup before chatting — testing now would mean testing a half-configured agent.'
+        ctaLabel='Finish setup'
+        onCta={onJumpToBuild}
+      />
+    )
+  }
+
+  if (sessionsQuery.isLoading || triggersQuery.isLoading) {
+    return <div className='h-full' />
+  }
+
+  const dmTrigger = triggersQuery.data?.find((t) => t.kind === 'dm')
+  if (!dmTrigger?.enabled) {
+    return (
+      <EmptyChatState
+        icon={<MessageSquareOff className='size-6' />}
+        title='Direct messages are disabled'
+        description='Enable them on the Triggers tab to start chatting with this agent.'
+      />
+    )
+  }
+
+  const initialSessionId = sessionsQuery.data?.items[0]?.id ?? null
+
+  return (
+    <KopilotChatProvider
+      options={{
+        allowModelPicker: false,
+        allowSlashCommands: false,
+        allowSenderPicker: false,
+        hideSuggestions: true,
+        emptyStateDescription:
+          agentDescription ??
+          (agentName
+            ? `Say hi to ${agentName} — they have their own toolset and persona.`
+            : 'Say hi to this agent.'),
+      }}>
+      <KopilotContext
+        page='agents.dm'
+        activeAgentId={agentId}
+        activeAgentLabel={agentName ?? 'Untitled agent'}
+      />
+      <div className='h-full flex flex-col'>
+        <KopilotChat
+          page='agents.dm'
+          agentId={agentId}
+          sessionType='kopilot'
+          triggerKind='dm'
+          initialSessionId={initialSessionId}
+        />
+      </div>
+    </KopilotChatProvider>
+  )
+}
+
+interface EmptyChatStateProps {
+  icon: React.ReactNode
+  title: string
+  description: string
+  ctaLabel?: string
+  onCta?: () => void
+}
+
+function EmptyChatState({ icon, title, description, ctaLabel, onCta }: EmptyChatStateProps) {
+  return (
+    <div className='flex h-full flex-col items-center justify-center px-6 text-center'>
+      <div className='text-muted-foreground mb-3'>{icon}</div>
+      <p className='text-sm font-medium text-foreground'>{title}</p>
+      <p className='mt-1 text-xs text-muted-foreground max-w-xs'>{description}</p>
+      {ctaLabel && onCta ? (
+        <button
+          type='button'
+          className='mt-4 text-xs font-medium text-primary underline-offset-4 hover:underline'
+          onClick={onCta}>
+          {ctaLabel}
+        </button>
+      ) : null}
+    </div>
   )
 }

--- a/apps/web/src/components/agents/ui/detail/triggers/agent-trigger-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/agent-trigger-dialog.tsx
@@ -35,7 +35,7 @@ import { type Interval, TriggerIntervalSelector } from './trigger-interval-selec
 
 type Trigger = RouterOutputs['agentTrigger']['list'][number]
 
-type Kind = 'scheduled' | 'event' | 'mention' | 'assignment'
+type Kind = 'scheduled' | 'event' | 'mention' | 'assignment' | 'dm'
 type ScheduledMode = 'simple' | 'cron'
 type CrudTriggerType = 'created' | 'updated' | 'deleted'
 
@@ -112,6 +112,8 @@ function instructionsPlaceholder(kind: Kind): string {
       return 'e.g. "When @mentioned, draft a reply that matches the requested tone."'
     case 'assignment':
       return 'e.g. "When assigned, triage and answer or escalate to the right team."'
+    case 'dm':
+      return 'e.g. "Greet the user, then help them debug their integration step by step."'
   }
 }
 
@@ -144,9 +146,12 @@ export function AgentTriggerDialog({
         ? 'mention'
         : trigger?.kind === 'assignment'
           ? 'assignment'
-          : 'scheduled'
+          : trigger?.kind === 'dm'
+            ? 'dm'
+            : 'scheduled'
     : kind
-  const isBuiltinKind = effectiveKind === 'mention' || effectiveKind === 'assignment'
+  const isBuiltinKind =
+    effectiveKind === 'mention' || effectiveKind === 'assignment' || effectiveKind === 'dm'
 
   const { resources } = useResources()
   const fallbackEntityId = resources[0]?.id ?? 'ticket'
@@ -259,6 +264,9 @@ export function AgentTriggerDialog({
     if (effectiveKind === 'assignment') {
       return { kind: 'assignment' as const }
     }
+    if (effectiveKind === 'dm') {
+      return { kind: 'dm' as const }
+    }
 
     if (!eventState.entityDefinitionId) {
       toastError({ title: 'Pick a resource' })
@@ -310,7 +318,9 @@ export function AgentTriggerDialog({
                   ? 'Fire this agent when it is mentioned in a comment.'
                   : effectiveKind === 'assignment'
                     ? 'Fire this agent when it is assigned to a ticket.'
-                    : 'Fire this agent when a resource is created, updated, or deleted.'}
+                    : effectiveKind === 'dm'
+                      ? 'Fire this agent when a user direct-messages it.'
+                      : 'Fire this agent when a resource is created, updated, or deleted.'}
             </DialogDescription>
           </DialogHeader>
 

--- a/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
@@ -18,10 +18,10 @@ import { TriggerLabel } from './trigger-label'
 
 type Trigger = RouterOutputs['agentTrigger']['list'][number]
 
-type TriggerKind = 'scheduled' | 'event' | 'app' | 'mention' | 'assignment'
-type BuiltinKind = 'mention' | 'assignment'
+type TriggerKind = 'scheduled' | 'event' | 'app' | 'mention' | 'assignment' | 'dm'
+type BuiltinKind = 'mention' | 'assignment' | 'dm'
 
-const BUILTIN_KINDS: BuiltinKind[] = ['mention', 'assignment']
+const BUILTIN_KINDS: BuiltinKind[] = ['mention', 'assignment', 'dm']
 
 const KIND_META: Record<
   TriggerKind,
@@ -41,6 +41,12 @@ const KIND_META: Record<
     iconId: 'user-plus',
     color: 'sky',
     description: 'Fires whenever this agent is assigned to a ticket.',
+  },
+  dm: {
+    label: 'Direct message',
+    iconId: 'message-circle',
+    color: 'rose',
+    description: 'Fires whenever a user direct-messages this agent.',
   },
 }
 
@@ -93,11 +99,14 @@ export function TriggersSectionContent({
   const builtinByKind: Record<BuiltinKind, Trigger | undefined> = {
     mention: rows.find((r) => r.kind === 'mention'),
     assignment: rows.find((r) => r.kind === 'assignment'),
+    dm: rows.find((r) => r.kind === 'dm'),
   }
-  const customRows = rows.filter((r) => r.kind !== 'mention' && r.kind !== 'assignment')
+  const customRows = rows.filter(
+    (r) => r.kind !== 'mention' && r.kind !== 'assignment' && r.kind !== 'dm'
+  )
 
   const isDialogOpen = !!addingKind || !!editingTrigger || !!creatingBuiltinKind
-  const dialogKind: 'scheduled' | 'event' | 'mention' | 'assignment' =
+  const dialogKind: 'scheduled' | 'event' | 'mention' | 'assignment' | 'dm' =
     editingTrigger?.kind === 'event'
       ? 'event'
       : editingTrigger?.kind === 'scheduled'
@@ -106,7 +115,9 @@ export function TriggersSectionContent({
           ? 'mention'
           : editingTrigger?.kind === 'assignment'
             ? 'assignment'
-            : (creatingBuiltinKind ?? addingKind ?? 'scheduled')
+            : editingTrigger?.kind === 'dm'
+              ? 'dm'
+              : (creatingBuiltinKind ?? addingKind ?? 'scheduled')
 
   const handleDialogOpenChange = (open: boolean) => {
     if (open) return

--- a/apps/web/src/components/kopilot/hooks/use-kopilot-sessions.ts
+++ b/apps/web/src/components/kopilot/hooks/use-kopilot-sessions.ts
@@ -72,36 +72,45 @@ export function useLoadSession() {
   const utils = api.useUtils()
   const setMessages = useKopilotStore((s) => s.setMessages)
   const setActiveSessionId = useKopilotStore((s) => s.setActiveSessionId)
+  const setActiveSessionAgentId = useKopilotStore((s) => s.setActiveSessionAgentId)
   const setMessageFeedback = useKopilotStore((s) => s.setMessageFeedback)
   const setSelectedModelId = useKopilotStore((s) => s.setSelectedModelId)
+  const startNewSession = useKopilotStore((s) => s.startNewSession)
 
   return async (sessionId: string) => {
+    // Wipe per-session ephemera before the fetch so old messages, reply
+    // chips, dismissals, and edit state don't leak across a session swap.
+    startNewSession()
     setActiveSessionId(sessionId)
     const data = await utils.kopilot.getSession.fetch({ sessionId })
 
     // Restore model picker to the session's last-used model
     setSelectedModelId((data as any)?.modelId ?? null)
+    // Hydrate sender-picker lock state — once a session has an agentId
+    // (set when the user picked an agent on the first send), the composer
+    // renders the sender chip non-interactive.
+    setActiveSessionAgentId((data as any)?.agentId ?? null)
 
-    if (data?.messages) {
-      const raw = data.messages as PersistedMessage[]
+    const raw = (data?.messages ?? []) as PersistedMessage[]
 
-      // Persisted shape == render-ready shape. No filter, no reparent loop,
-      // no _pendingToolCall re-emit, no reconstructThinkingGroups.
-      const hydrated: KopilotMessage[] = raw.map((m, i) => ({
-        id: m.id,
-        role: m.role,
-        ...(m.content !== undefined ? { content: m.content } : {}),
-        ...(m.parts ? { parts: m.parts } : {}),
-        timestamp: m.timestamp ?? Date.now(),
-        parentId: m.parentId ?? (i > 0 ? (raw[i - 1]!.id ?? null) : null),
-        metadata: m.metadata as KopilotMessage['metadata'],
-        ...(m.approval ? { approval: m.approval } : {}),
-        ...(m.linkSnapshots ? { linkSnapshots: m.linkSnapshots } : {}),
-        ...(m.error ? { error: m.error } : {}),
-      }))
+    // Persisted shape == render-ready shape. No filter, no reparent loop,
+    // no _pendingToolCall re-emit, no reconstructThinkingGroups.
+    const hydrated: KopilotMessage[] = raw.map((m, i) => ({
+      id: m.id,
+      role: m.role,
+      ...(m.content !== undefined ? { content: m.content } : {}),
+      ...(m.parts ? { parts: m.parts } : {}),
+      timestamp: m.timestamp ?? Date.now(),
+      parentId: m.parentId ?? (i > 0 ? (raw[i - 1]!.id ?? null) : null),
+      metadata: m.metadata as KopilotMessage['metadata'],
+      ...(m.approval ? { approval: m.approval } : {}),
+      ...(m.linkSnapshots ? { linkSnapshots: m.linkSnapshots } : {}),
+      ...(m.error ? { error: m.error } : {}),
+    }))
 
-      setMessages(hydrated)
+    setMessages(hydrated)
 
+    if (hydrated.length > 0) {
       // Hydrate feedback from server
       const feedbackMap = await utils.kopilot.getSessionFeedback.fetch({ sessionId })
       for (const [messageId, isPositive] of Object.entries(feedbackMap)) {

--- a/apps/web/src/components/kopilot/hooks/use-kopilot-sse.ts
+++ b/apps/web/src/components/kopilot/hooks/use-kopilot-sse.ts
@@ -23,6 +23,12 @@ export interface KopilotRequest {
   agentId?: string | null
   /** Session-domain discriminator on session create. Defaults to 'kopilot' server-side. */
   sessionType?: 'kopilot' | 'builder'
+  /**
+   * Trigger discriminator. 'dm' means the request originated from the agent
+   * Chat tab or the composer sender picker; the SSE route gates the agent's
+   * `dm` AgentTrigger and layers DM trigger-instructions into the prompt.
+   */
+  triggerKind?: 'dm'
 }
 
 interface UseKopilotSSEOptions {

--- a/apps/web/src/components/kopilot/options/kopilot-chat-provider.tsx
+++ b/apps/web/src/components/kopilot/options/kopilot-chat-provider.tsx
@@ -11,6 +11,7 @@ const DEFAULTS: Required<
   Pick<
     KopilotChatOptions,
     | 'allowModelPicker'
+    | 'allowSenderPicker'
     | 'allowSlashCommands'
     | 'allowReferencePicker'
     | 'showSessionPicker'
@@ -19,6 +20,7 @@ const DEFAULTS: Required<
   >
 > = {
   allowModelPicker: true,
+  allowSenderPicker: true,
   allowSlashCommands: true,
   allowReferencePicker: true,
   showSessionPicker: true,
@@ -35,6 +37,7 @@ export function KopilotChatProvider({ children, options }: KopilotChatProviderPr
   const {
     placeholder,
     allowModelPicker,
+    allowSenderPicker,
     allowSlashCommands,
     allowReferencePicker,
     renderEmptyState,
@@ -50,6 +53,7 @@ export function KopilotChatProvider({ children, options }: KopilotChatProviderPr
       ...DEFAULTS,
       placeholder,
       ...(allowModelPicker !== undefined && { allowModelPicker }),
+      ...(allowSenderPicker !== undefined && { allowSenderPicker }),
       ...(allowSlashCommands !== undefined && { allowSlashCommands }),
       ...(allowReferencePicker !== undefined && { allowReferencePicker }),
       renderEmptyState,
@@ -61,6 +65,7 @@ export function KopilotChatProvider({ children, options }: KopilotChatProviderPr
     [
       placeholder,
       allowModelPicker,
+      allowSenderPicker,
       allowSlashCommands,
       allowReferencePicker,
       renderEmptyState,

--- a/apps/web/src/components/kopilot/options/types.ts
+++ b/apps/web/src/components/kopilot/options/types.ts
@@ -19,6 +19,13 @@ export interface KopilotChatOptions {
   allowModelPicker?: boolean
 
   /**
+   * Show the sender picker (pick which agent responds) in the composer
+   * toolbar. Default: true on master Kopilot. The agent Chat tab and the
+   * Build tab pass `false` — they already pin the responder upstream.
+   */
+  allowSenderPicker?: boolean
+
+  /**
    * Allow the `/` slash-command picker (prompt templates) in the composer.
    * Default: true.
    */

--- a/apps/web/src/components/kopilot/stores/kopilot-store.ts
+++ b/apps/web/src/components/kopilot/stores/kopilot-store.ts
@@ -205,6 +205,16 @@ interface KopilotState {
   setActiveSessionId: (id: string | null) => void
   startNewSession: () => void
 
+  /**
+   * Agent the active session is bound to (post-create), if any. Master Kopilot
+   * sessions leave this null. Hydrated from the server when `loadSession`
+   * runs; cleared on `startNewSession`. The composer's sender picker reads
+   * this for the locked-chip render — once a session has an agentId, the
+   * picker becomes non-interactive.
+   */
+  activeSessionAgentId: string | null
+  setActiveSessionAgentId: (id: string | null) => void
+
   // Model override — null means "use system default"
   selectedModelId: string | null
   setSelectedModelId: (modelId: string | null) => void
@@ -353,13 +363,18 @@ export const useKopilotStore = create<KopilotState>()(
       // Session
       activeSessionId: null,
       setActiveSessionId: (activeSessionId) => set({ activeSessionId }),
+      activeSessionAgentId: null,
+      setActiveSessionAgentId: (activeSessionAgentId) => set({ activeSessionAgentId }),
       startNewSession: () =>
         set({
           activeSessionId: null,
+          activeSessionAgentId: null,
           ...emptyTreeState,
           stream: { ...initialStreamState },
           isStreaming: false,
           editingMessageId: null,
+          pendingChipPrompts: [],
+          dismissedChipKeys: new Set<string>(),
         }),
 
       // Model override
@@ -561,10 +576,13 @@ export const useKopilotStore = create<KopilotState>()(
       reset: () =>
         set({
           activeSessionId: null,
+          activeSessionAgentId: null,
           ...emptyTreeState,
           stream: { ...initialStreamState },
           isStreaming: false,
           editingMessageId: null,
+          pendingChipPrompts: [],
+          dismissedChipKeys: new Set<string>(),
         }),
     }),
     {

--- a/apps/web/src/components/kopilot/ui/kopilot-chat.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-chat.tsx
@@ -38,6 +38,13 @@ export interface KopilotChatProps {
    */
   sessionType?: 'kopilot' | 'builder'
   /**
+   * Trigger discriminator for the run. 'dm' means the chat surface is the
+   * agent Chat tab (or, indirectly, the composer sender picker). The SSE
+   * route uses this to gate the agent's `dm` AgentTrigger and layer in DM
+   * trigger-instructions.
+   */
+  triggerKind?: 'dm'
+  /**
    * If set AND `initialSessionId` is null, this text is auto-submitted as the
    * first user turn after mount — same path as clicking an `autoSubmit`
    * suggestion chip, no chip rendered. Used by the agent builder to fire a
@@ -53,6 +60,7 @@ export function KopilotChat({
   contentClassName,
   agentId,
   sessionType,
+  triggerKind,
   initialMessage,
 }: KopilotChatProps) {
   const activeSessionId = useKopilotStore((s) => s.activeSessionId)
@@ -139,8 +147,9 @@ export function KopilotChat({
       ...request,
       ...(agentId ? { agentId } : {}),
       ...(sessionType ? { sessionType } : {}),
+      ...(triggerKind ? { triggerKind } : {}),
     }),
-    [agentId, sessionType]
+    [agentId, sessionType, triggerKind]
   )
 
   const handleSend = useCallback(

--- a/apps/web/src/components/kopilot/ui/kopilot-composer.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-composer.tsx
@@ -6,11 +6,15 @@ import { ModelType } from '@auxx/lib/ai/providers/types'
 import type { DocJSON } from '@auxx/lib/kb/markdown'
 import type { PromptTemplateItem } from '@auxx/lib/prompt-templates'
 import { docToText } from '@auxx/lib/tiptap'
+import { type ActorId, parseActorId } from '@auxx/types/actor'
+import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
 import { Button } from '@auxx/ui/components/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
 import { generateId } from '@auxx/utils/generateId'
+import { Extension } from '@tiptap/core'
 import { EditorContent } from '@tiptap/react'
-import { CornerDownLeft, Send, SquareSlash, X } from 'lucide-react'
+import { Bot, ChevronsUpDown, CornerDownLeft, Send, SquareSlash, X } from 'lucide-react'
 import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import {
   createPromptNode,
@@ -22,11 +26,13 @@ import {
 } from '~/components/editor/inline-picker'
 import { SubmitOnEnter } from '~/components/global/comments/comment-composer'
 import { Tooltip } from '~/components/global/tooltip'
+import { ActorPickerContent } from '~/components/pickers/actor-picker/actor-picker-content'
 import { AiModelPicker, type ModelPickerItem } from '~/components/pickers/ai-model-picker'
 import {
   ReferencePickerContent,
   type ReferencePickerHandle,
 } from '~/components/pickers/reference-picker/reference-picker-content'
+import { useActor } from '~/components/resources/hooks/use-actor'
 import { api } from '~/trpc/react'
 import { KopilotContextChipStrip } from '../context/kopilot-context-chip-strip'
 import type { SessionRef, SessionRefKind } from '../context/types'
@@ -133,15 +139,48 @@ function formatPromptBadgesForDisplay(
   })
 }
 
+interface SenderHotkeyOptions {
+  /**
+   * Called when `#` (Shift+3) is pressed. Return `true` to consume the
+   * keystroke (the `#` character is not inserted). Return `false` to let
+   * the character pass through to normal text input — used in the locked
+   * state where the session is pinned to one agent.
+   */
+  onTrigger: () => boolean
+}
+
+/**
+ * Tiptap extension that intercepts `#` (Shift+3) to open the composer's
+ * sender picker. Mirrors the slash-command picker's `/` hotkey but
+ * targets a different surface — see plans/kopilot/agents/dm/plan.md.
+ */
+const SenderHotkey = Extension.create<SenderHotkeyOptions>({
+  name: 'senderHotkey',
+  addOptions() {
+    return { onTrigger: () => false }
+  },
+  addKeyboardShortcuts() {
+    return {
+      'Shift-3': () => this.options.onTrigger(),
+    }
+  },
+})
+
 export function KopilotComposer({ ref, page, onSend, contentClassName }: KopilotComposerProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const handleSendRef = useRef<() => void>(() => {})
 
-  const { placeholder, allowModelPicker, allowSlashCommands, allowReferencePicker } =
-    useKopilotChatOptions()
+  const {
+    placeholder,
+    allowModelPicker,
+    allowSenderPicker,
+    allowSlashCommands,
+    allowReferencePicker,
+  } = useKopilotChatOptions()
 
   const isStreaming = useKopilotStore((s) => s.isStreaming)
   const activeSessionId = useKopilotStore((s) => s.activeSessionId)
+  const activeSessionAgentId = useKopilotStore((s) => s.activeSessionAgentId)
   const addMessage = useKopilotStore((s) => s.addMessage)
   const messages = useKopilotStore((s) => s.messages)
   const editingMessageId = useKopilotStore((s) => s.editingMessageId)
@@ -149,6 +188,17 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
   const messageMap = useKopilotStore((s) => s.messageMap)
   const selectedModelId = useKopilotStore((s) => s.selectedModelId)
   const setSelectedModelId = useKopilotStore((s) => s.setSelectedModelId)
+
+  // Sender picker — pre-send selection (post-send, the active session's
+  // agentId locks the chip). Master Kopilot only; the agent Chat tab / Build
+  // tab opt out via `allowSenderPicker: false`.
+  const [selectedAgentActorId, setSelectedAgentActorId] = useState<ActorId | null>(null)
+  const [isSenderPickerOpen, setIsSenderPickerOpen] = useState(false)
+  const lockedActorId: ActorId | null = activeSessionAgentId
+    ? (`agent:${activeSessionAgentId}` as ActorId)
+    : null
+  const displayActorId: ActorId | null = lockedActorId ?? selectedAgentActorId
+  const isSenderLocked = lockedActorId !== null
 
   // Resolve system LLM default to show in picker when no override is selected
   const { data: systemDefaults } = api.aiIntegration.getSystemModelDefaults.useQuery(undefined, {
@@ -213,6 +263,13 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
   // back into the active list. Wired below via `useReferencePickerEditor`.
   const referencePickerRef = useRef<ReferencePickerHandle | null>(null)
 
+  // Refs so the SenderHotkey extension (constructed once) can read the
+  // current open/locked state without re-instantiating the editor.
+  const senderHotkeyOpenRef = useRef<() => void>(() => {})
+  const senderHotkeyLockedRef = useRef<boolean>(false)
+  senderHotkeyLockedRef.current = isSenderLocked
+  senderHotkeyOpenRef.current = () => setIsSenderPickerOpen(true)
+
   const { editor, confirmReference, closePicker } = useReferencePickerEditor({
     placeholder: placeholder ?? 'Ask Kopilot...',
     editable: true,
@@ -234,6 +291,18 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
         },
       }),
       ...(allowSlashCommands ? [slashCommandExtension] : []),
+      ...(allowSenderPicker
+        ? [
+            SenderHotkey.configure({
+              onTrigger: () => {
+                // Locked state: let `#` fall through to normal text input.
+                if (senderHotkeyLockedRef.current) return false
+                senderHotkeyOpenRef.current()
+                return true
+              },
+            }),
+          ]
+        : []),
       promptNodeExtension,
     ],
   })
@@ -324,6 +393,10 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
       ...(combinedRefs.length > 0 ? { references: combinedRefs } : {}),
     }
 
+    // Sender pick — lock takes precedence over in-flight selection. Master
+    // Kopilot leaves both null and sends without `agentId` / `triggerKind`.
+    const senderAgentId = displayActorId ? parseActorId(displayActorId).id : null
+
     onSend({
       sessionId: activeSessionId ?? undefined,
       message: text.trim(),
@@ -331,6 +404,7 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
       page: surfaceContext.page ?? page,
       context: mergedContext,
       modelId: selectedModelId ?? undefined,
+      ...(senderAgentId ? { agentId: senderAgentId, triggerKind: 'dm' as const } : {}),
     })
 
     // Clear edit state and editor
@@ -353,6 +427,7 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
     templateDisplayMap,
     selectedModelId,
     allowReferencePicker,
+    displayActorId,
   ])
 
   // Keep ref in sync
@@ -480,8 +555,8 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
             </InlinePickerPopover>
           )}
         </div>
-        {allowModelPicker && (
-          <div className='absolute bottom-1 left-1'>
+        <div className='absolute bottom-1 left-1 flex items-center gap-0.5'>
+          {allowModelPicker && (
             <AiModelPicker
               value={selectedModelId ?? systemLlmDefault}
               onChange={handleModelFilter}
@@ -491,8 +566,21 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
               compact
               skipDeprecated
             />
-          </div>
-        )}
+          )}
+          {allowSenderPicker && (
+            <SenderPicker
+              displayActorId={displayActorId}
+              isLocked={isSenderLocked}
+              open={isSenderPickerOpen}
+              onOpenChange={setIsSenderPickerOpen}
+              onSelect={(actorId) => {
+                setSelectedAgentActorId(actorId)
+                setIsSenderPickerOpen(false)
+              }}
+              onClear={() => setSelectedAgentActorId(null)}
+            />
+          )}
+        </div>
         <div className='absolute bottom-1 right-1 flex items-center gap-0.5'>
           {allowSlashCommands && (
             <Tooltip content='Insert prompt template' shortcut='/' allowInteraction>
@@ -545,5 +633,111 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
         <PromptTemplateDialog open={browseDialogOpen} onOpenChange={setBrowseDialogOpen} />
       )}
     </div>
+  )
+}
+
+// ── Sender picker ──────────────────────────────────────────────────────────
+
+interface SenderPickerProps {
+  displayActorId: ActorId | null
+  isLocked: boolean
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (actorId: ActorId) => void
+  onClear: () => void
+}
+
+/**
+ * "Who's responding" chip + popover. Lives in the composer's bottom-left
+ * cluster next to the model picker. Master Kopilot is the default state
+ * (no selection — no chip clear); selecting an agent flips outgoing
+ * requests to `triggerKind: 'dm'` and binds the new session to that agent.
+ *
+ * Locked state: once the active session has an `agentId`, the chip
+ * renders read-only — the responder is pinned for the rest of the
+ * thread. The "Start new chat" affordance lands later.
+ */
+function SenderPicker({
+  displayActorId,
+  isLocked,
+  open,
+  onOpenChange,
+  onSelect,
+  onClear,
+}: SenderPickerProps) {
+  // Resolve the selected agent's display name + avatar from the actor store.
+  // Skipped entirely when nothing is picked — the null state renders a
+  // hardcoded "Kopilot" + bot icon (no fetch).
+  const { actor } = useActor({ actorId: displayActorId, enabled: !!displayActorId })
+
+  const label = displayActorId ? (actor?.name ?? 'Loading…') : 'Kopilot'
+  const avatarUrl = displayActorId ? actor?.avatarUrl : null
+
+  const chipBody = (
+    <span className='flex items-center gap-1.5'>
+      {avatarUrl ? (
+        <Avatar className='size-4'>
+          <AvatarImage src={avatarUrl} alt={label} />
+          <AvatarFallback className='text-[10px]'>{label.slice(0, 1)}</AvatarFallback>
+        </Avatar>
+      ) : (
+        <Bot className='size-3.5 opacity-70' />
+      )}
+      <span className='truncate max-w-[120px]'>{label}</span>
+    </span>
+  )
+
+  if (isLocked) {
+    // Post-send / hydrated lock — no chevron, no X, no popover.
+    return (
+      <div
+        className='flex items-center gap-1 h-7 px-2 text-xs text-muted-foreground opacity-70 pointer-events-none rounded-md'
+        aria-label={`Responding as ${label}`}>
+        {chipBody}
+      </div>
+    )
+  }
+
+  const showClear = displayActorId !== null
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          variant='ghost'
+          size='sm'
+          className='h-7 px-2 text-xs text-muted-foreground gap-1'
+          aria-label='Pick who responds'>
+          {chipBody}
+          {showClear ? (
+            <span
+              role='button'
+              tabIndex={-1}
+              className='ml-0.5 inline-flex items-center justify-center rounded hover:bg-primary-200/70 p-0.5'
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                onClear()
+              }}
+              aria-label='Clear sender — return to Kopilot'>
+              <X className='size-3' />
+            </span>
+          ) : (
+            <ChevronsUpDown className='size-3 opacity-50' />
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className='p-0 w-72' align='start' side='top'>
+        <ActorPickerContent
+          target='agent'
+          multi={false}
+          value={displayActorId ? [displayActorId] : []}
+          onChange={() => {
+            // Single-select path is handled by onSelectSingle.
+          }}
+          onSelectSingle={(actorId) => onSelect(actorId)}
+        />
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/apps/web/src/server/api/routers/agent-trigger.ts
+++ b/apps/web/src/server/api/routers/agent-trigger.ts
@@ -3,6 +3,7 @@
 import { database, schema } from '@auxx/database'
 import { type AgentTriggerInput, AgentTriggerService, agentExistsInOrg } from '@auxx/lib/agents'
 import { enqueueAgentJob } from '@auxx/lib/ai/agent-framework'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { createScopedLogger } from '@auxx/logger'
 import { createSession } from '@auxx/services'
 import { TRPCError } from '@trpc/server'
@@ -56,6 +57,7 @@ const appInputSchema = z.object({
 
 const mentionInputSchema = z.object({ kind: z.literal('mention') })
 const assignmentInputSchema = z.object({ kind: z.literal('assignment') })
+const dmInputSchema = z.object({ kind: z.literal('dm') })
 
 const triggerInputSchema = z.union([
   scheduledInputSchema,
@@ -63,6 +65,7 @@ const triggerInputSchema = z.union([
   appInputSchema,
   mentionInputSchema,
   assignmentInputSchema,
+  dmInputSchema,
 ])
 
 async function ensureAgentInOrg(organizationId: string, agentId: string): Promise<void> {
@@ -128,6 +131,12 @@ export const agentTriggerRouter = createTRPCRouter({
         trigger: input.trigger as AgentTriggerInput,
       })
 
+      // DM state lives on the cached agent — invalidate so subsequent
+      // sends pick up the new enabled/instructions/triggerId.
+      if (row.kind === 'dm') {
+        await onCacheEvent('agent.updated', { orgId: organizationId })
+      }
+
       logger.info('Agent trigger created', {
         organizationId,
         agentId: input.agentId,
@@ -154,6 +163,9 @@ export const agentTriggerRouter = createTRPCRouter({
         instructions: input.instructions,
         trigger: input.trigger as AgentTriggerInput | undefined,
       })
+      if (row.kind === 'dm') {
+        await onCacheEvent('agent.updated', { orgId: organizationId })
+      }
       return rowToDto(row)
     }),
 
@@ -161,7 +173,12 @@ export const agentTriggerRouter = createTRPCRouter({
     .input(z.object({ id: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      await new AgentTriggerService().deleteTrigger(input.id, organizationId)
+      const service = new AgentTriggerService()
+      const existing = await service.getTrigger(input.id, organizationId)
+      await service.deleteTrigger(input.id, organizationId)
+      if (existing?.kind === 'dm') {
+        await onCacheEvent('agent.updated', { orgId: organizationId })
+      }
       return { ok: true as const }
     }),
 

--- a/packages/lib/src/agents/agent-service.ts
+++ b/packages/lib/src/agents/agent-service.ts
@@ -170,10 +170,11 @@ export async function createAgent(
       updatedAt: now,
     })
 
-    // 5. Auto-create mention + assignment triggers (enabled by default).
-    //    Phase 1.5: every agent fires when @-mentioned in a comment or
-    //    assigned to a ticket. Cascade on agentId cleans these up when the
-    //    agent is archived/deleted.
+    // 5. Auto-create mention + assignment + dm triggers (enabled by default).
+    //    Phase 1.5 / 2: every agent fires when @-mentioned in a comment,
+    //    assigned to a ticket, or direct-messaged via the Chat tab /
+    //    composer sender picker. Cascade on agentId cleans these up when
+    //    the agent is archived/deleted.
     await tx.insert(schema.AgentTrigger).values([
       {
         agentId: agent.id,
@@ -188,6 +189,15 @@ export async function createAgent(
         agentId: agent.id,
         organizationId,
         kind: 'assignment',
+        enabled: true,
+        config: {},
+        createdById,
+        updatedAt: now,
+      },
+      {
+        agentId: agent.id,
+        organizationId,
+        kind: 'dm',
         enabled: true,
         config: {},
         createdById,

--- a/packages/lib/src/agents/agent-trigger-label.ts
+++ b/packages/lib/src/agents/agent-trigger-label.ts
@@ -49,6 +49,8 @@ function baseLabel(trigger: {
       return 'Mention'
     case 'assignment':
       return 'Assignment'
+    case 'dm':
+      return 'Direct message'
     default:
       return trigger.kind
   }

--- a/packages/lib/src/agents/agent-trigger-service.ts
+++ b/packages/lib/src/agents/agent-trigger-service.ts
@@ -14,7 +14,7 @@ import { convertToCronPattern, type ScheduledTriggerConfig } from '../workflows/
 const logger = createScopedLogger('agent-trigger-service')
 
 /** Trigger kinds. */
-export type AgentTriggerKind = 'scheduled' | 'event' | 'app' | 'mention' | 'assignment'
+export type AgentTriggerKind = 'scheduled' | 'event' | 'app' | 'mention' | 'assignment' | 'dm'
 
 /** CRUD-mode event triggerType. */
 export type AgentEventTriggerType = 'created' | 'updated' | 'deleted'
@@ -65,12 +65,18 @@ export interface AssignmentTriggerInput {
   kind: 'assignment'
 }
 
+/** Phase 2: fires when a user direct-messages this agent (Chat tab, composer sender picker). */
+export interface DmTriggerInput {
+  kind: 'dm'
+}
+
 export type AgentTriggerInput =
   | ScheduledTriggerInput
   | CrudEventTriggerInput
   | AppTriggerInput
   | MentionTriggerInput
   | AssignmentTriggerInput
+  | DmTriggerInput
 
 export interface CreateAgentTriggerInput {
   agentId: string
@@ -147,7 +153,7 @@ function partitionTriggerInput(trigger: AgentTriggerInput): {
     }
   }
 
-  if (trigger.kind === 'mention' || trigger.kind === 'assignment') {
+  if (trigger.kind === 'mention' || trigger.kind === 'assignment' || trigger.kind === 'dm') {
     return {
       kind: trigger.kind,
       columns: { ...empty },

--- a/packages/lib/src/agents/build-dm-trigger-context.ts
+++ b/packages/lib/src/agents/build-dm-trigger-context.ts
@@ -1,0 +1,37 @@
+// packages/lib/src/agents/build-dm-trigger-context.ts
+
+import type { CachedAgent } from '../cache/org-cache-keys'
+import { ForbiddenError } from '../errors'
+
+export interface DmTriggerContext {
+  kind: 'dm'
+  triggerId: string
+  firedAt: string
+}
+
+export interface BuildDmTriggerContextResult {
+  triggerContext: DmTriggerContext
+  triggerInstructions: Record<string, unknown> | null
+}
+
+/**
+ * Resolves DM trigger gating from a cached agent. Throws `ForbiddenError`
+ * if DMs are disabled or the `dm` AgentTrigger row is missing.
+ *
+ * Pure — no DB I/O. The cached agent carries `dmEnabled` / `dmInstructions`
+ * / `dmTriggerId` from the `agents` cache provider's left-join on
+ * `AgentTrigger` where `kind = 'dm'`.
+ */
+export function buildDmTriggerContext(args: { agent: CachedAgent }): BuildDmTriggerContextResult {
+  if (!args.agent.dmEnabled || !args.agent.dmTriggerId) {
+    throw new ForbiddenError('Direct messages are disabled for this agent')
+  }
+  return {
+    triggerContext: {
+      kind: 'dm',
+      triggerId: args.agent.dmTriggerId,
+      firedAt: new Date().toISOString(),
+    },
+    triggerInstructions: args.agent.dmInstructions,
+  }
+}

--- a/packages/lib/src/agents/index.ts
+++ b/packages/lib/src/agents/index.ts
@@ -50,11 +50,19 @@ export {
   ALLOWED_DIRECT_EVENT_TYPES,
   type AllowedDirectEventType,
   type AppTriggerInput,
+  type AssignmentTriggerInput,
   type CreateAgentTriggerInput,
   type CrudEventTriggerInput,
+  type DmTriggerInput,
+  type MentionTriggerInput,
   type ScheduledTriggerInput,
   type UpdateAgentTriggerInput,
 } from './agent-trigger-service'
+export {
+  type BuildDmTriggerContextResult,
+  buildDmTriggerContext,
+  type DmTriggerContext,
+} from './build-dm-trigger-context'
 export { BUILTIN_APP, BUILTIN_TOOLSETS, getBuiltinToolset } from './builtin-app'
 export { BUILTIN_DEFAULT_TOOLSETS, resolveDefaultToolsets } from './default-toolsets'
 export { filterToolsByToolsets } from './filter-tools'

--- a/packages/lib/src/ai/agent-framework/enqueue-agent-job.ts
+++ b/packages/lib/src/ai/agent-framework/enqueue-agent-job.ts
@@ -36,6 +36,13 @@ export interface AgentJobPayload {
    * `lastFiredAt` / `lastError` after the engine finishes.
    */
   agentTriggerId?: string | null
+  /**
+   * Trigger discriminator for the run. 'dm' means the request originated
+   * from the agent Chat tab or composer sender picker. Forwarded for
+   * analytics / future routing — the worker re-resolves the trigger
+   * context from `session.agentTriggerId` regardless.
+   */
+  triggerKind?: 'dm'
 }
 
 /**

--- a/packages/lib/src/ai/agent-framework/process-agent-job.ts
+++ b/packages/lib/src/ai/agent-framework/process-agent-job.ts
@@ -421,7 +421,7 @@ function renderInstructionsAsText(
 
 function asKind(value: unknown): TriggerKind | null {
   if (value === 'scheduled' || value === 'event' || value === 'app') return value
-  if (value === 'mention' || value === 'assignment') return value
+  if (value === 'mention' || value === 'assignment' || value === 'dm') return value
   return null
 }
 

--- a/packages/lib/src/ai/kopilot/index.ts
+++ b/packages/lib/src/ai/kopilot/index.ts
@@ -22,6 +22,7 @@ export {
 export { applyContextDefaults, findAllRefs, findRef } from './context-refs'
 export type { KopilotDomainConfigOptions } from './domain-config'
 export { createKopilotDomainConfig } from './domain-config'
+export type { TriggerContext, TriggerKind } from './prompts/trigger-context'
 export { generateSessionTitle } from './session-title'
 export type {
   KopilotDomainState,

--- a/packages/lib/src/ai/kopilot/prompts/build-kopilot-prompt.ts
+++ b/packages/lib/src/ai/kopilot/prompts/build-kopilot-prompt.ts
@@ -84,11 +84,15 @@ export function buildKopilotPromptSerialized(args: BuildKopilotPromptArgs): stri
 }
 
 function buildPromptCtx(args: BuildKopilotPromptArgs): PromptCtx {
-  const runMode: RunMode = args.triggerContext ? 'autonomous' : 'interactive'
+  // DM is an interactive trigger — a human is in the loop, just authored on a
+  // specific agent's surface. All other trigger kinds run autonomously.
+  const isDmTrigger = args.triggerContext?.kind === 'dm'
+  const runMode: RunMode = args.triggerContext && !isDmTrigger ? 'autonomous' : 'interactive'
 
-  // Autonomous runs are always backed by a user-authored agent; the master
-  // Kopilot never runs on a trigger. Fail fast if they ever contradict.
-  if (runMode === 'autonomous' && (!args.agentConfig || args.agentConfig.agentId === null)) {
+  // Any triggerContext (autonomous or DM) is always backed by a user-authored
+  // agent; the master Kopilot never runs on a trigger. Fail fast if they ever
+  // contradict.
+  if (args.triggerContext && (!args.agentConfig || args.agentConfig.agentId === null)) {
     throw new Error('buildKopilotPrompt: triggerContext set without a user-authored agentConfig')
   }
 

--- a/packages/lib/src/ai/kopilot/prompts/sections/trigger-instructions.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/trigger-instructions.ts
@@ -1,15 +1,20 @@
 // packages/lib/src/ai/kopilot/prompts/sections/trigger-instructions.ts
 
 import { renderTriggerInstructions } from '../trigger-context'
-import { AUTONOMOUS_ONLY, type PromptSection } from './types'
+import { ALL_MODES, type PromptSection } from './types'
 
 /**
  * "## Trigger instructions" — the operator's authored prose. Changes only
  * on admin edit, so tier 2.
+ *
+ * Renders in both autonomous and interactive (DM) modes — DM is the one
+ * interactive run that still wants per-agent trigger instructions layered
+ * in. The render gate is the presence of trigger-context instructions,
+ * which is only set when a trigger row backs the run.
  */
 export const triggerInstructions: PromptSection = {
   id: 'trigger-instructions',
-  modes: AUTONOMOUS_ONLY,
+  modes: ALL_MODES,
   stability: 'org',
   render: (ctx) => {
     const text = ctx.triggerContext?.instructions

--- a/packages/lib/src/ai/kopilot/prompts/trigger-context.ts
+++ b/packages/lib/src/ai/kopilot/prompts/trigger-context.ts
@@ -12,7 +12,7 @@
  * See plans/kopilot/agents/trigger-instructions.md for the design.
  */
 
-export type TriggerKind = 'scheduled' | 'event' | 'app' | 'mention' | 'assignment'
+export type TriggerKind = 'scheduled' | 'event' | 'app' | 'mention' | 'assignment' | 'dm'
 
 export interface TriggerContext {
   kind: TriggerKind
@@ -68,6 +68,8 @@ export function renderTriggerKindBlock(triggerContext: TriggerContext): string {
       return renderMentionBlock(payload)
     case 'assignment':
       return renderAssignmentBlock(payload)
+    case 'dm':
+      return renderDmBlock(payload)
   }
 }
 
@@ -137,6 +139,19 @@ function renderMentionBlock(payload: Record<string, unknown>): string {
     'Sibling references and the full mention payload are in domain state under `mention`.',
     '',
     'Copy the `Mentioned in:` id verbatim when calling tools that take a recordId — do not prepend an entity slug or guess a prefix.',
+  ].filter(Boolean)
+  return lines.join('\n')
+}
+
+function renderDmBlock(payload: Record<string, unknown>): string {
+  const firedAt = asString(payload.firedAt) ?? new Date().toISOString()
+  const lines = [
+    '## Trigger fired',
+    '',
+    'Kind: `dm`',
+    `Fired at: ${firedAt}`,
+    '',
+    'A user is direct-messaging you in an interactive chat. The user message in this turn is the human-authored prompt — respond to them directly.',
   ].filter(Boolean)
   return lines.join('\n')
 }

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -114,6 +114,12 @@ export interface CachedAgent {
   setupCompletedAt: string | null
   /** ISO string when archived; null when active. */
   archivedAt: string | null
+  /** Whether direct messages to this agent are enabled. Mirrors the `dm` AgentTrigger row. */
+  dmEnabled: boolean
+  /** Per-DM trigger instructions (Tiptap doc); null when the `dm` row has no addendum. */
+  dmInstructions: Record<string, unknown> | null
+  /** AgentTrigger.id for the `dm` row; null only if the row is missing (pre-existing dev agent). */
+  dmTriggerId: string | null
   createdAt: string
   updatedAt: string
 }

--- a/packages/lib/src/cache/providers/agents-provider.ts
+++ b/packages/lib/src/cache/providers/agents-provider.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/cache/providers/agents-provider.ts
 
 import { schema } from '@auxx/database'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { MediaAssetService } from '../../files'
 import { createScopedLogger } from '../../logger'
 import type { CachedAgent } from '../org-cache-keys'
@@ -37,9 +37,16 @@ export const agentsProvider: CacheProvider<CachedAgent[]> = {
         updatedAt: schema.Agent.updatedAt,
         userName: schema.User.name,
         avatarAssetId: schema.User.avatarAssetId,
+        dmTriggerId: schema.AgentTrigger.id,
+        dmEnabled: schema.AgentTrigger.enabled,
+        dmInstructions: schema.AgentTrigger.instructions,
       })
       .from(schema.Agent)
       .innerJoin(schema.User, eq(schema.User.id, schema.Agent.userId))
+      .leftJoin(
+        schema.AgentTrigger,
+        and(eq(schema.AgentTrigger.agentId, schema.Agent.id), eq(schema.AgentTrigger.kind, 'dm'))
+      )
       .where(eq(schema.Agent.organizationId, orgId))
 
     return Promise.all(
@@ -71,6 +78,9 @@ export const agentsProvider: CacheProvider<CachedAgent[]> = {
           mentionable: row.mentionable,
           setupCompletedAt: row.setupCompletedAt ? row.setupCompletedAt.toISOString() : null,
           archivedAt: row.archivedAt ? row.archivedAt.toISOString() : null,
+          dmEnabled: row.dmEnabled ?? false,
+          dmInstructions: (row.dmInstructions ?? null) as Record<string, unknown> | null,
+          dmTriggerId: row.dmTriggerId ?? null,
           createdAt: row.createdAt.toISOString(),
           updatedAt: row.updatedAt.toISOString(),
         }


### PR DESCRIPTION
## Summary

- Adds `dm` as a fifth `AgentTrigger` kind (alongside `scheduled`, `event`, `app`, `mention`, `assignment`) — fires when a user direct-messages an agent. Auto-created enabled on agent create.
- Agent detail splits into Build / Chat tabs. Chat is a kopilot session bound to `(user, agent)` with `triggerKind: 'dm'`; defaults to whichever tab matches `setupCompletedAt` and persists via `?panel=`.
- Composer gains a sender picker (chip next to model picker, `Shift+3` hotkey). Picking an agent on master Kopilot routes the next send as a DM and pins the session; once pinned, the chip locks read-only.
- Cached agent now carries `dmEnabled` / `dmInstructions` / `dmTriggerId` via a left-join on the `dm` AgentTrigger row, so the SSE route gates every send without a DB read. DM trigger writes invalidate the cache.
- DM is the one interactive trigger that still layers `## Trigger instructions` into the system prompt; it also gets its own kind block via `renderDmBlock`.

## Test plan

- [ ] Create a new agent → confirm `dm` AgentTrigger row exists, enabled, default config.
- [ ] On agent detail, default tab matches setup state (Build mid-setup, Chat after `setupCompletedAt`); `?panel=` round-trips on refresh.
- [ ] Chat tab: hydrates the latest `(user, agent, type='kopilot')` session; first send creates one if missing.
- [ ] Master Kopilot composer: `Shift+3` opens picker; picking an agent shows chip + sends with `triggerKind: 'dm'`; clearing returns to Kopilot.
- [ ] After a DM send, the session is locked to that agent (chip is read-only; `displayActorId` stays pinned across reloads via `activeSessionAgentId`).
- [ ] Triggers tab: `dm` row shows alongside mention/assignment; toggling enabled → 403 on next DM send (cache invalidation).
- [ ] Per-DM instructions edited via the trigger dialog appear in the system prompt on the next send.
- [ ] Worker path: existing autonomous triggers (mention/assignment/scheduled/event/app) still render trigger instructions in autonomous mode.