### PR TITLE
feat(chat): widget v2 KB tab — section browse + article reader

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -25,6 +25,7 @@ import freeToolLeads from './routes/free-tool-leads'
 // Routes
 import health from './routes/health'
 import installations from './routes/installations'
+import kb from './routes/kb'
 import me from './routes/me'
 import organizations from './routes/organizations'
 import recordingWebhooks from './routes/recording-webhooks'
@@ -82,6 +83,7 @@ async function main() {
   app.route('/api/v1/sdk/entities', entitiesFindContactByPhone) // SDK callback: Lambda → API (AI tools, whatsapp)
   app.route('/api/v1/workflows', workflows) // Workflow execution routes
   app.route('/api/chat', chat) // Visitor-facing chat widget routes (passport-gated)
+  app.route('/api/kb', kb) // Visitor-facing KB browse/read routes (passport-gated)
   app.route('/api/v1/public/free-tool-leads', freeToolLeads) // Public lead capture from /free-tools/*
   app.route('/webhooks/recording', recordingWebhooks) // Recording bot provider webhooks (before generic /webhooks to avoid param collision)
   app.route('/webhooks', webhooks) // Public webhook receiver (no /api/v1 prefix)

--- a/apps/api/src/routes/kb/articles.ts
+++ b/apps/api/src/routes/kb/articles.ts
@@ -1,0 +1,75 @@
+// apps/api/src/routes/kb/articles.ts
+
+import { KB_URL } from '@auxx/config/server'
+import { database, schema } from '@auxx/database'
+import { renderArticleHtml } from '@auxx/lib/kb'
+import type { ArticleNodeJSON } from '@auxx/lib/kb/markdown'
+import { and, eq } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { applyChatCorsHeaders } from '../chat/lib'
+import { forbidden, loadWidgetKnowledgeBase, notFound } from './lib'
+
+const articlesRoute = new Hono()
+
+articlesRoute.options('/:id', (c) => {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  return c.body(null, 204)
+})
+
+/**
+ * GET /api/kb/articles/:id
+ *
+ * Renders the requested article to a sanitized HTML string for the widget.
+ * The article must belong to the widget's linked KB; cross-widget access by
+ * id returns 404. Cached for 60s.
+ */
+articlesRoute.get('/:id', async (c) => {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  const kb = await loadWidgetKnowledgeBase(c)
+  if (!kb) return notFound(c, 'No knowledge base linked to this widget')
+  if (kb.visibility !== 'PUBLIC') {
+    return forbidden(c, 'This widget is linked to an internal knowledge base.')
+  }
+
+  const articleId = c.req.param('id')
+  const article = await database.query.Article.findFirst({
+    where: and(
+      eq(schema.Article.id, articleId),
+      eq(schema.Article.knowledgeBaseId, kb.knowledgeBaseId),
+      eq(schema.Article.organizationId, kb.organizationId),
+      eq(schema.Article.isPublished, true)
+    ),
+    with: { publishedRevision: true },
+  })
+  if (!article || !article.publishedRevision) {
+    return notFound(c, 'Article not found')
+  }
+
+  const rev = article.publishedRevision
+  const contentJson = (rev.contentJson ?? []) as
+    | ArticleNodeJSON[]
+    | { type: 'doc'; content: ArticleNodeJSON[] }
+
+  const publicArticleUrl = `${KB_URL}/r/${article.id}`
+  const html = renderArticleHtml(contentJson, {
+    coverImageUrl: rev.coverImage,
+    title: rev.title,
+    emoji: rev.emoji,
+    publicArticleUrl,
+  })
+
+  c.header('Cache-Control', 'public, max-age=60')
+  return c.json({
+    success: true,
+    data: {
+      id: article.id,
+      title: rev.title,
+      emoji: rev.emoji ?? undefined,
+      coverImageUrl: rev.coverImage ?? undefined,
+      html,
+      updatedAt: rev.updatedAt,
+    },
+  })
+})
+
+export default articlesRoute

--- a/apps/api/src/routes/kb/index.ts
+++ b/apps/api/src/routes/kb/index.ts
@@ -1,0 +1,18 @@
+// apps/api/src/routes/kb/index.ts
+
+import { Hono } from 'hono'
+import { chatPassportMiddleware } from '../../middleware/chat-passport'
+import articlesRoute from './articles'
+import treeRoute from './tree'
+
+const kbRoutes = new Hono()
+
+// All KB visitor surfaces require a chat passport. CORS is applied per-route
+// so the OPTIONS preflight still succeeds without the Authorization header.
+kbRoutes.use('/tree', chatPassportMiddleware)
+kbRoutes.use('/articles/*', chatPassportMiddleware)
+
+kbRoutes.route('/tree', treeRoute)
+kbRoutes.route('/articles', articlesRoute)
+
+export default kbRoutes

--- a/apps/api/src/routes/kb/lib.ts
+++ b/apps/api/src/routes/kb/lib.ts
@@ -1,0 +1,68 @@
+// apps/api/src/routes/kb/lib.ts
+
+import { database, schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import type { Context } from 'hono'
+import { applyChatCorsHeaders } from '../chat/lib'
+
+export interface ResolvedWidgetKb {
+  organizationId: string
+  knowledgeBaseId: string
+  name: string
+  slug: string
+  description: string | null
+  logoUrl: string | null
+  visibility: 'PUBLIC' | 'INTERNAL'
+}
+
+/**
+ * Load the KB linked to the widget identified by the verified chat passport
+ * on `c.var.chat`. Returns `null` when the widget has no linkage or the KB
+ * has been deleted. Visibility is returned so the caller can short-circuit
+ * INTERNAL KBs with a friendly error.
+ */
+export async function loadWidgetKnowledgeBase(c: Context): Promise<ResolvedWidgetKb | null> {
+  const chat = c.get('chat')
+  const widget = await database.query.ChatWidget.findFirst({
+    where: (w, { eq: e }) => e(w.integrationId, chat.channelId),
+    columns: { knowledgeBaseId: true, organizationId: true },
+  })
+  if (!widget?.knowledgeBaseId) return null
+
+  const kb = await database.query.KnowledgeBase.findFirst({
+    where: and(
+      eq(schema.KnowledgeBase.id, widget.knowledgeBaseId),
+      eq(schema.KnowledgeBase.organizationId, widget.organizationId)
+    ),
+    columns: {
+      id: true,
+      name: true,
+      slug: true,
+      description: true,
+      logoLight: true,
+      logoDark: true,
+      visibility: true,
+    },
+  })
+  if (!kb) return null
+
+  return {
+    organizationId: widget.organizationId,
+    knowledgeBaseId: kb.id,
+    name: kb.name,
+    slug: kb.slug,
+    description: kb.description ?? null,
+    logoUrl: kb.logoLight ?? kb.logoDark ?? null,
+    visibility: kb.visibility as 'PUBLIC' | 'INTERNAL',
+  }
+}
+
+export function notFound(c: Context, message: string) {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  return c.json({ success: false, error: { code: 'NOT_FOUND', message } }, 404)
+}
+
+export function forbidden(c: Context, message: string) {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  return c.json({ success: false, error: { code: 'FORBIDDEN', message } }, 403)
+}

--- a/apps/api/src/routes/kb/tree.ts
+++ b/apps/api/src/routes/kb/tree.ts
@@ -1,0 +1,72 @@
+// apps/api/src/routes/kb/tree.ts
+
+import { database, schema } from '@auxx/database'
+import { and, asc, eq } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { applyChatCorsHeaders } from '../chat/lib'
+import { forbidden, loadWidgetKnowledgeBase, notFound } from './lib'
+
+const treeRoute = new Hono()
+
+treeRoute.options('/', (c) => {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  return c.body(null, 204)
+})
+
+/**
+ * GET /api/kb/tree
+ *
+ * Metadata-only article tree for the KB linked to the caller's widget.
+ * Cached for 60s so first-paint in the widget is instant. Returns 404 if
+ * the widget has no linked KB; 403 if the linked KB is INTERNAL (v1 only
+ * supports PUBLIC KBs in the widget).
+ */
+treeRoute.get('/', async (c) => {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  const kb = await loadWidgetKnowledgeBase(c)
+  if (!kb) return notFound(c, 'No knowledge base linked to this widget')
+  if (kb.visibility !== 'PUBLIC') {
+    return forbidden(c, 'This widget is linked to an internal knowledge base.')
+  }
+
+  const rows = await database
+    .select({
+      id: schema.Article.id,
+      parentId: schema.Article.parentId,
+      title: schema.Article.title,
+      emoji: schema.Article.emoji,
+      articleKind: schema.Article.articleKind,
+      sortOrder: schema.Article.sortOrder,
+    })
+    .from(schema.Article)
+    .where(
+      and(
+        eq(schema.Article.knowledgeBaseId, kb.knowledgeBaseId),
+        eq(schema.Article.organizationId, kb.organizationId),
+        eq(schema.Article.isPublished, true)
+      )
+    )
+    .orderBy(asc(schema.Article.parentId), asc(schema.Article.sortOrder))
+
+  c.header('Cache-Control', 'public, max-age=60')
+  return c.json({
+    success: true,
+    data: {
+      site: {
+        name: kb.name,
+        description: kb.description ?? undefined,
+        logoUrl: kb.logoUrl ?? undefined,
+      },
+      nodes: rows.map((r) => ({
+        id: r.id,
+        parentId: r.parentId,
+        title: r.title ?? 'Untitled',
+        emoji: r.emoji ?? undefined,
+        articleKind: r.articleKind,
+        sortOrder: r.sortOrder,
+      })),
+    },
+  })
+})
+
+export default treeRoute

--- a/apps/chat-widget/src/styles.css
+++ b/apps/chat-widget/src/styles.css
@@ -11,6 +11,7 @@
  */
 
 @import 'tailwindcss';
+@import './views/kb/article-typography.css';
 
 @source "./**/*.{ts,tsx}";
 

--- a/apps/chat-widget/src/transport/api-client.ts
+++ b/apps/chat-widget/src/transport/api-client.ts
@@ -1,0 +1,58 @@
+// apps/chat-widget/src/transport/api-client.ts
+//
+// Shared fetch wrapper for the visitor-facing api surface. Owns passport
+// minting + bearer auth, single-retry on 401 with a forced passport refresh,
+// and ApiEnvelope unwrapping so endpoint files stay declarative.
+
+import { getChatPassport } from './passport'
+
+export interface ApiEnvelope<T> {
+  success: boolean
+  data?: T
+  error?: { code: string; message: string }
+}
+
+export interface ApiRequest {
+  method?: string
+  body?: unknown
+  query?: Record<string, string>
+}
+
+export async function authedFetch<T>(
+  channelId: string,
+  path: string,
+  init: ApiRequest = {}
+): Promise<T> {
+  const method = init.method ?? 'GET'
+
+  const doFetch = async (token: string) => {
+    let url = `${__AUXX_API_BASE_URL__}${path}`
+    if (init.query) {
+      const qs = new URLSearchParams(init.query).toString()
+      if (qs) url += `?${qs}`
+    }
+    return fetch(url, {
+      method,
+      credentials: 'include',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(init.body ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: init.body ? JSON.stringify(init.body) : undefined,
+    })
+  }
+
+  let { passport } = await getChatPassport(channelId)
+  let res = await doFetch(passport)
+
+  if (res.status === 401) {
+    passport = (await getChatPassport(channelId, { force: true })).passport
+    res = await doFetch(passport)
+  }
+
+  const json = (await res.json()) as ApiEnvelope<T>
+  if (!res.ok || !json.success || json.data === undefined) {
+    throw new Error(json.error?.message ?? `Request failed (${res.status})`)
+  }
+  return json.data
+}

--- a/apps/chat-widget/src/transport/chat-api.ts
+++ b/apps/chat-widget/src/transport/chat-api.ts
@@ -1,6 +1,6 @@
 // apps/chat-widget/src/transport/chat-api.ts
 
-import { getChatPassport } from './passport'
+import { authedFetch } from './api-client'
 
 export interface ChatMessage {
   id: string
@@ -28,49 +28,6 @@ export interface IdentifyApiPayload {
   externalId?: string
 }
 
-interface ApiEnvelope<T> {
-  success: boolean
-  data?: T
-  error?: { code: string; message: string }
-}
-
-async function call<T>(
-  channelId: string,
-  path: string,
-  init: { method: string; body?: unknown; query?: Record<string, string> }
-): Promise<T> {
-  const doFetch = async (token: string) => {
-    let url = `${__AUXX_API_BASE_URL__}${path}`
-    if (init.query) {
-      const qs = new URLSearchParams(init.query).toString()
-      if (qs) url += `?${qs}`
-    }
-    return fetch(url, {
-      method: init.method,
-      credentials: 'include',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        ...(init.body ? { 'Content-Type': 'application/json' } : {}),
-      },
-      body: init.body ? JSON.stringify(init.body) : undefined,
-    })
-  }
-
-  let { passport } = await getChatPassport(channelId)
-  let res = await doFetch(passport)
-
-  if (res.status === 401) {
-    passport = (await getChatPassport(channelId, { force: true })).passport
-    res = await doFetch(passport)
-  }
-
-  const json = (await res.json()) as ApiEnvelope<T>
-  if (!res.ok || !json.success || json.data === undefined) {
-    throw new Error(json.error?.message ?? `Request failed (${res.status})`)
-  }
-  return json.data
-}
-
 export function chatApi(channelId: string) {
   return {
     initialize: (body: {
@@ -83,7 +40,7 @@ export function chatApi(channelId: string) {
       threadId?: string
       identify?: IdentifyApiPayload
     }) =>
-      call<InitializeResponse>(channelId, '/api/chat/initialize', {
+      authedFetch<InitializeResponse>(channelId, '/api/chat/initialize', {
         method: 'POST',
         body,
       }),
@@ -94,45 +51,45 @@ export function chatApi(channelId: string) {
       content: string
       clientMessageId?: string
     }) =>
-      call<{ messageId: string; status: string; createdAt: string }>(
+      authedFetch<{ messageId: string; status: string; createdAt: string }>(
         channelId,
         '/api/chat/messages',
         { method: 'POST', body }
       ),
 
     getHistory: (threadId: string, sessionId: string) =>
-      call<{ messages: ChatMessage[]; nextCursor: string | null }>(
+      authedFetch<{ messages: ChatMessage[]; nextCursor: string | null }>(
         channelId,
         `/api/chat/threads/${threadId}/messages`,
         { method: 'GET', query: { sessionId } }
       ),
 
     setTyping: (sessionId: string, isTyping: boolean) =>
-      call<Record<string, never>>(channelId, '/api/chat/typing', {
+      authedFetch<Record<string, never>>(channelId, '/api/chat/typing', {
         method: 'POST',
         body: { sessionId, isTyping },
       }),
 
     markDelivered: (messageIds: string[]) =>
-      call<{ updated: number }>(channelId, '/api/chat/receipts/delivered', {
+      authedFetch<{ updated: number }>(channelId, '/api/chat/receipts/delivered', {
         method: 'POST',
         body: { messageIds },
       }),
 
     markRead: (messageIds: string[]) =>
-      call<{ updated: number }>(channelId, '/api/chat/receipts/read', {
+      authedFetch<{ updated: number }>(channelId, '/api/chat/receipts/read', {
         method: 'POST',
         body: { messageIds },
       }),
 
     createThread: (body: { url?: string; referrer?: string; userAgent?: string } = {}) =>
-      call<{ threadId: string; pusherChannel: string }>(channelId, '/api/chat/threads', {
+      authedFetch<{ threadId: string; pusherChannel: string }>(channelId, '/api/chat/threads', {
         method: 'POST',
         body,
       }),
 
     getRecentThread: () =>
-      call<{
+      authedFetch<{
         thread: {
           id: string
           subject: string | null
@@ -146,7 +103,7 @@ export function chatApi(channelId: string) {
       visitorEmail?: string
       identify?: IdentifyApiPayload
     }) =>
-      call<{ passport?: { token: string; expiresIn: string } }>(
+      authedFetch<{ passport?: { token: string; expiresIn: string } }>(
         channelId,
         '/api/chat/visitor-info',
         {

--- a/apps/chat-widget/src/transport/kb-api.ts
+++ b/apps/chat-widget/src/transport/kb-api.ts
@@ -1,0 +1,38 @@
+// apps/chat-widget/src/transport/kb-api.ts
+//
+// Minimal client for the visitor-facing /api/kb/* surface.
+
+import { authedFetch } from './api-client'
+
+export type KbArticleKind = 'page' | 'category' | 'header' | 'tab' | 'link'
+
+export interface KbTreeNode {
+  id: string
+  parentId: string | null
+  title: string
+  emoji?: string
+  articleKind: KbArticleKind
+  sortOrder: string
+}
+
+export interface KbTreeResponse {
+  site: { name: string; description?: string; logoUrl?: string }
+  nodes: KbTreeNode[]
+}
+
+export interface KbArticleResponse {
+  id: string
+  title: string
+  emoji?: string
+  coverImageUrl?: string
+  html: string
+  updatedAt: string
+}
+
+export function kbApi(channelId: string) {
+  return {
+    getTree: () => authedFetch<KbTreeResponse>(channelId, '/api/kb/tree'),
+    getArticle: (id: string) =>
+      authedFetch<KbArticleResponse>(channelId, `/api/kb/articles/${encodeURIComponent(id)}`),
+  }
+}

--- a/apps/chat-widget/src/views/kb/article-typography.css
+++ b/apps/chat-widget/src/views/kb/article-typography.css
@@ -1,0 +1,173 @@
+/* apps/chat-widget/src/views/kb/article-typography.css
+ *
+ * Styles for the server-rendered article HTML. Selectors target the
+ * `data-auxx-*` attributes emitted by `renderArticleHtml` so a future
+ * change to that allowlist surfaces obvious unstyled HTML rather than
+ * silently leaking unknown tags through generic selectors.
+ */
+
+.auxx-kb-article {
+  color: var(--color-fg);
+  font-size: 14px;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
+.auxx-kb-article [data-auxx-article-head] {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.auxx-kb-article [data-auxx-article-cover] {
+  width: 100%;
+  max-height: 200px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+}
+
+.auxx-kb-article [data-auxx-article-title] {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  color: var(--color-fg);
+}
+
+.auxx-kb-article [data-auxx-article-emoji] {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.auxx-kb-article [data-auxx-block='heading'][data-level='1'] {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 1.25rem 0 0.5rem;
+}
+
+.auxx-kb-article [data-auxx-block='heading'][data-level='2'] {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 1rem 0 0.5rem;
+}
+
+.auxx-kb-article [data-auxx-block='heading'][data-level='3'] {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0.75rem 0 0.25rem;
+}
+
+.auxx-kb-article [data-auxx-block='text'] {
+  margin: 0 0 0.75rem;
+}
+
+.auxx-kb-article [data-auxx-block='bullet-list'],
+.auxx-kb-article [data-auxx-block='numbered-list'] {
+  margin: 0 0 0.5rem;
+  padding-left: 1.25rem;
+}
+
+.auxx-kb-article [data-auxx-block='bullet-list'] li,
+.auxx-kb-article [data-auxx-block='numbered-list'] li {
+  margin-bottom: 0.25rem;
+}
+
+.auxx-kb-article [data-auxx-block='quote'] {
+  margin: 0.5rem 0;
+  padding: 0.25rem 0 0.25rem 0.75rem;
+  border-left: 3px solid var(--color-border);
+  color: var(--color-muted);
+  font-style: italic;
+}
+
+.auxx-kb-article [data-auxx-block='callout'] {
+  margin: 0.75rem 0;
+  padding: 0.625rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.auxx-kb-article [data-auxx-block='callout'][data-variant='warn'],
+.auxx-kb-article [data-auxx-block='callout'][data-variant='error'] {
+  border-color: color-mix(in srgb, var(--color-fg) 10%, transparent);
+  background: color-mix(in srgb, var(--color-fg) 5%, transparent);
+}
+
+.auxx-kb-article [data-auxx-block='code'] {
+  margin: 0.5rem 0 0.75rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: 0.5rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8125rem;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.auxx-kb-article [data-auxx-inline-code] {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+  padding: 0.1em 0.3em;
+  border-radius: 0.25rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+}
+
+.auxx-kb-article [data-auxx-block='divider'] {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: 1rem 0;
+}
+
+.auxx-kb-article [data-auxx-block='image'] {
+  margin: 0.75rem 0;
+  text-align: center;
+}
+
+.auxx-kb-article [data-auxx-block='image'] img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.375rem;
+}
+
+.auxx-kb-article [data-auxx-block='todo'] {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.auxx-kb-article [data-auxx-todo-box] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--color-border);
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
+.auxx-kb-article a {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.auxx-kb-article a:hover {
+  text-decoration-thickness: 2px;
+}
+
+.auxx-kb-article [data-auxx-article-fallback] {
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px dashed var(--color-border);
+  text-align: center;
+  font-size: 0.8125rem;
+}

--- a/apps/chat-widget/src/views/kb/kb-article-view.tsx
+++ b/apps/chat-widget/src/views/kb/kb-article-view.tsx
@@ -1,0 +1,100 @@
+// apps/chat-widget/src/views/kb/kb-article-view.tsx
+//
+// Inline article reader. Pulls the rendered HTML from /api/kb/articles/:id
+// and dangerously sets it into a Preact root — the renderer already escaped
+// and allowlisted everything server-side, so the body is safe to inject.
+// Click on a `data-auxx-article-link` element pushes another kb-article
+// frame instead of letting the browser navigate.
+
+import type { JSX } from 'preact'
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+import { useNavStack } from '~/navigation/nav-stack-context'
+import { type KbArticleResponse, kbApi } from '~/transport/kb-api'
+
+interface KbArticleViewProps {
+  channelId: string
+  articleId: string
+}
+
+export function KbArticleView({ channelId, articleId }: KbArticleViewProps) {
+  const nav = useNavStack()
+  const [data, setData] = useState<KbArticleResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // Stable reference so the nav object identity (which churns on every stack
+  // mutation) doesn't retrigger the fetch effect.
+  const navRef = useRef(nav)
+  navRef.current = nav
+
+  useEffect(() => {
+    let cancelled = false
+    setError(null)
+    setData(null)
+    kbApi(channelId)
+      .getArticle(articleId)
+      .then((d) => {
+        if (cancelled) return
+        setData(d)
+        // Refresh the frame title now that the real article title is known —
+        // matters most for internal-link pushes that started as "Loading…".
+        navRef.current.replace({
+          id: d.id,
+          label: d.title,
+          view: 'kb-article',
+          params: { articleId: d.id },
+        })
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load article')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [channelId, articleId])
+
+  // Capture clicks on internal article references so they push a new
+  // kb-article frame instead of triggering the browser's navigation.
+  const handleClick = useCallback(
+    (event: JSX.TargetedMouseEvent<HTMLDivElement>) => {
+      const target = event.target as Element | null
+      const anchor = target?.closest('a[data-auxx-article-link]') as HTMLAnchorElement | null
+      if (!anchor) return
+      event.preventDefault()
+      const nextId = anchor.getAttribute('data-auxx-article-link')
+      if (!nextId) return
+      nav.push({
+        id: nextId,
+        label: 'Loading…',
+        view: 'kb-article',
+        params: { articleId: nextId },
+      })
+    },
+    [nav]
+  )
+
+  if (error) {
+    return (
+      <div className='flex flex-1 items-center justify-center p-6 text-center text-sm text-[color:var(--color-muted)]'>
+        {error}
+      </div>
+    )
+  }
+  if (!data) {
+    return (
+      <div className='flex flex-1 items-center justify-center p-6 text-center text-xs text-[color:var(--color-muted)]'>
+        Loading…
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex min-h-0 flex-1 flex-col overflow-y-auto bg-[color:var(--color-bg)]'>
+      <div
+        className='auxx-kb-article px-5 py-4'
+        onClick={handleClick}
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML is server-sanitized by renderArticleHtml (allowlisted tags + escaped text + URL allowlist).
+        dangerouslySetInnerHTML={{ __html: data.html }}
+      />
+    </div>
+  )
+}

--- a/apps/chat-widget/src/views/kb/kb-section-view.tsx
+++ b/apps/chat-widget/src/views/kb/kb-section-view.tsx
@@ -1,0 +1,169 @@
+// apps/chat-widget/src/views/kb/kb-section-view.tsx
+//
+// Browse-all view + section drill-down. Reads the cached KB tree once, then
+// renders the children of `parentId` (null = root). Tappable rows push
+// kb-section or kb-article frames depending on whether the child has
+// children of its own.
+
+import { ChevronRight, FileText } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { cn } from '~/lib/cn'
+import { useNavStack } from '~/navigation/nav-stack-context'
+import type { KbTreeNode, KbTreeResponse } from '~/transport/kb-api'
+import { loadKbTree } from './kb-tree-store'
+
+interface KbSectionViewProps {
+  channelId: string
+  sectionId: string | null
+}
+
+export function KbSectionView({ channelId, sectionId }: KbSectionViewProps) {
+  const nav = useNavStack()
+  const [tree, setTree] = useState<KbTreeResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setError(null)
+    loadKbTree(channelId)
+      .then((t) => {
+        if (!cancelled) setTree(t)
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load articles')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [channelId])
+
+  const childrenMap = useMemo(() => buildChildrenMap(tree?.nodes ?? []), [tree])
+  const rows = useMemo(() => flattenSection(sectionId, childrenMap), [sectionId, childrenMap])
+
+  if (error) {
+    return (
+      <div className='flex flex-1 items-center justify-center p-6 text-center text-sm text-[color:var(--color-muted)]'>
+        {error}
+      </div>
+    )
+  }
+  if (!tree) {
+    return (
+      <div className='flex flex-1 items-center justify-center p-6 text-center text-xs text-[color:var(--color-muted)]'>
+        Loading…
+      </div>
+    )
+  }
+  if (rows.length === 0) {
+    return (
+      <div className='flex flex-1 items-center justify-center p-6 text-center text-sm text-[color:var(--color-muted)]'>
+        Nothing here yet
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto bg-[color:var(--color-surface)] p-3'>
+      {rows.map((row) => {
+        if (row.kind === 'header') {
+          return (
+            <div
+              key={row.node.id}
+              className='px-3 pb-1 pt-3 text-[11px] font-semibold uppercase tracking-wide text-[color:var(--color-muted)]'>
+              {row.node.emoji ? <span className='mr-1.5'>{row.node.emoji}</span> : null}
+              {row.node.title}
+            </div>
+          )
+        }
+        return (
+          <button
+            key={row.node.id}
+            type='button'
+            onClick={() => {
+              if (row.hasChildren) {
+                nav.push({
+                  id: row.node.id,
+                  label: row.node.title,
+                  view: 'kb-section',
+                  params: { sectionId: row.node.id },
+                })
+              } else {
+                nav.push({
+                  id: row.node.id,
+                  label: row.node.title,
+                  view: 'kb-article',
+                  params: { articleId: row.node.id },
+                })
+              }
+            }}
+            className={cn(
+              'group flex w-full items-center gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2.5 text-left transition-colors hover:bg-[color:var(--color-surface)]'
+            )}>
+            <span className='flex size-5 shrink-0 items-center justify-center text-base leading-none'>
+              {row.node.emoji ?? (
+                <FileText className='size-4 text-[color:var(--color-muted)]' aria-hidden='true' />
+              )}
+            </span>
+            <span className='min-w-0 flex-1 truncate text-sm text-[color:var(--color-fg)]'>
+              {row.node.title}
+            </span>
+            <ChevronRight
+              className='size-4 shrink-0 text-[color:var(--color-muted)] transition-transform group-hover:translate-x-0.5'
+              aria-hidden='true'
+            />
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+type Row =
+  | { kind: 'page'; node: KbTreeNode; hasChildren: boolean }
+  | { kind: 'header'; node: KbTreeNode }
+
+function buildChildrenMap(nodes: KbTreeNode[]): Map<string | null, KbTreeNode[]> {
+  const map = new Map<string | null, KbTreeNode[]>()
+  for (const node of nodes) {
+    const key = node.parentId ?? null
+    const list = map.get(key)
+    if (list) list.push(node)
+    else map.set(key, [node])
+  }
+  return map
+}
+
+/**
+ * Project a section's children into render rows. `tab` items are treated as
+ * containers — their children get promoted into the current list — while
+ * `header` items render as non-tappable section headers and `page`/everything
+ * else renders as a tappable row.
+ */
+function flattenSection(
+  sectionId: string | null,
+  childrenMap: Map<string | null, KbTreeNode[]>
+): Row[] {
+  const direct = childrenMap.get(sectionId) ?? []
+  const rows: Row[] = []
+  for (const node of direct) {
+    if (node.articleKind === 'tab') {
+      // Promote the tab's children into this section.
+      const grandchildren = childrenMap.get(node.id) ?? []
+      for (const gc of grandchildren) {
+        rows.push(toRow(gc, childrenMap))
+      }
+      continue
+    }
+    if (node.articleKind === 'header') {
+      rows.push({ kind: 'header', node })
+      continue
+    }
+    rows.push(toRow(node, childrenMap))
+  }
+  return rows
+}
+
+function toRow(node: KbTreeNode, childrenMap: Map<string | null, KbTreeNode[]>): Row {
+  if (node.articleKind === 'header') return { kind: 'header', node }
+  return { kind: 'page', node, hasChildren: (childrenMap.get(node.id) ?? []).length > 0 }
+}

--- a/apps/chat-widget/src/views/kb/kb-tree-store.ts
+++ b/apps/chat-widget/src/views/kb/kb-tree-store.ts
@@ -1,0 +1,24 @@
+// apps/chat-widget/src/views/kb/kb-tree-store.ts
+//
+// In-memory cache for the KB tree. The tree is fetched on the first KB
+// navigation and reused across every kb-section frame for the rest of the
+// widget session. Cross-frame navigation between sections is a memory walk,
+// not a network call.
+
+import { type KbTreeResponse, kbApi } from '~/transport/kb-api'
+
+const cache = new Map<string, Promise<KbTreeResponse>>()
+
+export function loadKbTree(channelId: string): Promise<KbTreeResponse> {
+  const existing = cache.get(channelId)
+  if (existing) return existing
+  const fetched = kbApi(channelId)
+    .getTree()
+    .catch((err) => {
+      // Invalidate so a retry attempts the network again.
+      cache.delete(channelId)
+      throw err
+    })
+  cache.set(channelId, fetched)
+  return fetched
+}

--- a/apps/chat-widget/src/views/placeholder.tsx
+++ b/apps/chat-widget/src/views/placeholder.tsx
@@ -1,8 +1,6 @@
 // apps/chat-widget/src/views/placeholder.tsx
 //
-// Stub frame views. Phase 4 replaces HomeView, Phase 5 replaces the KB views,
-// Phase 6 replaces MessagesView + ThreadView. Each renders its label so the
-// shell + router can be smoke-tested before real content lands.
+// Remaining stub frame views. Phase 6 replaces MessagesView + ThreadView.
 
 import { useNavStack } from '~/navigation/nav-stack-context'
 import { Button } from '~/ui/button'
@@ -12,29 +10,6 @@ function StubBody({ label, hint }: { label: string; hint?: string }) {
     <div className='flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center text-[color:var(--color-muted)]'>
       <span className='text-sm font-medium text-[color:var(--color-fg)]'>{label}</span>
       {hint ? <span className='text-xs'>{hint}</span> : null}
-    </div>
-  )
-}
-
-export function HomeView() {
-  const nav = useNavStack()
-  return (
-    <div className='flex flex-1 flex-col gap-4 p-5'>
-      <p className='text-sm text-[color:var(--color-muted)]'>
-        Home placeholder — Phase 4 fills this in.
-      </p>
-      <Button
-        size='sm'
-        variant='outline'
-        onClick={() => nav.push({ id: 'kb-root', label: 'Knowledge base', view: 'kb-section' })}>
-        Open KB section (test deep frame)
-      </Button>
-      <Button
-        size='sm'
-        variant='outline'
-        onClick={() => nav.push({ id: 'demo', label: 'Demo article', view: 'kb-article' })}>
-        Open KB article (test deep frame)
-      </Button>
     </div>
   )
 }
@@ -58,12 +33,4 @@ export function MessagesView() {
 
 export function ThreadView({ label }: { label: string }) {
   return <StubBody label={label} hint='Thread view — Phase 6 fills this in.' />
-}
-
-export function KbSectionView({ label }: { label: string }) {
-  return <StubBody label={label} hint='KB section view — Phase 5 fills this in.' />
-}
-
-export function KbArticleView({ label }: { label: string }) {
-  return <StubBody label={label} hint='KB article view — Phase 5 fills this in.' />
 }

--- a/apps/chat-widget/src/widget.tsx
+++ b/apps/chat-widget/src/widget.tsx
@@ -13,7 +13,9 @@ import type { NavFrame, NavView } from './navigation/use-navigation-stack'
 import { type TabId, useTabRouter } from './navigation/use-tab-router'
 import { type ChatConfig, fetchChatConfig } from './transport/config'
 import { HomeView } from './views/home/home-view'
-import { KbArticleView, KbSectionView, MessagesView, ThreadView } from './views/placeholder'
+import { KbArticleView } from './views/kb/kb-article-view'
+import { KbSectionView } from './views/kb/kb-section-view'
+import { MessagesView, ThreadView } from './views/placeholder'
 
 interface WidgetProps {
   channelId: string
@@ -160,9 +162,15 @@ function renderFrame(view: NavView, frame: NavFrame | null, channelId: string, c
       return <MessagesView />
     case 'thread':
       return <ThreadView label={label} />
-    case 'kb-section':
-      return <KbSectionView label={label} />
-    case 'kb-article':
-      return <KbArticleView label={label} />
+    case 'kb-section': {
+      const raw = frame?.params?.sectionId
+      const sectionId = typeof raw === 'string' ? raw : null
+      return <KbSectionView channelId={channelId} sectionId={sectionId} />
+    }
+    case 'kb-article': {
+      const raw = frame?.params?.articleId
+      if (typeof raw !== 'string') return null
+      return <KbArticleView channelId={channelId} articleId={raw} />
+    }
   }
 }

--- a/apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
@@ -60,6 +60,27 @@ const behaviorSchema = z.object({
 
 type BehaviorForm = z.infer<typeof behaviorSchema>
 
+/**
+ * Inline warning rendered under the KB picker when the selected KB is
+ * INTERNAL. The widget reader only supports PUBLIC KBs in v1 — the server
+ * also rejects the save, this just surfaces it before the click so the
+ * admin doesn't waste the round-trip.
+ */
+function KbVisibilityWarning({ knowledgeBaseId }: { knowledgeBaseId: string | null }) {
+  const enabled = !!knowledgeBaseId
+  const { data } = api.kb.byId.useQuery(
+    { id: knowledgeBaseId ?? '' },
+    { enabled, staleTime: 60_000 }
+  )
+  if (!enabled || !data || data.visibility === 'PUBLIC') return null
+  return (
+    <p className='text-sm text-destructive'>
+      This knowledge base is set to INTERNAL. Switch it to PUBLIC before saving — chat widgets only
+      support PUBLIC knowledge bases.
+    </p>
+  )
+}
+
 export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
   const utils = api.useUtils()
 
@@ -362,6 +383,7 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                         }}
                       />
                     </FormControl>
+                    <KbVisibilityWarning knowledgeBaseId={field.value} />
                     <FormDescription>
                       Articles from this KB power the widget's featured cards and Browse all view.
                     </FormDescription>

--- a/packages/lib/src/chat-widget/config.ts
+++ b/packages/lib/src/chat-widget/config.ts
@@ -115,6 +115,27 @@ export async function updateChatWidget(
     }
   }
 
+  // v1 of the in-widget KB reader only supports PUBLIC KBs — INTERNAL KBs
+  // need the signed-identity flow that doesn't exist yet. Reject the link
+  // here so admins get a clear error instead of a confusing 403 in the widget.
+  if (input.knowledgeBaseId) {
+    const kb = await ctx.db.query.KnowledgeBase.findFirst({
+      where: (k, { and, eq }) =>
+        and(eq(k.id, input.knowledgeBaseId!), eq(k.organizationId, ctx.organizationId)),
+      columns: { id: true, visibility: true },
+    })
+    if (!kb) {
+      return Result.error(
+        new BadRequestError('Selected knowledge base not found in this organization')
+      )
+    }
+    if (kb.visibility !== 'PUBLIC') {
+      return Result.error(
+        new BadRequestError('PUBLIC visibility required for chat widget integration')
+      )
+    }
+  }
+
   const { name, inboxId, ...widgetData } = input
   const hasInboxKey = Object.hasOwn(input, 'inboxId')
 

--- a/packages/lib/src/kb/index.ts
+++ b/packages/lib/src/kb/index.ts
@@ -33,4 +33,5 @@ export {
 } from './kopilot-snapshot'
 export { articleToMarkdown } from './markdown/article-to-markdown'
 export { type KbArticleEvent, kbArticleChannel, publishKbArticleEvent } from './realtime'
+export { type RenderArticleOptions, renderArticleHtml } from './render-article-html'
 export { syncArticleDenormalizedFields } from './sync-article-denormalized-fields'

--- a/packages/lib/src/kb/markdown/index.ts
+++ b/packages/lib/src/kb/markdown/index.ts
@@ -6,10 +6,12 @@ export { computeArticleJsonHash, computeContentHash } from './hash'
 export { type FrontmatterFields, mdToBlocks, parseFrontmatter } from './md-to-blocks'
 export { stampBlockIds } from './stamp-ids'
 export type {
+  ArticleNodeJSON,
   BlockAttrs,
   BlockJSON,
   BlockType,
   CalloutVariant,
+  ContainerBlockJSON,
   DocJSON,
   EmbedAspect,
   EmbedProvider,

--- a/packages/lib/src/kb/render-article-html.test.ts
+++ b/packages/lib/src/kb/render-article-html.test.ts
@@ -1,0 +1,211 @@
+// packages/lib/src/kb/render-article-html.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { ArticleNodeJSON, BlockJSON, InlineJSON } from './markdown/types'
+import { renderArticleHtml } from './render-article-html'
+
+function block(
+  blockType: string,
+  attrs: Record<string, unknown> = {},
+  content: InlineJSON[] = []
+): BlockJSON {
+  return { type: 'block', attrs: { blockType, ...attrs } as BlockJSON['attrs'], content }
+}
+
+const text = (s: string, marks?: InlineJSON['marks']): InlineJSON =>
+  marks ? { type: 'text', text: s, marks } : { type: 'text', text: s }
+
+describe('renderArticleHtml — blocks', () => {
+  it('renders paragraphs as <p>', () => {
+    const html = renderArticleHtml([block('text', {}, [text('hello')])])
+    expect(html).toContain('<p data-auxx-block="text">hello</p>')
+  })
+
+  it('renders headings at clamped levels', () => {
+    const nodes: ArticleNodeJSON[] = [
+      block('heading', { level: 1 }, [text('H1')]),
+      block('heading', { level: 2 }, [text('H2')]),
+      block('heading', { level: 4 }, [text('H4')]),
+    ]
+    const html = renderArticleHtml(nodes)
+    expect(html).toContain('<h2 data-auxx-block="heading" data-level="1">H1</h2>')
+    expect(html).toContain('<h3 data-auxx-block="heading" data-level="2">H2</h3>')
+    expect(html).toContain('<h4 data-auxx-block="heading" data-level="3">H4</h4>')
+  })
+
+  it('renders bullet and numbered list items', () => {
+    const html = renderArticleHtml([
+      block('bulletListItem', {}, [text('a')]),
+      block('numberedListItem', {}, [text('b')]),
+    ])
+    expect(html).toContain('<ul data-auxx-block="bullet-list"')
+    expect(html).toContain('<ol data-auxx-block="numbered-list"')
+  })
+
+  it('renders code blocks with escaped content', () => {
+    const html = renderArticleHtml([
+      block('codeBlock', { codeLanguage: 'ts' }, [text('const x = <T>(y) => y')]),
+    ])
+    expect(html).toContain('data-language="ts"')
+    expect(html).toContain('<code>const x = &lt;T&gt;(y) =&gt; y</code>')
+  })
+
+  it('renders images with safe URLs and drops javascript: srcs', () => {
+    const safe = renderArticleHtml([
+      block('image', { imageUrl: 'https://example.com/x.png', imageAlign: 'center' }),
+    ])
+    expect(safe).toContain('<img src="https://example.com/x.png"')
+
+    const unsafe = renderArticleHtml([
+      block('image', { imageUrl: 'javascript:alert(1)', imageAlign: 'center' }),
+    ])
+    expect(unsafe).not.toContain('javascript')
+  })
+
+  it('renders dividers, callouts, and quotes', () => {
+    const html = renderArticleHtml([
+      block('divider'),
+      block('callout', { calloutVariant: 'warn' }, [text('careful')]),
+      block('quote', {}, [text('q')]),
+    ])
+    expect(html).toContain('<hr data-auxx-block="divider"')
+    expect(html).toContain('data-variant="warn"')
+    expect(html).toContain('<blockquote data-auxx-block="quote">q</blockquote>')
+  })
+})
+
+describe('renderArticleHtml — inline marks', () => {
+  it('wraps bold/italic/underline/strike/code/highlight', () => {
+    const html = renderArticleHtml([
+      block('text', {}, [
+        text('a', [{ type: 'bold' }]),
+        text('b', [{ type: 'italic' }]),
+        text('c', [{ type: 'underline' }]),
+        text('d', [{ type: 'strike' }]),
+        text('e', [{ type: 'code' }]),
+        text('f', [{ type: 'highlight' }]),
+      ]),
+    ])
+    expect(html).toContain('<strong>a</strong>')
+    expect(html).toContain('<em>b</em>')
+    expect(html).toContain('<u>c</u>')
+    expect(html).toContain('<s>d</s>')
+    expect(html).toContain('<code data-auxx-inline-code>e</code>')
+    expect(html).toContain('<mark>f</mark>')
+  })
+})
+
+describe('renderArticleHtml — link rewriting', () => {
+  it('rewrites external links to target=_blank with rel=noopener noreferrer', () => {
+    const html = renderArticleHtml([
+      block('text', {}, [text('go', [{ type: 'link', attrs: { href: 'https://example.com' } }])]),
+    ])
+    expect(html).toContain('href="https://example.com"')
+    expect(html).toContain('target="_blank"')
+    expect(html).toContain('rel="noopener noreferrer"')
+  })
+
+  it('emits data-auxx-article-link for auxx:// internal references', () => {
+    const html = renderArticleHtml([
+      block('text', {}, [
+        text('inner', [{ type: 'link', attrs: { href: 'auxx://kb/article/abc' } }]),
+      ]),
+    ])
+    expect(html).toContain('data-auxx-article-link="abc"')
+    expect(html).not.toContain('target="_blank"')
+  })
+
+  it('strips javascript: links entirely (keeps the text)', () => {
+    const html = renderArticleHtml([
+      block('text', {}, [
+        text('phish', [{ type: 'link', attrs: { href: 'javascript:alert(1)' } }]),
+      ]),
+    ])
+    expect(html).not.toContain('javascript')
+    expect(html).not.toContain('<a ')
+    expect(html).toContain('phish')
+  })
+})
+
+describe('renderArticleHtml — sanitization', () => {
+  it('escapes <script> in text content', () => {
+    const html = renderArticleHtml([block('text', {}, [text('<script>alert(1)</script>')])])
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+
+  it('escapes script-injection attempts inside code blocks', () => {
+    const html = renderArticleHtml([block('codeBlock', {}, [text('"</code><script>x</script>')])])
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;/code&gt;')
+  })
+})
+
+describe('renderArticleHtml — header', () => {
+  it('renders nothing for empty header opts', () => {
+    expect(renderArticleHtml([])).toBe('')
+  })
+
+  it('renders cover + emoji + title together', () => {
+    const html = renderArticleHtml([], {
+      coverImageUrl: 'https://cdn.example.com/c.png',
+      emoji: '📚',
+      title: 'Welcome',
+    })
+    expect(html).toContain('<header data-auxx-article-head>')
+    expect(html).toContain('data-auxx-article-cover')
+    expect(html).toContain('<h1 data-auxx-article-title>')
+    expect(html).toContain('📚')
+    expect(html).toContain('Welcome')
+  })
+
+  it('renders emoji-only header without collapsing the title block', () => {
+    const html = renderArticleHtml([], { emoji: '✨' })
+    expect(html).toContain('<h1 data-auxx-article-title>')
+    expect(html).toContain('✨')
+  })
+
+  it('drops javascript: cover URLs', () => {
+    const html = renderArticleHtml([], {
+      coverImageUrl: 'javascript:alert(1)',
+      title: 'X',
+    })
+    expect(html).not.toContain('javascript')
+  })
+})
+
+describe('renderArticleHtml — containers', () => {
+  it('flattens tabs to their inner blocks and appends a view-full-article link', () => {
+    const nodes: ArticleNodeJSON[] = [
+      {
+        type: 'tabs',
+        attrs: { activeTab: null },
+        content: [
+          {
+            type: 'panel',
+            attrs: { id: 'p1', label: 'One' },
+            content: [block('text', {}, [text('first')])],
+          },
+          {
+            type: 'panel',
+            attrs: { id: 'p2', label: 'Two' },
+            content: [block('text', {}, [text('second')])],
+          },
+        ],
+      },
+    ]
+    const html = renderArticleHtml(nodes, { publicArticleUrl: 'https://kb.example.com/x' })
+    expect(html).toContain('first')
+    expect(html).toContain('second')
+    expect(html).toContain('href="https://kb.example.com/x"')
+    expect(html).toContain('View full article')
+  })
+
+  it('accepts a doc-wrapped input', () => {
+    const html = renderArticleHtml({
+      type: 'doc',
+      content: [block('text', {}, [text('hi')])],
+    })
+    expect(html).toContain('<p data-auxx-block="text">hi</p>')
+  })
+})

--- a/packages/lib/src/kb/render-article-html.ts
+++ b/packages/lib/src/kb/render-article-html.ts
@@ -1,0 +1,255 @@
+// packages/lib/src/kb/render-article-html.ts
+
+import type {
+  ArticleNodeJSON,
+  BlockJSON,
+  CalloutVariant,
+  InlineJSON,
+  MarkJSON,
+} from './markdown/types'
+
+export interface RenderArticleOptions {
+  /** Cover image URL rendered above the title. */
+  coverImageUrl?: string | null
+  /** Article title rendered as `<h1>` in the header block. */
+  title?: string | null
+  /** Article emoji rendered next to the title. */
+  emoji?: string | null
+  /**
+   * Absolute URL of the article on the public KB site, used by container
+   * blocks (tabs/accordion/table) that can't be rendered inline in v1.
+   * When omitted those blocks degrade to flat content without the link.
+   */
+  publicArticleUrl?: string | null
+}
+
+type DocInput = ArticleNodeJSON[] | { type: 'doc'; content: ArticleNodeJSON[] }
+
+const AUXX_KB_PREFIX = 'auxx://kb/article/'
+const SAFE_URL_SCHEMES = /^(https?:|mailto:|tel:)/i
+
+/**
+ * Render an article's `contentJson` to a sanitized HTML string suitable for
+ * the chat widget's inline reader. Every output tag is hand-emitted, every
+ * text value escaped, and every URL whitelisted — there is no raw-HTML
+ * passthrough, so we don't need an external sanitizer.
+ *
+ * Output uses semantic tags with `data-auxx-*` attributes so the widget CSS
+ * can target only what the renderer emits.
+ */
+export function renderArticleHtml(contentJson: DocInput, opts: RenderArticleOptions = {}): string {
+  const nodes = Array.isArray(contentJson) ? contentJson : (contentJson?.content ?? [])
+  const header = renderHeader(opts)
+  const body = nodes.map((node) => renderTopLevelNode(node, opts.publicArticleUrl ?? null)).join('')
+  return `${header}${body}`
+}
+
+function renderHeader(opts: RenderArticleOptions): string {
+  const hasCover = !!opts.coverImageUrl
+  const hasTitle = !!(opts.title && opts.title.trim())
+  const hasEmoji = !!(opts.emoji && opts.emoji.trim())
+  if (!hasCover && !hasTitle && !hasEmoji) return ''
+
+  const parts: string[] = ['<header data-auxx-article-head>']
+  if (hasCover) {
+    parts.push(
+      `<img data-auxx-article-cover src="${escapeAttr(safeUrl(opts.coverImageUrl!) ?? '')}" alt="" />`
+    )
+  }
+  if (hasTitle || hasEmoji) {
+    parts.push('<h1 data-auxx-article-title>')
+    if (hasEmoji) {
+      parts.push(
+        `<span data-auxx-article-emoji aria-hidden="true">${escapeText(opts.emoji!)}</span>`
+      )
+    }
+    if (hasTitle) {
+      parts.push(`<span data-auxx-article-titletext>${escapeText(opts.title!)}</span>`)
+    }
+    parts.push('</h1>')
+  }
+  parts.push('</header>')
+  return parts.join('')
+}
+
+function renderTopLevelNode(node: ArticleNodeJSON, publicArticleUrl: string | null): string {
+  if (node.type === 'block') return renderBlock(node)
+  // Tabs / accordion / table: flatten the inner text content and append a
+  // "view full article" link. Keeps the renderer narrow; the public KB site
+  // is the source of truth for the interactive rendering.
+  const flat = flattenContainerToBlocks(node).map(renderBlock).join('')
+  const link = publicArticleUrl
+    ? `<p data-auxx-article-fallback><a href="${escapeAttr(
+        safeUrl(publicArticleUrl) ?? '#'
+      )}" target="_blank" rel="noopener noreferrer">View full article</a></p>`
+    : ''
+  return flat + link
+}
+
+function flattenContainerToBlocks(node: ArticleNodeJSON): BlockJSON[] {
+  if (node.type === 'block') return [node]
+  if (node.type === 'tabs' || node.type === 'accordion') {
+    return node.content.flatMap((panel) => panel.content)
+  }
+  // table
+  return node.content.flatMap((row) => row.content.flatMap((cell) => cell.content))
+}
+
+function renderBlock(node: BlockJSON): string {
+  const blockType = node.attrs?.blockType ?? 'text'
+  const inline = renderInline(node.content)
+
+  switch (blockType) {
+    case 'heading': {
+      const level = clampHeading(node.attrs?.level ?? 1)
+      const tag = level === 1 ? 'h2' : level === 2 ? 'h3' : 'h4'
+      return `<${tag} data-auxx-block="heading" data-level="${level}">${inline}</${tag}>`
+    }
+    case 'bulletListItem': {
+      const indent = clampIndent(node.attrs?.level ?? 1)
+      return `<ul data-auxx-block="bullet-list" data-indent="${indent}"><li>${inline}</li></ul>`
+    }
+    case 'numberedListItem': {
+      const indent = clampIndent(node.attrs?.level ?? 1)
+      return `<ol data-auxx-block="numbered-list" data-indent="${indent}"><li>${inline}</li></ol>`
+    }
+    case 'todoListItem': {
+      const checked = !!node.attrs?.checked
+      return `<div data-auxx-block="todo" data-checked="${checked}"><span data-auxx-todo-box aria-hidden="true">${
+        checked ? '&#10003;' : ''
+      }</span><span>${inline}</span></div>`
+    }
+    case 'quote':
+      return `<blockquote data-auxx-block="quote">${inline}</blockquote>`
+    case 'callout': {
+      const variant: CalloutVariant = node.attrs?.calloutVariant ?? 'info'
+      return `<aside data-auxx-block="callout" data-variant="${escapeAttr(
+        variant
+      )}" role="note">${inline}</aside>`
+    }
+    case 'codeBlock': {
+      const language = node.attrs?.codeLanguage ?? 'plaintext'
+      const text = collectInlineText(node.content)
+      return `<pre data-auxx-block="code" data-language="${escapeAttr(
+        language
+      )}"><code>${escapeText(text)}</code></pre>`
+    }
+    case 'image': {
+      const url = safeUrl(node.attrs?.imageUrl)
+      if (!url) return ''
+      const align = node.attrs?.imageAlign ?? 'center'
+      return `<figure data-auxx-block="image" data-align="${escapeAttr(
+        align
+      )}"><img src="${escapeAttr(url)}" alt="" /></figure>`
+    }
+    case 'divider':
+      return '<hr data-auxx-block="divider" />'
+    case 'embed':
+    case 'cards':
+      // Out of scope for v1: render the inner text as a paragraph if any.
+      return inline ? `<p data-auxx-block="text">${inline}</p>` : ''
+    case 'text':
+    default:
+      return `<p data-auxx-block="text">${inline}</p>`
+  }
+}
+
+function renderInline(content: InlineJSON[] | undefined): string {
+  if (!content || content.length === 0) return ''
+  return content.map(renderInlineNode).join('')
+}
+
+function renderInlineNode(node: InlineJSON): string {
+  if (node.type === 'hardBreak') return '<br />'
+  if (node.type === 'placeholder') {
+    const label = typeof node.attrs?.label === 'string' ? node.attrs.label : ''
+    return `<span data-auxx-placeholder>${escapeText(label ? `{${label}}` : '')}</span>`
+  }
+  if (node.type !== 'text') return ''
+  const text = node.text ?? ''
+  if (!text) return ''
+  return applyMarks(escapeText(text), node.marks ?? [])
+}
+
+function applyMarks(escaped: string, marks: MarkJSON[]): string {
+  let html = escaped
+  for (const mark of marks) {
+    html = wrapMark(html, mark)
+  }
+  return html
+}
+
+function wrapMark(html: string, mark: MarkJSON): string {
+  switch (mark.type) {
+    case 'bold':
+      return `<strong>${html}</strong>`
+    case 'italic':
+      return `<em>${html}</em>`
+    case 'underline':
+      return `<u>${html}</u>`
+    case 'strike':
+      return `<s>${html}</s>`
+    case 'code':
+      return `<code data-auxx-inline-code>${html}</code>`
+    case 'highlight':
+      return `<mark>${html}</mark>`
+    case 'link': {
+      const rawHref = typeof mark.attrs?.href === 'string' ? mark.attrs.href : ''
+      if (rawHref.startsWith(AUXX_KB_PREFIX)) {
+        const articleId = rawHref.slice(AUXX_KB_PREFIX.length)
+        // Widget intercepts clicks via data attribute and pushes another
+        // kb-article frame instead of navigating.
+        return `<a data-auxx-article-link="${escapeAttr(articleId)}" href="#">${html}</a>`
+      }
+      const safe = safeUrl(rawHref)
+      if (!safe) return html
+      return `<a href="${escapeAttr(safe)}" target="_blank" rel="noopener noreferrer">${html}</a>`
+    }
+    default:
+      return html
+  }
+}
+
+function collectInlineText(content: InlineJSON[] | undefined): string {
+  if (!content) return ''
+  let out = ''
+  for (const node of content) {
+    if (node.type === 'text' && node.text) out += node.text
+    else if (node.type === 'hardBreak') out += '\n'
+  }
+  return out
+}
+
+function safeUrl(input: string | null | undefined): string | null {
+  if (!input) return null
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  // Allow protocol-relative and root-relative URLs implicitly.
+  if (trimmed.startsWith('/') || trimmed.startsWith('#')) return trimmed
+  if (SAFE_URL_SCHEMES.test(trimmed)) return trimmed
+  return null
+}
+
+function clampHeading(level: number): 1 | 2 | 3 {
+  if (level <= 1) return 1
+  if (level === 2) return 2
+  return 3
+}
+
+function clampIndent(level: number): number {
+  if (level < 1) return 1
+  if (level > 5) return 5
+  return level
+}
+
+function escapeText(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}


### PR DESCRIPTION
## Summary
- New passport-gated `/api/kb` routes (tree + articles) backing the widget KB tab
- KB section + article views in the widget, with a shared `authedFetch` client and rendered article HTML
- Reject linking INTERNAL KBs to chat widgets (v1 reader is PUBLIC-only); inline warning in widget settings

## Test plan
- [ ] Load the widget against a PUBLIC KB — section browse + article reader render correctly
- [ ] Attempt to link an INTERNAL KB in widget settings — save is rejected, inline warning appears
- [ ] Verify passport refresh on 401 still works via `authedFetch`
- [ ] Confirm `renderArticleHtml` unit tests pass