### PR TITLE
feat(agents): app-kind triggers in agent UI

### DIFF
--- a/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
@@ -11,7 +11,7 @@ import {
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Section } from '@auxx/ui/components/section'
 import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
-import { BookOpen, Clock, FileText, Plus, Wrench, Zap } from 'lucide-react'
+import { BookOpen, Clock, FileText, Plug, Plus, Wrench, Zap } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AGENT_TABS, type AgentTab, DEFAULT_AGENT_TAB } from '../../constant'
@@ -55,7 +55,7 @@ interface AgentDetailTabsProps {
  */
 export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProps) {
   const [tab, setTab] = useQueryState('tab', { defaultValue: DEFAULT_AGENT_TAB })
-  const [addingKind, setAddingKind] = useState<'scheduled' | 'event' | null>(null)
+  const [addingKind, setAddingKind] = useState<'scheduled' | 'event' | 'app' | null>(null)
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const sectionRefs = useRef<Record<AgentTab, HTMLDivElement | null>>({
     prompt: null,
@@ -206,6 +206,10 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
                   <DropdownMenuItem onClick={() => setAddingKind('event')}>
                     <Zap />
                     Event
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setAddingKind('app')}>
+                    <Plug />
+                    App
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/apps/web/src/components/agents/ui/detail/triggers/agent-app-trigger-picker-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/agent-app-trigger-picker-dialog.tsx
@@ -1,0 +1,268 @@
+// apps/web/src/components/agents/ui/detail/triggers/agent-app-trigger-picker-dialog.tsx
+'use client'
+
+import type { CatalogTriggerProjection } from '@auxx/database'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Separator } from '@auxx/ui/components/separator'
+import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
+import { pluralize } from '@auxx/utils/strings'
+import { ChevronLeft } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type AppInstallation,
+  useExtensionsContext,
+} from '~/providers/extensions/extensions-context'
+import { ToolSelectRow } from '../tools/tool-select-row'
+
+export interface AppTriggerSelection {
+  installation: AppInstallation
+  trigger: CatalogTriggerProjection
+}
+
+interface AgentAppTriggerPickerDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (selection: AppTriggerSelection) => void
+}
+
+type ViewMode = 'list' | 'app-detail'
+type ListTab = 'all' | 'apps'
+
+/**
+ * Picker dialog for selecting an (app, trigger) pair from installed apps that
+ * expose `agentTriggers` in their catalog. Mirrors the toolset picker shell —
+ * tabs for All / Apps, plus an App-detail view. On select, fires `onSelect`
+ * with the installation + trigger projection so the parent can open the
+ * agent-trigger config dialog pre-filled.
+ */
+export function AgentAppTriggerPickerDialog({
+  open,
+  onOpenChange,
+  onSelect,
+}: AgentAppTriggerPickerDialogProps) {
+  const { appInstallations, isLoading } = useExtensionsContext()
+
+  const [viewMode, setViewMode] = useState<ViewMode>('list')
+  const [tab, setTab] = useState<ListTab>('all')
+  const [selectedAppId, setSelectedAppId] = useState<string | null>(null)
+  const [search, setSearch] = useState('')
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (open) {
+      setViewMode('list')
+      setTab('all')
+      setSelectedAppId(null)
+      setSearch('')
+    }
+  }, [open])
+
+  const appsWithTriggers = useMemo(
+    () => appInstallations.filter((i) => (i.agentTriggers?.length ?? 0) > 0),
+    [appInstallations]
+  )
+
+  const flat = useMemo(() => {
+    const out: Array<{ installation: AppInstallation; trigger: CatalogTriggerProjection }> = []
+    for (const inst of appsWithTriggers) {
+      for (const trigger of inst.agentTriggers ?? []) {
+        out.push({ installation: inst, trigger })
+      }
+    }
+    return out
+  }, [appsWithTriggers])
+
+  const filteredFlat = useMemo(() => {
+    if (!search.trim()) return flat
+    const q = search.trim().toLowerCase()
+    return flat.filter(
+      (e) =>
+        e.trigger.label.toLowerCase().includes(q) ||
+        (e.trigger.description ?? '').toLowerCase().includes(q) ||
+        e.installation.app.title.toLowerCase().includes(q)
+    )
+  }, [flat, search])
+
+  const filteredApps = useMemo(() => {
+    if (!search.trim()) return appsWithTriggers
+    const q = search.trim().toLowerCase()
+    return appsWithTriggers.filter((i) => i.app.title.toLowerCase().includes(q))
+  }, [appsWithTriggers, search])
+
+  const selectedApp = useMemo(
+    () => (selectedAppId ? appsWithTriggers.find((i) => i.app.id === selectedAppId) : null),
+    [appsWithTriggers, selectedAppId]
+  )
+
+  const handleOpenApp = (installation: AppInstallation) => {
+    setSelectedAppId(installation.app.id)
+    setViewMode('app-detail')
+    setSearch('')
+  }
+
+  const handleBack = () => {
+    setViewMode('list')
+    setTab('apps')
+    setSelectedAppId(null)
+    setSearch('')
+  }
+
+  const handlePick = (installation: AppInstallation, trigger: CatalogTriggerProjection) => {
+    onSelect({ installation, trigger })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className='h-dvh sm:h-[600px]'
+        innerClassName='p-0'
+        position='tc'
+        size='lg'
+        onOpenAutoFocus={(e) => {
+          e.preventDefault()
+          searchInputRef.current?.focus()
+        }}>
+        <div className='flex flex-1 flex-col min-h-0'>
+          {viewMode === 'list' ? (
+            <>
+              <DialogHeader className='mb-0 flex h-10 flex-row items-center justify-between border-b px-3'>
+                <div>
+                  <Button variant='ghost' size='sm'>
+                    Add app trigger
+                  </Button>
+                  <DialogTitle className='sr-only'>Add app trigger</DialogTitle>
+                  <DialogDescription className='sr-only'>
+                    Pick a trigger from one of your installed apps to fire this agent.
+                  </DialogDescription>
+                </div>
+              </DialogHeader>
+
+              <div className='flex items-center justify-between gap-2 border-b px-3 py-2'>
+                <Tabs value={tab} onValueChange={(v) => setTab(v as ListTab)}>
+                  <TabsList>
+                    <TabsTrigger value='all'>All</TabsTrigger>
+                    <TabsTrigger value='apps'>Apps</TabsTrigger>
+                  </TabsList>
+                </Tabs>
+                <div className='flex-1 max-w-xs'>
+                  <InputSearch
+                    ref={searchInputRef}
+                    placeholder='Search triggers...'
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    onClear={() => setSearch('')}
+                  />
+                </div>
+              </div>
+
+              <ScrollArea className='flex-1' scrollbarClassName='w-1!'>
+                <div className='py-3 px-3'>
+                  {isLoading ? (
+                    <div className='py-12 text-center text-sm text-muted-foreground'>Loading…</div>
+                  ) : tab === 'all' ? (
+                    filteredFlat.length === 0 ? (
+                      <EmptyResult search={search} />
+                    ) : (
+                      <div className='space-y-1'>
+                        {filteredFlat.map((entry) => (
+                          <ToolSelectRow
+                            key={`${entry.installation.installationId}:${entry.trigger.triggerId}`}
+                            id={`${entry.installation.installationId}:${entry.trigger.triggerId}`}
+                            iconId={entry.installation.app.avatarUrl ?? 'package'}
+                            color={null}
+                            label={entry.trigger.label}
+                            description={entry.trigger.description}
+                            subtitle={entry.installation.app.title}
+                            installed={false}
+                            onSelect={() => handlePick(entry.installation, entry.trigger)}
+                          />
+                        ))}
+                      </div>
+                    )
+                  ) : filteredApps.length === 0 ? (
+                    <EmptyResult search={search} />
+                  ) : (
+                    <div className='space-y-1'>
+                      {filteredApps.map((inst) => {
+                        const triggerCount = inst.agentTriggers?.length ?? 0
+                        return (
+                          <ToolSelectRow
+                            key={inst.installationId}
+                            id={inst.installationId}
+                            iconId={inst.app.avatarUrl ?? 'package'}
+                            color={null}
+                            label={inst.app.title}
+                            subtitle={`${triggerCount} ${pluralize(triggerCount, 'trigger')}`}
+                            installed={false}
+                            onSelect={() => handleOpenApp(inst)}
+                          />
+                        )
+                      })}
+                    </div>
+                  )}
+                </div>
+              </ScrollArea>
+            </>
+          ) : selectedApp ? (
+            <>
+              <DialogHeader className='mb-0 flex h-10 flex-row items-center border-b px-3'>
+                <div className='flex items-center gap-1'>
+                  <Button variant='ghost' size='sm' onClick={handleBack}>
+                    <ChevronLeft />
+                    Back
+                  </Button>
+                  <Separator orientation='vertical' className='h-5' />
+                  <Button variant='ghost' size='sm'>
+                    {selectedApp.app.title}
+                  </Button>
+                  <DialogTitle className='sr-only'>{selectedApp.app.title}</DialogTitle>
+                  <DialogDescription className='sr-only'>
+                    Triggers exposed by {selectedApp.app.title}.
+                  </DialogDescription>
+                </div>
+              </DialogHeader>
+
+              <ScrollArea className='flex-1' scrollbarClassName='w-1!'>
+                <div className='p-3 space-y-1'>
+                  {(selectedApp.agentTriggers ?? []).map((trigger) => (
+                    <ToolSelectRow
+                      key={trigger.triggerId}
+                      id={trigger.triggerId}
+                      iconId={selectedApp.app.avatarUrl ?? 'package'}
+                      color={null}
+                      label={trigger.label}
+                      description={trigger.description}
+                      installed={false}
+                      onSelect={() => handlePick(selectedApp, trigger)}
+                    />
+                  ))}
+                </div>
+              </ScrollArea>
+            </>
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function EmptyResult({ search }: { search: string }) {
+  return (
+    <div className='flex flex-col items-center justify-center py-12 text-center'>
+      <p className='text-sm text-muted-foreground'>
+        {search.trim()
+          ? `No triggers match "${search}".`
+          : 'No installed apps expose agent triggers yet.'}
+      </p>
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/triggers/agent-trigger-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/agent-trigger-dialog.tsx
@@ -3,6 +3,7 @@
 
 import { isNonEmptyDoc, type TiptapDoc } from '@auxx/lib/tiptap'
 import { Button } from '@auxx/ui/components/button'
+import { Checkbox } from '@auxx/ui/components/checkbox'
 import {
   Dialog,
   DialogContent,
@@ -12,7 +13,9 @@ import {
   DialogTitle,
 } from '@auxx/ui/components/dialog'
 import { Field, FieldLabel } from '@auxx/ui/components/field'
+import { Input } from '@auxx/ui/components/input'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { Field as ResourceField } from '@auxx/ui/components/section'
 import {
@@ -24,8 +27,10 @@ import {
 } from '@auxx/ui/components/select'
 import { toastError } from '@auxx/ui/components/toast'
 import type { JSONContent } from '@tiptap/core'
-import { Trash2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { ChevronDown, Trash2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { AppAccountPicker } from '~/components/apps/ui/app-account-picker'
+import { AppIcon } from '~/components/apps/ui/app-icon'
 import { DEFAULT_TABS } from '~/components/editor/inline-picker'
 import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
 import { PromptEditor } from '~/components/editor/prompt-editor'
@@ -33,6 +38,7 @@ import { ResourcePicker } from '~/components/pickers/resource-picker'
 import { useResources } from '~/components/resources/hooks/use-resources'
 import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useExtensionsContext } from '~/providers/extensions/extensions-context'
 import { api, type RouterOutputs } from '~/trpc/react'
 import { TriggerCronEditor } from './trigger-cron-editor'
 import { type Interval, TriggerIntervalSelector } from './trigger-interval-selector'
@@ -47,6 +53,10 @@ const KIND_COPY: Record<Kind, { label: string; description: string }> = {
   event: {
     label: 'event',
     description: 'Fire this agent when a resource is created, updated, or deleted.',
+  },
+  app: {
+    label: 'app',
+    description: 'Fire this agent when an installed app emits a trigger event.',
   },
   mention: {
     label: 'mention',
@@ -72,7 +82,7 @@ function readPromptContent(doc: TiptapDoc | null | undefined): JSONContent[] | n
 
 type Trigger = RouterOutputs['agentTrigger']['list'][number]
 
-type Kind = 'scheduled' | 'event' | 'mention' | 'assignment' | 'dm'
+type Kind = 'scheduled' | 'event' | 'app' | 'mention' | 'assignment' | 'dm'
 type ScheduledMode = 'simple' | 'cron'
 type CrudTriggerType = 'created' | 'updated' | 'deleted'
 
@@ -91,6 +101,20 @@ interface AgentTriggerDialogProps {
   kind: Kind
   /** When provided, dialog is in edit mode for this trigger. */
   trigger?: Trigger
+  /**
+   * Pre-selected app + trigger metadata when opening for a new `app` kind.
+   * Required to render the header chip and inputs form before the row exists.
+   */
+  appSelection?: {
+    installationId: string
+    appId: string
+    appTitle: string
+    appAvatarUrl: string | null
+    triggerId: string
+    triggerLabel: string
+    triggerDescription?: string
+    inputsJsonSchema: Record<string, unknown>
+  }
   onSuccess?: () => void
 }
 
@@ -116,6 +140,17 @@ interface EventState {
 const DEFAULT_EVENT_STATE: EventState = {
   triggerType: 'created',
   entityDefinitionId: 'ticket',
+}
+
+interface AppState {
+  /** `null` means "any connection". */
+  connectionId: string | null
+  userInputs: Record<string, unknown>
+}
+
+const DEFAULT_APP_STATE: AppState = {
+  connectionId: null,
+  userInputs: {},
 }
 
 function scheduledFromTrigger(trigger: Trigger): ScheduledState {
@@ -146,10 +181,76 @@ function eventStateFromTrigger(trigger: Trigger, fallbackEntityId: string): Even
   }
 }
 
+function appStateFromTrigger(trigger: Trigger): AppState {
+  const config = (trigger.config as Record<string, unknown> | null) ?? {}
+  const userInputsRaw = (config.userInputs as Record<string, unknown> | undefined) ?? {}
+  return {
+    connectionId: trigger.triggerConnectionId ?? null,
+    userInputs: { ...userInputsRaw },
+  }
+}
+
+interface SelectOption {
+  value: string
+  label: string
+}
+
+interface FieldNodeMetadata {
+  label?: string
+  description?: string
+  placeholder?: string
+  multi?: boolean
+  defaultValue?: unknown
+  options?: SelectOption[]
+}
+
+interface FieldNode {
+  type: string
+  isOptional?: boolean
+  _metadata?: FieldNodeMetadata
+}
+
+interface FieldEntry {
+  key: string
+  node: FieldNode
+  meta: FieldNodeMetadata
+  required: boolean
+}
+
+function readFieldNodes(schema: Record<string, unknown> | null | undefined): FieldEntry[] {
+  if (!schema) return []
+  const entries: FieldEntry[] = []
+  for (const [key, raw] of Object.entries(schema)) {
+    if (!raw || typeof raw !== 'object') continue
+    const node = raw as FieldNode
+    if (typeof node.type !== 'string') continue
+    const meta = node._metadata ?? {}
+    entries.push({ key, node, meta, required: node.isOptional !== true })
+  }
+  return entries
+}
+
+function isMissing(value: unknown): boolean {
+  if (value == null) return true
+  if (typeof value === 'string') return value.trim() === ''
+  if (Array.isArray(value)) return value.length === 0
+  return false
+}
+
+function seedDefaults(fields: FieldEntry[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const { key, meta } of fields) {
+    if (meta.defaultValue !== undefined) {
+      out[key] = meta.defaultValue
+    }
+  }
+  return out
+}
+
 /**
  * Dialog for creating or editing an agent trigger. The `kind` is selected
  * upstream (from the section-header dropdown) and is immutable in this
- * dialog. `app` triggers cannot be edited here.
+ * dialog.
  */
 export function AgentTriggerDialog({
   open,
@@ -157,15 +258,43 @@ export function AgentTriggerDialog({
   agentId,
   kind,
   trigger,
+  appSelection,
   onSuccess,
 }: AgentTriggerDialogProps) {
   const isEditMode = !!trigger
-  const isAppKind = trigger?.kind === 'app'
-  const effectiveKind: Kind =
-    isEditMode && trigger && trigger.kind !== 'app' ? (trigger.kind as Kind) : kind
+  const effectiveKind: Kind = isEditMode && trigger ? (trigger.kind as Kind) : kind
   const kindCopy = KIND_COPY[effectiveKind]
   const isBuiltinKind =
     effectiveKind === 'mention' || effectiveKind === 'assignment' || effectiveKind === 'dm'
+  const isAppKind = effectiveKind === 'app'
+
+  const { appInstallations, appConnections } = useExtensionsContext()
+
+  // For app-kind edit: resolve the installation + trigger projection from the
+  // cache envelope so we can render header chip + inputs form.
+  const appContext = useMemo(() => {
+    if (!isAppKind) return null
+    if (appSelection) {
+      return appSelection
+    }
+    if (!trigger) return null
+    const installation =
+      appInstallations.find((i) => i.installationId === trigger.triggerInstallationId) ??
+      appInstallations.find((i) => i.app.id === trigger.triggerAppId)
+    const triggerProj = installation?.agentTriggers?.find(
+      (t) => t.triggerId === trigger.triggerAppTriggerId
+    )
+    return {
+      installationId: installation?.installationId ?? trigger.triggerInstallationId ?? '',
+      appId: trigger.triggerAppId ?? installation?.app.id ?? '',
+      appTitle: installation?.app.title ?? trigger.triggerAppId ?? 'App',
+      appAvatarUrl: installation?.app.avatarUrl ?? null,
+      triggerId: trigger.triggerAppTriggerId ?? '',
+      triggerLabel: triggerProj?.label ?? trigger.triggerAppTriggerId ?? '',
+      triggerDescription: triggerProj?.description,
+      inputsJsonSchema: (triggerProj?.inputsJsonSchema as Record<string, unknown>) ?? {},
+    }
+  }, [isAppKind, appSelection, trigger, appInstallations])
 
   const { resources } = useResources()
   const fallbackEntityId = resources[0]?.id ?? 'ticket'
@@ -173,8 +302,10 @@ export function AgentTriggerDialog({
   const [confirm, ConfirmDialog] = useConfirm()
   const [scheduledState, setScheduledState] = useState<ScheduledState>(DEFAULT_SCHEDULED_STATE)
   const [eventState, setEventState] = useState<EventState>(DEFAULT_EVENT_STATE)
+  const [appState, setAppState] = useState<AppState>(DEFAULT_APP_STATE)
   const [instructions, setInstructions] = useState<TiptapDoc>(emptyPromptDoc)
   const [editorKey, setEditorKey] = useState(0)
+  const [accountPopoverOpen, setAccountPopoverOpen] = useState(false)
 
   useEffect(() => {
     if (!open) return
@@ -182,9 +313,15 @@ export function AgentTriggerDialog({
       setScheduledState(scheduledFromTrigger(trigger))
     } else if (trigger?.kind === 'event') {
       setEventState(eventStateFromTrigger(trigger, fallbackEntityId))
+    } else if (trigger?.kind === 'app') {
+      setAppState(appStateFromTrigger(trigger))
     } else {
       setScheduledState(DEFAULT_SCHEDULED_STATE)
       setEventState({ ...DEFAULT_EVENT_STATE, entityDefinitionId: fallbackEntityId })
+      setAppState({
+        connectionId: null,
+        userInputs: seedDefaults(readFieldNodes(appSelection?.inputsJsonSchema)),
+      })
     }
     const raw = trigger?.instructions as unknown
     if (raw && typeof raw === 'object' && Array.isArray((raw as TiptapDoc).content)) {
@@ -193,7 +330,7 @@ export function AgentTriggerDialog({
       setInstructions(emptyPromptDoc())
     }
     setEditorKey((k) => k + 1)
-  }, [open, trigger, fallbackEntityId])
+  }, [open, trigger, fallbackEntityId, appSelection?.inputsJsonSchema])
 
   const setScheduledMode = (mode: ScheduledMode) =>
     setScheduledState((prev) => ({
@@ -243,6 +380,11 @@ export function AgentTriggerDialog({
     if (confirmed) destroy.mutate({ id: trigger.id })
   }
 
+  const fieldNodes = useMemo(
+    () => readFieldNodes(appContext?.inputsJsonSchema),
+    [appContext?.inputsJsonSchema]
+  )
+
   const buildTriggerInput = () => {
     if (effectiveKind === 'scheduled') {
       if (scheduledState.mode === 'cron') {
@@ -281,6 +423,27 @@ export function AgentTriggerDialog({
       return { kind: 'dm' as const }
     }
 
+    if (effectiveKind === 'app') {
+      if (!appContext || !appContext.appId || !appContext.triggerId || !appContext.installationId) {
+        toastError({ title: 'App trigger metadata is missing' })
+        return null
+      }
+      for (const { key, required, meta } of fieldNodes) {
+        if (required && isMissing(appState.userInputs[key])) {
+          toastError({ title: `"${meta.label ?? key}" is required` })
+          return null
+        }
+      }
+      return {
+        kind: 'app' as const,
+        triggerAppId: appContext.appId,
+        triggerAppTriggerId: appContext.triggerId,
+        triggerInstallationId: appContext.installationId,
+        triggerConnectionId: appState.connectionId ?? undefined,
+        userInputs: appState.userInputs,
+      }
+    }
+
     if (!eventState.entityDefinitionId) {
       toastError({ title: 'Pick a resource' })
       return null
@@ -315,6 +478,11 @@ export function AgentTriggerDialog({
     })
   }
 
+  const selectedConnection = useMemo(() => {
+    if (!appState.connectionId) return null
+    return appConnections.find((c) => c.id === appState.connectionId) ?? null
+  }, [appState.connectionId, appConnections])
+
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
@@ -326,104 +494,190 @@ export function AgentTriggerDialog({
             <DialogDescription>{kindCopy.description}</DialogDescription>
           </DialogHeader>
 
-          {isAppKind ? (
-            <div className='rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground'>
-              App triggers can't be edited here. Manage them from the app catalog.
-            </div>
-          ) : (
-            <div className='space-y-4'>
-              {effectiveKind === 'scheduled' ? (
-                <>
-                  <Field orientation='horizontal'>
-                    <FieldLabel>Mode</FieldLabel>
-                    <RadioTab
-                      value={scheduledState.mode}
-                      onValueChange={(v) => setScheduledMode(v as ScheduledMode)}
-                      size='sm'>
-                      <RadioTabItem value='simple' size='sm'>
-                        Simple
-                      </RadioTabItem>
-                      <RadioTabItem value='cron' size='sm'>
-                        Cron
-                      </RadioTabItem>
-                    </RadioTab>
-                  </Field>
+          <div className='space-y-4'>
+            {effectiveKind === 'scheduled' ? (
+              <>
+                <Field orientation='horizontal'>
+                  <FieldLabel>Mode</FieldLabel>
+                  <RadioTab
+                    value={scheduledState.mode}
+                    onValueChange={(v) => setScheduledMode(v as ScheduledMode)}
+                    size='sm'>
+                    <RadioTabItem value='simple' size='sm'>
+                      Simple
+                    </RadioTabItem>
+                    <RadioTabItem value='cron' size='sm'>
+                      Cron
+                    </RadioTabItem>
+                  </RadioTab>
+                </Field>
 
-                  {scheduledState.mode === 'cron' ? (
-                    <TriggerCronEditor
-                      value={scheduledState.customCron}
-                      onChange={(customCron) =>
-                        setScheduledState((prev) => ({ ...prev, customCron }))
-                      }
+                {scheduledState.mode === 'cron' ? (
+                  <TriggerCronEditor
+                    value={scheduledState.customCron}
+                    onChange={(customCron) =>
+                      setScheduledState((prev) => ({ ...prev, customCron }))
+                    }
+                  />
+                ) : (
+                  <TriggerIntervalSelector
+                    interval={scheduledState.interval}
+                    value={scheduledState.value}
+                    onIntervalChange={(interval) =>
+                      setScheduledState((prev) => ({ ...prev, interval }))
+                    }
+                    onValueChange={(value) => setScheduledState((prev) => ({ ...prev, value }))}
+                  />
+                )}
+              </>
+            ) : effectiveKind === 'event' ? (
+              <ResourceField
+                title='Resource'
+                description='Select the operation and type of resource for this trigger'>
+                <VarEditorField className='px-0.5'>
+                  <div className='flex flex-row'>
+                    <div>
+                      <Select
+                        value={eventState.triggerType}
+                        onValueChange={(v) => setEventField('triggerType', v as CrudTriggerType)}>
+                        <SelectTrigger variant='outline' size='xs'>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {Object.entries(RESOURCE_OPERATIONS).map(([key, config]) => (
+                            <SelectItem key={key} value={key}>
+                              {config.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className='flex-1'>
+                      <ResourcePicker
+                        value={eventState.entityDefinitionId ? [eventState.entityDefinitionId] : []}
+                        onChange={(selected) =>
+                          setEventField('entityDefinitionId', selected[0] ?? '')
+                        }
+                        triggerProps={{ variant: 'transparent', className: 'w-full h-6 pe-2' }}
+                        emptyLabel='Select resource...'
+                      />
+                    </div>
+                  </div>
+                </VarEditorField>
+              </ResourceField>
+            ) : effectiveKind === 'app' && appContext ? (
+              <>
+                <Field orientation='vertical'>
+                  <FieldLabel>Trigger</FieldLabel>
+                  <div className='flex items-center gap-3 rounded-md border bg-muted/30 px-3 py-2'>
+                    <AppIcon
+                      iconId={appContext.appAvatarUrl ?? 'package'}
+                      size='lg'
+                      className='border border-foreground/5'
                     />
-                  ) : (
-                    <TriggerIntervalSelector
-                      interval={scheduledState.interval}
-                      value={scheduledState.value}
-                      onIntervalChange={(interval) =>
-                        setScheduledState((prev) => ({ ...prev, interval }))
-                      }
-                      onValueChange={(value) => setScheduledState((prev) => ({ ...prev, value }))}
-                    />
-                  )}
-                </>
-              ) : effectiveKind === 'event' ? (
-                <ResourceField
-                  title='Resource'
-                  description='Select the operation and type of resource for this trigger'>
-                  <VarEditorField className='px-0.5'>
-                    <div className='flex flex-row'>
-                      <div>
-                        <Select
-                          value={eventState.triggerType}
-                          onValueChange={(v) => setEventField('triggerType', v as CrudTriggerType)}>
-                          <SelectTrigger variant='outline' size='xs'>
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {Object.entries(RESOURCE_OPERATIONS).map(([key, config]) => (
-                              <SelectItem key={key} value={key}>
-                                {config.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <div className='flex-1'>
-                        <ResourcePicker
-                          value={
-                            eventState.entityDefinitionId ? [eventState.entityDefinitionId] : []
-                          }
-                          onChange={(selected) =>
-                            setEventField('entityDefinitionId', selected[0] ?? '')
-                          }
-                          triggerProps={{ variant: 'transparent', className: 'w-full h-6 pe-2' }}
-                          emptyLabel='Select resource...'
+                    <div className='flex min-w-0 flex-col'>
+                      <span className='truncate text-sm font-medium'>
+                        {appContext.appTitle} · {appContext.triggerLabel}
+                      </span>
+                      {appContext.triggerDescription && (
+                        <span className='truncate text-xs text-muted-foreground'>
+                          {appContext.triggerDescription}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </Field>
+
+                <Field orientation='vertical'>
+                  <FieldLabel>Connection</FieldLabel>
+                  <Popover open={accountPopoverOpen} onOpenChange={setAccountPopoverOpen}>
+                    <PopoverTrigger asChild>
+                      <Button
+                        type='button'
+                        variant='outline'
+                        size='sm'
+                        className='w-full justify-between'>
+                        {selectedConnection ? (
+                          <span className='flex min-w-0 items-center gap-2'>
+                            <AppIcon iconId={appContext.appAvatarUrl ?? 'package'} size='sm' />
+                            <span className='truncate'>
+                              {selectedConnection.label ?? selectedConnection.appName}
+                            </span>
+                          </span>
+                        ) : (
+                          <span className='truncate'>Any connection</span>
+                        )}
+                        <ChevronDown className='size-3.5 text-muted-foreground' />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className='p-1 w-[--radix-popover-trigger-width]' align='start'>
+                      <div className='space-y-1'>
+                        <button
+                          type='button'
+                          className='flex w-full items-center rounded-sm px-2 py-1.5 text-sm hover:bg-primary-100/80'
+                          onClick={() => {
+                            setAppState((prev) => ({ ...prev, connectionId: null }))
+                            setAccountPopoverOpen(false)
+                          }}>
+                          Any connection
+                        </button>
+                        <AppAccountPicker
+                          appId={appContext.appId}
+                          value={appState.connectionId ?? undefined}
+                          onPick={(credId) => {
+                            setAppState((prev) => ({ ...prev, connectionId: credId }))
+                            setAccountPopoverOpen(false)
+                          }}
+                          onConnected={(credId) => {
+                            setAppState((prev) => ({ ...prev, connectionId: credId }))
+                            setAccountPopoverOpen(false)
+                          }}
                         />
                       </div>
-                    </div>
-                  </VarEditorField>
-                </ResourceField>
-              ) : null}
+                    </PopoverContent>
+                  </Popover>
+                </Field>
 
-              <Field orientation='vertical'>
-                <FieldLabel>Instructions</FieldLabel>
-                <div className='rounded-md flex flex-col border bg-background min-h-[160px] px-3 py-2'>
-                  <PromptEditor
-                    key={editorKey}
-                    initialContent={readPromptContent(instructions)}
-                    onChange={({ json }) => setInstructions(json as TiptapDoc)}
-                    referenceTabs={TEMPLATE_REFERENCE_TABS}
-                    placeholderText='Write your instructions here'
-                  />
-                  <div className='flex text-sm gap-1 text-muted-foreground mt-2'>
-                    Type <Kbd variant='outline'>@</Kbd> to specify tools or{' '}
-                    <Kbd variant='outline'>/</Kbd> for formatting.
-                  </div>
+                {fieldNodes.length > 0 && (
+                  <Field orientation='vertical'>
+                    <FieldLabel>Inputs</FieldLabel>
+                    <div className='space-y-3'>
+                      {fieldNodes.map((entry) => (
+                        <AppInputField
+                          key={entry.key}
+                          entry={entry}
+                          value={appState.userInputs[entry.key]}
+                          onChange={(next) =>
+                            setAppState((prev) => ({
+                              ...prev,
+                              userInputs: { ...prev.userInputs, [entry.key]: next },
+                            }))
+                          }
+                        />
+                      ))}
+                    </div>
+                  </Field>
+                )}
+              </>
+            ) : null}
+
+            <Field orientation='vertical'>
+              <FieldLabel>Instructions</FieldLabel>
+              <div className='rounded-md flex flex-col border bg-background min-h-[160px] px-3 py-2'>
+                <PromptEditor
+                  key={editorKey}
+                  initialContent={readPromptContent(instructions)}
+                  onChange={({ json }) => setInstructions(json as TiptapDoc)}
+                  referenceTabs={TEMPLATE_REFERENCE_TABS}
+                  placeholderText='Write your instructions here'
+                />
+                <div className='flex text-sm gap-1 text-muted-foreground mt-2'>
+                  Type <Kbd variant='outline'>@</Kbd> to specify tools or{' '}
+                  <Kbd variant='outline'>/</Kbd> for formatting.
                 </div>
-              </Field>
-            </div>
-          )}
+              </div>
+            </Field>
+          </div>
 
           <DialogFooter className='flex sm:justify-between!'>
             {isEditMode && !isBuiltinKind ? (
@@ -453,7 +707,6 @@ export function AgentTriggerDialog({
                 variant='outline'
                 loading={isPending}
                 loadingText={isEditMode ? 'Updating...' : 'Adding...'}
-                disabled={isAppKind}
                 data-dialog-submit>
                 {isEditMode ? 'Update trigger' : 'Add trigger'}{' '}
                 <KbdSubmit variant='outline' size='sm' />
@@ -464,5 +717,163 @@ export function AgentTriggerDialog({
       </Dialog>
       <ConfirmDialog />
     </>
+  )
+}
+
+interface AppInputFieldProps {
+  entry: FieldEntry
+  value: unknown
+  onChange: (next: unknown) => void
+}
+
+function AppInputField({ entry, value, onChange }: AppInputFieldProps) {
+  const { key, node, meta, required } = entry
+  const inputId = `app-input-${key}`
+  const label = meta.label ?? key
+
+  const labelEl = (
+    <label className='text-xs text-muted-foreground' htmlFor={inputId}>
+      {label}
+      {required && <span className='text-red-500'>*</span>}
+    </label>
+  )
+
+  if (node.type === 'select') {
+    const options = meta.options ?? []
+    if (meta.multi) {
+      const selected = Array.isArray(value) ? (value as string[]) : []
+      const toggle = (optionValue: string, checked: boolean) => {
+        onChange(checked ? [...selected, optionValue] : selected.filter((v) => v !== optionValue))
+      }
+      return (
+        <div className='flex flex-col gap-1.5'>
+          {labelEl}
+          {options.length === 0 ? (
+            <span className='text-xs text-muted-foreground'>No options available.</span>
+          ) : (
+            <div className='space-y-1.5 rounded-md border bg-background px-3 py-2'>
+              {options.map((option) => {
+                const optionId = `${inputId}-${option.value}`
+                const checked = selected.includes(option.value)
+                return (
+                  <div key={option.value} className='flex items-center gap-2'>
+                    <Checkbox
+                      id={optionId}
+                      checked={checked}
+                      onCheckedChange={(next) => toggle(option.value, next === true)}
+                    />
+                    <label htmlFor={optionId} className='text-sm'>
+                      {option.label}
+                    </label>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+          {meta.description && (
+            <span className='text-xs text-muted-foreground'>{meta.description}</span>
+          )}
+        </div>
+      )
+    }
+    if (options.length === 0) {
+      return (
+        <div className='flex flex-col gap-1'>
+          {labelEl}
+          <Input
+            id={inputId}
+            value={typeof value === 'string' ? value : ''}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={meta.placeholder}
+          />
+          {meta.description && (
+            <span className='text-xs text-muted-foreground'>{meta.description}</span>
+          )}
+        </div>
+      )
+    }
+    return (
+      <div className='flex flex-col gap-1'>
+        {labelEl}
+        <Select value={typeof value === 'string' ? value : ''} onValueChange={(v) => onChange(v)}>
+          <SelectTrigger id={inputId} size='sm'>
+            <SelectValue placeholder={meta.placeholder ?? 'Select...'} />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {meta.description && (
+          <span className='text-xs text-muted-foreground'>{meta.description}</span>
+        )}
+      </div>
+    )
+  }
+
+  if (node.type === 'boolean') {
+    const checked = value === true
+    return (
+      <div className='flex items-start gap-2'>
+        <Checkbox
+          id={inputId}
+          checked={checked}
+          onCheckedChange={(next) => onChange(next === true)}
+        />
+        <div className='flex flex-col gap-0.5'>
+          <label htmlFor={inputId} className='text-sm'>
+            {label}
+            {required && <span className='text-red-500'>*</span>}
+          </label>
+          {meta.description && (
+            <span className='text-xs text-muted-foreground'>{meta.description}</span>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  if (node.type === 'number') {
+    return (
+      <div className='flex flex-col gap-1'>
+        {labelEl}
+        <Input
+          id={inputId}
+          type='number'
+          value={typeof value === 'number' || typeof value === 'string' ? String(value) : ''}
+          onChange={(e) => {
+            const raw = e.target.value
+            if (raw === '') {
+              onChange(undefined)
+              return
+            }
+            const parsed = Number(raw)
+            onChange(Number.isNaN(parsed) ? raw : parsed)
+          }}
+          placeholder={meta.placeholder}
+        />
+        {meta.description && (
+          <span className='text-xs text-muted-foreground'>{meta.description}</span>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex flex-col gap-1'>
+      {labelEl}
+      <Input
+        id={inputId}
+        value={typeof value === 'string' ? value : value == null ? '' : String(value)}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={meta.placeholder}
+      />
+      {meta.description && (
+        <span className='text-xs text-muted-foreground'>{meta.description}</span>
+      )}
+    </div>
   )
 }

--- a/apps/web/src/components/agents/ui/detail/triggers/trigger-label.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/trigger-label.tsx
@@ -3,25 +3,41 @@
 
 import { getTriggerLabel } from '@auxx/lib/agents/client'
 import { useResource } from '~/components/resources/hooks/use-resource'
+import { useExtensionsContext } from '~/providers/extensions/extensions-context'
 import type { RouterOutputs } from '~/trpc/react'
 
 type Trigger = RouterOutputs['agentTrigger']['list'][number]
 
 /**
- * Resolves the human label for an agent trigger row. For CRUD-event rows we
- * look up the resource client-side so custom entities render their label
- * (e.g. `On Vendor created`) rather than a raw cuid. All other kinds fall
- * back to the server-safe `getTriggerLabel`.
+ * Resolves the human label for an agent trigger row. CRUD-event rows look up
+ * the resource client-side so custom entities render their label (e.g.
+ * `On Vendor created`). App-kind rows resolve `triggerAppId` /
+ * `triggerAppTriggerId` against `useExtensionsContext()` so we surface the
+ * app's display title + the trigger's label rather than raw ids. All other
+ * kinds fall back to the server-safe `getTriggerLabel`.
  */
 export function TriggerLabel({ row }: { row: Trigger }) {
   const isCrudEvent = row.kind === 'event' && !!row.entityDefinitionId && !!row.triggerType
   const { resource } = useResource(isCrudEvent ? row.entityDefinitionId : undefined)
+  const { appInstallations } = useExtensionsContext()
 
   if (isCrudEvent) {
     const base = resource?.label
       ? `On ${resource.label} ${row.triggerType}`
       : `On ${row.entityDefinitionId}:${row.triggerType}`
     return <span>{base}</span>
+  }
+
+  if (row.kind === 'app' && row.triggerAppId && row.triggerAppTriggerId) {
+    const installation =
+      appInstallations.find((i) => i.installationId === row.triggerInstallationId) ??
+      appInstallations.find((i) => i.app.id === row.triggerAppId)
+    const triggerProj = installation?.agentTriggers?.find(
+      (t) => t.triggerId === row.triggerAppTriggerId
+    )
+    const appTitle = installation?.app.title ?? row.triggerAppId
+    const triggerLabel = triggerProj?.label ?? row.triggerAppTriggerId
+    return <span>{`${appTitle} · ${triggerLabel}`}</span>
   }
 
   return <span>{getTriggerLabel(row)}</span>

--- a/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
@@ -9,10 +9,16 @@ import { TreeRow } from '@auxx/ui/components/tree-row'
 import { AlertTriangle, Pencil, Trash2 } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useState } from 'react'
+import { AppIcon } from '~/components/apps/ui/app-icon'
 import { Tooltip } from '~/components/global/tooltip'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useExtensionsContext } from '~/providers/extensions/extensions-context'
 import { api, type RouterOutputs } from '~/trpc/react'
 import type { AgentDetail } from '../../../store/agent-store'
+import {
+  AgentAppTriggerPickerDialog,
+  type AppTriggerSelection,
+} from './agent-app-trigger-picker-dialog'
 import { AgentTriggerDialog } from './agent-trigger-dialog'
 import { TriggerLabel } from './trigger-label'
 
@@ -52,8 +58,8 @@ const KIND_META: Record<
 
 interface TriggersSectionContentProps {
   agent: AgentDetail
-  addingKind: 'scheduled' | 'event' | null
-  onAddingKindChange: (kind: 'scheduled' | 'event' | null) => void
+  addingKind: 'scheduled' | 'event' | 'app' | null
+  onAddingKindChange: (kind: 'scheduled' | 'event' | 'app' | null) => void
 }
 
 /**
@@ -73,6 +79,8 @@ export function TriggersSectionContent({
   const [confirm, ConfirmDialog] = useConfirm()
   const [editingTrigger, setEditingTrigger] = useState<Trigger | null>(null)
   const [creatingBuiltinKind, setCreatingBuiltinKind] = useState<BuiltinKind | null>(null)
+  const [pendingAppSelection, setPendingAppSelection] = useState<AppTriggerSelection | null>(null)
+  const { appInstallations } = useExtensionsContext()
   const utils = api.useUtils()
 
   const triggers = api.agentTrigger.list.useQuery({ agentId: agent.id })
@@ -105,25 +113,57 @@ export function TriggersSectionContent({
     (r) => r.kind !== 'mention' && r.kind !== 'assignment' && r.kind !== 'dm'
   )
 
-  const isDialogOpen = !!addingKind || !!editingTrigger || !!creatingBuiltinKind
-  const dialogKind: 'scheduled' | 'event' | 'mention' | 'assignment' | 'dm' =
-    editingTrigger?.kind === 'event'
-      ? 'event'
-      : editingTrigger?.kind === 'scheduled'
-        ? 'scheduled'
-        : editingTrigger?.kind === 'mention'
-          ? 'mention'
-          : editingTrigger?.kind === 'assignment'
-            ? 'assignment'
-            : editingTrigger?.kind === 'dm'
-              ? 'dm'
-              : (creatingBuiltinKind ?? addingKind ?? 'scheduled')
+  // App-picker dialog is open whenever the user picked "App" from the dropdown
+  // but hasn't selected a (app, trigger) pair yet.
+  const isAppPickerOpen = addingKind === 'app' && !pendingAppSelection
+
+  // The config dialog opens for: editing a row, creating a built-in row,
+  // creating a scheduled/event row, OR after the user picked an app trigger.
+  const isDialogOpen =
+    !!editingTrigger ||
+    !!creatingBuiltinKind ||
+    addingKind === 'scheduled' ||
+    addingKind === 'event' ||
+    (addingKind === 'app' && !!pendingAppSelection)
+
+  const dialogKind: TriggerKind = editingTrigger?.kind
+    ? (editingTrigger.kind as TriggerKind)
+    : creatingBuiltinKind
+      ? creatingBuiltinKind
+      : addingKind === 'app'
+        ? 'app'
+        : (addingKind ?? 'scheduled')
+
+  const appSelectionForDialog =
+    addingKind === 'app' && pendingAppSelection
+      ? {
+          installationId: pendingAppSelection.installation.installationId,
+          appId: pendingAppSelection.installation.app.id,
+          appTitle: pendingAppSelection.installation.app.title,
+          appAvatarUrl: pendingAppSelection.installation.app.avatarUrl,
+          triggerId: pendingAppSelection.trigger.triggerId,
+          triggerLabel: pendingAppSelection.trigger.label,
+          triggerDescription: pendingAppSelection.trigger.description,
+          inputsJsonSchema: pendingAppSelection.trigger.inputsJsonSchema,
+        }
+      : undefined
 
   const handleDialogOpenChange = (open: boolean) => {
     if (open) return
     onAddingKindChange(null)
     setEditingTrigger(null)
     setCreatingBuiltinKind(null)
+    setPendingAppSelection(null)
+  }
+
+  const handleAppPickerOpenChange = (open: boolean) => {
+    if (!open && addingKind === 'app') {
+      onAddingKindChange(null)
+    }
+  }
+
+  const handleAppSelected = (selection: AppTriggerSelection) => {
+    setPendingAppSelection(selection)
   }
 
   const handleDelete = async (row: Trigger) => {
@@ -139,12 +179,19 @@ export function TriggersSectionContent({
 
   return (
     <div className='space-y-4'>
+      <AgentAppTriggerPickerDialog
+        open={isAppPickerOpen}
+        onOpenChange={handleAppPickerOpenChange}
+        onSelect={handleAppSelected}
+      />
+
       <AgentTriggerDialog
         open={isDialogOpen}
         onOpenChange={handleDialogOpenChange}
         agentId={agent.id}
         kind={dialogKind}
         trigger={editingTrigger ?? undefined}
+        appSelection={appSelectionForDialog}
         onSuccess={invalidateList}
       />
 
@@ -201,11 +248,30 @@ export function TriggersSectionContent({
             const meta = KIND_META[row.kind as TriggerKind]
             const isDirectEventRow =
               row.kind === 'event' && !row.entityDefinitionId && !!row.eventType
-            const isEditable = row.kind !== 'app' && !isDirectEventRow
+            const isEditable = !isDirectEventRow
+
+            let iconOverride: ReactNode | undefined
+            if (row.kind === 'app' && row.triggerAppId) {
+              const installation =
+                appInstallations.find((i) => i.installationId === row.triggerInstallationId) ??
+                appInstallations.find((i) => i.app.id === row.triggerAppId)
+              const avatarUrl = installation?.app.avatarUrl
+              if (avatarUrl) {
+                iconOverride = (
+                  <Tooltip content={installation?.app.title ?? meta.label}>
+                    <span className='inline-flex'>
+                      <AppIcon iconId={avatarUrl} size='sm' />
+                    </span>
+                  </Tooltip>
+                )
+              }
+            }
+
             return (
               <TriggerRow
                 key={row.id}
                 meta={meta}
+                icon={iconOverride}
                 title={<TriggerLabel row={row} />}
                 lastFiredAt={row.lastFiredAt}
                 hasError={!!row.lastError}
@@ -228,6 +294,8 @@ export function TriggersSectionContent({
 
 interface TriggerRowProps {
   meta: { label: string; iconId: string; color: string }
+  /** When provided, replaces the default EntityIcon for this row. */
+  icon?: ReactNode
   title: ReactNode
   description?: string
   lastFiredAt: string | null
@@ -247,6 +315,7 @@ interface TriggerRowProps {
  */
 function TriggerRow({
   meta,
+  icon,
   title,
   description,
   lastFiredAt,
@@ -266,17 +335,19 @@ function TriggerRow({
     <TreeRow
       description={description}
       icon={
-        <Tooltip content={meta.label}>
-          <span className='inline-flex'>
-            <EntityIcon
-              iconId={meta.iconId}
-              color={meta.color}
-              size='sm'
-              inverse
-              className='inset-shadow-xs inset-shadow-black/20'
-            />
-          </span>
-        </Tooltip>
+        icon ?? (
+          <Tooltip content={meta.label}>
+            <span className='inline-flex'>
+              <EntityIcon
+                iconId={meta.iconId}
+                color={meta.color}
+                size='sm'
+                inverse
+                className='inset-shadow-xs inset-shadow-black/20'
+              />
+            </span>
+          </Tooltip>
+        )
       }
       title={
         <Tooltip content={lastFiredLabel} allowInteraction>

--- a/apps/web/src/server/api/routers/agent-trigger.ts
+++ b/apps/web/src/server/api/routers/agent-trigger.ts
@@ -35,7 +35,7 @@ const crudEventInputSchema = z.object({
   kind: z.literal('event'),
   triggerType: z.enum(['created', 'updated', 'deleted']),
   entityDefinitionId: z.string().min(1),
-  filter: z.record(z.unknown()).optional(),
+  filter: z.record(z.string(), z.unknown()).optional(),
 })
 
 const appInputSchema = z.object({
@@ -44,8 +44,8 @@ const appInputSchema = z.object({
   triggerAppTriggerId: z.string().min(1),
   triggerInstallationId: z.string().min(1),
   triggerConnectionId: z.string().optional(),
-  userInputs: z.record(z.unknown()).optional(),
-  filter: z.record(z.unknown()).optional(),
+  userInputs: z.record(z.string(), z.unknown()).optional(),
+  filter: z.record(z.string(), z.unknown()).optional(),
   polling: z
     .object({
       intervalMinutes: z.number().int().positive(),
@@ -114,7 +114,7 @@ export const agentTriggerRouter = createTRPCRouter({
       z.object({
         agentId: z.string().min(1),
         enabled: z.boolean().optional(),
-        instructions: z.record(z.unknown()).nullable().optional(),
+        instructions: z.record(z.string(), z.unknown()).nullable().optional(),
         trigger: triggerInputSchema,
       })
     )
@@ -150,7 +150,7 @@ export const agentTriggerRouter = createTRPCRouter({
       z.object({
         id: z.string().min(1),
         enabled: z.boolean().optional(),
-        instructions: z.record(z.unknown()).nullable().optional(),
+        instructions: z.record(z.string(), z.unknown()).nullable().optional(),
         trigger: triggerInputSchema.optional(),
       })
     )

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "@postman/node-keytar",
       "deno"
     ],
     "ignoredBuiltDependencies": [

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -74,7 +74,10 @@ export interface CatalogTriggerProjection {
   triggerId: string
   label: string
   description?: string
-  defaultEnabled?: boolean
+  iconKey: string | null
+  color?: string
+  inputsJsonSchema: Record<string, unknown>
+  refs: Array<{ path: string[]; kind: string }>
 }
 
 export interface CatalogBlock {

--- a/packages/sdk/src/build/server/find-workflow-block-server-modules.ts
+++ b/packages/sdk/src/build/server/find-workflow-block-server-modules.ts
@@ -416,10 +416,20 @@ function visitBlock(
     // Unwrap TypeScript type annotations (satisfies, as, etc.)
     value = unwrapTypeAnnotations(value)
 
+    // `defineTrigger({...})` / `defineBlock({...})` — unwrap to the first argument.
+    if (value?.type === 'CallExpression') {
+      visitBlock(value.arguments[0], targetScope, result, targetPath, helpers)
+      return
+    }
     if (!value || value.type !== 'ObjectExpression') {
       throw new Error(`Expected variable ${node.name} to have an initializer`)
     }
     visitBlock(value, targetScope, result, targetPath, helpers)
+    return
+  }
+  // `defineTrigger({...})` — unwrap to its first argument.
+  if (node.type === 'CallExpression') {
+    visitBlock(node.arguments[0], scope, result, currPath, helpers)
     return
   }
   if (node.type === 'ObjectExpression') {

--- a/packages/sdk/src/util/__tests__/compile-and-extract-catalog.test.ts
+++ b/packages/sdk/src/util/__tests__/compile-and-extract-catalog.test.ts
@@ -96,21 +96,24 @@ describe('compileAndExtractCatalog', () => {
       description: 'Fires when a new message arrives.',
       iconKey: null,
     })
-    expect(catalog.workflow.triggers).toEqual([
-      {
-        triggerId: 'on_message_received',
-        label: 'Message received',
-        description: 'Fires when a new message arrives.',
-      },
-    ])
-    expect(catalog.agent.triggers).toEqual([
-      {
-        triggerId: 'on_message_received',
-        label: 'Message received',
-        description: 'New message arrived in a channel.',
-        defaultEnabled: true,
-      },
-    ])
+    expect(catalog.workflow.triggers).toHaveLength(1)
+    expect(catalog.workflow.triggers[0]).toMatchObject({
+      triggerId: 'on_message_received',
+      label: 'Message received',
+      description: 'Fires when a new message arrives.',
+      iconKey: null,
+    })
+    expect(catalog.workflow.triggers[0]?.inputsJsonSchema).toBeDefined()
+    expect(catalog.agent.triggers).toHaveLength(1)
+    expect(catalog.agent.triggers[0]).toMatchObject({
+      triggerId: 'on_message_received',
+      label: 'Message received',
+      description: 'New message arrived in a channel.',
+      iconKey: null,
+    })
+    expect(catalog.agent.triggers[0]?.inputsJsonSchema).toBeDefined()
+    // defaultEnabled removed from projection
+    expect(catalog.agent.triggers[0]).not.toHaveProperty('defaultEnabled')
 
     // Workflow blocks — `toolMap` is the dispatcher table the runtime reads.
     expect(catalog.workflow.blocks).toHaveLength(1)

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -79,7 +79,10 @@ export interface CatalogTriggerProjection {
   triggerId: string
   label: string
   description?: string
-  defaultEnabled?: boolean
+  iconKey: string | null
+  color?: string
+  inputsJsonSchema: Record<string, unknown>
+  refs: Array<{ path: string[]; kind: string }>
 }
 
 export interface CatalogBlock {
@@ -349,13 +352,14 @@ export async function compileAndExtractCatalog(): Promise<
     if (!trigger?.id) {
       return errored({ code: 'CATALOG_VALIDATION_FAILED', message: 'Trigger is missing an id' })
     }
+    const triggerInputs = serializeWorkflowSchemaInputs(trigger.schema)
     cataloguedTriggers.push({
       id: trigger.id,
       label: trigger.label,
       description: trigger.description,
       iconKey: null,
       color: trigger.color,
-      inputsJsonSchema: serializeWorkflowSchemaInputs(trigger.schema),
+      inputsJsonSchema: triggerInputs,
       refs: [],
     })
     if (trigger.workflow) {
@@ -363,6 +367,10 @@ export async function compileAndExtractCatalog(): Promise<
         triggerId: trigger.id,
         label: trigger.label,
         description: trigger.description,
+        iconKey: null,
+        color: trigger.color,
+        inputsJsonSchema: triggerInputs,
+        refs: [],
       })
     }
     if (trigger.agent) {
@@ -370,7 +378,10 @@ export async function compileAndExtractCatalog(): Promise<
         triggerId: trigger.id,
         label: trigger.agent.label ?? trigger.label,
         description: trigger.agent.description ?? trigger.description,
-        defaultEnabled: trigger.agent.defaultEnabled,
+        iconKey: null,
+        color: trigger.color,
+        inputsJsonSchema: triggerInputs,
+        refs: [],
       })
     }
   }


### PR DESCRIPTION
## Summary
- New "App" option in the agent triggers dropdown opens a picker over installed apps that expose `agentTriggers`, then opens the existing trigger dialog pre-filled with the (app, trigger) pair.
- Trigger dialog now supports the `app` kind end-to-end: connection picker (any-connection or a specific account) + dynamic inputs form generated from the trigger's `inputsJsonSchema` (select single/multi, boolean, number, string). App-kind rows are editable and render the installed app's avatar as the row icon.
- `CatalogTriggerProjection` (workflow + agent) widened with `iconKey`, `color`, `inputsJsonSchema`, `refs` so the client can render the inputs form from the catalog envelope without an extra fetch. SDK extractor also unwraps `defineTrigger(...)` / `defineBlock(...)` call expressions.

## Test plan
- [ ] From an agent detail, add → App → pick an installed app + trigger → dialog opens pre-filled
- [ ] Connection picker: "Any connection" and a specific account both persist correctly
- [ ] Inputs form renders for select / multi-select / boolean / number / string and required fields block submit
- [ ] Edit an existing app-kind trigger: chip, connection, and inputs hydrate from saved state
- [ ] App-kind row in the triggers list shows the app avatar and `App · Trigger` label