### PR TITLE
feat(agents): contact lookup SDK callbacks + agent trigger fanout

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,6 +18,8 @@ import sdkBundles from './routes/bundles'
 import deployments from './routes/deployments'
 import developers from './routes/developers'
 import entitiesFindByIntegrationId from './routes/entities/find-by-integration-id'
+import entitiesFindContactByEmail from './routes/entities/find-contact-by-email'
+import entitiesFindContactByPhone from './routes/entities/find-contact-by-phone'
 import freeToolLeads from './routes/free-tool-leads'
 // Routes
 import health from './routes/health'
@@ -75,6 +77,8 @@ async function main() {
   app.route('/api/v1/sdk/webhooks', webhookHandlers) // SDK callback: Lambda → API
   app.route('/api/v1/sdk/settings', settings) // SDK callback: Lambda → API
   app.route('/api/v1/sdk/entities', entitiesFindByIntegrationId) // SDK callback: Lambda → API (AI tools)
+  app.route('/api/v1/sdk/entities', entitiesFindContactByEmail) // SDK callback: Lambda → API (AI tools, slack)
+  app.route('/api/v1/sdk/entities', entitiesFindContactByPhone) // SDK callback: Lambda → API (AI tools, whatsapp)
   app.route('/api/v1/workflows', workflows) // Workflow execution routes
   app.route('/api/v1/public/free-tool-leads', freeToolLeads) // Public lead capture from /free-tools/*
   app.route('/webhooks/recording', recordingWebhooks) // Recording bot provider webhooks (before generic /webhooks to avoid param collision)

--- a/apps/api/src/routes/entities/find-contact-by-email.ts
+++ b/apps/api/src/routes/entities/find-contact-by-email.ts
@@ -1,0 +1,86 @@
+// apps/api/src/routes/entities/find-contact-by-email.ts
+
+/**
+ * Lambda SDK callback for `ctx.entities.findContactByEmail`.
+ *
+ * Authorized via the `entities` callback token scope minted by
+ * `prepareLambdaContext` for AI tool invocations. Looks up a contact-kind
+ * EntityInstance whose primary EMAIL FieldValue matches (case-insensitive)
+ * and returns the auxx recordId (`<defId>:<instId>`) plus display name.
+ *
+ * Used by integrations that don't have a contact-import source path —
+ * Slack first, Gmail next. See plans/kopilot/apps/slack-overhaul.md §6.
+ */
+
+import { database, schema } from '@auxx/database'
+import { getCachedCustomFields, getCachedEntityDefId } from '@auxx/lib/cache'
+import { and, eq, inArray, sql } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { verifyCallbackAuth } from '../../lib/callback-auth'
+import { errorResponse } from '../../lib/response'
+import type { AppContext } from '../../types/context'
+
+const findContactByEmail = new Hono<AppContext>()
+
+const FindContactByEmailSchema = z.object({
+  email: z.string().email(),
+})
+
+findContactByEmail.post('/find-contact-by-email', async (c) => {
+  const auth = verifyCallbackAuth(c, 'entities')
+  if (!auth) return c.res
+
+  let body: unknown
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json(errorResponse('BAD_REQUEST', 'Invalid JSON body'), 400)
+  }
+
+  const parsed = FindContactByEmailSchema.safeParse(body)
+  if (!parsed.success) {
+    return c.json(errorResponse('BAD_REQUEST', 'Invalid input'), 400)
+  }
+  const email = parsed.data.email.trim().toLowerCase()
+  if (!email) return c.json({ entity: null })
+
+  // Resolve the org's contact EntityDefinition + EMAIL field ids from cache.
+  const defId = await getCachedEntityDefId(auth.organizationId, 'contact')
+  if (!defId) return c.json({ entity: null })
+
+  const fields = await getCachedCustomFields(auth.organizationId, defId)
+  const emailFieldIds = fields.filter((f) => f.type === 'EMAIL').map((f) => f.id)
+  if (emailFieldIds.length === 0) return c.json({ entity: null })
+
+  // Look up the EMAIL FieldValue (case-insensitive) and join to the
+  // EntityInstance to return its display name.
+  const row = await database
+    .select({
+      instanceId: schema.EntityInstance.id,
+      displayName: schema.EntityInstance.displayName,
+    })
+    .from(schema.FieldValue)
+    .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, auth.organizationId),
+        eq(schema.FieldValue.entityDefinitionId, defId),
+        inArray(schema.FieldValue.fieldId, emailFieldIds),
+        sql`lower(${schema.FieldValue.valueText}) = ${email}`
+      )
+    )
+    .limit(1)
+
+  const hit = row[0]
+  if (!hit) return c.json({ entity: null })
+
+  return c.json({
+    entity: {
+      recordId: `${defId}:${hit.instanceId}`,
+      displayName: hit.displayName,
+    },
+  })
+})
+
+export default findContactByEmail

--- a/apps/api/src/routes/entities/find-contact-by-phone.ts
+++ b/apps/api/src/routes/entities/find-contact-by-phone.ts
@@ -1,0 +1,106 @@
+// apps/api/src/routes/entities/find-contact-by-phone.ts
+
+/**
+ * Lambda SDK callback for `ctx.entities.findContactByPhone`.
+ *
+ * Authorized via the `entities` callback token scope minted by
+ * `prepareLambdaContext` for AI tool invocations. Normalizes the input
+ * phone to E.164 (when possible), then looks up a contact-kind
+ * EntityInstance whose PHONE-type FieldValue matches (case-insensitive
+ * exact). Returns the auxx recordId (`<defId>:<instId>`) plus display name.
+ *
+ * Used by integrations whose identity is keyed on a phone number —
+ * WhatsApp first, Twilio next. See plans/kopilot/apps/whatsapp-overhaul.md §6.
+ */
+
+import { database, schema } from '@auxx/database'
+import { getCachedCustomFields, getCachedEntityDefId } from '@auxx/lib/cache'
+import { and, eq, inArray, sql } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { verifyCallbackAuth } from '../../lib/callback-auth'
+import { errorResponse } from '../../lib/response'
+import type { AppContext } from '../../types/context'
+
+const findContactByPhone = new Hono<AppContext>()
+
+const FindContactByPhoneSchema = z.object({
+  phone: z.string().min(1),
+})
+
+/**
+ * Best-effort E.164 normalization: strip all formatting, prepend `+`.
+ *
+ * Mirrors the client-side `normalizePhone` in the WhatsApp tool surface
+ * (`apps/whatsapp/src/tools/shared/normalize-phone.ts`) so both sides
+ * round-trip the same value. This is intentionally dumb — no country
+ * inference, no validation. Inputs without a country code stored at the
+ * other side won't match; that's a data-quality issue flagged in the
+ * overhaul plan §8, not a normalizer concern.
+ */
+function normalizeToE164(input: string): string {
+  const trimmed = input.trim()
+  if (!trimmed) return ''
+  if (trimmed.startsWith('+')) {
+    return `+${trimmed.slice(1).replace(/[^\d]/g, '')}`
+  }
+  const digits = trimmed.replace(/[^\d]/g, '')
+  if (!digits) return ''
+  return `+${digits}`
+}
+
+findContactByPhone.post('/find-contact-by-phone', async (c) => {
+  const auth = verifyCallbackAuth(c, 'entities')
+  if (!auth) return c.res
+
+  let body: unknown
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json(errorResponse('BAD_REQUEST', 'Invalid JSON body'), 400)
+  }
+
+  const parsed = FindContactByPhoneSchema.safeParse(body)
+  if (!parsed.success) {
+    return c.json(errorResponse('BAD_REQUEST', 'Invalid input'), 400)
+  }
+
+  const normalized = normalizeToE164(parsed.data.phone)
+  if (!normalized) return c.json({ entity: null })
+
+  const defId = await getCachedEntityDefId(auth.organizationId, 'contact')
+  if (!defId) return c.json({ entity: null })
+
+  const fields = await getCachedCustomFields(auth.organizationId, defId)
+  const phoneFieldIds = fields.filter((f) => f.type === 'PHONE_INTL').map((f) => f.id)
+  if (phoneFieldIds.length === 0) return c.json({ entity: null })
+
+  const row = await database
+    .select({
+      instanceId: schema.EntityInstance.id,
+      displayName: schema.EntityInstance.displayName,
+    })
+    .from(schema.FieldValue)
+    .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, auth.organizationId),
+        eq(schema.FieldValue.entityDefinitionId, defId),
+        inArray(schema.FieldValue.fieldId, phoneFieldIds),
+        sql`lower(${schema.FieldValue.valueText}) = ${normalized.toLowerCase()}`
+      )
+    )
+    .limit(1)
+
+  const hit = row[0]
+  if (!hit) return c.json({ entity: null })
+
+  return c.json({
+    entity: {
+      recordId: `${defId}:${hit.instanceId}`,
+      displayName: hit.displayName,
+    },
+  })
+})
+
+export default findContactByPhone

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -143,19 +143,24 @@ async function handleWebhookRequest(c: any) {
       handlerId,
     })
 
-    // 7. If handler returned trigger data and handler has a triggerId, enqueue dispatch job
+    // 7. If handler returned trigger data and handler has a triggerId, enqueue
+    //    dispatch jobs. One emit → two consumers (workflows + agents). Mirrors
+    //    the polling-trigger-job side; see plans/kopilot/apps/app-triggers-brainstorm.md §2.
     if (handlerExecutionResult.triggerData && handler.triggerId) {
+      const dispatchPayload = {
+        appInstallationId: installationId,
+        appId: installation.appId,
+        triggerId: handler.triggerId,
+        connectionId: handler.connectionId ?? undefined,
+        triggerData: handlerExecutionResult.triggerData,
+        eventId: handlerExecutionResult.eventId || randomUUID(),
+        organizationId: installation.organizationId,
+      }
+
       try {
         const appTriggerQueue = getQueue(Queues.appTriggerQueue)
-        await appTriggerQueue.add('dispatchAppTrigger', {
-          appInstallationId: installationId,
-          appId: installation.appId,
-          triggerId: handler.triggerId,
-          connectionId: handler.connectionId ?? undefined,
-          triggerData: handlerExecutionResult.triggerData,
-          eventId: handlerExecutionResult.eventId || randomUUID(),
-          organizationId: installation.organizationId,
-        })
+        await appTriggerQueue.add('dispatchAppTrigger', dispatchPayload)
+        await appTriggerQueue.add('dispatchAppTriggerToAgents', dispatchPayload)
 
         log.info('Enqueued app trigger dispatch', {
           installationId,

--- a/apps/web/src/components/apps/ui/app-account-dialog.tsx
+++ b/apps/web/src/components/apps/ui/app-account-dialog.tsx
@@ -73,7 +73,7 @@ export function AppAccountDialog({
 
   return (
     <Dialog open={open && !!appId} onOpenChange={onOpenChange}>
-      <DialogContent size='md' position='tc'>
+      <DialogContent size='sm' position='tc'>
         <DialogHeader>
           <div className='flex items-center gap-2'>
             {avatarUrl && <AppIcon iconId={avatarUrl} size='sm' />}

--- a/apps/web/src/components/apps/ui/app-account-picker.tsx
+++ b/apps/web/src/components/apps/ui/app-account-picker.tsx
@@ -1,7 +1,13 @@
 // apps/web/src/components/apps/ui/app-account-picker.tsx
 'use client'
 
-import { Command, CommandGroup, CommandItem, CommandList } from '@auxx/ui/components/command'
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@auxx/ui/components/command'
 import { Check, User as UserIcon, Users } from 'lucide-react'
 import { useMemo } from 'react'
 import { useUser } from '~/hooks/use-user'
@@ -90,7 +96,7 @@ export function AppAccountPicker({ appId, value, onPick, onConnected }: AppAccou
               ))}
             </CommandGroup>
           )}
-
+          <CommandSeparator />
           <CommandGroup>
             {userDef && target && (
               <CommandItem
@@ -143,7 +149,7 @@ function AccountRow({
       value={cred.label ?? cred.appName ?? cred.id}
       onSelect={onSelect}
       className='cursor-pointer h-7.5'>
-      <AppIcon iconId={avatarUrl ?? 'package'} size='xs' />
+      <AppIcon iconId={avatarUrl ?? 'package'} size='sm' />
       <span className='truncate'>{cred.label ?? cred.appName}</span>
       {selected && (
         <div className='ml-auto rounded-full size-4 bg-info flex items-center justify-center border border-blue-800'>

--- a/apps/web/src/components/apps/ui/app-account-popover.tsx
+++ b/apps/web/src/components/apps/ui/app-account-popover.tsx
@@ -66,7 +66,7 @@ export function AppAccountPopover({
           <span className='truncate'>{triggerLabel}</span>
         </PickerTrigger>
       </PopoverTrigger>
-      <PopoverContentDialogAware className='w-72 p-0' align='start'>
+      <PopoverContentDialogAware className='p-0' align='start'>
         <AppAccountPicker
           appId={appId}
           value={value}

--- a/apps/web/src/components/apps/ui/app-with-status-icon.tsx
+++ b/apps/web/src/components/apps/ui/app-with-status-icon.tsx
@@ -23,6 +23,8 @@ export interface AppConnectionStatusOption {
   label: string
   /** Tailwind background class for the dot, or `null` to skip the overlay. */
   color: string | null
+  /** Tailwind text color class for inline labels referencing this status. */
+  textColor?: string
   icon: LucideIcon
 }
 
@@ -34,10 +36,15 @@ export interface AppConnectionStatusOption {
  */
 export const appConnectionStatusOptions: Record<AppConnectionStatus, AppConnectionStatusOption> = {
   connected: { label: 'Connected', color: 'bg-green-500', icon: Check },
-  expired: { label: 'Expired', color: 'bg-amber-500', icon: Clock },
-  unbound: { label: 'Not set', color: 'bg-amber-500', icon: Minus },
-  gone: { label: 'Disconnected', color: 'bg-red-500', icon: X },
-  not_connected: { label: 'Disconnected', color: 'bg-red-500', icon: Plug },
+  expired: { label: 'Expired', color: 'bg-amber-500', textColor: 'text-amber-600', icon: Clock },
+  unbound: { label: 'Not set', color: 'bg-amber-500', textColor: 'text-amber-600', icon: Minus },
+  gone: { label: 'Disconnected', color: 'bg-red-500', textColor: 'text-red-600', icon: X },
+  not_connected: {
+    label: 'Disconnected',
+    color: 'bg-red-500',
+    textColor: 'text-red-600',
+    icon: Plug,
+  },
   none: { label: '', color: null, icon: Minus },
 }
 

--- a/apps/web/src/components/apps/ui/credential-badge.tsx
+++ b/apps/web/src/components/apps/ui/credential-badge.tsx
@@ -27,8 +27,9 @@ interface CredentialBadgeProps {
 export function CredentialBadge({ credId, onPick }: CredentialBadgeProps) {
   const bound = useBoundCredential(credId)
   const { status } = bound
-  const dotColor =
-    appConnectionStatusOptions[status === 'none' ? 'unbound' : status].color ?? 'bg-muted'
+  const textColor =
+    appConnectionStatusOptions[status === 'none' ? 'unbound' : status].textColor ??
+    'text-muted-foreground'
 
   const label = renderLabel(bound.status, bound.label)
   const tooltip = renderTooltip(bound)
@@ -48,8 +49,15 @@ export function CredentialBadge({ credId, onPick }: CredentialBadgeProps) {
             }
           : undefined
       }>
-      <span className={cn('inline-block size-1.5 rounded-full', dotColor)} />
-      <span className='truncate max-w-[160px]'>{label}</span>
+      {/* <span className={cn('inline-block size-1.5 rounded-full', dotColor)} /> */}
+      <span
+        className={cn(
+          'text-sm  truncate max-w-[160px]',
+          textColor,
+          interactive && 'hover:underline'
+        )}>
+        {label}
+      </span>
     </span>
   )
 
@@ -71,7 +79,7 @@ function renderLabel(status: BoundCredentialStatus, label: string | null): strin
     case 'not_connected':
       return 'Disconnected'
     case 'unbound':
-      return 'Not set'
+      return 'Make connection'
   }
 }
 

--- a/packages/sdk/src/root/tools/types.ts
+++ b/packages/sdk/src/root/tools/types.ts
@@ -140,5 +140,23 @@ export interface ToolExecuteContext {
       source: string
       externalId: string
     }) => Promise<{ recordId: string; displayName: string | null } | null>
+    /**
+     * Lookup helper for `refs.entity('contact')` resolution by primary email.
+     * Used by integrations that don't have a contact-import source path
+     * (e.g. Slack, Gmail). See plans/kopilot/apps/slack-overhaul.md §6 and
+     * refs.md §9.
+     */
+    findContactByEmail: (input: {
+      email: string
+    }) => Promise<{ recordId: string; displayName: string | null } | null>
+    /**
+     * Lookup helper for `refs.entity('contact')` resolution by primary phone.
+     * Input is normalized to E.164 server-side and matched against any
+     * PHONE_INTL-type contact field. Used by phone-keyed integrations
+     * (WhatsApp, Twilio). See plans/kopilot/apps/whatsapp-overhaul.md §6.
+     */
+    findContactByPhone: (input: {
+      phone: string
+    }) => Promise<{ recordId: string; displayName: string | null } | null>
   }
 }


### PR DESCRIPTION
## Summary
- Add `/api/v1/sdk/entities/find-contact-by-email` and `find-contact-by-phone` callbacks so AI tools (Slack, WhatsApp) can resolve `refs.entity('contact')` without a contact-import source path
- Fan webhook trigger dispatch out to both the workflow queue and the new agents queue (one emit → two consumers)
- Expose `findContactByEmail` / `findContactByPhone` on the SDK `ToolExecuteContext.entities`
- Polish app account UI: smaller dialog, separator above user accounts, text-only status label colored per `appConnectionStatusOptions.textColor`, "Make connection" copy for unbound badges

## Test plan
- [ ] Slack tool calling `refs.entity('contact')` by email resolves to a recordId
- [ ] WhatsApp tool calling `refs.entity('contact')` by phone (E.164 + un-normalized) resolves to a recordId
- [ ] Webhook with a `triggerId` enqueues both `dispatchAppTrigger` and `dispatchAppTriggerToAgents`
- [ ] App account popover/dialog/badge visually match the new spacing and colors