### PR TITLE
feat(shopify): app-store-initiated install with claim flow

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -8,8 +8,10 @@ import { configService } from '@auxx/credentials'
  * Uses @auxx/config for environment variables and SST secrets
  */
 
-/** Server port */
-export const PORT = configService.get<number>('API_PORT') ?? 3007
+/** Server port (Railway sets PORT; local/dev can override with API_PORT) */
+const rawPort = configService.get<string>('PORT')
+export const PORT =
+  (rawPort ? Number(rawPort) : undefined) ?? configService.get<number>('API_PORT') ?? 3007
 
 /** Node environment */
 export const NODE_ENV = configService.get<string>('NODE_ENV') || 'development'

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -107,9 +107,10 @@ async function main() {
     {
       fetch: app.fetch,
       port: PORT,
+      hostname: '0.0.0.0',
     },
     (info) => {
-      log.info(`✓ Auxx API server running at http://localhost:${info.port}`)
+      log.info(`✓ Auxx API server running at http://${info.address}:${info.port}`)
     }
   )
 

--- a/apps/web/src/app/(auth)/_components/signup-form.tsx
+++ b/apps/web/src/app/(auth)/_components/signup-form.tsx
@@ -303,7 +303,10 @@ export function SignUpForm() {
                           text='Login with Google'
                           onClick={() => {
                             posthog?.capture('user_signed_up', { method: 'google' })
-                            client.signIn.social({ provider: 'google' })
+                            const callbackUrl =
+                              new URLSearchParams(window.location.search).get('callbackUrl') ||
+                              '/app'
+                            client.signIn.social({ provider: 'google', callbackURL: callbackUrl })
                           }}
                         />
                         <GeneralSubmitButton
@@ -313,7 +316,10 @@ export function SignUpForm() {
                           text='Login with Github'
                           onClick={() => {
                             posthog?.capture('user_signed_up', { method: 'github' })
-                            client.signIn.social({ provider: 'github' })
+                            const callbackUrl =
+                              new URLSearchParams(window.location.search).get('callbackUrl') ||
+                              '/app'
+                            client.signIn.social({ provider: 'github', callbackURL: callbackUrl })
                           }}
                         />
                       </div>

--- a/apps/web/src/app/(auth)/shopify/claim/_components/claim-expired.tsx
+++ b/apps/web/src/app/(auth)/shopify/claim/_components/claim-expired.tsx
@@ -1,0 +1,33 @@
+// apps/web/src/app/(auth)/shopify/claim/_components/claim-expired.tsx
+
+import { Button } from '@auxx/ui/components/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@auxx/ui/components/card'
+import { AlertTriangle } from 'lucide-react'
+
+export function ClaimExpired() {
+  return (
+    <div className='flex min-h-[calc(100vh-8rem)] w-screen items-center justify-center p-4'>
+      <div className='flex w-full max-w-md flex-col items-center space-y-5 px-6'>
+        <Card variant='translucent' className='w-full shadow-md shadow-black/20 border-transparent'>
+          <CardHeader className='text-center'>
+            <div className='mx-auto mb-5 size-14 border flex items-center justify-center rounded-2xl bg-muted'>
+              <AlertTriangle className='size-8 text-info' />
+            </div>
+            <CardTitle className='text-white'>Install link expired</CardTitle>
+            <CardDescription>
+              This Shopify install link has expired. Reinstall Auxx from the Shopify App Store to
+              continue.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant='translucent' className='w-full'>
+              <a href='https://apps.shopify.com/auxx-ai' target='_blank' rel='noopener noreferrer'>
+                Open Shopify App Store
+              </a>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(auth)/shopify/claim/_components/claim-flow.tsx
+++ b/apps/web/src/app/(auth)/shopify/claim/_components/claim-flow.tsx
@@ -1,0 +1,102 @@
+// apps/web/src/app/(auth)/shopify/claim/_components/claim-flow.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@auxx/ui/components/card'
+import { toastError } from '@auxx/ui/components/toast'
+import { Building, Store } from 'lucide-react'
+import { useState } from 'react'
+import { api } from '~/trpc/react'
+
+interface ClaimFlowProps {
+  shop: string
+  orgs: { id: string; name: string | null; handle: string | null }[]
+  defaultOrganizationId: string | null
+  claimToken: string
+}
+
+/**
+ * Org picker for an App-Store-initiated install. The shop's access token is
+ * parked in Redis; clicking a card finalizes the install against that org.
+ */
+export function ClaimFlow({ shop, orgs, defaultOrganizationId, claimToken }: ClaimFlowProps) {
+  const [pendingOrgId, setPendingOrgId] = useState<string | null>(null)
+
+  const finalize = api.shopify.finalizeAppStoreInstall.useMutation({
+    onSuccess: ({ redirectUrl }) => {
+      window.location.href = redirectUrl
+    },
+    onError: (error) => {
+      toastError({
+        title: 'Failed to connect Shopify',
+        description: error.message,
+      })
+      setPendingOrgId(null)
+    },
+  })
+
+  const handleSelect = (organizationId: string) => {
+    setPendingOrgId(organizationId)
+    finalize.mutate({ organizationId, claimToken })
+  }
+
+  return (
+    <div className='flex min-h-[calc(100vh-8rem)] w-screen items-center justify-center p-4'>
+      <div className='flex w-full max-w-md flex-col items-center space-y-5 px-6'>
+        <Card variant='translucent' className='w-full shadow-md shadow-black/20 border-transparent'>
+          <CardHeader className='text-center'>
+            <div className='mx-auto mb-5 size-14 border flex items-center justify-center rounded-2xl bg-muted'>
+              <Store className='size-8 text-info' />
+            </div>
+            <CardTitle className='text-white'>
+              Connect <span className='font-mono text-base'>{shop}</span> to Auxx
+            </CardTitle>
+            <CardDescription>Choose the workspace this shop belongs to.</CardDescription>
+          </CardHeader>
+          <CardContent className='flex flex-col'>
+            <div className='space-y-3'>
+              {orgs.length > 0 ? (
+                orgs.map((org) => (
+                  <button
+                    type='button'
+                    key={org.id}
+                    onClick={() => handleSelect(org.id)}
+                    disabled={!!pendingOrgId}
+                    className='group flex w-full cursor-pointer hover:bg-muted/10 items-center justify-between rounded-2xl border-0 ring-1 ring-white/20 py-2 px-3 transition-colors duration-200 disabled:opacity-50'>
+                    <div className='flex flex-row items-center gap-2'>
+                      <div className='size-8 border bg-muted/10 border-white/10 rounded-lg flex items-center justify-center shrink-0 group-hover:bg-muted/20'>
+                        <Building className='size-4' />
+                      </div>
+                      <div className='flex flex-col items-start'>
+                        <div className='flex items-center gap-2'>
+                          <span className='text-sm'>
+                            {org.name || `Organization ${org.id.substring(0, 6)}`}
+                          </span>
+                          {org.id === defaultOrganizationId && (
+                            <Badge size='xs' variant='default'>
+                              Current
+                            </Badge>
+                          )}
+                        </div>
+                        <span className='text-xs text-white/50'>
+                          {org.handle || `@${org.id.substring(0, 8)}`}
+                        </span>
+                      </div>
+                    </div>
+                    {pendingOrgId === org.id && (
+                      <span className='text-xs text-white/60'>Connecting…</span>
+                    )}
+                  </button>
+                ))
+              ) : (
+                <p className='text-center text-sm text-white/50 py-4'>
+                  You are not a member of any workspace yet.
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(auth)/shopify/claim/page.tsx
+++ b/apps/web/src/app/(auth)/shopify/claim/page.tsx
@@ -1,0 +1,85 @@
+// apps/web/src/app/(auth)/shopify/claim/page.tsx
+
+import { getOrgCache, getUserCache } from '@auxx/lib/cache'
+import { createScopedLogger } from '@auxx/logger'
+import { getRedisClient } from '@auxx/redis'
+import { cookies, headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { auth } from '~/auth/server'
+import { ClaimExpired } from './_components/claim-expired'
+import { ClaimFlow } from './_components/claim-flow'
+
+const CLAIM_COOKIE_NAME = 'shopify_claim_token'
+const logger = createScopedLogger('shopify-claim-page')
+
+interface PageProps {
+  searchParams: Promise<{ token?: string }>
+}
+
+/**
+ * Shopify App Store claim page. Lives outside `(protected)` so we own the
+ * unauthenticated bounce explicitly (the (protected) layout strips the
+ * deep-link when there is no `auxx-org-deep-link` cookie — that would lose
+ * the claim path on sign-in).
+ *
+ * Token source priority: cookie → `?token=` query param (cross-device fallback,
+ * §7.3 of the plan).
+ */
+export default async function ShopifyClaimPage({ searchParams }: PageProps) {
+  const cookieStore = await cookies()
+  const queryToken = (await searchParams).token
+  const cookieToken = cookieStore.get(CLAIM_COOKIE_NAME)?.value
+  const claimToken = cookieToken || queryToken
+
+  // Resolve claimToken before the session check so we can carry it through the
+  // login round-trip — cross-device / cross-domain signup loses both the cookie
+  // and the original URL, so the callback must reconstruct the ?token= param.
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session?.user) {
+    const callback = claimToken
+      ? `/shopify/claim?token=${encodeURIComponent(claimToken)}`
+      : '/shopify/claim'
+    redirect(`/login?callbackUrl=${encodeURIComponent(callback)}`)
+  }
+
+  if (!claimToken) {
+    return <ClaimExpired />
+  }
+
+  const redis = await getRedisClient()
+  if (!redis) {
+    logger.error('Redis unavailable on claim page')
+    return <ClaimExpired />
+  }
+
+  const raw = await redis.get(`shopify:pending-claim:${claimToken}`)
+  if (!raw) {
+    return <ClaimExpired />
+  }
+
+  const claim = JSON.parse(raw) as { shop: string }
+
+  // Cached user→org memberships (one Redis lookup) + per-org profile (cached).
+  // A Shopify store can be attached to more than one Auxx org, so we always show
+  // the picker with every workspace the user is in.
+  const memberships = await getUserCache().get(session.user.id, 'userMemberships')
+  const activeMemberships = memberships.filter((m) => m.status === 'ACTIVE')
+  const orgs = await Promise.all(
+    activeMemberships.map(async (m) => {
+      const profile = await getOrgCache().get(m.organizationId, 'orgProfile')
+      return { id: profile.id, name: profile.name, handle: profile.handle }
+    })
+  )
+
+  const defaultOrgId =
+    (session.user as { defaultOrganizationId?: string | null }).defaultOrganizationId ?? null
+
+  return (
+    <ClaimFlow
+      shop={claim.shop}
+      orgs={orgs}
+      defaultOrganizationId={defaultOrgId}
+      claimToken={claimToken}
+    />
+  )
+}

--- a/apps/web/src/app/(protected)/onboarding/page.tsx
+++ b/apps/web/src/app/(protected)/onboarding/page.tsx
@@ -2,7 +2,7 @@
 
 import { database, schema } from '@auxx/database'
 import { eq } from 'drizzle-orm'
-import { headers } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { auth } from '~/auth/server'
 
@@ -58,8 +58,15 @@ export default async function OnboardingPage() {
     userCompletedOnboarding,
   })
 
-  // If organization onboarding is complete, go to dashboard
+  // If organization onboarding is complete, route to /app — unless this user landed
+  // here mid-Shopify-App-Store install, in which case finish the claim flow first.
   if (org?.completedOnboarding) {
+    const cookieStore = await cookies()
+    const claimToken = cookieStore.get('shopify_claim_token')?.value
+    if (claimToken) {
+      console.log('[Onboarding] Org onboarding complete, claim cookie set, redirecting to claim')
+      redirect('/shopify/claim')
+    }
     console.log('[Onboarding] Org onboarding complete, redirecting to /app')
     redirect('/app')
   }

--- a/apps/web/src/app/(protected)/onboarding/team/page.tsx
+++ b/apps/web/src/app/(protected)/onboarding/team/page.tsx
@@ -128,8 +128,10 @@ export default function TeamOnboardingPage() {
       resetState()
       // 6. Update auth session to reflect completedOnboarding
       await updateUser({ completedOnboarding: true })
-      // 7. Redirect to main app (full reload to get fresh dehydrated state)
-      window.location.href = '/app'
+      // 7. Redirect through /onboarding so the entry-point routes to /app or to
+      //    /shopify/claim (App-Store-initiated installs) in one place.
+      //    Full reload to get fresh dehydrated state.
+      window.location.href = '/onboarding'
     } catch (error) {
       console.error('Failed to complete onboarding:', error)
       toastError({

--- a/apps/web/src/app/api/apps/shopify/install/callback/route.ts
+++ b/apps/web/src/app/api/apps/shopify/install/callback/route.ts
@@ -1,0 +1,172 @@
+// apps/web/src/app/api/apps/shopify/install/callback/route.ts
+
+import { WEBAPP_URL } from '@auxx/config/urls'
+import { database as db } from '@auxx/database'
+import { resolveAppSlug } from '@auxx/lib/cache'
+import { createScopedLogger } from '@auxx/logger'
+import { getRedisClient } from '@auxx/redis'
+import { interpolateConnectionFields } from '@auxx/services/app-connections'
+import crypto from 'crypto'
+import { type NextRequest, NextResponse } from 'next/server'
+
+const logger = createScopedLogger('shopify-install-callback')
+
+const CLAIM_COOKIE_NAME = 'shopify_claim_token'
+const CLAIM_COOKIE_MAX_AGE = 3600
+const CLAIM_TTL_SECONDS = 3600
+
+/**
+ * App-Store install callback. Physically separate from the generic
+ * `/api/apps/[slug]/oauth2/callback` so the anonymous, pre-org code path
+ * never touches the shared trust boundary that other apps rely on.
+ *
+ * Flow:
+ *  1. Verify state from Redis + HMAC.
+ *  2. Exchange code for access token.
+ *  3. Detect reinstall via Redis shop→credential lookup; if known, upsert silently.
+ *  4. Otherwise park `{shop, accessToken, scope, ...}` under a fresh claimToken
+ *     and 302 the merchant to `/shopify/claim` with the token in an httpOnly cookie.
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams
+  const shop = searchParams.get('shop')
+  const code = searchParams.get('code')
+  const state = searchParams.get('state')
+  const hmac = searchParams.get('hmac')
+
+  if (!shop || !code || !state || !hmac) {
+    return new NextResponse('Missing required parameters', { status: 400 })
+  }
+
+  const secret = process.env.SHOPIFY_API_SECRET
+  if (!secret) {
+    logger.error('SHOPIFY_API_SECRET not configured')
+    return new NextResponse('Server misconfigured', { status: 500 })
+  }
+
+  // Verify HMAC of callback params
+  const params: Record<string, string> = {}
+  for (const [k, v] of searchParams.entries()) {
+    if (k !== 'hmac') params[k] = v
+  }
+  const message = Object.entries(params)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v}`)
+    .join('&')
+  const expectedHmac = crypto.createHmac('sha256', secret).update(message).digest('hex')
+  const hmacBuf = Buffer.from(hmac, 'hex')
+  const expectedBuf = Buffer.from(expectedHmac, 'hex')
+  if (hmacBuf.length !== expectedBuf.length || !crypto.timingSafeEqual(hmacBuf, expectedBuf)) {
+    logger.warn('Callback HMAC verification failed', { shop })
+    return new NextResponse('Invalid HMAC', { status: 403 })
+  }
+
+  try {
+    const redis = await getRedisClient()
+    if (!redis) throw new Error('Redis client unavailable')
+
+    const stateKey = `oauth:shopify-install:${state}`
+    const stateRaw = await redis.get(stateKey)
+    if (!stateRaw) {
+      return new NextResponse('Invalid or expired state', { status: 400 })
+    }
+    const stateData = JSON.parse(stateRaw) as {
+      shop: string
+      host?: string
+      source?: string
+      startedAt: string
+      connectionDefinitionId: string
+    }
+
+    if (stateData.shop !== shop) {
+      logger.warn('Shop mismatch between state and callback', {
+        stateShop: stateData.shop,
+        callbackShop: shop,
+      })
+      return new NextResponse('State validation failed', { status: 400 })
+    }
+
+    const appId = await resolveAppSlug('shopify')
+    if (!appId) {
+      return new NextResponse('App not configured', { status: 500 })
+    }
+
+    const connDef = await db.query.ConnectionDefinition.findFirst({
+      where: (cd, { eq }) => eq(cd.id, stateData.connectionDefinitionId),
+    })
+    if (!connDef) {
+      throw new Error('Connection definition not found')
+    }
+
+    const shopSubdomain = shop.replace(/\.myshopify\.com$/, '')
+    const resolved = interpolateConnectionFields(connDef, { shop: shopSubdomain })
+
+    // Exchange code for token. Shopify accepts both form-encoded and JSON; use JSON to
+    // match Shopify's documented example and the legacy route.
+    const tokenResponse = await fetch(resolved.accessTokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({
+        client_id: resolved.clientId,
+        client_secret: resolved.clientSecret,
+        code,
+      }),
+    })
+
+    if (!tokenResponse.ok) {
+      const errText = await tokenResponse.text()
+      logger.error('Shopify token exchange failed', { status: tokenResponse.status, errText })
+      throw new Error(`Token exchange failed: ${tokenResponse.status}`)
+    }
+
+    const tokens = (await tokenResponse.json()) as {
+      access_token?: string
+      scope?: string
+    }
+    if (!tokens.access_token) {
+      throw new Error('Token response missing access_token')
+    }
+
+    // Park pending claim. claimToken is independent of the OAuth state to avoid
+    // ever exposing the state value past callback termination. A shop can be
+    // attached to multiple Auxx orgs — the claim page lets the merchant pick which.
+    const claimToken = crypto.randomBytes(32).toString('hex')
+    const claimPayload = {
+      shop,
+      accessToken: tokens.access_token,
+      scope: tokens.scope,
+      connectionDefinitionId: connDef.id,
+      createdAt: new Date().toISOString(),
+    }
+    await redis.setex(
+      `shopify:pending-claim:${claimToken}`,
+      CLAIM_TTL_SECONDS,
+      JSON.stringify(claimPayload)
+    )
+    await redis.del(stateKey)
+
+    // Redirect to the claim page. Token lives only in the httpOnly cookie for the
+    // primary path; the claim page also accepts ?token=... as a cross-device fallback
+    // (see §7.3 of the plan — email verification on a different device).
+    const claimUrl = new URL('/shopify/claim', WEBAPP_URL)
+    // Cross-device fallback: include token in URL so a verification email opened on
+    // a different device (no cookie) can still resolve the Redis entry.
+    claimUrl.searchParams.set('token', claimToken)
+
+    const response = NextResponse.redirect(claimUrl.toString())
+    response.cookies.set(CLAIM_COOKIE_NAME, claimToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: CLAIM_COOKIE_MAX_AGE,
+    })
+    return response
+  } catch (error) {
+    logger.error('Shopify install callback failed', {
+      error: error instanceof Error ? error.message : String(error),
+      shop,
+    })
+    return new NextResponse('Installation failed', { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/apps/shopify/install/route.ts
+++ b/apps/web/src/app/api/apps/shopify/install/route.ts
@@ -1,0 +1,136 @@
+// apps/web/src/app/api/apps/shopify/install/route.ts
+
+import { WEBAPP_URL } from '@auxx/config/urls'
+import type { OAuth2Features } from '@auxx/database'
+import { database as db } from '@auxx/database'
+import { resolveAppSlug } from '@auxx/lib/cache'
+import { createScopedLogger } from '@auxx/logger'
+import { getRedisClient } from '@auxx/redis'
+import { interpolateConnectionFields } from '@auxx/services/app-connections'
+import crypto from 'crypto'
+import { type NextRequest, NextResponse } from 'next/server'
+
+const OAUTH_REDIRECT_BASE = process.env.NGROK_URL || WEBAPP_URL
+const SHOP_DOMAIN_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.com$/
+
+const logger = createScopedLogger('shopify-install')
+
+/**
+ * Shopify App Store install entry point.
+ *
+ * Reached by Shopify's "Install" action with `?shop=...&hmac=...&timestamp=...&host=...`.
+ * Does no UI, no session lookup — verifies HMAC, parks CSRF state in Redis with a short TTL,
+ * and 302s straight to the Shopify authorize page. This satisfies the App Store rule that
+ * the merchant must hit OAuth before seeing any of our UI.
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams
+  const shop = searchParams.get('shop')
+  const hmac = searchParams.get('hmac')
+  const host = searchParams.get('host')
+
+  if (!shop || !hmac) {
+    return new NextResponse('Missing required parameters', { status: 400 })
+  }
+
+  if (!SHOP_DOMAIN_REGEX.test(shop)) {
+    return new NextResponse('Invalid shop domain', { status: 400 })
+  }
+
+  // Verify HMAC against SHOPIFY_API_SECRET per Shopify's spec
+  // (all params except hmac, sorted alphabetically, joined as key=value pairs)
+  const secret = process.env.SHOPIFY_API_SECRET
+  if (!secret) {
+    logger.error('SHOPIFY_API_SECRET not configured')
+    return new NextResponse('Server misconfigured', { status: 500 })
+  }
+
+  const params: Record<string, string> = {}
+  for (const [key, value] of searchParams.entries()) {
+    if (key !== 'hmac') params[key] = value
+  }
+  const message = Object.entries(params)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&')
+  const expectedHmac = crypto.createHmac('sha256', secret).update(message).digest('hex')
+
+  // Use timing-safe comparison
+  const hmacBuf = Buffer.from(hmac, 'hex')
+  const expectedBuf = Buffer.from(expectedHmac, 'hex')
+  if (hmacBuf.length !== expectedBuf.length || !crypto.timingSafeEqual(hmacBuf, expectedBuf)) {
+    logger.warn('HMAC verification failed', { shop })
+    return new NextResponse('Invalid HMAC', { status: 403 })
+  }
+
+  try {
+    const appId = await resolveAppSlug('shopify')
+    if (!appId) {
+      logger.error('Shopify app not found in catalog')
+      return new NextResponse('App not configured', { status: 500 })
+    }
+
+    // Prefer global (org-wide) Shopify connection definition; fall back to any
+    const connDef =
+      (await db.query.ConnectionDefinition.findFirst({
+        where: (cd, { eq, and }) => and(eq(cd.appId, appId), eq(cd.global, true)),
+      })) ??
+      (await db.query.ConnectionDefinition.findFirst({
+        where: (cd, { eq }) => eq(cd.appId, appId),
+      }))
+
+    if (!connDef || connDef.connectionType !== 'oauth2-code') {
+      logger.error('Shopify ConnectionDefinition missing or not oauth2-code')
+      return new NextResponse('App not configured', { status: 500 })
+    }
+
+    const features = (connDef.oauth2Features ?? {}) as OAuth2Features
+    // Shop subdomain (e.g. "acme" from "acme.myshopify.com") — used by ConnectionDefinition
+    // templates like https://{shop}.myshopify.com/admin/oauth/authorize.
+    const shopSubdomain = shop.replace(/\.myshopify\.com$/, '')
+    const resolved = interpolateConnectionFields(connDef, { shop: shopSubdomain })
+
+    const state = crypto.randomBytes(32).toString('hex')
+
+    const redis = await getRedisClient()
+    if (!redis) {
+      throw new Error('Redis client unavailable')
+    }
+    await redis.setex(
+      `oauth:shopify-install:${state}`,
+      600,
+      JSON.stringify({
+        shop,
+        host,
+        source: 'app_store',
+        startedAt: new Date().toISOString(),
+        connectionDefinitionId: connDef.id,
+      })
+    )
+
+    const callbackBase = features.callbackBaseUrl || OAUTH_REDIRECT_BASE
+    const scopeSeparator = features.scopeSeparator || ','
+    const scopes = (connDef.oauth2Scopes ?? []).join(scopeSeparator)
+
+    const authUrl = new URL(resolved.authorizeUrl)
+    authUrl.searchParams.set('client_id', resolved.clientId)
+    authUrl.searchParams.set('scope', scopes)
+    authUrl.searchParams.set('redirect_uri', `${callbackBase}/api/apps/shopify/install/callback`)
+    authUrl.searchParams.set('state', state)
+
+    if (features.additionalAuthorizeParams) {
+      for (const [key, value] of Object.entries(features.additionalAuthorizeParams)) {
+        authUrl.searchParams.set(key, value)
+      }
+    }
+
+    logger.info('Redirecting App Store install to Shopify authorize', { shop })
+    return NextResponse.redirect(authUrl.toString())
+  } catch (error) {
+    logger.error('Shopify install failed', {
+      error: error instanceof Error ? error.message : String(error),
+      shop,
+    })
+    return new NextResponse('Failed to start install', { status: 500 })
+  }
+}

--- a/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
+++ b/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
@@ -203,7 +203,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
   return (
     <div
       ref={containerRef}
-      className={`${styles.editor} relative flex-1 min-h-0 flex w-full`}
+      className={`${styles.editor} relative flex-1 min-h-0 flex w-full pb-4`}
       onMouseDown={handleHostMouseDown}>
       <EditorContent
         editor={editor}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -33,6 +33,7 @@ const KNOWN_ROUTE_PREFIXES = new Set([
   'two-factor',
   // (public) routes
   'accept-invitation',
+  'shopify',
   'workflows',
   // Top-level routes
   'admin',

--- a/apps/web/src/server/api/routers/shopify.ts
+++ b/apps/web/src/server/api/routers/shopify.ts
@@ -1,12 +1,19 @@
 import { WEBAPP_URL } from '@auxx/config/server'
 import { database as db, schema } from '@auxx/database'
+import { getOrgCache, isOrgMember, onCacheEvent, resolveAppSlug } from '@auxx/lib/cache'
 import { getQueue, Queues } from '@auxx/lib/jobs/queues'
 import { disableWebhooks, isShopifyConnected, SyncManager } from '@auxx/lib/shopify'
 import { createScopedLogger } from '@auxx/logger'
+import { getRedisClient } from '@auxx/redis'
+import { saveAppConnection } from '@auxx/services/app-connections'
+import { installApp } from '@auxx/services/apps'
 import { TRPCError } from '@trpc/server'
 import { and, count, desc, eq } from 'drizzle-orm'
+import { cookies } from 'next/headers'
 import { z } from 'zod'
 import { adminProcedure, createTRPCRouter, notDemo, protectedProcedure } from '../trpc'
+
+const CLAIM_COOKIE_NAME = 'shopify_claim_token'
 
 const logger = createScopedLogger('shopify-router')
 
@@ -399,6 +406,137 @@ export const shopifyRouter = createTRPCRouter({
           message: 'Failed to fetch webhook events',
         })
       }
+    }),
+
+  /**
+   * Finalize an App-Store-initiated Shopify install by attaching the parked credential
+   * to the chosen organization.
+   *
+   * Reads the claim token from the `shopify_claim_token` cookie, validates the user is
+   * a member of `organizationId`, lazily creates the AppInstallation if missing, writes
+   * the WorkflowCredentials row, then deletes the Redis entry and clears the cookie.
+   *
+   * Returns the URL the client should navigate to next.
+   */
+  finalizeAppStoreInstall: protectedProcedure
+    .input(z.object({ organizationId: z.string(), claimToken: z.string().optional() }))
+    .mutation(async ({ ctx, input }) => {
+      const cookieStore = await cookies()
+      // Cookie is the primary source (prod, single-device). The optional input is the
+      // cross-device / cross-domain fallback used when the cookie isn't present —
+      // mirrors the read priority on the claim page itself.
+      const claimToken = cookieStore.get(CLAIM_COOKIE_NAME)?.value ?? input.claimToken
+      if (!claimToken) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No pending Shopify install. Reinstall from the App Store to continue.',
+        })
+      }
+
+      const userId = ctx.session.user.id
+      const { organizationId } = input
+
+      // Membership check via cached members set (any role can connect — we land here
+      // from an App Store install, not a permission-gated UI).
+      if (!(await isOrgMember(organizationId, userId))) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'You are not a member of this organization.',
+        })
+      }
+
+      const redis = await getRedisClient()
+      if (!redis) {
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Redis unavailable' })
+      }
+
+      const claimKey = `shopify:pending-claim:${claimToken}`
+      const raw = await redis.get(claimKey)
+      if (!raw) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'This install link has expired. Reinstall from the App Store to continue.',
+        })
+      }
+      const claim = JSON.parse(raw) as {
+        shop: string
+        accessToken: string
+        scope?: string
+        connectionDefinitionId: string
+      }
+
+      const appId = await resolveAppSlug('shopify')
+      if (!appId) {
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Shopify app not found' })
+      }
+
+      // Lazy: ensure AppInstallation exists for this org. If already installed,
+      // resolve the installationId via the cached installedApps set.
+      let installationId: string | null = null
+      const installResult = await installApp({
+        appId,
+        organizationId,
+        installationType: 'production',
+        installedById: userId,
+      })
+      if (installResult.isOk()) {
+        installationId = installResult.value.installation.id
+        await onCacheEvent('app.installed', { orgId: organizationId })
+      } else if (installResult.error.code === 'APP_ALREADY_INSTALLED') {
+        const installedApps = await getOrgCache().get(organizationId, 'installedApps')
+        installationId =
+          installedApps.find((i) => i.app.id === appId && i.installationType === 'production')
+            ?.installationId ?? null
+      } else {
+        logger.error('Failed to install Shopify app for org', {
+          error: installResult.error,
+          organizationId,
+        })
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: installResult.error.message,
+        })
+      }
+
+      if (!installationId) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to resolve Shopify installation',
+        })
+      }
+
+      const saveResult = await saveAppConnection(
+        appId,
+        installationId,
+        'Shopify',
+        organizationId,
+        userId,
+        null, // org-scoped
+        {
+          accessToken: claim.accessToken,
+          metadata: {
+            scope: claim.scope,
+            shopDomain: claim.shop,
+          },
+        }
+      )
+
+      if (saveResult.isErr()) {
+        logger.error('Failed to save Shopify connection', {
+          error: saveResult.error,
+          organizationId,
+        })
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to save Shopify connection',
+        })
+      }
+
+      await redis.del(claimKey)
+      cookieStore.delete(CLAIM_COOKIE_NAME)
+
+      const redirectUrl = `/app/settings/apps/installed/shopify/connections?attached=${encodeURIComponent(claim.shop)}`
+      return { redirectUrl, shop: claim.shop }
     }),
 
   // Get integration details

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -131,6 +131,7 @@ export const RESERVED_ORGANIZATION_HANDLES = [
   'ph',
   'preview',
   'setup',
+  'shopify',
   'subscription',
   'workflows',
 


### PR DESCRIPTION
## Summary
- New install entry + OAuth callback under `apps/web/src/app/api/apps/shopify/install/` that park the Shopify access token in Redis with a `shopify_claim_token` cookie, then route the user through signup → onboarding → `/shopify/claim`.
- New `/shopify/claim` page + components that resolve the claim, pick an org, and call the new `shopify.finalizeAppStoreInstall` tRPC mutation to attach the parked credential as an `AppConnection` (lazily installing the Shopify app for the org if needed).
- Team-onboarding completion now redirects through `/onboarding` so the claim handoff is decided in one place; signup social buttons preserve `callbackUrl`; `shopify` reserved as an org handle and added to known public route prefixes.
- API server fix: bind `0.0.0.0` and honor Railway's `PORT` (falls back to `API_PORT` locally).

## Test plan
- [ ] Install from Shopify App Store as a brand-new user → signup → team onboarding → lands on `/shopify/claim` and finalizes against the new org.
- [ ] Install from App Store as an existing logged-in user with multiple orgs → `/shopify/claim` lets them pick and attaches the connection.
- [ ] Existing user with finished onboarding and no claim cookie still lands on `/app`.
- [ ] Claim token expired in Redis → claim-expired UI renders.
- [ ] Social sign-in with `?callbackUrl=...` honors the callback.
- [ ] `apps/api` boots on Railway (`PORT` env) and locally (`API_PORT`).