### PR TITLE
fix(sdk): make WorkflowExecuteFunction ctx required

### DIFF
--- a/packages/sdk/src/root/workflow/types.ts
+++ b/packages/sdk/src/root/workflow/types.ts
@@ -285,13 +285,14 @@ export interface WorkflowExecuteContext {
 /**
  * Execute function signature for workflow blocks.
  *
- * The `ctx` arg is optional — most blocks ignore it and reach the server
- * SDK via global imports (`@auxx/sdk/server`). Router-style blocks that
- * carry a `toolMap` use `ctx.runTool(toolId, input)` to dispatch.
+ * `ctx` is always injected by the runtime — blocks that don't need it
+ * can omit the parameter (TypeScript allows shorter-arity functions to
+ * satisfy this signature). Router-style blocks with a `toolMap` use
+ * `ctx.runTool(toolId, input)` to dispatch.
  */
 export type WorkflowExecuteFunction<TSchema extends WorkflowSchema = WorkflowSchema> = (
   input: InferWorkflowInput<TSchema>,
-  ctx?: WorkflowExecuteContext
+  ctx: WorkflowExecuteContext
 ) => Promise<InferWorkflowOutput<TSchema>>
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #631. That PR shipped \`ctx?: WorkflowExecuteContext\`
(optional), but apps that declare ctx as a required parameter — e.g.
the quickbooks block dispatcher \`(input, ctx) => ctx.runTool(...)\` —
still can't be assigned to a slot expecting an optional ctx, because
TypeScript's function-arg contravariance says a caller might legally
invoke the slot with one arg.

Concretely, this error remained after #631 merged:

\`\`\`
Type '(input: Record<string, any>, ctx: { runTool: ... }) => Promise<...>'
  is not assignable to type 'WorkflowExecuteFunction<...>'.
    Target signature provides too few arguments. Expected 2 or more, but got 1.
\`\`\`

Make \`ctx\` required. Function arity in TS is forgiving in the other
direction: \`(input) => ...\` still satisfies \`(input, ctx) => ...\`,
so blocks that ignore ctx keep their single-arg shape unchanged.

## Test plan

- [ ] \`npx tsc --noEmit\` in \`apps/quickbooks\` (linked to this SDK)
      passes — verified locally.
- [ ] Other apps that don't reference ctx still typecheck (the
      shorter-arity path).