### PR TITLE
feat(chat): widget renders thread events (P4.4)

### DIFF
--- a/apps/api/src/routes/chat/initialize.ts
+++ b/apps/api/src/routes/chat/initialize.ts
@@ -9,7 +9,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { asc, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { parseIdentifyPayload } from './identify'
-import { applyChatCorsHeaders } from './lib'
+import { applyChatCorsHeaders, loadThreadEvents } from './lib'
 
 const log = createScopedLogger('chat-initialize-route')
 
@@ -106,6 +106,11 @@ initializeRoute.post('/', async (c) => {
       status: 'DELIVERED',
     }))
 
+    // Hydrate thread lifecycle events so the widget can render centered
+    // system lines (taken_over / returned_to_ai / archived / reopened / …)
+    // alongside the persisted message transcript.
+    const threadEvents = isNew ? [] : await loadThreadEvents(chat.organizationId, thread.id)
+
     // If the visitor identified during this initialize (new claim with an
     // email) and we have an active thread, emit the lifecycle event so the
     // admin sees a centered system line in the conversation.
@@ -147,7 +152,9 @@ initializeRoute.post('/', async (c) => {
         visitorId: chat.sessionId,
         isNewSession: isNew,
         messages,
+        threadEvents,
         pusherChannel: `chat-${visitorChatSessionId}`,
+        threadPusherChannel: `private-thread-${thread.id}`,
         visitorPusherChannel: `private-visitor-${chat.visitorParticipantId}`,
         ...(passport ? { passport } : {}),
       },

--- a/apps/api/src/routes/chat/lib.ts
+++ b/apps/api/src/routes/chat/lib.ts
@@ -1,8 +1,73 @@
 // apps/api/src/routes/chat/lib.ts
 
 import { database, schema } from '@auxx/database'
-import { and, asc, eq, inArray } from 'drizzle-orm'
+import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import type { Context } from 'hono'
+
+/**
+ * Thread lifecycle event types the widget renders as centered system lines.
+ *
+ * Keep in sync with `apps/chat-widget/src/transport/thread-events.ts` —
+ * the union is duplicated rather than imported because the widget cannot
+ * pull `@auxx/lib/events` (server deps).
+ */
+export const WIDGET_THREAD_EVENT_TYPES = [
+  'thread:taken_over',
+  'thread:returned_to_ai',
+  'thread:archived',
+  'thread:reopened',
+  'thread:assignee:changed',
+  'thread:visitor:identified',
+] as const
+
+export type WidgetThreadEventType = (typeof WIDGET_THREAD_EVENT_TYPES)[number]
+
+export interface WidgetThreadEvent {
+  id: string
+  type: WidgetThreadEventType
+  createdAt: Date
+  data: Record<string, unknown>
+}
+
+/** Cap analogous to message history pagination; anonymous chats are short. */
+const THREAD_EVENT_LIMIT = 50
+
+/**
+ * Fetch the persisted thread lifecycle events for a given thread, org-scoped.
+ *
+ * Uses the `Event_threadId_expr_idx` expression index on `data->>'threadId'`
+ * (added in #664) plus the `Event_type_idx` to narrow to widget-visible types.
+ * Returned newest-last so the widget can append in chronological order.
+ */
+export async function loadThreadEvents(
+  organizationId: string,
+  threadId: string
+): Promise<WidgetThreadEvent[]> {
+  const rows = await database
+    .select({
+      id: schema.Event.id,
+      type: schema.Event.type,
+      createdAt: schema.Event.createdAt,
+      data: schema.Event.data,
+    })
+    .from(schema.Event)
+    .where(
+      and(
+        eq(schema.Event.organizationId, organizationId),
+        inArray(schema.Event.type, [...WIDGET_THREAD_EVENT_TYPES]),
+        sql`(${schema.Event.data}->>'threadId') = ${threadId}`
+      )
+    )
+    .orderBy(asc(schema.Event.createdAt))
+    .limit(THREAD_EVENT_LIMIT)
+
+  return rows.map((r) => ({
+    id: r.id,
+    type: r.type as WidgetThreadEventType,
+    createdAt: r.createdAt,
+    data: (r.data ?? {}) as Record<string, unknown>,
+  }))
+}
 
 export interface LoadedChatWidget {
   channelId: string

--- a/apps/api/src/routes/chat/pusher-auth.ts
+++ b/apps/api/src/routes/chat/pusher-auth.ts
@@ -1,7 +1,10 @@
 // apps/api/src/routes/chat/pusher-auth.ts
 
+import { database, schema } from '@auxx/database'
 import { getRealtimeService } from '@auxx/lib/realtime'
+import type { ChatThreadMetadata } from '@auxx/lib/threads/types'
 import { createScopedLogger } from '@auxx/logger'
+import { and, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { applyChatCorsHeaders } from './lib'
 
@@ -21,8 +24,17 @@ pusherAuthRoute.options('/', (c) => {
  * `channel_name`, verifies the channel belongs to the visitor whose passport
  * authenticated the request, and signs the Pusher auth response.
  *
- * Only `private-visitor-<visitorParticipantId>` channels are gated here. The
- * existing per-thread `chat-<id>` channels remain public.
+ * Two private channel families are gated here:
+ *
+ *   - `private-visitor-<visitorParticipantId>` — matches the visitor's
+ *     participant id encoded in the passport. Cross-thread fanout.
+ *   - `private-thread-<threadId>` — matches a thread whose
+ *     `metadata.visitorParticipantId` equals the passport's visitor. Carries
+ *     thread lifecycle events (taken_over, returned_to_ai, archived, …) that
+ *     the widget renders as centered system lines.
+ *
+ * The existing public `chat-<id>` channels (message broadcast) remain
+ * unauthenticated and untouched.
  */
 pusherAuthRoute.post('/', async (c) => {
   applyChatCorsHeaders(c, { allowCredentials: true })
@@ -42,11 +54,22 @@ pusherAuthRoute.post('/', async (c) => {
     )
   }
 
-  const expected = `private-visitor-${chat.visitorParticipantId}`
-  if (channelName !== expected) {
+  const expectedVisitor = `private-visitor-${chat.visitorParticipantId}`
+  let allowed = channelName === expectedVisitor
+
+  if (!allowed && channelName.startsWith('private-thread-')) {
+    const threadId = channelName.slice('private-thread-'.length)
+    allowed = await visitorOwnsThread({
+      threadId,
+      organizationId: chat.organizationId,
+      visitorParticipantId: chat.visitorParticipantId,
+    })
+  }
+
+  if (!allowed) {
     log.warn('Rejected pusher auth — channel does not match passport visitor', {
       channelName,
-      expected,
+      expectedVisitor,
     })
     return c.json(
       { success: false, error: { code: 'FORBIDDEN', message: 'Channel not allowed' } },
@@ -63,5 +86,31 @@ pusherAuthRoute.post('/', async (c) => {
   }
   return c.json(auth)
 })
+
+/**
+ * ACL helper: a visitor can subscribe to `private-thread-{threadId}` only when
+ * the thread's `metadata.visitorParticipantId` matches their passport. The org
+ * scope is enforced via the same query so a leaked passport from one org can
+ * never authorize a sibling-org thread channel.
+ */
+async function visitorOwnsThread(args: {
+  threadId: string
+  organizationId: string
+  visitorParticipantId: string
+}): Promise<boolean> {
+  const [row] = await database
+    .select({ metadata: schema.Thread.metadata })
+    .from(schema.Thread)
+    .where(
+      and(
+        eq(schema.Thread.id, args.threadId),
+        eq(schema.Thread.organizationId, args.organizationId)
+      )
+    )
+    .limit(1)
+  if (!row) return false
+  const meta = (row.metadata ?? {}) as Partial<ChatThreadMetadata>
+  return meta.channel === 'chat' && meta.visitorParticipantId === args.visitorParticipantId
+}
 
 export default pusherAuthRoute

--- a/apps/api/src/routes/chat/threads.ts
+++ b/apps/api/src/routes/chat/threads.ts
@@ -7,7 +7,7 @@ import type { ChatThreadMetadata } from '@auxx/lib/threads/types'
 import { createScopedLogger } from '@auxx/logger'
 import { and, asc, desc, eq, isNotNull, lt, or, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
-import { applyChatCorsHeaders, loadChatWidgetByChannelId } from './lib'
+import { applyChatCorsHeaders, loadChatWidgetByChannelId, loadThreadEvents } from './lib'
 
 const log = createScopedLogger('chat-threads-route')
 
@@ -219,7 +219,11 @@ threadsRoute.get('/:threadId/messages', async (c) => {
       status: 'DELIVERED',
     }))
 
-    return c.json({ success: true, data: { messages, nextCursor: null } })
+    // Hydrate the thread's lifecycle events so the widget can interleave
+    // centered system lines with the message transcript on reload.
+    const threadEvents = await loadThreadEvents(chat.organizationId, threadId)
+
+    return c.json({ success: true, data: { messages, threadEvents, nextCursor: null } })
   } catch (error) {
     log.error('Failed to load chat history', {
       threadId,

--- a/apps/chat-widget/src/transport/chat-api.ts
+++ b/apps/chat-widget/src/transport/chat-api.ts
@@ -1,6 +1,7 @@
 // apps/chat-widget/src/transport/chat-api.ts
 
 import { authedFetch } from './api-client'
+import type { ThreadEvent } from './thread-events'
 
 export interface ChatMessage {
   id: string
@@ -17,7 +18,11 @@ export interface InitializeResponse {
   visitorId: string
   isNewSession: boolean
   messages: ChatMessage[]
+  /** Persisted thread lifecycle events (taken_over / archived / …). */
+  threadEvents: ThreadEvent[]
   pusherChannel: string
+  /** Private per-thread channel for live lifecycle events. */
+  threadPusherChannel: string
   visitorPusherChannel: string
   passport?: { token: string; expiresIn: string }
 }
@@ -67,11 +72,14 @@ export function chatApi(channelId: string) {
     },
 
     getHistory: (threadId: string, sessionId: string) =>
-      authedFetch<{ messages: ChatMessage[]; nextCursor: string | null }>(
-        channelId,
-        `/api/chat/threads/${threadId}/messages`,
-        { method: 'GET', query: { sessionId } }
-      ),
+      authedFetch<{
+        messages: ChatMessage[]
+        threadEvents: ThreadEvent[]
+        nextCursor: string | null
+      }>(channelId, `/api/chat/threads/${threadId}/messages`, {
+        method: 'GET',
+        query: { sessionId },
+      }),
 
     setTyping: (sessionId: string, isTyping: boolean) =>
       authedFetch<Record<string, never>>(channelId, '/api/chat/typing', {

--- a/apps/chat-widget/src/transport/thread-events.ts
+++ b/apps/chat-widget/src/transport/thread-events.ts
@@ -1,0 +1,77 @@
+// apps/chat-widget/src/transport/thread-events.ts
+//
+// Thread lifecycle event types the widget renders as centered system lines.
+//
+// Duplicated locally (rather than imported from `@auxx/lib/events`) because
+// the widget bundle cannot pull `@auxx/lib` — its event types transitively
+// import server-only deps (`@auxx/database/types`, `@auxx/types/...`).
+//
+// Keep this union in sync with `apps/api/src/routes/chat/lib.ts`'s
+// `WIDGET_THREAD_EVENT_TYPES` constant.
+
+export const THREAD_EVENT_TYPES = [
+  'thread:taken_over',
+  'thread:returned_to_ai',
+  'thread:archived',
+  'thread:reopened',
+  'thread:assignee:changed',
+  'thread:visitor:identified',
+] as const
+
+export type ThreadEventType = (typeof THREAD_EVENT_TYPES)[number]
+
+export interface ThreadEvent {
+  id: string
+  type: ThreadEventType
+  /** ISO string from the server, or Date when freshly published over Pusher. */
+  createdAt: string
+  data: ThreadEventData
+}
+
+/** Per-event payload shapes — mirrored from `packages/lib/src/events/types.ts`. */
+export type ThreadEventData =
+  | ThreadTakenOverData
+  | ThreadReturnedToAiData
+  | ThreadArchivedData
+  | ThreadReopenedData
+  | ThreadAssigneeChangedData
+  | ThreadVisitorIdentifiedData
+
+export interface ThreadTakenOverData {
+  threadId: string
+  organizationId: string
+  userId: string
+  previousState: 'ai' | 'human'
+}
+
+export interface ThreadReturnedToAiData {
+  threadId: string
+  organizationId: string
+  userId: string
+}
+
+export interface ThreadArchivedData {
+  threadId: string
+  organizationId: string
+  userId: string
+}
+
+export interface ThreadReopenedData {
+  threadId: string
+  organizationId: string
+  userId: string
+}
+
+export interface ThreadAssigneeChangedData {
+  threadId: string
+  organizationId: string
+  fromUserId: string | null
+  toUserId: string | null
+}
+
+export interface ThreadVisitorIdentifiedData {
+  threadId: string
+  organizationId: string
+  visitorEmail: string
+  participantId: string
+}

--- a/apps/chat-widget/src/views/conversation/conversation-view.tsx
+++ b/apps/chat-widget/src/views/conversation/conversation-view.tsx
@@ -11,10 +11,16 @@ import { dismissPrivacyBanner, isPrivacyBannerDismissed } from '~/persistence/pr
 import { markThreadRead } from '~/persistence/unread'
 import { type ChatMessage, chatApi } from '~/transport/chat-api'
 import type { ChatConfig } from '~/transport/config'
-import { connectPusher } from '~/transport/pusher'
+import { connectPrivatePusher, connectPusher } from '~/transport/pusher'
+import {
+  THREAD_EVENT_TYPES,
+  type ThreadEvent,
+  type ThreadEventData,
+} from '~/transport/thread-events'
 import { Composer, type ComposerSendArgs } from './composer/composer'
 import { PrivacyBanner } from './privacy-banner'
 import { SuggestedReplies } from './suggested-replies'
+import { SystemLine } from './system-line'
 
 interface ConversationViewProps {
   channelId: string
@@ -25,11 +31,13 @@ interface ConversationViewProps {
 interface InitState {
   sessionId: string
   pusherChannel: string
+  threadPusherChannel: string
 }
 
 export function ConversationView({ channelId, threadId, config }: ConversationViewProps) {
   const api = useMemo(() => chatApi(channelId), [channelId])
   const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [threadEvents, setThreadEvents] = useState<ThreadEvent[]>([])
   const [init, setInit] = useState<InitState | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [privacyDismissed, setPrivacyDismissed] = useState(() =>
@@ -51,14 +59,23 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
       })
       .then((data) => {
         if (cancelled) return
-        setInit({ sessionId: data.sessionId, pusherChannel: data.pusherChannel })
+        setInit({
+          sessionId: data.sessionId,
+          pusherChannel: data.pusherChannel,
+          threadPusherChannel: data.threadPusherChannel,
+        })
         if (data.threadId === threadId) {
           setMessages(data.messages)
+          setThreadEvents(data.threadEvents ?? [])
         } else {
           // Fallback for cases where initialize resumed a different thread.
           api
             .getHistory(threadId, data.sessionId)
-            .then((hist) => !cancelled && setMessages(hist.messages))
+            .then((hist) => {
+              if (cancelled) return
+              setMessages(hist.messages)
+              setThreadEvents(hist.threadEvents ?? [])
+            })
             .catch(() => {})
         }
       })
@@ -110,17 +127,67 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
     }
   }, [init, threadId, config.realtime.key, config.realtime.cluster])
 
+  // Subscribe to the per-thread private channel for live lifecycle events
+  // (taken_over / returned_to_ai / archived / reopened / …). The server pushes
+  // these via the shared realtime helper; the widget binds the same set of
+  // type names directly as Pusher event keys.
+  useEffect(() => {
+    if (!init) return
+    const channelName = init.threadPusherChannel
+    const expected = `private-thread-${threadId}`
+    if (channelName !== expected) return
+    const conn = connectPrivatePusher({
+      key: config.realtime.key,
+      cluster: config.realtime.cluster,
+      channelName,
+      channelId,
+    })
+    const handlers = THREAD_EVENT_TYPES.map((type) => {
+      const handler = (payload: { id?: string; createdAt?: string } & ThreadEventData) => {
+        if ((payload as { threadId?: string }).threadId !== threadId) return
+        setThreadEvents((prev) => {
+          // Dedupe by id when the server provides one; fall back to
+          // (type, threadId, createdAt) for transient payloads.
+          const id =
+            payload.id ?? `${type}:${threadId}:${payload.createdAt ?? new Date().toISOString()}`
+          if (prev.some((e) => e.id === id)) return prev
+          return [
+            ...prev,
+            {
+              id,
+              type,
+              createdAt: payload.createdAt ?? new Date().toISOString(),
+              data: payload as ThreadEventData,
+            },
+          ]
+        })
+      }
+      conn.channel.bind(type, handler)
+      return { type, handler }
+    })
+    return () => {
+      for (const { type, handler } of handlers) {
+        try {
+          conn.channel.unbind(type, handler)
+        } catch {
+          /* ignore */
+        }
+      }
+      conn.disconnect()
+    }
+  }, [init, threadId, channelId, config.realtime.key, config.realtime.cluster])
+
   // Mark read whenever the last message changes.
   useEffect(() => {
     if (messages.length === 0) return
     markThreadRead(channelId, threadId)
   }, [channelId, threadId, messages.length])
 
-  // Auto-scroll to bottom on new messages.
+  // Auto-scroll to bottom on new messages or thread events.
   useEffect(() => {
     const el = bodyRef.current
     if (el) el.scrollTop = el.scrollHeight
-  }, [messages.length])
+  }, [messages.length, threadEvents.length])
 
   const handleSend = useCallback(
     async ({ content, attachmentIds }: ComposerSendArgs) => {
@@ -152,7 +219,7 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
     [api, init, threadId]
   )
 
-  const grouped = useMemo(() => groupConsecutive(messages), [messages])
+  const timeline = useMemo(() => buildTimeline(messages, threadEvents), [messages, threadEvents])
 
   return (
     <div className='flex min-h-0 flex-1 flex-col bg-muted [&>*:last-child]:rounded-b-2xl'>
@@ -162,9 +229,13 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
             {error}
           </div>
         ) : null}
-        {grouped.map((group, gi) => (
-          <Bubble key={`g-${gi}`} group={group} />
-        ))}
+        {timeline.map((item, i) =>
+          item.kind === 'event' ? (
+            <SystemLine key={`e-${item.event.id}`} event={item.event} />
+          ) : (
+            <Bubble key={`g-${i}`} group={item.group} />
+          )
+        )}
       </div>
       {init && messages.length === 0 ? (
         <SuggestedReplies
@@ -196,17 +267,51 @@ interface MessageGroup {
   messages: ChatMessage[]
 }
 
-function groupConsecutive(messages: ChatMessage[]): MessageGroup[] {
-  const groups: MessageGroup[] = []
-  for (const m of messages) {
-    const last = groups[groups.length - 1]
-    if (last && last.sender === m.sender) {
-      last.messages.push(m)
+type TimelineItem =
+  | { kind: 'group'; group: MessageGroup; createdAt: number }
+  | { kind: 'event'; event: ThreadEvent; createdAt: number }
+
+/**
+ * Interleave messages and thread events by `createdAt`. Consecutive messages
+ * from the same sender are grouped into a single bubble cluster; any event
+ * between them breaks the cluster.
+ */
+function buildTimeline(messages: ChatMessage[], events: ThreadEvent[]): TimelineItem[] {
+  type Entry =
+    | { kind: 'message'; createdAt: number; message: ChatMessage }
+    | { kind: 'event'; createdAt: number; event: ThreadEvent }
+  const entries: Entry[] = [
+    ...messages.map((m) => ({
+      kind: 'message' as const,
+      createdAt: new Date(m.createdAt).getTime(),
+      message: m,
+    })),
+    ...events.map((e) => ({
+      kind: 'event' as const,
+      createdAt: new Date(e.createdAt).getTime(),
+      event: e,
+    })),
+  ]
+  entries.sort((a, b) => a.createdAt - b.createdAt)
+
+  const out: TimelineItem[] = []
+  for (const entry of entries) {
+    if (entry.kind === 'event') {
+      out.push({ kind: 'event', event: entry.event, createdAt: entry.createdAt })
+      continue
+    }
+    const last = out[out.length - 1]
+    if (last && last.kind === 'group' && last.group.sender === entry.message.sender) {
+      last.group.messages.push(entry.message)
     } else {
-      groups.push({ sender: m.sender, messages: [m] })
+      out.push({
+        kind: 'group',
+        group: { sender: entry.message.sender, messages: [entry.message] },
+        createdAt: entry.createdAt,
+      })
     }
   }
-  return groups
+  return out
 }
 
 function Bubble({ group }: { group: MessageGroup }) {

--- a/apps/chat-widget/src/views/conversation/system-line.tsx
+++ b/apps/chat-widget/src/views/conversation/system-line.tsx
@@ -1,0 +1,55 @@
+// apps/chat-widget/src/views/conversation/system-line.tsx
+//
+// Centered, muted text rendered between message bubbles for thread lifecycle
+// events (taken_over / returned_to_ai / archived / reopened / assignee changed
+// / visitor identified).
+//
+// Renders visitor-facing copy only — P4.4 ships the functional surface; the
+// polished admin/header treatment lives in Phase 4b.
+
+import type { ThreadEvent } from '~/transport/thread-events'
+
+interface SystemLineProps {
+  event: ThreadEvent
+}
+
+export function SystemLine({ event }: SystemLineProps) {
+  const text = visitorCopyFor(event)
+  if (!text) return null
+  const timestamp = new Date(event.createdAt).toLocaleString()
+  return (
+    <div
+      className='self-center px-3 text-center text-xs italic text-muted-foreground'
+      title={timestamp}>
+      {text}
+    </div>
+  )
+}
+
+/**
+ * Resolve visitor-facing copy for a thread event. Returning `null` hides the
+ * event entirely (assignee churn, visitor-self-identified, etc.).
+ */
+function visitorCopyFor(event: ThreadEvent): string | null {
+  switch (event.type) {
+    case 'thread:taken_over':
+      return 'An agent joined the chat'
+    case 'thread:returned_to_ai':
+      return 'AI is responding again'
+    case 'thread:archived':
+      return 'Chat ended'
+    case 'thread:reopened':
+      return 'Chat reopened'
+    case 'thread:assignee:changed':
+      // Pure internal triage churn — the visitor doesn't care which human is
+      // the current row owner. The visible "agent joined" line comes from
+      // `thread:taken_over` instead.
+      return null
+    case 'thread:visitor:identified':
+      // The visitor performed this action themselves; surfacing it would be
+      // noise. The admin-side view renders this one.
+      return null
+    default:
+      return null
+  }
+}


### PR DESCRIPTION
## Summary
Closes the take-over loop end-to-end. Admin clicks Take over (#663) → server publishes thread events (#664) → widget now hydrates history + subscribes live and renders centered system lines.

### Backend (apps/api)
- Initialize + thread-history routes return `threadEvents: Array<{ id, type, createdAt, data }>` sourced from the `Event` table via the expression index added in #664 (last 50, ASC).
- Pusher auth route allows visitor passports to sign `private-thread-{threadId}` when the thread's `metadata.visitorParticipantId` matches the passport.
- Initialize also returns `threadPusherChannel` so the widget knows the exact channel to bind without re-deriving it.

### Widget (apps/chat-widget)
- Subscribes to `private-thread-{threadId}` via the existing Pusher transport. Widget-side migration to the new realtime layer stays deferred per the realtime plan.
- New `<SystemLine>` component. Visible for `taken_over` / `returned_to_ai` / `archived` / `reopened` with simple visitor-facing copy. `assignee:changed` (internal triage churn) and `visitor:identified` (visitor did it themselves) render nothing.
- `buildTimeline` interleaves messages + events by `createdAt`, breaking message clusters on any event.
- Event payload union duplicated locally (`transport/thread-events.ts`) since the widget can't import `@auxx/lib/events` (server deps).

## Visitor-facing copy

| Event | Copy |
|---|---|
| `taken_over` | "An agent joined the chat" |
| `returned_to_ai` | "AI is responding again" |
| `archived` | "Chat ended" |
| `reopened` | "Chat reopened" |
| `assignee:changed` | (hidden) |
| `visitor:identified` | (hidden) |

Phase 4b owns the polished admin copy.

## Known limitation (acceptable)

Live Pusher frames carry only the event `data` payload (not the `Event` row's `id` or `createdAt`). The widget synthesizes both for in-session dedupe; on hydration the array is replaced wholesale with canonical values. If the admin view later needs stable ids at publish time, the publisher in `publish-thread-event-to-realtime.ts` can include them — minor change, out of scope here.

## Out of scope (intentional)

- Polished admin centered system-line rendering → Phase 4b.
- Header banner (`🤖 AI is replying. [Take over]`) → Phase 4b.
- Widget transport migration to `RealtimeAdapter` → deferred follow-up.
- Welcome bubble → P4.1 (Step 2).

## Plan
[`plans/chat/v3/phase-4-welcome-and-thread-events.md`](../plans/chat/v3/phase-4-welcome-and-thread-events.md) — P4.4 section.

## Test plan
- [ ] Widget hydrates `threadEvents` on initial load (DevTools network: `/api/chat/initialize` response has `threadEvents: [...]` + `threadPusherChannel: 'private-thread-…'`)
- [ ] Widget binds to `private-thread-{id}` (DevTools network: `pusher:subscribe` frame)
- [ ] Take over from admin → widget renders "An agent joined the chat" live, no reload
- [ ] Return to AI → widget renders "AI is responding again"
- [ ] Archive thread from admin → widget renders "Chat ended"
- [ ] Reopen → widget renders "Chat reopened"
- [ ] Assignee reassignment (without take-over) → widget renders nothing
- [ ] `identify()` from widget → no system line in own widget (correct; visitor already knows)
- [ ] System line is centered, muted, no avatar, timestamp on hover
- [ ] Events interleave by `createdAt` between message bubbles
- [ ] Visitor with mismatched passport gets 403 on `private-thread-{otherThreadId}` auth attempt