### PR TITLE
fix(workflow): AI v2 nodes — built-in capabilities + explicit appAccounts

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
@@ -48,6 +48,14 @@ export async function createAppCapabilities(deps: {
   sessionId?: string
   /** Used by the bridge's execute() to construct lambda payloads. */
   getToolDeps?: GetToolDeps
+  /**
+   * Explicit per-app credential bindings. When provided, takes precedence over
+   * the agent / master-Kopilot lookup. Used by the workflow AI node, which owns
+   * its own bindings on the node config (no agent row, not master settings).
+   * Behaves like an agent run for the connection-presence gate (workspace
+   * cred fallback is allowed).
+   */
+  appAccounts?: Record<string, { credId: string }>
 }): Promise<PageCapability> {
   const { organizationId, userId, agentId, triggerId, sessionId } = deps
   const installedApps = await getOrgCache().get(organizationId, 'installedApps')
@@ -59,11 +67,17 @@ export async function createAppCapabilities(deps: {
   // Per plans/kopilot/apps/agent-credentials.md §3.5 — when an agent is
   // active, registration is gated on `Agent.appAccounts[appId].credId`. The
   // master Kopilot path reads `kopilot.appAccounts` from org settings
-  // (plans/kopilot/settings — explicit pin only, no fallbacks).
+  // (plans/kopilot/settings — explicit pin only, no fallbacks). When the
+  // caller passes `appAccounts` explicitly (workflow AI node), we use those
+  // and treat the run like an agent for the connection-presence gate.
   const agent = agentId ? await getCachedAgentById(organizationId, agentId) : null
-  const appAccounts: Record<string, { credId: string }> = agent
-    ? (agent.appAccounts ?? {})
-    : (await loadMasterKopilotSettings(organizationId)).appAccounts
+  const hasExplicitAppAccounts = deps.appAccounts !== undefined
+  const allowWorkspaceFallback = !!agent || hasExplicitAppAccounts
+  const appAccounts: Record<string, { credId: string }> = hasExplicitAppAccounts
+    ? (deps.appAccounts ?? {})
+    : agent
+      ? (agent.appAccounts ?? {})
+      : (await loadMasterKopilotSettings(organizationId)).appAccounts
 
   const tools: AgentToolDefinition[] = []
 
@@ -88,10 +102,11 @@ export async function createAppCapabilities(deps: {
     for (const tool of catalogTools) {
       // Connection-presence gate (decision A4).
       if (tool.requiresConnection) {
-        if (agent) {
-          // Agent run: require an explicit binding OR a workspace cred
-          // fallback. User-scope tools are no longer special-cased — the
-          // creator's pick (workspace or personal) is the binding.
+        if (allowWorkspaceFallback) {
+          // Agent run / workflow AI node: require an explicit binding OR a
+          // workspace cred fallback. User-scope tools are no longer
+          // special-cased — the creator's pick (workspace or personal) is the
+          // binding.
           if (!boundCredId && !installation.orgConnectionPresent) continue
         } else {
           // Master Kopilot: explicit pin only, no fallback.
@@ -117,7 +132,7 @@ export async function createAppCapabilities(deps: {
         const resolveInput: Parameters<typeof resolveAppConnectionForRuntime>[0] | null =
           boundCredId
             ? { appId, organizationId, userId: userId ?? '', connectionId: boundCredId }
-            : agent
+            : allowWorkspaceFallback
               ? { appId, organizationId, userId: userId ?? '' }
               : null
 

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/ai-v2.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/ai-v2.ts
@@ -333,8 +333,15 @@ export class AIProcessorV2 extends BaseAiNodeProcessor {
       import('../../../ai/kopilot'),
     ])
     const {
+      createActorCapabilities,
       createAppCapabilities,
+      createEntityCapabilities,
+      createKbCapabilities,
+      createKbReadCapabilities,
+      createKnowledgeCapabilities,
+      createMailCapabilities,
       createNativeWorkflowCapabilities,
+      createTaskCapabilities,
       createToolDepsFactory,
       runStructuredOutputPass,
       runWorkflowAiTurn,
@@ -360,12 +367,25 @@ export class AIProcessorV2 extends BaseAiNodeProcessor {
       hasStructuredOutput: !!config.structured_output?.enabled,
     })
 
-    // Capability factories — same pipeline the agent surface uses.
+    // Capability factories — same pipeline the agent surface uses. The
+    // built-in Auxx tools (mail / entities / knowledge / actors / tasks / KB)
+    // are registered through their dedicated factories; `createAppCapabilities`
+    // is for third-party installed apps only (the synthetic auxx installation
+    // row has `currentDeployment: null` and is skipped by that path).
     const getToolDeps = createToolDepsFactory({
       organizationId,
       userId,
       sessionId,
     })
+    const builtinCaps = [
+      createEntityCapabilities(getToolDeps),
+      createKnowledgeCapabilities(getToolDeps),
+      createMailCapabilities(getToolDeps),
+      createActorCapabilities(getToolDeps),
+      createTaskCapabilities(getToolDeps),
+      createKbReadCapabilities(getToolDeps),
+      createKbCapabilities(getToolDeps),
+    ]
     const appCaps = await createAppCapabilities({
       organizationId,
       userId,
@@ -373,10 +393,14 @@ export class AIProcessorV2 extends BaseAiNodeProcessor {
       triggerId: null,
       sessionId,
       getToolDeps,
+      // AI nodes own their own per-app credential bindings. Passing this
+      // explicitly opts into the agent-style connection-presence gate
+      // (workspace cred fallback allowed).
+      appAccounts: config.appAccounts ?? {},
     })
     const nativeCaps = createNativeWorkflowCapabilities(getToolDeps)
 
-    const allTools = [...appCaps.tools, ...nativeCaps.tools]
+    const allTools = [...builtinCaps.flatMap((c) => c.tools), ...appCaps.tools, ...nativeCaps.tools]
     const filtered = filterToolsByToolsets(allTools, this.buildResolvedAgentShim(config))
 
     if (filtered.length === 0) {


### PR DESCRIPTION
## Summary
- Wires the missing built-in Auxx capability factories (entity / knowledge / mail / actor / task / KB read+write) into `AIProcessorV2`. After #659 the workflow AI node only had third-party app tools + native workflow capabilities — first-party Auxx tools were unreachable.
- Extends `createAppCapabilities` with an explicit `appAccounts` parameter so AI nodes can own per-app credential bindings on the node config (no agent row, not master Kopilot settings). When passed, the call behaves like an agent run for the connection-presence gate (workspace cred fallback allowed).

Follow-up to #659.

## Test plan
- [ ] Create a workflow with an AI v2 node; confirm built-in tools (entity / mail / KB) appear in the available toolset
- [ ] Toolset filtering on the node still applies (tools the user de-selected don't fire)
- [ ] AI node with `appAccounts` config can call third-party app tools using the explicit binding
- [ ] AI node without `appAccounts` falls back to workspace creds for tools that allow it
- [ ] Master Kopilot behavior unchanged (no `appAccounts`, no agent → explicit pin only)