### PR TITLE
feat(chat): widget v2 Home tab — greeting, KB cards, recent message

### DIFF
--- a/apps/api/src/routes/chat/config.ts
+++ b/apps/api/src/routes/chat/config.ts
@@ -2,7 +2,12 @@
 
 import { configService } from '@auxx/credentials'
 import { Hono } from 'hono'
-import { applyChatCorsHeaders, loadChatWidgetByChannelId } from './lib'
+import {
+  applyChatCorsHeaders,
+  loadChatWidgetByChannelId,
+  loadHomeFeaturedArticles,
+  loadHomeKnowledgeBase,
+} from './lib'
 
 const configRoute = new Hono()
 
@@ -32,10 +37,26 @@ configRoute.get('/:channelId', async (c) => {
 
   c.header('Cache-Control', 'public, max-age=60, s-maxage=300, stale-while-revalidate=300')
 
+  const [knowledgeBase, featuredArticles] = await Promise.all([
+    loadHomeKnowledgeBase(widget.organizationId, widget.home.knowledgeBaseId),
+    loadHomeFeaturedArticles(widget.organizationId, widget.home.featuredArticleIds),
+  ])
+
   return c.json({
     channelId: widget.channelId,
     isActive: widget.isActive,
     appearance: widget.appearance,
+    home: {
+      greetingTemplate: widget.home.greetingTemplate,
+      showRecentMessage: widget.home.showRecentMessage,
+      showSendMessageCta: widget.home.showSendMessageCta,
+      expandedWidthPx: widget.home.expandedWidthPx,
+      knowledgeBase,
+      featuredArticles,
+    },
+    branding: {
+      footerEnabled: widget.branding.footerEnabled,
+    },
     realtime: {
       provider: 'pusher' as const,
       key: configService.get<string>('PUSHER_KEY') ?? '',

--- a/apps/api/src/routes/chat/lib.ts
+++ b/apps/api/src/routes/chat/lib.ts
@@ -1,7 +1,7 @@
 // apps/api/src/routes/chat/lib.ts
 
 import { database, schema } from '@auxx/database'
-import { and, eq } from 'drizzle-orm'
+import { and, asc, eq, inArray } from 'drizzle-orm'
 import type { Context } from 'hono'
 
 export interface LoadedChatWidget {
@@ -22,6 +22,17 @@ export interface LoadedChatWidget {
     mobileFullScreen: boolean
     collectUserInfo: boolean
     offlineMessage: string | null
+  }
+  home: {
+    greetingTemplate: unknown
+    showRecentMessage: boolean
+    showSendMessageCta: boolean
+    expandedWidthPx: number
+    knowledgeBaseId: string | null
+    featuredArticleIds: string[]
+  }
+  branding: {
+    footerEnabled: boolean
   }
 }
 
@@ -60,7 +71,107 @@ export async function loadChatWidgetByChannelId(
       collectUserInfo: row.chatWidget.collectUserInfo,
       offlineMessage: row.chatWidget.offlineMessage ?? null,
     },
+    home: {
+      greetingTemplate: row.chatWidget.homeGreetingTemplate ?? null,
+      showRecentMessage: row.chatWidget.homeShowRecentMessage,
+      showSendMessageCta: row.chatWidget.homeShowSendMessageCta,
+      expandedWidthPx: row.chatWidget.expandedWidthPx,
+      knowledgeBaseId: row.chatWidget.knowledgeBaseId ?? null,
+      featuredArticleIds: row.chatWidget.featuredArticleIds ?? [],
+    },
+    branding: {
+      footerEnabled: row.chatWidget.brandingFooterEnabled,
+    },
   }
+}
+
+export interface HomeKnowledgeBaseInfo {
+  siteSlug: string
+  siteName: string
+  rootArticles: { id: string; title: string; emoji: string | null }[]
+}
+
+export interface HomeFeaturedArticle {
+  id: string
+  title: string
+  description: string | null
+  emoji: string | null
+}
+
+/**
+ * Resolve the KB site info + top-level published articles for the chat
+ * widget's Home tab. Returns `null` when the widget has no linked KB or the
+ * KB has been deleted.
+ */
+export async function loadHomeKnowledgeBase(
+  organizationId: string,
+  knowledgeBaseId: string | null
+): Promise<HomeKnowledgeBaseInfo | null> {
+  if (!knowledgeBaseId) return null
+  const kb = await database.query.KnowledgeBase.findFirst({
+    where: (k, { and: a, eq: e }) =>
+      a(e(k.id, knowledgeBaseId), e(k.organizationId, organizationId)),
+    columns: { id: true, name: true, slug: true },
+  })
+  if (!kb) return null
+
+  const articles = await database
+    .select({
+      id: schema.Article.id,
+      title: schema.Article.title,
+      emoji: schema.Article.emoji,
+    })
+    .from(schema.Article)
+    .where(
+      and(eq(schema.Article.knowledgeBaseId, knowledgeBaseId), eq(schema.Article.isPublished, true))
+    )
+    .orderBy(asc(schema.Article.sortOrder))
+
+  const rootArticles = articles
+    .filter((a) => a.title)
+    .map((a) => ({ id: a.id, title: a.title ?? '', emoji: a.emoji ?? null }))
+
+  return { siteSlug: kb.slug, siteName: kb.name, rootArticles }
+}
+
+/**
+ * Fetch the ordered set of featured articles for the chat widget Home tab.
+ * Filters out missing / unpublished entries and preserves the admin-set order.
+ */
+export async function loadHomeFeaturedArticles(
+  organizationId: string,
+  featuredArticleIds: string[]
+): Promise<HomeFeaturedArticle[]> {
+  if (featuredArticleIds.length === 0) return []
+  const rows = await database
+    .select({
+      id: schema.Article.id,
+      title: schema.Article.title,
+      excerpt: schema.Article.excerpt,
+      emoji: schema.Article.emoji,
+    })
+    .from(schema.Article)
+    .where(
+      and(
+        eq(schema.Article.organizationId, organizationId),
+        eq(schema.Article.isPublished, true),
+        inArray(schema.Article.id, featuredArticleIds)
+      )
+    )
+
+  const byId = new Map(rows.map((r) => [r.id, r]))
+  const out: HomeFeaturedArticle[] = []
+  for (const id of featuredArticleIds) {
+    const row = byId.get(id)
+    if (!row) continue
+    out.push({
+      id: row.id,
+      title: row.title ?? 'Untitled',
+      description: row.excerpt ?? null,
+      emoji: row.emoji ?? null,
+    })
+  }
+  return out
 }
 
 /** Extract hostname from an Origin/Referer header value, or null. */

--- a/apps/api/src/routes/chat/threads.ts
+++ b/apps/api/src/routes/chat/threads.ts
@@ -1,8 +1,10 @@
 // apps/api/src/routes/chat/threads.ts
 
 import { database, schema } from '@auxx/database'
+import { initializeOrResumeChatThread } from '@auxx/lib/chat'
+import type { ChatThreadMetadata } from '@auxx/lib/threads/types'
 import { createScopedLogger } from '@auxx/logger'
-import { and, asc, eq } from 'drizzle-orm'
+import { and, asc, desc, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { applyChatCorsHeaders } from './lib'
 
@@ -10,9 +12,144 @@ const log = createScopedLogger('chat-threads-route')
 
 const threadsRoute = new Hono()
 
+threadsRoute.options('/', (c) => {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  return c.body(null, 204)
+})
+
+threadsRoute.options('/recent', (c) => {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  return c.body(null, 204)
+})
+
 threadsRoute.options('/:threadId/messages', (c) => {
   applyChatCorsHeaders(c, { allowCredentials: true })
   return c.body(null, 204)
+})
+
+/**
+ * POST /api/chat/threads
+ *
+ * Create a fresh chat thread for the visitor. Always creates — the resume
+ * path lives on `POST /api/chat/initialize`. Used by the Home "Send us a
+ * message" CTA so every tap lands the visitor in a new conversation.
+ */
+threadsRoute.post('/', async (c) => {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  const chat = c.get('chat')
+  const body = await c.req.json().catch(() => ({}))
+
+  const result = await initializeOrResumeChatThread(
+    { db: database, organizationId: chat.organizationId },
+    {
+      channelId: chat.channelId,
+      visitorId: chat.sessionId,
+      forceNewThread: true,
+      visit: {
+        url: typeof body.url === 'string' ? body.url : undefined,
+        referrer: typeof body.referrer === 'string' ? body.referrer : undefined,
+        userAgent: typeof body.userAgent === 'string' ? body.userAgent : undefined,
+      },
+      visitorName: chat.identify?.name,
+      visitorEmail: chat.identify?.email,
+      visitorExternalId: chat.identify?.externalId,
+    }
+  )
+
+  if (result.error) {
+    log.error('Failed to create chat thread', {
+      channelId: chat.channelId,
+      error: result.error.message,
+    })
+    return c.json(
+      { success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create thread' } },
+      500
+    )
+  }
+
+  return c.json({
+    success: true,
+    data: {
+      threadId: result.value.thread.id,
+      pusherChannel: `chat-${result.value.visitorChatSessionId}`,
+    },
+  })
+})
+
+/**
+ * GET /api/chat/threads/recent
+ *
+ * Return the visitor's most recently active thread + a one-line preview for
+ * the Home "Recent message" card. Returns `{ thread: null }` when the visitor
+ * has no threads on this channel.
+ */
+threadsRoute.get('/recent', async (c) => {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  const chat = c.get('chat')
+
+  try {
+    const threads = await database
+      .select()
+      .from(schema.Thread)
+      .where(
+        and(
+          eq(schema.Thread.organizationId, chat.organizationId),
+          eq(schema.Thread.integrationId, chat.channelId)
+        )
+      )
+      .orderBy(desc(schema.Thread.lastMessageAt))
+      .limit(20)
+
+    const recent = threads.find((t) => {
+      const meta = (t.metadata ?? {}) as Partial<ChatThreadMetadata>
+      return meta.channel === 'chat' && meta.visitorParticipantId === chat.visitorParticipantId
+    })
+
+    if (!recent) {
+      return c.json({ success: true, data: { thread: null } })
+    }
+
+    const [lastMessage] = await database
+      .select({
+        textPlain: schema.Message.textPlain,
+        textHtml: schema.Message.textHtml,
+        isInbound: schema.Message.isInbound,
+        sentAt: schema.Message.sentAt,
+        createdAt: schema.Message.createdAt,
+      })
+      .from(schema.Message)
+      .where(eq(schema.Message.threadId, recent.id))
+      .orderBy(desc(schema.Message.sentAt))
+      .limit(1)
+
+    if (!lastMessage) {
+      return c.json({ success: true, data: { thread: null } })
+    }
+
+    return c.json({
+      success: true,
+      data: {
+        thread: {
+          id: recent.id,
+          subject: recent.subject,
+          lastMessage: {
+            preview: (lastMessage.textPlain ?? lastMessage.textHtml ?? '').slice(0, 160),
+            isInbound: lastMessage.isInbound,
+            timestamp: lastMessage.sentAt ?? lastMessage.createdAt,
+          },
+        },
+      },
+    })
+  } catch (error) {
+    log.error('Failed to load recent chat thread', {
+      channelId: chat.channelId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return c.json(
+      { success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load thread' } },
+      500
+    )
+  }
 })
 
 /**

--- a/apps/chat-widget/package.json
+++ b/apps/chat-widget/package.json
@@ -9,12 +9,19 @@
     "clean": "rm -rf dist node_modules .turbo *.tsbuildinfo"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "catalog:",
     "preact": "^10.24.0",
-    "pusher-js": "catalog:"
+    "pusher-js": "catalog:",
+    "radix-ui": "^1.4.2",
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@auxx/typescript-config": "workspace:*",
+    "@tailwindcss/vite": "^4.1.7",
     "@types/node": "catalog:",
+    "tailwindcss": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:"
   }

--- a/apps/chat-widget/src/components/frame-header.tsx
+++ b/apps/chat-widget/src/components/frame-header.tsx
@@ -1,0 +1,105 @@
+// apps/chat-widget/src/components/frame-header.tsx
+//
+// Three header variants share most of their shape, so a single component
+// switches on `variant`. Phases 4–6 fill in the slotted content:
+//   - dark hero    → Home root: logo + greeting on a primary-colored band
+//   - plain title  → Messages root: centered "Messages" on a flat band
+//   - contextual   → deep frames: back chevron + custom title + actions slot
+
+import { ArrowLeft, X } from 'lucide-react'
+import type { ComponentChildren } from 'preact'
+import { cn } from '~/lib/cn'
+
+export type FrameHeaderVariant = 'dark-hero' | 'plain' | 'contextual'
+
+interface FrameHeaderProps {
+  variant: FrameHeaderVariant
+  title?: string
+  subtitle?: string
+  logoUrl?: string | null
+  onClose: () => void
+  onBack?: () => void
+  actions?: ComponentChildren
+  children?: ComponentChildren
+}
+
+export function FrameHeader({
+  variant,
+  title,
+  subtitle,
+  logoUrl,
+  onClose,
+  onBack,
+  actions,
+  children,
+}: FrameHeaderProps) {
+  if (variant === 'dark-hero') {
+    return (
+      <header className='relative flex shrink-0 flex-col gap-4 bg-[color:var(--color-primary)] px-5 py-5 text-[color:var(--color-primary-foreground)]'>
+        <div className='flex items-start justify-between'>
+          {logoUrl ? <img src={logoUrl} alt='' className='h-8 w-auto' /> : <span className='h-8' />}
+          <CloseButton onClose={onClose} tone='light' />
+        </div>
+        {children ?? (
+          <div className='flex flex-col gap-1'>
+            {title ? <h1 className='text-xl font-semibold leading-tight'>{title}</h1> : null}
+            {subtitle ? <p className='text-sm opacity-90'>{subtitle}</p> : null}
+          </div>
+        )}
+      </header>
+    )
+  }
+
+  if (variant === 'plain') {
+    return (
+      <header className='relative flex shrink-0 items-center justify-between border-b border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-4 py-3'>
+        <span className='w-6' />
+        <h1 className='text-sm font-semibold'>{title}</h1>
+        <CloseButton onClose={onClose} tone='dark' />
+      </header>
+    )
+  }
+
+  return (
+    <header className='relative flex shrink-0 items-center gap-2 border-b border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2'>
+      {onBack ? (
+        <button
+          type='button'
+          onClick={onBack}
+          className='flex size-7 items-center justify-center rounded text-[color:var(--color-muted)] hover:bg-[color:var(--color-surface)] hover:text-[color:var(--color-fg)]'
+          aria-label='Back'>
+          <ArrowLeft className='size-4' aria-hidden='true' />
+        </button>
+      ) : null}
+      <div className='flex min-w-0 flex-1 flex-col'>
+        {title ? (
+          <span className='truncate text-sm font-semibold text-[color:var(--color-fg)]'>
+            {title}
+          </span>
+        ) : null}
+        {subtitle ? (
+          <span className='truncate text-xs text-[color:var(--color-muted)]'>{subtitle}</span>
+        ) : null}
+      </div>
+      {actions}
+      <CloseButton onClose={onClose} tone='dark' />
+    </header>
+  )
+}
+
+function CloseButton({ onClose, tone }: { onClose: () => void; tone: 'light' | 'dark' }) {
+  return (
+    <button
+      type='button'
+      onClick={onClose}
+      aria-label='Close chat'
+      className={cn(
+        'flex size-7 items-center justify-center rounded transition-colors',
+        tone === 'light'
+          ? 'text-white/90 hover:bg-white/10 hover:text-white'
+          : 'text-[color:var(--color-muted)] hover:bg-[color:var(--color-surface)] hover:text-[color:var(--color-fg)]'
+      )}>
+      <X className='size-4' aria-hidden='true' />
+    </button>
+  )
+}

--- a/apps/chat-widget/src/components/tab-bar.tsx
+++ b/apps/chat-widget/src/components/tab-bar.tsx
@@ -1,0 +1,48 @@
+// apps/chat-widget/src/components/tab-bar.tsx
+//
+// Bottom tab bar with Home + Messages. Only rendered when the active tab's
+// stack is at root — pushing a deep frame (thread, kb-article…) hides the
+// bar so the user can focus on content.
+
+import { Home, MessageSquare } from 'lucide-react'
+import { cn } from '~/lib/cn'
+import type { TabId } from '~/navigation/use-tab-router'
+
+interface TabBarProps {
+  activeTab: TabId
+  onChange: (tab: TabId) => void
+}
+
+const TABS: { id: TabId; label: string; icon: typeof Home }[] = [
+  { id: 'home', label: 'Home', icon: Home },
+  { id: 'messages', label: 'Messages', icon: MessageSquare },
+]
+
+export function TabBar({ activeTab, onChange }: TabBarProps) {
+  return (
+    <nav
+      className='flex shrink-0 items-stretch justify-around divide-x divide-[color:var(--color-border)] border-t border-[color:var(--color-border)] bg-[color:var(--color-bg)]'
+      aria-label='Widget sections'>
+      {TABS.map((tab) => {
+        const isActive = tab.id === activeTab
+        const IconComponent = tab.icon
+        return (
+          <button
+            key={tab.id}
+            type='button'
+            className={cn(
+              'flex flex-1 flex-col items-center justify-center gap-1 px-2 py-2 text-xs font-medium transition-colors',
+              isActive
+                ? 'text-[color:var(--color-primary)]'
+                : 'text-[color:var(--color-muted)] hover:text-[color:var(--color-fg)]'
+            )}
+            onClick={() => onChange(tab.id)}
+            aria-current={isActive ? 'page' : undefined}>
+            <IconComponent className='size-5' aria-hidden='true' />
+            <span>{tab.label}</span>
+          </button>
+        )
+      })}
+    </nav>
+  )
+}

--- a/apps/chat-widget/src/lib/cn.ts
+++ b/apps/chat-widget/src/lib/cn.ts
@@ -1,0 +1,8 @@
+// apps/chat-widget/src/lib/cn.ts
+
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs))
+}

--- a/apps/chat-widget/src/main.tsx
+++ b/apps/chat-widget/src/main.tsx
@@ -1,16 +1,12 @@
 // apps/chat-widget/src/main.tsx
 //
 // Entry point for the embedded chat widget. Reads `data-channel-id` off its
-// own <script> tag, mounts the Preact app inside a body-level container, and
-// injects the inlined stylesheet so the bundle is fully self-contained.
+// own <script> tag and mounts the Preact app inside a closed Shadow DOM via
+// `mountWidget` so host-page CSS cannot leak in.
 
-import { render } from 'preact'
 import { installIdentifyQueue } from './identify'
-import styles from './styles.css?inline'
+import { mountWidget } from './shadow-root'
 import { Widget } from './widget'
-
-const ROOT_ID = 'auxx-chat-widget-root'
-const STYLE_ID = 'auxx-chat-widget-styles'
 
 function findScriptTag(): HTMLScriptElement | null {
   const current = document.currentScript as HTMLScriptElement | null
@@ -19,24 +15,9 @@ function findScriptTag(): HTMLScriptElement | null {
   return all[all.length - 1] ?? null
 }
 
-function injectStyles(): void {
-  if (document.getElementById(STYLE_ID)) return
-  const tag = document.createElement('style')
-  tag.id = STYLE_ID
-  tag.textContent = styles
-  document.head.appendChild(tag)
-}
-
 function mount(channelId: string): void {
   installIdentifyQueue(channelId)
-  injectStyles()
-  let root = document.getElementById(ROOT_ID)
-  if (!root) {
-    root = document.createElement('div')
-    root.id = ROOT_ID
-    document.body.appendChild(root)
-  }
-  render(<Widget channelId={channelId} />, root)
+  mountWidget(<Widget channelId={channelId} />)
 }
 
 function boot(): void {

--- a/apps/chat-widget/src/navigation/nav-stack-context.ts
+++ b/apps/chat-widget/src/navigation/nav-stack-context.ts
@@ -1,0 +1,19 @@
+// apps/chat-widget/src/navigation/nav-stack-context.ts
+//
+// Lets any frame view call `useNavStack()` to push/pop without prop drilling.
+// The provider lives in widget.tsx and supplies whichever tab's stack is
+// currently active.
+
+import { createContext } from 'preact'
+import { useContext } from 'preact/hooks'
+import type { NavStack } from './use-navigation-stack'
+
+const NavStackContext = createContext<NavStack | null>(null)
+
+export const NavStackProvider = NavStackContext.Provider
+
+export function useNavStack(): NavStack {
+  const ctx = useContext(NavStackContext)
+  if (!ctx) throw new Error('useNavStack must be used within a NavStackProvider')
+  return ctx
+}

--- a/apps/chat-widget/src/navigation/use-navigation-stack.ts
+++ b/apps/chat-widget/src/navigation/use-navigation-stack.ts
@@ -1,0 +1,66 @@
+// apps/chat-widget/src/navigation/use-navigation-stack.ts
+//
+// Per-tab navigation stack. Modeled on the React `CommandNavigation` pattern
+// in `@auxx/ui/components/command` but stripped of the keyboard surface and
+// search flag (the widget has neither), and extended with `replace` so the
+// Messages list can swap the top thread frame without growing the stack.
+
+import { useCallback, useMemo, useState } from 'preact/hooks'
+
+export type NavView = 'home' | 'messages' | 'thread' | 'kb-section' | 'kb-article'
+
+export interface NavFrame {
+  id: string
+  label: string
+  view: NavView
+  params?: Record<string, unknown>
+}
+
+export interface NavStack {
+  stack: NavFrame[]
+  current: NavFrame | null
+  isAtRoot: boolean
+  push: (frame: NavFrame) => void
+  pop: () => void
+  navigateTo: (index: number) => void
+  reset: () => void
+  replace: (frame: NavFrame) => void
+}
+
+export function useNavigationStack(initialStack: NavFrame[] = []): NavStack {
+  const [stack, setStack] = useState<NavFrame[]>(initialStack)
+
+  const push = useCallback((frame: NavFrame) => {
+    setStack((prev) => [...prev, frame])
+  }, [])
+
+  const pop = useCallback(() => {
+    setStack((prev) => (prev.length > 0 ? prev.slice(0, -1) : prev))
+  }, [])
+
+  const navigateTo = useCallback((index: number) => {
+    setStack((prev) => prev.slice(0, Math.max(0, index + 1)))
+  }, [])
+
+  const reset = useCallback(() => {
+    setStack([])
+  }, [])
+
+  const replace = useCallback((frame: NavFrame) => {
+    setStack((prev) => (prev.length === 0 ? [frame] : [...prev.slice(0, -1), frame]))
+  }, [])
+
+  return useMemo<NavStack>(
+    () => ({
+      stack,
+      current: stack.length > 0 ? stack[stack.length - 1] : null,
+      isAtRoot: stack.length === 0,
+      push,
+      pop,
+      navigateTo,
+      reset,
+      replace,
+    }),
+    [stack, push, pop, navigateTo, reset, replace]
+  )
+}

--- a/apps/chat-widget/src/navigation/use-tab-router.ts
+++ b/apps/chat-widget/src/navigation/use-tab-router.ts
@@ -1,0 +1,85 @@
+// apps/chat-widget/src/navigation/use-tab-router.ts
+//
+// Per-tab router: each tab owns its own navigation stack and switching tabs
+// preserves position in the other tab's stack. A debounced snapshot lands in
+// localStorage so reopening the widget on a later page load returns to the
+// same active tab.
+//
+// Deeper-frame restoration is intentionally minimal in Phase 3: the snapshot
+// remembers the active tab only, dropping deeper frames on cross-page reload.
+// Phases 4–6 can opt in to validating + restoring deeper frames once their
+// entities (article id, thread id, section id) have resolvers wired up.
+
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { type NavStack, useNavigationStack } from './use-navigation-stack'
+
+export type TabId = 'home' | 'messages'
+
+interface PersistedSnapshot {
+  activeTab: TabId
+}
+
+interface TabRouter {
+  activeTab: TabId
+  setActiveTab: (tab: TabId) => void
+  homeStack: NavStack
+  messagesStack: NavStack
+  currentStack: NavStack
+}
+
+const STORAGE_PREFIX = 'auxx-chat-route:'
+const PERSIST_DEBOUNCE_MS = 200
+
+function storageKey(channelId: string): string {
+  return `${STORAGE_PREFIX}${channelId}`
+}
+
+function readSnapshot(channelId: string): PersistedSnapshot | null {
+  try {
+    const raw = window.localStorage.getItem(storageKey(channelId))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as { activeTab?: unknown }
+    if (parsed.activeTab === 'home' || parsed.activeTab === 'messages') {
+      return { activeTab: parsed.activeTab }
+    }
+  } catch {
+    // ignore — fall back to defaults
+  }
+  return null
+}
+
+function writeSnapshot(channelId: string, snapshot: PersistedSnapshot): void {
+  try {
+    window.localStorage.setItem(storageKey(channelId), JSON.stringify(snapshot))
+  } catch {
+    // ignore — storage may be full or disabled
+  }
+}
+
+export function useTabRouter(channelId: string, initialTab: TabId = 'home'): TabRouter {
+  const [activeTab, setActiveTab] = useState<TabId>(() => {
+    if (typeof window === 'undefined') return initialTab
+    return readSnapshot(channelId)?.activeTab ?? initialTab
+  })
+
+  const homeStack = useNavigationStack()
+  const messagesStack = useNavigationStack()
+  const currentStack = activeTab === 'home' ? homeStack : messagesStack
+
+  const timerRef = useRef<number | null>(null)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current)
+    timerRef.current = window.setTimeout(() => {
+      writeSnapshot(channelId, { activeTab })
+    }, PERSIST_DEBOUNCE_MS)
+    return () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current)
+    }
+  }, [channelId, activeTab])
+
+  return useMemo(
+    () => ({ activeTab, setActiveTab, homeStack, messagesStack, currentStack }),
+    [activeTab, homeStack, messagesStack, currentStack]
+  )
+}

--- a/apps/chat-widget/src/shadow-root.tsx
+++ b/apps/chat-widget/src/shadow-root.tsx
@@ -1,0 +1,91 @@
+// apps/chat-widget/src/shadow-root.tsx
+//
+// Encapsulates the widget inside a closed Shadow DOM so host-page CSS cannot
+// leak in and Tailwind's preflight cannot leak out. Exposes the shadow root
+// via context so Radix portal consumers can target it instead of
+// `document.body` (which lives outside the shadow tree and breaks styling).
+
+import type { ComponentChildren, VNode } from 'preact'
+import { createContext, render } from 'preact'
+import { useContext } from 'preact/hooks'
+import widgetCss from './styles.css?inline'
+import { PortalContainerProvider } from './ui/portal-container'
+
+const HOST_ID = 'auxx-chat-widget-root'
+const PROPERTIES_STYLE_ID = 'auxx-chat-widget-properties'
+const ROOT_CLASS = 'auxx-root'
+
+interface Mount {
+  shadowRoot: ShadowRoot
+  rootEl: HTMLElement
+}
+
+// Browsers ignore `@property` rules that live inside a Shadow Root — they only
+// register in the main document's property registry. Tailwind v4 relies on
+// `@property` to give vars like `--tw-border-style` an `initial-value: solid`,
+// so we extract every `@property` block from the bundled CSS, hoist it to
+// `document.head` (registers globally → inherits into the shadow root), and
+// keep the rest of the stylesheet scoped to the shadow root.
+const PROPERTY_RULE_RE = /@property\s+--[^{]+\{[^}]*\}/g
+
+function splitProperties(css: string): { properties: string; rest: string } {
+  const properties = css.match(PROPERTY_RULE_RE)?.join('') ?? ''
+  const rest = css.replace(PROPERTY_RULE_RE, '')
+  return { properties, rest }
+}
+
+function injectStyles(shadowRoot: ShadowRoot): void {
+  const { properties, rest } = splitProperties(widgetCss)
+
+  if (properties && !document.getElementById(PROPERTIES_STYLE_ID)) {
+    const headTag = document.createElement('style')
+    headTag.id = PROPERTIES_STYLE_ID
+    headTag.textContent = properties
+    document.head.appendChild(headTag)
+  }
+
+  const tag = document.createElement('style')
+  tag.textContent = rest
+  shadowRoot.appendChild(tag)
+}
+
+function createMount(): Mount {
+  let host = document.getElementById(HOST_ID)
+  if (!host) {
+    host = document.createElement('div')
+    host.id = HOST_ID
+    document.body.appendChild(host)
+  }
+  const shadowRoot = host.attachShadow({ mode: 'closed' })
+  injectStyles(shadowRoot)
+  const rootEl = document.createElement('div')
+  rootEl.className = ROOT_CLASS
+  shadowRoot.appendChild(rootEl)
+  return { shadowRoot, rootEl }
+}
+
+const ShadowRootContext = createContext<ShadowRoot | null>(null)
+
+export function useShadowRoot(): ShadowRoot | null {
+  return useContext(ShadowRootContext)
+}
+
+interface ShadowRootProviderProps {
+  shadowRoot: ShadowRoot
+  children: ComponentChildren
+}
+
+export function ShadowRootProvider({ shadowRoot, children }: ShadowRootProviderProps) {
+  return <ShadowRootContext.Provider value={shadowRoot}>{children}</ShadowRootContext.Provider>
+}
+
+export function mountWidget(tree: VNode): ShadowRoot {
+  const { shadowRoot, rootEl } = createMount()
+  render(
+    <ShadowRootProvider shadowRoot={shadowRoot}>
+      <PortalContainerProvider value={rootEl}>{tree}</PortalContainerProvider>
+    </ShadowRootProvider>,
+    rootEl
+  )
+  return shadowRoot
+}

--- a/apps/chat-widget/src/styles.css
+++ b/apps/chat-widget/src/styles.css
@@ -1,243 +1,276 @@
 /* apps/chat-widget/src/styles.css
  *
- * Scoped under `.auxx-chat-*` to limit collisions with host page styles. We
- * do not use Shadow DOM so customers can override these rules for white-label
- * cases — that's a feature, not a bug.
+ * Loaded by `?inline` import into the closed Shadow DOM mount. Tailwind v4
+ * scans the widget's own source via `@source` and JITs the utility output,
+ * which is safely confined to the shadow root — preflight cannot leak to the
+ * host page, and host-page CSS cannot leak in.
  *
- * All tunable values live as CSS custom properties on `.auxx-chat-root`; rules
- * below reference them via `var(...)`. This lets the widget runtime write
- * per-config values inline on the root and lets customers override any single
- * value from the host page.
+ * The handwritten `.auxx-chat-*` classes that drive the v1 shell remain here
+ * as `@layer components` so the existing shell keeps rendering while Phase 3+
+ * migrates surface by surface to Tailwind utilities + shadcn-style wrappers.
  */
 
-.auxx-chat-root {
-  /* Geometry */
-  --auxx-chat-shell-closed-size: 56px;
-  --auxx-chat-shell-open-width: 360px;
-  --auxx-chat-shell-open-height: 540px;
-  --auxx-chat-shell-closed-radius: 28px;
-  --auxx-chat-shell-open-radius: 16px;
-  --auxx-chat-shell-edge-gap: 20px;
+@import 'tailwindcss';
 
-  /* Surface */
-  --auxx-chat-primary: #4f46e5;
-  --auxx-chat-surface: #fff;
-  --auxx-chat-shell-closed-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  --auxx-chat-shell-open-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+@source "./**/*.{ts,tsx}";
 
-  /* Motion */
-  --auxx-chat-shell-duration: 280ms;
-  --auxx-chat-shell-ease: cubic-bezier(0.32, 0.72, 0, 1);
-  --auxx-chat-icon-duration: 120ms;
-  --auxx-chat-panel-duration: 160ms;
-  --auxx-chat-panel-open-delay: 140ms;
-  --auxx-chat-panel-close-delay: 0ms;
+@theme {
+  --color-bg: #ffffff;
+  --color-fg: #111111;
+  --color-muted: #6b7280;
+  --color-border: #e5e7eb;
+  --color-surface: #f7f8fa;
+  --color-primary: var(--auxx-chat-primary, #4f46e5);
+  --color-primary-foreground: #ffffff;
+  --color-danger: #b91c1c;
 
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  color: #111;
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
 
-.auxx-chat-shell {
-  position: fixed;
-  z-index: 2147483000;
-  overflow: hidden;
-  width: var(--auxx-chat-shell-closed-size);
-  height: var(--auxx-chat-shell-closed-size);
-  border-radius: var(--auxx-chat-shell-closed-radius);
-  background: var(--auxx-chat-primary);
-  box-shadow: var(--auxx-chat-shell-closed-shadow);
-  transition:
-    width var(--auxx-chat-shell-duration) var(--auxx-chat-shell-ease),
-    height var(--auxx-chat-shell-duration) var(--auxx-chat-shell-ease),
-    border-radius var(--auxx-chat-shell-duration) var(--auxx-chat-shell-ease),
-    background var(--auxx-chat-shell-duration) var(--auxx-chat-shell-ease),
-    box-shadow var(--auxx-chat-shell-duration) var(--auxx-chat-shell-ease);
+@layer base {
+  .auxx-root,
+  .auxx-root *,
+  .auxx-root *::before,
+  .auxx-root *::after {
+    box-sizing: border-box;
+  }
+  .auxx-root {
+    font-family: var(--font-sans);
+    color: var(--color-fg);
+    line-height: 1.4;
+  }
 }
 
-.auxx-chat-shell--bottom-right {
-  right: var(--auxx-chat-shell-edge-gap);
-  bottom: var(--auxx-chat-shell-edge-gap);
-  transform-origin: bottom right;
-}
-.auxx-chat-shell--bottom-left {
-  left: var(--auxx-chat-shell-edge-gap);
-  bottom: var(--auxx-chat-shell-edge-gap);
-  transform-origin: bottom left;
-}
+@layer components {
+  /* Legacy v1 shell — kept until Phase 3 replaces it with a navigation + tab UI. */
 
-.auxx-chat-shell--open {
-  width: var(--auxx-chat-shell-open-width);
-  height: var(--auxx-chat-shell-open-height);
-  max-width: calc(100vw - calc(var(--auxx-chat-shell-edge-gap) * 2));
-  max-height: calc(100vh - calc(var(--auxx-chat-shell-edge-gap) * 5));
-  border-radius: var(--auxx-chat-shell-open-radius);
-  background: var(--auxx-chat-surface);
-  box-shadow: var(--auxx-chat-shell-open-shadow);
-}
+  .auxx-chat-root {
+    --auxx-chat-shell-closed-size: 56px;
+    --auxx-chat-shell-open-width: 360px;
+    --auxx-chat-shell-open-height: 540px;
+    --auxx-chat-shell-closed-radius: 28px;
+    --auxx-chat-shell-open-radius: 16px;
+    --auxx-chat-shell-edge-gap: 20px;
 
-.auxx-chat-shell__trigger {
-  position: absolute;
-  inset: 0;
-  background: transparent;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  color: #fff;
-  z-index: 2;
-}
-.auxx-chat-shell__trigger:focus {
-  outline: 2px solid rgba(0, 0, 0, 0.25);
-  outline-offset: 2px;
-}
-.auxx-chat-shell--open .auxx-chat-shell__trigger {
-  pointer-events: none;
-}
+    --auxx-chat-primary: #4f46e5;
+    --auxx-chat-surface: #fff;
+    --auxx-chat-shell-closed-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    --auxx-chat-shell-open-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
 
-.auxx-chat-shell__icon {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 24px;
-  height: 24px;
-  margin-top: -12px;
-  margin-left: -12px;
-  color: #fff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 1;
-  pointer-events: none;
-  z-index: 1;
-  transition: opacity var(--auxx-chat-icon-duration) ease-out;
-}
-.auxx-chat-shell__icon svg {
-  width: 24px;
-  height: 24px;
-  fill: currentColor;
-}
-.auxx-chat-shell--open .auxx-chat-shell__icon {
-  opacity: 0;
-}
+    --auxx-chat-shell-duration: 280ms;
+    --auxx-chat-shell-ease: cubic-bezier(0.32, 0.72, 0, 1);
+    --auxx-chat-icon-duration: 120ms;
+    --auxx-chat-panel-duration: 160ms;
+    --auxx-chat-panel-open-delay: 140ms;
+    --auxx-chat-panel-close-delay: 0ms;
+  }
 
-.auxx-chat-shell__panel {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity var(--auxx-chat-panel-duration) ease-out;
-  transition-delay: var(--auxx-chat-panel-close-delay);
-}
-.auxx-chat-shell--open .auxx-chat-shell__panel {
-  opacity: 1;
-  pointer-events: auto;
-  transition-delay: var(--auxx-chat-panel-open-delay);
-}
+  .auxx-chat-shell {
+    position: fixed;
+    z-index: 2147483000;
+    overflow: hidden;
+    width: var(--auxx-chat-shell-closed-size);
+    height: var(--auxx-chat-shell-closed-size);
+    border-radius: var(--auxx-chat-shell-closed-radius);
+    background: var(--auxx-chat-primary);
+    box-shadow: var(--auxx-chat-shell-closed-shadow);
+    transition:
+      width var(--auxx-chat-shell-duration) var(--auxx-chat-shell-ease),
+      height var(--auxx-chat-shell-duration) var(--auxx-chat-shell-ease),
+      border-radius var(--auxx-chat-shell-duration) var(--auxx-chat-shell-ease),
+      background var(--auxx-chat-shell-duration) var(--auxx-chat-shell-ease),
+      box-shadow var(--auxx-chat-shell-duration) var(--auxx-chat-shell-ease);
+  }
+  .auxx-chat-shell--bottom-right {
+    right: var(--auxx-chat-shell-edge-gap);
+    bottom: var(--auxx-chat-shell-edge-gap);
+    transform-origin: bottom right;
+  }
+  .auxx-chat-shell--bottom-left {
+    left: var(--auxx-chat-shell-edge-gap);
+    bottom: var(--auxx-chat-shell-edge-gap);
+    transform-origin: bottom left;
+  }
+  .auxx-chat-shell--open {
+    width: var(--auxx-chat-shell-open-width);
+    height: var(--auxx-chat-shell-open-height);
+    max-width: calc(100vw - calc(var(--auxx-chat-shell-edge-gap) * 2));
+    max-height: calc(100vh - calc(var(--auxx-chat-shell-edge-gap) * 5));
+    border-radius: var(--auxx-chat-shell-open-radius);
+    background: var(--auxx-chat-surface);
+    box-shadow: var(--auxx-chat-shell-open-shadow);
+  }
 
-.auxx-chat-header {
-  padding: 14px 16px;
-  background: var(--auxx-chat-primary);
-  color: #fff;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-shrink: 0;
-}
-.auxx-chat-header__title {
-  font-size: 15px;
-  font-weight: 600;
-}
-.auxx-chat-header__subtitle {
-  font-size: 12px;
-  opacity: 0.85;
-}
-.auxx-chat-header__close {
-  background: transparent;
-  border: none;
-  color: inherit;
-  cursor: pointer;
-  font-size: 18px;
-  line-height: 1;
-}
+  .auxx-chat-shell__trigger {
+    position: absolute;
+    inset: 0;
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    color: #fff;
+    z-index: 2;
+  }
+  .auxx-chat-shell__trigger:focus {
+    outline: 2px solid rgba(0, 0, 0, 0.25);
+    outline-offset: 2px;
+  }
+  .auxx-chat-shell--open .auxx-chat-shell__trigger {
+    pointer-events: none;
+  }
 
-.auxx-chat-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: 12px;
-  background: #f7f8fa;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
+  .auxx-chat-shell__icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 24px;
+    height: 24px;
+    margin-top: -12px;
+    margin-left: -12px;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 1;
+    pointer-events: none;
+    z-index: 1;
+    transition: opacity var(--auxx-chat-icon-duration) ease-out;
+  }
+  .auxx-chat-shell__icon svg {
+    width: 24px;
+    height: 24px;
+    fill: currentColor;
+  }
+  .auxx-chat-shell--open .auxx-chat-shell__icon {
+    opacity: 0;
+  }
 
-.auxx-chat-message {
-  max-width: 80%;
-  padding: 8px 12px;
-  border-radius: 14px;
-  font-size: 13px;
-  line-height: 1.4;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-}
-.auxx-chat-message--user {
-  align-self: flex-end;
-  background: var(--auxx-chat-primary);
-  color: #fff;
-  border-bottom-right-radius: 4px;
-}
-.auxx-chat-message--agent {
-  align-self: flex-start;
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-bottom-left-radius: 4px;
-}
-.auxx-chat-message--system {
-  align-self: center;
-  background: transparent;
-  color: #6b7280;
-  font-style: italic;
-  font-size: 12px;
-}
+  .auxx-chat-shell__panel {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--auxx-chat-panel-duration) ease-out;
+    transition-delay: var(--auxx-chat-panel-close-delay);
+  }
+  .auxx-chat-shell--open .auxx-chat-shell__panel {
+    opacity: 1;
+    pointer-events: auto;
+    transition-delay: var(--auxx-chat-panel-open-delay);
+  }
 
-.auxx-chat-footer {
-  border-top: 1px solid #e5e7eb;
-  padding: 10px;
-  background: #fff;
-  display: flex;
-  gap: 8px;
-  flex-shrink: 0;
-}
-.auxx-chat-input {
-  flex: 1;
-  border: 1px solid #e5e7eb;
-  border-radius: 999px;
-  padding: 8px 12px;
-  font-size: 13px;
-  outline: none;
-}
-.auxx-chat-input:focus {
-  border-color: var(--auxx-chat-primary);
-}
-.auxx-chat-send {
-  background: var(--auxx-chat-primary);
-  color: #fff;
-  border: none;
-  border-radius: 999px;
-  padding: 8px 14px;
-  font-size: 13px;
-  cursor: pointer;
-}
-.auxx-chat-send:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+  .auxx-chat-header {
+    padding: 14px 16px;
+    background: var(--auxx-chat-primary);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-shrink: 0;
+  }
+  .auxx-chat-header__title {
+    font-size: 15px;
+    font-weight: 600;
+  }
+  .auxx-chat-header__subtitle {
+    font-size: 12px;
+    opacity: 0.85;
+  }
+  .auxx-chat-header__close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+  }
 
-.auxx-chat-error {
-  color: #b91c1c;
-  font-size: 12px;
-  padding: 6px 10px;
-  text-align: center;
+  .auxx-chat-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px;
+    background: #f7f8fa;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .auxx-chat-message {
+    max-width: 80%;
+    padding: 8px 12px;
+    border-radius: 14px;
+    font-size: 13px;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+  .auxx-chat-message--user {
+    align-self: flex-end;
+    background: var(--auxx-chat-primary);
+    color: #fff;
+    border-bottom-right-radius: 4px;
+  }
+  .auxx-chat-message--agent {
+    align-self: flex-start;
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-bottom-left-radius: 4px;
+  }
+  .auxx-chat-message--system {
+    align-self: center;
+    background: transparent;
+    color: #6b7280;
+    font-style: italic;
+    font-size: 12px;
+  }
+
+  .auxx-chat-footer {
+    border-top: 1px solid #e5e7eb;
+    padding: 10px;
+    background: #fff;
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+  .auxx-chat-input {
+    flex: 1;
+    border: 1px solid #e5e7eb;
+    border-radius: 999px;
+    padding: 8px 12px;
+    font-size: 13px;
+    outline: none;
+  }
+  .auxx-chat-input:focus {
+    border-color: var(--auxx-chat-primary);
+  }
+  .auxx-chat-send {
+    background: var(--auxx-chat-primary);
+    color: #fff;
+    border: none;
+    border-radius: 999px;
+    padding: 8px 14px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .auxx-chat-send:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .auxx-chat-error {
+    color: #b91c1c;
+    font-size: 12px;
+    padding: 6px 10px;
+    text-align: center;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/chat-widget/src/transport/chat-api.ts
+++ b/apps/chat-widget/src/transport/chat-api.ts
@@ -125,6 +125,21 @@ export function chatApi(channelId: string) {
         body: { messageIds },
       }),
 
+    createThread: (body: { url?: string; referrer?: string; userAgent?: string } = {}) =>
+      call<{ threadId: string; pusherChannel: string }>(channelId, '/api/chat/threads', {
+        method: 'POST',
+        body,
+      }),
+
+    getRecentThread: () =>
+      call<{
+        thread: {
+          id: string
+          subject: string | null
+          lastMessage: { preview: string; isInbound: boolean; timestamp: string }
+        } | null
+      }>(channelId, '/api/chat/threads/recent', { method: 'GET' }),
+
     updateVisitorInfo: (body: {
       threadId: string
       visitorName?: string

--- a/apps/chat-widget/src/transport/config.ts
+++ b/apps/chat-widget/src/transport/config.ts
@@ -1,5 +1,34 @@
 // apps/chat-widget/src/transport/config.ts
 
+/** Tiptap JSON document. Loose shape — we walk it as a tree and render any
+ * leaf with `text` as plain text. `placeholder` nodes carry the visitor-claim
+ * id and an encoded `data-fallback` string. */
+export interface TiptapNode {
+  type?: string
+  text?: string
+  content?: TiptapNode[]
+  attrs?: Record<string, unknown>
+  marks?: { type: string; attrs?: Record<string, unknown> }[]
+}
+
+export interface ChatHomeConfig {
+  greetingTemplate: TiptapNode | null
+  showRecentMessage: boolean
+  showSendMessageCta: boolean
+  expandedWidthPx: number
+  knowledgeBase: {
+    siteSlug: string
+    siteName: string
+    rootArticles: { id: string; title: string; emoji: string | null }[]
+  } | null
+  featuredArticles: {
+    id: string
+    title: string
+    description: string | null
+    emoji: string | null
+  }[]
+}
+
 export interface ChatConfig {
   channelId: string
   isActive: boolean
@@ -15,6 +44,8 @@ export interface ChatConfig {
     collectUserInfo: boolean
     offlineMessage: string | null
   }
+  home: ChatHomeConfig
+  branding: { footerEnabled: boolean }
   realtime: { provider: 'pusher'; key: string; cluster: string }
 }
 

--- a/apps/chat-widget/src/ui/button.tsx
+++ b/apps/chat-widget/src/ui/button.tsx
@@ -1,0 +1,47 @@
+// apps/chat-widget/src/ui/button.tsx
+
+import { cva, type VariantProps } from 'class-variance-authority'
+import type { ComponentProps } from 'preact/compat'
+import { forwardRef } from 'preact/compat'
+import { cn } from '~/lib/cn'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:var(--color-primary)]/40 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-[color:var(--color-primary)] text-[color:var(--color-primary-foreground)] hover:brightness-110 active:brightness-95',
+        outline:
+          'border border-[color:var(--color-border)] bg-[color:var(--color-bg)] hover:bg-[color:var(--color-surface)]',
+        ghost: 'hover:bg-[color:var(--color-surface)]',
+      },
+      size: {
+        default: 'h-9 px-4',
+        sm: 'h-7 rounded px-3 text-xs',
+        icon: 'h-9 w-9',
+      },
+    },
+    defaultVariants: { variant: 'default', size: 'default' },
+  }
+)
+
+export interface ButtonProps
+  extends ComponentProps<'button'>,
+    VariantProps<typeof buttonVariants> {}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { className, variant, size, type = 'button', ...props },
+  ref
+) {
+  return (
+    <button
+      ref={ref}
+      type={type}
+      className={cn(buttonVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+})
+
+export { buttonVariants }

--- a/apps/chat-widget/src/ui/dialog.tsx
+++ b/apps/chat-widget/src/ui/dialog.tsx
@@ -1,0 +1,33 @@
+// apps/chat-widget/src/ui/dialog.tsx
+
+import type { ComponentProps } from 'preact/compat'
+import { Dialog as DialogPrimitive } from 'radix-ui'
+import { cn } from '~/lib/cn'
+import { usePortalContainer } from './portal-container'
+
+export const Dialog = DialogPrimitive.Root
+export const DialogTrigger = DialogPrimitive.Trigger
+export const DialogClose = DialogPrimitive.Close
+export const DialogTitle = DialogPrimitive.Title
+export const DialogDescription = DialogPrimitive.Description
+
+export function DialogContent({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Content>) {
+  const container = usePortalContainer()
+  return (
+    <DialogPrimitive.Portal container={container ?? undefined}>
+      <DialogPrimitive.Overlay className='fixed inset-0 z-50 bg-black/40' />
+      <DialogPrimitive.Content
+        className={cn(
+          'fixed left-1/2 top-1/2 z-50 w-[90%] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-4 shadow-lg outline-none',
+          className
+        )}
+        {...props}>
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  )
+}

--- a/apps/chat-widget/src/ui/dropdown-menu.tsx
+++ b/apps/chat-widget/src/ui/dropdown-menu.tsx
@@ -1,0 +1,54 @@
+// apps/chat-widget/src/ui/dropdown-menu.tsx
+
+import type { ComponentProps } from 'preact/compat'
+import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui'
+import { cn } from '~/lib/cn'
+import { usePortalContainer } from './portal-container'
+
+export const DropdownMenu = DropdownMenuPrimitive.Root
+export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+export const DropdownMenuGroup = DropdownMenuPrimitive.Group
+export const DropdownMenuSeparator = ({
+  className,
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Separator>) => (
+  <DropdownMenuPrimitive.Separator
+    className={cn('my-1 h-px bg-[color:var(--color-border)]', className)}
+    {...props}
+  />
+)
+
+export function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  const container = usePortalContainer()
+  return (
+    <DropdownMenuPrimitive.Portal container={container ?? undefined}>
+      <DropdownMenuPrimitive.Content
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 min-w-[10rem] overflow-hidden rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-1 text-sm shadow-md',
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+export function DropdownMenuItem({
+  className,
+  ...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Item>) {
+  return (
+    <DropdownMenuPrimitive.Item
+      className={cn(
+        'relative flex cursor-pointer select-none items-center gap-2 rounded px-2 py-1.5 outline-none focus:bg-[color:var(--color-surface)] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  )
+}

--- a/apps/chat-widget/src/ui/icon.tsx
+++ b/apps/chat-widget/src/ui/icon.tsx
@@ -1,0 +1,15 @@
+// apps/chat-widget/src/ui/icon.tsx
+//
+// Light wrapper over `lucide-react` so call sites don't repeat sizing/stroke
+// boilerplate and tree-shake picks up only the icons we actually use.
+
+import type { LucideIcon, LucideProps } from 'lucide-react'
+import { cn } from '~/lib/cn'
+
+export interface IconProps extends LucideProps {
+  icon: LucideIcon
+}
+
+export function Icon({ icon: LucideComponent, className, ...props }: IconProps) {
+  return <LucideComponent className={cn('size-4 shrink-0', className)} {...props} />
+}

--- a/apps/chat-widget/src/ui/index.ts
+++ b/apps/chat-widget/src/ui/index.ts
@@ -1,0 +1,24 @@
+// apps/chat-widget/src/ui/index.ts
+
+export { Button, type ButtonProps, buttonVariants } from './button'
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from './dialog'
+export {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from './dropdown-menu'
+export { Icon, type IconProps } from './icon'
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from './popover'
+export { PortalContainerProvider, usePortalContainer } from './portal-container'
+export { ScrollArea } from './scroll-area'
+export { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs'

--- a/apps/chat-widget/src/ui/popover.tsx
+++ b/apps/chat-widget/src/ui/popover.tsx
@@ -1,0 +1,32 @@
+// apps/chat-widget/src/ui/popover.tsx
+
+import type { ComponentProps } from 'preact/compat'
+import { Popover as PopoverPrimitive } from 'radix-ui'
+import { cn } from '~/lib/cn'
+import { usePortalContainer } from './portal-container'
+
+export const Popover = PopoverPrimitive.Root
+export const PopoverTrigger = PopoverPrimitive.Trigger
+export const PopoverAnchor = PopoverPrimitive.Anchor
+
+export function PopoverContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: ComponentProps<typeof PopoverPrimitive.Content>) {
+  const container = usePortalContainer()
+  return (
+    <PopoverPrimitive.Portal container={container ?? undefined}>
+      <PopoverPrimitive.Content
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-3 text-sm shadow-md outline-none',
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}

--- a/apps/chat-widget/src/ui/portal-container.tsx
+++ b/apps/chat-widget/src/ui/portal-container.tsx
@@ -1,0 +1,17 @@
+// apps/chat-widget/src/ui/portal-container.tsx
+//
+// Provides the element Radix portal primitives (Popover, Dialog, DropdownMenu,
+// Tooltip) should render into. Inside a closed Shadow DOM the default
+// `document.body` target lives outside the shadow tree, which breaks both
+// styling (Tailwind utilities aren't available) and focus/pointer behavior.
+
+import { createContext } from 'preact'
+import { useContext } from 'preact/hooks'
+
+const PortalContainerCtx = createContext<HTMLElement | null>(null)
+
+export const PortalContainerProvider = PortalContainerCtx.Provider
+
+export function usePortalContainer(): HTMLElement | null {
+  return useContext(PortalContainerCtx)
+}

--- a/apps/chat-widget/src/ui/scroll-area.tsx
+++ b/apps/chat-widget/src/ui/scroll-area.tsx
@@ -1,0 +1,25 @@
+// apps/chat-widget/src/ui/scroll-area.tsx
+
+import type { ComponentProps } from 'preact/compat'
+import { ScrollArea as ScrollAreaPrimitive } from 'radix-ui'
+import { cn } from '~/lib/cn'
+
+export function ScrollArea({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root className={cn('relative overflow-hidden', className)} {...props}>
+      <ScrollAreaPrimitive.Viewport className='h-full w-full rounded-[inherit]'>
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollAreaPrimitive.Scrollbar
+        orientation='vertical'
+        className='flex w-2 touch-none select-none transition-colors'>
+        <ScrollAreaPrimitive.Thumb className='relative flex-1 rounded-full bg-[color:var(--color-border)]' />
+      </ScrollAreaPrimitive.Scrollbar>
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}

--- a/apps/chat-widget/src/ui/tabs.tsx
+++ b/apps/chat-widget/src/ui/tabs.tsx
@@ -1,0 +1,35 @@
+// apps/chat-widget/src/ui/tabs.tsx
+
+import type { ComponentProps } from 'preact/compat'
+import { Tabs as TabsPrimitive } from 'radix-ui'
+import { cn } from '~/lib/cn'
+
+export const Tabs = TabsPrimitive.Root
+
+export function TabsList({ className, ...props }: ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      className={cn(
+        'inline-flex h-9 items-center justify-center rounded-md bg-[color:var(--color-surface)] p-1 text-[color:var(--color-muted)]',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export function TabsTrigger({ className, ...props }: ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      className={cn(
+        'inline-flex items-center justify-center whitespace-nowrap rounded px-3 py-1 text-sm font-medium transition-all data-[state=active]:bg-[color:var(--color-bg)] data-[state=active]:text-[color:var(--color-fg)] data-[state=active]:shadow-sm',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export function TabsContent({ className, ...props }: ComponentProps<typeof TabsPrimitive.Content>) {
+  return <TabsPrimitive.Content className={cn('mt-2 outline-none', className)} {...props} />
+}

--- a/apps/chat-widget/src/views/home/cards/article-card.tsx
+++ b/apps/chat-widget/src/views/home/cards/article-card.tsx
@@ -1,0 +1,34 @@
+// apps/chat-widget/src/views/home/cards/article-card.tsx
+
+import { FileText } from 'lucide-react'
+import { HomeCard } from './card'
+
+interface ArticleCardProps {
+  title: string
+  description: string | null
+  emoji: string | null
+  onClick: () => void
+}
+
+export function ArticleCard({ title, description, emoji, onClick }: ArticleCardProps) {
+  return (
+    <HomeCard onClick={onClick}>
+      <div className='flex items-center gap-2'>
+        {emoji ? (
+          <span className='text-base leading-none' aria-hidden='true'>
+            {emoji}
+          </span>
+        ) : (
+          <FileText
+            className='size-4 shrink-0 text-[color:var(--color-muted)]'
+            aria-hidden='true'
+          />
+        )}
+        <span className='truncate text-sm font-medium text-[color:var(--color-fg)]'>{title}</span>
+      </div>
+      {description ? (
+        <span className='line-clamp-2 text-xs text-[color:var(--color-muted)]'>{description}</span>
+      ) : null}
+    </HomeCard>
+  )
+}

--- a/apps/chat-widget/src/views/home/cards/browse-all-card.tsx
+++ b/apps/chat-widget/src/views/home/cards/browse-all-card.tsx
@@ -1,0 +1,26 @@
+// apps/chat-widget/src/views/home/cards/browse-all-card.tsx
+
+import { BookOpen } from 'lucide-react'
+import { HomeCard } from './card'
+
+interface BrowseAllCardProps {
+  siteName: string
+  onClick: () => void
+}
+
+export function BrowseAllCard({ siteName, onClick }: BrowseAllCardProps) {
+  return (
+    <HomeCard onClick={onClick}>
+      <div className='flex items-center gap-2'>
+        <BookOpen
+          className='size-4 shrink-0 text-[color:var(--color-primary)]'
+          aria-hidden='true'
+        />
+        <span className='text-sm font-medium text-[color:var(--color-fg)]'>
+          Browse all articles
+        </span>
+      </div>
+      <span className='truncate text-xs text-[color:var(--color-muted)]'>{siteName}</span>
+    </HomeCard>
+  )
+}

--- a/apps/chat-widget/src/views/home/cards/card.tsx
+++ b/apps/chat-widget/src/views/home/cards/card.tsx
@@ -1,0 +1,43 @@
+// apps/chat-widget/src/views/home/cards/card.tsx
+//
+// Shared visual primitive for the Home tab card stack.
+
+import { ChevronRight } from 'lucide-react'
+import type { ComponentChildren } from 'preact'
+import { cn } from '~/lib/cn'
+
+interface HomeCardProps {
+  onClick?: () => void
+  disabled?: boolean
+  children: ComponentChildren
+  className?: string
+  /** When true, shows a trailing chevron — purely decorative. */
+  showChevron?: boolean
+}
+
+export function HomeCard({
+  onClick,
+  disabled,
+  children,
+  className,
+  showChevron = true,
+}: HomeCardProps) {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'group flex w-full items-center gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-3 text-left transition-colors hover:bg-[color:var(--color-surface)] disabled:cursor-not-allowed disabled:opacity-60',
+        className
+      )}>
+      <div className='flex min-w-0 flex-1 flex-col gap-0.5'>{children}</div>
+      {showChevron ? (
+        <ChevronRight
+          className='size-4 shrink-0 text-[color:var(--color-muted)] transition-transform group-hover:translate-x-0.5'
+          aria-hidden='true'
+        />
+      ) : null}
+    </button>
+  )
+}

--- a/apps/chat-widget/src/views/home/cards/recent-message-card.tsx
+++ b/apps/chat-widget/src/views/home/cards/recent-message-card.tsx
@@ -1,0 +1,49 @@
+// apps/chat-widget/src/views/home/cards/recent-message-card.tsx
+
+import { HomeCard } from './card'
+
+interface RecentMessageCardProps {
+  subject: string | null
+  preview: string
+  isInbound: boolean
+  timestamp: string
+  onOpen: () => void
+}
+
+export function RecentMessageCard({
+  subject,
+  preview,
+  isInbound,
+  timestamp,
+  onOpen,
+}: RecentMessageCardProps) {
+  const relative = formatRelativeTime(timestamp)
+  return (
+    <HomeCard onClick={onOpen}>
+      <div className='flex items-center justify-between gap-2'>
+        <span className='truncate text-sm font-medium text-[color:var(--color-fg)]'>
+          {subject || 'Recent conversation'}
+        </span>
+        <span className='shrink-0 text-xs text-[color:var(--color-muted)]'>{relative}</span>
+      </div>
+      <span className='truncate text-xs text-[color:var(--color-muted)]'>
+        {isInbound ? 'You: ' : ''}
+        {preview}
+      </span>
+    </HomeCard>
+  )
+}
+
+function formatRelativeTime(iso: string): string {
+  const t = Date.parse(iso)
+  if (Number.isNaN(t)) return ''
+  const diff = Date.now() - t
+  const minute = 60_000
+  const hour = 60 * minute
+  const day = 24 * hour
+  if (diff < minute) return 'just now'
+  if (diff < hour) return `${Math.floor(diff / minute)}m`
+  if (diff < day) return `${Math.floor(diff / hour)}h`
+  if (diff < 7 * day) return `${Math.floor(diff / day)}d`
+  return new Date(t).toLocaleDateString()
+}

--- a/apps/chat-widget/src/views/home/cards/send-message-card.tsx
+++ b/apps/chat-widget/src/views/home/cards/send-message-card.tsx
@@ -1,0 +1,28 @@
+// apps/chat-widget/src/views/home/cards/send-message-card.tsx
+
+import { MessageSquarePlus } from 'lucide-react'
+import { HomeCard } from './card'
+
+interface SendMessageCardProps {
+  onClick: () => void
+  isPending: boolean
+}
+
+export function SendMessageCard({ onClick, isPending }: SendMessageCardProps) {
+  return (
+    <HomeCard onClick={onClick} disabled={isPending}>
+      <div className='flex items-center gap-2'>
+        <MessageSquarePlus
+          className='size-4 shrink-0 text-[color:var(--color-primary)]'
+          aria-hidden='true'
+        />
+        <span className='text-sm font-medium text-[color:var(--color-fg)]'>
+          {isPending ? 'Starting…' : 'Send us a message'}
+        </span>
+      </div>
+      <span className='text-xs text-[color:var(--color-muted)]'>
+        We usually reply within a few minutes.
+      </span>
+    </HomeCard>
+  )
+}

--- a/apps/chat-widget/src/views/home/greeting.tsx
+++ b/apps/chat-widget/src/views/home/greeting.tsx
@@ -1,0 +1,132 @@
+// apps/chat-widget/src/views/home/greeting.tsx
+//
+// Tiptap JSON renderer for the Home greeting. Walks the doc and substitutes
+// `placeholder` nodes whose id starts with `visitor:` against the widget's
+// identify claims, falling back to the badge's stored fallback payload (or an
+// empty string). All other text/inline content renders verbatim.
+
+import type { IdentifyPayload } from '~/identify'
+import type { TiptapNode } from '~/transport/config'
+
+interface GreetingProps {
+  doc: TiptapNode | null
+  fallbackText: string | null
+  identify: IdentifyPayload | null
+}
+
+export function Greeting({ doc, fallbackText, identify }: GreetingProps) {
+  if (!doc) {
+    if (!fallbackText) return null
+    return <h2 className='text-xl font-semibold leading-tight'>{fallbackText}</h2>
+  }
+  return (
+    <h2 className='text-xl font-semibold leading-tight'>
+      {renderNodes(doc.content ?? [], identify, true)}
+    </h2>
+  )
+}
+
+function renderNodes(
+  nodes: TiptapNode[],
+  identify: IdentifyPayload | null,
+  collapseBlocks: boolean
+) {
+  return nodes.map((node, i) => renderNode(node, identify, collapseBlocks, i))
+}
+
+function renderNode(
+  node: TiptapNode,
+  identify: IdentifyPayload | null,
+  collapseBlocks: boolean,
+  key: number
+) {
+  if (node.type === 'text') {
+    const text = node.text ?? ''
+    return applyMarks(text, node.marks ?? [], key)
+  }
+  if (node.type === 'placeholder') {
+    const id = String(node.attrs?.id ?? '')
+    const value = resolveVisitor(id, identify)
+    if (value !== null && value !== '') return <span key={key}>{value}</span>
+    const fallback = decodeFallbackText(node.attrs?.fallback)
+    return <span key={key}>{fallback ?? ''}</span>
+  }
+  if (node.type === 'paragraph') {
+    const children = renderNodes(node.content ?? [], identify, false)
+    if (collapseBlocks) return <span key={key}>{children}</span>
+    return (
+      <span key={key} className='block'>
+        {children}
+      </span>
+    )
+  }
+  if (node.type === 'hardBreak') {
+    return <br key={key} />
+  }
+  if (node.content) {
+    return <span key={key}>{renderNodes(node.content, identify, false)}</span>
+  }
+  return null
+}
+
+function applyMarks(text: string, marks: { type: string }[], key: number) {
+  let node: preact.ComponentChildren = text
+  for (const mark of marks) {
+    if (mark.type === 'bold' || mark.type === 'strong') node = <strong>{node}</strong>
+    else if (mark.type === 'italic' || mark.type === 'em') node = <em>{node}</em>
+    else if (mark.type === 'underline') node = <u>{node}</u>
+    else if (mark.type === 'code') node = <code>{node}</code>
+  }
+  return <span key={key}>{node}</span>
+}
+
+function resolveVisitor(id: string, identify: IdentifyPayload | null): string | null {
+  if (!id.startsWith('visitor:')) return null
+  const slug = id.slice('visitor:'.length)
+  if (!identify) return null
+  if (slug === 'name') return identify.name ?? null
+  if (slug === 'email') return identify.email ?? null
+  if (slug === 'externalId') return identify.externalId ?? null
+  return null
+}
+
+/**
+ * Decode the placeholder node's `fallback` attr. In editor state this is the
+ * decoded `FallbackPayload` object (object form); when round-tripped through
+ * HTML it can also be a JSON string. Both shapes resolve to plain text.
+ */
+function decodeFallbackText(raw: unknown): string | null {
+  if (!raw) return null
+  if (typeof raw === 'string') {
+    try {
+      raw = JSON.parse(raw)
+    } catch {
+      return raw
+    }
+  }
+  if (typeof raw !== 'object' || raw === null) return null
+  const payload = raw as { v?: number; t?: string; d?: unknown }
+  if (payload.v !== 1) return null
+  switch (payload.t) {
+    case 'TEXT':
+    case 'URL':
+    case 'EMAIL':
+    case 'PHONE_INTL':
+    case 'DATE':
+    case 'DATETIME':
+    case 'TIME':
+      return typeof payload.d === 'string' ? payload.d : null
+    case 'NUMBER':
+    case 'CURRENCY':
+      return typeof payload.d === 'number' ? String(payload.d) : null
+    case 'CHECKBOX':
+      return payload.d ? 'Yes' : 'No'
+    case 'NAME': {
+      const d = payload.d as { firstName?: string; lastName?: string } | undefined
+      if (!d) return null
+      return [d.firstName, d.lastName].filter(Boolean).join(' ') || null
+    }
+    default:
+      return null
+  }
+}

--- a/apps/chat-widget/src/views/home/home-view.tsx
+++ b/apps/chat-widget/src/views/home/home-view.tsx
@@ -1,0 +1,157 @@
+// apps/chat-widget/src/views/home/home-view.tsx
+//
+// Home tab root view. Renders the greeting hero + a card stack:
+//   1. RecentMessageCard — when the visitor has any thread on this channel
+//   2. SendMessageCard   — always (when admin-enabled), creates a fresh thread
+//   3. ArticleCard[]     — featured articles, in admin-set order
+//   4. BrowseAllCard     — links into the KB section root
+//
+// Greeting + card visibility are driven by `config.home`. Identify claims
+// substitute into the greeting via the Tiptap-JSON walker in ./greeting.
+
+import { useCallback, useEffect, useState } from 'preact/hooks'
+import { getStoredIdentify, type IdentifyPayload, onIdentify } from '~/identify'
+import { useNavStack } from '~/navigation/nav-stack-context'
+import { chatApi } from '~/transport/chat-api'
+import type { ChatConfig } from '~/transport/config'
+import { ArticleCard } from './cards/article-card'
+import { BrowseAllCard } from './cards/browse-all-card'
+import { RecentMessageCard } from './cards/recent-message-card'
+import { SendMessageCard } from './cards/send-message-card'
+import { Greeting } from './greeting'
+
+interface HomeViewProps {
+  channelId: string
+  config: ChatConfig
+}
+
+interface RecentThread {
+  id: string
+  subject: string | null
+  lastMessage: { preview: string; isInbound: boolean; timestamp: string }
+}
+
+export function HomeView({ channelId, config }: HomeViewProps) {
+  const nav = useNavStack()
+  const [identify, setIdentify] = useState<IdentifyPayload | null>(() =>
+    getStoredIdentify(channelId)
+  )
+  const [recent, setRecent] = useState<RecentThread | null>(null)
+  const [creating, setCreating] = useState(false)
+
+  useEffect(() => onIdentify((p) => setIdentify(p)), [])
+
+  const api = chatApi(channelId)
+  const { home } = config
+
+  // Load recent thread for the card. We only do this when the admin enabled
+  // the card; otherwise the API call is wasted.
+  useEffect(() => {
+    if (!home.showRecentMessage) {
+      setRecent(null)
+      return
+    }
+    let cancelled = false
+    api
+      .getRecentThread()
+      .then((data) => {
+        if (!cancelled) setRecent(data.thread)
+      })
+      .catch(() => {
+        if (!cancelled) setRecent(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [home.showRecentMessage])
+
+  const openThread = useCallback(
+    (threadId: string, label: string) => {
+      nav.push({ id: threadId, label, view: 'thread', params: { threadId } })
+    },
+    [nav]
+  )
+
+  const handleSendMessage = useCallback(async () => {
+    setCreating(true)
+    try {
+      const { threadId } = await api.createThread({
+        url: typeof window !== 'undefined' ? window.location.href : undefined,
+        referrer: typeof document !== 'undefined' ? document.referrer || undefined : undefined,
+        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+      })
+      openThread(threadId, 'New conversation')
+    } catch {
+      // Surface via the existing global error band — keep silent here.
+    } finally {
+      setCreating(false)
+    }
+  }, [api, openThread])
+
+  const cards = [
+    home.showRecentMessage && recent ? (
+      <RecentMessageCard
+        key='recent'
+        subject={recent.subject}
+        preview={recent.lastMessage.preview}
+        isInbound={recent.lastMessage.isInbound}
+        timestamp={recent.lastMessage.timestamp}
+        onOpen={() => openThread(recent.id, recent.subject || 'Conversation')}
+      />
+    ) : null,
+    home.showSendMessageCta ? (
+      <SendMessageCard key='send' onClick={handleSendMessage} isPending={creating} />
+    ) : null,
+    ...home.featuredArticles.map((a) => (
+      <ArticleCard
+        key={a.id}
+        title={a.title}
+        description={a.description}
+        emoji={a.emoji}
+        onClick={() =>
+          nav.push({ id: a.id, label: a.title, view: 'kb-article', params: { articleId: a.id } })
+        }
+      />
+    )),
+    home.knowledgeBase ? (
+      <BrowseAllCard
+        key='browse'
+        siteName={home.knowledgeBase.siteName}
+        onClick={() =>
+          nav.push({
+            id: 'kb-root',
+            label: home.knowledgeBase!.siteName,
+            view: 'kb-section',
+            params: { sectionId: null },
+          })
+        }
+      />
+    ) : null,
+  ].filter(Boolean)
+
+  return (
+    <div className='flex min-h-0 flex-1 flex-col'>
+      <div className='flex flex-col gap-1 px-5 pb-4 -mt-2 text-[color:var(--color-primary-foreground)]'>
+        <Greeting
+          doc={home.greetingTemplate ?? null}
+          fallbackText={config.appearance.welcomeMessage}
+          identify={identify}
+        />
+      </div>
+      <div className='flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto bg-[color:var(--color-surface)] p-3'>
+        {cards.length === 0 ? (
+          <p className='py-6 text-center text-xs text-[color:var(--color-muted)]'>
+            No conversations yet
+          </p>
+        ) : (
+          cards
+        )}
+      </div>
+      {config.branding.footerEnabled ? (
+        <div className='border-t border-[color:var(--color-border)] bg-[color:var(--color-bg)] py-2 text-center text-[10px] uppercase tracking-wide text-[color:var(--color-muted)]'>
+          Powered by Auxx
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/chat-widget/src/views/placeholder.tsx
+++ b/apps/chat-widget/src/views/placeholder.tsx
@@ -1,0 +1,69 @@
+// apps/chat-widget/src/views/placeholder.tsx
+//
+// Stub frame views. Phase 4 replaces HomeView, Phase 5 replaces the KB views,
+// Phase 6 replaces MessagesView + ThreadView. Each renders its label so the
+// shell + router can be smoke-tested before real content lands.
+
+import { useNavStack } from '~/navigation/nav-stack-context'
+import { Button } from '~/ui/button'
+
+function StubBody({ label, hint }: { label: string; hint?: string }) {
+  return (
+    <div className='flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center text-[color:var(--color-muted)]'>
+      <span className='text-sm font-medium text-[color:var(--color-fg)]'>{label}</span>
+      {hint ? <span className='text-xs'>{hint}</span> : null}
+    </div>
+  )
+}
+
+export function HomeView() {
+  const nav = useNavStack()
+  return (
+    <div className='flex flex-1 flex-col gap-4 p-5'>
+      <p className='text-sm text-[color:var(--color-muted)]'>
+        Home placeholder — Phase 4 fills this in.
+      </p>
+      <Button
+        size='sm'
+        variant='outline'
+        onClick={() => nav.push({ id: 'kb-root', label: 'Knowledge base', view: 'kb-section' })}>
+        Open KB section (test deep frame)
+      </Button>
+      <Button
+        size='sm'
+        variant='outline'
+        onClick={() => nav.push({ id: 'demo', label: 'Demo article', view: 'kb-article' })}>
+        Open KB article (test deep frame)
+      </Button>
+    </div>
+  )
+}
+
+export function MessagesView() {
+  const nav = useNavStack()
+  return (
+    <div className='flex flex-1 flex-col gap-4 p-5'>
+      <p className='text-sm text-[color:var(--color-muted)]'>
+        Messages placeholder — Phase 6 fills this in.
+      </p>
+      <Button
+        size='sm'
+        variant='outline'
+        onClick={() => nav.push({ id: 'demo', label: 'Demo thread', view: 'thread' })}>
+        Open thread (test deep frame)
+      </Button>
+    </div>
+  )
+}
+
+export function ThreadView({ label }: { label: string }) {
+  return <StubBody label={label} hint='Thread view — Phase 6 fills this in.' />
+}
+
+export function KbSectionView({ label }: { label: string }) {
+  return <StubBody label={label} hint='KB section view — Phase 5 fills this in.' />
+}
+
+export function KbArticleView({ label }: { label: string }) {
+  return <StubBody label={label} hint='KB article view — Phase 5 fills this in.' />
+}

--- a/apps/chat-widget/src/widget.tsx
+++ b/apps/chat-widget/src/widget.tsx
@@ -1,12 +1,19 @@
 // apps/chat-widget/src/widget.tsx
+//
+// Outer pillbox shell + tab router. The shell handles open/closed animation
+// and the trigger button. Inside, a `useTabRouter` selects which tab's stack
+// is active and renders the matching frame. Phase 6 will re-introduce the
+// chat-session/Pusher wiring inside ThreadView.
 
-import { useEffect, useRef, useState } from 'preact/hooks'
-import { ChatPanel } from './chat-window'
-import { getStoredIdentify, type IdentifyPayload, onIdentify } from './identify'
-import { type ChatMessage, chatApi, type InitializeResponse } from './transport/chat-api'
+import { useEffect, useState } from 'preact/hooks'
+import { FrameHeader, type FrameHeaderVariant } from './components/frame-header'
+import { TabBar } from './components/tab-bar'
+import { NavStackProvider } from './navigation/nav-stack-context'
+import type { NavFrame, NavView } from './navigation/use-navigation-stack'
+import { type TabId, useTabRouter } from './navigation/use-tab-router'
 import { type ChatConfig, fetchChatConfig } from './transport/config'
-import { updateStoredPassport } from './transport/passport'
-import { connectPusher, type PusherConnection } from './transport/pusher'
+import { HomeView } from './views/home/home-view'
+import { KbArticleView, KbSectionView, MessagesView, ThreadView } from './views/placeholder'
 
 interface WidgetProps {
   channelId: string
@@ -14,19 +21,11 @@ interface WidgetProps {
 
 export function Widget({ channelId }: WidgetProps) {
   const [config, setConfig] = useState<ChatConfig | null>(null)
-  const [session, setSession] = useState<InitializeResponse | null>(null)
-  const [messages, setMessages] = useState<ChatMessage[]>([])
   const [open, setOpen] = useState(false)
-  const [sending, setSending] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const pusherRef = useRef<PusherConnection | null>(null)
-  const triggerRef = useRef<HTMLButtonElement | null>(null)
-  const inputRef = useRef<HTMLInputElement | null>(null)
-  const mountedRef = useRef(false)
-  const api = useRef(chatApi(channelId)).current
+  const router = useTabRouter(channelId)
 
-  // Load config once on mount.
   useEffect(() => {
     fetchChatConfig(channelId)
       .then((c) => {
@@ -36,166 +35,134 @@ export function Widget({ channelId }: WidgetProps) {
       .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load chat'))
   }, [channelId])
 
-  // Initialize session when the widget is first opened.
-  useEffect(() => {
-    if (!open || session || !config) return
-    let cancelled = false
-    setError(null)
-    api
-      .initialize({
-        url: window.location.href,
-        referrer: document.referrer || undefined,
-        userAgent: navigator.userAgent,
-        identify: getStoredIdentify(channelId) ?? undefined,
-      })
-      .then((res) => {
-        if (cancelled) return
-        if (res.passport) updateStoredPassport(channelId, res.passport)
-        setSession(res)
-        setMessages(res.messages)
-      })
-      .catch((e) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to start chat')
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [open, session, config, api, channelId])
-
-  // Push later identify() calls to the backend once a session exists. Pre-session
-  // calls are persisted to sessionStorage and picked up by initialize() above.
-  useEffect(() => {
-    if (!session) return
-    const dispatch = (payload: IdentifyPayload) => {
-      api
-        .updateVisitorInfo({ threadId: session.threadId, identify: payload })
-        .then((res) => {
-          if (res?.passport) updateStoredPassport(channelId, res.passport)
-        })
-        .catch(() => {})
-    }
-    return onIdentify(dispatch)
-  }, [session, api, channelId])
-
-  // Subscribe to Pusher once the session exists.
-  useEffect(() => {
-    if (!session || !config) return
-    const conn = connectPusher({
-      key: config.realtime.key,
-      cluster: config.realtime.cluster,
-      channelName: session.pusherChannel,
-    })
-    pusherRef.current = conn
-
-    conn.channel.bind('new-message', (message: ChatMessage) => {
-      setMessages((prev) => {
-        if (prev.some((m) => m.id === message.id)) return prev
-        return [...prev, message]
-      })
-      if (message.sender !== 'USER') {
-        api.markDelivered([message.id]).catch(() => {})
-      }
-    })
-
-    return () => {
-      conn.disconnect()
-      pusherRef.current = null
-    }
-  }, [session, config, api])
-
-  // Move focus on open/close transitions. Skip the very first render so we
-  // don't yank focus on initial mount if autoOpen is off.
-  useEffect(() => {
-    if (!mountedRef.current) {
-      mountedRef.current = true
-      return
-    }
-    if (open) inputRef.current?.focus()
-    else triggerRef.current?.focus()
-  }, [open])
-
-  const handleSend = async (content: string) => {
-    if (!session) return
-    setSending(true)
-    setError(null)
-    const clientMessageId = `c_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
-    const optimistic: ChatMessage = {
-      id: clientMessageId,
-      content,
-      sender: 'USER',
-      createdAt: new Date().toISOString(),
-      status: 'sending',
-    }
-    setMessages((prev) => [...prev, optimistic])
-
-    try {
-      const res = await api.sendMessage({
-        sessionId: session.sessionId,
-        threadId: session.threadId,
-        content,
-        clientMessageId,
-      })
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === clientMessageId
-            ? { ...m, id: res.messageId, status: res.status, createdAt: res.createdAt }
-            : m
-        )
-      )
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to send')
-      setMessages((prev) => prev.filter((m) => m.id !== clientMessageId))
-    } finally {
-      setSending(false)
-    }
-  }
-
   if (!config) return null
 
   const positionClass = config.appearance.position.toLowerCase().includes('left')
     ? 'auxx-chat-shell--bottom-left'
     : 'auxx-chat-shell--bottom-right'
   const stateClass = open ? 'auxx-chat-shell--open' : 'auxx-chat-shell--closed'
-
   const rootStyle = { '--auxx-chat-primary': config.appearance.primaryColor } as Record<
     string,
     string
   >
 
   return (
-    <div class='auxx-chat-root' style={rootStyle}>
-      <div class={`auxx-chat-shell ${stateClass} ${positionClass}`}>
+    <div className='auxx-chat-root' style={rootStyle}>
+      <div className={`auxx-chat-shell ${stateClass} ${positionClass}`}>
         <button
-          ref={triggerRef}
           type='button'
-          class='auxx-chat-shell__trigger'
+          className='auxx-chat-shell__trigger'
           onClick={() => setOpen((v) => !v)}
           aria-label={open ? 'Close chat' : 'Open chat'}
           aria-expanded={open}
           tabIndex={open ? -1 : 0}
         />
-        <span class='auxx-chat-shell__icon' aria-hidden='true'>
+        <span className='auxx-chat-shell__icon' aria-hidden='true'>
           <svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'>
             <path d='M20 2H4a2 2 0 0 0-2 2v18l4-4h14a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2zM6 9h12v2H6V9zm8 5H6v-2h8v2z' />
           </svg>
         </span>
         <div
-          class='auxx-chat-shell__panel'
+          className='auxx-chat-shell__panel'
           role='dialog'
           aria-modal='false'
           aria-label={config.appearance.title}
           aria-hidden={!open}>
-          <ChatPanel
-            config={config}
-            messages={messages}
-            sending={sending}
-            error={error}
-            inputRef={inputRef}
-            onClose={() => setOpen(false)}
-            onSend={handleSend}
-          />
+          <NavStackProvider value={router.currentStack}>
+            <PanelShell
+              channelId={channelId}
+              config={config}
+              activeTab={router.activeTab}
+              onTabChange={router.setActiveTab}
+              currentFrame={router.currentStack.current}
+              isAtRoot={router.currentStack.isAtRoot}
+              onBack={router.currentStack.pop}
+              onClose={() => setOpen(false)}
+              error={error}
+            />
+          </NavStackProvider>
         </div>
       </div>
     </div>
   )
+}
+
+interface PanelShellProps {
+  channelId: string
+  config: ChatConfig
+  activeTab: TabId
+  onTabChange: (tab: TabId) => void
+  currentFrame: NavFrame | null
+  isAtRoot: boolean
+  onBack: () => void
+  onClose: () => void
+  error: string | null
+}
+
+function PanelShell({
+  channelId,
+  config,
+  activeTab,
+  onTabChange,
+  currentFrame,
+  isAtRoot,
+  onBack,
+  onClose,
+  error,
+}: PanelShellProps) {
+  const view: NavView = currentFrame?.view ?? activeTab
+  const headerVariant = pickHeaderVariant(view, isAtRoot)
+
+  return (
+    <div className='flex h-full flex-col'>
+      <FrameHeader
+        variant={headerVariant}
+        title={headerTitle(view, currentFrame, config)}
+        subtitle={
+          view === 'home' && isAtRoot ? (config.appearance.subtitle ?? undefined) : undefined
+        }
+        logoUrl={config.appearance.logoUrl}
+        onBack={isAtRoot ? undefined : onBack}
+        onClose={onClose}
+      />
+      {error ? (
+        <div className='auxx-chat-error' role='alert'>
+          {error}
+        </div>
+      ) : null}
+      <div className='flex min-h-0 flex-1 flex-col bg-[color:var(--color-bg)]'>
+        {renderFrame(view, currentFrame, channelId, config)}
+      </div>
+      {isAtRoot ? <TabBar activeTab={activeTab} onChange={onTabChange} /> : null}
+    </div>
+  )
+}
+
+function pickHeaderVariant(view: NavView, isAtRoot: boolean): FrameHeaderVariant {
+  if (!isAtRoot) return 'contextual'
+  if (view === 'home') return 'dark-hero'
+  return 'plain'
+}
+
+function headerTitle(view: NavView, frame: NavFrame | null, config: ChatConfig): string {
+  if (frame) return frame.label
+  if (view === 'home') return config.appearance.title
+  if (view === 'messages') return 'Messages'
+  return ''
+}
+
+function renderFrame(view: NavView, frame: NavFrame | null, channelId: string, config: ChatConfig) {
+  const label = frame?.label ?? ''
+  switch (view) {
+    case 'home':
+      return <HomeView channelId={channelId} config={config} />
+    case 'messages':
+      return <MessagesView />
+    case 'thread':
+      return <ThreadView label={label} />
+    case 'kb-section':
+      return <KbSectionView label={label} />
+    case 'kb-article':
+      return <KbArticleView label={label} />
+  }
 }

--- a/apps/chat-widget/vite.config.ts
+++ b/apps/chat-widget/vite.config.ts
@@ -1,6 +1,7 @@
 // apps/chat-widget/vite.config.ts
 
 import { resolve } from 'node:path'
+import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vite'
 
 /**
@@ -41,6 +42,7 @@ function resolveApiUrl(): string {
 }
 
 export default defineConfig({
+  plugins: [tailwindcss()],
   resolve: {
     alias: {
       react: 'preact/compat',

--- a/apps/web/src/components/chat-widget/ui/settings/featured-articles-field.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/featured-articles-field.tsx
@@ -1,0 +1,183 @@
+// apps/web/src/components/chat-widget/ui/settings/featured-articles-field.tsx
+
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { GripVertical, Plus, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { useArticleList } from '~/components/kb/hooks/use-article-list'
+import { ArticlePicker } from '~/components/kb/ui/articles/article-picker'
+
+interface FeaturedArticlesFieldProps {
+  /** KB the picker scopes to; when null the field is disabled. */
+  knowledgeBaseId: string | null
+  /** Currently-selected article ids, in the visitor-facing order. */
+  value: string[]
+  onChange: (value: string[]) => void
+  disabled?: boolean
+}
+
+/**
+ * Admin control for the chat widget's featured-article list. Renders the
+ * selected articles as a draggable list with remove buttons + an "Add article"
+ * popover (an `ArticlePicker` scoped to the linked KB).
+ */
+export function FeaturedArticlesField({
+  knowledgeBaseId,
+  value,
+  onChange,
+  disabled,
+}: FeaturedArticlesFieldProps) {
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const articles = useArticleList(knowledgeBaseId)
+  const articleById = useMemo(() => new Map(articles.map((a) => [a.id, a])), [articles])
+  const selectedSet = useMemo(() => new Set(value), [value])
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = value.indexOf(String(active.id))
+    const newIndex = value.indexOf(String(over.id))
+    if (oldIndex < 0 || newIndex < 0) return
+    onChange(arrayMove(value, oldIndex, newIndex))
+  }
+
+  const handleRemove = (id: string) => {
+    onChange(value.filter((v) => v !== id))
+  }
+
+  if (!knowledgeBaseId) {
+    return (
+      <p className='text-xs text-muted-foreground'>
+        Link a knowledge base above to feature articles.
+      </p>
+    )
+  }
+
+  return (
+    <div className='space-y-2'>
+      {value.length > 0 && (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={value} strategy={verticalListSortingStrategy}>
+            <ul className='space-y-1.5'>
+              {value.map((articleId) => {
+                const article = articleById.get(articleId)
+                return (
+                  <SortableRow
+                    key={articleId}
+                    id={articleId}
+                    title={article?.title ?? 'Untitled'}
+                    emoji={article?.emoji ?? null}
+                    missing={!article}
+                    onRemove={() => handleRemove(articleId)}
+                    disabled={disabled}
+                  />
+                )
+              })}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+        <PopoverTrigger asChild>
+          <Button type='button' variant='outline' size='sm' disabled={disabled}>
+            <Plus className='size-3.5' /> Add article
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align='start'
+          sideOffset={4}
+          className='p-0 w-72'
+          onOpenAutoFocus={(e) => e.preventDefault()}>
+          <ArticlePicker
+            knowledgeBaseId={knowledgeBaseId}
+            allowedKinds={['page']}
+            forbiddenIds={selectedSet}
+            flattenSearch
+            rootLabel='Featured articles'
+            searchPlaceholder='Search articles…'
+            onPick={(articleId) => {
+              if (!value.includes(articleId)) onChange([...value, articleId])
+              setPickerOpen(false)
+            }}
+            onClose={() => setPickerOpen(false)}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}
+
+interface SortableRowProps {
+  id: string
+  title: string
+  emoji: string | null
+  missing: boolean
+  onRemove: () => void
+  disabled?: boolean
+}
+
+function SortableRow({ id, title, emoji, missing, onRemove, disabled }: SortableRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+  })
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+  }
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className='flex items-center gap-2 rounded-md border px-2 py-1.5 bg-background'>
+      <button
+        type='button'
+        className='cursor-grab text-muted-foreground hover:text-foreground touch-none'
+        aria-label='Drag to reorder'
+        {...attributes}
+        {...listeners}>
+        <GripVertical className='size-3.5' />
+      </button>
+      <EntityIcon iconId={emoji ?? 'file-text'} size='xs' className='text-muted-foreground' />
+      <span className={`flex-1 truncate text-sm ${missing ? 'italic text-muted-foreground' : ''}`}>
+        {missing ? `Missing article (${id.slice(0, 6)}…)` : title}
+      </span>
+      <Button
+        type='button'
+        variant='ghost'
+        size='icon-xs'
+        onClick={onRemove}
+        disabled={disabled}
+        aria-label='Remove'>
+        <X className='size-3.5' />
+      </Button>
+    </li>
+  )
+}

--- a/apps/web/src/components/chat-widget/ui/settings/greeting-editor.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/greeting-editor.tsx
@@ -1,0 +1,172 @@
+// apps/web/src/components/chat-widget/ui/settings/greeting-editor.tsx
+
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { cn } from '@auxx/ui/lib/utils'
+import Placeholder from '@tiptap/extension-placeholder'
+import { EditorContent, type JSONContent, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import { Braces } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import {
+  createPlaceholderNode,
+  InlinePickerPopover,
+  PlaceholderBadge,
+  useSlashCommand,
+} from '~/components/editor/inline-picker'
+import { Tooltip } from '~/components/global/tooltip'
+import { VisitorClaimPickerContent } from './visitor-claim-picker-content'
+
+interface GreetingEditorProps {
+  /** Tiptap JSON doc, or null for an empty editor. */
+  value: JSONContent | null
+  /** Fires on every change with the latest Tiptap JSON document. */
+  onChange: (doc: JSONContent | null) => void
+  placeholder?: string
+  /** Applied to the outer wrapper (border, focus ring). */
+  wrapperClassName?: string
+  /** Applied to the prose content area. */
+  className?: string
+}
+
+/**
+ * Tiptap-based greeting editor for the chat widget Home tab. Same shell as
+ * `SnippetEditor` (placeholder node + `{`-triggered picker + fallback editor)
+ * but the picker is restricted to the three visitor identify claims and the
+ * output is Tiptap JSON instead of HTML.
+ */
+export function GreetingEditor({
+  value,
+  onChange,
+  placeholder = 'Type { to insert a visitor field...',
+  wrapperClassName,
+  className,
+}: GreetingEditorProps) {
+  const slashCommand = useSlashCommand({ trigger: '{', allowedPrefixes: null })
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const placeholderNodeExtension = useMemo(
+    () => createPlaceholderNode((badgeProps) => <PlaceholderBadge {...badgeProps} />),
+    []
+  )
+
+  const extensions = useMemo(
+    () => [
+      StarterKit.configure({ heading: false }),
+      Placeholder.configure({ placeholder }),
+      slashCommand.slashCommandExtension,
+      placeholderNodeExtension,
+    ],
+    [placeholder, slashCommand.slashCommandExtension, placeholderNodeExtension]
+  )
+
+  const editor = useEditor(
+    {
+      extensions,
+      content: value ?? '',
+      immediatelyRender: false,
+      shouldRerenderOnTransaction: false,
+      editorProps: {
+        attributes: {
+          class: cn(
+            'tiptap-snippet-editor prose prose-sm prose-headings:my-1 prose-ul:my-1 prose-p:my-0 prose-li:my-0 focus:outline-hidden max-w-none dark:prose-invert flex-1',
+            className
+          ),
+        },
+      },
+      onCreate: ({ editor }) => {
+        slashCommand.setEditor(editor)
+      },
+      onDestroy: () => {
+        slashCommand.setEditor(null)
+      },
+      onUpdate: ({ editor }) => {
+        if (slashCommand.isOpenRef.current) return
+        const doc = editor.getJSON()
+        onChange(isEmptyDoc(doc) ? null : doc)
+      },
+    },
+    []
+  )
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return
+    const current = editor.getJSON()
+    if (!docsEqual(current, value)) {
+      editor.commands.setContent(value ?? '', false)
+    }
+  }, [editor, value])
+
+  const handleInsertTrigger = useCallback(() => {
+    if (!editor) return
+    if (!editor.isFocused) editor.commands.focus('end')
+    editor.commands.insertContent('{')
+  }, [editor])
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        'relative rounded-md border focus-within:ring-2 focus-within:ring-info',
+        wrapperClassName
+      )}>
+      <EditorContent
+        editor={editor}
+        className='w-full h-full flex flex-col bg-transparent px-3 py-2 text-[15px] leading-relaxed text-foreground outline-hidden ring-0 min-h-[80px] *:outline-hidden'
+      />
+      <div className='absolute bottom-1 right-1'>
+        <Tooltip content='Insert visitor field' shortcut='{' allowInteraction>
+          <Button
+            type='button'
+            size='icon-sm'
+            variant='ghost'
+            onMouseDown={(e) => {
+              e.preventDefault()
+              handleInsertTrigger()
+            }}>
+            <Braces />
+          </Button>
+        </Tooltip>
+      </div>
+      <InlinePickerPopover
+        state={slashCommand.suggestionState}
+        width={240}
+        className='z-[200]'
+        onClose={slashCommand.closePicker}>
+        <VisitorClaimPickerContent
+          onClose={slashCommand.closePicker}
+          onSelect={(id) => {
+            slashCommand.executeCommand((editor, range) => {
+              editor
+                .chain()
+                .focus()
+                .deleteRange(range)
+                .insertContent({ type: 'placeholder', attrs: { id } })
+                .insertContent(' ')
+                .run()
+            })
+          }}
+        />
+      </InlinePickerPopover>
+    </div>
+  )
+}
+
+/**
+ * Tiptap's default empty doc is `{ type: 'doc', content: [{ type: 'paragraph' }] }`.
+ * Persist `null` for that case so we can fall back to `welcomeMessage` cleanly.
+ */
+function isEmptyDoc(doc: JSONContent): boolean {
+  if (doc.type !== 'doc' || !Array.isArray(doc.content)) return true
+  if (doc.content.length === 0) return true
+  if (doc.content.length === 1) {
+    const only = doc.content[0]
+    if (only?.type === 'paragraph' && (!only.content || only.content.length === 0)) return true
+  }
+  return false
+}
+
+function docsEqual(a: JSONContent | null, b: JSONContent | null): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}

--- a/apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
@@ -1,6 +1,8 @@
 // apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
 'use client'
+import { FieldType } from '@auxx/database/enums'
 import type { ChatWidgetWithIntegration } from '@auxx/lib/chat-widget/config'
+import type { RecordId } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
 import {
   Form,
@@ -11,15 +13,30 @@ import {
   FormLabel,
   FormMessage,
 } from '@auxx/ui/components/form'
-import { Label } from '@auxx/ui/components/label'
-import { Switch } from '@auxx/ui/components/switch'
+import { Slider } from '@auxx/ui/components/slider'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-import { MessageSquareOff, MousePointerClick, SlidersHorizontal, UserPlus } from 'lucide-react'
+import type { JSONContent } from '@tiptap/react'
+import {
+  BookOpen,
+  Home,
+  MessageSquare,
+  MessageSquareOff,
+  MousePointerClick,
+  SlidersHorizontal,
+  Sparkles,
+  UserPlus,
+} from 'lucide-react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { MultiRelationInput } from '~/components/shared/multi-relation-input'
+import { BaseType } from '~/components/workflow/types'
+import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
+import { FeaturedArticlesField } from '../featured-articles-field'
+import { GreetingEditor } from '../greeting-editor'
 
 interface BehaviorSectionProps {
   widget: ChatWidgetWithIntegration
@@ -30,6 +47,15 @@ const behaviorSchema = z.object({
   autoOpen: z.boolean(),
   collectUserInfo: z.boolean(),
   offlineMessage: z.string().max(1000).optional(),
+  // Home group
+  homeGreetingTemplate: z.unknown().optional(),
+  homeShowRecentMessage: z.boolean(),
+  homeShowSendMessageCta: z.boolean(),
+  allowDownloadTranscript: z.boolean(),
+  brandingFooterEnabled: z.boolean(),
+  expandedWidthPx: z.number().int().min(480).max(960),
+  knowledgeBaseId: z.string().nullable(),
+  featuredArticleIds: z.array(z.string()),
 })
 
 type BehaviorForm = z.infer<typeof behaviorSchema>
@@ -44,12 +70,21 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
     onError: (e) => toastError({ title: 'Failed to save', description: e.message }),
   })
 
+  const cw = widget.chatWidget
   const form = useForm<BehaviorForm>({
     resolver: standardSchemaResolver(behaviorSchema),
     defaultValues: {
-      autoOpen: widget.chatWidget?.autoOpen ?? false,
-      collectUserInfo: widget.chatWidget?.collectUserInfo ?? false,
-      offlineMessage: widget.chatWidget?.offlineMessage ?? '',
+      autoOpen: cw?.autoOpen ?? false,
+      collectUserInfo: cw?.collectUserInfo ?? false,
+      offlineMessage: cw?.offlineMessage ?? '',
+      homeGreetingTemplate: (cw?.homeGreetingTemplate as JSONContent | null) ?? null,
+      homeShowRecentMessage: cw?.homeShowRecentMessage ?? true,
+      homeShowSendMessageCta: cw?.homeShowSendMessageCta ?? true,
+      allowDownloadTranscript: cw?.allowDownloadTranscript ?? true,
+      brandingFooterEnabled: cw?.brandingFooterEnabled ?? true,
+      expandedWidthPx: cw?.expandedWidthPx ?? 720,
+      knowledgeBaseId: cw?.knowledgeBaseId ?? null,
+      featuredArticleIds: cw?.featuredArticleIds ?? [],
     },
   })
 
@@ -59,6 +94,14 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
       autoOpen: values.autoOpen,
       collectUserInfo: values.collectUserInfo,
       offlineMessage: values.offlineMessage || undefined,
+      homeGreetingTemplate: values.homeGreetingTemplate ?? null,
+      homeShowRecentMessage: values.homeShowRecentMessage,
+      homeShowSendMessageCta: values.homeShowSendMessageCta,
+      allowDownloadTranscript: values.allowDownloadTranscript,
+      brandingFooterEnabled: values.brandingFooterEnabled,
+      expandedWidthPx: values.expandedWidthPx,
+      knowledgeBaseId: values.knowledgeBaseId,
+      featuredArticleIds: values.featuredArticleIds,
     })
   }
 
@@ -76,57 +119,137 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
               </p>
             </div>
 
-            <div className='space-y-4'>
+            <VarEditorField
+              orientation='responsive'
+              className='p-0 **:data-[slot=field-row-label]:w-auto! @sm:**:data-[slot=field-row-label]:w-auto! **:data-[slot=field-row-content]:flex **:data-[slot=field-row-content]:justify-end **:data-[slot=field-row-content]:pe-3'>
               <FormField
                 control={form.control}
                 name='autoOpen'
-                render={({ field }) => (
-                  <div className='rounded-xl border px-3 py-2.5'>
-                    <div
-                      className='flex cursor-pointer items-center justify-between'
-                      onClick={() => field.onChange(!field.value)}>
-                      <div className='space-y-0.5'>
-                        <Label className='flex cursor-pointer items-center gap-1.5 text-sm font-medium'>
-                          <MousePointerClick className='size-3.5 text-muted-foreground' />
-                          Auto-open
-                        </Label>
-                        <p className='text-xs text-muted-foreground'>
-                          Automatically open the widget when a visitor lands on the page.
-                        </p>
-                      </div>
-                      <div onClick={(e) => e.stopPropagation()}>
-                        <Switch size='sm' checked={field.value} onCheckedChange={field.onChange} />
-                      </div>
+                render={({ field, fieldState }) => (
+                  <VarEditorFieldRow
+                    title='Auto-open'
+                    description='Automatically open the widget when a visitor lands on the page.'
+                    type={BaseType.BOOLEAN}
+                    icon={<MousePointerClick className='size-3.5' />}
+                    showIcon
+                    validationError={fieldState.error?.message}>
+                    <div className='items-end'>
+                      <FieldInputAdapter
+                        fieldType={FieldType.CHECKBOX}
+                        fieldOptions={{ variant: 'switch' }}
+                        value={field.value}
+                        onChange={(v) => field.onChange(Boolean(v))}
+                      />
                     </div>
-                  </div>
+                  </VarEditorFieldRow>
                 )}
               />
 
               <FormField
                 control={form.control}
                 name='collectUserInfo'
-                render={({ field }) => (
-                  <div className='rounded-xl border px-3 py-2.5'>
-                    <div
-                      className='flex cursor-pointer items-center justify-between'
-                      onClick={() => field.onChange(!field.value)}>
-                      <div className='space-y-0.5'>
-                        <Label className='flex cursor-pointer items-center gap-1.5 text-sm font-medium'>
-                          <UserPlus className='size-3.5 text-muted-foreground' />
-                          Collect Visitor Info
-                        </Label>
-                        <p className='text-xs text-muted-foreground'>
-                          Prompt visitors for name and email before the chat starts.
-                        </p>
-                      </div>
-                      <div onClick={(e) => e.stopPropagation()}>
-                        <Switch size='sm' checked={field.value} onCheckedChange={field.onChange} />
-                      </div>
-                    </div>
-                  </div>
+                render={({ field, fieldState }) => (
+                  <VarEditorFieldRow
+                    title='Collect Visitor Info'
+                    description='Prompt visitors for name and email before the chat starts.'
+                    type={BaseType.BOOLEAN}
+                    icon={<UserPlus className='size-3.5' />}
+                    showIcon
+                    validationError={fieldState.error?.message}>
+                    <FieldInputAdapter
+                      fieldType={FieldType.CHECKBOX}
+                      fieldOptions={{ variant: 'switch' }}
+                      value={field.value}
+                      onChange={(v) => field.onChange(Boolean(v))}
+                    />
+                  </VarEditorFieldRow>
                 )}
               />
-            </div>
+
+              <FormField
+                control={form.control}
+                name='homeShowRecentMessage'
+                render={({ field, fieldState }) => (
+                  <VarEditorFieldRow
+                    title='Show recent message card'
+                    description="Show a card linking to the visitor's most recent conversation."
+                    type={BaseType.BOOLEAN}
+                    icon={<MessageSquare className='size-3.5' />}
+                    showIcon
+                    validationError={fieldState.error?.message}>
+                    <FieldInputAdapter
+                      fieldType={FieldType.CHECKBOX}
+                      fieldOptions={{ variant: 'switch' }}
+                      value={field.value}
+                      onChange={(v) => field.onChange(Boolean(v))}
+                    />
+                  </VarEditorFieldRow>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name='homeShowSendMessageCta'
+                render={({ field, fieldState }) => (
+                  <VarEditorFieldRow
+                    title='Show "Send us a message" card'
+                    description='Always-visible CTA that starts a new conversation.'
+                    type={BaseType.BOOLEAN}
+                    icon={<Sparkles className='size-3.5' />}
+                    showIcon
+                    validationError={fieldState.error?.message}>
+                    <FieldInputAdapter
+                      fieldType={FieldType.CHECKBOX}
+                      fieldOptions={{ variant: 'switch' }}
+                      value={field.value}
+                      onChange={(v) => field.onChange(Boolean(v))}
+                    />
+                  </VarEditorFieldRow>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name='allowDownloadTranscript'
+                render={({ field, fieldState }) => (
+                  <VarEditorFieldRow
+                    title='Allow transcript download'
+                    description='Let visitors download a conversation as text.'
+                    type={BaseType.BOOLEAN}
+                    icon={<BookOpen className='size-3.5' />}
+                    showIcon
+                    validationError={fieldState.error?.message}>
+                    <FieldInputAdapter
+                      fieldType={FieldType.CHECKBOX}
+                      fieldOptions={{ variant: 'switch' }}
+                      value={field.value}
+                      onChange={(v) => field.onChange(Boolean(v))}
+                    />
+                  </VarEditorFieldRow>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name='brandingFooterEnabled'
+                render={({ field, fieldState }) => (
+                  <VarEditorFieldRow
+                    title='Show "Powered by" footer'
+                    description='Display Auxx branding at the bottom of the widget.'
+                    type={BaseType.BOOLEAN}
+                    icon={<Home className='size-3.5' />}
+                    showIcon
+                    validationError={fieldState.error?.message}>
+                    <FieldInputAdapter
+                      fieldType={FieldType.CHECKBOX}
+                      fieldOptions={{ variant: 'switch' }}
+                      value={field.value}
+                      onChange={(v) => field.onChange(Boolean(v))}
+                    />
+                  </VarEditorFieldRow>
+                )}
+              />
+            </VarEditorField>
           </div>
 
           <div className='flex-1 border-t lg:border-t-0 lg:border-l p-6 lg:pl-6'>
@@ -152,6 +275,117 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                     Leave blank to fall back to the default message.
                   </FormDescription>
                   <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </div>
+
+        <div className='border-t p-6'>
+          <div className='space-y-1 mb-6'>
+            <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
+              <Home className='size-4' /> Home tab
+            </div>
+            <p className='text-sm text-muted-foreground'>
+              What visitors see on the widget's Home screen.
+            </p>
+          </div>
+
+          <div className='space-y-6'>
+            <FormField
+              control={form.control}
+              name='homeGreetingTemplate'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Greeting</FormLabel>
+                  <FormControl>
+                    <GreetingEditor
+                      value={(field.value as JSONContent | null) ?? null}
+                      onChange={field.onChange}
+                      placeholder='Hi {visitor:name} 👋'
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Type <code className='rounded bg-muted px-1'>{'{'}</code> to insert a visitor
+                    field. Click the badge to set a fallback for when the value isn't available.
+                  </FormDescription>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name='expandedWidthPx'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Expanded width — {field.value}px</FormLabel>
+                  <FormControl>
+                    <Slider
+                      min={480}
+                      max={960}
+                      step={10}
+                      value={[field.value]}
+                      onValueChange={(v) => field.onChange(v[0] ?? 720)}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Width of the widget when expanded on desktop (480–960px).
+                  </FormDescription>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name='knowledgeBaseId'
+              render={({ field }) => {
+                const recordId = field.value ? (`kb:${field.value}` as RecordId) : null
+                return (
+                  <FormItem>
+                    <FormLabel>Knowledge base</FormLabel>
+                    <FormControl>
+                      <MultiRelationInput
+                        entityDefinitionId='kb'
+                        value={recordId ? [recordId] : []}
+                        multi={false}
+                        placeholder='Link a knowledge base…'
+                        onChange={(ids) => {
+                          const first = ids[0]
+                          if (!first) {
+                            field.onChange(null)
+                            return
+                          }
+                          const instanceId = first.includes(':')
+                            ? first.split(':').slice(1).join(':')
+                            : first
+                          field.onChange(instanceId)
+                        }}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Articles from this KB power the widget's featured cards and Browse all view.
+                    </FormDescription>
+                  </FormItem>
+                )
+              }}
+            />
+
+            <FormField
+              control={form.control}
+              name='featuredArticleIds'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Featured articles</FormLabel>
+                  <FormControl>
+                    <FeaturedArticlesField
+                      knowledgeBaseId={form.watch('knowledgeBaseId')}
+                      value={field.value}
+                      onChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Pinned articles shown as cards on the Home screen. Drag to reorder.
+                  </FormDescription>
                 </FormItem>
               )}
             />

--- a/apps/web/src/components/chat-widget/ui/settings/visitor-claim-picker-content.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/visitor-claim-picker-content.tsx
@@ -1,0 +1,80 @@
+// apps/web/src/components/chat-widget/ui/settings/visitor-claim-picker-content.tsx
+
+'use client'
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@auxx/ui/components/command'
+import { Braces } from 'lucide-react'
+import { useState } from 'react'
+
+interface VisitorOption {
+  slug: 'name' | 'email' | 'externalId'
+  label: string
+}
+
+const VISITOR_OPTIONS: VisitorOption[] = [
+  { slug: 'name', label: 'Name' },
+  { slug: 'email', label: 'Email' },
+  { slug: 'externalId', label: 'External ID' },
+]
+
+interface VisitorClaimPickerContentProps {
+  onSelect: (id: string) => void
+  onClose: () => void
+}
+
+/**
+ * Flat-list picker for the chat-widget greeting editor. Only exposes the
+ * three visitor identify claims (`visitor:name`, `visitor:email`,
+ * `visitor:externalId`) — no roots, no breadcrumb, no other entity sources.
+ */
+export function VisitorClaimPickerContent({ onSelect, onClose }: VisitorClaimPickerContentProps) {
+  const [search, setSearch] = useState('')
+  const q = search.toLowerCase().trim()
+  const filtered = q
+    ? VISITOR_OPTIONS.filter((o) => o.label.toLowerCase().includes(q))
+    : VISITOR_OPTIONS
+
+  return (
+    <Command
+      shouldFilter={false}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.stopPropagation()
+          onClose()
+          return
+        }
+        if (e.key === 'Backspace' && !search) {
+          e.preventDefault()
+          onClose()
+        }
+      }}>
+      <CommandInput
+        placeholder='Pick a visitor field...'
+        value={search}
+        onValueChange={setSearch}
+        autoFocus
+      />
+      <CommandList>
+        <CommandEmpty>No fields found.</CommandEmpty>
+        <CommandGroup heading='Visitor'>
+          {filtered.map((o) => (
+            <CommandItem
+              key={o.slug}
+              value={o.label}
+              onSelect={() => onSelect(`visitor:${o.slug}`)}>
+              <Braces className='size-4 text-muted-foreground' />
+              <span>{o.label}</span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}

--- a/apps/web/src/components/editor/placeholders/catalog.ts
+++ b/apps/web/src/components/editor/placeholders/catalog.ts
@@ -10,6 +10,7 @@ import {
   type OrgSlug,
   tryParsePlaceholderId,
   type UserSlug,
+  type VisitorSlug,
 } from '@auxx/lib/placeholders/client'
 import type { ResourceField } from '@auxx/lib/resources/client'
 import { mapBaseTypeToFieldType } from '@auxx/lib/workflow-engine/client'
@@ -20,7 +21,7 @@ import { useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useResourceProperty } from '~/components/resources'
 import { useResourceStore } from '~/components/resources/store/resource-store'
-import { shimFieldForOrg, shimFieldForUser } from './field-shim'
+import { shimFieldForOrg, shimFieldForUser, shimFieldForVisitor } from './field-shim'
 
 const DATE_SLUG_LABELS: Record<string, string> = {
   today: 'Today',
@@ -55,6 +56,18 @@ const USER_SLUG_FIELD_TYPES: Record<UserSlug, FallbackSupportedType> = {
   name: 'TEXT',
   firstName: 'TEXT',
   lastName: 'TEXT',
+}
+
+const VISITOR_SLUG_LABELS: Record<VisitorSlug, string> = {
+  name: 'Name',
+  email: 'Email',
+  externalId: 'External ID',
+}
+
+const VISITOR_SLUG_FIELD_TYPES: Record<VisitorSlug, FallbackSupportedType> = {
+  name: 'TEXT',
+  email: 'EMAIL',
+  externalId: 'TEXT',
 }
 
 /** Stable module-level empty array — reused so shallow-equality holds across renders. */
@@ -124,6 +137,7 @@ export function usePlaceholderLabel(id: string): PlaceholderLabel {
     if (parsed.kind === 'date') return 'Date'
     if (parsed.kind === 'org') return 'Organization'
     if (parsed.kind === 'user') return 'Sender'
+    if (parsed.kind === 'visitor') return 'Visitor'
     const res = state.getEffectiveResource(parsed.rootEntityDefinitionId)
     return res?.label ?? parsed.rootEntityDefinitionId
   })
@@ -181,6 +195,20 @@ export function usePlaceholderLabel(id: string): PlaceholderLabel {
       const fieldType = USER_SLUG_FIELD_TYPES[parsed.slug]
       return {
         breadcrumb: `Sender › ${label}`,
+        resolved: true,
+        iconId: fieldTypeOptions[fieldType]?.iconId ?? 'text',
+        field: shim,
+        fieldType,
+        fallbackSupported: true,
+      }
+    }
+
+    if (parsed.kind === 'visitor') {
+      const label = VISITOR_SLUG_LABELS[parsed.slug]
+      const shim = shimFieldForVisitor(parsed.slug)
+      const fieldType = VISITOR_SLUG_FIELD_TYPES[parsed.slug]
+      return {
+        breadcrumb: `Visitor › ${label}`,
         resolved: true,
         iconId: fieldTypeOptions[fieldType]?.iconId ?? 'text',
         field: shim,

--- a/apps/web/src/components/editor/placeholders/field-shim.ts
+++ b/apps/web/src/components/editor/placeholders/field-shim.ts
@@ -1,6 +1,6 @@
 // apps/web/src/components/editor/placeholders/field-shim.ts
 
-import type { OrgSlug, UserSlug } from '@auxx/lib/placeholders/client'
+import type { OrgSlug, UserSlug, VisitorSlug } from '@auxx/lib/placeholders/client'
 import type { ResourceField } from '@auxx/lib/resources/client'
 import type { FieldId } from '@auxx/types/field'
 
@@ -70,4 +70,36 @@ const USER_LABELS: Record<UserSlug, string> = {
   name: 'Name',
   firstName: 'First Name',
   lastName: 'Last Name',
+}
+
+/**
+ * Synthesize a `ResourceField` for a synthetic `visitor:<slug>` token. Used
+ * by the chat-widget greeting template; resolved client-side from the
+ * widget's identify() claims, so all fallback-supported slugs are TEXT (or
+ * EMAIL).
+ */
+export function shimFieldForVisitor(slug: VisitorSlug): ResourceField {
+  const label = VISITOR_LABELS[slug]
+  const fieldType = slug === 'email' ? 'EMAIL' : 'TEXT'
+  return {
+    id: `visitor:${slug}` as FieldId,
+    key: slug,
+    label,
+    type: 'string',
+    fieldType,
+    required: false,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: false,
+      updatable: true,
+      configurable: false,
+    },
+  }
+}
+
+const VISITOR_LABELS: Record<VisitorSlug, string> = {
+  name: 'Name',
+  email: 'Email',
+  externalId: 'External ID',
 }

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -325,6 +325,16 @@ export const channelRouter = createTRPCRouter({
         isActive: z.boolean().optional(),
         inboxId: z.string().optional().nullable(),
         agentId: z.string().optional().nullable(),
+
+        // v2 Home config
+        homeGreetingTemplate: z.unknown().optional(),
+        homeShowRecentMessage: z.boolean().optional(),
+        homeShowSendMessageCta: z.boolean().optional(),
+        brandingFooterEnabled: z.boolean().optional(),
+        allowDownloadTranscript: z.boolean().optional(),
+        expandedWidthPx: z.number().int().min(480).max(960).optional(),
+        knowledgeBaseId: z.string().optional().nullable(),
+        featuredArticleIds: z.array(z.string()).optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {

--- a/packages/database/drizzle/0165_chat_widget_greeting_jsonb.sql
+++ b/packages/database/drizzle/0165_chat_widget_greeting_jsonb.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "ChatWidget" ALTER COLUMN "homeGreetingTemplate" SET DATA TYPE jsonb USING NULL;

--- a/packages/database/drizzle/meta/0165_snapshot.json
+++ b/packages/database/drizzle/meta/0165_snapshot.json
@@ -1,0 +1,32061 @@
+{
+  "id": "dcf68b86-1e9d-4383-bd34-752a9daa7832",
+  "prevId": "5e3c9695-9a90-4e25-9baa-fe134474a69f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHistoryId": {
+          "name": "lastHistoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_providerId_accountId_key": {
+          "name": "account_providerId_accountId_key",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_User_id_fk": {
+          "name": "account_userId_User_id_fk",
+          "tableFrom": "account",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Address": {
+      "name": "Address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address1": {
+          "name": "address1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address2": {
+          "name": "address2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "countryCode": {
+          "name": "countryCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provinceCode": {
+          "name": "provinceCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orderType": {
+          "name": "orderType",
+          "type": "ORDER_ADDRESS_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Address_customerId_idx": {
+          "name": "Address_customerId_idx",
+          "columns": [
+            {
+              "expression": "customerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Address_orderId_idx": {
+          "name": "Address_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Address_customerId_shopify_customers_id_fk": {
+          "name": "Address_customerId_shopify_customers_id_fk",
+          "tableFrom": "Address",
+          "tableTo": "shopify_customers",
+          "columnsFrom": ["customerId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Address_organizationId_Organization_id_fk": {
+          "name": "Address_organizationId_Organization_id_fk",
+          "tableFrom": "Address",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Address_integrationId_ShopifyIntegration_id_fk": {
+          "name": "Address_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "Address",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AdminActionLog": {
+      "name": "AdminActionLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "adminUserId": {
+          "name": "adminUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionType": {
+          "name": "actionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetType": {
+          "name": "targetType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousState": {
+          "name": "previousState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newState": {
+          "name": "newState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AdminActionLog_organizationId_idx": {
+          "name": "AdminActionLog_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminActionLog_adminUserId_idx": {
+          "name": "AdminActionLog_adminUserId_idx",
+          "columns": [
+            {
+              "expression": "adminUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminActionLog_createdAt_idx": {
+          "name": "AdminActionLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminActionLog_actionType_idx": {
+          "name": "AdminActionLog_actionType_idx",
+          "columns": [
+            {
+              "expression": "actionType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AdminActionLog_adminUserId_User_id_fk": {
+          "name": "AdminActionLog_adminUserId_User_id_fk",
+          "tableFrom": "AdminActionLog",
+          "tableTo": "User",
+          "columnsFrom": ["adminUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "AdminActionLog_organizationId_Organization_id_fk": {
+          "name": "AdminActionLog_organizationId_Organization_id_fk",
+          "tableFrom": "AdminActionLog",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentTrigger": {
+      "name": "AgentTrigger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAppId": {
+          "name": "triggerAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAppTriggerId": {
+          "name": "triggerAppTriggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerInstallationId": {
+          "name": "triggerInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerConnectionId": {
+          "name": "triggerConnectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentTrigger_agentId_idx": {
+          "name": "AgentTrigger_agentId_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentTrigger_orgId_event_crud_idx": {
+          "name": "AgentTrigger_orgId_event_crud_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentTrigger_orgId_event_direct_idx": {
+          "name": "AgentTrigger_orgId_event_direct_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentTrigger_orgId_app_idx": {
+          "name": "AgentTrigger_orgId_app_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerAppTriggerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentTrigger_orgId_kind_enabled_idx": {
+          "name": "AgentTrigger_orgId_kind_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentTrigger_agentId_Agent_id_fk": {
+          "name": "AgentTrigger_agentId_Agent_id_fk",
+          "tableFrom": "AgentTrigger",
+          "tableTo": "Agent",
+          "columnsFrom": ["agentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AgentTrigger_organizationId_Organization_id_fk": {
+          "name": "AgentTrigger_organizationId_Organization_id_fk",
+          "tableFrom": "AgentTrigger",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AgentTrigger_triggerInstallationId_AppInstallation_id_fk": {
+          "name": "AgentTrigger_triggerInstallationId_AppInstallation_id_fk",
+          "tableFrom": "AgentTrigger",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["triggerInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AgentTrigger_createdById_User_id_fk": {
+          "name": "AgentTrigger_createdById_User_id_fk",
+          "tableFrom": "AgentTrigger",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Agent": {
+      "name": "Agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "toolsets": {
+          "name": "toolsets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "knowledge": {
+          "name": "knowledge",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "appAccounts": {
+          "name": "appAccounts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "mentionable": {
+          "name": "mentionable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setupCompletedAt": {
+          "name": "setupCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Agent_organizationId_slug_idx": {
+          "name": "Agent_organizationId_slug_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_organizationId_idx": {
+          "name": "Agent_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_createdById_idx": {
+          "name": "Agent_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_organizationId_archivedAt_idx": {
+          "name": "Agent_organizationId_archivedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_userId_idx": {
+          "name": "Agent_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Agent_organizationId_Organization_id_fk": {
+          "name": "Agent_organizationId_Organization_id_fk",
+          "tableFrom": "Agent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Agent_userId_User_id_fk": {
+          "name": "Agent_userId_User_id_fk",
+          "tableFrom": "Agent",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Agent_createdById_User_id_fk": {
+          "name": "Agent_createdById_User_id_fk",
+          "tableFrom": "Agent",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Agent_userId_unique": {
+          "name": "Agent_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiAgentSession": {
+      "name": "AiAgentSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "domainState": {
+          "name": "domainState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentTriggerId": {
+          "name": "agentTriggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerContext": {
+          "name": "triggerContext",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "AiAgentSession_organizationId_userId_type_idx": {
+          "name": "AiAgentSession_organizationId_userId_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiAgentSession_userId_type_updatedAt_idx": {
+          "name": "AiAgentSession_userId_type_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiAgentSession_agentId_updatedAt_idx": {
+          "name": "AiAgentSession_agentId_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiAgentSession_agentTriggerId_updatedAt_idx": {
+          "name": "AiAgentSession_agentTriggerId_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "agentTriggerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiAgentSession_organizationId_Organization_id_fk": {
+          "name": "AiAgentSession_organizationId_Organization_id_fk",
+          "tableFrom": "AiAgentSession",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiAgentSession_userId_User_id_fk": {
+          "name": "AiAgentSession_userId_User_id_fk",
+          "tableFrom": "AiAgentSession",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiAgentSession_agentId_Agent_id_fk": {
+          "name": "AiAgentSession_agentId_Agent_id_fk",
+          "tableFrom": "AiAgentSession",
+          "tableTo": "Agent",
+          "columnsFrom": ["agentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "AiAgentSession_agentTriggerId_AgentTrigger_id_fk": {
+          "name": "AiAgentSession_agentTriggerId_AgentTrigger_id_fk",
+          "tableFrom": "AiAgentSession",
+          "tableTo": "AgentTrigger",
+          "columnsFrom": ["agentTriggerId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiIntegration": {
+      "name": "AiIntegration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiKey": {
+          "name": "apiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "AiIntegrationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryptedCredentials": {
+          "name": "encryptedCredentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loadBalancingEnabled": {
+          "name": "loadBalancingEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm'"
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "quotaLimit": {
+          "name": "quotaLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-1'"
+        },
+        "quotaType": {
+          "name": "quotaType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaUsed": {
+          "name": "quotaUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "AiIntegration_organizationId_idx": {
+          "name": "AiIntegration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_organizationId_isDefault_idx": {
+          "name": "AiIntegration_organizationId_isDefault_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isDefault",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_organizationId_modelType_idx": {
+          "name": "AiIntegration_organizationId_modelType_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_organizationId_providerType_idx": {
+          "name": "AiIntegration_organizationId_providerType_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_provider_organizationId_key": {
+          "name": "AiIntegration_provider_organizationId_key",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiIntegration_organizationId_Organization_id_fk": {
+          "name": "AiIntegration_organizationId_Organization_id_fk",
+          "tableFrom": "AiIntegration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiIntegration_userId_User_id_fk": {
+          "name": "AiIntegration_userId_User_id_fk",
+          "tableFrom": "AiIntegration",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiMessageFeedback": {
+      "name": "AiMessageFeedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isPositive": {
+          "name": "isPositive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "AiMessageFeedback_sessionId_messageId_userId_key": {
+          "name": "AiMessageFeedback_sessionId_messageId_userId_key",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiMessageFeedback_organizationId_idx": {
+          "name": "AiMessageFeedback_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiMessageFeedback_isPositive_idx": {
+          "name": "AiMessageFeedback_isPositive_idx",
+          "columns": [
+            {
+              "expression": "isPositive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiMessageFeedback_sessionId_AiAgentSession_id_fk": {
+          "name": "AiMessageFeedback_sessionId_AiAgentSession_id_fk",
+          "tableFrom": "AiMessageFeedback",
+          "tableTo": "AiAgentSession",
+          "columnsFrom": ["sessionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiMessageFeedback_organizationId_Organization_id_fk": {
+          "name": "AiMessageFeedback_organizationId_Organization_id_fk",
+          "tableFrom": "AiMessageFeedback",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiMessageFeedback_userId_User_id_fk": {
+          "name": "AiMessageFeedback_userId_User_id_fk",
+          "tableFrom": "AiMessageFeedback",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiSuggestion": {
+      "name": "AiSuggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerUserId": {
+          "name": "ownerUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle": {
+          "name": "bundle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionCount": {
+          "name": "actionCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computedForActivityAt": {
+          "name": "computedForActivityAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computedForLatestMessageId": {
+          "name": "computedForLatestMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerSource": {
+          "name": "triggerSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerEventType": {
+          "name": "triggerEventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FRESH'"
+        },
+        "outcomes": {
+          "name": "outcomes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decidedById": {
+          "name": "decidedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decidedAt": {
+          "name": "decidedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AiSuggestion_org_entity_active_key": {
+          "name": "AiSuggestion_org_entity_active_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'FRESH'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiSuggestion_org_status_idx": {
+          "name": "AiSuggestion_org_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiSuggestion_org_entity_createdAt_idx": {
+          "name": "AiSuggestion_org_entity_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiSuggestion_org_entityDef_status_idx": {
+          "name": "AiSuggestion_org_entityDef_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiSuggestion_organizationId_Organization_id_fk": {
+          "name": "AiSuggestion_organizationId_Organization_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_entityInstanceId_EntityInstance_id_fk": {
+          "name": "AiSuggestion_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "AiSuggestion_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_threadId_Thread_id_fk": {
+          "name": "AiSuggestion_threadId_Thread_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_ownerUserId_User_id_fk": {
+          "name": "AiSuggestion_ownerUserId_User_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "User",
+          "columnsFrom": ["ownerUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_decidedById_User_id_fk": {
+          "name": "AiSuggestion_decidedById_User_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "User",
+          "columnsFrom": ["decidedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiUsage": {
+      "name": "AiUsage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputTokens": {
+          "name": "inputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm'"
+        },
+        "outputTokens": {
+          "name": "outputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creditsUsed": {
+          "name": "creditsUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "ProviderType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialSource": {
+          "name": "credentialSource",
+          "type": "CredentialSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "AiUsage_createdAt_idx": {
+          "name": "AiUsage_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiUsage_organizationId_createdAt_idx": {
+          "name": "AiUsage_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiUsage_provider_model_idx": {
+          "name": "AiUsage_provider_model_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiUsage_source_idx": {
+          "name": "AiUsage_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiUsage_organizationId_Organization_id_fk": {
+          "name": "AiUsage_organizationId_Organization_id_fk",
+          "tableFrom": "AiUsage",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiUsage_userId_User_id_fk": {
+          "name": "AiUsage_userId_User_id_fk",
+          "tableFrom": "AiUsage",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApiKey": {
+      "name": "ApiKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashedKey": {
+          "name": "hashedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app'"
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ApiKey_hashedKey_key": {
+          "name": "ApiKey_hashedKey_key",
+          "columns": [
+            {
+              "expression": "hashedKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApiKey_userId_isActive_idx": {
+          "name": "ApiKey_userId_isActive_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApiKey_type_referenceId_idx": {
+          "name": "ApiKey_type_referenceId_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referenceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApiKey_userId_User_id_fk": {
+          "name": "ApiKey_userId_User_id_fk",
+          "tableFrom": "ApiKey",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ApiKey_organizationId_Organization_id_fk": {
+          "name": "ApiKey_organizationId_Organization_id_fk",
+          "tableFrom": "ApiKey",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppBundle": {
+      "name": "AppBundle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundleType": {
+          "name": "bundleType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploadedAt": {
+          "name": "uploadedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppBundle_content_idx": {
+          "name": "AppBundle_content_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundleType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppBundle_appId_idx": {
+          "name": "AppBundle_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppBundle_appId_App_id_fk": {
+          "name": "AppBundle_appId_App_id_fk",
+          "tableFrom": "AppBundle",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppDeployment": {
+      "name": "AppDeployment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deploymentType": {
+          "name": "deploymentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientBundleId": {
+          "name": "clientBundleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverBundleId": {
+          "name": "serverBundleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settingsSchema": {
+          "name": "settingsSchema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalog": {
+          "name": "catalog",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetOrganizationId": {
+          "name": "targetOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environmentVariables": {
+          "name": "environmentVariables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "reviewedAt": {
+          "name": "reviewedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewedBy": {
+          "name": "reviewedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectionReason": {
+          "name": "rejectionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "releaseNotes": {
+          "name": "releaseNotes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppDeployment_appId_idx": {
+          "name": "AppDeployment_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppDeployment_type_idx": {
+          "name": "AppDeployment_type_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deploymentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppDeployment_targetOrganizationId_idx": {
+          "name": "AppDeployment_targetOrganizationId_idx",
+          "columns": [
+            {
+              "expression": "targetOrganizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppDeployment_appId_App_id_fk": {
+          "name": "AppDeployment_appId_App_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppDeployment_clientBundleId_AppBundle_id_fk": {
+          "name": "AppDeployment_clientBundleId_AppBundle_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "AppBundle",
+          "columnsFrom": ["clientBundleId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "AppDeployment_serverBundleId_AppBundle_id_fk": {
+          "name": "AppDeployment_serverBundleId_AppBundle_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "AppBundle",
+          "columnsFrom": ["serverBundleId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "AppDeployment_targetOrganizationId_Organization_id_fk": {
+          "name": "AppDeployment_targetOrganizationId_Organization_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "Organization",
+          "columnsFrom": ["targetOrganizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppEventLog": {
+      "name": "AppEventLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appDeploymentId": {
+          "name": "appDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventData": {
+          "name": "eventData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestMethod": {
+          "name": "requestMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestPath": {
+          "name": "requestPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseStatus": {
+          "name": "responseStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppEventLog_appId_idx": {
+          "name": "AppEventLog_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppEventLog_organizationId_idx": {
+          "name": "AppEventLog_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppEventLog_appDeploymentId_idx": {
+          "name": "AppEventLog_appDeploymentId_idx",
+          "columns": [
+            {
+              "expression": "appDeploymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppEventLog_timestamp_idx": {
+          "name": "AppEventLog_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppEventLog_appId_App_id_fk": {
+          "name": "AppEventLog_appId_App_id_fk",
+          "tableFrom": "AppEventLog",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppEventLog_organizationId_Organization_id_fk": {
+          "name": "AppEventLog_organizationId_Organization_id_fk",
+          "tableFrom": "AppEventLog",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppEventLog_appDeploymentId_AppDeployment_id_fk": {
+          "name": "AppEventLog_appDeploymentId_AppDeployment_id_fk",
+          "tableFrom": "AppEventLog",
+          "tableTo": "AppDeployment",
+          "columnsFrom": ["appDeploymentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppInstallation": {
+      "name": "AppInstallation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installationType": {
+          "name": "installationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentDeploymentId": {
+          "name": "currentDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installedAt": {
+          "name": "installedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "uninstalledAt": {
+          "name": "uninstalledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppInstallation_unique_idx": {
+          "name": "AppInstallation_unique_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppInstallation_appId_idx": {
+          "name": "AppInstallation_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppInstallation_organizationId_idx": {
+          "name": "AppInstallation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppInstallation_appId_App_id_fk": {
+          "name": "AppInstallation_appId_App_id_fk",
+          "tableFrom": "AppInstallation",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppInstallation_organizationId_Organization_id_fk": {
+          "name": "AppInstallation_organizationId_Organization_id_fk",
+          "tableFrom": "AppInstallation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppInstallation_currentDeploymentId_AppDeployment_id_fk": {
+          "name": "AppInstallation_currentDeploymentId_AppDeployment_id_fk",
+          "tableFrom": "AppInstallation",
+          "tableTo": "AppDeployment",
+          "columnsFrom": ["currentDeploymentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppMarketplaceImage": {
+      "name": "AppMarketplaceImage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileExtension": {
+          "name": "fileExtension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "savedSortOrder": {
+          "name": "savedSortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploadCompletedAt": {
+          "name": "uploadCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSavedAt": {
+          "name": "lastSavedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppMarketplaceImage_appId_idx": {
+          "name": "AppMarketplaceImage_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppMarketplaceImage_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "AppMarketplaceImage_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "AppMarketplaceImage",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppMarketplaceImage_appId_App_id_fk": {
+          "name": "AppMarketplaceImage_appId_App_id_fk",
+          "tableFrom": "AppMarketplaceImage",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppSetting": {
+      "name": "AppSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appDeploymentId": {
+          "name": "appDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppSetting_appInstallationId_key_key": {
+          "name": "AppSetting_appInstallationId_key_key",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppSetting_appInstallationId_idx": {
+          "name": "AppSetting_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppSetting_appDeploymentId_idx": {
+          "name": "AppSetting_appDeploymentId_idx",
+          "columns": [
+            {
+              "expression": "appDeploymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppSetting_appInstallationId_AppInstallation_id_fk": {
+          "name": "AppSetting_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "AppSetting",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppSetting_appDeploymentId_AppDeployment_id_fk": {
+          "name": "AppSetting_appDeploymentId_AppDeployment_id_fk",
+          "tableFrom": "AppSetting",
+          "tableTo": "AppDeployment",
+          "columnsFrom": ["appDeploymentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppWebhookHandler": {
+      "name": "AppWebhookHandler",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handlerId": {
+          "name": "handlerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalWebhookId": {
+          "name": "externalWebhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerId": {
+          "name": "triggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppWebhookHandler_unique_idx": {
+          "name": "AppWebhookHandler_unique_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handlerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppWebhookHandler_appInstallationId_idx": {
+          "name": "AppWebhookHandler_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppWebhookHandler_appInstallationId_AppInstallation_id_fk": {
+          "name": "AppWebhookHandler_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "AppWebhookHandler",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "AppWebhookHandler_connectionId_WorkflowCredentials_id_fk": {
+          "name": "AppWebhookHandler_connectionId_WorkflowCredentials_id_fk",
+          "tableFrom": "AppWebhookHandler",
+          "tableTo": "WorkflowCredentials",
+          "columnsFrom": ["connectionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.App": {
+      "name": "App",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarId": {
+          "name": "avatarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "websiteUrl": {
+          "name": "websiteUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentationUrl": {
+          "name": "documentationUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contactUrl": {
+          "name": "contactUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supportSiteUrl": {
+          "name": "supportSiteUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termsOfServiceUrl": {
+          "name": "termsOfServiceUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentOverview": {
+          "name": "contentOverview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentHowItWorks": {
+          "name": "contentHowItWorks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentConfigure": {
+          "name": "contentConfigure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "hasOauth": {
+          "name": "hasOauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "oauthApplicationId": {
+          "name": "oauthApplicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauthExternalEntrypointUrl": {
+          "name": "oauthExternalEntrypointUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasBundle": {
+          "name": "hasBundle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "publicationStatus": {
+          "name": "publicationStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpublished'"
+        },
+        "reviewStatus": {
+          "name": "reviewStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autoApprove": {
+          "name": "autoApprove",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "App_slug_idx": {
+          "name": "App_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "App_developerAccountId_idx": {
+          "name": "App_developerAccountId_idx",
+          "columns": [
+            {
+              "expression": "developerAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "App_reviewStatus_idx": {
+          "name": "App_reviewStatus_idx",
+          "columns": [
+            {
+              "expression": "reviewStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "App_autoApprove_idx": {
+          "name": "App_autoApprove_idx",
+          "columns": [
+            {
+              "expression": "autoApprove",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "App_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "App_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "App",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "App_oauthApplicationId_oauthApplication_id_fk": {
+          "name": "App_oauthApplicationId_oauthApplication_id_fk",
+          "tableFrom": "App",
+          "tableTo": "oauthApplication",
+          "columnsFrom": ["oauthApplicationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "App_slug_unique": {
+          "name": "App_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApprovalRequest": {
+      "name": "ApprovalRequest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowRunId": {
+          "name": "workflowRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeName": {
+          "name": "nodeName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ApprovalStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeUsers": {
+          "name": "assigneeUsers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeGroups": {
+          "name": "assigneeGroups",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflowName": {
+          "name": "workflowName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ApprovalRequest_createdById_idx": {
+          "name": "ApprovalRequest_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_organizationId_assigneeGroups_idx": {
+          "name": "ApprovalRequest_organizationId_assigneeGroups_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigneeGroups",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_organizationId_assigneeUsers_idx": {
+          "name": "ApprovalRequest_organizationId_assigneeUsers_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigneeUsers",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_organizationId_idx": {
+          "name": "ApprovalRequest_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_status_expiresAt_idx": {
+          "name": "ApprovalRequest_status_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_workflowRunId_idx": {
+          "name": "ApprovalRequest_workflowRunId_idx",
+          "columns": [
+            {
+              "expression": "workflowRunId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApprovalRequest_organizationId_Organization_id_fk": {
+          "name": "ApprovalRequest_organizationId_Organization_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ApprovalRequest_workflowId_Workflow_id_fk": {
+          "name": "ApprovalRequest_workflowId_Workflow_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ApprovalRequest_workflowRunId_WorkflowRun_id_fk": {
+          "name": "ApprovalRequest_workflowRunId_WorkflowRun_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "WorkflowRun",
+          "columnsFrom": ["workflowRunId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ApprovalRequest_createdById_User_id_fk": {
+          "name": "ApprovalRequest_createdById_User_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApprovalResponse": {
+      "name": "ApprovalResponse",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "approvalRequestId": {
+          "name": "approvalRequestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "ApprovalAction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responseMethod": {
+          "name": "responseMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ApprovalResponse_approvalRequestId_userId_key": {
+          "name": "ApprovalResponse_approvalRequestId_userId_key",
+          "columns": [
+            {
+              "expression": "approvalRequestId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalResponse_userId_idx": {
+          "name": "ApprovalResponse_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApprovalResponse_approvalRequestId_ApprovalRequest_id_fk": {
+          "name": "ApprovalResponse_approvalRequestId_ApprovalRequest_id_fk",
+          "tableFrom": "ApprovalResponse",
+          "tableTo": "ApprovalRequest",
+          "columnsFrom": ["approvalRequestId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ApprovalResponse_userId_User_id_fk": {
+          "name": "ApprovalResponse_userId_User_id_fk",
+          "tableFrom": "ApprovalResponse",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ArticleRevision": {
+      "name": "ArticleRevision",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentJson": {
+          "name": "contentJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverImage": {
+          "name": "coverImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverImageId": {
+          "name": "coverImageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editorId": {
+          "name": "editorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ArticleRevision_articleId_idx": {
+          "name": "ArticleRevision_articleId_idx",
+          "columns": [
+            {
+              "expression": "articleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ArticleRevision_articleId_versionNumber_key": {
+          "name": "ArticleRevision_articleId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "articleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"versionNumber\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ArticleRevision_articleId_Article_id_fk": {
+          "name": "ArticleRevision_articleId_Article_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "Article",
+          "columnsFrom": ["articleId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ArticleRevision_organizationId_Organization_id_fk": {
+          "name": "ArticleRevision_organizationId_Organization_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ArticleRevision_coverImageId_MediaAsset_id_fk": {
+          "name": "ArticleRevision_coverImageId_MediaAsset_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["coverImageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "ArticleRevision_editorId_User_id_fk": {
+          "name": "ArticleRevision_editorId_User_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "User",
+          "columnsFrom": ["editorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Article": {
+      "name": "Article",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "articleKind": {
+          "name": "articleKind",
+          "type": "articleKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ArticleStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastReviewedAt": {
+          "name": "lastReviewedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewsCount": {
+          "name": "viewsCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "knowledgeBaseId": {
+          "name": "knowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a0'"
+        },
+        "isPublished": {
+          "name": "isPublished",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishedRevisionId": {
+          "name": "publishedRevisionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draftRevisionId": {
+          "name": "draftRevisionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishedById": {
+          "name": "publishedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasUnpublishedChanges": {
+          "name": "hasUnpublishedChanges",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiEnabled": {
+          "name": "aiEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "Article_articleKind_idx": {
+          "name": "Article_articleKind_idx",
+          "columns": [
+            {
+              "expression": "articleKind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_knowledgeBaseId_idx": {
+          "name": "Article_knowledgeBaseId_idx",
+          "columns": [
+            {
+              "expression": "knowledgeBaseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_knowledgeBaseId_slug_key": {
+          "name": "Article_knowledgeBaseId_slug_key",
+          "columns": [
+            {
+              "expression": "knowledgeBaseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_parentId_idx": {
+          "name": "Article_parentId_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_kb_parent_sortOrder_idx": {
+          "name": "Article_kb_parent_sortOrder_idx",
+          "columns": [
+            {
+              "expression": "knowledgeBaseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortOrder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_title_idx": {
+          "name": "Article_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_archived_at_idx": {
+          "name": "Article_archived_at_idx",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Article_authorId_User_id_fk": {
+          "name": "Article_authorId_User_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "User",
+          "columnsFrom": ["authorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Article_knowledgeBaseId_KnowledgeBase_id_fk": {
+          "name": "Article_knowledgeBaseId_KnowledgeBase_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "KnowledgeBase",
+          "columnsFrom": ["knowledgeBaseId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Article_organizationId_Organization_id_fk": {
+          "name": "Article_organizationId_Organization_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Article_parentId_Article_id_fk": {
+          "name": "Article_parentId_Article_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "Article",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Article_publishedRevisionId_ArticleRevision_id_fk": {
+          "name": "Article_publishedRevisionId_ArticleRevision_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "ArticleRevision",
+          "columnsFrom": ["publishedRevisionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Article_draftRevisionId_ArticleRevision_id_fk": {
+          "name": "Article_draftRevisionId_ArticleRevision_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "ArticleRevision",
+          "columnsFrom": ["draftRevisionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Article_publishedById_User_id_fk": {
+          "name": "Article_publishedById_User_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "User",
+          "columnsFrom": ["publishedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Attachment": {
+      "name": "Attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ATTACHMENT'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort": {
+          "name": "sort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileVersionId": {
+          "name": "fileVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assetVersionId": {
+          "name": "assetVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentId": {
+          "name": "contentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Attachment_assetId_idx": {
+          "name": "Attachment_assetId_idx",
+          "columns": [
+            {
+              "expression": "assetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_createdAt_idx": {
+          "name": "Attachment_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_entityType_entityId_idx": {
+          "name": "Attachment_entityType_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_fileId_idx": {
+          "name": "Attachment_fileId_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_id_organizationId_key": {
+          "name": "Attachment_id_organizationId_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_organizationId_entityType_entityId_idx": {
+          "name": "Attachment_organizationId_entityType_entityId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Attachment_organizationId_Organization_id_fk": {
+          "name": "Attachment_organizationId_Organization_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Attachment_fileId_FolderFile_id_fk": {
+          "name": "Attachment_fileId_FolderFile_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "FolderFile",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Attachment_fileVersionId_FileVersion_id_fk": {
+          "name": "Attachment_fileVersionId_FileVersion_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "FileVersion",
+          "columnsFrom": ["fileVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Attachment_assetId_MediaAsset_id_fk": {
+          "name": "Attachment_assetId_MediaAsset_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["assetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Attachment_assetVersionId_MediaAssetVersion_id_fk": {
+          "name": "Attachment_assetVersionId_MediaAssetVersion_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "MediaAssetVersion",
+          "columnsFrom": ["assetVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Attachment_createdById_User_id_fk": {
+          "name": "Attachment_createdById_User_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CalendarEvent": {
+      "name": "CalendarEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "CalendarProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetingUrl": {
+          "name": "meetingUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetingPlatform": {
+          "name": "meetingPlatform",
+          "type": "MeetingPlatform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAllDay": {
+          "name": "isAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "CalendarEventStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirmed'"
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendees": {
+          "name": "attendees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "isExternal": {
+          "name": "isExternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recurringEventId": {
+          "name": "recurringEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rawData": {
+          "name": "rawData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncedAt": {
+          "name": "syncedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "CalendarEvent_org_provider_externalId_key": {
+          "name": "CalendarEvent_org_provider_externalId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CalendarEvent_organizationId_idx": {
+          "name": "CalendarEvent_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CalendarEvent_userId_idx": {
+          "name": "CalendarEvent_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CalendarEvent_startTime_endTime_idx": {
+          "name": "CalendarEvent_startTime_endTime_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CalendarEvent_entityInstanceId_idx": {
+          "name": "CalendarEvent_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CalendarEvent_organizationId_Organization_id_fk": {
+          "name": "CalendarEvent_organizationId_Organization_id_fk",
+          "tableFrom": "CalendarEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CalendarEvent_userId_User_id_fk": {
+          "name": "CalendarEvent_userId_User_id_fk",
+          "tableFrom": "CalendarEvent",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CalendarEvent_entityInstanceId_EntityInstance_id_fk": {
+          "name": "CalendarEvent_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "CalendarEvent",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CallRecording": {
+      "name": "CallRecording",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetingId": {
+          "name": "meetingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "RecordingProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetingPlatform": {
+          "name": "meetingPlatform",
+          "type": "MeetingPlatform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalBotId": {
+          "name": "externalBotId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "RecordingStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "videoAssetId": {
+          "name": "videoAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audioAssetId": {
+          "name": "audioAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videoPreviewAssetId": {
+          "name": "videoPreviewAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videoStoryboardAssetId": {
+          "name": "videoStoryboardAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationSeconds": {
+          "name": "durationSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "botName": {
+          "name": "botName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentMessage": {
+          "name": "consentMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summaryText": {
+          "name": "summaryText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actionItems": {
+          "name": "actionItems",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProcessingStatus": {
+          "name": "aiProcessingStatus",
+          "type": "AiProcessingStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "aiProcessingError": {
+          "name": "aiProcessingError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProcessedAt": {
+          "name": "aiProcessedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "CallRecording_organizationId_idx": {
+          "name": "CallRecording_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_meetingId_idx": {
+          "name": "CallRecording_meetingId_idx",
+          "columns": [
+            {
+              "expression": "meetingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_calendarEventId_idx": {
+          "name": "CallRecording_calendarEventId_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_status_idx": {
+          "name": "CallRecording_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_organizationId_status_idx": {
+          "name": "CallRecording_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_externalBotId_idx": {
+          "name": "CallRecording_externalBotId_idx",
+          "columns": [
+            {
+              "expression": "externalBotId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_createdById_idx": {
+          "name": "CallRecording_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_organizationId_calendarEventId_key": {
+          "name": "CallRecording_organizationId_calendarEventId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendarEventId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CallRecording_organizationId_Organization_id_fk": {
+          "name": "CallRecording_organizationId_Organization_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_meetingId_EntityInstance_id_fk": {
+          "name": "CallRecording_meetingId_EntityInstance_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["meetingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_calendarEventId_CalendarEvent_id_fk": {
+          "name": "CallRecording_calendarEventId_CalendarEvent_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "CalendarEvent",
+          "columnsFrom": ["calendarEventId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_videoAssetId_MediaAsset_id_fk": {
+          "name": "CallRecording_videoAssetId_MediaAsset_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["videoAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_audioAssetId_MediaAsset_id_fk": {
+          "name": "CallRecording_audioAssetId_MediaAsset_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["audioAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_videoPreviewAssetId_MediaAsset_id_fk": {
+          "name": "CallRecording_videoPreviewAssetId_MediaAsset_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["videoPreviewAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_videoStoryboardAssetId_MediaAsset_id_fk": {
+          "name": "CallRecording_videoStoryboardAssetId_MediaAsset_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["videoStoryboardAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_createdById_User_id_fk": {
+          "name": "CallRecording_createdById_User_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatAttachment": {
+      "name": "ChatAttachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ChatAttachment_messageId_idx": {
+          "name": "ChatAttachment_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatAttachment_sessionId_idx": {
+          "name": "ChatAttachment_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatAttachment_sessionId_ChatSession_id_fk": {
+          "name": "ChatAttachment_sessionId_ChatSession_id_fk",
+          "tableFrom": "ChatAttachment",
+          "tableTo": "ChatSession",
+          "columnsFrom": ["sessionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatAttachment_messageId_ChatMessage_id_fk": {
+          "name": "ChatAttachment_messageId_ChatMessage_id_fk",
+          "tableFrom": "ChatAttachment",
+          "tableTo": "ChatMessage",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatMessage": {
+      "name": "ChatMessage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SENT'"
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ChatMessage_agentId_idx": {
+          "name": "ChatMessage_agentId_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatMessage_createdAt_idx": {
+          "name": "ChatMessage_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatMessage_sessionId_idx": {
+          "name": "ChatMessage_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatMessage_threadId_idx": {
+          "name": "ChatMessage_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatMessage_sessionId_ChatSession_id_fk": {
+          "name": "ChatMessage_sessionId_ChatSession_id_fk",
+          "tableFrom": "ChatMessage",
+          "tableTo": "ChatSession",
+          "columnsFrom": ["sessionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatMessage_agentId_User_id_fk": {
+          "name": "ChatMessage_agentId_User_id_fk",
+          "tableFrom": "ChatMessage",
+          "tableTo": "User",
+          "columnsFrom": ["agentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ChatMessage_threadId_Thread_id_fk": {
+          "name": "ChatMessage_threadId_Thread_id_fk",
+          "tableFrom": "ChatMessage",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatSession": {
+      "name": "ChatSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "widgetId": {
+          "name": "widgetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "lastActivityAt": {
+          "name": "lastActivityAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closedById": {
+          "name": "closedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorId": {
+          "name": "visitorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitorName": {
+          "name": "visitorName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorEmail": {
+          "name": "visitorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ChatSession_lastActivityAt_idx": {
+          "name": "ChatSession_lastActivityAt_idx",
+          "columns": [
+            {
+              "expression": "lastActivityAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatSession_organizationId_idx": {
+          "name": "ChatSession_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatSession_status_idx": {
+          "name": "ChatSession_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatSession_visitorId_idx": {
+          "name": "ChatSession_visitorId_idx",
+          "columns": [
+            {
+              "expression": "visitorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatSession_widgetId_idx": {
+          "name": "ChatSession_widgetId_idx",
+          "columns": [
+            {
+              "expression": "widgetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatSession_widgetId_ChatWidget_id_fk": {
+          "name": "ChatSession_widgetId_ChatWidget_id_fk",
+          "tableFrom": "ChatSession",
+          "tableTo": "ChatWidget",
+          "columnsFrom": ["widgetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatSession_organizationId_Organization_id_fk": {
+          "name": "ChatSession_organizationId_Organization_id_fk",
+          "tableFrom": "ChatSession",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatSession_threadId_Thread_id_fk": {
+          "name": "ChatSession_threadId_Thread_id_fk",
+          "tableFrom": "ChatSession",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatSession_closedById_User_id_fk": {
+          "name": "ChatSession_closedById_User_id_fk",
+          "tableFrom": "ChatSession",
+          "tableTo": "User",
+          "columnsFrom": ["closedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatWidget": {
+      "name": "ChatWidget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Chat Support'"
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryColor": {
+          "name": "primaryColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#4F46E5'"
+        },
+        "logoUrl": {
+          "name": "logoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BOTTOM_RIGHT'"
+        },
+        "welcomeMessage": {
+          "name": "welcomeMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autoOpen": {
+          "name": "autoOpen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mobileFullScreen": {
+          "name": "mobileFullScreen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collectUserInfo": {
+          "name": "collectUserInfo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "offlineMessage": {
+          "name": "offlineMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'We''re currently offline. Please leave a message and we''ll get back to you as soon as possible.'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowedDomains": {
+          "name": "allowedDomains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homeGreetingTemplate": {
+          "name": "homeGreetingTemplate",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homeShowRecentMessage": {
+          "name": "homeShowRecentMessage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "homeShowSendMessageCta": {
+          "name": "homeShowSendMessageCta",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "brandingFooterEnabled": {
+          "name": "brandingFooterEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expandedWidthPx": {
+          "name": "expandedWidthPx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 720
+        },
+        "knowledgeBaseId": {
+          "name": "knowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featuredArticleIds": {
+          "name": "featuredArticleIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowDownloadTranscript": {
+          "name": "allowDownloadTranscript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "ChatWidget_integrationId_key": {
+          "name": "ChatWidget_integrationId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatWidget_organizationId_idx": {
+          "name": "ChatWidget_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatWidget_organizationId_name_key": {
+          "name": "ChatWidget_organizationId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatWidget_integrationId_Integration_id_fk": {
+          "name": "ChatWidget_integrationId_Integration_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatWidget_organizationId_Organization_id_fk": {
+          "name": "ChatWidget_organizationId_Organization_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatWidget_agentId_Agent_id_fk": {
+          "name": "ChatWidget_agentId_Agent_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "Agent",
+          "columnsFrom": ["agentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ChatWidget_knowledgeBaseId_KnowledgeBase_id_fk": {
+          "name": "ChatWidget_knowledgeBaseId_KnowledgeBase_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "KnowledgeBase",
+          "columnsFrom": ["knowledgeBaseId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CommentReaction": {
+      "name": "CommentReaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "CommentReaction_commentId_idx": {
+          "name": "CommentReaction_commentId_idx",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReaction_commentId_userId_type_emoji_key": {
+          "name": "CommentReaction_commentId_userId_type_emoji_key",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReaction_type_idx": {
+          "name": "CommentReaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReaction_userId_idx": {
+          "name": "CommentReaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CommentReaction_commentId_Comment_id_fk": {
+          "name": "CommentReaction_commentId_Comment_id_fk",
+          "tableFrom": "CommentReaction",
+          "tableTo": "Comment",
+          "columnsFrom": ["commentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CommentReaction_userId_User_id_fk": {
+          "name": "CommentReaction_userId_User_id_fk",
+          "tableFrom": "CommentReaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CommentReference": {
+      "name": "CommentReference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "CommentReference_commentId_idx": {
+          "name": "CommentReference_commentId_idx",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReference_commentId_def_inst_key": {
+          "name": "CommentReference_commentId_def_inst_key",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReference_def_inst_idx": {
+          "name": "CommentReference_def_inst_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CommentReference_commentId_Comment_id_fk": {
+          "name": "CommentReference_commentId_Comment_id_fk",
+          "tableFrom": "CommentReference",
+          "tableTo": "Comment",
+          "columnsFrom": ["commentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Comment": {
+      "name": "Comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contentJson": {
+          "name": "contentJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinnedAt": {
+          "name": "pinnedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinnedById": {
+          "name": "pinnedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Comment_createdById_idx": {
+          "name": "Comment_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_deletedAt_idx": {
+          "name": "Comment_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_entityId_entityDefinitionId_idx": {
+          "name": "Comment_entityId_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_isPinned_idx": {
+          "name": "Comment_isPinned_idx",
+          "columns": [
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_organizationId_idx": {
+          "name": "Comment_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_parentId_idx": {
+          "name": "Comment_parentId_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Comment_createdById_User_id_fk": {
+          "name": "Comment_createdById_User_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Comment_organizationId_Organization_id_fk": {
+          "name": "Comment_organizationId_Organization_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Comment_parentId_Comment_id_fk": {
+          "name": "Comment_parentId_Comment_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "Comment",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Comment_pinnedById_User_id_fk": {
+          "name": "Comment_pinnedById_User_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "User",
+          "columnsFrom": ["pinnedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ConnectionDefinition": {
+      "name": "ConnectionDefinition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major": {
+          "name": "major",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionType": {
+          "name": "connectionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global": {
+          "name": "global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "oauth2AuthorizeUrl": {
+          "name": "oauth2AuthorizeUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2AccessTokenUrl": {
+          "name": "oauth2AccessTokenUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2Scopes": {
+          "name": "oauth2Scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "oauth2ClientId": {
+          "name": "oauth2ClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2ClientSecret": {
+          "name": "oauth2ClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2TokenRequestAuthMethod": {
+          "name": "oauth2TokenRequestAuthMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'request-body'"
+        },
+        "oauth2RefreshTokenIntervalSeconds": {
+          "name": "oauth2RefreshTokenIntervalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2Features": {
+          "name": "oauth2Features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ConnectionDefinition_app_version_idx": {
+          "name": "ConnectionDefinition_app_version_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "major",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ConnectionDefinition_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "ConnectionDefinition_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "ConnectionDefinition",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ConnectionDefinition_appId_App_id_fk": {
+          "name": "ConnectionDefinition_appId_App_id_fk",
+          "tableFrom": "ConnectionDefinition",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CustomField": {
+      "name": "CustomField",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "ContactFieldType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a0'"
+        },
+        "displayOptions": {
+          "name": "displayOptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "defaultValue": {
+          "name": "defaultValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contact'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isCustom": {
+          "name": "isCustom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "systemAttribute": {
+          "name": "systemAttribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isUnique": {
+          "name": "isUnique",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isCreatable": {
+          "name": "isCreatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isUpdatable": {
+          "name": "isUpdatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isComputed": {
+          "name": "isComputed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isSortable": {
+          "name": "isSortable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isFilterable": {
+          "name": "isFilterable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "CustomField_modelType_idx": {
+          "name": "CustomField_modelType_idx",
+          "columns": [
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_name_org_model_entity_key": {
+          "name": "CustomField_name_org_model_entity_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_organizationId_idx": {
+          "name": "CustomField_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_entityDefinitionId_idx": {
+          "name": "CustomField_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_organizationId_entityDefinitionId_sortOrder_idx": {
+          "name": "CustomField_organizationId_entityDefinitionId_sortOrder_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortOrder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CustomField_organizationId_Organization_id_fk": {
+          "name": "CustomField_organizationId_Organization_id_fk",
+          "tableFrom": "CustomField",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CustomField_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "CustomField_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "CustomField",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DatasetMetadata": {
+      "name": "DatasetMetadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "DatasetMetadata_datasetId_idx": {
+          "name": "DatasetMetadata_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetMetadata_datasetId_name_key": {
+          "name": "DatasetMetadata_datasetId_name_key",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetMetadata_type_idx": {
+          "name": "DatasetMetadata_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DatasetMetadata_datasetId_Dataset_id_fk": {
+          "name": "DatasetMetadata_datasetId_Dataset_id_fk",
+          "tableFrom": "DatasetMetadata",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DatasetSearchQuery": {
+      "name": "DatasetSearchQuery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queryType": {
+          "name": "queryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hybrid'"
+        },
+        "resultsCount": {
+          "name": "resultsCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vectorSimilarityThreshold": {
+          "name": "vectorSimilarityThreshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.7
+        },
+        "maxResults": {
+          "name": "maxResults",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "DatasetSearchQuery_createdAt_idx": {
+          "name": "DatasetSearchQuery_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchQuery_datasetId_idx": {
+          "name": "DatasetSearchQuery_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchQuery_organizationId_idx": {
+          "name": "DatasetSearchQuery_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchQuery_userId_idx": {
+          "name": "DatasetSearchQuery_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DatasetSearchQuery_datasetId_Dataset_id_fk": {
+          "name": "DatasetSearchQuery_datasetId_Dataset_id_fk",
+          "tableFrom": "DatasetSearchQuery",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DatasetSearchQuery_organizationId_Organization_id_fk": {
+          "name": "DatasetSearchQuery_organizationId_Organization_id_fk",
+          "tableFrom": "DatasetSearchQuery",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DatasetSearchQuery_userId_User_id_fk": {
+          "name": "DatasetSearchQuery_userId_User_id_fk",
+          "tableFrom": "DatasetSearchQuery",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DatasetSearchResult": {
+      "name": "DatasetSearchResult",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queryId": {
+          "name": "queryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segmentId": {
+          "name": "segmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "DatasetSearchResult_queryId_idx": {
+          "name": "DatasetSearchResult_queryId_idx",
+          "columns": [
+            {
+              "expression": "queryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_queryId_segmentId_key": {
+          "name": "DatasetSearchResult_queryId_segmentId_key",
+          "columns": [
+            {
+              "expression": "queryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_rank_idx": {
+          "name": "DatasetSearchResult_rank_idx",
+          "columns": [
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_score_idx": {
+          "name": "DatasetSearchResult_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_segmentId_idx": {
+          "name": "DatasetSearchResult_segmentId_idx",
+          "columns": [
+            {
+              "expression": "segmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DatasetSearchResult_queryId_DatasetSearchQuery_id_fk": {
+          "name": "DatasetSearchResult_queryId_DatasetSearchQuery_id_fk",
+          "tableFrom": "DatasetSearchResult",
+          "tableTo": "DatasetSearchQuery",
+          "columnsFrom": ["queryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DatasetSearchResult_segmentId_DocumentSegment_id_fk": {
+          "name": "DatasetSearchResult_segmentId_DocumentSegment_id_fk",
+          "tableFrom": "DatasetSearchResult",
+          "tableTo": "DocumentSegment",
+          "columnsFrom": ["segmentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Dataset": {
+      "name": "Dataset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "DatasetStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "documentCount": {
+          "name": "documentCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalSize": {
+          "name": "totalSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastIndexedAt": {
+          "name": "lastIndexedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunkSettings": {
+          "name": "chunkSettings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"strategy\":\"FIXED_SIZE\",\"size\":1024,\"overlap\":50,\"delimiter\":\"\\n\\n\",\"preprocessing\":{\"normalizeWhitespace\":true,\"removeUrlsAndEmails\":false}}'::jsonb"
+        },
+        "vectorDbConfig": {
+          "name": "vectorDbConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingModel": {
+          "name": "embeddingModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vectorDimension": {
+          "name": "vectorDimension",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vectorDbType": {
+          "name": "vectorDbType",
+          "type": "VectorDbType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POSTGRESQL'"
+        },
+        "searchConfig": {
+          "name": "searchConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"searchType\":\"hybrid\"}'::jsonb"
+        },
+        "isManaged": {
+          "name": "isManaged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Dataset_createdById_idx": {
+          "name": "Dataset_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Dataset_organizationId_idx": {
+          "name": "Dataset_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Dataset_organizationId_name_key": {
+          "name": "Dataset_organizationId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Dataset_status_idx": {
+          "name": "Dataset_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dataset_org_status": {
+          "name": "idx_dataset_org_status",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dataset_org_managed": {
+          "name": "idx_dataset_org_managed",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isManaged",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Dataset_organizationId_Organization_id_fk": {
+          "name": "Dataset_organizationId_Organization_id_fk",
+          "tableFrom": "Dataset",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Dataset_createdById_User_id_fk": {
+          "name": "Dataset_createdById_User_id_fk",
+          "tableFrom": "Dataset",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeveloperAccountInvite": {
+      "name": "DeveloperAccountInvite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailAddress": {
+          "name": "emailAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessLevel": {
+          "name": "accessLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "failedToSend": {
+          "name": "failedToSend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeveloperAccountInvite_account_idx": {
+          "name": "DeveloperAccountInvite_account_idx",
+          "columns": [
+            {
+              "expression": "developerAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeveloperAccountInvite_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "DeveloperAccountInvite_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "DeveloperAccountInvite",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeveloperAccountMember": {
+      "name": "DeveloperAccountMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailAddress": {
+          "name": "emailAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessLevel": {
+          "name": "accessLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeveloperAccountMember_unique_idx": {
+          "name": "DeveloperAccountMember_unique_idx",
+          "columns": [
+            {
+              "expression": "developerAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DeveloperAccountMember_userId_idx": {
+          "name": "DeveloperAccountMember_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeveloperAccountMember_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "DeveloperAccountMember_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "DeveloperAccountMember",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DeveloperAccountMember_userId_User_id_fk": {
+          "name": "DeveloperAccountMember_userId_User_id_fk",
+          "tableFrom": "DeveloperAccountMember",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeveloperAccount": {
+      "name": "DeveloperAccount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logoId": {
+          "name": "logoId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoUrl": {
+          "name": "logoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featureFlags": {
+          "name": "featureFlags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"legacy-collection-scopes\":false,\"search-records-api\":false,\"find-create-meetings-api\":false,\"get-list-meetings-api\":true,\"write-call-recordings-api\":false,\"read-call-recordings-api\":true}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeveloperAccount_slug_idx": {
+          "name": "DeveloperAccount_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "DeveloperAccount_slug_unique": {
+          "name": "DeveloperAccount_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DocumentSegment": {
+      "name": "DocumentSegment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startOffset": {
+          "name": "startOffset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endOffset": {
+          "name": "endOffset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenCount": {
+          "name": "tokenCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_512": {
+          "name": "embedding_512",
+          "type": "vector(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_768": {
+          "name": "embedding_768",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_1024": {
+          "name": "embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_1536": {
+          "name": "embedding_1536",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_3072": {
+          "name": "embedding_3072",
+          "type": "vector(3072)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingModel": {
+          "name": "embeddingModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingDimension": {
+          "name": "embeddingDimension",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "indexStatus": {
+          "name": "indexStatus",
+          "type": "IndexStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "searchMetadata": {
+          "name": "searchMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchVector": {
+          "name": "searchVector",
+          "type": "tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "DocumentSegment_documentId_idx": {
+          "name": "DocumentSegment_documentId_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DocumentSegment_organizationId_idx": {
+          "name": "DocumentSegment_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DocumentSegment_position_idx": {
+          "name": "DocumentSegment_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_embedding_512_hnsw": {
+          "name": "idx_embedding_512_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_512",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_512 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_embedding_768_hnsw": {
+          "name": "idx_embedding_768_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_768",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_768 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_embedding_1024_hnsw": {
+          "name": "idx_embedding_1024_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_1024",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_1024 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_embedding_1536_hnsw": {
+          "name": "idx_embedding_1536_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_1536",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_1536 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_document_segment_search_vector": {
+          "name": "idx_document_segment_search_vector",
+          "columns": [
+            {
+              "expression": "searchVector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_document_segment_dataset_filter": {
+          "name": "idx_document_segment_dataset_filter",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((enabled = true) AND (\"indexStatus\" = 'INDEXED'::\"IndexStatus\"))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DocumentSegment_documentId_Document_id_fk": {
+          "name": "DocumentSegment_documentId_Document_id_fk",
+          "tableFrom": "DocumentSegment",
+          "tableTo": "Document",
+          "columnsFrom": ["documentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DocumentSegment_organizationId_Organization_id_fk": {
+          "name": "DocumentSegment_organizationId_Organization_id_fk",
+          "tableFrom": "DocumentSegment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalPath": {
+          "name": "originalPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "DocumentType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "DocumentStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UPLOADED'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingTime": {
+          "name": "processingTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalChunks": {
+          "name": "totalChunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploadedById": {
+          "name": "uploadedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunkSettings": {
+          "name": "chunkSettings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mediaAssetId": {
+          "name": "mediaAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Document_checksum_idx": {
+          "name": "Document_checksum_idx",
+          "columns": [
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_datasetId_checksum_key": {
+          "name": "Document_datasetId_checksum_key",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_datasetId_idx": {
+          "name": "Document_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_enabled_idx": {
+          "name": "Document_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_mediaAssetId_idx": {
+          "name": "Document_mediaAssetId_idx",
+          "columns": [
+            {
+              "expression": "mediaAssetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_organizationId_idx": {
+          "name": "Document_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_status_idx": {
+          "name": "Document_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_type_idx": {
+          "name": "Document_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_uploadedById_idx": {
+          "name": "Document_uploadedById_idx",
+          "columns": [
+            {
+              "expression": "uploadedById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_document_dataset_enabled": {
+          "name": "idx_document_dataset_enabled",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Document_datasetId_Dataset_id_fk": {
+          "name": "Document_datasetId_Dataset_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Document_organizationId_Organization_id_fk": {
+          "name": "Document_organizationId_Organization_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Document_uploadedById_User_id_fk": {
+          "name": "Document_uploadedById_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["uploadedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Document_mediaAssetId_MediaAsset_id_fk": {
+          "name": "Document_mediaAssetId_MediaAsset_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["mediaAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Draft": {
+      "name": "Draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inReplyToMessageId": {
+          "name": "inReplyToMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerThreadId": {
+          "name": "providerThreadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Draft_organizationId_idx": {
+          "name": "Draft_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_createdById_idx": {
+          "name": "Draft_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_threadId_idx": {
+          "name": "Draft_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_integrationId_idx": {
+          "name": "Draft_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_threadId_createdById_key": {
+          "name": "Draft_threadId_createdById_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"threadId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_organizationId_providerId_key": {
+          "name": "Draft_organizationId_providerId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"providerId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_organizationId_createdById_idx": {
+          "name": "Draft_organizationId_createdById_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Draft_organizationId_Organization_id_fk": {
+          "name": "Draft_organizationId_Organization_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Draft_createdById_User_id_fk": {
+          "name": "Draft_createdById_User_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Draft_threadId_Thread_id_fk": {
+          "name": "Draft_threadId_Thread_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Draft_inReplyToMessageId_Message_id_fk": {
+          "name": "Draft_inReplyToMessageId_Message_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Message",
+          "columnsFrom": ["inReplyToMessageId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Draft_integrationId_Integration_id_fk": {
+          "name": "Draft_integrationId_Integration_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailAddress": {
+      "name": "EmailAddress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationType": {
+          "name": "integrationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "EmailAddress_integrationId_address_key": {
+          "name": "EmailAddress_integrationId_address_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailEmbedding": {
+      "name": "EmailEmbedding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text-embedding-3-small'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EmailEmbedding_messageId_idx": {
+          "name": "EmailEmbedding_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EmailEmbedding_messageId_Message_id_fk": {
+          "name": "EmailEmbedding_messageId_Message_id_fk",
+          "tableFrom": "EmailEmbedding",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailTemplate": {
+      "name": "EmailTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "EmailTemplateType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bodyHtml": {
+          "name": "bodyHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bodyPlain": {
+          "name": "bodyPlain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "EmailTemplate_organizationId_type_idx": {
+          "name": "EmailTemplate_organizationId_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EmailTemplate_organizationId_type_isDefault_key": {
+          "name": "EmailTemplate_organizationId_type_isDefault_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isDefault",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EmailTemplate_organizationId_Organization_id_fk": {
+          "name": "EmailTemplate_organizationId_Organization_id_fk",
+          "tableFrom": "EmailTemplate",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EndUser": {
+      "name": "EndUser",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "totalRuns": {
+          "name": "totalRuns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EndUser_workflowAppId_idx": {
+          "name": "EndUser_workflowAppId_idx",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_sessionId_idx": {
+          "name": "EndUser_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_userId_idx": {
+          "name": "EndUser_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_workflowAppId_sessionId_idx": {
+          "name": "EndUser_workflowAppId_sessionId_idx",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_workflowAppId_userId_idx": {
+          "name": "EndUser_workflowAppId_userId_idx",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EndUser_workflowAppId_WorkflowApp_id_fk": {
+          "name": "EndUser_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "EndUser",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EndUser_userId_User_id_fk": {
+          "name": "EndUser_userId_User_id_fk",
+          "tableFrom": "EndUser",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EntityDefinition": {
+      "name": "EntityDefinition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiSlug": {
+          "name": "apiSlug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Box'"
+        },
+        "singular": {
+          "name": "singular",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plural": {
+          "name": "plural",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standardType": {
+          "name": "standardType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryDisplayFieldId": {
+          "name": "primaryDisplayFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondaryDisplayFieldId": {
+          "name": "secondaryDisplayFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarFieldId": {
+          "name": "avatarFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isVisible": {
+          "name": "isVisible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "EntityDefinition_apiSlug_organizationId_key": {
+          "name": "EntityDefinition_apiSlug_organizationId_key",
+          "columns": [
+            {
+              "expression": "apiSlug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"EntityDefinition\".\"archivedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_organizationId_idx": {
+          "name": "EntityDefinition_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_entityType_idx": {
+          "name": "EntityDefinition_entityType_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_archivedAt_idx": {
+          "name": "EntityDefinition_archivedAt_idx",
+          "columns": [
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EntityDefinition_organizationId_Organization_id_fk": {
+          "name": "EntityDefinition_organizationId_Organization_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_primaryDisplayFieldId_CustomField_id_fk": {
+          "name": "EntityDefinition_primaryDisplayFieldId_CustomField_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "CustomField",
+          "columnsFrom": ["primaryDisplayFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_secondaryDisplayFieldId_CustomField_id_fk": {
+          "name": "EntityDefinition_secondaryDisplayFieldId_CustomField_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "CustomField",
+          "columnsFrom": ["secondaryDisplayFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_avatarFieldId_CustomField_id_fk": {
+          "name": "EntityDefinition_avatarFieldId_CustomField_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "CustomField",
+          "columnsFrom": ["avatarFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EntityGroupMember": {
+      "name": "EntityGroupMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "groupInstanceId": {
+          "name": "groupInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memberType": {
+          "name": "memberType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memberRefId": {
+          "name": "memberRefId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedById": {
+          "name": "addedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortKey": {
+          "name": "sortKey",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a0'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EntityGroupMember_group_member_key": {
+          "name": "EntityGroupMember_group_member_key",
+          "columns": [
+            {
+              "expression": "groupInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memberType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memberRefId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityGroupMember_group_idx": {
+          "name": "EntityGroupMember_group_idx",
+          "columns": [
+            {
+              "expression": "groupInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityGroupMember_member_idx": {
+          "name": "EntityGroupMember_member_idx",
+          "columns": [
+            {
+              "expression": "memberType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memberRefId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EntityGroupMember_groupInstanceId_EntityInstance_id_fk": {
+          "name": "EntityGroupMember_groupInstanceId_EntityInstance_id_fk",
+          "tableFrom": "EntityGroupMember",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["groupInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityGroupMember_addedById_User_id_fk": {
+          "name": "EntityGroupMember_addedById_User_id_fk",
+          "tableFrom": "EntityGroupMember",
+          "tableTo": "User",
+          "columnsFrom": ["addedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EntityInstance": {
+      "name": "EntityInstance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondaryDisplayValue": {
+          "name": "secondaryDisplayValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchText": {
+          "name": "searchText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActivityAt": {
+          "name": "lastActivityAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSuggestionScanAt": {
+          "name": "lastSuggestionScanAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrationSource": {
+          "name": "integrationSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "EntityInstance_entityDefinitionId_idx": {
+          "name": "EntityInstance_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_organizationId_idx": {
+          "name": "EntityInstance_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_archivedAt_idx": {
+          "name": "EntityInstance_archivedAt_idx",
+          "columns": [
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_orgId_defId_idx": {
+          "name": "EntityInstance_orgId_defId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_displayName_idx": {
+          "name": "EntityInstance_displayName_idx",
+          "columns": [
+            {
+              "expression": "displayName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_organizationId_entityDefinitionId_lastActivityAt_idx": {
+          "name": "EntityInstance_organizationId_entityDefinitionId_lastActivityAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastActivityAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_integrationLookup_idx": {
+          "name": "EntityInstance_integrationLookup_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationSource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_org_def_scan_idx": {
+          "name": "EntityInstance_org_def_scan_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastActivityAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastSuggestionScanAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"archivedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EntityInstance_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "EntityInstance_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "EntityInstance",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityInstance_organizationId_Organization_id_fk": {
+          "name": "EntityInstance_organizationId_Organization_id_fk",
+          "tableFrom": "EntityInstance",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityInstance_createdById_User_id_fk": {
+          "name": "EntityInstance_createdById_User_id_fk",
+          "tableFrom": "EntityInstance",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Event": {
+      "name": "Event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "Event_organizationId_idx": {
+          "name": "Event_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Event_type_idx": {
+          "name": "Event_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Event_organizationId_Organization_id_fk": {
+          "name": "Event_organizationId_Organization_id_fk",
+          "tableFrom": "Event",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ExternalKnowledgeSource": {
+      "name": "ExternalKnowledgeSource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "syncEnabled": {
+          "name": "syncEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "syncInterval": {
+          "name": "syncInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextSyncAt": {
+          "name": "nextSyncAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ExternalKnowledgeSource_datasetId_idx": {
+          "name": "ExternalKnowledgeSource_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_datasetId_name_key": {
+          "name": "ExternalKnowledgeSource_datasetId_name_key",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_nextSyncAt_idx": {
+          "name": "ExternalKnowledgeSource_nextSyncAt_idx",
+          "columns": [
+            {
+              "expression": "nextSyncAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_organizationId_idx": {
+          "name": "ExternalKnowledgeSource_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_status_idx": {
+          "name": "ExternalKnowledgeSource_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ExternalKnowledgeSource_datasetId_Dataset_id_fk": {
+          "name": "ExternalKnowledgeSource_datasetId_Dataset_id_fk",
+          "tableFrom": "ExternalKnowledgeSource",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ExternalKnowledgeSource_organizationId_Organization_id_fk": {
+          "name": "ExternalKnowledgeSource_organizationId_Organization_id_fk",
+          "tableFrom": "ExternalKnowledgeSource",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ExternalKnowledgeSource_createdById_User_id_fk": {
+          "name": "ExternalKnowledgeSource_createdById_User_id_fk",
+          "tableFrom": "ExternalKnowledgeSource",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Favorite": {
+      "name": "Favorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationMemberId": {
+          "name": "organizationMemberId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeType": {
+          "name": "nodeType",
+          "type": "FavoriteNodeType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetType": {
+          "name": "targetType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetIds": {
+          "name": "targetIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentFolderId": {
+          "name": "parentFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Favorite_member_idx": {
+          "name": "Favorite_member_idx",
+          "columns": [
+            {
+              "expression": "organizationMemberId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Favorite_organizationId_idx": {
+          "name": "Favorite_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Favorite_parentFolderId_idx": {
+          "name": "Favorite_parentFolderId_idx",
+          "columns": [
+            {
+              "expression": "parentFolderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Favorite_organizationId_Organization_id_fk": {
+          "name": "Favorite_organizationId_Organization_id_fk",
+          "tableFrom": "Favorite",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Favorite_organizationMemberId_OrganizationMember_id_fk": {
+          "name": "Favorite_organizationMemberId_OrganizationMember_id_fk",
+          "tableFrom": "Favorite",
+          "tableTo": "OrganizationMember",
+          "columnsFrom": ["organizationMemberId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Favorite_userId_User_id_fk": {
+          "name": "Favorite_userId_User_id_fk",
+          "tableFrom": "Favorite",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Favorite_parentFolderId_Favorite_id_fk": {
+          "name": "Favorite_parentFolderId_Favorite_id_fk",
+          "tableFrom": "Favorite",
+          "tableTo": "Favorite",
+          "columnsFrom": ["parentFolderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FieldValue": {
+      "name": "FieldValue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fieldId": {
+          "name": "fieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valueText": {
+          "name": "valueText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueNumber": {
+          "name": "valueNumber",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueBoolean": {
+          "name": "valueBoolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueDate": {
+          "name": "valueDate",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueJson": {
+          "name": "valueJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optionId": {
+          "name": "optionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedEntityId": {
+          "name": "relatedEntityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedEntityDefinitionId": {
+          "name": "relatedEntityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortKey": {
+          "name": "sortKey",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a'"
+        },
+        "aiStatus": {
+          "name": "aiStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FieldValue_organizationId_idx": {
+          "name": "FieldValue_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityId_idx": {
+          "name": "FieldValue_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityDefinitionId_idx": {
+          "name": "FieldValue_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_fieldId_idx": {
+          "name": "FieldValue_fieldId_idx",
+          "columns": [
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityId_fieldId_idx": {
+          "name": "FieldValue_entityId_fieldId_idx",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityDefinitionId_entityId_idx": {
+          "name": "FieldValue_entityDefinitionId_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_orgId_fieldId_relatedEntityId_idx": {
+          "name": "FieldValue_orgId_fieldId_relatedEntityId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_optionId_idx": {
+          "name": "FieldValue_optionId_idx",
+          "columns": [
+            {
+              "expression": "optionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_relatedEntityId_idx": {
+          "name": "FieldValue_relatedEntityId_idx",
+          "columns": [
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_relatedEntityDefinitionId_idx": {
+          "name": "FieldValue_relatedEntityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "relatedEntityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_actorId_idx": {
+          "name": "FieldValue_actorId_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entity_field_sortKey_key": {
+          "name": "FieldValue_entity_field_sortKey_key",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_text_idx": {
+          "name": "FieldValue_lookup_text_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueText",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"valueText\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_number_idx": {
+          "name": "FieldValue_lookup_number_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"valueNumber\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_option_idx": {
+          "name": "FieldValue_lookup_option_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "optionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"optionId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_related_idx": {
+          "name": "FieldValue_lookup_related_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relatedEntityId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_actor_idx": {
+          "name": "FieldValue_lookup_actor_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"actorId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_date_idx": {
+          "name": "FieldValue_lookup_date_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"valueDate\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FieldValue_organizationId_Organization_id_fk": {
+          "name": "FieldValue_organizationId_Organization_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FieldValue_fieldId_CustomField_id_fk": {
+          "name": "FieldValue_fieldId_CustomField_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "CustomField",
+          "columnsFrom": ["fieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FieldValue_actorId_User_id_fk": {
+          "name": "FieldValue_actorId_User_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "User",
+          "columnsFrom": ["actorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FileAttachment": {
+      "name": "FileAttachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachableId": {
+          "name": "attachableId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachableType": {
+          "name": "attachableType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FileAttachment_attachableId_attachableType_idx": {
+          "name": "FileAttachment_attachableId_attachableType_idx",
+          "columns": [
+            {
+              "expression": "attachableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachableType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FileAttachment_fileId_attachableId_attachableType_key": {
+          "name": "FileAttachment_fileId_attachableId_attachableType_key",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachableType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FileAttachment_fileId_File_id_fk": {
+          "name": "FileAttachment_fileId_File_id_fk",
+          "tableFrom": "FileAttachment",
+          "tableTo": "File",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FileVersion": {
+      "name": "FileVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageLocationId": {
+          "name": "storageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "FileVersion_fileId_createdAt_idx": {
+          "name": "FileVersion_fileId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FileVersion_fileId_versionNumber_key": {
+          "name": "FileVersion_fileId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FileVersion_fileId_FolderFile_id_fk": {
+          "name": "FileVersion_fileId_FolderFile_id_fk",
+          "tableFrom": "FileVersion",
+          "tableTo": "FolderFile",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FileVersion_storageLocationId_StorageLocation_id_fk": {
+          "name": "FileVersion_storageLocationId_StorageLocation_id_fk",
+          "tableFrom": "FileVersion",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["storageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.File": {
+      "name": "File",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashedKey": {
+          "name": "hashedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedById": {
+          "name": "deletedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "knowledgeBaseId": {
+          "name": "knowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmedAt": {
+          "name": "confirmedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "downloadCount": {
+          "name": "downloadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "FileStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "FileVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        }
+      },
+      "indexes": {
+        "File_checksum_organizationId_idx": {
+          "name": "File_checksum_organizationId_idx",
+          "columns": [
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_hashedKey_key": {
+          "name": "File_hashedKey_key",
+          "columns": [
+            {
+              "expression": "hashedKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_organizationId_status_idx": {
+          "name": "File_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_status_expiresAt_idx": {
+          "name": "File_status_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_visibility_hashedKey_idx": {
+          "name": "File_visibility_hashedKey_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hashedKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "File_createdById_User_id_fk": {
+          "name": "File_createdById_User_id_fk",
+          "tableFrom": "File",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "File_organizationId_Organization_id_fk": {
+          "name": "File_organizationId_Organization_id_fk",
+          "tableFrom": "File",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "File_deletedById_User_id_fk": {
+          "name": "File_deletedById_User_id_fk",
+          "tableFrom": "File",
+          "tableTo": "User",
+          "columnsFrom": ["deletedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "File_articleId_Article_id_fk": {
+          "name": "File_articleId_Article_id_fk",
+          "tableFrom": "File",
+          "tableTo": "Article",
+          "columnsFrom": ["articleId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "File_knowledgeBaseId_KnowledgeBase_id_fk": {
+          "name": "File_knowledgeBaseId_KnowledgeBase_id_fk",
+          "tableFrom": "File",
+          "tableTo": "KnowledgeBase",
+          "columnsFrom": ["knowledgeBaseId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FolderFile": {
+      "name": "FolderFile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentVersionId": {
+          "name": "currentVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "StorageProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FolderFile_currentVersionId_key": {
+          "name": "FolderFile_currentVersionId_key",
+          "columns": [
+            {
+              "expression": "currentVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_checksum_idx": {
+          "name": "FolderFile_organizationId_checksum_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_deletedAt_isArchived_idx": {
+          "name": "FolderFile_organizationId_deletedAt_isArchived_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_ext_createdAt_idx": {
+          "name": "FolderFile_organizationId_ext_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ext",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_folderId_idx": {
+          "name": "FolderFile_organizationId_folderId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_folderId_path_idx": {
+          "name": "FolderFile_organizationId_folderId_path_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_mimeType_updatedAt_idx": {
+          "name": "FolderFile_organizationId_mimeType_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mimeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_name_idx": {
+          "name": "FolderFile_organizationId_name_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_path_idx": {
+          "name": "FolderFile_organizationId_path_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_updatedAt_idx": {
+          "name": "FolderFile_organizationId_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_path_name_idx": {
+          "name": "FolderFile_path_name_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FolderFile_organizationId_Organization_id_fk": {
+          "name": "FolderFile_organizationId_Organization_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FolderFile_folderId_Folder_id_fk": {
+          "name": "FolderFile_folderId_Folder_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "Folder",
+          "columnsFrom": ["folderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "FolderFile_currentVersionId_FileVersion_id_fk": {
+          "name": "FolderFile_currentVersionId_FileVersion_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "FileVersion",
+          "columnsFrom": ["currentVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "FolderFile_createdById_User_id_fk": {
+          "name": "FolderFile_createdById_User_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Folder": {
+      "name": "Folder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Folder_organizationId_deletedAt_isArchived_idx": {
+          "name": "Folder_organizationId_deletedAt_isArchived_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_organizationId_depth_path_idx": {
+          "name": "Folder_organizationId_depth_path_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_organizationId_parentId_idx": {
+          "name": "Folder_organizationId_parentId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_organizationId_parentId_name_key": {
+          "name": "Folder_organizationId_parentId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_parentId_name_idx": {
+          "name": "Folder_parentId_name_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Folder_organizationId_Organization_id_fk": {
+          "name": "Folder_organizationId_Organization_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Folder_parentId_Folder_id_fk": {
+          "name": "Folder_parentId_Folder_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "Folder",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Folder_createdById_User_id_fk": {
+          "name": "Folder_createdById_User_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FreeToolLead": {
+      "name": "FreeToolLead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolSlug": {
+          "name": "toolSlug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utmSource": {
+          "name": "utmSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utmMedium": {
+          "name": "utmMedium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utmCampaign": {
+          "name": "utmCampaign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FreeToolLead_toolSlug_idx": {
+          "name": "FreeToolLead_toolSlug_idx",
+          "columns": [
+            {
+              "expression": "toolSlug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FreeToolLead_email_idx": {
+          "name": "FreeToolLead_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FreeToolLead_createdAt_idx": {
+          "name": "FreeToolLead_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FulfillmentTracking": {
+      "name": "FulfillmentTracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillmentId": {
+          "name": "fulfillmentId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "FulfillmentTracking_fulfillmentId_idx": {
+          "name": "FulfillmentTracking_fulfillmentId_idx",
+          "columns": [
+            {
+              "expression": "fulfillmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FulfillmentTracking_number_idx": {
+          "name": "FulfillmentTracking_number_idx",
+          "columns": [
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FulfillmentTracking_number_key": {
+          "name": "FulfillmentTracking_number_key",
+          "columns": [
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FulfillmentTracking_orderId_idx": {
+          "name": "FulfillmentTracking_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FulfillmentTracking_orderId_Order_id_fk": {
+          "name": "FulfillmentTracking_orderId_Order_id_fk",
+          "tableFrom": "FulfillmentTracking",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FulfillmentTracking_fulfillmentId_OrderFulfillment_id_fk": {
+          "name": "FulfillmentTracking_fulfillmentId_OrderFulfillment_id_fk",
+          "tableFrom": "FulfillmentTracking",
+          "tableTo": "OrderFulfillment",
+          "columnsFrom": ["fulfillmentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJobMappableProperty": {
+      "name": "ImportJobMappableProperty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnIndex": {
+          "name": "columnIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibleName": {
+          "name": "visibleName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ImportJobMappableProperty_importJobId_idx": {
+          "name": "ImportJobMappableProperty_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobMappableProperty_jobId_columnIndex_key": {
+          "name": "ImportJobMappableProperty_jobId_columnIndex_key",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "columnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJobMappableProperty_importJobId_ImportJob_id_fk": {
+          "name": "ImportJobMappableProperty_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportJobMappableProperty",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJobProperty": {
+      "name": "ImportJobProperty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importMappingPropertyId": {
+          "name": "importMappingPropertyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uniqueValueCount": {
+          "name": "uniqueValueCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolvedCount": {
+          "name": "resolvedCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errorCount": {
+          "name": "errorCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ImportJobProperty_importJobId_idx": {
+          "name": "ImportJobProperty_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobProperty_jobId_mappingPropertyId_key": {
+          "name": "ImportJobProperty_jobId_mappingPropertyId_key",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "importMappingPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJobProperty_importJobId_ImportJob_id_fk": {
+          "name": "ImportJobProperty_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportJobProperty",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportJobProperty_importMappingPropertyId_ImportMappingProperty_id_fk": {
+          "name": "ImportJobProperty_importMappingPropertyId_ImportMappingProperty_id_fk",
+          "tableFrom": "ImportJobProperty",
+          "tableTo": "ImportMappingProperty",
+          "columnsFrom": ["importMappingPropertyId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJobRawData": {
+      "name": "ImportJobRawData",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnIndex": {
+          "name": "columnIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "valueHash": {
+          "name": "valueHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ImportJobRawData_importJobId_idx": {
+          "name": "ImportJobRawData_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobRawData_importJobId_rowIndex_idx": {
+          "name": "ImportJobRawData_importJobId_rowIndex_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobRawData_importJobId_columnIndex_idx": {
+          "name": "ImportJobRawData_importJobId_columnIndex_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "columnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobRawData_valueHash_idx": {
+          "name": "ImportJobRawData_valueHash_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "columnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJobRawData_importJobId_ImportJob_id_fk": {
+          "name": "ImportJobRawData_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportJobRawData",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJob": {
+      "name": "ImportJob",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importMappingId": {
+          "name": "importMappingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceFileName": {
+          "name": "sourceFileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnCount": {
+          "name": "columnCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowCount": {
+          "name": "rowCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalChunks": {
+          "name": "totalChunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedChunks": {
+          "name": "receivedChunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportJobStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "ingestionFailureReason": {
+          "name": "ingestionFailureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowPlanGeneration": {
+          "name": "allowPlanGeneration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmedAt": {
+          "name": "confirmedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedExecutionAt": {
+          "name": "startedExecutionAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportJob_organizationId_idx": {
+          "name": "ImportJob_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJob_importMappingId_idx": {
+          "name": "ImportJob_importMappingId_idx",
+          "columns": [
+            {
+              "expression": "importMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJob_status_idx": {
+          "name": "ImportJob_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJob_createdById_idx": {
+          "name": "ImportJob_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJob_organizationId_Organization_id_fk": {
+          "name": "ImportJob_organizationId_Organization_id_fk",
+          "tableFrom": "ImportJob",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportJob_importMappingId_ImportMapping_id_fk": {
+          "name": "ImportJob_importMappingId_ImportMapping_id_fk",
+          "tableFrom": "ImportJob",
+          "tableTo": "ImportMapping",
+          "columnsFrom": ["importMappingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportJob_createdById_User_id_fk": {
+          "name": "ImportJob_createdById_User_id_fk",
+          "tableFrom": "ImportJob",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportMappingProperty": {
+      "name": "ImportMappingProperty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importMappingId": {
+          "name": "importMappingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceColumnIndex": {
+          "name": "sourceColumnIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceColumnName": {
+          "name": "sourceColumnName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetType": {
+          "name": "targetType",
+          "type": "ImportMappingTargetType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skip'"
+        },
+        "targetFieldKey": {
+          "name": "targetFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customFieldId": {
+          "name": "customFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolutionType": {
+          "name": "resolutionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text:value'"
+        },
+        "resolutionConfig": {
+          "name": "resolutionConfig",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportMappingProperty_importMappingId_idx": {
+          "name": "ImportMappingProperty_importMappingId_idx",
+          "columns": [
+            {
+              "expression": "importMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportMappingProperty_sourceColumnIndex_idx": {
+          "name": "ImportMappingProperty_sourceColumnIndex_idx",
+          "columns": [
+            {
+              "expression": "importMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceColumnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportMappingProperty_importMappingId_ImportMapping_id_fk": {
+          "name": "ImportMappingProperty_importMappingId_ImportMapping_id_fk",
+          "tableFrom": "ImportMappingProperty",
+          "tableTo": "ImportMapping",
+          "columnsFrom": ["importMappingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportMappingProperty_customFieldId_CustomField_id_fk": {
+          "name": "ImportMappingProperty_customFieldId_CustomField_id_fk",
+          "tableFrom": "ImportMappingProperty",
+          "tableTo": "CustomField",
+          "columnsFrom": ["customFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportMapping": {
+      "name": "ImportMapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv'"
+        },
+        "defaultStrategy": {
+          "name": "defaultStrategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'create'"
+        },
+        "identifierFieldKey": {
+          "name": "identifierFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportMapping_organizationId_idx": {
+          "name": "ImportMapping_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportMapping_entityDefinitionId_idx": {
+          "name": "ImportMapping_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportMapping_organizationId_Organization_id_fk": {
+          "name": "ImportMapping_organizationId_Organization_id_fk",
+          "tableFrom": "ImportMapping",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportMapping_createdById_User_id_fk": {
+          "name": "ImportMapping_createdById_User_id_fk",
+          "tableFrom": "ImportMapping",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportPlanRow": {
+      "name": "ImportPlanRow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importPlanStrategyId": {
+          "name": "importPlanStrategyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "existingRecordId": {
+          "name": "existingRecordId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportPlanRowStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "resultRecordId": {
+          "name": "resultRecordId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executedAt": {
+          "name": "executedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportPlanRow_importPlanStrategyId_idx": {
+          "name": "ImportPlanRow_importPlanStrategyId_idx",
+          "columns": [
+            {
+              "expression": "importPlanStrategyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlanRow_status_idx": {
+          "name": "ImportPlanRow_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlanRow_strategyId_rowIndex_key": {
+          "name": "ImportPlanRow_strategyId_rowIndex_key",
+          "columns": [
+            {
+              "expression": "importPlanStrategyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportPlanRow_importPlanStrategyId_ImportPlanStrategy_id_fk": {
+          "name": "ImportPlanRow_importPlanStrategyId_ImportPlanStrategy_id_fk",
+          "tableFrom": "ImportPlanRow",
+          "tableTo": "ImportPlanStrategy",
+          "columnsFrom": ["importPlanStrategyId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportPlanStrategy": {
+      "name": "ImportPlanStrategy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importPlanId": {
+          "name": "importPlanId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "ImportStrategyType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matchingFieldKey": {
+          "name": "matchingFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matchingCustomFieldId": {
+          "name": "matchingCustomFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportStrategyStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planning_queued'"
+        },
+        "planningProgress": {
+          "name": "planningProgress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planningStartedAt": {
+          "name": "planningStartedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planningCompletedAt": {
+          "name": "planningCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionStartedAt": {
+          "name": "executionStartedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionCompletedAt": {
+          "name": "executionCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportPlanStrategy_importPlanId_idx": {
+          "name": "ImportPlanStrategy_importPlanId_idx",
+          "columns": [
+            {
+              "expression": "importPlanId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlanStrategy_strategy_idx": {
+          "name": "ImportPlanStrategy_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportPlanStrategy_importPlanId_ImportPlan_id_fk": {
+          "name": "ImportPlanStrategy_importPlanId_ImportPlan_id_fk",
+          "tableFrom": "ImportPlanStrategy",
+          "tableTo": "ImportPlan",
+          "columnsFrom": ["importPlanId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportPlanStrategy_matchingCustomFieldId_CustomField_id_fk": {
+          "name": "ImportPlanStrategy_matchingCustomFieldId_CustomField_id_fk",
+          "tableFrom": "ImportPlanStrategy",
+          "tableTo": "CustomField",
+          "columnsFrom": ["matchingCustomFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportPlan": {
+      "name": "ImportPlan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportPlanStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planning'"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportPlan_importJobId_idx": {
+          "name": "ImportPlan_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlan_status_idx": {
+          "name": "ImportPlan_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportPlan_importJobId_ImportJob_id_fk": {
+          "name": "ImportPlan_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportPlan",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportValueResolution": {
+      "name": "ImportValueResolution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importJobPropertyId": {
+          "name": "importJobPropertyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashedValue": {
+          "name": "hashedValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rawValue": {
+          "name": "rawValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cellCount": {
+          "name": "cellCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "resolvedValues": {
+          "name": "resolvedValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportResolutionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "isValid": {
+          "name": "isValid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userOverride": {
+          "name": "userOverride",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overriddenAt": {
+          "name": "overriddenAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportValueResolution_importJobPropertyId_idx": {
+          "name": "ImportValueResolution_importJobPropertyId_idx",
+          "columns": [
+            {
+              "expression": "importJobPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportValueResolution_propertyId_hash_key": {
+          "name": "ImportValueResolution_propertyId_hash_key",
+          "columns": [
+            {
+              "expression": "importJobPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hashedValue",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportValueResolution_status_idx": {
+          "name": "ImportValueResolution_status_idx",
+          "columns": [
+            {
+              "expression": "importJobPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportValueResolution_importJobPropertyId_ImportJobProperty_id_fk": {
+          "name": "ImportValueResolution_importJobPropertyId_ImportJobProperty_id_fk",
+          "tableFrom": "ImportValueResolution",
+          "tableTo": "ImportJobProperty",
+          "columnsFrom": ["importJobPropertyId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.InboxIntegration": {
+      "name": "InboxIntegration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "inboxId": {
+          "name": "inboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "InboxIntegration_inboxId_idx": {
+          "name": "InboxIntegration_inboxId_idx",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "InboxIntegration_inboxId_integrationId_key": {
+          "name": "InboxIntegration_inboxId_integrationId_key",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "InboxIntegration_integrationId_key": {
+          "name": "InboxIntegration_integrationId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "InboxIntegration_inboxId_EntityInstance_id_fk": {
+          "name": "InboxIntegration_inboxId_EntityInstance_id_fk",
+          "tableFrom": "InboxIntegration",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["inboxId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "InboxIntegration_integrationId_Integration_id_fk": {
+          "name": "InboxIntegration_integrationId_Integration_id_fk",
+          "tableFrom": "InboxIntegration",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.InsightTemplate": {
+      "name": "InsightTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aiTitle": {
+          "name": "aiTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "InsightTemplateStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enabled'"
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "InsightTemplate_organizationId_idx": {
+          "name": "InsightTemplate_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "InsightTemplate_organizationId_status_idx": {
+          "name": "InsightTemplate_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "InsightTemplate_organizationId_Organization_id_fk": {
+          "name": "InsightTemplate_organizationId_Organization_id_fk",
+          "tableFrom": "InsightTemplate",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "InsightTemplate_createdById_User_id_fk": {
+          "name": "InsightTemplate_createdById_User_id_fk",
+          "tableFrom": "InsightTemplate",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Integration": {
+      "name": "Integration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "IntegrationProviderType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSuccessfulSync": {
+          "name": "lastSuccessfulSync",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHistoryId": {
+          "name": "lastHistoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authStatus": {
+          "name": "authStatus",
+          "type": "IntegrationAuthStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AUTHENTICATED'"
+        },
+        "requiresReauth": {
+          "name": "requiresReauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastAuthError": {
+          "name": "lastAuthError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAuthErrorAt": {
+          "name": "lastAuthErrorAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncStatus": {
+          "name": "syncStatus",
+          "type": "IntegrationSyncStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOT_SYNCED'"
+        },
+        "syncStage": {
+          "name": "syncStage",
+          "type": "IntegrationSyncStage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDLE'"
+        },
+        "syncStageStartedAt": {
+          "name": "syncStageStartedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "throttleFailureCount": {
+          "name": "throttleFailureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "throttleRetryAfter": {
+          "name": "throttleRetryAfter",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncMode": {
+          "name": "syncMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "pollingIntervalMs": {
+          "name": "pollingIntervalMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 300000
+        },
+        "is_example": {
+          "name": "is_example",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Integration_organizationId_email_key": {
+          "name": "Integration_organizationId_email_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"Integration\".\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_organizationId_idx": {
+          "name": "Integration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_provider_organizationId_idx": {
+          "name": "Integration_provider_organizationId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_credentialId_idx": {
+          "name": "Integration_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credentialId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_syncStatus_idx": {
+          "name": "Integration_syncStatus_idx",
+          "columns": [
+            {
+              "expression": "syncStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Integration_organizationId_Organization_id_fk": {
+          "name": "Integration_organizationId_Organization_id_fk",
+          "tableFrom": "Integration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Integration_credentialId_WorkflowCredentials_id_fk": {
+          "name": "Integration_credentialId_WorkflowCredentials_id_fk",
+          "tableFrom": "Integration",
+          "tableTo": "WorkflowCredentials",
+          "columnsFrom": ["credentialId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.IntegrationTagLabel": {
+      "name": "IntegrationTagLabel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IntegrationTagLabel_integrationId_idx": {
+          "name": "IntegrationTagLabel_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IntegrationTagLabel_integrationId_labelId_key": {
+          "name": "IntegrationTagLabel_integrationId_labelId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "labelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IntegrationTagLabel_integrationId_tagId_key": {
+          "name": "IntegrationTagLabel_integrationId_tagId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IntegrationTagLabel_organizationId_idx": {
+          "name": "IntegrationTagLabel_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "IntegrationTagLabel_tagId_Tag_id_fk": {
+          "name": "IntegrationTagLabel_tagId_Tag_id_fk",
+          "tableFrom": "IntegrationTagLabel",
+          "tableTo": "Tag",
+          "columnsFrom": ["tagId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "IntegrationTagLabel_labelId_Label_id_fk": {
+          "name": "IntegrationTagLabel_labelId_Label_id_fk",
+          "tableFrom": "IntegrationTagLabel",
+          "tableTo": "Label",
+          "columnsFrom": ["labelId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "IntegrationTagLabel_organizationId_Organization_id_fk": {
+          "name": "IntegrationTagLabel_organizationId_Organization_id_fk",
+          "tableFrom": "IntegrationTagLabel",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Invoice": {
+      "name": "Invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoiceNumber": {
+          "name": "invoiceNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "InvoiceStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "invoiceDate": {
+          "name": "invoiceDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paidDate": {
+          "name": "paidDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billingReason": {
+          "name": "billingReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeInvoiceId": {
+          "name": "stripeInvoiceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdfUrl": {
+          "name": "pdfUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Invoice_organizationId_idx": {
+          "name": "Invoice_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Invoice_stripeInvoiceId_key": {
+          "name": "Invoice_stripeInvoiceId_key",
+          "columns": [
+            {
+              "expression": "stripeInvoiceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Invoice_subscriptionId_idx": {
+          "name": "Invoice_subscriptionId_idx",
+          "columns": [
+            {
+              "expression": "subscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Invoice_organizationId_Organization_id_fk": {
+          "name": "Invoice_organizationId_Organization_id_fk",
+          "tableFrom": "Invoice",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Invoice_subscriptionId_PlanSubscription_id_fk": {
+          "name": "Invoice_subscriptionId_PlanSubscription_id_fk",
+          "tableFrom": "Invoice",
+          "tableTo": "PlanSubscription",
+          "columnsFrom": ["subscriptionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KeyValuePair": {
+      "name": "KeyValuePair",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEncrypted": {
+          "name": "isEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedById": {
+          "name": "updatedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "KeyValuePair_key_userId_organizationId_key": {
+          "name": "KeyValuePair_key_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_key_organizationId_null_userId_key": {
+          "name": "KeyValuePair_key_organizationId_null_userId_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"userId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_key_userId_null_organizationId_key": {
+          "name": "KeyValuePair_key_userId_null_organizationId_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organizationId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_key_system_unique": {
+          "name": "KeyValuePair_key_system_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"userId\" IS NULL AND \"organizationId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_type_idx": {
+          "name": "KeyValuePair_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_organizationId_idx": {
+          "name": "KeyValuePair_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_userId_idx": {
+          "name": "KeyValuePair_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "KeyValuePair_organizationId_Organization_id_fk": {
+          "name": "KeyValuePair_organizationId_Organization_id_fk",
+          "tableFrom": "KeyValuePair",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KeyValuePair_userId_User_id_fk": {
+          "name": "KeyValuePair_userId_User_id_fk",
+          "tableFrom": "KeyValuePair",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KeyValuePair_updatedById_User_id_fk": {
+          "name": "KeyValuePair_updatedById_User_id_fk",
+          "tableFrom": "KeyValuePair",
+          "tableTo": "User",
+          "columnsFrom": ["updatedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KnowledgeBase": {
+      "name": "KnowledgeBase",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishStatus": {
+          "name": "publishStatus",
+          "type": "KBPublishStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPublishedAt": {
+          "name": "lastPublishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "KBVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLIC'"
+        },
+        "customDomainVerifiedAt": {
+          "name": "customDomainVerifiedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customDomain": {
+          "name": "customDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoDark": {
+          "name": "logoDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoLight": {
+          "name": "logoLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'clean'"
+        },
+        "showMode": {
+          "name": "showMode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "defaultMode": {
+          "name": "defaultMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'light'"
+        },
+        "primaryColorLight": {
+          "name": "primaryColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryColorDark": {
+          "name": "primaryColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tintColorLight": {
+          "name": "tintColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tintColorDark": {
+          "name": "tintColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "infoColorLight": {
+          "name": "infoColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "infoColorDark": {
+          "name": "infoColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successColorLight": {
+          "name": "successColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successColorDark": {
+          "name": "successColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warningColorLight": {
+          "name": "warningColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warningColorDark": {
+          "name": "warningColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dangerColorLight": {
+          "name": "dangerColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dangerColorDark": {
+          "name": "dangerColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fontFamily": {
+          "name": "fontFamily",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iconsFamily": {
+          "name": "iconsFamily",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'regular'"
+        },
+        "cornerStyle": {
+          "name": "cornerStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'rounded'"
+        },
+        "sidebarListStyle": {
+          "name": "sidebarListStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "searchbarPosition": {
+          "name": "searchbarPosition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'center'"
+        },
+        "headerEnabled": {
+          "name": "headerEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "footerEnabled": {
+          "name": "footerEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "headerNavigation": {
+          "name": "headerNavigation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "footerNavigation": {
+          "name": "footerNavigation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoDarkId": {
+          "name": "logoDarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoLightId": {
+          "name": "logoLightId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draftSettings": {
+          "name": "draftSettings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "KnowledgeBase_logoDarkId_key": {
+          "name": "KnowledgeBase_logoDarkId_key",
+          "columns": [
+            {
+              "expression": "logoDarkId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeBase_logoLightId_key": {
+          "name": "KnowledgeBase_logoLightId_key",
+          "columns": [
+            {
+              "expression": "logoLightId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeBase_organizationId_idx": {
+          "name": "KnowledgeBase_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeBase_organizationId_slug_key": {
+          "name": "KnowledgeBase_organizationId_slug_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "KnowledgeBase_organizationId_Organization_id_fk": {
+          "name": "KnowledgeBase_organizationId_Organization_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeBase_logoDarkId_MediaAsset_id_fk": {
+          "name": "KnowledgeBase_logoDarkId_MediaAsset_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["logoDarkId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeBase_logoLightId_MediaAsset_id_fk": {
+          "name": "KnowledgeBase_logoLightId_MediaAsset_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["logoLightId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeBase_datasetId_Dataset_id_fk": {
+          "name": "KnowledgeBase_datasetId_Dataset_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Label": {
+      "name": "Label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationType": {
+          "name": "integrationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isVisible": {
+          "name": "isVisible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "backgroundColor": {
+          "name": "backgroundColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "textColor": {
+          "name": "textColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "LabelType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerCursor": {
+          "name": "providerCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pendingAction": {
+          "name": "pendingAction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isSentBox": {
+          "name": "isSentBox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parentLabelId": {
+          "name": "parentLabelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCheckpoint": {
+          "name": "syncCheckpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Label_labelId_organizationId_integrationId_key": {
+          "name": "Label_labelId_organizationId_integrationId_key",
+          "columns": [
+            {
+              "expression": "labelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Label_name_organizationId_integrationId_idx": {
+          "name": "Label_name_organizationId_integrationId_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Label_integrationId_idx": {
+          "name": "Label_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Label_organizationId_Organization_id_fk": {
+          "name": "Label_organizationId_Organization_id_fk",
+          "tableFrom": "Label",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Label_parentLabelId_Label_id_fk": {
+          "name": "Label_parentLabelId_Label_id_fk",
+          "tableFrom": "Label",
+          "tableTo": "Label",
+          "columnsFrom": ["parentLabelId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LabelsOnThread": {
+      "name": "LabelsOnThread",
+      "schema": "",
+      "columns": {
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "LabelsOnThread_threadId_Thread_id_fk": {
+          "name": "LabelsOnThread_threadId_Thread_id_fk",
+          "tableFrom": "LabelsOnThread",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "LabelsOnThread_labelId_Label_id_fk": {
+          "name": "LabelsOnThread_labelId_Label_id_fk",
+          "tableFrom": "LabelsOnThread",
+          "tableTo": "Label",
+          "columnsFrom": ["labelId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "LabelsOnThread_pkey": {
+          "name": "LabelsOnThread_pkey",
+          "columns": ["threadId", "labelId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LoadBalancingConfig": {
+      "name": "LoadBalancingConfig",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "LoadBalancingConfig_organizationId_provider_model_idx": {
+          "name": "LoadBalancingConfig_organizationId_provider_model_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LoadBalancingConfig_organizationId_provider_model_modelType_key": {
+          "name": "LoadBalancingConfig_organizationId_provider_model_modelType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LoadBalancingConfig_organizationId_Organization_id_fk": {
+          "name": "LoadBalancingConfig_organizationId_Organization_id_fk",
+          "tableFrom": "LoadBalancingConfig",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MailDomain": {
+      "name": "MailDomain",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "DomainType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CUSTOM'"
+        },
+        "routingPrefix": {
+          "name": "routingPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "isVerified": {
+          "name": "isVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verificationToken": {
+          "name": "verificationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookKey": {
+          "name": "webhookKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "MailDomain_organizationId_domain_key": {
+          "name": "MailDomain_organizationId_domain_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MailDomain_organizationId_Organization_id_fk": {
+          "name": "MailDomain_organizationId_Organization_id_fk",
+          "tableFrom": "MailDomain",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MailView": {
+      "name": "MailView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortField": {
+          "name": "sortField",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortDirection": {
+          "name": "sortDirection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'desc'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "MailView_isDefault_idx": {
+          "name": "MailView_isDefault_idx",
+          "columns": [
+            {
+              "expression": "isDefault",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MailView_name_userId_organizationId_key": {
+          "name": "MailView_name_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MailView_organizationId_idx": {
+          "name": "MailView_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MailView_userId_idx": {
+          "name": "MailView_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MailView_organizationId_Organization_id_fk": {
+          "name": "MailView_organizationId_Organization_id_fk",
+          "tableFrom": "MailView",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MailView_userId_User_id_fk": {
+          "name": "MailView_userId_User_id_fk",
+          "tableFrom": "MailView",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MediaAsset": {
+      "name": "MediaAsset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPrivate": {
+          "name": "isPrivate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentVersionId": {
+          "name": "currentVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ORIGINAL'"
+        }
+      },
+      "indexes": {
+        "MediaAsset_currentVersionId_key": {
+          "name": "MediaAsset_currentVersionId_key",
+          "columns": [
+            {
+              "expression": "currentVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_expiresAt_idx": {
+          "name": "MediaAsset_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_id_organizationId_key": {
+          "name": "MediaAsset_id_organizationId_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_kind_isPrivate_idx": {
+          "name": "MediaAsset_kind_isPrivate_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPrivate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_organizationId_expiresAt_idx": {
+          "name": "MediaAsset_organizationId_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_organizationId_kind_idx": {
+          "name": "MediaAsset_organizationId_kind_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_organizationId_purpose_kind_idx": {
+          "name": "MediaAsset_organizationId_purpose_kind_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thumbnail_assets": {
+          "name": "idx_thumbnail_assets",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((kind = 'THUMBNAIL'::text) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MediaAsset_organizationId_Organization_id_fk": {
+          "name": "MediaAsset_organizationId_Organization_id_fk",
+          "tableFrom": "MediaAsset",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MediaAsset_currentVersionId_MediaAssetVersion_id_fk": {
+          "name": "MediaAsset_currentVersionId_MediaAssetVersion_id_fk",
+          "tableFrom": "MediaAsset",
+          "tableTo": "MediaAssetVersion",
+          "columnsFrom": ["currentVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "MediaAsset_createdById_User_id_fk": {
+          "name": "MediaAsset_createdById_User_id_fk",
+          "tableFrom": "MediaAsset",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MediaAssetVersion": {
+      "name": "MediaAssetVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageLocationId": {
+          "name": "storageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivedFromVersionId": {
+          "name": "derivedFromVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preset": {
+          "name": "preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "AssetVersionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        }
+      },
+      "indexes": {
+        "MediaAssetVersion_assetId_createdAt_idx": {
+          "name": "MediaAssetVersion_assetId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "assetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_assetId_versionNumber_key": {
+          "name": "MediaAssetVersion_assetId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "assetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_derivedFromVersionId_preset_key": {
+          "name": "MediaAssetVersion_derivedFromVersionId_preset_key",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_derivedFromVersionId_preset_status_idx": {
+          "name": "MediaAssetVersion_derivedFromVersionId_preset_status_idx",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_status_idx": {
+          "name": "MediaAssetVersion_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thumbnail_cleanup": {
+          "name": "idx_thumbnail_cleanup",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((\"derivedFromVersionId\" IS NOT NULL) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thumbnail_lookup_covering": {
+          "name": "idx_thumbnail_lookup_covering",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((\"derivedFromVersionId\" IS NOT NULL) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_thumbnail": {
+          "name": "idx_unique_thumbnail",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((\"derivedFromVersionId\" IS NOT NULL) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MediaAssetVersion_assetId_MediaAsset_id_fk": {
+          "name": "MediaAssetVersion_assetId_MediaAsset_id_fk",
+          "tableFrom": "MediaAssetVersion",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["assetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MediaAssetVersion_storageLocationId_StorageLocation_id_fk": {
+          "name": "MediaAssetVersion_storageLocationId_StorageLocation_id_fk",
+          "tableFrom": "MediaAssetVersion",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["storageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MediaAssetVersion_derivedFromVersionId_MediaAssetVersion_id_fk": {
+          "name": "MediaAssetVersion_derivedFromVersionId_MediaAssetVersion_id_fk",
+          "tableFrom": "MediaAssetVersion",
+          "tableTo": "MediaAssetVersion",
+          "columnsFrom": ["derivedFromVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MeetingParticipant": {
+      "name": "MeetingParticipant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetingId": {
+          "name": "meetingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailDomain": {
+          "name": "emailDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contactEntityInstanceId": {
+          "name": "contactEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "companyEntityInstanceId": {
+          "name": "companyEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOrganizer": {
+          "name": "isOrganizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rsvpStatus": {
+          "name": "rsvpStatus",
+          "type": "RsvpStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'needs_action'"
+        },
+        "isBot": {
+          "name": "isBot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isExternal": {
+          "name": "isExternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "MeetingParticipant_organizationId_idx": {
+          "name": "MeetingParticipant_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_meetingId_idx": {
+          "name": "MeetingParticipant_meetingId_idx",
+          "columns": [
+            {
+              "expression": "meetingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_calendarEventId_idx": {
+          "name": "MeetingParticipant_calendarEventId_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_email_idx": {
+          "name": "MeetingParticipant_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_emailDomain_idx": {
+          "name": "MeetingParticipant_emailDomain_idx",
+          "columns": [
+            {
+              "expression": "emailDomain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_contactEntityInstanceId_idx": {
+          "name": "MeetingParticipant_contactEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "contactEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_companyEntityInstanceId_idx": {
+          "name": "MeetingParticipant_companyEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "companyEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MeetingParticipant_organizationId_Organization_id_fk": {
+          "name": "MeetingParticipant_organizationId_Organization_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_meetingId_EntityInstance_id_fk": {
+          "name": "MeetingParticipant_meetingId_EntityInstance_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["meetingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_calendarEventId_CalendarEvent_id_fk": {
+          "name": "MeetingParticipant_calendarEventId_CalendarEvent_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "CalendarEvent",
+          "columnsFrom": ["calendarEventId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_userId_User_id_fk": {
+          "name": "MeetingParticipant_userId_User_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_contactEntityInstanceId_EntityInstance_id_fk": {
+          "name": "MeetingParticipant_contactEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["contactEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_companyEntityInstanceId_EntityInstance_id_fk": {
+          "name": "MeetingParticipant_companyEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["companyEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalThreadId": {
+          "name": "externalThreadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isInbound": {
+          "name": "isInbound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isFirstInThread": {
+          "name": "isFirstInThread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "textHtml": {
+          "name": "textHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "textPlain": {
+          "name": "textPlain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internetMessageId": {
+          "name": "internetMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromId": {
+          "name": "fromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replyToId": {
+          "name": "replyToId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isReply": {
+          "name": "isReply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "historyId": {
+          "name": "historyId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedAt": {
+          "name": "receivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureId": {
+          "name": "signatureId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "htmlBodyStorageLocationId": {
+          "name": "htmlBodyStorageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasAttachments": {
+          "name": "hasAttachments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerError": {
+          "name": "providerError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sendStatus": {
+          "name": "sendStatus",
+          "type": "SendStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'SENT'"
+        },
+        "sendToken": {
+          "name": "sendToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Message_createdById_idx": {
+          "name": "Message_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_fromId_idx": {
+          "name": "Message_fromId_idx",
+          "columns": [
+            {
+              "expression": "fromId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_integrationId_externalId_key": {
+          "name": "Message_integrationId_externalId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_integrationId_idx": {
+          "name": "Message_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_organizationId_idx": {
+          "name": "Message_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_organizationId_internetMessageId_key": {
+          "name": "Message_organizationId_internetMessageId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internetMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"internetMessageId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_replyToId_idx": {
+          "name": "Message_replyToId_idx",
+          "columns": [
+            {
+              "expression": "replyToId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_sendToken_key": {
+          "name": "Message_sendToken_key",
+          "columns": [
+            {
+              "expression": "sendToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"sendToken\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_sentAt_idx": {
+          "name": "Message_sentAt_idx",
+          "columns": [
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_threadId_createdById_idx": {
+          "name": "Message_threadId_createdById_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_threadId_idx": {
+          "name": "Message_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retry_queue_idx": {
+          "name": "retry_queue_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sendStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastAttemptAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_messages_idx": {
+          "name": "thread_messages_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Message_threadId_Thread_id_fk": {
+          "name": "Message_threadId_Thread_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Message_integrationId_Integration_id_fk": {
+          "name": "Message_integrationId_Integration_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Message_createdById_User_id_fk": {
+          "name": "Message_createdById_User_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Message_organizationId_Organization_id_fk": {
+          "name": "Message_organizationId_Organization_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Message_fromId_Participant_id_fk": {
+          "name": "Message_fromId_Participant_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Participant",
+          "columnsFrom": ["fromId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "Message_replyToId_Participant_id_fk": {
+          "name": "Message_replyToId_Participant_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Participant",
+          "columnsFrom": ["replyToId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Message_signatureId_EntityInstance_id_fk": {
+          "name": "Message_signatureId_EntityInstance_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["signatureId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Message_htmlBodyStorageLocationId_StorageLocation_id_fk": {
+          "name": "Message_htmlBodyStorageLocationId_StorageLocation_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["htmlBodyStorageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MessageParticipant": {
+      "name": "MessageParticipant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "ParticipantRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participantId": {
+          "name": "participantId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "MessageParticipant_messageId_idx": {
+          "name": "MessageParticipant_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageParticipant_messageId_participantId_role_key": {
+          "name": "MessageParticipant_messageId_participantId_role_key",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "participantId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageParticipant_participantId_idx": {
+          "name": "MessageParticipant_participantId_idx",
+          "columns": [
+            {
+              "expression": "participantId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageParticipant_role_idx": {
+          "name": "MessageParticipant_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_idx": {
+          "name": "contact_history_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "participant_lookup_idx": {
+          "name": "participant_lookup_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MessageParticipant_messageId_Message_id_fk": {
+          "name": "MessageParticipant_messageId_Message_id_fk",
+          "tableFrom": "MessageParticipant",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MessageParticipant_participantId_Participant_id_fk": {
+          "name": "MessageParticipant_participantId_Participant_id_fk",
+          "tableFrom": "MessageParticipant",
+          "tableTo": "Participant",
+          "columnsFrom": ["participantId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MessageReceipt": {
+      "name": "MessageReceipt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientParticipantId": {
+          "name": "recipientParticipantId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "MessageReceipt_message_recipient_key": {
+          "name": "MessageReceipt_message_recipient_key",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipientParticipantId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageReceipt_messageId_idx": {
+          "name": "MessageReceipt_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MessageReceipt_messageId_Message_id_fk": {
+          "name": "MessageReceipt_messageId_Message_id_fk",
+          "tableFrom": "MessageReceipt",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MessageReceipt_recipientParticipantId_Participant_id_fk": {
+          "name": "MessageReceipt_recipientParticipantId_Participant_id_fk",
+          "tableFrom": "MessageReceipt",
+          "tableTo": "Participant",
+          "columnsFrom": ["recipientParticipantId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ModelConfiguration": {
+      "name": "ModelConfiguration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ModelConfiguration_organizationId_enabled_idx": {
+          "name": "ModelConfiguration_organizationId_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModelConfiguration_organizationId_provider_idx": {
+          "name": "ModelConfiguration_organizationId_provider_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModelConfiguration_organizationId_provider_model_modelType_key": {
+          "name": "ModelConfiguration_organizationId_provider_model_modelType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ModelConfiguration_organizationId_Organization_id_fk": {
+          "name": "ModelConfiguration_organizationId_Organization_id_fk",
+          "tableFrom": "ModelConfiguration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Notification": {
+      "name": "Notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryMethod": {
+          "name": "deliveryMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Notification_entityType_entityId_idx": {
+          "name": "Notification_entityType_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_organizationId_idx": {
+          "name": "Notification_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_userId_createdAt_idx": {
+          "name": "Notification_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_userId_isRead_idx": {
+          "name": "Notification_userId_isRead_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Notification_userId_User_id_fk": {
+          "name": "Notification_userId_User_id_fk",
+          "tableFrom": "Notification",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Notification_actorId_User_id_fk": {
+          "name": "Notification_actorId_User_id_fk",
+          "tableFrom": "Notification",
+          "tableTo": "User",
+          "columnsFrom": ["actorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Notification_organizationId_Organization_id_fk": {
+          "name": "Notification_organizationId_Organization_id_fk",
+          "tableFrom": "Notification",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauthAccessToken_userId_User_id_fk": {
+          "name": "oauthAccessToken_userId_User_id_fk",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthAccessToken_accessToken_unique": {
+          "name": "oauthAccessToken_accessToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["accessToken"]
+        },
+        "oauthAccessToken_refreshToken_unique": {
+          "name": "oauthAccessToken_refreshToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refreshToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthApplication": {
+      "name": "oauthApplication",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectURLs": {
+          "name": "redirectURLs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauthApplication_userId_User_id_fk": {
+          "name": "oauthApplication_userId_User_id_fk",
+          "tableFrom": "oauthApplication",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthApplication_clientId_unique": {
+          "name": "oauthApplication_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["clientId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthConsent": {
+      "name": "oauthConsent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentGiven": {
+          "name": "consentGiven",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauthConsent_userId_User_id_fk": {
+          "name": "oauthConsent_userId_User_id_fk",
+          "tableFrom": "oauthConsent",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OperatingHours": {
+      "name": "OperatingHours",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgetId": {
+          "name": "widgetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dayOfWeek": {
+          "name": "dayOfWeek",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startHour": {
+          "name": "startHour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startMinute": {
+          "name": "startMinute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endHour": {
+          "name": "endHour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endMinute": {
+          "name": "endMinute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        }
+      },
+      "indexes": {
+        "OperatingHours_widgetId_dayOfWeek_key": {
+          "name": "OperatingHours_widgetId_dayOfWeek_key",
+          "columns": [
+            {
+              "expression": "widgetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dayOfWeek",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OperatingHours_widgetId_idx": {
+          "name": "OperatingHours_widgetId_idx",
+          "columns": [
+            {
+              "expression": "widgetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OperatingHours_widgetId_ChatWidget_id_fk": {
+          "name": "OperatingHours_widgetId_ChatWidget_id_fk",
+          "tableFrom": "OperatingHours",
+          "tableTo": "ChatWidget",
+          "columnsFrom": ["widgetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Order": {
+      "name": "Order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelReason": {
+          "name": "cancelReason",
+          "type": "ORDER_CANCEL_REASON",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canNotifyCustomer": {
+          "name": "canNotifyCustomer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confirmationNumber": {
+          "name": "confirmationNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "discountCode": {
+          "name": "discountCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "financialStatus": {
+          "name": "financialStatus",
+          "type": "ORDER_FINANCIAL_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillmentStatus": {
+          "name": "fulfillmentStatus",
+          "type": "ORDER_FULFILLMENT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poNumber": {
+          "name": "poNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returnStatus": {
+          "name": "returnStatus",
+          "type": "ORDER_RETURN_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taxExempt": {
+          "name": "taxExempt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "subtotalPrice": {
+          "name": "subtotalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalDiscounts": {
+          "name": "totalDiscounts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalRefunded": {
+          "name": "totalRefunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalShippingPrice": {
+          "name": "totalShippingPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalTax": {
+          "name": "totalTax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shippingAddressId": {
+          "name": "shippingAddressId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billingAddressId": {
+          "name": "billingAddressId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Order_customerId_idx": {
+          "name": "Order_customerId_idx",
+          "columns": [
+            {
+              "expression": "customerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Order_name_idx": {
+          "name": "Order_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Order_shippingAddressId_Address_id_fk": {
+          "name": "Order_shippingAddressId_Address_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "Address",
+          "columnsFrom": ["shippingAddressId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Order_billingAddressId_Address_id_fk": {
+          "name": "Order_billingAddressId_Address_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "Address",
+          "columnsFrom": ["billingAddressId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Order_customerId_shopify_customers_id_fk": {
+          "name": "Order_customerId_shopify_customers_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "shopify_customers",
+          "columnsFrom": ["customerId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Order_organizationId_Organization_id_fk": {
+          "name": "Order_organizationId_Organization_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Order_integrationId_ShopifyIntegration_id_fk": {
+          "name": "Order_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "Order",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrderFulfillment": {
+      "name": "OrderFulfillment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "FULFILLMENT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "requiresShipping": {
+          "name": "requiresShipping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrderFulfillment_orderId_idx": {
+          "name": "OrderFulfillment_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrderFulfillment_status_idx": {
+          "name": "OrderFulfillment_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrderFulfillment_orderId_Order_id_fk": {
+          "name": "OrderFulfillment_orderId_Order_id_fk",
+          "tableFrom": "OrderFulfillment",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrderLineItem": {
+      "name": "OrderLineItem",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productId": {
+          "name": "productId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variantId": {
+          "name": "variantId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalTotal": {
+          "name": "originalTotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "originalUnitPrice": {
+          "name": "originalUnitPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrderLineItem_orderId_idx": {
+          "name": "OrderLineItem_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrderLineItem_orderId_Order_id_fk": {
+          "name": "OrderLineItem_orderId_Order_id_fk",
+          "tableFrom": "OrderLineItem",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrderRefund": {
+      "name": "OrderRefund",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalRefundedAmount": {
+          "name": "totalRefundedAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currencyCode": {
+          "name": "currencyCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrderRefund_orderId_idx": {
+          "name": "OrderRefund_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrderRefund_orderId_Order_id_fk": {
+          "name": "OrderRefund_orderId_Order_id_fk",
+          "tableFrom": "OrderRefund",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrderReturn": {
+      "name": "OrderReturn",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "RETURN_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrderReturn_orderId_idx": {
+          "name": "OrderReturn_orderId_idx",
+          "columns": [
+            {
+              "expression": "orderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrderReturn_orderId_Order_id_fk": {
+          "name": "OrderReturn_orderId_Order_id_fk",
+          "tableFrom": "OrderReturn",
+          "tableTo": "Order",
+          "columnsFrom": ["orderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domains": {
+          "name": "domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "OrganizationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'TEAM'"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "systemUserId": {
+          "name": "systemUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledReason": {
+          "name": "disabledReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledBy": {
+          "name": "disabledBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedOnboarding": {
+          "name": "completedOnboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "demo_expires_at": {
+          "name": "demo_expires_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Organization_handle_idx": {
+          "name": "Organization_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_handle_key": {
+          "name": "Organization_handle_key",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_systemUserId_key": {
+          "name": "Organization_systemUserId_key",
+          "columns": [
+            {
+              "expression": "systemUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Organization_createdById_User_id_fk": {
+          "name": "Organization_createdById_User_id_fk",
+          "tableFrom": "Organization",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "Organization_systemUserId_User_id_fk": {
+          "name": "Organization_systemUserId_User_id_fk",
+          "tableFrom": "Organization",
+          "tableTo": "User",
+          "columnsFrom": ["systemUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationAiQuota": {
+      "name": "OrganizationAiQuota",
+      "schema": "",
+      "columns": {
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quotaType": {
+          "name": "quotaType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quotaLimit": {
+          "name": "quotaLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quotaUsed": {
+          "name": "quotaUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "quotaPeriodStart": {
+          "name": "quotaPeriodStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "quotaPeriodEnd": {
+          "name": "quotaPeriodEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "OrganizationAiQuota_organizationId_Organization_id_fk": {
+          "name": "OrganizationAiQuota_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationAiQuota",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationInvitation": {
+      "name": "OrganizationInvitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "OrganizationRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "InvitationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitedById": {
+          "name": "invitedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptedById": {
+          "name": "acceptedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "OrganizationInvitation_email_idx": {
+          "name": "OrganizationInvitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationInvitation_organizationId_idx": {
+          "name": "OrganizationInvitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationInvitation_status_idx": {
+          "name": "OrganizationInvitation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationInvitation_token_key": {
+          "name": "OrganizationInvitation_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationInvitation_organizationId_Organization_id_fk": {
+          "name": "OrganizationInvitation_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationInvitation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationInvitation_invitedById_User_id_fk": {
+          "name": "OrganizationInvitation_invitedById_User_id_fk",
+          "tableFrom": "OrganizationInvitation",
+          "tableTo": "User",
+          "columnsFrom": ["invitedById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationInvitation_acceptedById_User_id_fk": {
+          "name": "OrganizationInvitation_acceptedById_User_id_fk",
+          "tableFrom": "OrganizationInvitation",
+          "tableTo": "User",
+          "columnsFrom": ["acceptedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationMember": {
+      "name": "OrganizationMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "OrganizationMemberStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "role": {
+          "name": "role",
+          "type": "OrganizationRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        }
+      },
+      "indexes": {
+        "OrganizationMember_organizationId_idx": {
+          "name": "OrganizationMember_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_userId_idx": {
+          "name": "OrganizationMember_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_userId_organizationId_key": {
+          "name": "OrganizationMember_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationMember_userId_User_id_fk": {
+          "name": "OrganizationMember_userId_User_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationMember_organizationId_Organization_id_fk": {
+          "name": "OrganizationMember_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationSetting": {
+      "name": "OrganizationSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowUserOverride": {
+          "name": "allowUserOverride",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "SettingScope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GENERAL'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrganizationSetting_key_idx": {
+          "name": "OrganizationSetting_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationSetting_organizationId_idx": {
+          "name": "OrganizationSetting_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationSetting_organizationId_key_key": {
+          "name": "OrganizationSetting_organizationId_key_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationSetting_scope_idx": {
+          "name": "OrganizationSetting_scope_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationSetting_organizationId_Organization_id_fk": {
+          "name": "OrganizationSetting_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationSetting",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Participant": {
+      "name": "Participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifierType": {
+          "name": "identifierType",
+          "type": "IdentifierType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isSpammer": {
+          "name": "isSpammer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isInternal": {
+          "name": "isInternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstInteractionDate": {
+          "name": "firstInteractionDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstInteractionType": {
+          "name": "firstInteractionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasReceivedMessage": {
+          "name": "hasReceivedMessage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSentMessageAt": {
+          "name": "lastSentMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Participant_entityInstanceId_idx": {
+          "name": "Participant_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_identifierType_idx": {
+          "name": "Participant_identifierType_idx",
+          "columns": [
+            {
+              "expression": "identifierType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_identifier_idx": {
+          "name": "Participant_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_organizationId_identifier_identifierType_key": {
+          "name": "Participant_organizationId_identifier_identifierType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifierType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_organizationId_idx": {
+          "name": "Participant_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Participant_entityInstanceId_EntityInstance_id_fk": {
+          "name": "Participant_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "Participant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Participant_organizationId_Organization_id_fk": {
+          "name": "Participant_organizationId_Organization_id_fk",
+          "tableFrom": "Participant",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Passkey": {
+      "name": "Passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Passkey_userId_User_id_fk": {
+          "name": "Passkey_userId_User_id_fk",
+          "tableFrom": "Passkey",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PasswordResetToken": {
+      "name": "PasswordResetToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "PasswordResetToken_token_key": {
+          "name": "PasswordResetToken_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PasswordResetToken_userId_idx": {
+          "name": "PasswordResetToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PasswordResetToken_userId_User_id_fk": {
+          "name": "PasswordResetToken_userId_User_id_fk",
+          "tableFrom": "PasswordResetToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Plan": {
+      "name": "Plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "monthlyPrice": {
+          "name": "monthlyPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annualPrice": {
+          "name": "annualPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isCustomPricing": {
+          "name": "isCustomPricing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trialDays": {
+          "name": "trialDays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "hasTrial": {
+          "name": "hasTrial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "minSeats": {
+          "name": "minSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "maxSeats": {
+          "name": "maxSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "isLegacy": {
+          "name": "isLegacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selfServed": {
+          "name": "selfServed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isMostPopular": {
+          "name": "isMostPopular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isFree": {
+          "name": "isFree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featureLimits": {
+          "name": "featureLimits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "trialFeatureLimits": {
+          "name": "trialFeatureLimits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeProductId": {
+          "name": "stripeProductId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripePriceIdMonthly": {
+          "name": "stripePriceIdMonthly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripePriceIdAnnual": {
+          "name": "stripePriceIdAnnual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchyLevel": {
+          "name": "hierarchyLevel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PlanSubscription": {
+      "name": "PlanSubscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planId": {
+          "name": "planId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incomplete'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "billingCycle": {
+          "name": "billingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MONTHLY'"
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "creditsBalance": {
+          "name": "creditsBalance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "trialStart": {
+          "name": "trialStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trialEnd": {
+          "name": "trialEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasTrialEnded": {
+          "name": "hasTrialEnded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trialConversionStatus": {
+          "name": "trialConversionStatus",
+          "type": "TrialConversionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEligibleForTrial": {
+          "name": "isEligibleForTrial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trialEligibilityReason": {
+          "name": "trialEligibilityReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPlanId": {
+          "name": "scheduledPlanId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPlan": {
+          "name": "scheduledPlan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledBillingCycle": {
+          "name": "scheduledBillingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledSeats": {
+          "name": "scheduledSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledChangeAt": {
+          "name": "scheduledChangeAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeletionNotificationSent": {
+          "name": "lastDeletionNotificationSent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeletionNotificationDate": {
+          "name": "lastDeletionNotificationDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletionScheduledDate": {
+          "name": "deletionScheduledDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletionReason": {
+          "name": "deletionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customFeatureLimits": {
+          "name": "customFeatureLimits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customPricingMonthly": {
+          "name": "customPricingMonthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customPricingAnnual": {
+          "name": "customPricingAnnual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customPricingNotes": {
+          "name": "customPricingNotes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "PlanSubscription_organizationId_key": {
+          "name": "PlanSubscription_organizationId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PlanSubscription_organizationId_Organization_id_fk": {
+          "name": "PlanSubscription_organizationId_Organization_id_fk",
+          "tableFrom": "PlanSubscription",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PlanSubscription_planId_Plan_id_fk": {
+          "name": "PlanSubscription_planId_Plan_id_fk",
+          "tableFrom": "PlanSubscription",
+          "tableTo": "Plan",
+          "columnsFrom": ["planId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PlanSubscription_scheduledPlanId_Plan_id_fk": {
+          "name": "PlanSubscription_scheduledPlanId_Plan_id_fk",
+          "tableFrom": "PlanSubscription",
+          "tableTo": "Plan",
+          "columnsFrom": ["scheduledPlanId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PlanSubscriptionHistory": {
+      "name": "PlanSubscriptionHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changeType": {
+          "name": "changeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromPlan": {
+          "name": "fromPlan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toPlan": {
+          "name": "toPlan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromBillingCycle": {
+          "name": "fromBillingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toBillingCycle": {
+          "name": "toBillingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromSeats": {
+          "name": "fromSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toSeats": {
+          "name": "toSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immediate": {
+          "name": "immediate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledFor": {
+          "name": "scheduledFor",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appliedAt": {
+          "name": "appliedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prorationAmount": {
+          "name": "prorationAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PollingTriggerState": {
+      "name": "PollingTriggerState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerId": {
+          "name": "triggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "lastPollAt": {
+          "name": "lastPollAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPollStatus": {
+          "name": "lastPollStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPollError": {
+          "name": "lastPollError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutiveErrors": {
+          "name": "consecutiveErrors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "PollingTriggerState_workflowAppId_triggerId_key": {
+          "name": "PollingTriggerState_workflowAppId_triggerId_key",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PollingTriggerState_organizationId_idx": {
+          "name": "PollingTriggerState_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PollingTriggerState_organizationId_Organization_id_fk": {
+          "name": "PollingTriggerState_organizationId_Organization_id_fk",
+          "tableFrom": "PollingTriggerState",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PollingTriggerState_workflowAppId_WorkflowApp_id_fk": {
+          "name": "PollingTriggerState_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "PollingTriggerState",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Product": {
+      "name": "Product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descriptionHtml": {
+          "name": "descriptionHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasOnlyDefaultVariant": {
+          "name": "hasOnlyDefaultVariant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productType": {
+          "name": "productType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "PRODUDT_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracksInventory": {
+          "name": "tracksInventory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalInventory": {
+          "name": "totalInventory",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Product_handle_key": {
+          "name": "Product_handle_key",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Product_integrationId_ShopifyIntegration_id_fk": {
+          "name": "Product_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "Product",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Product_organizationId_Organization_id_fk": {
+          "name": "Product_organizationId_Organization_id_fk",
+          "tableFrom": "Product",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProductMedia": {
+      "name": "ProductMedia",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mediaContentType": {
+          "name": "mediaContentType",
+          "type": "MEDIA_CONTENT_TYPE",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IMAGE'"
+        },
+        "previewId": {
+          "name": "previewId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previewAlt": {
+          "name": "previewAlt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewHeight": {
+          "name": "previewHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewWidth": {
+          "name": "previewWidth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewUrl": {
+          "name": "previewUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variantIds": {
+          "name": "variantIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProductMedia_productId_idx": {
+          "name": "ProductMedia_productId_idx",
+          "columns": [
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProductMedia_productId_Product_id_fk": {
+          "name": "ProductMedia_productId_Product_id_fk",
+          "tableFrom": "ProductMedia",
+          "tableTo": "Product",
+          "columnsFrom": ["productId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProductOption": {
+      "name": "ProductOption",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "values": {
+          "name": "values",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProductOption_productId_idx": {
+          "name": "ProductOption_productId_idx",
+          "columns": [
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProductOption_productId_Product_id_fk": {
+          "name": "ProductOption_productId_Product_id_fk",
+          "tableFrom": "ProductOption",
+          "tableTo": "Product",
+          "columnsFrom": ["productId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProductVariant": {
+      "name": "ProductVariant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "availableForSale": {
+          "name": "availableForSale",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compareAtPrice": {
+          "name": "compareAtPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selectedOptions": {
+          "name": "selectedOptions",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageId": {
+          "name": "imageId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventoryItemId": {
+          "name": "inventoryItemId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventoryManagement": {
+          "name": "inventoryManagement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventoryPolicy": {
+          "name": "inventoryPolicy",
+          "type": "INVENTORY_POLICY",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CONTINUE'"
+        },
+        "inventoryQuantity": {
+          "name": "inventoryQuantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weightUnit": {
+          "name": "weightUnit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProductVariant_productId_idx": {
+          "name": "ProductVariant_productId_idx",
+          "columns": [
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProductVariant_productId_Product_id_fk": {
+          "name": "ProductVariant_productId_Product_id_fk",
+          "tableFrom": "ProductVariant",
+          "tableTo": "Product",
+          "columnsFrom": ["productId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ProductVariant_organizationId_Organization_id_fk": {
+          "name": "ProductVariant_organizationId_Organization_id_fk",
+          "tableFrom": "ProductVariant",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ProductVariant_integrationId_ShopifyIntegration_id_fk": {
+          "name": "ProductVariant_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "ProductVariant",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PromptHistory": {
+      "name": "PromptHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "PromptHistory_userId_User_id_fk": {
+          "name": "PromptHistory_userId_User_id_fk",
+          "tableFrom": "PromptHistory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PromptTemplate": {
+      "name": "PromptTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "PromptTemplate_organizationId_idx": {
+          "name": "PromptTemplate_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PromptTemplate_categories_idx": {
+          "name": "PromptTemplate_categories_idx",
+          "columns": [
+            {
+              "expression": "categories",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PromptTemplate_organizationId_Organization_id_fk": {
+          "name": "PromptTemplate_organizationId_Organization_id_fk",
+          "tableFrom": "PromptTemplate",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PromptTemplate_createdById_User_id_fk": {
+          "name": "PromptTemplate_createdById_User_id_fk",
+          "tableFrom": "PromptTemplate",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProviderConfiguration": {
+      "name": "ProviderConfiguration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "quotaType": {
+          "name": "quotaType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaLimit": {
+          "name": "quotaLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-1'"
+        },
+        "quotaPeriodEnd": {
+          "name": "quotaPeriodEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaPeriodStart": {
+          "name": "quotaPeriodStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaUsed": {
+          "name": "quotaUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ProviderConfiguration_organizationId_provider_idx": {
+          "name": "ProviderConfiguration_organizationId_provider_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ProviderConfiguration_org_provider_type_key": {
+          "name": "ProviderConfiguration_org_provider_type_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProviderConfiguration_organizationId_Organization_id_fk": {
+          "name": "ProviderConfiguration_organizationId_Organization_id_fk",
+          "tableFrom": "ProviderConfiguration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProviderPreference": {
+      "name": "ProviderPreference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferredType": {
+          "name": "preferredType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProviderPreference_organizationId_provider_idx": {
+          "name": "ProviderPreference_organizationId_provider_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ProviderPreference_organizationId_provider_key": {
+          "name": "ProviderPreference_organizationId_provider_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProviderPreference_organizationId_Organization_id_fk": {
+          "name": "ProviderPreference_organizationId_Organization_id_fk",
+          "tableFrom": "ProviderPreference",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecordingChapter": {
+      "name": "RecordingChapter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startMs": {
+          "name": "startMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endMs": {
+          "name": "endMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "RecordingChapter_callRecordingId_sortOrder_idx": {
+          "name": "RecordingChapter_callRecordingId_sortOrder_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortOrder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecordingChapter_organizationId_Organization_id_fk": {
+          "name": "RecordingChapter_organizationId_Organization_id_fk",
+          "tableFrom": "RecordingChapter",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingChapter_callRecordingId_CallRecording_id_fk": {
+          "name": "RecordingChapter_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "RecordingChapter",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecordingInsight": {
+      "name": "RecordingInsight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "insightTemplateId": {
+          "name": "insightTemplateId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "InsightStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "RecordingInsight_callRecordingId_idx": {
+          "name": "RecordingInsight_callRecordingId_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordingInsight_insightTemplateId_idx": {
+          "name": "RecordingInsight_insightTemplateId_idx",
+          "columns": [
+            {
+              "expression": "insightTemplateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordingInsight_organizationId_idx": {
+          "name": "RecordingInsight_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecordingInsight_organizationId_Organization_id_fk": {
+          "name": "RecordingInsight_organizationId_Organization_id_fk",
+          "tableFrom": "RecordingInsight",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingInsight_callRecordingId_CallRecording_id_fk": {
+          "name": "RecordingInsight_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "RecordingInsight",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingInsight_insightTemplateId_InsightTemplate_id_fk": {
+          "name": "RecordingInsight_insightTemplateId_InsightTemplate_id_fk",
+          "tableFrom": "RecordingInsight",
+          "tableTo": "InsightTemplate",
+          "columnsFrom": ["insightTemplateId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecordingShareLink": {
+      "name": "RecordingShareLink",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeVideo": {
+          "name": "includeVideo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeTranscript": {
+          "name": "includeTranscript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeInsights": {
+          "name": "includeInsights",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "RecordingShareLink_publicId_key": {
+          "name": "RecordingShareLink_publicId_key",
+          "columns": [
+            {
+              "expression": "publicId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordingShareLink_callRecordingId_idx": {
+          "name": "RecordingShareLink_callRecordingId_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecordingShareLink_organizationId_Organization_id_fk": {
+          "name": "RecordingShareLink_organizationId_Organization_id_fk",
+          "tableFrom": "RecordingShareLink",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingShareLink_callRecordingId_CallRecording_id_fk": {
+          "name": "RecordingShareLink_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "RecordingShareLink",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingShareLink_createdById_User_id_fk": {
+          "name": "RecordingShareLink_createdById_User_id_fk",
+          "tableFrom": "RecordingShareLink",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ResourceAccess": {
+      "name": "ResourceAccess",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granteeType": {
+          "name": "granteeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granteeId": {
+          "name": "granteeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantedById": {
+          "name": "grantedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ResourceAccess_entity_grantee_key": {
+          "name": "ResourceAccess_entity_grantee_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granteeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granteeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_entityDef_idx": {
+          "name": "ResourceAccess_entityDef_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_instance_idx": {
+          "name": "ResourceAccess_instance_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_grantee_idx": {
+          "name": "ResourceAccess_grantee_idx",
+          "columns": [
+            {
+              "expression": "granteeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granteeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_org_idx": {
+          "name": "ResourceAccess_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ResourceAccess_organizationId_Organization_id_fk": {
+          "name": "ResourceAccess_organizationId_Organization_id_fk",
+          "tableFrom": "ResourceAccess",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ResourceAccess_grantedById_User_id_fk": {
+          "name": "ResourceAccess_grantedById_User_id_fk",
+          "tableFrom": "ResourceAccess",
+          "tableTo": "User",
+          "columnsFrom": ["grantedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ScheduledMessage": {
+      "name": "ScheduledMessage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draftId": {
+          "name": "draftId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledAt": {
+          "name": "scheduledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ScheduledMessageStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "jobId": {
+          "name": "jobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sendPayload": {
+          "name": "sendPayload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "ScheduledMessageSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER_SCHEDULED'"
+        },
+        "approvedById": {
+          "name": "approvedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledById": {
+          "name": "cancelledById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiSuggestionId": {
+          "name": "aiSuggestionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ScheduledMessage_orgId_status_scheduledAt_idx": {
+          "name": "ScheduledMessage_orgId_status_scheduledAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduledAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ScheduledMessage_draftId_idx": {
+          "name": "ScheduledMessage_draftId_idx",
+          "columns": [
+            {
+              "expression": "draftId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ScheduledMessage_orgId_source_approvedById_status_idx": {
+          "name": "ScheduledMessage_orgId_source_approvedById_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "approvedById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ScheduledMessage_organizationId_Organization_id_fk": {
+          "name": "ScheduledMessage_organizationId_Organization_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_draftId_Draft_id_fk": {
+          "name": "ScheduledMessage_draftId_Draft_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "Draft",
+          "columnsFrom": ["draftId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_integrationId_Integration_id_fk": {
+          "name": "ScheduledMessage_integrationId_Integration_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_threadId_Thread_id_fk": {
+          "name": "ScheduledMessage_threadId_Thread_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_createdById_User_id_fk": {
+          "name": "ScheduledMessage_createdById_User_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_approvedById_User_id_fk": {
+          "name": "ScheduledMessage_approvedById_User_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "User",
+          "columnsFrom": ["approvedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_cancelledById_User_id_fk": {
+          "name": "ScheduledMessage_cancelledById_User_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "User",
+          "columnsFrom": ["cancelledById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_aiSuggestionId_AiSuggestion_id_fk": {
+          "name": "ScheduledMessage_aiSuggestionId_AiSuggestion_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "AiSuggestion",
+          "columnsFrom": ["aiSuggestionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SearchHistory": {
+      "name": "SearchHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "searchedAt": {
+          "name": "searchedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SearchHistory_userId_organizationId_searchedAt_idx": {
+          "name": "SearchHistory_userId_organizationId_searchedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "searchedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SearchHistory_userId_User_id_fk": {
+          "name": "SearchHistory_userId_User_id_fk",
+          "tableFrom": "SearchHistory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SearchHistory_organizationId_Organization_id_fk": {
+          "name": "SearchHistory_organizationId_Organization_id_fk",
+          "tableFrom": "SearchHistory",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonatedBy": {
+          "name": "impersonatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_User_id_fk": {
+          "name": "session_userId_User_id_fk",
+          "tableFrom": "session",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ShopifyAuthState": {
+      "name": "ShopifyAuthState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shopDomain": {
+          "name": "shopDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ShopifyAuthState_state_idx": {
+          "name": "ShopifyAuthState_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ShopifyAuthState_userId_idx": {
+          "name": "ShopifyAuthState_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ShopifyAuthState_userId_User_id_fk": {
+          "name": "ShopifyAuthState_userId_User_id_fk",
+          "tableFrom": "ShopifyAuthState",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ShopifyAuthState_organizationId_Organization_id_fk": {
+          "name": "ShopifyAuthState_organizationId_Organization_id_fk",
+          "tableFrom": "ShopifyAuthState",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopify_customers": {
+      "name": "shopify_customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "numberOfOrders": {
+          "name": "numberOfOrders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amountSpent": {
+          "name": "amountSpent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifiedEmail": {
+          "name": "verifiedEmail",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multipassIdentifier": {
+          "name": "multipassIdentifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taxExempt": {
+          "name": "taxExempt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defaultAddressId": {
+          "name": "defaultAddressId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastOrderId": {
+          "name": "lastOrderId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastOrderName": {
+          "name": "lastOrderName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shopify_customers_entityInstanceId_idx": {
+          "name": "shopify_customers_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopify_customers_defaultAddressId_key": {
+          "name": "shopify_customers_defaultAddressId_key",
+          "columns": [
+            {
+              "expression": "defaultAddressId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopify_customers_email_idx": {
+          "name": "shopify_customers_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopify_customers_lastOrderId_key": {
+          "name": "shopify_customers_lastOrderId_key",
+          "columns": [
+            {
+              "expression": "lastOrderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopify_customers_phone_idx": {
+          "name": "shopify_customers_phone_idx",
+          "columns": [
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopify_customers_defaultAddressId_Address_id_fk": {
+          "name": "shopify_customers_defaultAddressId_Address_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "Address",
+          "columnsFrom": ["defaultAddressId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "shopify_customers_lastOrderId_Order_id_fk": {
+          "name": "shopify_customers_lastOrderId_Order_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "Order",
+          "columnsFrom": ["lastOrderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "shopify_customers_organizationId_Organization_id_fk": {
+          "name": "shopify_customers_organizationId_Organization_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "shopify_customers_integrationId_ShopifyIntegration_id_fk": {
+          "name": "shopify_customers_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "shopify_customers_entityInstanceId_EntityInstance_id_fk": {
+          "name": "shopify_customers_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "shopify_customers",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ShopifyIntegration": {
+      "name": "ShopifyIntegration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shopDomain": {
+          "name": "shopDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ShopifyIntegration_organizationId_idx": {
+          "name": "ShopifyIntegration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ShopifyIntegration_organizationId_shopDomain_key": {
+          "name": "ShopifyIntegration_organizationId_shopDomain_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shopDomain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ShopifyIntegration_shopDomain_idx": {
+          "name": "ShopifyIntegration_shopDomain_idx",
+          "columns": [
+            {
+              "expression": "shopDomain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ShopifyIntegration_organizationId_Organization_id_fk": {
+          "name": "ShopifyIntegration_organizationId_Organization_id_fk",
+          "tableFrom": "ShopifyIntegration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ShopifyIntegration_createdById_User_id_fk": {
+          "name": "ShopifyIntegration_createdById_User_id_fk",
+          "tableFrom": "ShopifyIntegration",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SignatureIntegrationShare": {
+      "name": "SignatureIntegrationShare",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SignatureIntegrationShare_integrationId_idx": {
+          "name": "SignatureIntegrationShare_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SignatureIntegrationShare_entityInstanceId_idx": {
+          "name": "SignatureIntegrationShare_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SignatureIntegrationShare_entityInstanceId_integrationId_key": {
+          "name": "SignatureIntegrationShare_entityInstanceId_integrationId_key",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SignatureIntegrationShare_entityInstanceId_EntityInstance_id_fk": {
+          "name": "SignatureIntegrationShare_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "SignatureIntegrationShare",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SignatureIntegrationShare_integrationId_Integration_id_fk": {
+          "name": "SignatureIntegrationShare_integrationId_Integration_id_fk",
+          "tableFrom": "SignatureIntegrationShare",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Snippet": {
+      "name": "Snippet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHtml": {
+          "name": "contentHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDeleted": {
+          "name": "isDeleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharingType": {
+          "name": "sharingType",
+          "type": "SnippetSharingType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "isFavorite": {
+          "name": "isFavorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usageCount": {
+          "name": "usageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "Snippet_createdById_idx": {
+          "name": "Snippet_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Snippet_folderId_idx": {
+          "name": "Snippet_folderId_idx",
+          "columns": [
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Snippet_organizationId_idx": {
+          "name": "Snippet_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Snippet_sharingType_idx": {
+          "name": "Snippet_sharingType_idx",
+          "columns": [
+            {
+              "expression": "sharingType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Snippet_folderId_SnippetFolder_id_fk": {
+          "name": "Snippet_folderId_SnippetFolder_id_fk",
+          "tableFrom": "Snippet",
+          "tableTo": "SnippetFolder",
+          "columnsFrom": ["folderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Snippet_organizationId_Organization_id_fk": {
+          "name": "Snippet_organizationId_Organization_id_fk",
+          "tableFrom": "Snippet",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Snippet_createdById_User_id_fk": {
+          "name": "Snippet_createdById_User_id_fk",
+          "tableFrom": "Snippet",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SnippetFolder": {
+      "name": "SnippetFolder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "SnippetFolder_createdById_idx": {
+          "name": "SnippetFolder_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SnippetFolder_organizationId_idx": {
+          "name": "SnippetFolder_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SnippetFolder_organizationId_parentId_name_key": {
+          "name": "SnippetFolder_organizationId_parentId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SnippetFolder_parentId_SnippetFolder_id_fk": {
+          "name": "SnippetFolder_parentId_SnippetFolder_id_fk",
+          "tableFrom": "SnippetFolder",
+          "tableTo": "SnippetFolder",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "SnippetFolder_organizationId_Organization_id_fk": {
+          "name": "SnippetFolder_organizationId_Organization_id_fk",
+          "tableFrom": "SnippetFolder",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SnippetFolder_createdById_User_id_fk": {
+          "name": "SnippetFolder_createdById_User_id_fk",
+          "tableFrom": "SnippetFolder",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.StorageLocation": {
+      "name": "StorageLocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "StorageProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalUrl": {
+          "name": "externalUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalRev": {
+          "name": "externalRev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "StorageLocation_credentialId_idx": {
+          "name": "StorageLocation_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credentialId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StorageLocation_provider_externalId_idx": {
+          "name": "StorageLocation_provider_externalId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StorageLocation_organizationId_idx": {
+          "name": "StorageLocation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StorageLocation_deletedAt_idx": {
+          "name": "StorageLocation_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"StorageLocation\".\"deletedAt\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "StorageLocation_organizationId_Organization_id_fk": {
+          "name": "StorageLocation_organizationId_Organization_id_fk",
+          "tableFrom": "StorageLocation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "StorageLocation_credentialId_WorkflowCredentials_id_fk": {
+          "name": "StorageLocation_credentialId_WorkflowCredentials_id_fk",
+          "tableFrom": "StorageLocation",
+          "tableTo": "WorkflowCredentials",
+          "columnsFrom": ["credentialId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Subscription": {
+      "name": "Subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Subscription_provider_integrationId_topic_key": {
+          "name": "Subscription_provider_integrationId_topic_key",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Subscription_organizationId_Organization_id_fk": {
+          "name": "Subscription_organizationId_Organization_id_fk",
+          "tableFrom": "Subscription",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Subscription_integrationId_ShopifyIntegration_id_fk": {
+          "name": "Subscription_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "Subscription",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SuggestionDismissal": {
+      "name": "SuggestionDismissal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissedAtActivity": {
+          "name": "dismissedAtActivity",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snoozeUntil": {
+          "name": "snoozeUntil",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SuggestionDismissal_org_user_entity_key": {
+          "name": "SuggestionDismissal_org_user_entity_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SuggestionDismissal_org_user_idx": {
+          "name": "SuggestionDismissal_org_user_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SuggestionDismissal_organizationId_Organization_id_fk": {
+          "name": "SuggestionDismissal_organizationId_Organization_id_fk",
+          "tableFrom": "SuggestionDismissal",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SuggestionDismissal_userId_User_id_fk": {
+          "name": "SuggestionDismissal_userId_User_id_fk",
+          "tableFrom": "SuggestionDismissal",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SuggestionDismissal_entityInstanceId_EntityInstance_id_fk": {
+          "name": "SuggestionDismissal_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "SuggestionDismissal",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SyncJob": {
+      "name": "SyncJob",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "SYNC_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalRecords": {
+          "name": "totalRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processedRecords": {
+          "name": "processedRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failedRecords": {
+          "name": "failedRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "integrationCategory": {
+          "name": "integrationCategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'message'"
+        },
+        "integrationSyncJobIds": {
+          "name": "integrationSyncJobIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"RAY\"}'"
+        }
+      },
+      "indexes": {
+        "SyncJob_organizationId_integrationCategory_integrationId_idx": {
+          "name": "SyncJob_organizationId_integrationCategory_integrationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationCategory",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SyncJob_organizationId_integrationCategory_status_idx": {
+          "name": "SyncJob_organizationId_integrationCategory_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationCategory",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SyncJob_organizationId_type_status_idx": {
+          "name": "SyncJob_organizationId_type_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SyncJob_organizationId_Organization_id_fk": {
+          "name": "SyncJob_organizationId_Organization_id_fk",
+          "tableFrom": "SyncJob",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SystemModelDefault": {
+      "name": "SystemModelDefault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "SystemModelDefault_organizationId_modelType_key": {
+          "name": "SystemModelDefault_organizationId_modelType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SystemModelDefault_organizationId_idx": {
+          "name": "SystemModelDefault_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SystemModelDefault_organizationId_Organization_id_fk": {
+          "name": "SystemModelDefault_organizationId_Organization_id_fk",
+          "tableFrom": "SystemModelDefault",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TableView": {
+      "name": "TableView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tableId": {
+          "name": "tableId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextType": {
+          "name": "contextType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'table'"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TableView_tableId_organizationId_idx": {
+          "name": "TableView_tableId_organizationId_idx",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TableView_tableId_organizationId_contextType_isDefault_key": {
+          "name": "TableView_tableId_organizationId_contextType_isDefault_key",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"TableView\".\"isDefault\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TableView_tableId_userId_idx": {
+          "name": "TableView_tableId_userId_idx",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TableView_tableId_userId_name_contextType_key": {
+          "name": "TableView_tableId_userId_name_contextType_key",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TableView_userId_User_id_fk": {
+          "name": "TableView_userId_User_id_fk",
+          "tableFrom": "TableView",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TableView_organizationId_Organization_id_fk": {
+          "name": "TableView_organizationId_Organization_id_fk",
+          "tableFrom": "TableView",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Tag": {
+      "name": "Tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isSystemTag": {
+          "name": "isSystemTag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Tag_organizationId_idx": {
+          "name": "Tag_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Tag_parentId_idx": {
+          "name": "Tag_parentId_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Tag_title_organizationId_parentId_key": {
+          "name": "Tag_title_organizationId_parentId_key",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Tag_parentId_Tag_id_fk": {
+          "name": "Tag_parentId_Tag_id_fk",
+          "tableFrom": "Tag",
+          "tableTo": "Tag",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Tag_organizationId_Organization_id_fk": {
+          "name": "Tag_organizationId_Organization_id_fk",
+          "tableFrom": "Tag",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Task": {
+      "name": "Task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedById": {
+          "name": "completedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firedAt": {
+          "name": "firedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchText": {
+          "name": "searchText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedUserCount": {
+          "name": "assignedUserCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "referenceCount": {
+          "name": "referenceCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Task_organizationId_idx": {
+          "name": "Task_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_archivedAt_deadline_idx": {
+          "name": "Task_organizationId_archivedAt_deadline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_createdById_idx": {
+          "name": "Task_organizationId_createdById_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_deadline_idx": {
+          "name": "Task_organizationId_deadline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_createdAt_idx": {
+          "name": "Task_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_completedAt_idx": {
+          "name": "Task_organizationId_completedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_firedAt_deadline_idx": {
+          "name": "Task_organizationId_firedAt_deadline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"completedAt\" IS NULL AND \"archivedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Task_organizationId_Organization_id_fk": {
+          "name": "Task_organizationId_Organization_id_fk",
+          "tableFrom": "Task",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Task_createdById_User_id_fk": {
+          "name": "Task_createdById_User_id_fk",
+          "tableFrom": "Task",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Task_completedById_User_id_fk": {
+          "name": "Task_completedById_User_id_fk",
+          "tableFrom": "Task",
+          "tableTo": "User",
+          "columnsFrom": ["completedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TaskAssignment": {
+      "name": "TaskAssignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedToUserId": {
+          "name": "assignedToUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedAt": {
+          "name": "assignedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "assignedById": {
+          "name": "assignedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unassignedAt": {
+          "name": "unassignedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TaskAssignment_organizationId_idx": {
+          "name": "TaskAssignment_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_taskId_idx": {
+          "name": "TaskAssignment_taskId_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_assignedToUserId_idx": {
+          "name": "TaskAssignment_assignedToUserId_idx",
+          "columns": [
+            {
+              "expression": "assignedToUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_organizationId_assignedToUserId_unassignedAt_idx": {
+          "name": "TaskAssignment_organizationId_assignedToUserId_unassignedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedToUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "unassignedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_taskId_assignedAt_idx": {
+          "name": "TaskAssignment_taskId_assignedAt_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_unassignedAt_idx": {
+          "name": "TaskAssignment_unassignedAt_idx",
+          "columns": [
+            {
+              "expression": "unassignedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_taskId_assignedToUserId_key": {
+          "name": "TaskAssignment_taskId_assignedToUserId_key",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedToUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TaskAssignment_organizationId_Organization_id_fk": {
+          "name": "TaskAssignment_organizationId_Organization_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskAssignment_taskId_Task_id_fk": {
+          "name": "TaskAssignment_taskId_Task_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "Task",
+          "columnsFrom": ["taskId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskAssignment_assignedToUserId_User_id_fk": {
+          "name": "TaskAssignment_assignedToUserId_User_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "User",
+          "columnsFrom": ["assignedToUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskAssignment_assignedById_User_id_fk": {
+          "name": "TaskAssignment_assignedById_User_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "User",
+          "columnsFrom": ["assignedById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TaskReference": {
+      "name": "TaskReference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referencedEntityInstanceId": {
+          "name": "referencedEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referencedEntityDefinitionId": {
+          "name": "referencedEntityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TaskReference_organizationId_idx": {
+          "name": "TaskReference_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_taskId_idx": {
+          "name": "TaskReference_taskId_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_referencedEntityInstanceId_idx": {
+          "name": "TaskReference_referencedEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "referencedEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_referencedEntityDefinitionId_idx": {
+          "name": "TaskReference_referencedEntityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "referencedEntityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_organizationId_referencedEntityInstanceId_deletedAt_idx": {
+          "name": "TaskReference_organizationId_referencedEntityInstanceId_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referencedEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_deletedAt_idx": {
+          "name": "TaskReference_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_taskId_referencedEntityInstanceId_key": {
+          "name": "TaskReference_taskId_referencedEntityInstanceId_key",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referencedEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TaskReference_organizationId_Organization_id_fk": {
+          "name": "TaskReference_organizationId_Organization_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_taskId_Task_id_fk": {
+          "name": "TaskReference_taskId_Task_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "Task",
+          "columnsFrom": ["taskId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_referencedEntityInstanceId_EntityInstance_id_fk": {
+          "name": "TaskReference_referencedEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["referencedEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_referencedEntityDefinitionId_EntityDefinition_id_fk": {
+          "name": "TaskReference_referencedEntityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["referencedEntityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_createdById_User_id_fk": {
+          "name": "TaskReference_createdById_User_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Thread": {
+      "name": "Thread",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ThreadStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "messageCount": {
+          "name": "messageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participantCount": {
+          "name": "participantCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "firstMessageAt": {
+          "name": "firstMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latestMessageId": {
+          "name": "latestMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latestCommentId": {
+          "name": "latestCommentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inboxId": {
+          "name": "inboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryEntityInstanceId": {
+          "name": "primaryEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryEntityDefinitionId": {
+          "name": "primaryEntityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repliedAt": {
+          "name": "repliedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitingSince": {
+          "name": "waitingSince",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Thread_integrationId_externalId_key": {
+          "name": "Thread_integrationId_externalId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_integrationId_idx": {
+          "name": "Thread_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_lastMessageAt_idx": {
+          "name": "Thread_lastMessageAt_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_assigneeId_status_idx": {
+          "name": "Thread_organizationId_assigneeId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigneeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_createdAt_idx": {
+          "name": "Thread_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_idx": {
+          "name": "Thread_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_status_idx": {
+          "name": "Thread_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_status_idx": {
+          "name": "Thread_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_pagination_idx": {
+          "name": "thread_pagination_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_inboxId_idx": {
+          "name": "Thread_inboxId_idx",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_primaryEntityInstanceId_idx": {
+          "name": "Thread_organizationId_primaryEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "primaryEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_primaryEntityDefinitionId_lastMessageAt_idx": {
+          "name": "Thread_organizationId_primaryEntityDefinitionId_lastMessageAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "primaryEntityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Thread_organizationId_Organization_id_fk": {
+          "name": "Thread_organizationId_Organization_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Thread_integrationId_Integration_id_fk": {
+          "name": "Thread_integrationId_Integration_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Thread_assigneeId_User_id_fk": {
+          "name": "Thread_assigneeId_User_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "User",
+          "columnsFrom": ["assigneeId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_latestMessageId_Message_id_fk": {
+          "name": "Thread_latestMessageId_Message_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Message",
+          "columnsFrom": ["latestMessageId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_latestCommentId_Comment_id_fk": {
+          "name": "Thread_latestCommentId_Comment_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Comment",
+          "columnsFrom": ["latestCommentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_inboxId_EntityInstance_id_fk": {
+          "name": "Thread_inboxId_EntityInstance_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["inboxId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_primaryEntityInstanceId_EntityInstance_id_fk": {
+          "name": "Thread_primaryEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["primaryEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_primaryEntityDefinitionId_EntityDefinition_id_fk": {
+          "name": "Thread_primaryEntityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["primaryEntityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ThreadEntityLink": {
+      "name": "ThreadEntityLink",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unlinkedAt": {
+          "name": "unlinkedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ThreadEntityLink_organizationId_idx": {
+          "name": "ThreadEntityLink_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_threadId_idx": {
+          "name": "ThreadEntityLink_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_entityInstanceId_idx": {
+          "name": "ThreadEntityLink_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_entityDefinitionId_idx": {
+          "name": "ThreadEntityLink_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_unlinkedAt_idx": {
+          "name": "ThreadEntityLink_unlinkedAt_idx",
+          "columns": [
+            {
+              "expression": "unlinkedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_threadId_entityInstanceId_active_key": {
+          "name": "ThreadEntityLink_threadId_entityInstanceId_active_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"unlinkedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ThreadEntityLink_organizationId_Organization_id_fk": {
+          "name": "ThreadEntityLink_organizationId_Organization_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadEntityLink_threadId_Thread_id_fk": {
+          "name": "ThreadEntityLink_threadId_Thread_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadEntityLink_entityInstanceId_EntityInstance_id_fk": {
+          "name": "ThreadEntityLink_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadEntityLink_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "ThreadEntityLink_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadEntityLink_createdById_User_id_fk": {
+          "name": "ThreadEntityLink_createdById_User_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ThreadParticipant": {
+      "name": "ThreadParticipant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isInternal": {
+          "name": "isInternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "messageCount": {
+          "name": "messageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "firstMessageAt": {
+          "name": "firstMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ThreadParticipant_threadId_email_key": {
+          "name": "ThreadParticipant_threadId_email_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ThreadParticipant_threadId_Thread_id_fk": {
+          "name": "ThreadParticipant_threadId_Thread_id_fk",
+          "tableFrom": "ThreadParticipant",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ThreadReadStatus": {
+      "name": "ThreadReadStatus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSeenMessageId": {
+          "name": "lastSeenMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ThreadReadStatus_isRead_idx": {
+          "name": "ThreadReadStatus_isRead_idx",
+          "columns": [
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_organizationId_idx": {
+          "name": "ThreadReadStatus_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_organizationId_userId_idx": {
+          "name": "ThreadReadStatus_organizationId_userId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_threadId_idx": {
+          "name": "ThreadReadStatus_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_threadId_userId_key": {
+          "name": "ThreadReadStatus_threadId_userId_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_userId_idx": {
+          "name": "ThreadReadStatus_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_userId_isRead_idx": {
+          "name": "ThreadReadStatus_userId_isRead_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ThreadReadStatus_threadId_Thread_id_fk": {
+          "name": "ThreadReadStatus_threadId_Thread_id_fk",
+          "tableFrom": "ThreadReadStatus",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadReadStatus_userId_User_id_fk": {
+          "name": "ThreadReadStatus_userId_User_id_fk",
+          "tableFrom": "ThreadReadStatus",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadReadStatus_organizationId_Organization_id_fk": {
+          "name": "ThreadReadStatus_organizationId_Organization_id_fk",
+          "tableFrom": "ThreadReadStatus",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TicketSequence": {
+      "name": "TicketSequence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentNumber": {
+          "name": "currentNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paddingLength": {
+          "name": "paddingLength",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4
+        },
+        "usePrefix": {
+          "name": "usePrefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "useDateInPrefix": {
+          "name": "useDateInPrefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dateFormat": {
+          "name": "dateFormat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'YYMM'"
+        },
+        "separator": {
+          "name": "separator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-'"
+        },
+        "suffix": {
+          "name": "suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "useSuffix": {
+          "name": "useSuffix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TicketSequence_organizationId_key": {
+          "name": "TicketSequence_organizationId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TicketSequence_organizationId_Organization_id_fk": {
+          "name": "TicketSequence_organizationId_Organization_id_fk",
+          "tableFrom": "TicketSequence",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TimelineEvent": {
+      "name": "TimelineEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relatedEntityType": {
+          "name": "relatedEntityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedEntityId": {
+          "name": "relatedEntityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorType": {
+          "name": "actorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventData": {
+          "name": "eventData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isGrouped": {
+          "name": "isGrouped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "groupedEventIds": {
+          "name": "groupedEventIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TimelineEvent_entity_idx": {
+          "name": "TimelineEvent_entity_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_actor_idx": {
+          "name": "TimelineEvent_actor_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actorType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_type_idx": {
+          "name": "TimelineEvent_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_related_entity_idx": {
+          "name": "TimelineEvent_related_entity_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_org_timeline_idx": {
+          "name": "TimelineEvent_org_timeline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TimelineEvent_organizationId_Organization_id_fk": {
+          "name": "TimelineEvent_organizationId_Organization_id_fk",
+          "tableFrom": "TimelineEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Transcript": {
+      "name": "Transcript",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcriptionProvider": {
+          "name": "transcriptionProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TranscriptType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "TranscriptStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "externalJobId": {
+          "name": "externalJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fullText": {
+          "name": "fullText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wordCount": {
+          "name": "wordCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Transcript_organizationId_idx": {
+          "name": "Transcript_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transcript_callRecordingId_idx": {
+          "name": "Transcript_callRecordingId_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transcript_status_idx": {
+          "name": "Transcript_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Transcript_organizationId_Organization_id_fk": {
+          "name": "Transcript_organizationId_Organization_id_fk",
+          "tableFrom": "Transcript",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Transcript_callRecordingId_CallRecording_id_fk": {
+          "name": "Transcript_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "Transcript",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TranscriptSpeaker": {
+      "name": "TranscriptSpeaker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcriptId": {
+          "name": "transcriptId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isHost": {
+          "name": "isHost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participantId": {
+          "name": "participantId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manualParticipantId": {
+          "name": "manualParticipantId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "TranscriptSpeaker_transcriptId_idx": {
+          "name": "TranscriptSpeaker_transcriptId_idx",
+          "columns": [
+            {
+              "expression": "transcriptId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TranscriptSpeaker_callRecordingId_idx": {
+          "name": "TranscriptSpeaker_callRecordingId_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TranscriptSpeaker_organizationId_Organization_id_fk": {
+          "name": "TranscriptSpeaker_organizationId_Organization_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptSpeaker_transcriptId_Transcript_id_fk": {
+          "name": "TranscriptSpeaker_transcriptId_Transcript_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "Transcript",
+          "columnsFrom": ["transcriptId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptSpeaker_callRecordingId_CallRecording_id_fk": {
+          "name": "TranscriptSpeaker_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptSpeaker_participantId_MeetingParticipant_id_fk": {
+          "name": "TranscriptSpeaker_participantId_MeetingParticipant_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "MeetingParticipant",
+          "columnsFrom": ["participantId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "TranscriptSpeaker_manualParticipantId_MeetingParticipant_id_fk": {
+          "name": "TranscriptSpeaker_manualParticipantId_MeetingParticipant_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "MeetingParticipant",
+          "columnsFrom": ["manualParticipantId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TranscriptUtterance": {
+      "name": "TranscriptUtterance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcriptId": {
+          "name": "transcriptId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speakerId": {
+          "name": "speakerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startMs": {
+          "name": "startMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endMs": {
+          "name": "endMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "words": {
+          "name": "words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "TranscriptUtterance_transcriptId_sortOrder_idx": {
+          "name": "TranscriptUtterance_transcriptId_sortOrder_idx",
+          "columns": [
+            {
+              "expression": "transcriptId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortOrder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TranscriptUtterance_speakerId_idx": {
+          "name": "TranscriptUtterance_speakerId_idx",
+          "columns": [
+            {
+              "expression": "speakerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TranscriptUtterance_organizationId_Organization_id_fk": {
+          "name": "TranscriptUtterance_organizationId_Organization_id_fk",
+          "tableFrom": "TranscriptUtterance",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptUtterance_transcriptId_Transcript_id_fk": {
+          "name": "TranscriptUtterance_transcriptId_Transcript_id_fk",
+          "tableFrom": "TranscriptUtterance",
+          "tableTo": "Transcript",
+          "columnsFrom": ["transcriptId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptUtterance_speakerId_TranscriptSpeaker_id_fk": {
+          "name": "TranscriptUtterance_speakerId_TranscriptSpeaker_id_fk",
+          "tableFrom": "TranscriptUtterance",
+          "tableTo": "TranscriptSpeaker",
+          "columnsFrom": ["speakerId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TwoFactor": {
+      "name": "TwoFactor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backupCodes": {
+          "name": "backupCodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TwoFactor_userId_key": {
+          "name": "TwoFactor_userId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TwoFactor_userId_User_id_fk": {
+          "name": "TwoFactor_userId_User_id_fk",
+          "tableFrom": "TwoFactor",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UploadSession": {
+      "name": "UploadSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "StorageProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S3'"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expectedSize": {
+          "name": "expectedSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UploadSession_organizationId_createdById_idx": {
+          "name": "UploadSession_organizationId_createdById_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UploadSession_provider_externalId_idx": {
+          "name": "UploadSession_provider_externalId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UploadSession_organizationId_Organization_id_fk": {
+          "name": "UploadSession_organizationId_Organization_id_fk",
+          "tableFrom": "UploadSession",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UsageEvent": {
+      "name": "UsageEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodKey": {
+          "name": "periodKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UsageEvent_org_metric_period_idx": {
+          "name": "UsageEvent_org_metric_period_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "periodKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UsageEvent_organizationId_Organization_id_fk": {
+          "name": "UsageEvent_organizationId_Organization_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "UsageEvent_userId_User_id_fk": {
+          "name": "UsageEvent_userId_User_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastLoginAt": {
+          "name": "lastLoginAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferredTimezone": {
+          "name": "preferredTimezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedOnboarding": {
+          "name": "completedOnboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "twoFactorEnabled": {
+          "name": "twoFactorEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "hashedPassword": {
+          "name": "hashedPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchEmailsExpirationDate": {
+          "name": "watchEmailsExpirationDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isSuperAdmin": {
+          "name": "isSuperAdmin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "defaultOrganizationId": {
+          "name": "defaultOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "webhookSecret": {
+          "name": "webhookSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "phoneNumber": {
+          "name": "phoneNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phoneNumberVerified": {
+          "name": "phoneNumberVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatarAssetId": {
+          "name": "avatarAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userType": {
+          "name": "userType",
+          "type": "UserType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bannedReason": {
+          "name": "bannedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannedAt": {
+          "name": "bannedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forcePasswordChange": {
+          "name": "forcePasswordChange",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "User_avatarAssetId_key": {
+          "name": "User_avatarAssetId_key",
+          "columns": [
+            {
+              "expression": "avatarAssetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_email_key": {
+          "name": "User_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "User_avatarAssetId_MediaAsset_id_fk": {
+          "name": "User_avatarAssetId_MediaAsset_id_fk",
+          "tableFrom": "User",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["avatarAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserInboxUnreadCount": {
+      "name": "UserInboxUnreadCount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inboxId": {
+          "name": "inboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastUpdatedAt": {
+          "name": "lastUpdatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UserInboxUnreadCount_inboxId_idx": {
+          "name": "UserInboxUnreadCount_inboxId_idx",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_organizationId_idx": {
+          "name": "UserInboxUnreadCount_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_organizationId_inboxId_userId_key": {
+          "name": "UserInboxUnreadCount_organizationId_inboxId_userId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_organizationId_userId_idx": {
+          "name": "UserInboxUnreadCount_organizationId_userId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_userId_idx": {
+          "name": "UserInboxUnreadCount_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserInboxUnreadCount_inboxId_EntityInstance_id_fk": {
+          "name": "UserInboxUnreadCount_inboxId_EntityInstance_id_fk",
+          "tableFrom": "UserInboxUnreadCount",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["inboxId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "UserInboxUnreadCount_userId_User_id_fk": {
+          "name": "UserInboxUnreadCount_userId_User_id_fk",
+          "tableFrom": "UserInboxUnreadCount",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "UserInboxUnreadCount_organizationId_Organization_id_fk": {
+          "name": "UserInboxUnreadCount_organizationId_Organization_id_fk",
+          "tableFrom": "UserInboxUnreadCount",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserSetting": {
+      "name": "UserSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationSettingId": {
+          "name": "organizationSettingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UserSetting_organizationSettingId_idx": {
+          "name": "UserSetting_organizationSettingId_idx",
+          "columns": [
+            {
+              "expression": "organizationSettingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSetting_userId_idx": {
+          "name": "UserSetting_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSetting_userId_organizationSettingId_key": {
+          "name": "UserSetting_userId_organizationSettingId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationSettingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserSetting_userId_User_id_fk": {
+          "name": "UserSetting_userId_User_id_fk",
+          "tableFrom": "UserSetting",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "UserSetting_organizationSettingId_OrganizationSetting_id_fk": {
+          "name": "UserSetting_organizationSettingId_OrganizationSetting_id_fk",
+          "tableFrom": "UserSetting",
+          "tableTo": "OrganizationSetting",
+          "columnsFrom": ["organizationSettingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.VerificationToken": {
+      "name": "VerificationToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "VerificationToken_token_key": {
+          "name": "VerificationToken_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "VerificationToken_userId_idx": {
+          "name": "VerificationToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "VerificationToken_userId_User_id_fk": {
+          "name": "VerificationToken_userId_User_id_fk",
+          "tableFrom": "VerificationToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Webhook": {
+      "name": "Webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "eventTypes": {
+          "name": "eventTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastTriggeredAt": {
+          "name": "lastTriggeredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Webhook_organizationId_idx": {
+          "name": "Webhook_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Webhook_organizationId_Organization_id_fk": {
+          "name": "Webhook_organizationId_Organization_id_fk",
+          "tableFrom": "Webhook",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WebhookDelivery": {
+      "name": "WebhookDelivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookId": {
+          "name": "webhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responseStatus": {
+          "name": "responseStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responseBody": {
+          "name": "responseBody",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attemptCount": {
+          "name": "attemptCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "nextRetryAt": {
+          "name": "nextRetryAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "WebhookDelivery_webhookId_idx": {
+          "name": "WebhookDelivery_webhookId_idx",
+          "columns": [
+            {
+              "expression": "webhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WebhookDelivery_webhookId_Webhook_id_fk": {
+          "name": "WebhookDelivery_webhookId_Webhook_id_fk",
+          "tableFrom": "WebhookDelivery",
+          "tableTo": "Webhook",
+          "columnsFrom": ["webhookId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WebhookEvent": {
+      "name": "WebhookEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retryCount": {
+          "name": "retryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "SYNC_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WebhookEvent_integrationId_idx": {
+          "name": "WebhookEvent_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WebhookEvent_organizationId_idx": {
+          "name": "WebhookEvent_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WebhookEvent_subscriptionId_Subscription_id_fk": {
+          "name": "WebhookEvent_subscriptionId_Subscription_id_fk",
+          "tableFrom": "WebhookEvent",
+          "tableTo": "Subscription",
+          "columnsFrom": ["subscriptionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WebhookEvent_integrationId_ShopifyIntegration_id_fk": {
+          "name": "WebhookEvent_integrationId_ShopifyIntegration_id_fk",
+          "tableFrom": "WebhookEvent",
+          "tableTo": "ShopifyIntegration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WebhookEvent_organizationId_Organization_id_fk": {
+          "name": "WebhookEvent_organizationId_Organization_id_fk",
+          "tableFrom": "WebhookEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Workflow": {
+      "name": "Workflow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAppId": {
+          "name": "triggerAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerTriggerId": {
+          "name": "triggerTriggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerInstallationId": {
+          "name": "triggerInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerConnectionId": {
+          "name": "triggerConnectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Workflow_organizationId_enabled_idx": {
+          "name": "Workflow_organizationId_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Workflow_orgId_triggerType_entityDefId_idx": {
+          "name": "Workflow_orgId_triggerType_entityDefId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Workflow_orgId_appTrigger_idx": {
+          "name": "Workflow_orgId_appTrigger_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerTriggerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Workflow_organizationId_Organization_id_fk": {
+          "name": "Workflow_organizationId_Organization_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Workflow_createdById_User_id_fk": {
+          "name": "Workflow_createdById_User_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Workflow_workflowAppId_WorkflowApp_id_fk": {
+          "name": "Workflow_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowApp": {
+      "name": "WorkflowApp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isUniversal": {
+          "name": "isUniversal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draftWorkflowId": {
+          "name": "draftWorkflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shareToken": {
+          "name": "shareToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webEnabled": {
+          "name": "webEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "apiEnabled": {
+          "name": "apiEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessMode": {
+          "name": "accessMode",
+          "type": "WorkflowShareAccessMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rateLimit": {
+          "name": "rateLimit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalRuns": {
+          "name": "totalRuns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowApp_draftWorkflowId_key": {
+          "name": "WorkflowApp_draftWorkflowId_key",
+          "columns": [
+            {
+              "expression": "draftWorkflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_organizationId_enabled_idx": {
+          "name": "WorkflowApp_organizationId_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_organizationId_isPublic_idx": {
+          "name": "WorkflowApp_organizationId_isPublic_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_workflowId_key": {
+          "name": "WorkflowApp_workflowId_key",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_shareToken_key": {
+          "name": "WorkflowApp_shareToken_key",
+          "columns": [
+            {
+              "expression": "shareToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_webEnabled_idx": {
+          "name": "WorkflowApp_webEnabled_idx",
+          "columns": [
+            {
+              "expression": "webEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_apiEnabled_idx": {
+          "name": "WorkflowApp_apiEnabled_idx",
+          "columns": [
+            {
+              "expression": "apiEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowApp_organizationId_Organization_id_fk": {
+          "name": "WorkflowApp_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowApp_createdById_User_id_fk": {
+          "name": "WorkflowApp_createdById_User_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "WorkflowApp_workflowId_Workflow_id_fk": {
+          "name": "WorkflowApp_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "WorkflowApp_draftWorkflowId_Workflow_id_fk": {
+          "name": "WorkflowApp_draftWorkflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "Workflow",
+          "columnsFrom": ["draftWorkflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "WorkflowApp_shareToken_unique": {
+          "name": "WorkflowApp_shareToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["shareToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowCredentials": {
+      "name": "WorkflowCredentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryptedData": {
+          "name": "encryptedData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastTokenRefreshAt": {
+          "name": "lastTokenRefreshAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRefreshFailureAt": {
+          "name": "lastRefreshFailureAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutiveRefreshFailures": {
+          "name": "consecutiveRefreshFailures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "WorkflowCredentials_createdById_idx": {
+          "name": "WorkflowCredentials_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_organizationId_idx": {
+          "name": "WorkflowCredentials_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_organizationId_type_idx": {
+          "name": "WorkflowCredentials_organizationId_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_appId_organizationId_idx": {
+          "name": "WorkflowCredentials_appId_organizationId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_userId_appId_idx": {
+          "name": "WorkflowCredentials_userId_appId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_appInstallationId_idx": {
+          "name": "WorkflowCredentials_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_expiresAt_idx": {
+          "name": "WorkflowCredentials_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowCredentials_lastTokenRefreshAt_idx": {
+          "name": "WorkflowCredentials_lastTokenRefreshAt_idx",
+          "columns": [
+            {
+              "expression": "lastTokenRefreshAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowCredentials_organizationId_Organization_id_fk": {
+          "name": "WorkflowCredentials_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowCredentials_createdById_User_id_fk": {
+          "name": "WorkflowCredentials_createdById_User_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowCredentials_userId_User_id_fk": {
+          "name": "WorkflowCredentials_userId_User_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowCredentials_appId_App_id_fk": {
+          "name": "WorkflowCredentials_appId_App_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowCredentials_appInstallationId_AppInstallation_id_fk": {
+          "name": "WorkflowCredentials_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "WorkflowCredentials",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowFile": {
+      "name": "WorkflowFile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploadedAt": {
+          "name": "uploadedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "uploadSource": {
+          "name": "uploadSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "originalUrl": {
+          "name": "originalUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowFile_expiresAt_idx": {
+          "name": "WorkflowFile_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowFile_nodeId_idx": {
+          "name": "WorkflowFile_nodeId_idx",
+          "columns": [
+            {
+              "expression": "nodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowFile_workflowId_fileId_key": {
+          "name": "WorkflowFile_workflowId_fileId_key",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowFile_workflowId_idx": {
+          "name": "WorkflowFile_workflowId_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowFile_workflowId_Workflow_id_fk": {
+          "name": "WorkflowFile_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowFile",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowFile_fileId_File_id_fk": {
+          "name": "WorkflowFile_fileId_File_id_fk",
+          "tableFrom": "WorkflowFile",
+          "tableTo": "File",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowJoinState": {
+      "name": "WorkflowJoinState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joinNodeId": {
+          "name": "joinNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forkNodeId": {
+          "name": "forkNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expectedInputs": {
+          "name": "expectedInputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedInputs": {
+          "name": "completedInputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branchResults": {
+          "name": "branchResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "WorkflowJoinState_executionId_idx": {
+          "name": "WorkflowJoinState_executionId_idx",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowJoinState_executionId_joinNodeId_key": {
+          "name": "WorkflowJoinState_executionId_joinNodeId_key",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "joinNodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowJoinState_workflowId_idx": {
+          "name": "WorkflowJoinState_workflowId_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowJoinState_workflowId_Workflow_id_fk": {
+          "name": "WorkflowJoinState_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowJoinState",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowNodeExecution": {
+      "name": "WorkflowNodeExecution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggeredFrom": {
+          "name": "triggeredFrom",
+          "type": "NodeTriggerSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowRunId": {
+          "name": "workflowRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "predecessorNodeId": {
+          "name": "predecessorNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeType": {
+          "name": "nodeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processData": {
+          "name": "processData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "NodeExecutionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsedTime": {
+          "name": "elapsedTime",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionMetadata": {
+          "name": "executionMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowNodeExecution_nodeId_idx": {
+          "name": "WorkflowNodeExecution_nodeId_idx",
+          "columns": [
+            {
+              "expression": "nodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowNodeExecution_status_idx": {
+          "name": "WorkflowNodeExecution_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowNodeExecution_workflowRunId_idx": {
+          "name": "WorkflowNodeExecution_workflowRunId_idx",
+          "columns": [
+            {
+              "expression": "workflowRunId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowNodeExecution_organizationId_Organization_id_fk": {
+          "name": "WorkflowNodeExecution_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_workflowAppId_WorkflowApp_id_fk": {
+          "name": "WorkflowNodeExecution_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_workflowId_Workflow_id_fk": {
+          "name": "WorkflowNodeExecution_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_workflowRunId_WorkflowRun_id_fk": {
+          "name": "WorkflowNodeExecution_workflowRunId_WorkflowRun_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "WorkflowRun",
+          "columnsFrom": ["workflowRunId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_createdById_User_id_fk": {
+          "name": "WorkflowNodeExecution_createdById_User_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowRun": {
+      "name": "WorkflowRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequenceNumber": {
+          "name": "sequenceNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggeredFrom": {
+          "name": "triggeredFrom",
+          "type": "WorkflowTriggerSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsedTime": {
+          "name": "elapsedTime",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalSteps": {
+          "name": "totalSteps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pausedAt": {
+          "name": "pausedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pausedNodeId": {
+          "name": "pausedNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumeAt": {
+          "name": "resumeAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serializedState": {
+          "name": "serializedState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endUserId": {
+          "name": "endUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowRun_createdAt_idx": {
+          "name": "WorkflowRun_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_organizationId_workflowAppId_idx": {
+          "name": "WorkflowRun_organizationId_workflowAppId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_resumeAt_idx": {
+          "name": "WorkflowRun_resumeAt_idx",
+          "columns": [
+            {
+              "expression": "resumeAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_status_idx": {
+          "name": "WorkflowRun_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_workflowId_idx": {
+          "name": "WorkflowRun_workflowId_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowRun_organizationId_Organization_id_fk": {
+          "name": "WorkflowRun_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_workflowAppId_WorkflowApp_id_fk": {
+          "name": "WorkflowRun_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_workflowId_Workflow_id_fk": {
+          "name": "WorkflowRun_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_createdBy_User_id_fk": {
+          "name": "WorkflowRun_createdBy_User_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "User",
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_endUserId_EndUser_id_fk": {
+          "name": "WorkflowRun_endUserId_EndUser_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "EndUser",
+          "columnsFrom": ["endUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowTemplate": {
+      "name": "WorkflowTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "imgUrl": {
+          "name": "imgUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerConfig": {
+          "name": "triggerConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envVars": {
+          "name": "envVars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiredApps": {
+          "name": "requiredApps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "requiredEntities": {
+          "name": "requiredEntities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "WorkflowTemplate_status_idx": {
+          "name": "WorkflowTemplate_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowTemplate_popularity_idx": {
+          "name": "WorkflowTemplate_popularity_idx",
+          "columns": [
+            {
+              "expression": "popularity",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowTemplate_name_idx": {
+          "name": "WorkflowTemplate_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowTemplate_categories_idx": {
+          "name": "WorkflowTemplate_categories_idx",
+          "columns": [
+            {
+              "expression": "categories",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ActionType": {
+      "name": "ActionType",
+      "schema": "public",
+      "values": [
+        "ARCHIVE",
+        "LABEL",
+        "REPLY",
+        "FORWARD",
+        "MARK_SPAM",
+        "DRAFT_EMAIL",
+        "SEND_MESSAGE",
+        "APPLY_TAG",
+        "REMOVE_TAG",
+        "APPLY_LABEL",
+        "REMOVE_LABEL",
+        "MARK_TRASH",
+        "ASSIGN_THREAD",
+        "ARCHIVE_THREAD",
+        "UNARCHIVE_THREAD",
+        "MOVE_TO_TRASH",
+        "REACT_TO_MESSAGE",
+        "SHARE_MESSAGE",
+        "SEND_SMS",
+        "MAKE_CALL",
+        "ESCALATE",
+        "ASSIGN",
+        "NOTIFY",
+        "CREATE_TICKET",
+        "SHOPIFY_ORDER_LOOKUP",
+        "SHOPIFY_GENERATE_RESPONSE"
+      ]
+    },
+    "public.AiIntegrationStatus": {
+      "name": "AiIntegrationStatus",
+      "schema": "public",
+      "values": ["PENDING", "VALID", "INVALID"]
+    },
+    "public.AiProcessingStatus": {
+      "name": "AiProcessingStatus",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed"]
+    },
+    "public.ApprovalAction": {
+      "name": "ApprovalAction",
+      "schema": "public",
+      "values": ["approve", "deny"]
+    },
+    "public.ApprovalStatus": {
+      "name": "ApprovalStatus",
+      "schema": "public",
+      "values": ["pending", "approved", "denied", "timeout"]
+    },
+    "public.articleKind": {
+      "name": "articleKind",
+      "schema": "public",
+      "values": ["page", "category", "header", "tab", "link"]
+    },
+    "public.ArticleStatus": {
+      "name": "ArticleStatus",
+      "schema": "public",
+      "values": ["DRAFT", "PUBLISHED", "ARCHIVED"]
+    },
+    "public.AssetVersionStatus": {
+      "name": "AssetVersionStatus",
+      "schema": "public",
+      "values": ["PENDING", "PROCESSING", "READY", "FAILED"]
+    },
+    "public.BillingCycle": {
+      "name": "BillingCycle",
+      "schema": "public",
+      "values": ["MONTHLY", "ANNUAL"]
+    },
+    "public.CalendarEventStatus": {
+      "name": "CalendarEventStatus",
+      "schema": "public",
+      "values": ["confirmed", "tentative", "cancelled"]
+    },
+    "public.CalendarProvider": {
+      "name": "CalendarProvider",
+      "schema": "public",
+      "values": ["google", "outlook"]
+    },
+    "public.ChunkingStrategy": {
+      "name": "ChunkingStrategy",
+      "schema": "public",
+      "values": ["FIXED_SIZE", "SEMANTIC", "SENTENCE", "PARAGRAPH", "DOCUMENT"]
+    },
+    "public.ContactFieldType": {
+      "name": "ContactFieldType",
+      "schema": "public",
+      "values": [
+        "PHONE",
+        "EMAIL",
+        "ADDRESS",
+        "URL",
+        "TAGS",
+        "DATE",
+        "DATETIME",
+        "TIME",
+        "CHECKBOX",
+        "TEXT",
+        "NUMBER",
+        "CURRENCY",
+        "MULTI_SELECT",
+        "SINGLE_SELECT",
+        "RICH_TEXT",
+        "PHONE_INTL",
+        "ADDRESS_STRUCT",
+        "FILE",
+        "NAME",
+        "RELATIONSHIP",
+        "CALC",
+        "ACTOR",
+        "JSON"
+      ]
+    },
+    "public.CredentialSource": {
+      "name": "CredentialSource",
+      "schema": "public",
+      "values": ["SYSTEM", "CUSTOM", "MODEL_SPECIFIC", "LOAD_BALANCED"]
+    },
+    "public.CustomerSourceType": {
+      "name": "CustomerSourceType",
+      "schema": "public",
+      "values": ["EMAIL", "TICKET_SYSTEM", "SHOPIFY", "MANUAL", "OTHER", "FACEBOOK_PSID"]
+    },
+    "public.CustomerStatus": {
+      "name": "CustomerStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE", "SPAM", "MERGED"]
+    },
+    "public.DatasetStatus": {
+      "name": "DatasetStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE", "PROCESSING", "ERROR"]
+    },
+    "public.DeliveryStatus": {
+      "name": "DeliveryStatus",
+      "schema": "public",
+      "values": ["DELIVERED", "BOUNCED", "DELAYED", "DEFERRED", "REJECTED"]
+    },
+    "public.DocumentStatus": {
+      "name": "DocumentStatus",
+      "schema": "public",
+      "values": ["UPLOADED", "PROCESSING", "INDEXED", "FAILED", "ARCHIVED", "WAITING"]
+    },
+    "public.DocumentType": {
+      "name": "DocumentType",
+      "schema": "public",
+      "values": ["PDF", "DOCX", "TXT", "HTML", "MARKDOWN", "CSV", "JSON", "XML"]
+    },
+    "public.DomainType": {
+      "name": "DomainType",
+      "schema": "public",
+      "values": ["CUSTOM", "PROVIDER"]
+    },
+    "public.EmailLabel": {
+      "name": "EmailLabel",
+      "schema": "public",
+      "values": ["inbox", "sent", "draft"]
+    },
+    "public.EmailProvider": {
+      "name": "EmailProvider",
+      "schema": "public",
+      "values": ["GMAIL", "OUTLOOK", "IMAP"]
+    },
+    "public.EmailTemplateType": {
+      "name": "EmailTemplateType",
+      "schema": "public",
+      "values": [
+        "TICKET_CREATED",
+        "TICKET_REPLIED",
+        "TICKET_CLOSED",
+        "TICKET_REOPENED",
+        "TICKET_ASSIGNED",
+        "TICKET_STATUS_CHANGED",
+        "CUSTOM"
+      ]
+    },
+    "public.ExtractionRuleType": {
+      "name": "ExtractionRuleType",
+      "schema": "public",
+      "values": ["REGEX", "MARKER", "POSITION", "AI_ASSISTED", "VISUAL_SELECTION"]
+    },
+    "public.FavoriteNodeType": {
+      "name": "FavoriteNodeType",
+      "schema": "public",
+      "values": ["ITEM", "FOLDER"]
+    },
+    "public.FileStatus": {
+      "name": "FileStatus",
+      "schema": "public",
+      "values": ["PENDING", "CONFIRMED", "ARCHIVED", "DELETED", "FAILED"]
+    },
+    "public.FileVisibility": {
+      "name": "FileVisibility",
+      "schema": "public",
+      "values": ["PUBLIC", "PRIVATE", "INTERNAL"]
+    },
+    "public.FULFILLMENT_STATUS": {
+      "name": "FULFILLMENT_STATUS",
+      "schema": "public",
+      "values": ["CANCELLED", "ERROR", "FAILURE", "SUCCESS", "OPEN", "PENDING"]
+    },
+    "public.IdentifierType": {
+      "name": "IdentifierType",
+      "schema": "public",
+      "values": ["EMAIL", "PHONE", "FACEBOOK_PSID", "INSTAGRAM_IGSID", "CHAT_VISITOR"]
+    },
+    "public.ImportJobStatus": {
+      "name": "ImportJobStatus",
+      "schema": "public",
+      "values": [
+        "uploading",
+        "ingesting",
+        "waiting",
+        "planning",
+        "ready",
+        "executing",
+        "completed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.ImportMappingTargetType": {
+      "name": "ImportMappingTargetType",
+      "schema": "public",
+      "values": ["particle", "relation", "skip"]
+    },
+    "public.ImportPlanRowStatus": {
+      "name": "ImportPlanRowStatus",
+      "schema": "public",
+      "values": ["planned", "executing", "completed", "failed"]
+    },
+    "public.ImportPlanStatus": {
+      "name": "ImportPlanStatus",
+      "schema": "public",
+      "values": ["planning", "planned", "executing", "completed"]
+    },
+    "public.ImportResolutionStatus": {
+      "name": "ImportResolutionStatus",
+      "schema": "public",
+      "values": ["pending", "valid", "error", "warning", "create"]
+    },
+    "public.ImportStrategyStatus": {
+      "name": "ImportStrategyStatus",
+      "schema": "public",
+      "values": ["planning_queued", "planning", "planned", "executing", "completed"]
+    },
+    "public.ImportStrategyType": {
+      "name": "ImportStrategyType",
+      "schema": "public",
+      "values": ["create", "update", "skip"]
+    },
+    "public.InboxStatus": {
+      "name": "InboxStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "ARCHIVED", "PAUSED"]
+    },
+    "public.IndexStatus": {
+      "name": "IndexStatus",
+      "schema": "public",
+      "values": ["PENDING", "INDEXED", "ERROR"]
+    },
+    "public.InsightStatus": {
+      "name": "InsightStatus",
+      "schema": "public",
+      "values": ["processing", "completed", "failed"]
+    },
+    "public.InsightTemplateStatus": {
+      "name": "InsightTemplateStatus",
+      "schema": "public",
+      "values": ["enabled", "disabled", "archived"]
+    },
+    "public.IntegrationAuthStatus": {
+      "name": "IntegrationAuthStatus",
+      "schema": "public",
+      "values": [
+        "AUTHENTICATED",
+        "UNAUTHENTICATED",
+        "ERROR",
+        "INVALID_GRANT",
+        "EXPIRED_TOKEN",
+        "REVOKED_ACCESS",
+        "INSUFFICIENT_SCOPE",
+        "RATE_LIMITED",
+        "PROVIDER_ERROR",
+        "NETWORK_ERROR",
+        "UNKNOWN_ERROR"
+      ]
+    },
+    "public.IntegrationProviderType": {
+      "name": "IntegrationProviderType",
+      "schema": "public",
+      "values": [
+        "google",
+        "outlook",
+        "facebook",
+        "instagram",
+        "openphone",
+        "mailgun",
+        "sms",
+        "whatsapp",
+        "chat",
+        "email",
+        "shopify",
+        "imap"
+      ]
+    },
+    "public.IntegrationSyncStage": {
+      "name": "IntegrationSyncStage",
+      "schema": "public",
+      "values": [
+        "IDLE",
+        "MESSAGE_LIST_FETCH_PENDING",
+        "MESSAGE_LIST_FETCH",
+        "MESSAGES_IMPORT_PENDING",
+        "MESSAGES_IMPORT",
+        "FAILED"
+      ]
+    },
+    "public.IntegrationSyncStatus": {
+      "name": "IntegrationSyncStatus",
+      "schema": "public",
+      "values": ["NOT_SYNCED", "SYNCING", "ACTIVE", "FAILED"]
+    },
+    "public.INVENTORY_POLICY": {
+      "name": "INVENTORY_POLICY",
+      "schema": "public",
+      "values": ["CONTINUE", "DENY"]
+    },
+    "public.InvitationStatus": {
+      "name": "InvitationStatus",
+      "schema": "public",
+      "values": ["PENDING", "ACCEPTED", "EXPIRED", "CANCELLED"]
+    },
+    "public.InvoiceStatus": {
+      "name": "InvoiceStatus",
+      "schema": "public",
+      "values": ["PENDING", "PAID", "VOID", "UNCOLLECTIBLE", "DRAFT"]
+    },
+    "public.JobStatus": {
+      "name": "JobStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "PROCESSING",
+        "COMPLETED_SUCCESS",
+        "COMPLETED_PARTIAL",
+        "COMPLETED_FAILURE",
+        "FAILED",
+        "RETRYING"
+      ]
+    },
+    "public.KBPublishStatus": {
+      "name": "KBPublishStatus",
+      "schema": "public",
+      "values": ["DRAFT", "PUBLISHED", "UNLISTED"]
+    },
+    "public.KBVisibility": {
+      "name": "KBVisibility",
+      "schema": "public",
+      "values": ["PUBLIC", "INTERNAL"]
+    },
+    "public.LabelType": {
+      "name": "LabelType",
+      "schema": "public",
+      "values": ["system", "user"]
+    },
+    "public.MEDIA_CONTENT_TYPE": {
+      "name": "MEDIA_CONTENT_TYPE",
+      "schema": "public",
+      "values": ["EXTERNAL_VIDEO", "IMAGE", "MODEL_3D", "VIDEO"]
+    },
+    "public.MeetingMessageMethod": {
+      "name": "MeetingMessageMethod",
+      "schema": "public",
+      "values": ["request", "reply", "cancel", "counter", "other"]
+    },
+    "public.MeetingPlatform": {
+      "name": "MeetingPlatform",
+      "schema": "public",
+      "values": ["google_meet", "teams", "zoom", "unknown"]
+    },
+    "public.MessageType": {
+      "name": "MessageType",
+      "schema": "public",
+      "values": ["EMAIL", "FACEBOOK", "SMS", "WHATSAPP", "INSTAGRAM", "OPENPHONE", "CHAT"]
+    },
+    "public.ModelType": {
+      "name": "ModelType",
+      "schema": "public",
+      "values": ["LLM", "TEXT_EMBEDDING", "RERANK", "TTS", "SPEECH2TEXT", "MODERATION", "VISION"]
+    },
+    "public.NodeExecutionStatus": {
+      "name": "NodeExecutionStatus",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        "exception",
+        "skipped",
+        "stopped",
+        "waiting"
+      ]
+    },
+    "public.NodeTriggerSource": {
+      "name": "NodeTriggerSource",
+      "schema": "public",
+      "values": ["SINGLE_STEP", "WORKFLOW_RUN"]
+    },
+    "public.NotificationType": {
+      "name": "NotificationType",
+      "schema": "public",
+      "values": [
+        "COMMENT_MENTION",
+        "COMMENT_REPLY",
+        "COMMENT_REACTION",
+        "TICKET_ASSIGNED",
+        "TICKET_UPDATED",
+        "TICKET_MENTIONED",
+        "THREAD_ACTIVITY",
+        "SYSTEM_MESSAGE",
+        "WORKFLOW_APPROVAL_REQUIRED",
+        "WORKFLOW_APPROVAL_REMINDER",
+        "WORKFLOW_APPROVAL_COMPLETED",
+        "TASK_DEADLINE"
+      ]
+    },
+    "public.ORDER_ADDRESS_TYPE": {
+      "name": "ORDER_ADDRESS_TYPE",
+      "schema": "public",
+      "values": ["SHIPPING", "BILLING"]
+    },
+    "public.ORDER_CANCEL_REASON": {
+      "name": "ORDER_CANCEL_REASON",
+      "schema": "public",
+      "values": ["CUSTOMER", "DECLINED", "FRAUD", "INVENTORY", "OTHER", "STAFF"]
+    },
+    "public.ORDER_FINANCIAL_STATUS": {
+      "name": "ORDER_FINANCIAL_STATUS",
+      "schema": "public",
+      "values": [
+        "AUTHORIZED",
+        "EXPIRED",
+        "PAID",
+        "PARTIALLY_PAID",
+        "PARTIALLY_REFUNDED",
+        "PENDING",
+        "REFUNDED",
+        "VOIDED"
+      ]
+    },
+    "public.ORDER_FULFILLMENT_STATUS": {
+      "name": "ORDER_FULFILLMENT_STATUS",
+      "schema": "public",
+      "values": [
+        "FULFILLED",
+        "IN_PROGRESS",
+        "ON_HOLD",
+        "OPEN",
+        "PARTIALLY_FULFILLED",
+        "PENDING_FULFILLMENT",
+        "REQUEST_DECLINED",
+        "RESTOCKED",
+        "SCHEDULED",
+        "UNFULFILLED"
+      ]
+    },
+    "public.ORDER_RETURN_STATUS": {
+      "name": "ORDER_RETURN_STATUS",
+      "schema": "public",
+      "values": [
+        "INSPECTION_COMPLETED",
+        "IN_PROGRESS",
+        "NO_RETURN",
+        "RETURNED",
+        "RETURN_FAILED",
+        "RETURN_REQUESTED"
+      ]
+    },
+    "public.OrganizationMemberStatus": {
+      "name": "OrganizationMemberStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE"]
+    },
+    "public.OrganizationRole": {
+      "name": "OrganizationRole",
+      "schema": "public",
+      "values": ["OWNER", "ADMIN", "USER"]
+    },
+    "public.OrganizationType": {
+      "name": "OrganizationType",
+      "schema": "public",
+      "values": ["INDIVIDUAL", "TEAM"]
+    },
+    "public.ParticipantRole": {
+      "name": "ParticipantRole",
+      "schema": "public",
+      "values": ["FROM", "TO", "CC", "BCC", "REPLY_TO"]
+    },
+    "public.PRODUDT_STATUS": {
+      "name": "PRODUDT_STATUS",
+      "schema": "public",
+      "values": ["ACTIVE", "ARCHIVED", "DRAFT"]
+    },
+    "public.ProposedActionStatus": {
+      "name": "ProposedActionStatus",
+      "schema": "public",
+      "values": ["PENDING", "APPROVED", "REJECTED", "EXECUTED", "FAILED"]
+    },
+    "public.ProviderQuotaType": {
+      "name": "ProviderQuotaType",
+      "schema": "public",
+      "values": ["PAID", "FREE", "TRIAL"]
+    },
+    "public.ProviderType": {
+      "name": "ProviderType",
+      "schema": "public",
+      "values": ["SYSTEM", "CUSTOM"]
+    },
+    "public.RecipientRole": {
+      "name": "RecipientRole",
+      "schema": "public",
+      "values": ["FROM", "TO", "CC", "BCC"]
+    },
+    "public.RecordingProvider": {
+      "name": "RecordingProvider",
+      "schema": "public",
+      "values": ["recall", "babl", "self_hosted"]
+    },
+    "public.RecordingStatus": {
+      "name": "RecordingStatus",
+      "schema": "public",
+      "values": [
+        "created",
+        "joining",
+        "waiting",
+        "admitted",
+        "recording",
+        "processing",
+        "completed",
+        "failed",
+        "kicked",
+        "denied",
+        "timeout",
+        "cancelled"
+      ]
+    },
+    "public.ResponseStatus": {
+      "name": "ResponseStatus",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "PENDING_APPROVAL",
+        "APPROVED",
+        "SCHEDULED",
+        "SENDING",
+        "SENT",
+        "FAILED",
+        "CANCELLED"
+      ]
+    },
+    "public.ResponseType": {
+      "name": "ResponseType",
+      "schema": "public",
+      "values": ["MANUAL", "TEMPLATE", "AI_GENERATED", "RULE_BASED", "HYBRID"]
+    },
+    "public.RETURN_STATUS": {
+      "name": "RETURN_STATUS",
+      "schema": "public",
+      "values": ["CANCELLED", "CLOSED", "DECLINED", "OPEN", "REQUESTED"]
+    },
+    "public.RsvpStatus": {
+      "name": "RsvpStatus",
+      "schema": "public",
+      "values": ["accepted", "declined", "tentative", "needs_action"]
+    },
+    "public.RuleGroupOperator": {
+      "name": "RuleGroupOperator",
+      "schema": "public",
+      "values": ["AND", "OR", "NOT", "XOR", "THRESHOLD"]
+    },
+    "public.RuleType": {
+      "name": "RuleType",
+      "schema": "public",
+      "values": ["STATIC", "CATEGORY", "AI", "SPAM_HANDLER", "RULE_GROUP", "SHOPIFY_AUTOMATION"]
+    },
+    "public.ScheduledMessageSource": {
+      "name": "ScheduledMessageSource",
+      "schema": "public",
+      "values": ["USER_SCHEDULED", "AI_SUGGESTED", "AUTO_REPLY"]
+    },
+    "public.ScheduledMessageStatus": {
+      "name": "ScheduledMessageStatus",
+      "schema": "public",
+      "values": ["PENDING", "PROCESSING", "SENT", "FAILED", "CANCELLED"]
+    },
+    "public.SendStatus": {
+      "name": "SendStatus",
+      "schema": "public",
+      "values": ["PENDING", "SENT", "FAILED"]
+    },
+    "public.SenderType": {
+      "name": "SenderType",
+      "schema": "public",
+      "values": [
+        "INTERNAL_STAFF",
+        "INTERNAL_SYSTEM",
+        "PARTNER",
+        "CUSTOMER",
+        "VENDOR",
+        "UNKNOWN_EXTERNAL"
+      ]
+    },
+    "public.Sensitivity": {
+      "name": "Sensitivity",
+      "schema": "public",
+      "values": ["normal", "private", "personal", "confidential"]
+    },
+    "public.SettingScope": {
+      "name": "SettingScope",
+      "schema": "public",
+      "values": [
+        "APPEARANCE",
+        "NOTIFICATION",
+        "DASHBOARD",
+        "COMMUNICATION",
+        "SECURITY",
+        "INTEGRATION",
+        "GENERAL",
+        "SIDEBAR",
+        "RECORDING",
+        "KOPILOT"
+      ]
+    },
+    "public.SignatureSharingType": {
+      "name": "SignatureSharingType",
+      "schema": "public",
+      "values": ["PRIVATE", "ORGANIZATION_WIDE", "SPECIFIC_INTEGRATIONS"]
+    },
+    "public.SnippetPermission": {
+      "name": "SnippetPermission",
+      "schema": "public",
+      "values": ["VIEW", "EDIT"]
+    },
+    "public.SnippetSharingType": {
+      "name": "SnippetSharingType",
+      "schema": "public",
+      "values": ["PRIVATE", "ORGANIZATION", "GROUPS", "MEMBERS"]
+    },
+    "public.StaticRuleType": {
+      "name": "StaticRuleType",
+      "schema": "public",
+      "values": [
+        "SENDER_DOMAIN",
+        "SENDER_ADDRESS",
+        "RECIPIENT_PATTERN",
+        "SUBJECT_MATCH",
+        "BODY_KEYWORD",
+        "HEADER_CHECK",
+        "ATTACHMENT_TYPE",
+        "COMBINED",
+        "INTERNAL_EXTERNAL",
+        "THREAD_BASED"
+      ]
+    },
+    "public.StorageProvider": {
+      "name": "StorageProvider",
+      "schema": "public",
+      "values": ["S3", "GOOGLE_DRIVE", "DROPBOX", "ONEDRIVE", "BOX", "GENERIC_URL"]
+    },
+    "public.SYNC_STATUS": {
+      "name": "SYNC_STATUS",
+      "schema": "public",
+      "values": ["PENDING", "IN_PROGRESS", "COMPLETED", "FAILED"]
+    },
+    "public.ThreadStatus": {
+      "name": "ThreadStatus",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "ARCHIVED",
+        "ACTIVE",
+        "RESOLVED",
+        "PENDING",
+        "CLOSED",
+        "SPAM",
+        "TRASH",
+        "IGNORED"
+      ]
+    },
+    "public.ThreadType": {
+      "name": "ThreadType",
+      "schema": "public",
+      "values": ["EMAIL", "CHAT"]
+    },
+    "public.TicketPriority": {
+      "name": "TicketPriority",
+      "schema": "public",
+      "values": ["LOW", "MEDIUM", "HIGH", "URGENT"]
+    },
+    "public.TicketStatus": {
+      "name": "TicketStatus",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "IN_PROGRESS",
+        "WAITING_FOR_CUSTOMER",
+        "WAITING_FOR_THIRD_PARTY",
+        "RESOLVED",
+        "CLOSED",
+        "CANCELLED",
+        "MERGED"
+      ]
+    },
+    "public.TicketType": {
+      "name": "TicketType",
+      "schema": "public",
+      "values": [
+        "GENERAL",
+        "MISSING_ITEM",
+        "RETURN",
+        "REFUND",
+        "PRODUCT_ISSUE",
+        "SHIPPING_ISSUE",
+        "BILLING",
+        "TECHNICAL",
+        "OTHER"
+      ]
+    },
+    "public.TranscriptStatus": {
+      "name": "TranscriptStatus",
+      "schema": "public",
+      "values": ["processing", "completed", "failed"]
+    },
+    "public.TranscriptType": {
+      "name": "TranscriptType",
+      "schema": "public",
+      "values": ["realtime", "async"]
+    },
+    "public.TrialConversionStatus": {
+      "name": "TrialConversionStatus",
+      "schema": "public",
+      "values": [
+        "TRIAL_ACTIVE",
+        "CONVERTED_TO_PAID",
+        "EXPIRED_WITHOUT_CONVERSION",
+        "CANCELED_DURING_TRIAL",
+        "MANUAL_CONVERSION"
+      ]
+    },
+    "public.UserType": {
+      "name": "UserType",
+      "schema": "public",
+      "values": ["USER", "SYSTEM", "AGENT"]
+    },
+    "public.VectorDbType": {
+      "name": "VectorDbType",
+      "schema": "public",
+      "values": ["POSTGRESQL", "CHROMA", "QDRANT", "WEAVIATE", "PINECONE", "MILVUS"]
+    },
+    "public.WorkflowRunStatus": {
+      "name": "WorkflowRunStatus",
+      "schema": "public",
+      "values": ["RUNNING", "SUCCEEDED", "FAILED", "STOPPED", "WAITING"]
+    },
+    "public.WorkflowShareAccessMode": {
+      "name": "WorkflowShareAccessMode",
+      "schema": "public",
+      "values": ["public", "organization"]
+    },
+    "public.WorkflowTriggerSource": {
+      "name": "WorkflowTriggerSource",
+      "schema": "public",
+      "values": ["DEBUGGING", "APP_RUN", "SINGLE_STEP", "PUBLIC_SHARE", "API_KEY", "WEBHOOK"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -1156,6 +1156,13 @@
       "when": 1779395605979,
       "tag": "0164_chat_widget_v2_home_and_kb",
       "breakpoints": true
+    },
+    {
+      "idx": 165,
+      "version": "7",
+      "when": 1779402937184,
+      "tag": "0165_chat_widget_greeting_jsonb",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/db/schema/chat-widget.ts
+++ b/packages/database/src/db/schema/chat-widget.ts
@@ -7,6 +7,7 @@ import {
   boolean,
   index,
   integer,
+  jsonb,
   pgTable,
   text,
   timestamp,
@@ -57,8 +58,8 @@ export const ChatWidget = pgTable(
       onDelete: 'set null',
     }),
 
-    // v2 Home config
-    homeGreetingTemplate: text(),
+    // v2 Home config — Tiptap JSON doc with `visitor:*` placeholder nodes.
+    homeGreetingTemplate: jsonb(),
     homeShowRecentMessage: boolean().default(true).notNull(),
     homeShowSendMessageCta: boolean().default(true).notNull(),
     brandingFooterEnabled: boolean().default(true).notNull(),

--- a/packages/lib/src/chat-widget/config.ts
+++ b/packages/lib/src/chat-widget/config.ts
@@ -36,6 +36,18 @@ export interface UpdateChatWidgetInput {
   inboxId?: string | null
   /** Agent that auto-replies to widget messages. Pass `null` to disable AI auto-reply. */
   agentId?: string | null
+
+  // v2 Home config
+  /** Tiptap JSON doc, or `null` to clear. */
+  homeGreetingTemplate?: unknown
+  homeShowRecentMessage?: boolean
+  homeShowSendMessageCta?: boolean
+  brandingFooterEnabled?: boolean
+  allowDownloadTranscript?: boolean
+  expandedWidthPx?: number
+  /** Pass `null` to unlink the knowledge base. */
+  knowledgeBaseId?: string | null
+  featuredArticleIds?: string[]
 }
 
 /**

--- a/packages/lib/src/chat/session.ts
+++ b/packages/lib/src/chat/session.ts
@@ -22,6 +22,12 @@ export interface InitializeChatThreadInput {
   visitorEmail?: string
   /** Embedder-supplied external id (unverified in v1). Stored as `claimedExternalId`. */
   visitorExternalId?: string
+  /**
+   * When true, skip the resume-existing-thread lookup and always create a
+   * fresh thread. Used by the Home "Send us a message" CTA so each tap lands
+   * in a new conversation.
+   */
+  forceNewThread?: boolean
 }
 
 export interface InitializeChatThreadResult {
@@ -78,18 +84,20 @@ export async function initializeOrResumeChatThread(
     const visitor = visitorResult.value
 
     // Try to resume an open thread for this visitor on this channel.
-    const candidateThreads = await ctx.db
-      .select()
-      .from(schema.Thread)
-      .where(
-        and(
-          eq(schema.Thread.organizationId, ctx.organizationId),
-          eq(schema.Thread.integrationId, integration.id),
-          eq(schema.Thread.status, ThreadStatus.OPEN)
-        )
-      )
-      .orderBy(desc(schema.Thread.lastMessageAt))
-      .limit(20)
+    const candidateThreads = input.forceNewThread
+      ? []
+      : await ctx.db
+          .select()
+          .from(schema.Thread)
+          .where(
+            and(
+              eq(schema.Thread.organizationId, ctx.organizationId),
+              eq(schema.Thread.integrationId, integration.id),
+              eq(schema.Thread.status, ThreadStatus.OPEN)
+            )
+          )
+          .orderBy(desc(schema.Thread.lastMessageAt))
+          .limit(20)
 
     const resumable = candidateThreads.find((t) => {
       const meta = (t.metadata ?? {}) as Partial<ChatThreadMetadata>

--- a/packages/lib/src/placeholders/client.ts
+++ b/packages/lib/src/placeholders/client.ts
@@ -19,4 +19,6 @@ export {
   type ParsedPlaceholder,
   parsePlaceholderId,
   tryParsePlaceholderId,
+  type UserSlug,
+  type VisitorSlug,
 } from './path-parser'

--- a/packages/lib/src/placeholders/path-parser.ts
+++ b/packages/lib/src/placeholders/path-parser.ts
@@ -31,6 +31,16 @@ export type UserSlug = 'id' | 'email' | 'name' | 'firstName' | 'lastName'
 
 const USER_SLUGS = new Set<string>(['id', 'email', 'name', 'firstName', 'lastName'])
 
+/**
+ * Synthetic `visitor:` placeholder slugs. Used by the chat widget greeting
+ * template — the resolver substitutes the matching identify claim from the
+ * widget's `identify()` call. Each is plain TEXT (with EMAIL for `email`),
+ * fallback-supported.
+ */
+export type VisitorSlug = 'name' | 'email' | 'externalId'
+
+const VISITOR_SLUGS = new Set<string>(['name', 'email', 'externalId'])
+
 export type ParsedPlaceholder =
   | {
       kind: 'date'
@@ -43,6 +53,10 @@ export type ParsedPlaceholder =
   | {
       kind: 'user'
       slug: UserSlug
+    }
+  | {
+      kind: 'visitor'
+      slug: VisitorSlug
     }
   | {
       kind: 'field'
@@ -86,6 +100,14 @@ export function parsePlaceholderId(id: string): ParsedPlaceholder {
     if (USER_SLUGS.has(slug)) {
       return { kind: 'user', slug: slug as UserSlug }
     }
+  }
+
+  if (id.startsWith('visitor:') && !id.includes('::')) {
+    const slug = id.slice('visitor:'.length)
+    if (!VISITOR_SLUGS.has(slug)) {
+      throw new Error(`unknown visitor slug: ${slug}`)
+    }
+    return { kind: 'visitor', slug: slug as VisitorSlug }
   }
 
   const fieldRef = keyToFieldRef(id)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,7 +292,7 @@ importers:
         version: 7.22.0
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/api:
     dependencies:
@@ -371,7 +371,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/build:
     dependencies:
@@ -481,25 +481,46 @@ importers:
 
   apps/chat-widget:
     dependencies:
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: 'catalog:'
+        version: 0.575.0(react@19.2.3)
       preact:
         specifier: ^10.24.0
         version: 10.28.4
       pusher-js:
         specifier: 'catalog:'
         version: 8.4.0
+      radix-ui:
+        specifier: ^1.4.2
+        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      tailwind-merge:
+        specifier: ^3.3.1
+        version: 3.5.0
     devDependencies:
       '@auxx/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
+      '@tailwindcss/vite':
+        specifier: ^4.1.7
+        version: 4.3.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.13
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.2.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
       vite:
         specifier: 'catalog:'
-        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/docs:
     dependencies:
@@ -514,7 +535,7 @@ importers:
         version: 15.7.8(@types/react@19.2.3)(next@16.0.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       fumadocs-mdx:
         specifier: 11.8.3
-        version: 11.8.3(fumadocs-core@15.7.8(@types/react@19.2.3)(next@16.0.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(next@16.0.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 11.8.3(fumadocs-core@15.7.8(@types/react@19.2.3)(next@16.0.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(next@16.0.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       fumadocs-ui:
         specifier: 15.7.8
         version: 15.7.8(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(next@16.0.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.2.1)
@@ -615,7 +636,7 @@ importers:
         version: link:../../packages/typescript-config
       '@crxjs/vite-plugin':
         specifier: ^2.0.0-beta.32
-        version: 2.4.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 2.4.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.2.1
@@ -630,7 +651,7 @@ importers:
         version: 19.2.3(@types/react@19.2.3)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       postcss:
         specifier: 'catalog:'
         version: 8.5.6
@@ -642,7 +663,7 @@ importers:
         version: 5.9.2
       vite:
         specifier: 'catalog:'
-        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/homepage:
     dependencies:
@@ -1367,7 +1388,7 @@ importers:
         version: 0.7.39
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/ui':
         specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18)
@@ -1400,13 +1421,13 @@ importers:
         version: 5.9.2
       vite:
         specifier: 'catalog:'
-        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: 'catalog:'
-        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/worker:
     dependencies:
@@ -1552,10 +1573,10 @@ importers:
         version: 5.9.2
       vite-tsconfig-paths:
         specifier: 'catalog:'
-        version: 5.1.4(typescript@5.9.2)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(typescript@5.9.2)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/config:
     dependencies:
@@ -1617,7 +1638,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/database:
     dependencies:
@@ -2037,7 +2058,7 @@ importers:
         version: 19.2.3(@types/react@19.2.3)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       dotenv:
         specifier: 'catalog:'
         version: 16.6.1
@@ -2052,13 +2073,13 @@ importers:
         version: 5.9.2
       vite:
         specifier: 'catalog:'
-        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: 'catalog:'
-        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/logger:
     devDependencies:
@@ -2206,7 +2227,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       zimmerframe:
         specifier: 1.1.4
         version: 1.1.4
@@ -2304,7 +2325,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/services:
     dependencies:
@@ -2353,13 +2374,13 @@ importers:
         version: 5.9.2
       vite:
         specifier: 'catalog:'
-        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: 'catalog:'
-        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/test-utils:
     dependencies:
@@ -2396,7 +2417,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/types:
     dependencies:
@@ -2481,7 +2502,7 @@ importers:
         version: 19.2.3(@types/react@19.2.3)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/ui':
         specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18)
@@ -2568,13 +2589,13 @@ importers:
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       vite:
         specifier: 'catalog:'
-        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: 'catalog:'
-        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/utils:
     dependencies:
@@ -2605,7 +2626,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/workflow-nodes:
     dependencies:
@@ -2627,7 +2648,7 @@ importers:
         version: link:../typescript-config
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       tsc-esm-fix:
         specifier: 'catalog:'
         version: 3.1.2
@@ -2642,13 +2663,13 @@ importers:
         version: 5.9.2
       vite:
         specifier: 'catalog:'
-        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: 'catalog:'
-        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -7492,8 +7513,17 @@ packages:
   '@tailwindcss/node@4.2.1':
     resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
 
+  '@tailwindcss/node@4.3.0':
+    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
+
   '@tailwindcss/oxide-android-arm64@4.2.1':
     resolution: {integrity: sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
@@ -7504,8 +7534,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@tailwindcss/oxide-darwin-x64@4.2.1':
     resolution: {integrity: sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -7516,8 +7558,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
     resolution: {integrity: sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
@@ -7528,8 +7582,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -7540,8 +7606,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -7558,8 +7636,26 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
   '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
     resolution: {integrity: sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
@@ -7570,8 +7666,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
   '@tailwindcss/oxide@4.2.1':
     resolution: {integrity: sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/oxide@4.3.0':
+    resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
     engines: {node: '>= 20'}
 
   '@tailwindcss/postcss@4.2.1':
@@ -7581,6 +7687,11 @@ packages:
     resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
+  '@tailwindcss/vite@4.3.0':
+    resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
 
   '@tanstack/hotkeys@0.7.1':
     resolution: {integrity: sha512-YHVO1z6wnvUCu7bg870Kv5k2D+FIuIOSIcbN0dAmTTsJ3mLMDLwcTVx0qVaq+SZp1B514JJTqGVstvUp85yIpQ==}
@@ -9734,6 +9845,10 @@ packages:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
 
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+    engines: {node: '>=10.13.0'}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -11081,8 +11196,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.31.1:
     resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -11093,8 +11220,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.31.1:
     resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -11105,8 +11244,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.31.1:
     resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -11117,8 +11268,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -11129,8 +11292,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -11141,8 +11316,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.31.1:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@2.1.0:
@@ -13495,8 +13680,15 @@ packages:
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
 
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
+
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar-fs@2.1.4:
@@ -16284,7 +16476,7 @@ snapshots:
       conventional-commits-parser: 6.2.1
       picocolors: 1.1.1
 
-  '@crxjs/vite-plugin@2.4.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@crxjs/vite-plugin@2.4.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@webcomponents/custom-elements': 1.6.0
@@ -16302,7 +16494,7 @@ snapshots:
       react-refresh: 0.13.0
       rollup: 2.79.2
       rxjs: 7.5.7
-      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -20337,40 +20529,86 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.2.1
 
+  '@tailwindcss/node@4.3.0':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.0
+
   '@tailwindcss/oxide-android-arm64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.2.1':
     optional: true
 
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    optional: true
+
   '@tailwindcss/oxide-darwin-x64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.2.1':
     optional: true
 
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
     optional: true
 
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     optional: true
 
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    optional: true
+
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     optional: true
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     optional: true
 
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    optional: true
+
   '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
     optional: true
 
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    optional: true
+
   '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
     optional: true
 
   '@tailwindcss/oxide@4.2.1':
@@ -20388,6 +20626,21 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
 
+  '@tailwindcss/oxide@4.3.0':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-x64': 4.3.0
+      '@tailwindcss/oxide-freebsd-x64': 4.3.0
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
+
   '@tailwindcss/postcss@4.2.1':
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -20400,6 +20653,13 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.1
+
+  '@tailwindcss/vite@4.3.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@tanstack/hotkeys@0.7.1':
     dependencies:
@@ -21200,7 +21460,7 @@ snapshots:
       '@types/ms': 2.1.0
       ms: 2.1.3
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -21208,7 +21468,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -21221,21 +21481,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -21263,7 +21523,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -21646,7 +21906,7 @@ snapshots:
       pg: 8.19.0
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   better-call@1.1.8(zod@4.1.5):
     dependencies:
@@ -22587,6 +22847,11 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  enhanced-resolve@5.21.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
   entities@4.5.0: {}
 
   entities@6.0.1: {}
@@ -23216,7 +23481,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@11.8.3(fumadocs-core@15.7.8(@types/react@19.2.3)(next@16.0.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(next@16.0.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  fumadocs-mdx@11.8.3(fumadocs-core@15.7.8(@types/react@19.2.3)(next@16.0.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(next@16.0.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -23237,7 +23502,7 @@ snapshots:
     optionalDependencies:
       next: 16.0.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
-      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -24182,34 +24447,67 @@ snapshots:
   lightningcss-android-arm64@1.31.1:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.31.1:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.31.1:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.31.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.31.1:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.31.1:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.31.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.31.1:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.31.1:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.31.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.31.1:
@@ -24227,6 +24525,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.31.1
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@2.1.0: {}
 
@@ -27257,7 +27571,11 @@ snapshots:
 
   tailwindcss@4.2.1: {}
 
+  tailwindcss@4.3.0: {}
+
   tapable@2.3.0: {}
+
+  tapable@2.3.3: {}
 
   tar-fs@2.1.4:
     dependencies:
@@ -27824,29 +28142,29 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.2)
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.2)
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -27858,12 +28176,12 @@ snapshots:
       '@types/node': 22.19.13
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.31.1
+      lightningcss: 1.32.0
       terser: 5.46.0
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -27875,12 +28193,12 @@ snapshots:
       '@types/node': 20.19.35
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.31.1
+      lightningcss: 1.32.0
       terser: 5.46.0
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -27892,15 +28210,15 @@ snapshots:
       '@types/node': 22.19.13
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.31.1
+      lightningcss: 1.32.0
       terser: 5.46.0
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -27917,7 +28235,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -27937,10 +28255,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -27957,7 +28275,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## Summary
- Chat widget v2 Home tab — Tiptap greeting (with `visitor:*` placeholders), featured articles, browse-KB and recent-message cards, and a send-message CTA that spawns a fresh thread
- Widget gets Tailwind + shadow-root setup, UI primitives (button/dialog/popover/tabs/dropdown/scroll-area), and a navigation stack
- API: new `POST /api/chat/threads` (always-new) and `GET /api/chat/threads/recent`; `/config` now returns home + branding + KB info + featured articles
- Schema: `homeGreetingTemplate` migrated `text → jsonb` (Tiptap doc); channel router + `UpdateChatWidgetInput` accept the v2 Home fields

## Test plan
- [ ] Apply migration `0165_chat_widget_greeting_jsonb` against a dev DB
- [ ] Settings UI: edit greeting with `{{visitor.name}}` placeholder, set featured articles, link a KB
- [ ] Widget Home: greeting renders, featured articles + browse-all card show, recent-message card appears after a thread exists
- [ ] "Send us a message" creates a new thread every time
- [ ] `/api/chat/config/:channelId` shape matches widget expectations