### PR TITLE
feat(agents): command-based app account picker + orphan binding cleanup

### DIFF
--- a/apps/web/src/app/(protected)/app/agents/[slug]/page.tsx
+++ b/apps/web/src/app/(protected)/app/agents/[slug]/page.tsx
@@ -15,6 +15,7 @@ import { AgentsProvider } from '~/components/agents'
 import { useAgent } from '~/components/agents/hooks/use-agent'
 import { AgentDetailView } from '~/components/agents/ui/detail/agent-detail-view'
 import { EmptyState } from '~/components/global/empty-state'
+import { LoadingSpinner } from '~/components/global/loading-content'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
@@ -32,7 +33,7 @@ function AgentDetailLoader({ slug }: { slug: string }) {
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>
-          <div className='p-6 text-sm text-muted-foreground'>Loading agent…</div>
+          <LoadingSpinner />
         </MainPageContent>
       </MainPage>
     )

--- a/apps/web/src/components/agents/ui/detail/tools/catalog-node-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/catalog-node-row.tsx
@@ -43,7 +43,7 @@ interface CatalogNodeRowProps {
   onAddToApp?: (appId: string) => void
   /**
    * Optional — when supplied, app-kind container rows render a cog button
-   * that opens the credential picker for that app.
+   * that opens the credential picker dialog for that app.
    */
   onOpenAccountPicker?: (appId: string) => void
   /**
@@ -285,7 +285,7 @@ function ContainerInstalledStats({
         <Tooltip
           side='left'
           content={`${stats.locked} locked by ${pluralize(stats.locked, 'mention')} in instructions.`}>
-          <span className='inline-flex items-center gap-0.5 text-[11px] text-muted-foreground me-2'>
+          <span className='inline-flex items-center gap-0.5 text-[11px] text-muted-foreground me-2 opacity-0 group-hover/tree-row:opacity-100'>
             <Lock className='size-3' />
             {stats.locked}
           </span>

--- a/apps/web/src/components/agents/ui/detail/tools/tool-select-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tool-select-dialog.tsx
@@ -433,15 +433,6 @@ function AppDetailView({
         </Button>
       </div>
 
-      {!hasBoundAccount && (
-        <div className='flex items-start gap-2 border-b bg-amber-50 px-3 py-2 text-amber-900'>
-          <AlertCircle className='mt-0.5 size-4 shrink-0' />
-          <p className='text-xs'>
-            This app needs an account. Close this dialog and use the cog on the {app.label} row to
-            pick one.
-          </p>
-        </div>
-      )}
       <ScrollArea className='flex-1' scrollbarClassName='w-1!'>
         <div className='p-3'>
           {leaves.map((entry) => (

--- a/apps/web/src/components/agents/ui/detail/tools/tools-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tools-section-content.tsx
@@ -4,9 +4,10 @@
 import type { CatalogNode } from '@auxx/lib/agents/client'
 import { EmptySection } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
 import { Wrench } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
-import { AppAccountPicker } from '~/components/apps/ui/app-account-picker'
+import { AppAccountDialog } from '~/components/apps/ui/app-account-dialog'
 import { api } from '~/trpc/react'
 import type { AgentDetail } from '../../../store/agent-store'
 import type { AutosaveState } from '../../shared/autosave-indicator'
@@ -99,6 +100,31 @@ export function ToolsSectionContent({
 
   const [accountPickerAppId, setAccountPickerAppId] = useState<string | null>(null)
 
+  const utils = api.useUtils()
+  const updateAgent = api.agent.update.useMutation()
+
+  const bindAgentCredId = useCallback(
+    async (appId: string, credId: string) => {
+      const previous = utils.agent.getById.getData({ agentId: agent.slug })
+      utils.agent.getById.setData({ agentId: agent.slug }, (old) =>
+        old ? { ...old, appAccounts: { ...old.appAccounts, [appId]: { credId } } } : old
+      )
+      try {
+        await updateAgent.mutateAsync({
+          agentId: agent.id,
+          appAccounts: { [appId]: { credId } },
+        })
+      } catch (err) {
+        utils.agent.getById.setData({ agentId: agent.slug }, previous)
+        toastError({
+          title: 'Failed to set account',
+          description: err instanceof Error ? err.message : 'Unknown error',
+        })
+      }
+    },
+    [agent.id, agent.slug, utils, updateAgent]
+  )
+
   const toggleCollapsed = useCallback(
     (id: string) => {
       setCollapsedOverride((prev) => {
@@ -176,11 +202,14 @@ export function ToolsSectionContent({
           boundCredIdByApp={boundCredIdByApp}
         />
       ))}
-      <AppAccountPicker
+      <AppAccountDialog
         appId={accountPickerAppId}
-        agentId={agent.id}
-        agentSlug={agent.slug}
-        boundCredId={accountPickerAppId ? boundCredIdByApp[accountPickerAppId] : undefined}
+        value={accountPickerAppId ? boundCredIdByApp[accountPickerAppId] : undefined}
+        onSubmit={(next) => {
+          if (accountPickerAppId && typeof next === 'string') {
+            void bindAgentCredId(accountPickerAppId, next)
+          }
+        }}
         open={accountPickerAppId !== null}
         onOpenChange={(open) => {
           if (!open) setAccountPickerAppId(null)

--- a/apps/web/src/components/apps/ui/app-account-dialog.tsx
+++ b/apps/web/src/components/apps/ui/app-account-dialog.tsx
@@ -1,0 +1,124 @@
+// apps/web/src/components/apps/ui/app-account-dialog.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Field, FieldLabel } from '@auxx/ui/components/field'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { useEffect, useMemo, useState } from 'react'
+import { useExtensionsContext } from '~/providers/extensions/extensions-context'
+import { AppAccountPopover } from './app-account-popover'
+import { AppIcon } from './app-icon'
+
+interface AppAccountDialogProps {
+  /** App id (slug) the dialog is bound to. `null` keeps the dialog closed. */
+  appId: string | null
+  /** Currently-bound credId(s). Seeds the dialog's pending selection. */
+  value: string | string[] | undefined
+  /** Fires only when the user clicks Submit, with the final selection. */
+  onSubmit: (value: string | string[] | undefined) => void
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Dialog shell that hosts `AppAccountPopover`. Holds the pending selection
+ * locally — picks from the popover only mutate `pending`, and the host's
+ * `onSubmit` is fired only when the user clicks Submit. Cancel discards.
+ *
+ * See plans/kopilot/apps/app-account-picker-command-refactor.md §2.
+ */
+export function AppAccountDialog({
+  appId,
+  value,
+  onSubmit,
+  open,
+  onOpenChange,
+}: AppAccountDialogProps) {
+  const { appInstallations } = useExtensionsContext()
+  const installation = useMemo(
+    () => (appId ? appInstallations.find((i) => i.app.id === appId) : null),
+    [appInstallations, appId]
+  )
+  const appName = installation?.app.title ?? ''
+  const avatarUrl = installation?.app.avatarUrl ?? null
+
+  const [pending, setPending] = useState<string | string[] | undefined>(value)
+  useEffect(() => {
+    if (open) setPending(value)
+  }, [open, value])
+
+  const handlePick = (credId: string) => {
+    setPending((prev) => {
+      if (Array.isArray(prev)) {
+        return prev.includes(credId) ? prev.filter((id) => id !== credId) : [...prev, credId]
+      }
+      return credId
+    })
+  }
+
+  const handleSubmit = () => {
+    onSubmit(pending)
+    onOpenChange(false)
+  }
+
+  const dirty = !isSameSelection(pending, value)
+
+  return (
+    <Dialog open={open && !!appId} onOpenChange={onOpenChange}>
+      <DialogContent size='md' position='tc'>
+        <DialogHeader>
+          <div className='flex items-center gap-2'>
+            {avatarUrl && <AppIcon iconId={avatarUrl} size='sm' />}
+            <DialogTitle>Account for {appName}</DialogTitle>
+          </div>
+          <DialogDescription>
+            Choose which connected account this agent uses when running {appName} tools.
+          </DialogDescription>
+        </DialogHeader>
+        <Field>
+          <FieldLabel>Account</FieldLabel>
+          <AppAccountPopover
+            appId={appId}
+            value={pending}
+            onPick={handlePick}
+            onConnected={handlePick}
+          />
+        </Field>
+        <DialogFooter>
+          <Button type='button' size='sm' variant='ghost' onClick={() => onOpenChange(false)}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            type='button'
+            size='sm'
+            variant='outline'
+            disabled={!dirty}
+            onClick={handleSubmit}>
+            Submit <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function isSameSelection(
+  a: string | string[] | undefined,
+  b: string | string[] | undefined
+): boolean {
+  if (a === b) return true
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false
+    const set = new Set(a)
+    return b.every((id) => set.has(id))
+  }
+  return false
+}

--- a/apps/web/src/components/apps/ui/app-account-picker.tsx
+++ b/apps/web/src/components/apps/ui/app-account-picker.tsx
@@ -1,62 +1,45 @@
 // apps/web/src/components/apps/ui/app-account-picker.tsx
 'use client'
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@auxx/ui/components/dialog'
-import { Skeleton } from '@auxx/ui/components/skeleton'
-import { toastError } from '@auxx/ui/components/toast'
-import { cn } from '@auxx/ui/lib/utils'
+import { Command, CommandGroup, CommandItem, CommandList } from '@auxx/ui/components/command'
 import { Check, User as UserIcon, Users } from 'lucide-react'
 import { useMemo } from 'react'
 import { useUser } from '~/hooks/use-user'
 import { type AppConnection, useExtensionsContext } from '~/providers/extensions/extensions-context'
-import { api } from '~/trpc/react'
 import { useAppCredentialOptions } from '../hooks/use-app-credential-options'
 import { useBoundCredential } from '../hooks/use-bound-credential'
-import type { ConnectTarget } from '../hooks/use-connect-flow'
-import { ConnectButton } from './connect-button'
+import { type ConnectTarget, useConnectFlow } from '../hooks/use-connect-flow'
+import { AppIcon } from './app-icon'
+import { type AppConnectionStatus, AppWithStatusIcon } from './app-with-status-icon'
 
 interface AppAccountPickerProps {
-  /** App id (slug) the picker is bound to. `null` keeps the dialog closed. */
+  /** App id (slug) the picker is bound to. */
   appId: string | null
-  agentId: string
-  agentSlug: string
-  /** Currently-bound credential id, if any. */
-  boundCredId: string | undefined
-  open: boolean
-  onOpenChange: (open: boolean) => void
+  /** Currently-selected credId(s). String for single-select, array for multi-select. */
+  value: string | string[] | undefined
+  /** Fires once per pick with the picked credId. Host decides single vs multi semantics. */
+  onPick: (credId: string) => void
+  /** Fires when the connect flow returns a new credential. */
+  onConnected?: (credId: string) => void
 }
 
 /**
- * Cog-triggered dialog that lets the agent's admin pick which credential
- * the agent runs as for one app. Workspace + the current user's personal
- * creds are shown side-by-side; selecting a connected row writes the
- * binding via `agent.update`. "Connect another account" uses
- * `ConnectButton` with popup-mode OAuth — the new credId auto-binds via
- * the `onConnected` callback without the picker reloading.
- *
- * See plans/kopilot/apps/agent-credentials.md §5.4 +
- * plans/kopilot/apps/app-settings-dialog-refactor.md §5.
+ * Command-based account picker. Renders Personal + Workspace groups of
+ * connections plus a footer group with "Connect personal/workspace account"
+ * actions. Agnostic of binding semantics — see
+ * plans/kopilot/apps/app-account-picker-command-refactor.md §3.
  */
-export function AppAccountPicker({
-  appId,
-  agentId,
-  agentSlug,
-  boundCredId,
-  open,
-  onOpenChange,
-}: AppAccountPickerProps) {
+export function AppAccountPicker({ appId, value, onPick, onConnected }: AppAccountPickerProps) {
   const { appInstallations } = useExtensionsContext()
-  const utils = api.useUtils()
-  const updateAgent = api.agent.update.useMutation()
   const { isAdminOrOwner } = useUser()
+  const options = useAppCredentialOptions(appId)
 
   const installation = useMemo(
     () => (appId ? appInstallations.find((i) => i.app.id === appId) : null),
     [appInstallations, appId]
   )
-  const options = useAppCredentialOptions(appId)
   const { user: userDef, organization: orgDef } = installation?.connectionDefinitions ?? {}
-  const appName = installation?.app.title ?? ''
+  const avatarUrl = installation?.app.avatarUrl ?? null
 
   const target: ConnectTarget | null = useMemo(() => {
     if (!installation || !appId) return null
@@ -69,165 +52,104 @@ export function AppAccountPicker({
     }
   }, [installation, appId])
 
-  const bindCredId = async (credId: string) => {
-    if (!appId) return
-    const previous = utils.agent.getById.getData({ agentId: agentSlug })
-    utils.agent.getById.setData({ agentId: agentSlug }, (old) =>
-      old ? { ...old, appAccounts: { ...old.appAccounts, [appId]: { credId } } } : old
-    )
-    try {
-      await updateAgent.mutateAsync({ agentId, appAccounts: { [appId]: { credId } } })
-    } catch (err) {
-      utils.agent.getById.setData({ agentId: agentSlug }, previous)
-      toastError({
-        title: 'Failed to set account',
-        description: err instanceof Error ? err.message : 'Unknown error',
-      })
-    }
-  }
+  const flow = useConnectFlow({
+    onConnected: (credId) => onConnected?.(credId),
+  })
 
-  const handlePick = async (cred: AppConnection) => {
-    await bindCredId(cred.id)
-    onOpenChange(false)
-  }
+  const isSelected = (credId: string) =>
+    Array.isArray(value) ? value.includes(credId) : value === credId
 
   return (
-    <Dialog open={open && !!appId} onOpenChange={onOpenChange}>
-      <DialogContent size='md' position='tc'>
-        <DialogHeader>
-          <DialogTitle>Account for {appName}</DialogTitle>
-        </DialogHeader>
-        <div className='flex flex-col gap-4'>
-          {!installation && <Skeleton className='h-20 w-full' />}
-          {installation && options.workspace.length === 0 && options.personal.length === 0 && (
-            <p className='text-sm text-muted-foreground'>
-              No accounts connected yet. Connect one below.
-            </p>
-          )}
-          {orgDef && options.workspace.length > 0 && (
-            <Section title='Workspace'>
-              {options.workspace.map((c) => (
-                <CredRow
-                  key={c.id}
-                  cred={c}
-                  selected={c.id === boundCredId}
-                  onSelect={() => handlePick(c)}
-                />
-              ))}
-            </Section>
-          )}
+    <>
+      <Command className='w-full'>
+        <CommandList className='max-h-none'>
           {userDef && options.personal.length > 0 && (
-            <Section title='My accounts'>
+            <CommandGroup heading='Personal'>
               {options.personal.map((c) => (
-                <CredRow
+                <AccountRow
                   key={c.id}
                   cred={c}
-                  selected={c.id === boundCredId}
-                  onSelect={() => handlePick(c)}
+                  avatarUrl={avatarUrl}
+                  selected={isSelected(c.id)}
+                  onSelect={() => onPick(c.id)}
                 />
               ))}
-            </Section>
+            </CommandGroup>
           )}
-          {installation && target && (
-            <div className='flex flex-col gap-2 border-t pt-4'>
-              <p className='text-xs text-muted-foreground'>Connect another account</p>
-              <div className='flex flex-wrap gap-2'>
-                {userDef && (
-                  <ConnectButton
-                    target={target}
-                    scope='user'
-                    label={
-                      <span className='inline-flex items-center gap-1.5'>
-                        <UserIcon className='size-3.5' />
-                        Connect personal {appName}
-                      </span>
-                    }
-                    onConnected={(credId) => {
-                      void bindCredId(credId)
-                    }}
-                  />
-                )}
-                {orgDef && (
-                  <ConnectButton
-                    target={target}
-                    scope='organization'
-                    disabled={!isAdminOrOwner}
-                    disabledReason='Only admins can connect workspace accounts'
-                    label={
-                      <span className='inline-flex items-center gap-1.5'>
-                        <Users className='size-3.5' />
-                        Connect workspace {appName}
-                      </span>
-                    }
-                    onConnected={(credId) => {
-                      void bindCredId(credId)
-                    }}
-                  />
-                )}
-              </div>
-            </div>
+
+          {orgDef && options.workspace.length > 0 && (
+            <CommandGroup heading='Workspace'>
+              {options.workspace.map((c) => (
+                <AccountRow
+                  key={c.id}
+                  cred={c}
+                  avatarUrl={avatarUrl}
+                  selected={isSelected(c.id)}
+                  onSelect={() => onPick(c.id)}
+                />
+              ))}
+            </CommandGroup>
           )}
-        </div>
-      </DialogContent>
-    </Dialog>
+
+          <CommandGroup>
+            {userDef && target && (
+              <CommandItem
+                onSelect={() => flow.start({ target, scope: 'user' })}
+                className='cursor-pointer h-7.5'>
+                <UserIcon className='text-muted-foreground' />
+                <span>Connect personal account</span>
+              </CommandItem>
+            )}
+            {orgDef && target && (
+              <CommandItem
+                onSelect={() => {
+                  if (isAdminOrOwner) flow.start({ target, scope: 'organization' })
+                }}
+                disabled={!isAdminOrOwner}
+                className='cursor-pointer h-7.5'>
+                <Users className='text-muted-foreground' />
+                <span>Connect workspace account</span>
+              </CommandItem>
+            )}
+          </CommandGroup>
+        </CommandList>
+      </Command>
+      {flow.Dialogs}
+    </>
   )
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className='flex flex-col gap-1'>
-      <p className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>{title}</p>
-      <div className='flex flex-col rounded-md border'>{children}</div>
-    </div>
-  )
-}
-
-function CredRow({
+function AccountRow({
   cred,
+  avatarUrl,
   selected,
   onSelect,
 }: {
   cred: AppConnection
+  avatarUrl: string | null
   selected: boolean
   onSelect: () => void
 }) {
   const bound = useBoundCredential(cred.id)
-  const statusText =
+  const status: AppConnectionStatus =
     bound.status === 'connected'
-      ? 'Connected'
+      ? 'connected'
       : bound.status === 'expired'
-        ? 'Expired'
-        : 'Not connected'
+        ? 'expired'
+        : 'not_connected'
+
   return (
-    <button
-      type='button'
-      onClick={onSelect}
-      className={cn(
-        'flex items-center justify-between gap-3 px-3 py-2 text-left hover:bg-primary-50 border-b last:border-b-0',
-        selected && 'bg-primary-50'
-      )}>
-      <div className='flex flex-col min-w-0'>
-        <span className='text-sm truncate'>{cred.label ?? cred.appName}</span>
-        {cred.connectedBy && (
-          <span className='text-xs text-muted-foreground truncate'>
-            Connected by {cred.connectedBy}
-          </span>
-        )}
-      </div>
-      <div className='flex items-center gap-2 shrink-0'>
-        <span
-          className={cn(
-            'text-xs',
-            bound.status === 'connected'
-              ? 'text-green-600'
-              : bound.status === 'expired'
-                ? 'text-amber-600'
-                : 'text-muted-foreground'
-          )}>
-          {statusText}
-        </span>
-        {selected && <Check className='size-4 text-foreground' />}
-      </div>
-    </button>
+    <CommandItem
+      value={cred.label ?? cred.appName ?? cred.id}
+      onSelect={onSelect}
+      className='cursor-pointer h-7.5'>
+      <AppIcon iconId={avatarUrl ?? 'package'} size='xs' />
+      <span className='truncate'>{cred.label ?? cred.appName}</span>
+      {selected && (
+        <div className='ml-auto rounded-full size-4 bg-info flex items-center justify-center border border-blue-800'>
+          <Check className='size-2.5! text-white' strokeWidth={4} />
+        </div>
+      )}
+    </CommandItem>
   )
 }

--- a/apps/web/src/components/apps/ui/app-account-popover.tsx
+++ b/apps/web/src/components/apps/ui/app-account-popover.tsx
@@ -1,0 +1,82 @@
+// apps/web/src/components/apps/ui/app-account-popover.tsx
+'use client'
+
+import { Popover, PopoverContentDialogAware, PopoverTrigger } from '@auxx/ui/components/popover'
+import { useMemo, useState } from 'react'
+import { PickerTrigger } from '~/components/ui/picker-trigger'
+import { useExtensionsContext } from '~/providers/extensions/extensions-context'
+import { AppAccountPicker } from './app-account-picker'
+import { AppIcon } from './app-icon'
+
+interface AppAccountPopoverProps {
+  /** App id (slug) the popover is bound to. */
+  appId: string | null
+  /** Currently-selected credId(s). Renders as the trigger's value when single. */
+  value: string | string[] | undefined
+  /** Fires once per pick with the picked credId. Host decides single vs multi semantics. */
+  onPick: (credId: string) => void
+  /** Fires when the connect flow returns a new credential. */
+  onConnected?: (credId: string) => void
+  /** Trigger placeholder when no value is selected. */
+  placeholder?: string
+  /** Override the trigger button. Defaults to a compact `PickerTrigger`. */
+  triggerClassName?: string
+}
+
+/**
+ * Popover-wrapped account picker. The `PickerTrigger` shows the bound
+ * credential's label (or placeholder), and the popover content renders the
+ * `<Command>`-based `AppAccountPicker`.
+ *
+ * See plans/kopilot/apps/app-account-picker-command-refactor.md §2.
+ */
+export function AppAccountPopover({
+  appId,
+  value,
+  onPick,
+  onConnected,
+  placeholder = 'Choose account',
+  triggerClassName,
+}: AppAccountPopoverProps) {
+  const [open, setOpen] = useState(false)
+  const { appConnections, appInstallations } = useExtensionsContext()
+
+  const triggerLabel = useMemo(() => {
+    if (!value || Array.isArray(value)) return null
+    const cred = appConnections.find((c) => c.id === value)
+    return cred?.label ?? cred?.appName ?? null
+  }, [value, appConnections])
+
+  const avatarUrl = useMemo(() => {
+    if (!appId) return null
+    return appInstallations.find((i) => i.app.id === appId)?.app.avatarUrl ?? null
+  }, [appInstallations, appId])
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <PickerTrigger
+          open={open}
+          hasValue={!!triggerLabel}
+          placeholder={placeholder}
+          size='default'
+          variant='outline'
+          className={triggerClassName}>
+          {avatarUrl && <AppIcon iconId={avatarUrl} size='sm' />}
+          <span className='truncate'>{triggerLabel}</span>
+        </PickerTrigger>
+      </PopoverTrigger>
+      <PopoverContentDialogAware className='w-72 p-0' align='start'>
+        <AppAccountPicker
+          appId={appId}
+          value={value}
+          onPick={(credId) => {
+            onPick(credId)
+            setOpen(false)
+          }}
+          onConnected={onConnected}
+        />
+      </PopoverContentDialogAware>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/apps/ui/app-with-status-icon.tsx
+++ b/apps/web/src/components/apps/ui/app-with-status-icon.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { cn } from '@auxx/ui/lib/utils'
-import { Check } from 'lucide-react'
+import { Check, Clock, type LucideIcon, Minus, Plug, X } from 'lucide-react'
 import { AppIcon, type AppIconProps } from '~/components/apps/ui/app-icon'
 
 /**
@@ -19,26 +19,26 @@ export type AppConnectionStatus =
   | 'unbound'
   | 'none'
 
+export interface AppConnectionStatusOption {
+  label: string
+  /** Tailwind background class for the dot, or `null` to skip the overlay. */
+  color: string | null
+  icon: LucideIcon
+}
+
 /**
- * Color class for the small status dot, keyed by a credential's resolved
- * state. `none` returns `null` so the wrapper can skip the overlay entirely.
- * Co-located so other surfaces that already render their own pill
- * (`AppSettingsTrigger`) can adopt the same mapping incrementally.
+ * Status metadata keyed by a credential's resolved state. `none` has a
+ * `null` color so wrappers can skip the overlay entirely. Co-located so
+ * other surfaces that already render their own pill (`AppSettingsTrigger`)
+ * can adopt the same mapping incrementally.
  */
-export function getConnectionStatusColor(status: AppConnectionStatus): string | null {
-  switch (status) {
-    case 'connected':
-      return 'bg-green-500'
-    case 'expired':
-      return 'bg-amber-500'
-    case 'unbound':
-      return 'bg-amber-500'
-    case 'gone':
-    case 'not_connected':
-      return 'bg-red-500'
-    case 'none':
-      return null
-  }
+export const appConnectionStatusOptions: Record<AppConnectionStatus, AppConnectionStatusOption> = {
+  connected: { label: 'Connected', color: 'bg-green-500', icon: Check },
+  expired: { label: 'Expired', color: 'bg-amber-500', icon: Clock },
+  unbound: { label: 'Not set', color: 'bg-amber-500', icon: Minus },
+  gone: { label: 'Disconnected', color: 'bg-red-500', icon: X },
+  not_connected: { label: 'Disconnected', color: 'bg-red-500', icon: Plug },
+  none: { label: '', color: null, icon: Minus },
 }
 
 interface AppWithStatusIconProps extends AppIconProps {
@@ -52,17 +52,17 @@ export function AppWithStatusIcon({
   wrapperClassName,
   ...iconProps
 }: AppWithStatusIconProps) {
-  const dotColor = getConnectionStatusColor(status)
+  const { color, icon: StatusIcon } = appConnectionStatusOptions[status]
   return (
     <div className={cn('relative inline-flex shrink-0', wrapperClassName)}>
       <AppIcon {...iconProps} />
-      {dotColor && (
+      {color && (
         <span
           className={cn(
-            'absolute -top-0.5 -right-0.5 inline-flex size-2.5 items-center justify-center rounded-full ring-1 ring-background',
-            dotColor
+            'absolute top-0 right-0 inline-flex size-2 items-center justify-center rounded-full ring-1 ring-background',
+            color
           )}>
-          {status === 'connected' && <Check className='size-2 text-white' strokeWidth={3} />}
+          {status === 'connected' && <StatusIcon className='size-2 text-white' />}
         </span>
       )}
     </div>

--- a/apps/web/src/components/apps/ui/credential-badge.tsx
+++ b/apps/web/src/components/apps/ui/credential-badge.tsx
@@ -7,7 +7,7 @@ import {
   useBoundCredential,
 } from '~/components/apps/hooks/use-bound-credential'
 import { Tooltip } from '~/components/global/tooltip'
-import { getConnectionStatusColor } from './app-with-status-icon'
+import { appConnectionStatusOptions } from './app-with-status-icon'
 
 interface CredentialBadgeProps {
   credId: string | undefined | null
@@ -27,7 +27,8 @@ interface CredentialBadgeProps {
 export function CredentialBadge({ credId, onPick }: CredentialBadgeProps) {
   const bound = useBoundCredential(credId)
   const { status } = bound
-  const dotColor = getConnectionStatusColor(status === 'none' ? 'unbound' : status) ?? 'bg-muted'
+  const dotColor =
+    appConnectionStatusOptions[status === 'none' ? 'unbound' : status].color ?? 'bg-muted'
 
   const label = renderLabel(bound.status, bound.label)
   const tooltip = renderTooltip(bound)

--- a/packages/lib/src/agents/agent-toolset-service.ts
+++ b/packages/lib/src/agents/agent-toolset-service.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/agents/agent-toolset-service.ts
 
 import {
+  type AppAccountBinding,
   type Database,
   database as defaultDb,
   schema,
@@ -11,6 +12,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
 import { onCacheEvent } from '../cache'
 import type { AgentToolsetConfig } from './agent-toolset-types'
+import { getOrgToolsetCatalog } from './toolset-catalog'
 
 const logger = createScopedLogger('agent-toolset-service')
 
@@ -80,15 +82,75 @@ export function applyToolsetPatch(
   return current.map((t, i) => (i === idx ? next : t))
 }
 
-async function loadToolsetsForUpdate(tx: Transaction, agentId: string): Promise<ToolsetEntry[]> {
+interface AgentToolsetRow {
+  toolsets: ToolsetEntry[]
+  appAccounts: Record<string, AppAccountBinding>
+}
+
+async function loadAgentForToolsetUpdate(
+  tx: Transaction,
+  agentId: string
+): Promise<AgentToolsetRow> {
   const [row] = await tx
-    .select({ toolsets: schema.Agent.toolsets })
+    .select({
+      toolsets: schema.Agent.toolsets,
+      appAccounts: schema.Agent.appAccounts,
+    })
     .from(schema.Agent)
     .where(eq(schema.Agent.id, agentId))
     .for('update')
     .limit(1)
   if (!row) throw new Error(`Agent not found: ${agentId}`)
-  return row.toolsets ?? []
+  return {
+    toolsets: row.toolsets ?? [],
+    appAccounts: row.appAccounts ?? {},
+  }
+}
+
+/**
+ * Drop `appAccounts[appId]` entries for any app whose last enabled toolset
+ * was just turned off. Returns the same object reference when no changes
+ * are needed so callers can skip the write.
+ */
+async function clearOrphanedAppAccounts(
+  organizationId: string,
+  prevToolsets: ToolsetEntry[],
+  nextToolsets: ToolsetEntry[],
+  appAccounts: Record<string, AppAccountBinding>,
+  patches: AgentToolsetPatch[]
+): Promise<Record<string, AppAccountBinding>> {
+  const disabledSlugs = patches.filter((p) => p.enabled === false).map((p) => p.slug)
+  if (disabledSlugs.length === 0) return appAccounts
+  if (Object.keys(appAccounts).length === 0) return appAccounts
+
+  const catalog = await getOrgToolsetCatalog(organizationId)
+  const slugToAppId = new Map(catalog.map((c) => [c.slug, c.appId]))
+
+  const affectedAppIds = new Set<string>()
+  const prevBySlug = new Map(prevToolsets.map((t) => [t.slug, t]))
+  for (const slug of disabledSlugs) {
+    if (prevBySlug.get(slug)?.enabled !== true) continue
+    const appId = slugToAppId.get(slug)
+    if (appId && appAccounts[appId]) affectedAppIds.add(appId)
+  }
+  if (affectedAppIds.size === 0) return appAccounts
+
+  const enabledAppIds = new Set<string>()
+  for (const entry of nextToolsets) {
+    if (!entry.enabled) continue
+    const appId = slugToAppId.get(entry.slug)
+    if (appId) enabledAppIds.add(appId)
+  }
+
+  let changed = false
+  const next: Record<string, AppAccountBinding> = { ...appAccounts }
+  for (const appId of affectedAppIds) {
+    if (!enabledAppIds.has(appId)) {
+      delete next[appId]
+      changed = true
+    }
+  }
+  return changed ? next : appAccounts
 }
 
 /**
@@ -102,11 +164,22 @@ export async function updateAgentToolset(
   db: Database = defaultDb as Database
 ): Promise<void> {
   await db.transaction(async (tx) => {
-    const current = await loadToolsetsForUpdate(tx, agentId)
-    const next = applyToolsetPatch(current, patch)
+    const row = await loadAgentForToolsetUpdate(tx, agentId)
+    const next = applyToolsetPatch(row.toolsets, patch)
+    const nextAppAccounts = await clearOrphanedAppAccounts(
+      organizationId,
+      row.toolsets,
+      next,
+      row.appAccounts,
+      [patch]
+    )
     await tx
       .update(schema.Agent)
-      .set({ toolsets: next, updatedAt: new Date() })
+      .set({
+        toolsets: next,
+        ...(nextAppAccounts === row.appAccounts ? {} : { appAccounts: nextAppAccounts }),
+        updatedAt: new Date(),
+      })
       .where(eq(schema.Agent.id, agentId))
   })
 
@@ -133,14 +206,25 @@ export async function batchUpdateAgentToolsets(
   db: Database = defaultDb as Database
 ): Promise<void> {
   await db.transaction(async (tx) => {
-    const current = await loadToolsetsForUpdate(tx, agentId)
-    let next = current
+    const row = await loadAgentForToolsetUpdate(tx, agentId)
+    let next = row.toolsets
     for (const patch of patches) {
       next = applyToolsetPatch(next, patch)
     }
+    const nextAppAccounts = await clearOrphanedAppAccounts(
+      organizationId,
+      row.toolsets,
+      next,
+      row.appAccounts,
+      patches
+    )
     await tx
       .update(schema.Agent)
-      .set({ toolsets: next, updatedAt: new Date() })
+      .set({
+        toolsets: next,
+        ...(nextAppAccounts === row.appAccounts ? {} : { appAccounts: nextAppAccounts }),
+        updatedAt: new Date(),
+      })
       .where(eq(schema.Agent.id, agentId))
   })
 


### PR DESCRIPTION
## Summary
- Split the cog dialog into reusable pieces: `AppAccountPicker` is now a `Command`-based picker, `AppAccountPopover` wraps it for inline trigger use, and `AppAccountDialog` hosts it with pending-state Submit/Cancel.
- Tools section now binds account changes via local optimistic `agent.update` so the dialog wrapper stays binding-agnostic.
- Refactored `getConnectionStatusColor` into `appConnectionStatusOptions` (label + color + icon) and updated callers.
- Disabling the last enabled toolset for an app now drops that app's `appAccounts[appId]` binding inside `updateAgentToolset` / `batchUpdateAgentToolsets`.
- Misc: loading spinner on agent detail loader; locked-count badge hidden until row hover.

## Test plan
- [ ] Open an agent's Tools section, click the cog on an app row — dialog renders the picker, Submit binds the cred, Cancel discards.
- [ ] Disable all toolsets for an app — the bound account is cleared.
- [ ] Connect a new personal/workspace account from the picker — flows complete and the new credId is selected.
- [ ] `CredentialBadge` and `AppWithStatusIcon` still render the right colors per status.