### PR TITLE
feat(kopilot): app icons on tool pills + agent UI polish

### DIFF
--- a/apps/web/src/app/api/files/upload/[sessionId]/complete/route.ts
+++ b/apps/web/src/app/api/files/upload/[sessionId]/complete/route.ts
@@ -222,11 +222,20 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       storageLocationId,
     })
 
-    // 3.2 Invalidate dehydration cache so next page load fetches fresh data
+    // 3.2 Invalidate caches so next page load fetches fresh data
     if (session.entityType === 'USER_PROFILE') {
+      const targetUserId = session.entityId || session.userId
       const { DehydrationService } = await import('@auxx/lib/dehydration')
-      const dehydrationService = new DehydrationService()
-      await dehydrationService.invalidateUser(session.userId)
+      await new DehydrationService().invalidateUser(targetUserId)
+
+      // Agent avatar (admin uploading for an agent's synthetic user): bust the
+      // org `agents` cache so the avatar URL refreshes on next load. The
+      // processor's validateEntityAccess guarantees a mismatched entityId is
+      // an agent user.
+      if (session.entityId && session.entityId !== session.userId) {
+        const { onCacheEvent } = await import('@auxx/lib/cache')
+        await onCacheEvent('agent.updated', { orgId: session.organizationId })
+      }
     }
 
     // 3.3 Compute download URL for SSE

--- a/apps/web/src/components/agents/hooks/use-agent-mutations.ts
+++ b/apps/web/src/components/agents/hooks/use-agent-mutations.ts
@@ -149,6 +149,30 @@ export function useAgentMutations(): UseAgentMutationsResult {
         optimistic.archivedAt = patch.archivedAt ? patch.archivedAt.toISOString() : null
       }
       store.setAgentOptimistic(id, optimistic as never)
+
+      // The detail view reads `agent.getById` directly (not the store), so
+      // we also splice the patch into the query cache. Without this, the
+      // hero's name/description revert to the prop value the moment the
+      // inline editor closes and only flip to the new value after the
+      // mutation round-trip + invalidate refetch settle.
+      const stored = store.agentsById[id]
+      const slug = stored?.slug
+      const detailPatch: Partial<AgentDetail> = {}
+      if (patch.name !== undefined) detailPatch.name = patch.name
+      if (patch.slug !== undefined) detailPatch.slug = patch.slug
+      if (patch.description !== undefined) detailPatch.description = patch.description
+      if (patch.modelId !== undefined) detailPatch.modelId = patch.modelId
+      if (patch.mentionable !== undefined) detailPatch.mentionable = patch.mentionable
+      if (patch.archivedAt !== undefined) detailPatch.archivedAt = patch.archivedAt
+      const spliceDetail = (prev: AgentDetail | undefined): AgentDetail | undefined => {
+        if (!prev) return prev
+        return { ...prev, ...detailPatch }
+      }
+      utils.agent.getById.setData({ agentId: id }, spliceDetail)
+      if (slug && slug !== id) {
+        utils.agent.getById.setData({ agentId: slug }, spliceDetail)
+      }
+
       try {
         await updateMutation.mutateAsync({ agentId: id, ...patch })
         store.confirmAgentUpdate(id)

--- a/apps/web/src/components/kopilot/hooks/use-tool-app-resolver.ts
+++ b/apps/web/src/components/kopilot/hooks/use-tool-app-resolver.ts
@@ -1,0 +1,65 @@
+// apps/web/src/components/kopilot/hooks/use-tool-app-resolver.ts
+
+'use client'
+
+import { useMemo } from 'react'
+import {
+  type AppInstallation,
+  useExtensionsContext,
+} from '~/providers/extensions/extensions-context'
+
+export interface ResolvedTool {
+  /** Snake-case tool name as streamed in `ToolCallPart.name`. */
+  toolName: string
+  installation: AppInstallation
+  /** Ready-to-pass into `<AppIcon iconId={...} />`. */
+  iconId: string
+  /** Apps don't carry a color token today; reserved for future use. */
+  color: string | undefined
+  /** Human label, e.g. "Search Google Contacts". */
+  displayName: string
+  /** App title, e.g. "Google Contacts" — used for tooltips on the header stack. */
+  appTitle: string
+}
+
+/**
+ * Resolves a kopilot `ToolCallPart.name` to the installed app that owns it,
+ * so the tool-status pill can render `<AppIcon>` instead of a generic
+ * Lucide fallback.
+ *
+ * The map is built over `useExtensionsContext().appInstallations`, which is
+ * already loaded once per session by `ExtensionsProvider` (a hard
+ * dependency of `(protected)/app` layout). Each cached tool carries a
+ * pre-resolved `registeredName` and `iconId` — see
+ * `packages/lib/src/cache/providers/installed-apps-provider.ts` — so this
+ * hook performs no string manipulation and has no knowledge of the
+ * bridge's encoding (decision D1).
+ *
+ * Returns `undefined` for built-in tools (find_threads, search_kb, …);
+ * the pill falls back to `tool-status-pill-config.ts` in that case.
+ */
+export function useToolAppResolver() {
+  const { appInstallations } = useExtensionsContext()
+
+  const toolMap = useMemo(() => {
+    const map = new Map<string, ResolvedTool>()
+    for (const installation of appInstallations) {
+      for (const tool of installation.agentTools ?? []) {
+        map.set(tool.registeredName, {
+          toolName: tool.registeredName,
+          installation,
+          iconId: tool.iconId,
+          color: undefined,
+          displayName: tool.name,
+          appTitle: installation.app.title,
+        })
+      }
+    }
+    return map
+  }, [appInstallations])
+
+  return {
+    toolMap,
+    resolve: (toolName: string): ResolvedTool | undefined => toolMap.get(toolName),
+  }
+}

--- a/apps/web/src/components/kopilot/ui/kopilot-composer.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-composer.tsx
@@ -474,8 +474,8 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
         }}
       />
       <KopilotContextChipStrip />
-      <div className='relative flex flex-row items-end rounded-xl border min-h-[120px] bg-primary-150  focus-within:border-info'>
-        <div className='relative flex flex-1 flex-col self-stretch'>
+      <div className='relative flex flex-col rounded-xl border min-h-[120px] bg-primary-150 focus-within:border-info'>
+        <div className='relative flex flex-1 flex-col min-h-0'>
           {editingMessageId && (
             <div className='flex items-center justify-between border-b px-3 py-1.5 text-xs text-muted-foreground'>
               <span>Editing message</span>
@@ -555,61 +555,63 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
             </InlinePickerPopover>
           )}
         </div>
-        <div className='absolute bottom-1 left-1 flex items-center gap-0.5'>
-          {allowModelPicker && (
-            <AiModelPicker
-              value={selectedModelId ?? systemLlmDefault}
-              onChange={handleModelFilter}
-              modelTypes={[ModelType.LLM]}
-              triggerVariant='transparent'
-              triggerClassName='h-7 text-xs text-muted-foreground'
-              compact
-              skipDeprecated
-            />
-          )}
-          {allowSenderPicker && (
-            <SenderPicker
-              displayActorId={displayActorId}
-              isLocked={isSenderLocked}
-              open={isSenderPickerOpen}
-              onOpenChange={setIsSenderPickerOpen}
-              onSelect={(actorId) => {
-                setSelectedAgentActorId(actorId)
-                setIsSenderPickerOpen(false)
-              }}
-              onClear={() => setSelectedAgentActorId(null)}
-            />
-          )}
-        </div>
-        <div className='absolute bottom-1 right-1 flex items-center gap-0.5'>
-          {allowSlashCommands && (
-            <Tooltip content='Insert prompt template' shortcut='/' allowInteraction>
+        <div className='flex items-center justify-between p-1 '>
+          <div className='flex items-center gap-0.5 overflow-y-auto no-scrollbar overscroll-contain'>
+            {allowModelPicker && (
+              <AiModelPicker
+                value={selectedModelId ?? systemLlmDefault}
+                onChange={handleModelFilter}
+                modelTypes={[ModelType.LLM]}
+                triggerVariant='transparent'
+                triggerClassName='h-7 text-xs text-muted-foreground'
+                compact
+                skipDeprecated
+              />
+            )}
+            {allowSenderPicker && (
+              <SenderPicker
+                displayActorId={displayActorId}
+                isLocked={isSenderLocked}
+                open={isSenderPickerOpen}
+                onOpenChange={setIsSenderPickerOpen}
+                onSelect={(actorId) => {
+                  setSelectedAgentActorId(actorId)
+                  setIsSenderPickerOpen(false)
+                }}
+                onClear={() => setSelectedAgentActorId(null)}
+              />
+            )}
+          </div>
+          <div className='flex items-center gap-0.5 shrink-0'>
+            {allowSlashCommands && (
+              <Tooltip content='Insert prompt template' shortcut='/' allowInteraction>
+                <Button
+                  size='icon-sm'
+                  variant='ghost'
+                  className='shrink-0'
+                  onMouseDown={(e) => {
+                    // Prevent editor blur — keeps the Suggestion plugin state
+                    // alive so inserting "/" opens the picker.
+                    e.preventDefault()
+                    handleInsertSlash()
+                  }}
+                  disabled={isStreaming}
+                  title='Insert prompt template'>
+                  <SquareSlash />
+                </Button>
+              </Tooltip>
+            )}
+            <Tooltip content='Send message' shortcut={<CornerDownLeft className='size-4' />}>
               <Button
                 size='icon-sm'
                 variant='ghost'
                 className='shrink-0'
-                onMouseDown={(e) => {
-                  // Prevent editor blur — keeps the Suggestion plugin state
-                  // alive so inserting "/" opens the picker.
-                  e.preventDefault()
-                  handleInsertSlash()
-                }}
-                disabled={isStreaming}
-                title='Insert prompt template'>
-                <SquareSlash />
+                onClick={handleSend}
+                disabled={isStreaming || isEmpty}>
+                <Send />
               </Button>
             </Tooltip>
-          )}
-          <Tooltip content='Send message' shortcut={<CornerDownLeft className='size-4' />}>
-            <Button
-              size='icon-sm'
-              variant='ghost'
-              className='shrink-0'
-              onClick={handleSend}
-              disabled={isStreaming || isEmpty}>
-              <Send />
-            </Button>
-          </Tooltip>
+          </div>
         </div>
       </div>
       {promptDialogOpen && (

--- a/apps/web/src/components/kopilot/ui/messages/thinking-steps.tsx
+++ b/apps/web/src/components/kopilot/ui/messages/thinking-steps.tsx
@@ -6,7 +6,10 @@ import { cn } from '@auxx/ui/lib/utils'
 import { ChevronRight, Loader2 } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import type React from 'react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import { AppIcon } from '~/components/apps/ui/app-icon'
+import { Tooltip } from '~/components/global/tooltip'
+import { useToolAppResolver } from '../../hooks/use-tool-app-resolver'
 import type { KopilotMessage, ToolCallPart } from '../../stores/kopilot-store'
 import { type ApprovalCardProps, getApprovalCard } from '../blocks/approval-card-registry'
 import { GenericApprovalCard } from '../blocks/generic-approval-card'
@@ -64,11 +67,32 @@ export function ThinkingSteps({
   onApproval,
 }: ThinkingStepsProps) {
   const [isOpen, setIsOpen] = useState(isRunning)
+  const { resolve } = useToolAppResolver()
 
   const totalCount = steps.length
   const completedCount = steps.filter(
     (s) => s.toolCall.status === 'completed' || s.toolCall.status === 'error'
   ).length
+
+  // Unique app icons touched in this run, in first-touched order. Built-in
+  // tools (no resolver match) are intentionally skipped — the stack's purpose
+  // is to show *which third-party apps* the agent reached for.
+  const appIcons = useMemo(() => {
+    const seen = new Set<string>()
+    const out: { appId: string; iconId: string; title: string }[] = []
+    for (const step of steps) {
+      const r = resolve(step.toolCall.name)
+      if (!r) continue
+      if (seen.has(r.installation.app.id)) continue
+      seen.add(r.installation.app.id)
+      out.push({
+        appId: r.installation.app.id,
+        iconId: r.iconId,
+        title: r.appTitle,
+      })
+    }
+    return out
+  }, [steps, resolve])
 
   if (totalCount === 0 && !pendingThinking?.trim()) return null
 
@@ -106,6 +130,24 @@ export function ThinkingSteps({
           'flex items-center gap-1 rounded-md px-1 py-0.5 text-xs',
           'text-muted-foreground hover:bg-muted/50'
         )}>
+        {appIcons.length > 0 && (
+          <span className='flex items-center -space-x-1 mr-1'>
+            {appIcons.slice(0, 4).map((a) => (
+              <Tooltip key={a.appId} content={a.title} side='top'>
+                <AppIcon
+                  iconId={a.iconId}
+                  size='xs'
+                  className='ring-1 ring-background rounded-sm'
+                />
+              </Tooltip>
+            ))}
+            {appIcons.length > 4 && (
+              <span className='text-[10px] text-muted-foreground pl-1.5'>
+                +{appIcons.length - 4}
+              </span>
+            )}
+          </span>
+        )}
         {isRunning && <Loader2 className='size-3 animate-spin' />}
         <AnimatePresence mode='popLayout'>
           <motion.span
@@ -148,6 +190,7 @@ export function ThinkingSteps({
                     toolCall.output,
                     toolCall.digest
                   )
+                  const resolved = resolve(toolCall.name)
                   return (
                     <motion.div
                       key={step.id}
@@ -165,6 +208,9 @@ export function ThinkingSteps({
                             entities,
                           },
                         }}
+                        iconId={resolved?.iconId}
+                        color={resolved?.color}
+                        displayName={resolved?.displayName}
                       />
                       {step.thinking?.trim() && (
                         <p className='py-1 pl-2 text-xs text-muted-foreground/70 italic leading-relaxed'>

--- a/apps/web/src/components/kopilot/ui/messages/tool-status-pill-config.ts
+++ b/apps/web/src/components/kopilot/ui/messages/tool-status-pill-config.ts
@@ -10,8 +10,13 @@ export interface ToolPillLabels {
 }
 
 export interface ToolPillConfig {
-  /** Lucide icon name — resolved to component in the pill */
-  icon: string
+  /**
+   * Lucide icon name for built-in tools that have a per-tool entry below.
+   * App-backed tools get their icon from the cached app catalog via the
+   * pill's `iconId` prop instead, so this field is optional and unused for
+   * the fallback config.
+   */
+  icon?: string
   labels: ToolPillLabels
 }
 
@@ -215,19 +220,29 @@ function formatToolName(name: string): string {
   return name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
-/** Returns config for a tool, or a generic fallback */
-export function getToolPillConfig(toolName: string): ToolPillConfig {
-  return (
-    configs[toolName] ?? {
-      icon: 'Wrench',
-      labels: {
-        running: () => ({ label: formatToolName(toolName) }),
-        completed: (_args, summary) => ({
-          label: `${formatToolName(toolName)} completed`,
-          secondary: summary,
-        }),
-        error: () => ({ label: `Failed: ${formatToolName(toolName)}` }),
-      },
-    }
-  )
+/**
+ * Returns config for a tool, or a generic fallback. When the caller passes a
+ * `displayName` (resolved via `useToolAppResolver` for app-backed tools), the
+ * fallback uses it verbatim — so an app tool like
+ * `gog_contacts_search_google_contacts` renders as "Search Google Contacts",
+ * not "Gog Contacts Search Google Contacts". The app prefix is conveyed
+ * visually by the `<AppIcon>` next to the label.
+ */
+export function getToolPillConfig(
+  toolName: string,
+  options?: { displayName?: string }
+): ToolPillConfig {
+  const existing = configs[toolName]
+  if (existing) return existing
+  const label = options?.displayName ?? formatToolName(toolName)
+  return {
+    labels: {
+      running: () => ({ label }),
+      // Bare `label` here; the secondary slot already carries "Completed"
+      // (or a richer per-tool summary) from `summarizeToolResult`, so a
+      // `${label} completed` headline would just stack a duplicate.
+      completed: (_args, summary) => ({ label, secondary: summary }),
+      error: () => ({ label: `Failed: ${label}` }),
+    },
+  }
 }

--- a/apps/web/src/components/kopilot/ui/messages/tool-status-pill.tsx
+++ b/apps/web/src/components/kopilot/ui/messages/tool-status-pill.tsx
@@ -2,29 +2,9 @@
 
 'use client'
 
-import {
-  BookOpen,
-  Check,
-  Columns3,
-  Database,
-  FileEdit,
-  FileText,
-  LayoutGrid,
-  Loader2,
-  type LucideIcon,
-  Mail,
-  MailCheck,
-  MailOpen,
-  Pencil,
-  PencilLine,
-  PenTool,
-  Plus,
-  Search,
-  Send,
-  Wrench,
-  X,
-} from 'lucide-react'
+import { Check, Loader2, X } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
+import { AppIcon } from '~/components/apps/ui/app-icon'
 import { getToolPillConfig } from './tool-status-pill-config'
 
 /**
@@ -43,35 +23,30 @@ interface ThinkingStep {
   }
 }
 
-const iconMap: Record<string, LucideIcon> = {
-  Mail,
-  MailOpen,
-  MailCheck,
-  PenTool,
-  Send,
-  BookOpen,
-  LayoutGrid,
-  Columns3,
-  Search,
-  Database,
-  FileEdit,
-  FileText,
-  Plus,
-  Pencil,
-  PencilLine,
-  Wrench,
-}
-
 interface ToolStatusPillProps {
   step: ThinkingStep
+  /**
+   * Resolved icon for the tool, in `<AppIcon iconId>` shape (Lucide name,
+   * url:..., https:// URL, base64, or emoji). Supplied by `thinking-steps`
+   * via `useToolAppResolver` for app-backed tools; built-in tools fall back
+   * to the per-tool config's Lucide name, or the generic `'wrench'`.
+   */
+  iconId?: string | null
+  color?: string
+  /**
+   * Human label for app-backed tools (e.g. "Search Google Contacts"). Used
+   * by the fallback config when no per-tool entry exists so labels never
+   * include the snake-case `appSlug_` prefix.
+   */
+  displayName?: string
 }
 
-export function ToolStatusPill({ step }: ToolStatusPillProps) {
+export function ToolStatusPill({ step, iconId, color, displayName }: ToolStatusPillProps) {
   if (!step.tool) return null
 
   const { name, args, status, summary } = step.tool
-  const config = getToolPillConfig(name)
-  const Icon = iconMap[config.icon] ?? Wrench
+  const config = getToolPillConfig(name, { displayName })
+  const resolvedIconId = iconId ?? config.icon ?? 'wrench'
 
   const labelData =
     status === 'running'
@@ -97,7 +72,7 @@ export function ToolStatusPill({ step }: ToolStatusPillProps) {
           {status === 'error' && <X className='size-3 text-destructive' />}
         </motion.span>
       </AnimatePresence>
-      <Icon className='size-3 shrink-0 text-muted-foreground' />
+      <AppIcon iconId={resolvedIconId} color={color} size='xs' />
       <span className='font-medium text-foreground/80 shrink-0'>{labelData.label}</span>
       {labelData.secondary && (
         <span className='truncate text-muted-foreground'>{labelData.secondary}</span>

--- a/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
@@ -15,6 +15,7 @@ import type {
 import { loadMasterKopilotSettings } from '../../load-master-settings'
 import type { GetToolDeps, PageCapability } from '../types'
 import { buildAppToolDigest } from './digest'
+import { getRegisteredToolName } from './tool-naming'
 
 /**
  * AI tool bridge — registers app-backed tools alongside native capabilities.
@@ -75,9 +76,6 @@ export async function createAppCapabilities(deps: {
     const appId = installation.app.id
     const appSlug = installation.app.slug
     const installationId = installation.installationId
-    // Per decision D1 — kebab → snake on the slug portion so the LLM tool
-    // name regex `^[a-zA-Z0-9_-]{1,64}$` is honored cleanly.
-    const slugPrefix = appSlug.replace(/-/g, '_')
 
     // Per plans/kopilot/apps/agent-credentials.md §3.5 — registration is
     // gated on the bound credId from the agent's (or master's)
@@ -101,7 +99,7 @@ export async function createAppCapabilities(deps: {
         }
       }
 
-      const registeredName = `${slugPrefix}_${tool.id}`
+      const registeredName = getRegisteredToolName(appSlug, tool.id)
       const refDescriptors = tool.refs ?? []
       const toolId = tool.id
       const timeoutMs = tool.timeoutMs

--- a/packages/lib/src/ai/kopilot/capabilities/apps/tool-naming.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/apps/tool-naming.ts
@@ -1,0 +1,19 @@
+// packages/lib/src/ai/kopilot/capabilities/apps/tool-naming.ts
+
+/**
+ * Single source of truth for the LLM-facing tool-name encoding used by the
+ * Kopilot app bridge. Per decision D1 (plans/kopilot/agents/tool-loading-and-execution.md §5),
+ * each app-backed tool is registered as `<appSlug>_<toolId>` with the slug
+ * portion kebab→snake so the name stays portable across LLM providers and
+ * collisions between two apps publishing the same `toolId` are impossible.
+ *
+ * Called by:
+ *  - the bridge at registration time (packages/lib/src/ai/kopilot/capabilities/apps/index.ts)
+ *  - the installed-apps cache projection, so the client can do a direct
+ *    `Map<registeredName, ResolvedTool>` lookup without re-encoding
+ *    (apps/web/src/components/kopilot/hooks/use-tool-app-resolver.ts).
+ */
+export function getRegisteredToolName(appSlug: string, toolId: string): string {
+  const slugPrefix = appSlug.replace(/-/g, '_')
+  return `${slugPrefix}_${toolId}`
+}

--- a/packages/lib/src/cache/index.ts
+++ b/packages/lib/src/cache/index.ts
@@ -69,6 +69,7 @@ export {
 } from './org-cache-helpers'
 export type {
   CachedAgent,
+  CachedAgentTool,
   CachedAgentTrigger,
   CachedGroup,
   CachedInstalledApp,

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -198,6 +198,26 @@ export interface CachedSystemModelDefault {
   updatedAt: string
 }
 
+/**
+ * Cached agent-tool projection: the source `CatalogAgentTool` plus two
+ * pre-resolved view-model fields the kopilot UI consumes directly without
+ * re-encoding or walking the toolset list.
+ *
+ *  - `registeredName` — the LLM-facing name the bridge registers this tool
+ *    under (`getRegisteredToolName(appSlug, tool.id)`). Stamped here so the
+ *    client `useToolAppResolver` hook can do `Map<registeredName, …>`
+ *    lookups against `ToolCallPart.name` without duplicating the encoding.
+ *  - `iconId` — the resolved icon to render in `<AppIcon>`: toolset's own
+ *    `iconKey` wins (multi-toolset apps like Workspace ship distinct
+ *    Mail/Calendar/Drive icons), falls back to the app's `avatarUrl`, then
+ *    to the Lucide `'package'` glyph so the component always has something
+ *    to render.
+ */
+export interface CachedAgentTool extends CatalogAgentTool {
+  registeredName: string
+  iconId: string
+}
+
 /** Cached installed app shape (JSON-serializable) */
 export interface CachedInstalledApp {
   installationId: string
@@ -259,7 +279,7 @@ export interface CachedInstalledApp {
    *
    * See plans/kopilot/agents/triggers/app-surface-implementation-plan.md §5.3.
    */
-  agentTools?: CatalogAgentTool[]
+  agentTools?: CachedAgentTool[]
   agentToolsets?: CatalogToolset[]
   agentTriggers?: CatalogTriggerProjection[]
   workflowBlocks?: CatalogBlock[]

--- a/packages/lib/src/cache/providers/installed-apps-provider.ts
+++ b/packages/lib/src/cache/providers/installed-apps-provider.ts
@@ -2,7 +2,8 @@
 
 import { schema } from '@auxx/database'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
-import type { CachedInstalledApp } from '../org-cache-keys'
+import { getRegisteredToolName } from '../../ai/kopilot/capabilities/apps/tool-naming'
+import type { CachedAgentTool, CachedInstalledApp } from '../org-cache-keys'
 import type { CacheProvider } from '../org-cache-provider'
 
 /**
@@ -86,53 +87,72 @@ export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
     }
 
     // 3. Build serializable output
-    return installations.map((inst) => ({
-      installationId: inst.id,
-      installationType: inst.installationType as 'development' | 'production',
-      installedAt: inst.installedAt.toISOString(),
-      app: {
-        id: inst.app.id,
-        slug: inst.app.slug,
-        title: inst.app.title,
-        description: inst.app.description,
-        avatarUrl: inst.app.avatarUrl,
-        category: inst.app.category,
-      },
-      currentDeployment: inst.currentDeployment
-        ? {
-            id: inst.currentDeployment.id,
-            version: inst.currentDeployment.version,
-            deploymentType: inst.currentDeployment.deploymentType,
-            status: inst.currentDeployment.status,
-            clientBundleSha: inst.currentDeployment.clientBundle.sha256,
-            serverBundleSha: inst.currentDeployment.serverBundle.sha256,
-            createdAt: inst.currentDeployment.createdAt.toISOString(),
+    return installations.map((inst) => {
+      // Pre-resolve per-tool icon cascade once per app: toolset.iconKey →
+      // app.avatarUrl → 'package'. Same cascade as the admin tools tree
+      // (packages/lib/src/agents/toolset-catalog.ts:276-288) so the kopilot
+      // pill matches what users see in settings.
+      const appIconId = inst.app.avatarUrl ?? 'package'
+      const toolsetIconBySlug = new Map(
+        (inst.currentDeployment?.catalog?.agent.toolsets ?? []).map(
+          (ts) => [ts.slug, ts.iconKey] as const
+        )
+      )
+      const agentTools: CachedAgentTool[] | undefined =
+        inst.currentDeployment?.catalog?.agent.tools.map((t) => ({
+          ...t,
+          registeredName: getRegisteredToolName(inst.app.slug, t.id),
+          iconId: toolsetIconBySlug.get(t.toolsetSlug) ?? appIconId,
+        })) ?? undefined
+
+      return {
+        installationId: inst.id,
+        installationType: inst.installationType as 'development' | 'production',
+        installedAt: inst.installedAt.toISOString(),
+        app: {
+          id: inst.app.id,
+          slug: inst.app.slug,
+          title: inst.app.title,
+          description: inst.app.description,
+          avatarUrl: inst.app.avatarUrl,
+          category: inst.app.category,
+        },
+        currentDeployment: inst.currentDeployment
+          ? {
+              id: inst.currentDeployment.id,
+              version: inst.currentDeployment.version,
+              deploymentType: inst.currentDeployment.deploymentType,
+              status: inst.currentDeployment.status,
+              clientBundleSha: inst.currentDeployment.clientBundle.sha256,
+              serverBundleSha: inst.currentDeployment.serverBundle.sha256,
+              createdAt: inst.currentDeployment.createdAt.toISOString(),
+            }
+          : null,
+        connectionDefinitions: (() => {
+          const defs = connDefsByAppId.get(inst.app.id) ?? {}
+          const toCached = (def: (typeof connectionDefs)[0] | undefined) =>
+            def
+              ? {
+                  label: def.label,
+                  global: def.global,
+                  connectionType: def.connectionType,
+                  oauth2Features: def.oauth2Features as Record<string, unknown> | null,
+                }
+              : undefined
+          return {
+            user: toCached(defs.user),
+            organization: toCached(defs.organization),
           }
-        : null,
-      connectionDefinitions: (() => {
-        const defs = connDefsByAppId.get(inst.app.id) ?? {}
-        const toCached = (def: (typeof connectionDefs)[0] | undefined) =>
-          def
-            ? {
-                label: def.label,
-                global: def.global,
-                connectionType: def.connectionType,
-                oauth2Features: def.oauth2Features as Record<string, unknown> | null,
-              }
-            : undefined
-        return {
-          user: toCached(defs.user),
-          organization: toCached(defs.organization),
-        }
-      })(),
-      agentTools: inst.currentDeployment?.catalog?.agent.tools ?? undefined,
-      agentToolsets: inst.currentDeployment?.catalog?.agent.toolsets ?? undefined,
-      agentTriggers: inst.currentDeployment?.catalog?.agent.triggers ?? undefined,
-      workflowBlocks: inst.currentDeployment?.catalog?.workflow.blocks ?? undefined,
-      workflowTriggers: inst.currentDeployment?.catalog?.workflow.triggers ?? undefined,
-      actions: inst.currentDeployment?.catalog?.actions ?? undefined,
-      orgConnectionPresent: orgConnByAppId.get(inst.app.id)?.present ?? false,
-      orgConnectionExpiresAt: orgConnByAppId.get(inst.app.id)?.expiresAt?.toISOString() ?? null,
-    }))
+        })(),
+        agentTools,
+        agentToolsets: inst.currentDeployment?.catalog?.agent.toolsets ?? undefined,
+        agentTriggers: inst.currentDeployment?.catalog?.agent.triggers ?? undefined,
+        workflowBlocks: inst.currentDeployment?.catalog?.workflow.blocks ?? undefined,
+        workflowTriggers: inst.currentDeployment?.catalog?.workflow.triggers ?? undefined,
+        actions: inst.currentDeployment?.catalog?.actions ?? undefined,
+        orgConnectionPresent: orgConnByAppId.get(inst.app.id)?.present ?? false,
+        orgConnectionExpiresAt: orgConnByAppId.get(inst.app.id)?.expiresAt?.toISOString() ?? null,
+      }
+    })
   },
 }


### PR DESCRIPTION
## Summary

- Render `<AppIcon>` on tool-status pills for app-backed tools and stack unique app icons in the thinking-steps header. Tool-name encoding (`<appSlug>_<toolId>`) is centralized in a new `tool-naming.ts` and pre-resolved into the installed-apps cache (`registeredName`, `iconId`) so the client does a direct `Map` lookup with no re-encoding.
- Splice the patch into the `agent.getById` query cache on inline edit so the detail hero name/description update immediately on close instead of waiting for the mutation round-trip + invalidate refetch.
- Bust the org `agents` cache when an admin uploads an avatar for an agent's synthetic user so the new URL shows on next load.
- Composer: move model/sender/slash/send controls into a bottom row instead of absolute-positioned overlays so a tall draft can't cover them.

## Test plan

- [ ] Open a kopilot chat with at least one installed app — confirm app-backed tool pills show the app's icon (or toolset icon for multi-toolset apps like Google Workspace) and the label drops the `appSlug_` prefix.
- [ ] Thinking-steps header shows a stack of unique app icons (up to 4 + overflow) for the apps the agent touched in a turn; built-in tools are excluded.
- [ ] Open an agent's detail page, inline-edit the name/description — value persists immediately on Enter, no flash back to old value.
- [ ] Upload an avatar for an agent (admin uploading to the agent's user) — sidebar/list reflects the new avatar on next navigation.
- [ ] Compose a long multi-line kopilot message — model picker, sender picker, slash, and send buttons stay visible at the bottom row, not overlapped by editor content.