### PR TITLE
fix: visible turnstile + correct agentId in kopilot stream

### DIFF
--- a/apps/web/src/app/(auth)/_components/forgot-password-form.tsx
+++ b/apps/web/src/app/(auth)/_components/forgot-password-form.tsx
@@ -147,7 +147,7 @@ export function ForgotPasswordForm() {
             onSuccess={onTurnstileSuccess}
             onExpire={onTurnstileExpire}
             onError={onTurnstileError}
-            options={{ size: 'invisible' }}
+            options={{ size: 'flexible' }}
           />
         </div>
       )}

--- a/apps/web/src/app/(auth)/_components/login-form.tsx
+++ b/apps/web/src/app/(auth)/_components/login-form.tsx
@@ -675,7 +675,7 @@ export default function LoginForm({
             onSuccess={onTurnstileSuccess}
             onExpire={onTurnstileExpire}
             onError={onTurnstileError}
-            options={{ size: 'invisible' }}
+            options={{ size: 'flexible' }}
           />
         </div>
       )}

--- a/apps/web/src/app/(auth)/_components/signup-form.tsx
+++ b/apps/web/src/app/(auth)/_components/signup-form.tsx
@@ -614,7 +614,7 @@ export function SignUpForm() {
             onSuccess={onTurnstileSuccess}
             onExpire={onTurnstileExpire}
             onError={onTurnstileError}
-            options={{ size: 'invisible' }}
+            options={{ size: 'flexible' }}
           />
         </div>
       )}

--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -547,7 +547,7 @@ async function runInProcessPath(params: {
     await createAppCapabilities({
       organizationId,
       userId,
-      agentId: null,
+      agentId: isBuilder ? null : agentId,
       triggerId: null,
       sessionId,
       getToolDeps,


### PR DESCRIPTION
## Summary
- Switch auth Turnstile widgets (login, signup, forgot-password) from `invisible` to `flexible` so challenges render when required.
- Pass the real `agentId` into `createAppCapabilities` in the Kopilot stream route; only force `null` when running in builder mode.

## Test plan
- [ ] Load /login, /signup, /forgot-password and confirm the Turnstile widget renders.
- [ ] Trigger a Kopilot stream in builder mode and confirm `agentId` is null in capabilities.
- [ ] Trigger a Kopilot stream outside builder mode and confirm the correct `agentId` is propagated.