### PR TITLE
feat(agents): rich-text instructions in trigger dialog

### DIFF
--- a/apps/web/src/components/agents/ui/detail/triggers/agent-trigger-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/agent-trigger-dialog.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/agents/ui/detail/triggers/agent-trigger-dialog.tsx
 'use client'
 
-import { docToText, textToDoc } from '@auxx/lib/tiptap'
+import { isNonEmptyDoc, type TiptapDoc } from '@auxx/lib/tiptap'
 import { Button } from '@auxx/ui/components/button'
 import {
   Dialog,
@@ -23,8 +23,12 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { toastError } from '@auxx/ui/components/toast'
+import type { JSONContent } from '@tiptap/core'
 import { Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { DEFAULT_TABS } from '~/components/editor/inline-picker'
+import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
+import { PromptEditor } from '~/components/editor/prompt-editor'
 import { ResourcePicker } from '~/components/pickers/resource-picker'
 import { useResources } from '~/components/resources/hooks/use-resources'
 import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
@@ -32,6 +36,39 @@ import { useConfirm } from '~/hooks/use-confirm'
 import { api, type RouterOutputs } from '~/trpc/react'
 import { TriggerCronEditor } from './trigger-cron-editor'
 import { type Interval, TriggerIntervalSelector } from './trigger-interval-selector'
+
+const TEMPLATE_REFERENCE_TABS: ReferenceTab[] = [...DEFAULT_TABS, 'tools', 'resources', 'fields']
+
+const KIND_COPY: Record<Kind, { label: string; description: string }> = {
+  scheduled: {
+    label: 'scheduled',
+    description: 'Fire this agent on a recurring schedule.',
+  },
+  event: {
+    label: 'event',
+    description: 'Fire this agent when a resource is created, updated, or deleted.',
+  },
+  mention: {
+    label: 'mention',
+    description: 'Fire this agent when it is mentioned in a comment.',
+  },
+  assignment: {
+    label: 'assignment',
+    description: 'Fire this agent when it is assigned to a ticket.',
+  },
+  dm: {
+    label: 'DM',
+    description: 'Fire this agent when a user direct-messages it.',
+  },
+}
+
+function emptyPromptDoc(): TiptapDoc {
+  return { type: 'doc', content: [{ type: 'block', attrs: { blockType: 'text' }, content: [] }] }
+}
+
+function readPromptContent(doc: TiptapDoc | null | undefined): JSONContent[] | null {
+  return (doc?.content as JSONContent[] | undefined) ?? null
+}
 
 type Trigger = RouterOutputs['agentTrigger']['list'][number]
 
@@ -102,21 +139,6 @@ function scheduledFromTrigger(trigger: Trigger): ScheduledState {
   }
 }
 
-function instructionsPlaceholder(kind: Kind): string {
-  switch (kind) {
-    case 'scheduled':
-      return 'e.g. "Summarize new tickets received since the last run and post to #support."'
-    case 'event':
-      return 'e.g. "When this resource is created, draft a reply using the customer\'s order history."'
-    case 'mention':
-      return 'e.g. "When @mentioned, draft a reply that matches the requested tone."'
-    case 'assignment':
-      return 'e.g. "When assigned, triage and answer or escalate to the right team."'
-    case 'dm':
-      return 'e.g. "Greet the user, then help them debug their integration step by step."'
-  }
-}
-
 function eventStateFromTrigger(trigger: Trigger, fallbackEntityId: string): EventState {
   return {
     triggerType: (trigger.triggerType as CrudTriggerType) ?? 'created',
@@ -139,17 +161,9 @@ export function AgentTriggerDialog({
 }: AgentTriggerDialogProps) {
   const isEditMode = !!trigger
   const isAppKind = trigger?.kind === 'app'
-  const effectiveKind: Kind = isEditMode
-    ? trigger?.kind === 'event'
-      ? 'event'
-      : trigger?.kind === 'mention'
-        ? 'mention'
-        : trigger?.kind === 'assignment'
-          ? 'assignment'
-          : trigger?.kind === 'dm'
-            ? 'dm'
-            : 'scheduled'
-    : kind
+  const effectiveKind: Kind =
+    isEditMode && trigger && trigger.kind !== 'app' ? (trigger.kind as Kind) : kind
+  const kindCopy = KIND_COPY[effectiveKind]
   const isBuiltinKind =
     effectiveKind === 'mention' || effectiveKind === 'assignment' || effectiveKind === 'dm'
 
@@ -159,7 +173,8 @@ export function AgentTriggerDialog({
   const [confirm, ConfirmDialog] = useConfirm()
   const [scheduledState, setScheduledState] = useState<ScheduledState>(DEFAULT_SCHEDULED_STATE)
   const [eventState, setEventState] = useState<EventState>(DEFAULT_EVENT_STATE)
-  const [instructionsText, setInstructionsText] = useState<string>('')
+  const [instructions, setInstructions] = useState<TiptapDoc>(emptyPromptDoc)
+  const [editorKey, setEditorKey] = useState(0)
 
   useEffect(() => {
     if (!open) return
@@ -171,15 +186,13 @@ export function AgentTriggerDialog({
       setScheduledState(DEFAULT_SCHEDULED_STATE)
       setEventState({ ...DEFAULT_EVENT_STATE, entityDefinitionId: fallbackEntityId })
     }
-    // Hydrate Instructions from the JSONB column (string or Tiptap doc).
     const raw = trigger?.instructions as unknown
-    if (typeof raw === 'string') {
-      setInstructionsText(raw)
-    } else if (raw && typeof raw === 'object') {
-      setInstructionsText(docToText(raw))
+    if (raw && typeof raw === 'object' && Array.isArray((raw as TiptapDoc).content)) {
+      setInstructions(raw as TiptapDoc)
     } else {
-      setInstructionsText('')
+      setInstructions(emptyPromptDoc())
     }
+    setEditorKey((k) => k + 1)
   }, [open, trigger, fallbackEntityId])
 
   const setScheduledMode = (mode: ScheduledMode) =>
@@ -284,14 +297,13 @@ export function AgentTriggerDialog({
     const triggerInput = buildTriggerInput()
     if (!triggerInput) return
 
-    const trimmedInstructions = instructionsText.trim()
-    const instructions = trimmedInstructions ? textToDoc(trimmedInstructions) : null
+    const instructionsPayload = isNonEmptyDoc(instructions) ? instructions : null
 
     if (isEditMode && trigger) {
       update.mutate({
         id: trigger.id,
         trigger: triggerInput,
-        instructions,
+        instructions: instructionsPayload,
       })
       return
     }
@@ -299,7 +311,7 @@ export function AgentTriggerDialog({
     create.mutate({
       agentId,
       trigger: triggerInput,
-      ...(instructions ? { instructions } : {}),
+      instructions: instructionsPayload,
     })
   }
 
@@ -309,19 +321,9 @@ export function AgentTriggerDialog({
         <DialogContent className='sm:max-w-[500px]' position='tc'>
           <DialogHeader>
             <DialogTitle>
-              {isEditMode ? `Edit ${effectiveKind} trigger` : `Add ${effectiveKind} trigger`}
+              {isEditMode ? `Edit ${kindCopy.label} trigger` : `Add ${kindCopy.label} trigger`}
             </DialogTitle>
-            <DialogDescription>
-              {effectiveKind === 'scheduled'
-                ? 'Fire this agent on a recurring schedule.'
-                : effectiveKind === 'mention'
-                  ? 'Fire this agent when it is mentioned in a comment.'
-                  : effectiveKind === 'assignment'
-                    ? 'Fire this agent when it is assigned to a ticket.'
-                    : effectiveKind === 'dm'
-                      ? 'Fire this agent when a user direct-messages it.'
-                      : 'Fire this agent when a resource is created, updated, or deleted.'}
-            </DialogDescription>
+            <DialogDescription>{kindCopy.description}</DialogDescription>
           </DialogHeader>
 
           {isAppKind ? (
@@ -406,13 +408,19 @@ export function AgentTriggerDialog({
 
               <Field orientation='vertical'>
                 <FieldLabel>Instructions</FieldLabel>
-                <textarea
-                  value={instructionsText}
-                  onChange={(e) => setInstructionsText(e.target.value)}
-                  rows={6}
-                  placeholder={instructionsPlaceholder(effectiveKind)}
-                  className='w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
-                />
+                <div className='rounded-md flex flex-col border bg-background min-h-[160px] px-3 py-2'>
+                  <PromptEditor
+                    key={editorKey}
+                    initialContent={readPromptContent(instructions)}
+                    onChange={({ json }) => setInstructions(json as TiptapDoc)}
+                    referenceTabs={TEMPLATE_REFERENCE_TABS}
+                    placeholderText='Write your instructions here'
+                  />
+                  <div className='flex text-sm gap-1 text-muted-foreground mt-2'>
+                    Type <Kbd variant='outline'>@</Kbd> to specify tools or{' '}
+                    <Kbd variant='outline'>/</Kbd> for formatting.
+                  </div>
+                </div>
               </Field>
             </div>
           )}

--- a/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
@@ -279,7 +279,7 @@ function TriggerRow({
         </Tooltip>
       }
       title={
-        <Tooltip content={lastFiredLabel}>
+        <Tooltip content={lastFiredLabel} allowInteraction>
           <span className='inline-flex items-center gap-1'>
             {title}
             {hasError ? <AlertTriangle className='size-3 text-destructive' /> : null}
@@ -289,7 +289,7 @@ function TriggerRow({
       actions={
         <>
           {isEditable && onEdit ? (
-            <Tooltip side='left' content='Edit trigger'>
+            <Tooltip side='left' content='Edit trigger' allowInteraction>
               <button
                 type='button'
                 onClick={onEdit}
@@ -300,7 +300,7 @@ function TriggerRow({
             </Tooltip>
           ) : null}
           {isDeletable && onDelete ? (
-            <Tooltip side='left' content='Delete trigger'>
+            <Tooltip side='left' content='Delete trigger' allowInteraction>
               <button
                 type='button'
                 onClick={onDelete}

--- a/apps/web/src/components/editor/kb-article/block-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/block-node-view.tsx
@@ -22,6 +22,7 @@ import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import { Check, ChevronDown } from 'lucide-react'
 import type React from 'react'
 import { useState } from 'react'
+import type { BlockOptions } from './block-node'
 import styles from './block-node-view.module.css'
 import { CardsBlockView } from './cards-block-view'
 
@@ -130,7 +131,13 @@ function isNumberedStyle(v: unknown): v is NumberedListStyle {
   return v === '1' || v === 'a' || v === 'A' || v === 'i' || v === 'I'
 }
 
-export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeViewProps) {
+export function BlockNodeView({
+  node,
+  updateAttributes,
+  editor,
+  getPos,
+  extension,
+}: NodeViewProps) {
   const {
     blockType = 'text',
     level,
@@ -240,7 +247,7 @@ export function BlockNodeView({ node, updateAttributes, editor, getPos }: NodeVi
     ? "Press '/'"
     : blockType === 'heading'
       ? `Heading ${level ?? 1}`
-      : "Press '/' for commands"
+      : (extension.options as BlockOptions).placeholderText
 
   const submitEmbed = (raw: string) => {
     const trimmed = raw.trim()

--- a/apps/web/src/components/editor/kb-article/block-node.ts
+++ b/apps/web/src/components/editor/kb-article/block-node.ts
@@ -51,12 +51,20 @@ const escapeBlockDownward = (editor: Editor, depth: number): boolean => {
     .run()
 }
 
-export const Block = Node.create({
+export interface BlockOptions {
+  placeholderText: string
+}
+
+export const Block = Node.create<BlockOptions>({
   name: 'block',
   content: 'inline*',
   marks: '_',
   group: 'block',
   defining: true,
+
+  addOptions() {
+    return { placeholderText: "Press '/' for commands" }
+  },
 
   addAttributes() {
     return {

--- a/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
+++ b/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
@@ -54,6 +54,8 @@ interface PromptEditorContentProps {
    * `@`-picker are inert. Used by the template gallery preview.
    */
   editable?: boolean
+  /** Overrides the default-branch empty-block placeholder hint. */
+  placeholderText?: string
 }
 
 interface LinkPopoverState {
@@ -84,6 +86,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
   referencePickerRef,
   referenceTabs,
   editable = true,
+  placeholderText,
 }: PromptEditorContentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [linkPopover, setLinkPopover] = useState<LinkPopoverState | null>(null)
@@ -108,6 +111,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
     onPickerArrowVertical,
     referenceTabs,
     editable,
+    placeholderText,
   })
 
   const activePicker = useActivePicker(editor)
@@ -181,8 +185,26 @@ export const PromptEditorContent = memo(function PromptEditorContent({
     [editor, linkPopover]
   )
 
+  const handleHostMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!editor || editor.isDestroyed) return
+      const target = e.target as HTMLElement | null
+      // Let clicks inside the contenteditable run their normal PM behavior
+      // (caret placement, drag selection, picker triggers).
+      if (target?.closest('.ProseMirror')) return
+      // Click landed on the padded host gap below/around the editor — focus
+      // the editor and park the caret at the end of the doc.
+      e.preventDefault()
+      editor.commands.focus('end')
+    },
+    [editor]
+  )
+
   return (
-    <div ref={containerRef} className={`${styles.editor} relative flex-1 min-h-0 flex w-full`}>
+    <div
+      ref={containerRef}
+      className={`${styles.editor} relative flex-1 min-h-0 flex w-full`}
+      onMouseDown={handleHostMouseDown}>
       <EditorContent
         editor={editor}
         className='prose prose-sm max-w-none dark:prose-invert w-full [&_.ProseMirror]:outline-none [&_.ProseMirror]:focus:outline-none [&_.ProseMirror-focused]:outline-none focus:outline-none'

--- a/apps/web/src/components/editor/prompt-editor/prompt-editor.tsx
+++ b/apps/web/src/components/editor/prompt-editor/prompt-editor.tsx
@@ -30,6 +30,8 @@ export interface PromptEditorProps {
    * the template gallery detail view.
    */
   editable?: boolean
+  /** Overrides the default-branch empty-block placeholder hint. */
+  placeholderText?: string
 }
 
 /**
@@ -53,6 +55,7 @@ export function PromptEditor({
   onFocusChange,
   className,
   editable = true,
+  placeholderText,
 }: PromptEditorProps) {
   const referencePickerRef = useRef<ReferencePickerHandle | null>(null)
   const [, setFocused] = useState(false)
@@ -73,7 +76,7 @@ export function PromptEditor({
   )
 
   return (
-    <div className={cn('relative flex w-full', className)}>
+    <div className={cn('relative flex w-full flex-1', className)}>
       <PromptEditorContent
         initialContent={initialContent}
         onChange={onChange}
@@ -82,6 +85,7 @@ export function PromptEditor({
         referencePickerRef={referencePickerRef}
         referenceTabs={referenceTabs}
         editable={editable}
+        placeholderText={placeholderText}
       />
     </div>
   )

--- a/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
+++ b/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
@@ -100,6 +100,12 @@ export interface UseRichTextEditorOptions {
    * template gallery, etc.).
    */
   editable?: boolean
+  /**
+   * Overrides the default-branch placeholder rendered inside an empty text
+   * `Block`. Heading and table-cell branches still use their own placeholders.
+   * Defaults to `"Press '/' for commands"`.
+   */
+  placeholderText?: string
 }
 
 /**
@@ -120,6 +126,7 @@ export function useRichTextEditor({
   onPickerArrowVertical,
   referenceTabs,
   editable = true,
+  placeholderText,
 }: UseRichTextEditorOptions) {
   const normalizedInitialContent = useMemo<JSONContent>(() => {
     const migrated = migrateLegacyContent(initialContent)
@@ -175,7 +182,7 @@ export function useRichTextEditor({
           history: undefined,
           // Marks stay enabled (bold, italic, strike, code).
         }),
-        Block,
+        placeholderText ? Block.configure({ placeholderText }) : Block,
         Panel,
         Tabs,
         Accordion,

--- a/apps/web/src/components/pickers/field-picker/field-reference-list.tsx
+++ b/apps/web/src/components/pickers/field-picker/field-reference-list.tsx
@@ -74,7 +74,7 @@ export function FieldReferenceList({
 
   return (
     <div className={cn('flex flex-col', className)}>
-      <div className='flex gap-1 overflow-x-auto border-b px-2 py-1.5 shrink-0'>
+      <div className='flex gap-1 overflow-x-auto no-scrollbar border-b px-2 py-1.5 shrink-0'>
         {orderedResources.map((r) => (
           <button
             key={r.id}

--- a/apps/web/src/components/pickers/reference-picker/reference-picker-content.tsx
+++ b/apps/web/src/components/pickers/reference-picker/reference-picker-content.tsx
@@ -137,7 +137,9 @@ export function ReferencePickerContent({
 
   return (
     <div ref={containerRef} className={cn('rounded-lg', className)}>
-      <div className='flex items-center gap-0 border-b px-1 shrink-0' role='tablist'>
+      <div
+        className='flex items-center gap-0 border-b px-1 shrink-0 no-scrollbar overflow-x-auto'
+        role='tablist'>
         {tabs.map((t, idx) => (
           <button
             key={t}
@@ -149,7 +151,7 @@ export function ReferencePickerContent({
               onTabChange?.(t)
             }}
             className={cn(
-              'px-2.5 py-1.5 text-xs font-medium rounded-sm transition-colors',
+              'px-2.5 py-1.5 text-xs font-medium rounded-sm transition-colors shrink-0',
               tab === t ? 'text-foreground bg-muted' : 'text-muted-foreground hover:text-foreground'
             )}>
             {TAB_LABEL[t]}


### PR DESCRIPTION
## Summary
- Replace the plaintext textarea in the agent trigger dialog with the `PromptEditor` so instructions can use reference chips (tools/resources/fields) and slash commands
- Add a `placeholderText` option to the Block node / rich-text editor so callers can override the default \`Press '/' for commands\` hint
- Make trigger row tooltips (last-fired, edit, delete) interactive so the user can hover into them
- Consolidate the per-kind dialog copy into a single `KIND_COPY` map

## Test plan
- [ ] Open an agent → Triggers → add each kind (scheduled / event / mention / assignment / dm) and confirm the rich editor renders with the correct placeholder
- [ ] Type \`/\` and \`@\` inside the instructions editor and verify the slash + reference pickers open
- [ ] Save a trigger with instructions, reopen, and confirm the doc hydrates correctly
- [ ] Save a trigger with empty instructions and confirm the payload is \`null\`
- [ ] Hover trigger row title / edit / delete and confirm the tooltips are interactive