### PR TITLE
refactor(realtime): room registry + generic publish/subscribe

### DIFF
--- a/apps/web/src/app/api/pusher/auth/route.ts
+++ b/apps/web/src/app/api/pusher/auth/route.ts
@@ -1,11 +1,7 @@
 // ~/app/api/pusher/auth/route.ts
 
-import { database } from '@auxx/database'
-import { InboxService } from '@auxx/lib/inboxes'
-import { findMemberByUser } from '@auxx/lib/members'
 import { getRealtimeService } from '@auxx/lib/realtime'
 import { createScopedLogger } from '@auxx/logger'
-import { toRecordId } from '@auxx/types/resource'
 import { headers } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
 import { auth } from '~/auth/server'
@@ -13,134 +9,57 @@ import { ensureWebAppInitialized } from '~/server/bootstrap'
 
 const logger = createScopedLogger('pusher-auth')
 
+/**
+ * Pusher private/presence channel auth endpoint.
+ *
+ * Pulls `socket_id` + `channel_name` from the form body, resolves the room key
+ * from the registry, and signs the auth response if the ACL passes.
+ *
+ * The widget posts to `/api/chat/pusher/auth` (apps/api) — visitor-scoped rooms
+ * routed through this endpoint require a session, which the widget never has.
+ * Vestigial `private-chat-*` bindings here are handled by the registry's
+ * chat-session entry (anonymous-allowed, matching the legacy behavior).
+ */
 export async function POST(req: NextRequest) {
   await ensureWebAppInitialized()
-  logger.info('Received Pusher auth request')
   try {
     const formData = await req.formData()
     const socket_id = formData.get('socket_id') as string | null
     const channel_name = formData.get('channel_name') as string | null
 
-    // const { socket_id, channel_name } = body
-
-    logger.info('Pusher auth request', {
-      socket_id: socket_id?.substring(0, 10) + '...', // Log partial ID for privacy
-      channel_name,
-    })
-
     if (!socket_id || !channel_name) {
       logger.warn('Missing required parameters', { socket_id, channel_name })
       return NextResponse.json({ error: 'Missing socket_id or channel_name' }, { status: 400 })
     }
-    const realTimeService = getRealtimeService()
 
-    // Handle chat channels (no authentication required)
-    if (channel_name.startsWith('private-chat-')) {
-      logger.info('Authenticating chat channel', { channel_name })
-
-      // Authenticate the channel without user data. The visitor passport
-      // already authorizes the channel; Pusher-side channel binding enforces
-      // it on publish.
-      const authResponse = realTimeService.authenticateChannel(socket_id, channel_name)
-
-      if (!authResponse) {
-        logger.error('Failed to authenticate chat channel', { channel_name })
-        return NextResponse.json(
-          { error: 'Authentication failed for chat channel' },
-          { status: 500 }
-        )
-      }
-
-      logger.info('Chat channel authenticated successfully', {
-        channel_name,
-        auth: authResponse.auth?.substring(0, 10) + '...',
-      })
-      return NextResponse.json(authResponse)
-    }
-
-    // For all other channels, require user authentication
-    // const session = await auth()
     const session = await auth.api.getSession({ headers: await headers() })
+    const realtimeService = getRealtimeService()
 
-    if (!session || !session.user) {
-      logger.warn('Unauthorized access attempt', { channel_name })
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    const ctx = {
+      session: session?.user?.defaultOrganizationId
+        ? { userId: session.user.id, organizationId: session.user.defaultOrganizationId }
+        : null,
     }
 
-    // Optional: Verify organization membership for presence-org channels.
-    // Per-inbox channels (`presence-org-{org}-inbox-{inboxId|none}`) require
-    // an additional access check below.
-    if (channel_name.startsWith('presence-org-')) {
-      // Match `presence-org-{orgId}` and optionally `-inbox-{slug}`
-      const orgChannelMatch = channel_name.match(
-        /^presence-org-([^-]+(?:-[^-]+)*?)(?:-inbox-([^-]+))?$/
-      )
-      // Fallback: split on `-inbox-` boundary which is unambiguous.
-      const inboxSplit = channel_name.split('-inbox-')
-      const orgId = inboxSplit[0].replace('presence-org-', '')
-      const inboxSlug = inboxSplit[1] ?? null
-      void orgChannelMatch
-
-      try {
-        const membership = await findMemberByUser(orgId, session.user.id)
-
-        if (!membership && process.env.NODE_ENV !== 'development') {
-          logger.warn('User not part of organization', { userId: session.user.id, orgId })
-          return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    const userData = session?.user
+      ? {
+          id: session.user.id,
+          name: session.user.name || undefined,
+          email: session.user.email || undefined,
+          image: session.user.image || undefined,
         }
+      : undefined
 
-        // Per-inbox channel: verify inbox access.
-        // - `none` (triage / unassigned) is allowed for any org member.
-        // - Otherwise check the user's view permission on that inbox.
-        if (inboxSlug && inboxSlug !== 'none') {
-          const inboxService = new InboxService(database, orgId, session.user.id)
-          const allowed = await inboxService.hasUserAccess(
-            toRecordId('inbox', inboxSlug),
-            session.user.id
-          )
-          if (!allowed && process.env.NODE_ENV !== 'development') {
-            logger.warn('User has no access to requested inbox channel', {
-              userId: session.user.id,
-              orgId,
-              inboxId: inboxSlug,
-            })
-            return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-          }
-        }
-      } catch (error) {
-        logger.error('Error verifying organization / inbox membership', {
-          userId: session.user.id,
-          orgId,
-          inboxSlug,
-          error,
-        })
-        // We'll continue with auth in development mode
-        if (process.env.NODE_ENV !== 'development') {
-          return NextResponse.json(
-            { error: 'Error verifying organization membership' },
-            { status: 500 }
-          )
-        }
-      }
-    }
-
-    // Authenticate with user data for all other private/presence channels
-    const authResponse = realTimeService.authenticateChannel(socket_id, channel_name, {
-      id: session.user.id,
-      name: session.user.name || undefined,
-      email: session.user.email || undefined,
-      image: session.user.image || undefined,
-    })
+    const authResponse = await realtimeService.authorize(socket_id, channel_name, ctx, userData)
 
     if (!authResponse) {
-      logger.error('Failed to authenticate user channel', { userId: session.user.id, channel_name })
-      return NextResponse.json({ error: 'Authentication failed for user channel' }, { status: 500 })
+      logger.warn('Pusher auth denied', {
+        userId: session?.user?.id,
+        channel_name,
+      })
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
 
-    logger.info('User channel authenticated successfully', {
-      userId: session.user.id,
-      channel_name,
-    })
     return NextResponse.json(authResponse)
   } catch (error) {
     logger.error('Unexpected error in Pusher auth', { error })

--- a/apps/web/src/components/agents/hooks/use-agent-realtime.ts
+++ b/apps/web/src/components/agents/hooks/use-agent-realtime.ts
@@ -2,7 +2,7 @@
 
 'use client'
 
-import { useEffect } from 'react'
+import { useCallback } from 'react'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { useOrgChannel } from '~/realtime/hooks'
 import { api } from '~/trpc/react'
@@ -16,18 +16,20 @@ import { api } from '~/trpc/react'
  * becomes a problem we narrow to an agent-scoped channel.
  */
 export function useAgentRealtime() {
-  const orgChannel = useOrgChannel()
   const { hasAccess } = useFeatureFlags()
   const realtimeSyncEnabled = hasAccess('realtimeSync')
   const utils = api.useUtils()
 
-  useEffect(() => {
-    if (!orgChannel || !realtimeSyncEnabled) return
-    const onUpdate = () => {
-      void utils.agent.getById.invalidate()
-      void utils.agent.list.invalidate()
-    }
-    orgChannel.bind('agent:updated', onUpdate)
-    return () => orgChannel.unbind('agent:updated', onUpdate)
-  }, [orgChannel, realtimeSyncEnabled, utils])
+  const onEvent = useCallback(
+    (event: string) => {
+      if (!realtimeSyncEnabled) return
+      if (event === 'agent:updated') {
+        void utils.agent.getById.invalidate()
+        void utils.agent.list.invalidate()
+      }
+    },
+    [realtimeSyncEnabled, utils]
+  )
+
+  useOrgChannel({ onEvent })
 }

--- a/apps/web/src/components/resources/hooks/use-resource-sync.ts
+++ b/apps/web/src/components/resources/hooks/use-resource-sync.ts
@@ -9,7 +9,7 @@ import type {
   RecordDeletedEvent,
   RecordUpdatedEvent,
 } from '@auxx/lib/realtime'
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { useOrgChannel } from '~/realtime/hooks'
 import { api } from '~/trpc/react'
@@ -22,7 +22,6 @@ import { useRecordStore } from '../store/record-store'
  * Mount once in the app layout.
  */
 export function useResourceSync() {
-  const orgChannel = useOrgChannel()
   const { hasAccess } = useFeatureFlags()
   const realtimeSyncEnabled = hasAccess('realtimeSync')
   const utils = api.useUtils()
@@ -70,13 +69,8 @@ export function useResourceSync() {
     [setRecords, invalidateLists, setValues, utils]
   )
 
-  // Partial-update the cached record if we already have it. If the tab never
-  // fetched this record, do nothing — `useRecord` will fetch fresh when a
-  // component first mounts a card for it.
-  //
-  // Merge only keys present on the payload. The field-value layer emits
-  // column-specific events (`{ displayName }` or `{ avatarUrl }` only), so
-  // treat `undefined` as "don't touch" and `null` as "clear".
+  // Partial-update the cached record if we already have it. Merge only keys
+  // present on the payload — `undefined` means "don't touch", `null` clears.
   const handleRecordUpdated = useCallback(
     (raw: unknown) => {
       const data = raw as RecordUpdatedEvent['data']
@@ -112,29 +106,31 @@ export function useResourceSync() {
     [invalidateLists, utils]
   )
 
-  useEffect(() => {
-    if (!orgChannel || !realtimeSyncEnabled) return
+  const onEvent = useCallback(
+    (event: string, payload: unknown) => {
+      if (!realtimeSyncEnabled) return
+      switch (event) {
+        case 'fieldValues:updated':
+          return handleFieldValuesUpdated(payload)
+        case 'record:created':
+          return handleRecordCreated(payload)
+        case 'record:updated':
+          return handleRecordUpdated(payload)
+        case 'record:deleted':
+          return handleRecordDeleted(payload)
+        case 'record:archived':
+          return handleRecordArchived(payload)
+      }
+    },
+    [
+      realtimeSyncEnabled,
+      handleFieldValuesUpdated,
+      handleRecordCreated,
+      handleRecordUpdated,
+      handleRecordDeleted,
+      handleRecordArchived,
+    ]
+  )
 
-    orgChannel.bind('fieldValues:updated', handleFieldValuesUpdated)
-    orgChannel.bind('record:created', handleRecordCreated)
-    orgChannel.bind('record:updated', handleRecordUpdated)
-    orgChannel.bind('record:deleted', handleRecordDeleted)
-    orgChannel.bind('record:archived', handleRecordArchived)
-
-    return () => {
-      orgChannel.unbind('fieldValues:updated', handleFieldValuesUpdated)
-      orgChannel.unbind('record:created', handleRecordCreated)
-      orgChannel.unbind('record:updated', handleRecordUpdated)
-      orgChannel.unbind('record:deleted', handleRecordDeleted)
-      orgChannel.unbind('record:archived', handleRecordArchived)
-    }
-  }, [
-    orgChannel,
-    realtimeSyncEnabled,
-    handleFieldValuesUpdated,
-    handleRecordCreated,
-    handleRecordUpdated,
-    handleRecordDeleted,
-    handleRecordArchived,
-  ])
+  useOrgChannel({ onEvent })
 }

--- a/apps/web/src/components/threads/realtime/use-mail-sync.ts
+++ b/apps/web/src/components/threads/realtime/use-mail-sync.ts
@@ -13,7 +13,7 @@ import type {
   ThreadDeletedEvent,
   ThreadUpdatedEvent,
 } from '@auxx/lib/realtime/client'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { useInboxChannels, useOrgChannel } from '~/realtime/hooks'
@@ -38,7 +38,6 @@ export function useMailSync() {
   const { hasAccess } = useFeatureFlags()
   const realtimeMailEnabled = hasAccess('realtimeMail')
 
-  const orgChannel = useOrgChannel()
   const { inboxes } = useInboxes()
 
   // Build the slug set from accessible inboxes plus the implicit `none`
@@ -48,8 +47,6 @@ export function useMailSync() {
     list.push('none')
     return list
   }, [inboxes])
-
-  const inboxChannels = useInboxChannels(realtimeMailEnabled ? slugs : [])
 
   // Store actions (selectors to avoid re-renders).
   const requestThread = useThreadStore((s) => s.requestThread)
@@ -70,8 +67,7 @@ export function useMailSync() {
   const utils = api.useUtils()
 
   const handleThreadCreated = useCallback(
-    (raw: unknown) => {
-      const data = (raw as ThreadCreatedEvent['data']) ?? null
+    (data: ThreadCreatedEvent['data'] | null) => {
       if (!data?.threadId) return
       requestThread(data.threadId)
       invalidateAllContexts()
@@ -84,8 +80,7 @@ export function useMailSync() {
   // already skips keys with pending optimistic mutations. Drops events whose
   // `userId` belongs to a different user (per-user unread fanout).
   const handleThreadUpdated = useCallback(
-    (raw: unknown) => {
-      const data = (raw as ThreadUpdatedEvent['data']) ?? null
+    (data: ThreadUpdatedEvent['data'] | null) => {
       if (!data?.threadId || !data.patch) return
       const patch = { ...(data.patch as Record<string, unknown>) }
       if (patch.userId && currentUserId && patch.userId !== currentUserId) return
@@ -98,8 +93,7 @@ export function useMailSync() {
   )
 
   const handleThreadDeleted = useCallback(
-    (raw: unknown) => {
-      const data = (raw as ThreadDeletedEvent['data']) ?? null
+    (data: ThreadDeletedEvent['data'] | null) => {
       if (!data?.threadId) return
       removeThread(data.threadId)
       invalidateMessageList(data.threadId)
@@ -109,21 +103,16 @@ export function useMailSync() {
   )
 
   const handleMessageCreated = useCallback(
-    (raw: unknown) => {
-      const data = (raw as MessageCreatedEvent['data']) ?? null
+    (data: MessageCreatedEvent['data'] | null) => {
       if (!data?.messageId || !data?.threadId) return
       requestMessage(data.messageId)
       appendMessage(data.threadId, data.messageId)
-      // Thread metadata (lastMessageAt, latestMessageId, messageCount) lands
-      // via the metadata-recompute thread:updated event published by the
-      // ingest seam.
     },
     [requestMessage, appendMessage]
   )
 
   const handleMessageUpdated = useCallback(
-    (raw: unknown) => {
-      const data = (raw as MessageUpdatedEvent['data']) ?? null
+    (data: MessageUpdatedEvent['data'] | null) => {
       if (!data?.messageId || !data.patch) return
       const patch = { ...(data.patch as Record<string, unknown>) }
       delete patch.id
@@ -135,8 +124,7 @@ export function useMailSync() {
   )
 
   const handleMessageDeleted = useCallback(
-    (raw: unknown) => {
-      const data = (raw as MessageDeletedEvent['data']) ?? null
+    (data: MessageDeletedEvent['data'] | null) => {
       if (!data?.messageId || !data?.threadId) return
       removeMessage(data.messageId)
       removeFromMessageList(data.threadId, data.messageId)
@@ -145,8 +133,7 @@ export function useMailSync() {
   )
 
   const handleParticipantUpdated = useCallback(
-    (raw: unknown) => {
-      const data = (raw as ParticipantUpdatedEvent['data']) ?? null
+    (data: ParticipantUpdatedEvent['data'] | null) => {
       if (!data?.participantId || !data.patch) return
       const patch = { ...(data.patch as Record<string, unknown>) }
       delete patch.id
@@ -192,8 +179,7 @@ export function useMailSync() {
   )
 
   const handleMailBatch = useCallback(
-    (raw: unknown) => {
-      const data = (raw as MailBatchEvent['data']) ?? null
+    (data: MailBatchEvent['data'] | null) => {
       if (!Array.isArray(data?.events)) return
       for (const e of data.events) dispatchEvent(e)
       // One list invalidation at the end of a bundle.
@@ -202,49 +188,49 @@ export function useMailSync() {
     [dispatchEvent, utils]
   )
 
-  // Bind handlers on every active inbox channel.
-  useEffect(() => {
-    if (!realtimeMailEnabled) return
-    const cleanups: Array<() => void> = []
-    for (const channel of inboxChannels.values()) {
-      channel.bind('thread:created', handleThreadCreated)
-      channel.bind('thread:updated', handleThreadUpdated)
-      channel.bind('thread:deleted', handleThreadDeleted)
-      channel.bind('message:created', handleMessageCreated)
-      channel.bind('message:updated', handleMessageUpdated)
-      channel.bind('message:deleted', handleMessageDeleted)
-      channel.bind('mail:batch', handleMailBatch)
-      cleanups.push(() => {
-        channel.unbind('thread:created', handleThreadCreated)
-        channel.unbind('thread:updated', handleThreadUpdated)
-        channel.unbind('thread:deleted', handleThreadDeleted)
-        channel.unbind('message:created', handleMessageCreated)
-        channel.unbind('message:updated', handleMessageUpdated)
-        channel.unbind('message:deleted', handleMessageDeleted)
-        channel.unbind('mail:batch', handleMailBatch)
-      })
-    }
-    return () => {
-      for (const c of cleanups) c()
-    }
-  }, [
-    realtimeMailEnabled,
-    inboxChannels,
-    handleThreadCreated,
-    handleThreadUpdated,
-    handleThreadDeleted,
-    handleMessageCreated,
-    handleMessageUpdated,
-    handleMessageDeleted,
-    handleMailBatch,
-  ])
+  // Inbox-channel event dispatcher. Bound across every active per-inbox room
+  // by `useInboxChannels`.
+  const onInboxEvent = useCallback(
+    (event: string, payload: unknown) => {
+      switch (event) {
+        case 'thread:created':
+          return handleThreadCreated(payload as ThreadCreatedEvent['data'])
+        case 'thread:updated':
+          return handleThreadUpdated(payload as ThreadUpdatedEvent['data'])
+        case 'thread:deleted':
+          return handleThreadDeleted(payload as ThreadDeletedEvent['data'])
+        case 'message:created':
+          return handleMessageCreated(payload as MessageCreatedEvent['data'])
+        case 'message:updated':
+          return handleMessageUpdated(payload as MessageUpdatedEvent['data'])
+        case 'message:deleted':
+          return handleMessageDeleted(payload as MessageDeletedEvent['data'])
+        case 'mail:batch':
+          return handleMailBatch(payload as MailBatchEvent['data'])
+      }
+    },
+    [
+      handleThreadCreated,
+      handleThreadUpdated,
+      handleThreadDeleted,
+      handleMessageCreated,
+      handleMessageUpdated,
+      handleMessageDeleted,
+      handleMailBatch,
+    ]
+  )
 
-  // Participant events ride on the org channel.
-  useEffect(() => {
-    if (!realtimeMailEnabled || !orgChannel) return
-    orgChannel.bind('participant:updated', handleParticipantUpdated)
-    return () => {
-      orgChannel.unbind('participant:updated', handleParticipantUpdated)
-    }
-  }, [realtimeMailEnabled, orgChannel, handleParticipantUpdated])
+  // Org-channel event dispatcher (currently just participant updates).
+  const onOrgEvent = useCallback(
+    (event: string, payload: unknown) => {
+      if (!realtimeMailEnabled) return
+      if (event === 'participant:updated') {
+        handleParticipantUpdated(payload as ParticipantUpdatedEvent['data'])
+      }
+    },
+    [realtimeMailEnabled, handleParticipantUpdated]
+  )
+
+  useInboxChannels(realtimeMailEnabled ? slugs : [], { onEvent: onInboxEvent })
+  useOrgChannel({ onEvent: onOrgEvent })
 }

--- a/apps/web/src/realtime/hooks.ts
+++ b/apps/web/src/realtime/hooks.ts
@@ -2,18 +2,82 @@
 
 'use client'
 
-import type { ChannelSubscription } from '@auxx/lib/realtime/client'
-import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import type { PresenceHandlers, PresenceMember, SubscribeHandlers } from '@auxx/lib/realtime/client'
+import { rooms } from '@auxx/lib/realtime/client'
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 import { useUser } from '~/hooks/use-user'
 import { realtimeAdapter } from './adapter'
 
-/** Subscribe to the org channel. Re-renders only when channel reference changes. */
-export function useOrgChannel(): ChannelSubscription | null {
-  return useSyncExternalStore(
-    realtimeAdapter.subscribeToOrgChannel,
-    realtimeAdapter.getOrgChannelSnapshot,
-    realtimeAdapter.getServerOrgChannelSnapshot
+/**
+ * Subscribe to a single realtime room by key. Pass handlers; the hook
+ * refcounts the underlying Pusher channel and tears it down on unmount.
+ *
+ * Returns `true` once the channel is bound (so consumers can gate UI on it).
+ */
+export function useRealtimeRoom(
+  roomKey: string | null | undefined,
+  handlers: SubscribeHandlers
+): boolean {
+  // Keep the latest handlers in a ref so we can subscribe once per `roomKey`
+  // without re-binding every render when callbacks change.
+  const handlersRef = useRef(handlers)
+  handlersRef.current = handlers
+
+  useEffect(() => {
+    if (!roomKey) return
+    const sub = realtimeAdapter.subscribe(roomKey, {
+      onEvent: (event, payload) => handlersRef.current.onEvent?.(event, payload),
+    })
+    return () => sub.unsubscribe()
+  }, [roomKey])
+
+  const getSnapshot = useCallback(
+    () => (roomKey ? realtimeAdapter.getRoomSnapshot(roomKey) : false),
+    [roomKey]
   )
+  const getServerSnapshot = useCallback(
+    () => (roomKey ? realtimeAdapter.getServerRoomSnapshot(roomKey) : false),
+    [roomKey]
+  )
+  return useSyncExternalStore(realtimeAdapter.subscribeToRooms, getSnapshot, getServerSnapshot)
+}
+
+/**
+ * Subscribe to a presence room. Same refcount semantics as `useRealtimeRoom`,
+ * plus member tracking handlers. The `self` member payload is mostly
+ * informational — Pusher derives presence-self from the auth response.
+ */
+export function usePresence(
+  roomKey: string | null | undefined,
+  self: PresenceMember,
+  handlers: PresenceHandlers
+): boolean {
+  const handlersRef = useRef(handlers)
+  handlersRef.current = handlers
+  const selfRef = useRef(self)
+  selfRef.current = self
+
+  useEffect(() => {
+    if (!roomKey) return
+    const sub = realtimeAdapter.subscribePresence(roomKey, selfRef.current, {
+      onEvent: (e, p) => handlersRef.current.onEvent?.(e, p),
+      onMembers: (members) => handlersRef.current.onMembers?.(members),
+      onJoin: (m) => handlersRef.current.onJoin?.(m),
+      onLeave: (id) => handlersRef.current.onLeave?.(id),
+      onMemberUpdate: (m) => handlersRef.current.onMemberUpdate?.(m),
+    })
+    return () => sub.unsubscribe()
+  }, [roomKey])
+
+  const getSnapshot = useCallback(
+    () => (roomKey ? realtimeAdapter.getRoomSnapshot(roomKey) : false),
+    [roomKey]
+  )
+  const getServerSnapshot = useCallback(
+    () => (roomKey ? realtimeAdapter.getServerRoomSnapshot(roomKey) : false),
+    [roomKey]
+  )
+  return useSyncExternalStore(realtimeAdapter.subscribeToRooms, getSnapshot, getServerSnapshot)
 }
 
 /** Subscribe to connection state. Re-renders only on connect/disconnect. */
@@ -31,69 +95,101 @@ export function getRealtimeSocketId(): string | undefined {
 }
 
 /**
- * Subscribe to a single inbox channel by slug. Pass `'none'` for the
- * unassigned-triage channel. The hook reference-counts subscriptions so
- * multiple components can call it safely.
+ * Subscribe to the org presence channel. Listen to events via the returned
+ * handler registration; the hook refcounts so multiple call sites are safe.
  *
- * Returns the channel once subscription is established, or null while pending.
+ * Returns `true` once the channel is bound.
  */
-export function useInboxChannel(inboxSlug: string | null | undefined): ChannelSubscription | null {
+export function useOrgChannel(handlers?: SubscribeHandlers): boolean {
   const { organizationId } = useUser()
+  const roomKey = organizationId ? rooms.orgPresence(organizationId) : null
+  return useRealtimeRoom(roomKey, handlers ?? {})
+}
 
-  useEffect(() => {
-    if (!organizationId || !inboxSlug) return
-    realtimeAdapter.subscribeToInbox(organizationId, inboxSlug)
-    return () => {
-      realtimeAdapter.unsubscribeFromInbox(organizationId, inboxSlug)
-    }
-  }, [organizationId, inboxSlug])
-
-  const getSnapshot = useCallback(
-    () => (inboxSlug ? realtimeAdapter.getInboxChannelSnapshot(inboxSlug) : null),
-    [inboxSlug]
-  )
-  const getServerSnapshot = useCallback(
-    () => (inboxSlug ? realtimeAdapter.getServerInboxChannelSnapshot(inboxSlug) : null),
-    [inboxSlug]
-  )
-  return useSyncExternalStore(
-    realtimeAdapter.subscribeToInboxChannels,
-    getSnapshot,
-    getServerSnapshot
-  )
+/**
+ * Subscribe to a single inbox channel by slug. Pass `'none'` for the
+ * unassigned-triage channel. The hook refcounts subscriptions so multiple
+ * components can call it safely.
+ */
+export function useInboxChannel(
+  inboxSlug: string | null | undefined,
+  handlers?: SubscribeHandlers
+): boolean {
+  const { organizationId } = useUser()
+  const roomKey = organizationId && inboxSlug ? rooms.orgInbox(organizationId, inboxSlug) : null
+  return useRealtimeRoom(roomKey, handlers ?? {})
 }
 
 /**
  * Subscribe to many inbox channels at once. Manages add/remove based on the
- * given slugs and notifies React on any change. Returns the adapter's full
- * inbox-channel map snapshot (stable until membership changes).
+ * given slugs. Returns the set of currently-subscribed room keys for the
+ * requested slugs only (filtered from the adapter's global room map).
+ *
+ * The returned set is referentially stable until either the requested slug
+ * set changes or the adapter's subscribed-room contents change for those
+ * slugs — required by the `useSyncExternalStore` snapshot contract.
  *
  * Always include `'none'` in the slug set if you want unassigned-triage events.
  */
 export function useInboxChannels(
-  slugs: readonly string[]
-): ReadonlyMap<string, ChannelSubscription> {
+  slugs: readonly string[],
+  handlers?: SubscribeHandlers
+): ReadonlySet<string> {
   const { organizationId } = useUser()
+  const handlersRef = useRef(handlers)
+  handlersRef.current = handlers
 
   // Stable comma-joined key so the effect only re-runs when the slug set changes.
-  const slugKey = [...slugs].sort().join(',')
+  const slugKey = useMemo(() => [...slugs].sort().join(','), [slugs])
 
   useEffect(() => {
-    if (!organizationId) return
-    const list = slugKey ? slugKey.split(',') : []
-    for (const slug of list) {
-      realtimeAdapter.subscribeToInbox(organizationId, slug)
-    }
+    if (!organizationId || !slugKey) return
+    const list = slugKey.split(',')
+    const subs = list.map((slug) =>
+      realtimeAdapter.subscribe(rooms.orgInbox(organizationId, slug), {
+        onEvent: (event, payload) => handlersRef.current?.onEvent?.(event, payload),
+      })
+    )
     return () => {
-      for (const slug of list) {
-        realtimeAdapter.unsubscribeFromInbox(organizationId, slug)
-      }
+      for (const s of subs) s.unsubscribe()
     }
   }, [organizationId, slugKey])
 
-  return useSyncExternalStore(
-    realtimeAdapter.subscribeToInboxChannels,
-    realtimeAdapter.getInboxChannelMapSnapshot,
-    realtimeAdapter.getServerInboxChannelMapSnapshot
-  )
+  // Set of room keys we care about for this hook instance.
+  const requestedKeys = useMemo<ReadonlySet<string>>(() => {
+    if (!organizationId || !slugKey) return EMPTY_ROOM_SET
+    return new Set(slugKey.split(',').map((slug) => rooms.orgInbox(organizationId, slug)))
+  }, [organizationId, slugKey])
+
+  // Cache the last returned snapshot so identity stays stable until the
+  // filtered membership actually changes. `useSyncExternalStore` requires the
+  // snapshot fn to return the same reference for unchanged state.
+  const lastSnapshotRef = useRef<ReadonlySet<string>>(EMPTY_ROOM_SET)
+
+  const getSnapshot = useCallback((): ReadonlySet<string> => {
+    const all = realtimeAdapter.getRoomMapSnapshot()
+    const next = new Set<string>()
+    for (const key of requestedKeys) {
+      if (all.has(key)) next.add(key)
+    }
+    const prev = lastSnapshotRef.current
+    if (prev.size === next.size) {
+      let same = true
+      for (const k of next) {
+        if (!prev.has(k)) {
+          same = false
+          break
+        }
+      }
+      if (same) return prev
+    }
+    lastSnapshotRef.current = next
+    return next
+  }, [requestedKeys])
+
+  const getServerSnapshot = useCallback((): ReadonlySet<string> => EMPTY_ROOM_SET, [])
+
+  return useSyncExternalStore(realtimeAdapter.subscribeToRooms, getSnapshot, getServerSnapshot)
 }
+
+const EMPTY_ROOM_SET: ReadonlySet<string> = new Set()

--- a/apps/web/src/realtime/use-realtime-lifecycle.ts
+++ b/apps/web/src/realtime/use-realtime-lifecycle.ts
@@ -2,7 +2,7 @@
 
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useUser } from '~/hooks/use-user'
 import { useEnv } from '~/providers/dehydrated-state-provider'
 import { realtimeAdapter } from './adapter'
@@ -10,14 +10,20 @@ import { realtimeAdapter } from './adapter'
 /**
  * Drives the realtime adapter lifecycle based on auth state.
  * Mount once in the app layout. Renders nothing.
+ *
+ * On org change, tears down every room tied to the old org so the new org's
+ * subscriptions don't bleed through the refcount store. Mirrors the legacy
+ * `subscribeToOrg`-side cleanup that the old adapter did inline.
  */
 export function useRealtimeLifecycle() {
   const { user, organizationId } = useUser()
   const { pusher: config } = useEnv()
+  const previousOrgRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (!user || !organizationId) {
       realtimeAdapter.disconnect()
+      previousOrgRef.current = null
       return
     }
 
@@ -27,10 +33,32 @@ export function useRealtimeLifecycle() {
       authEndpoint: '/api/pusher/auth',
     })
 
-    realtimeAdapter.subscribeToOrg(organizationId)
+    // Org switch: tear down every room scoped to the previous org.
+    //
+    // Includes:
+    //   - `org-{oldOrgId}` (org presence)
+    //   - `org-{oldOrgId}-*` (org events, per-inbox channels)
+    //   - `thread-*` (chat threads are org-scoped — a thread belongs to one
+    //     org, so the previous org's thread subscriptions must be dropped)
+    //
+    // Intentionally excluded: `user-{userId}` — the same user crosses orgs,
+    // so their private user channel stays bound across org switches.
+    //
+    // Hook-level subscriptions (useOrgChannel, useInboxChannels, thread hooks)
+    // will re-subscribe on the next render with the new org id.
+    if (previousOrgRef.current && previousOrgRef.current !== organizationId) {
+      const stale = previousOrgRef.current
+      const stalePrefix = `org-${stale}`
+      realtimeAdapter.unsubscribeMatching(
+        (key) =>
+          key === stalePrefix || key.startsWith(`${stalePrefix}-`) || key.startsWith('thread-')
+      )
+    }
+    previousOrgRef.current = organizationId
 
     return () => {
       realtimeAdapter.disconnect()
+      previousOrgRef.current = null
     }
   }, [user, organizationId, config.key, config.cluster])
 }

--- a/apps/web/src/server/api/root.ts
+++ b/apps/web/src/server/api/root.ts
@@ -54,6 +54,7 @@ import { participantRouter } from './routers/participant'
 import { productRouter } from './routers/product'
 import { promptTemplateRouter } from './routers/promptTemplate'
 import { quickActionRouter } from './routers/quick-actions'
+import { realtimeRouter } from './routers/realtime'
 import { recordRouter } from './routers/record'
 import { recordingRouter } from './routers/recording'
 import { resourceRouter } from './routers/resource'
@@ -138,6 +139,7 @@ export const appRouter = createTRPCRouter({
   product: productRouter,
   promptTemplate: promptTemplateRouter,
   quickAction: quickActionRouter,
+  realtime: realtimeRouter,
   record: recordRouter,
   recording: recordingRouter,
   resource: resourceRouter,

--- a/apps/web/src/server/api/routers/realtime.ts
+++ b/apps/web/src/server/api/routers/realtime.ts
@@ -1,0 +1,114 @@
+// ~/server/api/routers/realtime.ts
+
+import { findRoom, getRealtimeService } from '@auxx/lib/realtime'
+import { createScopedLogger } from '@auxx/logger'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+
+const logger = createScopedLogger('realtime-router')
+
+/**
+ * Allow-list of event-name prefixes that may be published via the client-facing
+ * `realtime.publish` tRPC mutation.
+ *
+ * Server-published events (`thread:*`, `message:*`, `record:*`,
+ * `fieldValues:*`, `agent:*`, `mail:*`, `participant:*`) must NEVER be
+ * publishable from the client — they're authoritative server-side state
+ * changes and a spoofed copy from a logged-in org member would let a peer
+ * forge deletions, updates, or agent activity into any room they pass ACL on.
+ *
+ * Client-publishable events are limited to ephemeral peer-to-peer signals
+ * (typing indicators, presence meta) where forging only affects the spoofer's
+ * own UX peers within the same room. Add new prefixes here only after
+ * confirming the event is safe to spoof.
+ */
+const ALLOWED_EVENT_PREFIXES = ['typing:', 'presence:'] as const
+
+function isAllowedEvent(event: string): boolean {
+  return ALLOWED_EVENT_PREFIXES.some((prefix) => event.startsWith(prefix))
+}
+
+/**
+ * Realtime tRPC router. Two procedures:
+ *
+ *   - `publish(roomKey, event, payload)` — server-side mediated publish for
+ *     admin-only actions (e.g. an admin pushing into a typing room). Gated by
+ *     the room registry's `authorize` fn.
+ *
+ *   - `updateSelf(roomKey, meta)` — the only path for presence meta updates.
+ *     Posts a `member-update` event on the presence room via Pusher REST so
+ *     every state change goes through one ACL surface (no Pusher client-events).
+ *
+ * Channel auth itself stays on the existing `/api/pusher/auth` REST endpoint —
+ * Pusher's JS client needs an HTTP `authEndpoint`, and routing that through
+ * tRPC is friction with no benefit.
+ */
+export const realtimeRouter = createTRPCRouter({
+  publish: protectedProcedure
+    .input(
+      z.object({
+        roomKey: z.string().min(1).max(256),
+        event: z.string().min(1).max(128),
+        payload: z.unknown(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (!isAllowedEvent(input.event)) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Event name not permitted for client publish',
+        })
+      }
+
+      const def = findRoom(input.roomKey)
+      if (!def) throw new TRPCError({ code: 'NOT_FOUND', message: 'Unknown room' })
+
+      const allowed = await def.authorize(input.roomKey, {
+        session: {
+          userId: ctx.session.userId,
+          organizationId: ctx.session.organizationId,
+        },
+      })
+      if (!allowed) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Not allowed to publish to this room' })
+      }
+
+      const ok = await getRealtimeService().publish(input.roomKey, input.event, input.payload)
+      if (!ok) {
+        logger.warn('Realtime publish failed', { roomKey: input.roomKey, event: input.event })
+      }
+      return { ok }
+    }),
+
+  updateSelf: protectedProcedure
+    .input(
+      z.object({
+        roomKey: z.string().min(1).max(256),
+        meta: z.record(z.string(), z.unknown()),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const def = findRoom(input.roomKey)
+      if (!def) throw new TRPCError({ code: 'NOT_FOUND', message: 'Unknown room' })
+      if (def.kind !== 'presence') {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'updateSelf requires a presence room' })
+      }
+
+      const allowed = await def.authorize(input.roomKey, {
+        session: {
+          userId: ctx.session.userId,
+          organizationId: ctx.session.organizationId,
+        },
+      })
+      if (!allowed) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Not allowed to update this room' })
+      }
+
+      const ok = await getRealtimeService().publishMemberUpdate(input.roomKey, {
+        id: ctx.session.userId,
+        meta: input.meta,
+      })
+      return { ok }
+    }),
+})

--- a/packages/lib/src/chat/realtime.ts
+++ b/packages/lib/src/chat/realtime.ts
@@ -2,6 +2,7 @@
 
 import { publishMessageCreated, publishMessageUpdated } from '../realtime/publish-helpers'
 import type { RealtimeService } from '../realtime/realtime-service'
+import { rooms } from '../realtime/rooms'
 
 /**
  * Shape of a chat message frame the embedded widget renders. Loose typing —
@@ -48,11 +49,15 @@ export async function publishChatMessageCreated(
       threadId: args.threadId,
       inboxId: args.inboxId,
     }),
-    realtime.sendToChat(args.visitorChatSessionId, 'new-message', args.visitorPayload),
+    realtime.publish(
+      rooms.chatSession(args.visitorChatSessionId),
+      'new-message',
+      args.visitorPayload
+    ),
   ]
   if (args.visitorParticipantId) {
     tasks.push(
-      realtime.sendToVisitor(args.visitorParticipantId, 'thread-updated', {
+      realtime.publish(rooms.visitor(args.visitorParticipantId), 'thread-updated', {
         threadId: args.threadId,
         lastMessage: {
           sender: args.visitorPayload.sender,
@@ -74,7 +79,7 @@ export async function publishVisitorThreadCreated(
   realtime: RealtimeService,
   args: { visitorParticipantId: string; threadId: string; createdAt?: Date }
 ): Promise<void> {
-  await realtime.sendToVisitor(args.visitorParticipantId, 'thread-created', {
+  await realtime.publish(rooms.visitor(args.visitorParticipantId), 'thread-created', {
     threadId: args.threadId,
     createdAt: args.createdAt ?? new Date(),
   })
@@ -114,7 +119,7 @@ export async function publishChatTyping(
     agent?: { id: string; name: string }
   }
 ): Promise<void> {
-  await realtime.sendToChat(args.visitorChatSessionId, 'typing', {
+  await realtime.publish(rooms.chatSession(args.visitorChatSessionId), 'typing', {
     sender: args.sender,
     isTyping: args.isTyping,
     agent: args.agent,
@@ -127,7 +132,7 @@ export async function publishChatThreadClosed(
   realtime: RealtimeService,
   args: { visitorChatSessionId: string; closedBy: { id: string; name: string } }
 ): Promise<void> {
-  await realtime.sendToChat(args.visitorChatSessionId, 'session-closed', {
+  await realtime.publish(rooms.chatSession(args.visitorChatSessionId), 'session-closed', {
     closedBy: args.closedBy,
     createdAt: new Date(),
   })

--- a/packages/lib/src/field-values/field-value-helpers.ts
+++ b/packages/lib/src/field-values/field-value-helpers.ts
@@ -22,7 +22,7 @@ import { and, eq, inArray, sql } from 'drizzle-orm'
 import { findCachedResource, getCachedEntityDefId, getCachedResource, getOrgCache } from '../cache'
 import type { FieldOptions } from '../custom-fields/field-options'
 import { BadRequestError } from '../errors'
-import { getRealtimeService } from '../realtime'
+import { getRealtimeService, rooms } from '../realtime'
 import { isRecordId, parseRecordId, toRecordId } from '../resources/resource-id'
 import { cascadeDependentDisplayNames, getDisplayFieldDeps } from './display-field-deps'
 import { FieldValueValidator, fieldValueSchemas } from './field-value-validator'
@@ -891,8 +891,8 @@ async function publishRecordColumnUpdate(
     if (!features?.realtimeSync) return
     const recordId = toRecordId(entityDefId, entityInstanceId)
     getRealtimeService()
-      .sendToOrganization(
-        ctx.organizationId,
+      .publish(
+        rooms.orgPresence(ctx.organizationId),
         'record:updated',
         {
           entityDefinitionId: entityDefId,

--- a/packages/lib/src/jobs/maintenance/generate-thumbnail-job.ts
+++ b/packages/lib/src/jobs/maintenance/generate-thumbnail-job.ts
@@ -18,7 +18,7 @@ import type {
 } from '../../files/core/thumbnail-types'
 import { createStorageManager } from '../../files/storage/storage-manager'
 import { createScopedLogger } from '../../logger'
-import { getRealtimeService } from '../../realtime'
+import { getRealtimeService, rooms } from '../../realtime'
 import { toRecordId } from '../../resources/resource-id'
 
 /**
@@ -481,8 +481,8 @@ async function publishAvatarResolved(params: {
     await Promise.all(
       instances.map(({ entityInstanceId, entityDefinitionId }) =>
         realtime
-          .sendToOrganization(
-            orgId,
+          .publish(
+            rooms.orgPresence(orgId),
             'record:updated',
             {
               entityDefinitionId,

--- a/packages/lib/src/notifications/notification-service.ts
+++ b/packages/lib/src/notifications/notification-service.ts
@@ -3,7 +3,7 @@ import { database as db, schema } from '@auxx/database'
 import type { NotificationType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { and, count, desc, eq, gte, inArray, lt } from 'drizzle-orm'
-import { getRealtimeService } from '../realtime'
+import { getRealtimeService, rooms } from '../realtime'
 import type { RealtimeService } from '../realtime/realtime-service'
 
 const logger = createScopedLogger('notification-service')
@@ -95,7 +95,7 @@ export class NotificationService {
       // Send real-time notification if service is available
       if (this.realTimeService) {
         logger.debug('Sending real-time notification', { userId, notificationId: notification!.id })
-        await this.realTimeService.sendToUser(userId, 'notification', notification)
+        await this.realTimeService.publish(rooms.user(userId), 'notification', notification)
       } else {
         logger.warn('Real-time service not available, skipping real-time notification')
       }

--- a/packages/lib/src/realtime/client/adapters/pusher.ts
+++ b/packages/lib/src/realtime/client/adapters/pusher.ts
@@ -1,41 +1,54 @@
 // @auxx/lib/realtime/client/adapters/pusher.ts
 
 import Pusher from 'pusher-js'
-import type { ChannelSubscription, RealtimeAdapter } from '../types'
+import { toPusherChannel } from '../../room-keys'
+import type {
+  PresenceHandlers,
+  PresenceMember,
+  RealtimeAdapter,
+  SubscribeHandlers,
+  Subscription,
+} from '../types'
 
-/** Wrap a Pusher.Channel to satisfy the ChannelSubscription interface. */
-function wrapPusherChannel(channel: Pusher.Channel): ChannelSubscription {
-  return {
-    bind: (event, cb) => channel.bind(event, cb),
-    unbind: (event, cb) => channel.unbind(event, cb),
-    unbindAll: () => channel.unbind_all(),
+interface RoomEntry {
+  channel: Pusher.Channel
+  refCount: number
+  /** Bound event names so we can `unbind` cleanly on teardown. */
+  handlers: Set<SubscribeHandlers | PresenceHandlers>
+  /** Catch-all bind for `onEvent` — we use `bind_global` once per channel. */
+  globalListener?: (event: string, payload: unknown) => void
+  /** Presence-only listeners we attached for cleanup. */
+  presenceListeners?: {
+    onSubscriptionSucceeded?: () => void
+    onMemberAdded?: (member: { id: string; info?: Record<string, unknown> }) => void
+    onMemberRemoved?: (member: { id: string }) => void
+    onMemberUpdate?: (payload: { id: string; meta?: Record<string, unknown> }) => void
   }
 }
 
+const FRESH_ROOM_MAP: ReadonlySet<string> = new Set()
+
 /**
- * Client-side Pusher implementation of RealtimeAdapter.
- * Subscribe/getSnapshot methods are arrow-function class fields for stable references
- * (required by useSyncExternalStore to avoid infinite re-render loops).
+ * Pusher-backed RealtimeAdapter.
+ *
+ * Internal store layout:
+ *   - `rooms`: live `Map<roomKey, RoomEntry>` driving the subscription
+ *   - `roomsSnapshot`: frozen `Set<roomKey>` exposed to `useSyncExternalStore`
+ *     (replaced with a new reference on every membership change so React
+ *     re-renders, but identity-stable across no-op state changes).
  */
 export class PusherRealtimeAdapter implements RealtimeAdapter {
   private pusher: Pusher | null = null
   private connected = false
-  private orgChannel: ChannelSubscription | null = null
-  private currentOrgId: string | null = null
+  private authEndpoint = '/api/pusher/auth'
   private connectionListeners = new Set<() => void>()
-  private orgChannelListeners = new Set<() => void>()
-
-  /** slug → channel wrapper; slug is the raw inbox UUID or `'none'`. */
-  private inboxChannels: Map<string, ChannelSubscription> = new Map()
-  /** Frozen snapshot — replaced (new reference) only on membership change. */
-  private inboxChannelsSnapshot: ReadonlyMap<string, ChannelSubscription> = new Map()
-  /** Reference count per slug so multiple consumers can subscribe safely. */
-  private inboxRefCounts = new Map<string, number>()
-  private inboxChannelListeners = new Set<() => void>()
-  private static readonly EMPTY_INBOX_MAP: ReadonlyMap<string, ChannelSubscription> = new Map()
+  private rooms = new Map<string, RoomEntry>()
+  private roomsSnapshot: ReadonlySet<string> = new Set()
+  private roomListeners = new Set<() => void>()
 
   connect(config: { key: string; cluster: string; authEndpoint: string }) {
-    if (this.pusher) return // Already connected
+    if (this.pusher) return
+    this.authEndpoint = config.authEndpoint
     this.pusher = new Pusher(config.key, {
       cluster: config.cluster,
       authEndpoint: config.authEndpoint,
@@ -43,83 +56,23 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
     })
     this.pusher.connection.bind('connected', () => {
       this.connected = true
-      this.notifyConnectionListeners()
+      this.notifyConnection()
     })
     this.pusher.connection.bind('disconnected', () => {
       this.connected = false
-      this.notifyConnectionListeners()
+      this.notifyConnection()
     })
   }
 
   disconnect() {
-    if (this.pusher) {
-      this.pusher.disconnect()
-      this.pusher = null
-      this.connected = false
-      this.orgChannel = null
-      this.currentOrgId = null
-      this.inboxChannels.clear()
-      this.inboxRefCounts.clear()
-      this.refreshInboxSnapshot()
-      this.notifyConnectionListeners()
-      this.notifyOrgChannelListeners()
-      this.notifyInboxChannelListeners()
-    }
-  }
-
-  subscribeToOrg(organizationId: string) {
     if (!this.pusher) return
-    // Skip if already subscribed to this org
-    if (this.currentOrgId === organizationId && this.orgChannel) return
-
-    // Unsubscribe from previous org channel
-    if (this.currentOrgId) {
-      this.pusher.unsubscribe(`presence-org-${this.currentOrgId}`)
-      // Drop any stale per-inbox subscriptions tied to the previous org.
-      for (const slug of this.inboxChannels.keys()) {
-        this.pusher.unsubscribe(`presence-org-${this.currentOrgId}-inbox-${slug}`)
-      }
-      this.inboxChannels.clear()
-      this.inboxRefCounts.clear()
-      this.refreshInboxSnapshot()
-      this.notifyInboxChannelListeners()
-    }
-
-    const channel = this.pusher.subscribe(`presence-org-${organizationId}`)
-    this.orgChannel = wrapPusherChannel(channel)
-    this.currentOrgId = organizationId
-    this.notifyOrgChannelListeners()
-  }
-
-  subscribeToInbox(organizationId: string, inboxSlug: string) {
-    if (!this.pusher) return
-    if (this.currentOrgId !== organizationId) return
-
-    const refCount = (this.inboxRefCounts.get(inboxSlug) ?? 0) + 1
-    this.inboxRefCounts.set(inboxSlug, refCount)
-    if (this.inboxChannels.has(inboxSlug)) return
-
-    const channelName = `presence-org-${organizationId}-inbox-${inboxSlug}`
-    const channel = this.pusher.subscribe(channelName)
-    this.inboxChannels.set(inboxSlug, wrapPusherChannel(channel))
-    this.refreshInboxSnapshot()
-    this.notifyInboxChannelListeners()
-  }
-
-  unsubscribeFromInbox(organizationId: string, inboxSlug: string) {
-    if (!this.pusher) return
-    if (this.currentOrgId !== organizationId) return
-
-    const refCount = this.inboxRefCounts.get(inboxSlug) ?? 0
-    if (refCount <= 1) {
-      this.inboxRefCounts.delete(inboxSlug)
-      this.inboxChannels.delete(inboxSlug)
-      this.pusher.unsubscribe(`presence-org-${organizationId}-inbox-${inboxSlug}`)
-      this.refreshInboxSnapshot()
-      this.notifyInboxChannelListeners()
-    } else {
-      this.inboxRefCounts.set(inboxSlug, refCount - 1)
-    }
+    this.pusher.disconnect()
+    this.pusher = null
+    this.connected = false
+    this.rooms.clear()
+    this.refreshRoomsSnapshot()
+    this.notifyConnection()
+    this.notifyRooms()
   }
 
   getSocketId(): string | undefined {
@@ -130,7 +83,204 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
     return this.connected
   }
 
-  // --- useSyncExternalStore contract (stable arrow-function references) ---
+  // ----------------------------------------------------------------------
+  // Generic subscribe
+  // ----------------------------------------------------------------------
+
+  subscribe(roomKey: string, handlers: SubscribeHandlers): Subscription {
+    return this.subscribeInternal(roomKey, handlers, false)
+  }
+
+  subscribePresence(
+    roomKey: string,
+    _self: PresenceMember,
+    handlers: PresenceHandlers
+  ): Subscription {
+    // Pusher derives the presence-self payload from the auth response on the
+    // server (`channel_data` carries the user_id + user_info); the explicit
+    // `self` here is informational only.
+    return this.subscribeInternal(roomKey, handlers, true)
+  }
+
+  private subscribeInternal(
+    roomKey: string,
+    handlers: SubscribeHandlers | PresenceHandlers,
+    presence: boolean
+  ): Subscription {
+    if (!this.pusher) {
+      return { unsubscribe: () => {} }
+    }
+    const channelName = toPusherChannel(roomKey)
+    if (!channelName) {
+      // Unknown room — surface as a no-op rather than throwing inside React.
+      return { unsubscribe: () => {} }
+    }
+    if (presence && !channelName.startsWith('presence-')) {
+      return { unsubscribe: () => {} }
+    }
+
+    let entry = this.rooms.get(roomKey)
+    if (!entry) {
+      const channel = this.pusher.subscribe(channelName)
+      entry = {
+        channel,
+        refCount: 0,
+        handlers: new Set(),
+      }
+      // Single catch-all listener — fans out to every registered handler.
+      // Filter Pusher internal events (`pusher:subscription_succeeded`,
+      // `pusher:pong`, `pusher:cache_miss`, etc.) so consumers only see real
+      // domain events. Presence built-ins (`pusher:member_added` /
+      // `pusher:member_removed`) are bound explicitly above and routed through
+      // the presence handlers, not the global fan-out.
+      const globalListener = (event: string, payload: unknown) => {
+        if (event.startsWith('pusher:')) return
+        const current = this.rooms.get(roomKey)
+        if (!current) return
+        for (const h of current.handlers) {
+          h.onEvent?.(event, payload)
+        }
+      }
+      channel.bind_global(globalListener)
+      entry.globalListener = globalListener
+
+      if (presence) {
+        const presenceCh = channel as Pusher.PresenceChannel
+        const onSubSucceeded = () => {
+          const members: PresenceMember[] = []
+          presenceCh.members.each((m: { id: string; info?: Record<string, unknown> }) => {
+            members.push({ id: m.id, meta: m.info })
+          })
+          const current = this.rooms.get(roomKey)
+          if (!current) return
+          for (const h of current.handlers) {
+            ;(h as PresenceHandlers).onMembers?.(members)
+          }
+        }
+        const onMemberAdded = (member: { id: string; info?: Record<string, unknown> }) => {
+          const current = this.rooms.get(roomKey)
+          if (!current) return
+          for (const h of current.handlers) {
+            ;(h as PresenceHandlers).onJoin?.({ id: member.id, meta: member.info })
+          }
+        }
+        const onMemberRemoved = (member: { id: string }) => {
+          const current = this.rooms.get(roomKey)
+          if (!current) return
+          for (const h of current.handlers) {
+            ;(h as PresenceHandlers).onLeave?.(member.id)
+          }
+        }
+        const onMemberUpdate = (payload: { id: string; meta?: Record<string, unknown> }) => {
+          const current = this.rooms.get(roomKey)
+          if (!current) return
+          for (const h of current.handlers) {
+            ;(h as PresenceHandlers).onMemberUpdate?.(payload)
+          }
+        }
+        channel.bind('pusher:subscription_succeeded', onSubSucceeded)
+        channel.bind('pusher:member_added', onMemberAdded)
+        channel.bind('pusher:member_removed', onMemberRemoved)
+        // `member-update` is a custom server-mediated event (see
+        // `RealtimeService.publishMemberUpdate`). Routed through the same
+        // handler shape as Pusher's built-in member events.
+        channel.bind('member-update', onMemberUpdate)
+        entry.presenceListeners = {
+          onSubscriptionSucceeded: onSubSucceeded,
+          onMemberAdded,
+          onMemberRemoved,
+          onMemberUpdate,
+        }
+      }
+
+      this.rooms.set(roomKey, entry)
+    }
+
+    entry.handlers.add(handlers)
+    entry.refCount += 1
+    if (entry.refCount === 1) {
+      this.refreshRoomsSnapshot()
+      this.notifyRooms()
+    }
+
+    return {
+      unsubscribe: () => this.unsubscribe(roomKey, handlers),
+    }
+  }
+
+  private unsubscribe(roomKey: string, handlers: SubscribeHandlers | PresenceHandlers) {
+    const entry = this.rooms.get(roomKey)
+    if (!entry) return
+    entry.handlers.delete(handlers)
+    entry.refCount = Math.max(0, entry.refCount - 1)
+    if (entry.refCount === 0) {
+      this.teardownRoom(roomKey, entry)
+      this.refreshRoomsSnapshot()
+      this.notifyRooms()
+    }
+  }
+
+  private teardownRoom(roomKey: string, entry: RoomEntry) {
+    if (!this.pusher) {
+      this.rooms.delete(roomKey)
+      return
+    }
+    const channelName = toPusherChannel(roomKey)
+    try {
+      if (entry.globalListener) entry.channel.unbind_global(entry.globalListener)
+      if (entry.presenceListeners) {
+        const l = entry.presenceListeners
+        if (l.onSubscriptionSucceeded)
+          entry.channel.unbind('pusher:subscription_succeeded', l.onSubscriptionSucceeded)
+        if (l.onMemberAdded) entry.channel.unbind('pusher:member_added', l.onMemberAdded)
+        if (l.onMemberRemoved) entry.channel.unbind('pusher:member_removed', l.onMemberRemoved)
+        if (l.onMemberUpdate) entry.channel.unbind('member-update', l.onMemberUpdate)
+      }
+    } catch {
+      /* defensive — Pusher channels may already be torn down on disconnect */
+    }
+    if (channelName) {
+      this.pusher.unsubscribe(channelName)
+    }
+    this.rooms.delete(roomKey)
+  }
+
+  unsubscribeMatching(predicate: (roomKey: string) => boolean) {
+    const toRemove: string[] = []
+    for (const key of this.rooms.keys()) {
+      if (predicate(key)) toRemove.push(key)
+    }
+    if (toRemove.length === 0) return
+    for (const key of toRemove) {
+      const entry = this.rooms.get(key)
+      if (entry) this.teardownRoom(key, entry)
+    }
+    this.refreshRoomsSnapshot()
+    this.notifyRooms()
+  }
+
+  // ----------------------------------------------------------------------
+  // updateSelf — server-mediated presence meta update
+  // ----------------------------------------------------------------------
+
+  updateSelf = async (roomKey: string, meta: Record<string, unknown>): Promise<void> => {
+    // Posted to the colocated tRPC `realtime.updateSelf` mutation. Routed
+    // through plain fetch to keep the adapter free of tRPC-client deps.
+    const trpcEndpoint = '/api/trpc/realtime.updateSelf'
+    try {
+      await fetch(trpcEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ json: { roomKey, meta } }),
+      })
+    } catch {
+      /* ignore — fire-and-forget; idle transitions will retry next flip */
+    }
+  }
+
+  // ----------------------------------------------------------------------
+  // useSyncExternalStore plumbing
+  // ----------------------------------------------------------------------
 
   subscribeToConnection = (callback: () => void): (() => void) => {
     this.connectionListeners.add(callback)
@@ -138,50 +288,32 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
   }
 
   getConnectionSnapshot = (): boolean => this.connected
-
   getServerConnectionSnapshot = (): boolean => false
 
-  subscribeToOrgChannel = (callback: () => void): (() => void) => {
-    this.orgChannelListeners.add(callback)
-    return () => this.orgChannelListeners.delete(callback)
+  subscribeToRooms = (callback: () => void): (() => void) => {
+    this.roomListeners.add(callback)
+    return () => this.roomListeners.delete(callback)
   }
 
-  getOrgChannelSnapshot = (): ChannelSubscription | null => this.orgChannel
+  getRoomSnapshot = (roomKey: string): boolean => this.rooms.has(roomKey)
+  getServerRoomSnapshot = (_roomKey: string): boolean => false
 
-  getServerOrgChannelSnapshot = (): ChannelSubscription | null => null
+  getRoomMapSnapshot = (): ReadonlySet<string> => this.roomsSnapshot
+  getServerRoomMapSnapshot = (): ReadonlySet<string> => FRESH_ROOM_MAP
 
-  subscribeToInboxChannels = (callback: () => void): (() => void) => {
-    this.inboxChannelListeners.add(callback)
-    return () => this.inboxChannelListeners.delete(callback)
+  // ----------------------------------------------------------------------
+  // Internals
+  // ----------------------------------------------------------------------
+
+  private refreshRoomsSnapshot() {
+    this.roomsSnapshot = new Set(this.rooms.keys())
   }
 
-  getInboxChannelSnapshot = (inboxSlug: string): ChannelSubscription | null =>
-    this.inboxChannels.get(inboxSlug) ?? null
-
-  getServerInboxChannelSnapshot = (_inboxSlug: string): ChannelSubscription | null => null
-
-  getInboxChannelMapSnapshot = (): ReadonlyMap<string, ChannelSubscription> =>
-    this.inboxChannelsSnapshot
-
-  getServerInboxChannelMapSnapshot = (): ReadonlyMap<string, ChannelSubscription> =>
-    PusherRealtimeAdapter.EMPTY_INBOX_MAP
-
-  // --- Internal ---
-
-  /** Replace the public snapshot with a frozen copy of the live map. */
-  private refreshInboxSnapshot() {
-    this.inboxChannelsSnapshot = new Map(this.inboxChannels)
-  }
-
-  private notifyConnectionListeners() {
+  private notifyConnection() {
     for (const cb of this.connectionListeners) cb()
   }
 
-  private notifyOrgChannelListeners() {
-    for (const cb of this.orgChannelListeners) cb()
-  }
-
-  private notifyInboxChannelListeners() {
-    for (const cb of this.inboxChannelListeners) cb()
+  private notifyRooms() {
+    for (const cb of this.roomListeners) cb()
   }
 }

--- a/packages/lib/src/realtime/client/index.ts
+++ b/packages/lib/src/realtime/client/index.ts
@@ -20,5 +20,12 @@ export type {
   ThreadUpdatedEvent,
 } from '../events'
 export { getPusherClient } from '../pusher-client'
+export { type RoomKind, rooms } from '../room-keys'
 export { PusherRealtimeAdapter } from './adapters/pusher'
-export type { ChannelSubscription, RealtimeAdapter } from './types'
+export type {
+  PresenceHandlers,
+  PresenceMember,
+  RealtimeAdapter,
+  SubscribeHandlers,
+  Subscription,
+} from './types'

--- a/packages/lib/src/realtime/client/types.ts
+++ b/packages/lib/src/realtime/client/types.ts
@@ -1,55 +1,77 @@
 // @auxx/lib/realtime/client/types.ts
 
-/** A channel subscription that supports event binding/unbinding. */
-export interface ChannelSubscription {
-  bind(event: string, callback: (data: unknown) => void): void
-  unbind(event: string, callback?: (data: unknown) => void): void
-  unbindAll(): void
+/** A live subscription. Call `unsubscribe()` to release a single ref. */
+export interface Subscription {
+  unsubscribe(): void
+}
+
+/** Member info delivered on presence rooms. */
+export interface PresenceMember {
+  id: string
+  meta?: Record<string, unknown>
+}
+
+/** Event-only handlers (plain rooms). */
+export interface SubscribeHandlers {
+  onEvent?(event: string, payload: unknown): void
+}
+
+/** Presence-room handlers — extend plain handlers with member tracking. */
+export interface PresenceHandlers extends SubscribeHandlers {
+  /** Snapshot fired once after `pusher:subscription_succeeded`. */
+  onMembers?(members: PresenceMember[]): void
+  onJoin?(member: PresenceMember): void
+  onLeave?(memberId: string): void
+  onMemberUpdate?(member: PresenceMember): void
 }
 
 /**
  * Provider-agnostic client-side realtime adapter.
- * Manages connection lifecycle, org channel, and useSyncExternalStore-compatible subscriptions.
+ *
+ * Designed for `useSyncExternalStore` — every `subscribeToX` / `getXSnapshot`
+ * is an arrow-function class field so React gets stable references and avoids
+ * infinite re-render loops.
+ *
+ * The adapter is refcounted internally — multiple components can subscribe to
+ * the same room and only the last `unsubscribe()` tears down the underlying
+ * Pusher channel.
  */
 export interface RealtimeAdapter {
   // Lifecycle
   connect(config: { key: string; cluster: string; authEndpoint: string }): void
   disconnect(): void
-
-  // Channel management
-  subscribeToOrg(organizationId: string): void
-
-  /**
-   * Subscribe to a per-inbox channel. `inboxSlug` is the raw inbox UUID, or
-   * the literal string `'none'` for the unassigned-triage channel. Idempotent
-   * — multiple subscriptions to the same slug return the same channel.
-   */
-  subscribeToInbox(organizationId: string, inboxSlug: string): void
-
-  /** Unsubscribe from a per-inbox channel. */
-  unsubscribeFromInbox(organizationId: string, inboxSlug: string): void
-
-  // State reads (non-reactive, for imperative access)
   getSocketId(): string | undefined
   isConnected(): boolean
 
-  // useSyncExternalStore-compatible subscriptions for connection state
+  /** Subscribe to a plain (private-) room. Refcounted per `roomKey`. */
+  subscribe(roomKey: string, handlers: SubscribeHandlers): Subscription
+  /** Subscribe to a presence room. Refcounted per `roomKey`. */
+  subscribePresence(roomKey: string, self: PresenceMember, handlers: PresenceHandlers): Subscription
+  /**
+   * Server-mediated meta update. Posts to the `realtime.updateSelf` tRPC; the
+   * server publishes a `member-update` event on the room via Pusher REST.
+   * No Pusher client-events are emitted.
+   */
+  updateSelf(roomKey: string, meta: Record<string, unknown>): Promise<void>
+
+  // useSyncExternalStore — connection state
   subscribeToConnection(callback: () => void): () => void
   getConnectionSnapshot(): boolean
   getServerConnectionSnapshot(): boolean
 
-  // useSyncExternalStore-compatible subscriptions for org channel
-  subscribeToOrgChannel(callback: () => void): () => void
-  getOrgChannelSnapshot(): ChannelSubscription | null
-  getServerOrgChannelSnapshot(): ChannelSubscription | null
+  // useSyncExternalStore — per-room subscription tracking. Listeners fire
+  // whenever any subscription is added or removed. Snapshots are stable
+  // references until membership changes.
+  subscribeToRooms(callback: () => void): () => void
+  getRoomSnapshot(roomKey: string): boolean
+  getServerRoomSnapshot(roomKey: string): boolean
+  /** Snapshot of all currently-subscribed room keys (stable until membership changes). */
+  getRoomMapSnapshot(): ReadonlySet<string>
+  getServerRoomMapSnapshot(): ReadonlySet<string>
 
-  // useSyncExternalStore-compatible subscriptions for inbox channels.
-  // Listeners are notified whenever any inbox channel is added or removed.
-  // The map snapshot is stable until membership changes (referentially equal).
-  subscribeToInboxChannels(callback: () => void): () => void
-  getInboxChannelSnapshot(inboxSlug: string): ChannelSubscription | null
-  getServerInboxChannelSnapshot(inboxSlug: string): ChannelSubscription | null
-  /** Stable map snapshot — same reference until membership changes. */
-  getInboxChannelMapSnapshot(): ReadonlyMap<string, ChannelSubscription>
-  getServerInboxChannelMapSnapshot(): ReadonlyMap<string, ChannelSubscription>
+  /**
+   * Drop every subscription tied to a roomKey prefix. Used by the lifecycle
+   * hook to tear down org-scoped rooms when the active org switches.
+   */
+  unsubscribeMatching(predicate: (roomKey: string) => boolean): void
 }

--- a/packages/lib/src/realtime/index.ts
+++ b/packages/lib/src/realtime/index.ts
@@ -52,4 +52,15 @@ export {
   publishThreadUpdated,
 } from './publish-helpers'
 export { RealtimeService } from './realtime-service'
+export {
+  type AuthorizeCtx,
+  findRoom,
+  findRoomByChannel,
+  fromPusherChannel,
+  type RoomDef,
+  type RoomKind,
+  roomKindFor,
+  rooms,
+  toPusherChannel,
+} from './rooms'
 export type { RealtimeProvider } from './types'

--- a/packages/lib/src/realtime/publish-helpers.ts
+++ b/packages/lib/src/realtime/publish-helpers.ts
@@ -9,6 +9,7 @@ import type {
   ThreadMeta,
 } from './events'
 import type { RealtimeService } from './realtime-service'
+import { rooms } from './rooms'
 
 const CHUNK_SIZE = 50
 
@@ -33,13 +34,10 @@ export async function publishFieldValueUpdates(
   const { features } = await getOrgCache().getOrRecompute(organizationId, ['features'])
   if (!features?.realtimeSync) return
 
+  const roomKey = rooms.orgPresence(organizationId)
+
   if (entries.length <= CHUNK_SIZE) {
-    await realtimeService.sendToOrganization(
-      organizationId,
-      'fieldValues:updated',
-      { entries },
-      options
-    )
+    await realtimeService.publish(roomKey, 'fieldValues:updated', { entries }, options)
     return
   }
 
@@ -50,8 +48,8 @@ export async function publishFieldValueUpdates(
   for (let i = 0; i < totalChunks; i++) {
     const chunk = entries.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE)
     promises.push(
-      realtimeService.sendToOrganization(
-        organizationId,
+      realtimeService.publish(
+        roomKey,
         'fieldValues:updated',
         { entries: chunk, chunk: { index: i, total: totalChunks } },
         options
@@ -75,6 +73,11 @@ async function isMailRealtimeEnabled(organizationId: string): Promise<boolean> {
   return Boolean(features?.realtimeMail)
 }
 
+/** Resolve a nullable inboxId to its registry slug. `null` → `'none'`. */
+function inboxRoom(organizationId: string, inboxId: string | null): string {
+  return rooms.orgInbox(organizationId, inboxId ?? 'none')
+}
+
 /**
  * Publish `thread:created` on the inbox channel for the given thread.
  * `inboxId` is the raw EntityInstance id (or null for triage).
@@ -87,9 +90,8 @@ export async function publishThreadCreated(
 ) {
   if (!(await isMailRealtimeEnabled(organizationId))) return
   await realtimeService
-    .sendToInbox(
-      organizationId,
-      args.inboxId,
+    .publish(
+      inboxRoom(organizationId, args.inboxId),
       'thread:created',
       { threadId: args.threadId, inboxId: args.inboxRecordId ?? null },
       options
@@ -122,7 +124,12 @@ export async function publishThreadUpdated(
   }
   await Promise.allSettled(
     Array.from(targets).map((inboxId) =>
-      realtimeService.sendToInbox(organizationId, inboxId, 'thread:updated', payload, options)
+      realtimeService.publish(
+        inboxRoom(organizationId, inboxId),
+        'thread:updated',
+        payload,
+        options
+      )
     )
   )
 }
@@ -136,9 +143,8 @@ export async function publishThreadDeleted(
 ) {
   if (!(await isMailRealtimeEnabled(organizationId))) return
   await realtimeService
-    .sendToInbox(
-      organizationId,
-      args.inboxId,
+    .publish(
+      inboxRoom(organizationId, args.inboxId),
       'thread:deleted',
       { threadId: args.threadId },
       options
@@ -155,9 +161,8 @@ export async function publishMessageCreated(
 ) {
   if (!(await isMailRealtimeEnabled(organizationId))) return
   await realtimeService
-    .sendToInbox(
-      organizationId,
-      args.inboxId,
+    .publish(
+      inboxRoom(organizationId, args.inboxId),
       'message:created',
       { messageId: args.messageId, threadId: args.threadId },
       options
@@ -179,9 +184,8 @@ export async function publishMessageUpdated(
 ) {
   if (!(await isMailRealtimeEnabled(organizationId))) return
   await realtimeService
-    .sendToInbox(
-      organizationId,
-      args.inboxId,
+    .publish(
+      inboxRoom(organizationId, args.inboxId),
       'message:updated',
       {
         messageId: args.messageId,
@@ -202,9 +206,8 @@ export async function publishMessageDeleted(
 ) {
   if (!(await isMailRealtimeEnabled(organizationId))) return
   await realtimeService
-    .sendToInbox(
-      organizationId,
-      args.inboxId,
+    .publish(
+      inboxRoom(organizationId, args.inboxId),
       'message:deleted',
       { messageId: args.messageId, threadId: args.threadId },
       options
@@ -225,8 +228,8 @@ export async function publishParticipantUpdated(
 ) {
   if (!(await isMailRealtimeEnabled(organizationId))) return
   await realtimeService
-    .sendToOrganization(
-      organizationId,
+    .publish(
+      rooms.orgPresence(organizationId),
       'participant:updated',
       {
         participantId: args.participantId,
@@ -264,18 +267,10 @@ export async function flushMailBatch(
 
   const promises: Promise<boolean>[] = []
   for (const [slug, list] of buckets) {
-    const inboxId = slug === 'none' ? null : slug
+    const roomKey = rooms.orgInbox(organizationId, slug)
     for (let i = 0; i < list.length; i += CHUNK_SIZE) {
       const chunk = list.slice(i, i + CHUNK_SIZE)
-      promises.push(
-        realtimeService.sendToInbox(
-          organizationId,
-          inboxId,
-          'mail:batch',
-          { events: chunk },
-          options
-        )
-      )
+      promises.push(realtimeService.publish(roomKey, 'mail:batch', { events: chunk }, options))
     }
   }
   await Promise.allSettled(promises)
@@ -303,6 +298,6 @@ export async function publishAgentUpdated(
   const { features } = await getOrgCache().getOrRecompute(organizationId, ['features'])
   if (!features?.realtimeSync) return
   await realtimeService
-    .sendToOrganization(organizationId, 'agent:updated', { agentId: args.agentId }, options)
+    .publish(rooms.orgPresence(organizationId), 'agent:updated', { agentId: args.agentId }, options)
     .catch(() => {})
 }

--- a/packages/lib/src/realtime/realtime-service.ts
+++ b/packages/lib/src/realtime/realtime-service.ts
@@ -1,10 +1,14 @@
 // @auxx/lib/realtime/realtime-service.ts
 
+import { type AuthorizeCtx, findRoom, fromPusherChannel, toPusherChannel } from './rooms'
 import type { RealtimeProvider } from './types'
 
 /**
  * Provider-agnostic realtime service.
- * Wraps a RealtimeProvider with channel naming conventions and convenience methods.
+ *
+ * The public API is opaque-room-key based — callers build keys via
+ * `rooms.X(...)` helpers and the service handles the Pusher prefix mapping
+ * (`presence-` / `private-`) internally.
  */
 export class RealtimeService {
   private provider: RealtimeProvider
@@ -13,73 +17,65 @@ export class RealtimeService {
     this.provider = provider
   }
 
-  /** Publish to `presence-org-{organizationId}` */
-  async sendToOrganization(
-    organizationId: string,
+  /**
+   * Publish an event to a room. The Pusher channel name is derived from the
+   * room's registered kind (plain → `private-{key}`, presence → `presence-{key}`).
+   * Returns false if the room isn't registered or the provider isn't initialized.
+   */
+  async publish(
+    roomKey: string,
     event: string,
     data: unknown,
     options?: { excludeSocketId?: string }
   ): Promise<boolean> {
-    return this.provider.publish(`presence-org-${organizationId}`, event, data, options)
+    const channel = toPusherChannel(roomKey)
+    if (!channel) return false
+    return this.provider.publish(channel, event, data, options)
   }
 
   /**
-   * Publish to `presence-org-{organizationId}-inbox-{inboxId | 'none'}`.
-   * Mail events publish per-inbox so users only receive events for inboxes they
-   * can read. Unassigned threads (`inboxId = null`) ride on the `none` slug,
-   * which every org member subscribes to as the org-triage default.
+   * Publish a `member-update` event on a presence room. Used by
+   * `realtime.updateSelf` tRPC to fan out per-member meta changes (e.g. idle
+   * transitions, custom status) without relying on Pusher client-events.
    */
-  async sendToInbox(
-    organizationId: string,
-    inboxId: string | null,
-    event: string,
-    data: unknown,
-    options?: { excludeSocketId?: string }
+  async publishMemberUpdate(
+    roomKey: string,
+    member: { id: string; meta?: Record<string, unknown> }
   ): Promise<boolean> {
-    const slug = inboxId ?? 'none'
-    return this.provider.publish(
-      `presence-org-${organizationId}-inbox-${slug}`,
-      event,
-      data,
-      options
-    )
-  }
-
-  /** Publish to `private-user-{userId}` */
-  async sendToUser(
-    userId: string,
-    event: string,
-    data: unknown,
-    options?: { excludeSocketId?: string }
-  ): Promise<boolean> {
-    return this.provider.publish(`private-user-${userId}`, event, data, options)
-  }
-
-  /** Publish to `private-chat-{sessionId}` */
-  async sendToChat(
-    sessionId: string,
-    event: string,
-    data: unknown,
-    options?: { excludeSocketId?: string }
-  ): Promise<boolean> {
-    return this.provider.publish(`private-chat-${sessionId}`, event, data, options)
+    const def = findRoom(roomKey)
+    if (!def || def.kind !== 'presence') return false
+    return this.publish(roomKey, 'member-update', member)
   }
 
   /**
-   * Publish to `private-visitor-{visitorParticipantId}` — the cross-thread
-   * channel used by the chat widget to receive updates for any of the visitor's
-   * threads (Messages tab list + launcher unread badge).
+   * Authenticate a Pusher channel binding. Takes the raw Pusher channel name
+   * (e.g. `private-org-xxx-inbox-yyy`) so the route handler can pass through
+   * what Pusher sent it. ACL is dispatched via the room registry.
    */
-  async sendToVisitor(
-    visitorParticipantId: string,
-    event: string,
-    data: unknown,
-    options?: { excludeSocketId?: string }
-  ): Promise<boolean> {
-    return this.provider.publish(`private-visitor-${visitorParticipantId}`, event, data, options)
+  async authorize(
+    socketId: string,
+    channelName: string,
+    ctx: AuthorizeCtx,
+    userData?: { id: string; name?: string; email?: string; image?: string }
+  ): Promise<{ auth: string; channel_data?: string } | null> {
+    const roomKey = fromPusherChannel(channelName)
+    if (!roomKey) return null
+    const def = findRoom(roomKey)
+    if (!def) return null
+    // Reject if the channel prefix doesn't match the registered kind.
+    const expected = toPusherChannel(roomKey)
+    if (expected !== channelName) return null
+
+    const allowed = await def.authorize(roomKey, ctx)
+    if (!allowed) return null
+    return this.provider.authenticate(socketId, channelName, userData)
   }
 
-  /** Authenticate a client for a private/presence channel */
+  /**
+   * Raw Pusher authentication — used by the widget auth route which does its
+   * own visitor-passport check upstream. Prefer `authorize(...)` everywhere
+   * else.
+   */
   authenticateChannel(
     socketId: string,
     channel: string,

--- a/packages/lib/src/realtime/room-keys.ts
+++ b/packages/lib/src/realtime/room-keys.ts
@@ -1,0 +1,62 @@
+// @auxx/lib/realtime/room-keys.ts
+
+/**
+ * Client-safe room key helpers and prefix mapping.
+ *
+ * Lives separately from `rooms.ts` so the client adapter can import it without
+ * pulling in the server-only ACL logic (which touches the DB, inbox service,
+ * etc.).
+ *
+ * Both files share the same `RoomKind` definitions for every room family —
+ * the server registry adds `authorize(...)` fns on top.
+ */
+
+export type RoomKind = 'plain' | 'presence'
+
+/** Typed helpers to build room keys. Mirrored on `rooms` for server callers. */
+export const rooms = {
+  /** Org-wide events (records, agents, mail batches outside an inbox). */
+  orgEvents: (organizationId: string): string => `org-${organizationId}-events`,
+  /** Org presence room (member online/idle). */
+  orgPresence: (organizationId: string): string => `org-${organizationId}`,
+  /** Per-inbox channel. `inboxSlug` is the raw inbox UUID, or `'none'` for triage. */
+  orgInbox: (organizationId: string, inboxSlug: string): string =>
+    `org-${organizationId}-inbox-${inboxSlug}`,
+  /** Private per-user channel (notifications, personal events). */
+  user: (userId: string): string => `user-${userId}`,
+  /** Per-chat-thread admin channel. */
+  chatThread: (threadId: string): string => `thread-${threadId}`,
+  /** Visitor's chat session (widget-side). */
+  chatSession: (sessionId: string): string => `chat-${sessionId}`,
+  /** Visitor's cross-thread channel (widget-side). */
+  visitor: (participantId: string): string => `visitor-${participantId}`,
+}
+
+/**
+ * Resolve a room key to its kind. Same ordering as the server registry — must
+ * stay in sync. Returns null for unknown keys.
+ */
+export function roomKindFor(roomKey: string): RoomKind | null {
+  if (/^org-.+-inbox-.+$/.test(roomKey)) return 'plain'
+  if (/^org-.+-events$/.test(roomKey)) return 'plain'
+  if (roomKey.startsWith('org-')) return 'presence'
+  if (roomKey.startsWith('user-')) return 'plain'
+  if (roomKey.startsWith('thread-')) return 'plain'
+  if (roomKey.startsWith('chat-')) return 'plain'
+  if (roomKey.startsWith('visitor-')) return 'plain'
+  return null
+}
+
+/** Map a room key to its Pusher channel name (`private-` / `presence-`). */
+export function toPusherChannel(roomKey: string): string | null {
+  const kind = roomKindFor(roomKey)
+  if (!kind) return null
+  return kind === 'presence' ? `presence-${roomKey}` : `private-${roomKey}`
+}
+
+/** Strip the Pusher prefix to recover the room key. */
+export function fromPusherChannel(channelName: string): string | null {
+  if (channelName.startsWith('private-')) return channelName.slice('private-'.length)
+  if (channelName.startsWith('presence-')) return channelName.slice('presence-'.length)
+  return null
+}

--- a/packages/lib/src/realtime/rooms.ts
+++ b/packages/lib/src/realtime/rooms.ts
@@ -1,0 +1,163 @@
+// @auxx/lib/realtime/rooms.ts
+
+/**
+ * Server-side room registry — one entry per room family declares its ACL.
+ *
+ * The Pusher auth route and the server publish path both dispatch through
+ * `findRoom(...)`. Adding a new room family = one helper on `rooms`, one
+ * `roomKindFor(...)` branch in `room-keys.ts`, and one entry here.
+ *
+ * Client-safe helpers (key builders, kind lookup, prefix mapping) live in
+ * `./room-keys.ts` so the browser bundle never pulls in DB code.
+ */
+
+import { database } from '@auxx/database'
+import { toRecordId } from '@auxx/types/resource'
+import { InboxService } from '../inboxes'
+import { findMemberByUser } from '../members'
+import { fromPusherChannel, type RoomKind, toPusherChannel } from './room-keys'
+
+export type { RoomKind } from './room-keys'
+export { fromPusherChannel, roomKindFor, rooms, toPusherChannel } from './room-keys'
+
+/**
+ * Authorization context handed to every `authorize(...)` call.
+ *
+ * - `session` is non-null for authenticated users in the admin app.
+ * - `visitor` is populated by widget-facing auth surfaces after a passport check.
+ *   When both are null, only rooms that explicitly allow anonymous access pass.
+ */
+export interface AuthorizeCtx {
+  session: { userId: string; organizationId: string } | null
+  visitor?: { participantId: string; threadId?: string }
+}
+
+/** Registry row for one room family. */
+export interface RoomDef {
+  kind: RoomKind
+  /** Returns true if `roomKey` belongs to this family. */
+  match: (roomKey: string) => boolean
+  /** Per-key ACL. Return false to deny. */
+  authorize: (roomKey: string, ctx: AuthorizeCtx) => Promise<boolean> | boolean
+}
+
+const DEV = process.env.NODE_ENV === 'development'
+
+/** True iff the session is a member of the given org (with dev-mode bypass). */
+async function isOrgMember(orgId: string, ctx: AuthorizeCtx): Promise<boolean> {
+  if (!ctx.session) return false
+  try {
+    const membership = await findMemberByUser(orgId, ctx.session.userId)
+    if (membership) return true
+    return DEV
+  } catch {
+    return DEV
+  }
+}
+
+/**
+ * Registry order matters — `match` is greedy, so the more-specific patterns
+ * (`-inbox-`, `-events`) must come before the generic `org-` presence room.
+ */
+const REGISTRY: RoomDef[] = [
+  // Per-inbox channel: `org-{orgId}-inbox-{inboxSlug}`
+  {
+    kind: 'plain',
+    match: (k) => /^org-.+-inbox-.+$/.test(k),
+    authorize: async (key, ctx) => {
+      const parts = key.split('-inbox-')
+      if (parts.length !== 2) return false
+      const orgId = parts[0].replace(/^org-/, '')
+      const inboxSlug = parts[1]
+      if (!(await isOrgMember(orgId, ctx))) return false
+      // `none` (triage / unassigned) is open to all org members.
+      if (inboxSlug === 'none') return true
+      try {
+        const inboxService = new InboxService(database, orgId, ctx.session!.userId)
+        const allowed = await inboxService.hasUserAccess(
+          toRecordId('inbox', inboxSlug),
+          ctx.session!.userId
+        )
+        return allowed || DEV
+      } catch {
+        return DEV
+      }
+    },
+  },
+  // Org events: `org-{orgId}-events`
+  {
+    kind: 'plain',
+    match: (k) => /^org-.+-events$/.test(k),
+    authorize: async (key, ctx) => {
+      const orgId = key.replace(/^org-/, '').replace(/-events$/, '')
+      return isOrgMember(orgId, ctx)
+    },
+  },
+  // Org presence: `org-{orgId}` (must run after `-inbox-` and `-events` entries).
+  {
+    kind: 'presence',
+    match: (k) => k.startsWith('org-') && !k.includes('-inbox-') && !k.endsWith('-events'),
+    authorize: async (key, ctx) => {
+      const orgId = key.replace(/^org-/, '')
+      return isOrgMember(orgId, ctx)
+    },
+  },
+  // Private user channel: `user-{userId}`
+  {
+    kind: 'plain',
+    match: (k) => k.startsWith('user-'),
+    authorize: (key, ctx) => {
+      const userId = key.slice('user-'.length)
+      return !!ctx.session && ctx.session.userId === userId
+    },
+  },
+  // Chat thread (admin view): `thread-{threadId}`
+  {
+    kind: 'plain',
+    match: (k) => k.startsWith('thread-'),
+    authorize: (_key, ctx) => !!ctx.session,
+  },
+  // Visitor chat session (widget-side): `chat-{sessionId}`.
+  //
+  // The widget signs `chat-*` bindings via `/api/chat/pusher/auth` (apps/api),
+  // which validates the visitor passport and populates `ctx.visitor`. This
+  // surface (apps/web `/api/pusher/auth`) never populates `ctx.visitor`, so in
+  // practice the predicate below collapses to "authenticated admin only" here.
+  //
+  // Kept in the registry on purpose: when the widget's transport eventually
+  // migrates onto this codepath, the ACL row is already in place. Don't drop
+  // it just because the apps/web path can't satisfy it today.
+  {
+    kind: 'plain',
+    match: (k) => k.startsWith('chat-'),
+    authorize: (_key, ctx) => !!ctx.session || !!ctx.visitor,
+  },
+  // Visitor cross-thread (widget-side): `visitor-{participantId}`
+  {
+    kind: 'plain',
+    match: (k) => k.startsWith('visitor-'),
+    authorize: (key, ctx) => {
+      const participantId = key.slice('visitor-'.length)
+      return !!ctx.visitor && ctx.visitor.participantId === participantId
+    },
+  },
+]
+
+/** Find the registry entry that owns `roomKey`, or `null` if unknown. */
+export function findRoom(roomKey: string): RoomDef | null {
+  for (const def of REGISTRY) {
+    if (def.match(roomKey)) return def
+  }
+  return null
+}
+
+/** Convenience — resolves a Pusher channel name directly. */
+export function findRoomByChannel(channelName: string): RoomDef | null {
+  const key = fromPusherChannel(channelName)
+  if (!key) return null
+  const def = findRoom(key)
+  if (!def) return null
+  // Reject if the channel prefix doesn't match the registered kind.
+  if (toPusherChannel(key) !== channelName) return null
+  return def
+}

--- a/packages/lib/src/resources/crud/unified-handler-mutations.ts
+++ b/packages/lib/src/resources/crud/unified-handler-mutations.ts
@@ -15,7 +15,7 @@ import { UnprocessableEntityError } from '../../errors'
 import { publisher } from '../../events/publisher'
 import { getEntityPreDeleteHooks } from '../../field-hooks/registry'
 import type { FieldValueService } from '../../field-values'
-import { getRealtimeService } from '../../realtime'
+import { getRealtimeService, rooms } from '../../realtime'
 import { invalidateSnapshots } from '../../snapshot'
 import {
   captureEventData,
@@ -375,8 +375,8 @@ export async function createEntity(
     const { features } = await getOrgCache().getOrRecompute(ctx.organizationId, ['features'])
     if (features?.realtimeSync) {
       getRealtimeService()
-        .sendToOrganization(
-          ctx.organizationId,
+        .publish(
+          rooms.orgPresence(ctx.organizationId),
           'record:created',
           {
             entityDefinitionId: entityDef.id,
@@ -486,8 +486,8 @@ export async function updateEntity(
     const { features } = await getOrgCache().getOrRecompute(ctx.organizationId, ['features'])
     if (features?.realtimeSync) {
       getRealtimeService()
-        .sendToOrganization(
-          ctx.organizationId,
+        .publish(
+          rooms.orgPresence(ctx.organizationId),
           'record:updated',
           {
             entityDefinitionId: entityDef.id,
@@ -563,8 +563,8 @@ export async function archiveEntity(
     const { features } = await getOrgCache().getOrRecompute(ctx.organizationId, ['features'])
     if (features?.realtimeSync) {
       getRealtimeService()
-        .sendToOrganization(
-          ctx.organizationId,
+        .publish(
+          rooms.orgPresence(ctx.organizationId),
           'record:archived',
           { recordId, entityDefinitionId: entityDef.id },
           { excludeSocketId: ctx.socketId }
@@ -712,8 +712,8 @@ export async function deleteEntity(
     const { features } = await getOrgCache().getOrRecompute(ctx.organizationId, ['features'])
     if (features?.realtimeSync) {
       getRealtimeService()
-        .sendToOrganization(
-          ctx.organizationId,
+        .publish(
+          rooms.orgPresence(ctx.organizationId),
           'record:deleted',
           { recordId, entityDefinitionId: entityDef.id },
           { excludeSocketId: ctx.socketId }


### PR DESCRIPTION
## Summary
- Replaces `RealtimeService.sendToOrganization` / `sendToInbox` / `sendToUser` / `sendToChat` / `sendToVisitor` with a single `publish(roomKey, event, data)` driven by a room registry that owns both key generation and per-family ACL.
- Client adapter rewritten on top of a generic `subscribe(roomKey, handlers)` plus presence-aware `subscribePresence` / server-mediated `updateSelf`. The previous inline `/api/pusher/auth` ACL chain collapses into one registry dispatch.
- Adds tRPC `realtime.publish` (event-prefix allow-list: `typing:`, `presence:`) and `realtime.updateSelf` for the upcoming presence consumer.

## Background

Phase 4 of chat v3 needs (a) thread-event fan-out, (b) presence-aware client subscriptions with `onJoin` / `onLeave` / `onMembers`, and (c) a single ACL surface as new room types come online. The previous plan ([`plans/realtime/realtime-transport.md`](../plans/realtime/realtime-transport.md)) proposed a parallel transport layer; we instead refactored the existing realtime code in-place. No parallel system, no migration debt.

Plan: [`plans/realtime/realtime-refactor.md`](../plans/realtime/realtime-refactor.md) (locked decisions + implementation notes inline).

## Locked decisions

1. `org-{id}-inbox-{slug}` channels flipped from presence to plain (no membership consumers).
2. `updateSelf` is server-mediated only — no Pusher `client-*` events.
3. `AuthorizeCtx.visitor = { participantId, threadId? }` from the existing passport.
4. All five `sendToX` wrappers deleted in-PR; every caller migrated.

## Out of scope (intentional)

- `apps/chat-widget/**` and `apps/api/src/routes/chat/**` — widget transport untouched. Their room keys are entries in the new registry for the eventual migration.
- `apps/web/src/providers/pusher-provider.tsx` — dead code, zero importers; cleanup later.
- `apps/web/src/components/global/notifications/notification-center.tsx` — still uses legacy `getPusherClient` singleton; functional but bypasses the new ACL path. Migrate in a follow-up.

## Test plan
- [ ] Mail thread list refreshes via realtime on new message (inbox channel: `private-org-{id}-inbox-{slug}`)
- [ ] Resource sync (records / field values) updates rail in real time
- [ ] Agent rail invalidates on `agent:updated`
- [ ] Notification center receives `user-{id}` events (note: still on legacy singleton — verify no regression)
- [ ] Chat widget continues to work end-to-end (apps/api auth path unchanged)
- [ ] `/api/pusher/auth` returns 401 for unauthenticated requests to admin channels
- [ ] `/api/pusher/auth` returns 403 for org members hitting another org's channels
- [ ] Org switch tears down inbox + thread rooms (verify in DevTools network: `pusher:unsubscribe` for old org channels)