### PR TITLE
chore: docker-compose project name + widget privacy URL polish

### DIFF
--- a/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
@@ -262,10 +262,11 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
               </VarEditorFieldRow>
 
               <VarEditorFieldRow
-                title='Privacy Policy URL'
+                title='Privacy URL'
                 description='When set, the widget shows a consent banner under the composer linking to this URL. Leave blank to hide.'
                 type={BaseType.STRING}
                 icon={<LinkIcon className='size-3.5' />}
+                isRequired
                 showIcon>
                 <div
                   onBlur={() => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 # docker-compose.yml
 # Development infrastructure — run apps on host with `pnpm dev`
 
+name: auxxai
+
 services:
   postgres:
     image: ankane/pgvector:latest


### PR DESCRIPTION
## Summary
- Sets docker-compose `name: auxxai` so all dev services share a project namespace instead of inheriting the cwd name.
- Renames widget settings field "Privacy Policy URL" → "Privacy URL" and marks it as required.

## Test plan
- [ ] Run `docker compose up` — services namespaced under `auxxai`.
- [ ] Open the chat widget settings → General section → confirm "Privacy URL" label and required indicator.