### PR TITLE
feat(chat): admin handoff display UI (Phase 4b-i)

### DIFF
--- a/apps/web/src/components/mail/chat-handoff-banner.tsx
+++ b/apps/web/src/components/mail/chat-handoff-banner.tsx
@@ -1,0 +1,180 @@
+// apps/web/src/components/mail/chat-handoff-banner.tsx
+'use client'
+
+import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
+import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { Button } from '@auxx/ui/components/button'
+import { toastError } from '@auxx/ui/components/toast'
+import { Bot, HandMetal } from 'lucide-react'
+import { useCallback } from 'react'
+import { useSession } from '~/auth/auth-client'
+import { useActor } from '~/components/resources/hooks'
+import { useConfirm } from '~/hooks/use-confirm'
+import { api } from '~/trpc/react'
+
+interface ChatHandoffBannerProps {
+  threadId: string
+  handoffState: 'ai' | 'human'
+  assigneeId: ActorId | null
+}
+
+/**
+ * Three-state banner shown on chat threads in the admin thread view.
+ *
+ * - `handoffState === 'ai'`         → "Our AI is replying to this chat." + Take over
+ * - `handoffState === 'human'` & assignee !== me → "{name} is on this chat." + Take over (confirm)
+ * - `handoffState === 'human'` & assignee === me → "You're on this chat." + Return to AI
+ *
+ * Composes presence dots / "N teammates on duty" copy in future phases
+ * (4b-ii / 4c); degrades gracefully today without them.
+ */
+export function ChatHandoffBanner({ threadId, handoffState, assigneeId }: ChatHandoffBannerProps) {
+  const [confirm, ConfirmDialog] = useConfirm()
+  const { data: session } = useSession()
+  const currentUserId = session?.user?.id ?? null
+
+  const assigneeUserId = assigneeId
+    ? (() => {
+        try {
+          return parseActorId(assigneeId).id
+        } catch {
+          return null
+        }
+      })()
+    : null
+  const isAssignedToMe = !!currentUserId && assigneeUserId === currentUserId
+
+  const { actor: assignee } = useActor({
+    actorId: assigneeUserId ? toActorId('user', assigneeUserId) : null,
+    enabled: !!assigneeUserId,
+  })
+  const assigneeName = assignee?.name || 'A teammate'
+
+  const takeOver = api.thread.takeOver.useMutation()
+  const returnToAi = api.thread.returnToAi.useMutation()
+  const utils = api.useUtils()
+
+  const handleTakeOver = useCallback(async () => {
+    // When stealing from another teammate, confirm first so it isn't an
+    // accidental click on a chat someone else is actively handling.
+    if (handoffState === 'human' && !isAssignedToMe && assigneeUserId) {
+      const ok = await confirm({
+        title: `Take over from ${assigneeName}?`,
+        description: 'Their session will end and the chat will route to you.',
+        confirmText: 'Take over',
+        cancelText: 'Cancel',
+        destructive: false,
+      })
+      if (!ok) return
+    }
+    try {
+      await takeOver.mutateAsync({ threadId })
+      await utils.thread.invalidate()
+    } catch (error) {
+      toastError({
+        title: 'Failed to take over',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+  }, [
+    handoffState,
+    isAssignedToMe,
+    assigneeUserId,
+    assigneeName,
+    confirm,
+    takeOver,
+    utils,
+    threadId,
+  ])
+
+  const handleReturnToAi = useCallback(async () => {
+    try {
+      await returnToAi.mutateAsync({ threadId })
+      await utils.thread.invalidate()
+    } catch (error) {
+      toastError({
+        title: 'Failed to return to AI',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+  }, [returnToAi, utils, threadId])
+
+  // State 1 — AI is driving.
+  if (handoffState === 'ai') {
+    return (
+      <>
+        <ConfirmDialog />
+        <div className='mx-4 mt-2 flex items-center justify-between gap-3 rounded-md border bg-muted/40 px-3 py-2 text-sm'>
+          <div className='flex items-center gap-2 text-muted-foreground'>
+            <Bot className='size-4 shrink-0' />
+            <span>Our AI is replying to this chat.</span>
+          </div>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={handleTakeOver}
+            loading={takeOver.isPending}
+            loadingText='Taking over...'>
+            <HandMetal />
+            Take over
+          </Button>
+        </div>
+      </>
+    )
+  }
+
+  // State 3 — I'm the active responder.
+  if (isAssignedToMe) {
+    return (
+      <>
+        <ConfirmDialog />
+        <div className='mx-4 mt-2 flex items-center justify-between gap-3 rounded-md border bg-muted/40 px-3 py-2 text-sm'>
+          <div className='flex items-center gap-2 text-muted-foreground'>
+            <span>You're on this chat.</span>
+          </div>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={handleReturnToAi}
+            loading={returnToAi.isPending}
+            loadingText='Returning...'>
+            <Bot />
+            Return to AI
+          </Button>
+        </div>
+      </>
+    )
+  }
+
+  // State 2 — another teammate is on it.
+  return (
+    <>
+      <ConfirmDialog />
+      <div className='mx-4 mt-2 flex items-center justify-between gap-3 rounded-md border bg-muted/40 px-3 py-2 text-sm'>
+        <div className='flex items-center gap-2 text-muted-foreground'>
+          <Avatar className='size-5'>
+            <AvatarImage src={assignee?.image || undefined} alt={assigneeName} />
+            <AvatarFallback className='text-[10px]'>
+              {assigneeName
+                .split(' ')
+                .map((p) => p[0])
+                .join('')
+                .toUpperCase()
+                .substring(0, 2) || '?'}
+            </AvatarFallback>
+          </Avatar>
+          <span>{assigneeName} is on this chat.</span>
+        </div>
+        <Button
+          variant='outline'
+          size='sm'
+          onClick={handleTakeOver}
+          loading={takeOver.isPending}
+          loadingText='Taking over...'>
+          <HandMetal />
+          Take over
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/components/mail/chat-panel/messages.tsx
+++ b/apps/web/src/components/mail/chat-panel/messages.tsx
@@ -6,11 +6,11 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { useEffect, useMemo, useRef } from 'react'
 import { useMessages, useThreadMutation } from '~/components/threads/hooks'
-import type { MessageMeta } from '~/components/threads/store'
 import { ChatMessageGroup } from '../chat-message-group'
+import { buildChatTimeline } from '../chat-timeline'
 import type { EmailActions } from '../email-actions'
-
-const CHAT_GROUP_WINDOW_MS = 5 * 60_000
+import { SystemLine } from './system-line'
+import { useChatThreadEvents } from './use-thread-events'
 
 interface ChatPanelMessagesProps {
   threadId: string
@@ -23,6 +23,7 @@ interface ChatPanelMessagesProps {
  */
 export function ChatPanelMessages({ threadId }: ChatPanelMessagesProps) {
   const { messages, isLoading } = useMessages({ threadId })
+  const { events } = useChatThreadEvents({ threadId, enabled: true })
   const { update: updateThread } = useThreadMutation()
   const scrollRef = useRef<HTMLDivElement>(null)
 
@@ -50,13 +51,14 @@ export function ChatPanelMessages({ threadId }: ChatPanelMessagesProps) {
     [threadId, updateThread]
   )
 
-  // Auto-scroll to bottom on new messages
+  // Auto-scroll to bottom on new messages or thread events
   const latestMessageId = messages[messages.length - 1]?.id
+  const latestEventId = events[events.length - 1]?.id
   useEffect(() => {
     const el = scrollRef.current
     if (!el) return
     el.scrollTop = el.scrollHeight
-  }, [latestMessageId])
+  }, [latestMessageId, latestEventId])
 
   if (isLoading && messages.length === 0) {
     return (
@@ -68,7 +70,7 @@ export function ChatPanelMessages({ threadId }: ChatPanelMessagesProps) {
     )
   }
 
-  if (messages.length === 0) {
+  if (messages.length === 0 && events.length === 0) {
     return (
       <div className='flex flex-1 items-center justify-center p-4 text-xs text-muted-foreground'>
         No messages yet.
@@ -76,12 +78,15 @@ export function ChatPanelMessages({ threadId }: ChatPanelMessagesProps) {
     )
   }
 
-  const items = buildRenderItems(messages)
+  const items = buildChatTimeline(messages, events)
 
   return (
     <ScrollArea viewportRef={scrollRef} className='flex-1' scrollbarClassName='w-1!'>
       <div className='flex flex-col gap-2 px-3 py-2'>
         {items.map((item) => {
+          if (item.kind === 'event') {
+            return <SystemLine key={`evt:${item.event.id}`} event={item.event} />
+          }
           if (item.kind === 'chat-group') {
             const groupIsLast = item.endIndex === messages.length - 1
             return (
@@ -106,41 +111,4 @@ export function ChatPanelMessages({ threadId }: ChatPanelMessagesProps) {
       </div>
     </ScrollArea>
   )
-}
-
-type RenderItem =
-  | { kind: 'single'; message: MessageMeta; index: number }
-  | { kind: 'chat-group'; messages: MessageMeta[]; startIndex: number; endIndex: number }
-
-function buildRenderItems(messages: MessageMeta[]): RenderItem[] {
-  const items: RenderItem[] = []
-  for (let i = 0; i < messages.length; i++) {
-    const m = messages[i]!
-    if (m.messageType !== 'CHAT') {
-      items.push({ kind: 'single', message: m, index: i })
-      continue
-    }
-    const startIndex = i
-    const run: MessageMeta[] = [m]
-    while (i + 1 < messages.length && canGroupChat(run[run.length - 1]!, messages[i + 1]!)) {
-      i++
-      run.push(messages[i]!)
-    }
-    items.push({ kind: 'chat-group', messages: run, startIndex, endIndex: i })
-  }
-  return items
-}
-
-function canGroupChat(a: MessageMeta, b: MessageMeta): boolean {
-  if (b.messageType !== 'CHAT') return false
-  if (a.isInbound !== b.isInbound) return false
-  if (fromParticipant(a) !== fromParticipant(b)) return false
-  const aT = a.sentAt ? new Date(a.sentAt).getTime() : null
-  const bT = b.sentAt ? new Date(b.sentAt).getTime() : null
-  if (aT === null || bT === null) return true
-  return Math.abs(bT - aT) <= CHAT_GROUP_WINDOW_MS
-}
-
-function fromParticipant(m: MessageMeta): string | null {
-  return m.participants.find((p) => p.startsWith('from:')) ?? null
 }

--- a/apps/web/src/components/mail/chat-panel/system-line.tsx
+++ b/apps/web/src/components/mail/chat-panel/system-line.tsx
@@ -1,0 +1,128 @@
+// apps/web/src/components/mail/chat-panel/system-line.tsx
+'use client'
+
+import { toActorId } from '@auxx/types/actor'
+import { useSession } from '~/auth/auth-client'
+import { useActor } from '~/components/resources/hooks'
+
+export type ChatThreadEventType =
+  | 'thread:taken_over'
+  | 'thread:returned_to_ai'
+  | 'thread:archived'
+  | 'thread:reopened'
+  | 'thread:assignee:changed'
+  | 'thread:visitor:identified'
+
+export interface ChatThreadEvent {
+  id: string
+  type: ChatThreadEventType
+  createdAt: string
+  data: Record<string, unknown>
+}
+
+interface SystemLineProps {
+  event: ChatThreadEvent
+}
+
+/**
+ * Centered, muted text rendered between message bubbles for thread lifecycle
+ * events in the admin chat panel. Mirrors the visitor-facing system line in
+ * the widget, but with operator-facing copy ("You joined" vs "An agent
+ * joined", "Reassigned to X", "Visitor identified as X").
+ */
+export function SystemLine({ event }: SystemLineProps) {
+  const { data: session } = useSession()
+  const currentUserId = session?.user?.id ?? null
+
+  const actorUserId = pickActorUserId(event)
+  // `useActor` queues a batched fetch via the actor store. For events on
+  // teammates the org cache typically already has them; otherwise we fall
+  // back to a generic label until the fetch lands.
+  const { actor } = useActor({
+    actorId: actorUserId ? toActorId('user', actorUserId) : null,
+    enabled: !!actorUserId,
+  })
+
+  const text = adminCopyFor(event, {
+    currentUserId,
+    actorName: actor?.name ?? null,
+  })
+  if (!text) return null
+  const timestamp = new Date(event.createdAt).toLocaleString()
+  return (
+    <div
+      className='self-center px-3 text-center text-xs italic text-muted-foreground'
+      title={timestamp}>
+      {text}
+    </div>
+  )
+}
+
+/**
+ * Resolve the user id whose display name we want for this event line.
+ * Returns null for events that don't carry an actor.
+ */
+function pickActorUserId(event: ChatThreadEvent): string | null {
+  switch (event.type) {
+    case 'thread:taken_over':
+    case 'thread:returned_to_ai':
+    case 'thread:archived':
+    case 'thread:reopened':
+      return typeof event.data.userId === 'string' ? event.data.userId : null
+    case 'thread:assignee:changed':
+      return typeof event.data.toUserId === 'string' ? event.data.toUserId : null
+    case 'thread:visitor:identified':
+      return null
+    default:
+      return null
+  }
+}
+
+interface CopyContext {
+  currentUserId: string | null
+  actorName: string | null
+}
+
+/**
+ * Operator-facing copy for each event type. Falls back to "A teammate" when
+ * the actor lookup hasn't resolved yet (org cache hydrates members up front,
+ * so this only shows up briefly for fresh events).
+ */
+function adminCopyFor(event: ChatThreadEvent, ctx: CopyContext): string | null {
+  const isSelf = (id: unknown): boolean =>
+    typeof id === 'string' && !!ctx.currentUserId && id === ctx.currentUserId
+  const nameFor = (id: unknown): string => {
+    if (isSelf(id)) return 'You'
+    return ctx.actorName ?? 'A teammate'
+  }
+
+  switch (event.type) {
+    case 'thread:taken_over': {
+      const userId = event.data.userId
+      return isSelf(userId) ? 'You joined the chat' : `${nameFor(userId)} joined the chat`
+    }
+    case 'thread:returned_to_ai': {
+      const userId = event.data.userId
+      return isSelf(userId)
+        ? 'You handed the chat back to AI'
+        : `${nameFor(userId)} handed the chat back to AI`
+    }
+    case 'thread:archived':
+      return 'Chat ended'
+    case 'thread:reopened':
+      return 'Chat reopened'
+    case 'thread:assignee:changed': {
+      const toUserId = event.data.toUserId
+      if (!toUserId) return 'Unassigned'
+      if (isSelf(toUserId)) return 'Reassigned to you'
+      return `Reassigned to ${ctx.actorName ?? 'a teammate'}`
+    }
+    case 'thread:visitor:identified': {
+      const email = event.data.visitorEmail
+      if (typeof email !== 'string' || !email) return 'Visitor identified'
+      return `Visitor identified as ${email}`
+    }
+    default:
+      return null
+  }
+}

--- a/apps/web/src/components/mail/chat-panel/use-thread-events.ts
+++ b/apps/web/src/components/mail/chat-panel/use-thread-events.ts
@@ -1,0 +1,93 @@
+// apps/web/src/components/mail/chat-panel/use-thread-events.ts
+'use client'
+
+import { rooms } from '@auxx/lib/realtime/client'
+import { useEffect, useMemo, useState } from 'react'
+import { useRealtimeRoom } from '~/realtime/hooks'
+import { api } from '~/trpc/react'
+import type { ChatThreadEvent, ChatThreadEventType } from './system-line'
+
+const EVENT_TYPES: ChatThreadEventType[] = [
+  'thread:taken_over',
+  'thread:returned_to_ai',
+  'thread:archived',
+  'thread:reopened',
+  'thread:assignee:changed',
+  'thread:visitor:identified',
+]
+const EVENT_TYPE_SET = new Set<string>(EVENT_TYPES)
+
+/**
+ * Load the persisted thread lifecycle events for a chat thread and subscribe
+ * to the per-thread realtime room so new events appear without polling.
+ *
+ * Returns `{ events: [] }` when `enabled` is false (e.g. email threads).
+ * Dedupes by event id (the realtime publisher includes the row id +
+ * createdAt in the Pusher payload).
+ */
+export function useChatThreadEvents({
+  threadId,
+  enabled,
+}: {
+  threadId: string | null | undefined
+  enabled: boolean
+}): { events: ChatThreadEvent[] } {
+  const query = api.thread.listEvents.useQuery(
+    { threadId: threadId ?? '' },
+    { enabled: enabled && !!threadId, staleTime: 30_000 }
+  )
+
+  const [liveEvents, setLiveEvents] = useState<ChatThreadEvent[]>([])
+
+  // Reset the live buffer when the thread changes — events from a previous
+  // thread are obviously irrelevant on the new one.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: threadId is the trigger; setLiveEvents is stable.
+  useEffect(() => {
+    setLiveEvents([])
+  }, [threadId])
+
+  const roomKey = enabled && threadId ? rooms.chatThread(threadId) : null
+
+  useRealtimeRoom(roomKey, {
+    onEvent: (eventName, payload) => {
+      if (!EVENT_TYPE_SET.has(eventName)) return
+      if (!payload || typeof payload !== 'object') return
+      const data = payload as Record<string, unknown>
+      // Server publisher tucks `id` + `createdAt` into the payload; fall
+      // back to a synthetic id so dedupe still works on legacy publishes.
+      const id =
+        typeof data.id === 'string'
+          ? data.id
+          : `${eventName}:${threadId}:${data.createdAt ?? Date.now()}`
+      const createdAt =
+        typeof data.createdAt === 'string' ? data.createdAt : new Date().toISOString()
+      setLiveEvents((prev) => {
+        if (prev.some((e) => e.id === id)) return prev
+        return [
+          ...prev,
+          {
+            id,
+            type: eventName as ChatThreadEventType,
+            createdAt,
+            data,
+          },
+        ]
+      })
+    },
+  })
+
+  const events = useMemo<ChatThreadEvent[]>(() => {
+    const base = (query.data ?? []) as ChatThreadEvent[]
+    if (liveEvents.length === 0) return base
+    const seen = new Set(base.map((e) => e.id))
+    const merged = [...base]
+    for (const ev of liveEvents) {
+      if (seen.has(ev.id)) continue
+      merged.push(ev)
+      seen.add(ev.id)
+    }
+    return merged
+  }, [query.data, liveEvents])
+
+  return { events }
+}

--- a/apps/web/src/components/mail/chat-timeline.ts
+++ b/apps/web/src/components/mail/chat-timeline.ts
@@ -1,0 +1,100 @@
+// apps/web/src/components/mail/chat-timeline.ts
+//
+// Interleave admin-side chat messages with thread lifecycle events
+// (taken_over, returned_to_ai, archived, reopened, assignee:changed,
+// visitor:identified) into a single sorted render list. Consecutive
+// same-sender CHAT messages within a 5-minute window collapse into a
+// `chat-group`; any event between them breaks the cluster.
+//
+// Mirrors the widget's `buildTimeline` in
+// `apps/chat-widget/src/views/conversation/conversation-view.tsx`, but
+// operates on the admin `MessageMeta` shape and emits the same
+// `chat-group` / `single` item kinds the existing `thread-messages` and
+// `chat-panel/messages` renderers already understand.
+
+import type { MessageMeta } from '~/components/threads/store'
+import type { ChatThreadEvent } from './chat-panel/system-line'
+
+const CHAT_GROUP_WINDOW_MS = 5 * 60_000
+
+export type ChatTimelineItem =
+  | { kind: 'single'; message: MessageMeta; index: number }
+  | { kind: 'chat-group'; messages: MessageMeta[]; startIndex: number; endIndex: number }
+  | { kind: 'event'; event: ChatThreadEvent }
+
+/**
+ * Interleave messages and thread events by timestamp, collapsing consecutive
+ * same-sender CHAT messages into groups. `index` / `startIndex` / `endIndex`
+ * point back into the original `messages` array so existing per-message UI
+ * (latest-message check, animation delay) keeps working.
+ */
+export function buildChatTimeline(
+  messages: MessageMeta[],
+  events: ChatThreadEvent[]
+): ChatTimelineItem[] {
+  type Entry =
+    | { kind: 'message'; createdAt: number; message: MessageMeta; index: number }
+    | { kind: 'event'; createdAt: number; event: ChatThreadEvent }
+
+  const entries: Entry[] = [
+    ...messages.map((m, i) => ({
+      kind: 'message' as const,
+      createdAt: messageTimestamp(m),
+      message: m,
+      index: i,
+    })),
+    ...events.map((e) => ({
+      kind: 'event' as const,
+      createdAt: new Date(e.createdAt).getTime(),
+      event: e,
+    })),
+  ]
+  // Stable sort: messages tie-break by index so adjacent same-sender items
+  // stay adjacent (Array.prototype.sort is stable since ES2019).
+  entries.sort((a, b) => a.createdAt - b.createdAt)
+
+  const out: ChatTimelineItem[] = []
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i]!
+    if (entry.kind === 'event') {
+      out.push({ kind: 'event', event: entry.event })
+      continue
+    }
+    if (entry.message.messageType !== 'CHAT') {
+      out.push({ kind: 'single', message: entry.message, index: entry.index })
+      continue
+    }
+    const startIndex = entry.index
+    let endIndex = entry.index
+    const run: MessageMeta[] = [entry.message]
+    while (i + 1 < entries.length) {
+      const next = entries[i + 1]!
+      if (next.kind !== 'message') break
+      if (!canGroupChat(run[run.length - 1]!, next.message)) break
+      run.push(next.message)
+      endIndex = next.index
+      i++
+    }
+    out.push({ kind: 'chat-group', messages: run, startIndex, endIndex })
+  }
+  return out
+}
+
+function messageTimestamp(m: MessageMeta): number {
+  if (m.sentAt) return new Date(m.sentAt).getTime()
+  return 0
+}
+
+function canGroupChat(a: MessageMeta, b: MessageMeta): boolean {
+  if (b.messageType !== 'CHAT') return false
+  if (a.isInbound !== b.isInbound) return false
+  if (fromParticipant(a) !== fromParticipant(b)) return false
+  const aT = a.sentAt ? new Date(a.sentAt).getTime() : null
+  const bT = b.sentAt ? new Date(b.sentAt).getTime() : null
+  if (aT === null || bT === null) return true
+  return Math.abs(bT - aT) <= CHAT_GROUP_WINDOW_MS
+}
+
+function fromParticipant(m: MessageMeta): string | null {
+  return m.participants.find((p) => p.startsWith('from:')) ?? null
+}

--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -9,7 +9,16 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatDistanceToNowStrict } from 'date-fns'
 import DOMPurify from 'dompurify'
-import { Archive, Clock, ShieldAlert, Tag, Trash2, UserRound } from 'lucide-react'
+import {
+  Archive,
+  Bot,
+  Clock,
+  MessageCircle,
+  ShieldAlert,
+  Tag,
+  Trash2,
+  UserRound,
+} from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import type React from 'react'
 import { memo, useCallback, useMemo, useState } from 'react'
@@ -157,6 +166,18 @@ export const CompactThreadItem = memo(function CompactThreadItem({
 
   const hasTags = (thread?.tagIds?.length ?? 0) > 0
 
+  // --- Chat-specific affordances (4b-i) ---
+  const isChatThread = (thread?.integrationProvider as string | null) === 'chat'
+  const handoffState = thread?.handoffState ?? 'ai'
+  const isAssignedToMe =
+    !!currentUserId && !!thread?.assigneeId && thread.assigneeId.endsWith(`:${currentUserId}`)
+  const isLiveChat = useMemo(() => {
+    if (!isChatThread || !thread?.lastMessageAt) return false
+    if (!latestMessage?.isInbound) return false
+    const ts = new Date(thread.lastMessageAt).getTime()
+    return Date.now() - ts < 5 * 60_000
+  }, [isChatThread, thread?.lastMessageAt, latestMessage?.isInbound])
+
   if (isDeleted) {
     return null
   }
@@ -268,14 +289,50 @@ export const CompactThreadItem = memo(function CompactThreadItem({
 
             {/* Subject + Snippet */}
             <div className='flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden ms-2'>
+              {isChatThread && (
+                <MessageCircle
+                  className={cn(
+                    'size-3 shrink-0 text-muted-foreground',
+                    isLiveChat && 'text-blue-500'
+                  )}
+                  aria-label='Chat thread'
+                />
+              )}
               <span
                 className={cn(
                   'shrink-0 truncate text-xs',
                   isUnread ? 'text-foreground' : 'font-medium text-foreground/90',
-                  hasTags ? 'max-w-[40%]' : 'max-w-[50%]'
+                  hasTags ? 'max-w-[40%]' : 'max-w-[50%]',
+                  isLiveChat && 'font-semibold'
                 )}>
                 {thread.subject || '(no subject)'}
               </span>
+              {isChatThread &&
+                (handoffState === 'human' ? (
+                  <span
+                    className={cn(
+                      'shrink-0 rounded-full border px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide',
+                      isAssignedToMe
+                        ? 'border-blue-500/40 bg-blue-500/10 text-blue-700 dark:text-blue-300'
+                        : 'border-muted-foreground/20 bg-muted text-muted-foreground'
+                    )}
+                    title={isAssignedToMe ? 'You are on this chat' : 'A teammate is on this chat'}>
+                    {isAssignedToMe ? 'You' : 'Human'}
+                  </span>
+                ) : (
+                  <span
+                    className='shrink-0 inline-flex items-center gap-0.5 rounded-full border border-muted-foreground/20 bg-muted/60 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground'
+                    title='AI is replying'>
+                    <Bot className='size-2.5' />
+                    AI
+                  </span>
+                ))}
+              {isLiveChat && (
+                <span
+                  className='shrink-0 size-1.5 rounded-full bg-blue-500 animate-pulse'
+                  aria-label='Live chat'
+                />
+              )}
               {snippet && (
                 <>
                   <span className='shrink-0 text-muted-foreground/50'>—</span>

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -22,7 +22,16 @@ import { cn } from '@auxx/ui/lib/utils'
 import { useDraggable } from '@dnd-kit/core'
 import { formatDistanceToNowStrict } from 'date-fns'
 import DOMPurify from 'dompurify'
-import { Archive, Ban, Clock, MailWarning, MoreVertical, Trash2 } from 'lucide-react'
+import {
+  Archive,
+  Ban,
+  Bot,
+  Clock,
+  MailWarning,
+  MessageCircle,
+  MoreVertical,
+  Trash2,
+} from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import type React from 'react'
 import { memo, useCallback, useMemo } from 'react'
@@ -308,6 +317,21 @@ export const MailThreadItem = memo(function MailThreadItem({
 
   const hasTags = (thread?.tagIds?.length ?? 0) > 0
 
+  // --- Chat-specific affordances (4b-i) ---
+  // Channel marker, handoff badge, and "live" emphasis on rows whose latest
+  // inbound message landed in the last few minutes. Detection uses the
+  // lowercase `'chat'` provider value coming from the Integration row.
+  const isChatThread = (thread?.integrationProvider as string | null) === 'chat'
+  const handoffState = thread?.handoffState ?? 'ai'
+  const isAssignedToMe =
+    !!currentUserId && !!thread?.assigneeId && thread.assigneeId.endsWith(`:${currentUserId}`)
+  const isLiveChat = useMemo(() => {
+    if (!isChatThread || !thread?.lastMessageAt) return false
+    if (!latestMessage?.isInbound) return false
+    const ts = new Date(thread.lastMessageAt).getTime()
+    return Date.now() - ts < 5 * 60_000
+  }, [isChatThread, thread?.lastMessageAt, latestMessage?.isInbound])
+
   // --- Tombstoned (optimistic delete) — render nothing ---
   if (isDeleted) {
     return null
@@ -411,13 +435,51 @@ export const MailThreadItem = memo(function MailThreadItem({
 
               {/* Subject */}
               <div className='flex w-full items-center gap-1 min-w-0'>
+                {isChatThread && (
+                  <MessageCircle
+                    className={cn(
+                      'size-3 shrink-0 text-muted-foreground group-aria-selected:text-background/80',
+                      isLiveChat && 'text-blue-500 group-aria-selected:text-white'
+                    )}
+                    aria-label='Chat thread'
+                  />
+                )}
                 <div
                   className={cn(
                     'min-w-0 truncate text-xs font-medium group-aria-selected:text-background/80',
-                    hasTags && 'max-w-[60%] shrink-0'
+                    hasTags && 'max-w-[60%] shrink-0',
+                    isLiveChat && 'font-semibold'
                   )}>
                   {thread.subject || '(no subject)'}
                 </div>
+                {isChatThread &&
+                  (handoffState === 'human' ? (
+                    <span
+                      className={cn(
+                        'shrink-0 rounded-full border px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide',
+                        isAssignedToMe
+                          ? 'border-blue-500/40 bg-blue-500/10 text-blue-700 dark:text-blue-300'
+                          : 'border-muted-foreground/20 bg-muted text-muted-foreground'
+                      )}
+                      title={
+                        isAssignedToMe ? 'You are on this chat' : 'A teammate is on this chat'
+                      }>
+                      {isAssignedToMe ? 'You' : 'Human'}
+                    </span>
+                  ) : (
+                    <span
+                      className='shrink-0 inline-flex items-center gap-0.5 rounded-full border border-muted-foreground/20 bg-muted/60 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground'
+                      title='AI is replying'>
+                      <Bot className='size-2.5' />
+                      AI
+                    </span>
+                  ))}
+                {isLiveChat && (
+                  <span
+                    className={cn('shrink-0 size-1.5 rounded-full bg-blue-500', 'animate-pulse')}
+                    aria-label='Live chat'
+                  />
+                )}
                 <div className='min-w-0 flex-1'>
                   <OverflowRow collapseSlot='text' className='justify-end' gap={4}>
                     {thread.tagIds?.map((tagId) => (

--- a/apps/web/src/components/mail/thread-header.tsx
+++ b/apps/web/src/components/mail/thread-header.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { PLATFORM_CAPABILITIES } from '@auxx/lib/channels/client'
-import { type ActorId, parseActorId } from '@auxx/types/actor'
+import type { ActorId } from '@auxx/types/actor'
 import { toRecordId } from '@auxx/types/resource'
 import { Alert } from '@auxx/ui/components/alert'
 import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
@@ -17,8 +17,6 @@ import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import {
   Archive,
   ArchiveRestore,
-  Bot,
-  HandMetal,
   MailCheck,
   MailWarning,
   MoreHorizontal,
@@ -29,20 +27,19 @@ import {
   Zap,
 } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
-import { useSession } from '~/auth/auth-client'
 import { useChannel } from '~/components/channels/hooks/use-channels'
 import { useActor, useResource } from '~/components/resources/hooks'
 import { useThreadTags } from '~/components/tags/hooks/use-thread-tags'
 import { useInbox, useThread } from '~/components/threads/hooks'
 import { ManualTriggerButton } from '~/components/workflow/manual-trigger-button'
 import { useConfirm } from '~/hooks/use-confirm'
-import { api } from '~/trpc/react'
 import { EditableText } from '../editor/editable-text'
 import { Tooltip } from '../global/tooltip'
 import { ActorPicker } from '../pickers/actor-picker'
 import { InboxPicker } from '../pickers/inbox-picker'
 import { TagPicker } from '../pickers/tag-picker'
 import { RecordBadge } from '../resources/ui'
+import { ChatHandoffBanner } from './chat-handoff-banner'
 import { useThreadContext } from './thread-provider'
 import { ThreadTag } from './thread-tag'
 import { ThreadTicketControl } from './thread-ticket-control'
@@ -88,56 +85,6 @@ export function ThreadHeader() {
     : undefined
   const isEmailChannel = platformCaps ? platformCaps.channel === 'email' : true
   const isChatChannel = channel?.provider === 'chat'
-
-  // P4.2 — chat handoff buttons. "Take over" appears when AI is driving or
-  // someone else is assigned; "Return to AI" appears when the current user
-  // owns the thread and it's flipped to human. Polished header banner is
-  // Phase 4b — this is the minimal functional surface.
-  const { data: session } = useSession()
-  const currentUserId = session?.user?.id
-  const assigneeUserId = thread?.assigneeId
-    ? (() => {
-        try {
-          return parseActorId(thread.assigneeId).id
-        } catch {
-          return null
-        }
-      })()
-    : null
-  const isAssignedToMe = !!currentUserId && assigneeUserId === currentUserId
-  const handoffState = thread?.handoffState ?? 'ai'
-  const showTakeOver = isChatChannel && (handoffState === 'ai' || !isAssignedToMe)
-  const showReturnToAi = isChatChannel && handoffState === 'human' && isAssignedToMe
-
-  const takeOver = api.thread.takeOver.useMutation()
-  const returnToAi = api.thread.returnToAi.useMutation()
-  const utils = api.useUtils()
-
-  const handleTakeOver = useCallback(async () => {
-    if (!thread) return
-    try {
-      await takeOver.mutateAsync({ threadId: thread.id })
-      await utils.thread.invalidate()
-    } catch (error) {
-      toastError({
-        title: 'Failed to take over',
-        description: error instanceof Error ? error.message : 'Unknown error',
-      })
-    }
-  }, [thread, takeOver, utils])
-
-  const handleReturnToAi = useCallback(async () => {
-    if (!thread) return
-    try {
-      await returnToAi.mutateAsync({ threadId: thread.id })
-      await utils.thread.invalidate()
-    } catch (error) {
-      toastError({
-        title: 'Failed to return to AI',
-        description: error instanceof Error ? error.message : 'Unknown error',
-      })
-    }
-  }, [thread, returnToAi, utils])
 
   // Local state for tag popover
   const [open, setOpen] = useState(false)
@@ -367,34 +314,6 @@ export function ThreadHeader() {
               </Tooltip>
             </ManualTriggerButton>
 
-            {showTakeOver && (
-              <Tooltip content='Take over from AI'>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  onClick={handleTakeOver}
-                  loading={takeOver.isPending}
-                  loadingText='Taking over...'
-                  className='mr-2'>
-                  <HandMetal />
-                  Take over
-                </Button>
-              </Tooltip>
-            )}
-            {showReturnToAi && (
-              <Tooltip content='Hand thread back to AI'>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  onClick={handleReturnToAi}
-                  loading={returnToAi.isPending}
-                  loadingText='Returning...'
-                  className='mr-2'>
-                  <Bot />
-                  Return to AI
-                </Button>
-              </Tooltip>
-            )}
             <ActorPicker
               key={`assignee-${thread.id}`}
               value={assigneeValue}
@@ -484,6 +403,14 @@ export function ThreadHeader() {
           )}
         </div>
       </div>
+
+      {isChatChannel && (
+        <ChatHandoffBanner
+          threadId={thread.id}
+          handoffState={thread.handoffState ?? 'ai'}
+          assigneeId={thread.assigneeId}
+        />
+      )}
 
       {isTrash && (
         <div className='px-4 mt-2'>

--- a/apps/web/src/components/mail/thread-messages.tsx
+++ b/apps/web/src/components/mail/thread-messages.tsx
@@ -14,7 +14,6 @@ import {
   useThread,
   useThreadMutation,
 } from '~/components/threads/hooks'
-import type { MessageMeta } from '~/components/threads/store'
 import { useThreadStore } from '~/components/threads/store'
 import type { ScheduledMessageMeta } from '~/components/threads/store/thread-store'
 import { getThreadStoreState } from '~/components/threads/store/thread-store'
@@ -22,6 +21,9 @@ import { useCompose } from '~/hooks/use-compose'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { ChatMessageGroup } from './chat-message-group'
+import { SystemLine } from './chat-panel/system-line'
+import { useChatThreadEvents } from './chat-panel/use-thread-events'
+import { buildChatTimeline } from './chat-timeline'
 import EmailDisplay from './email-display'
 import type { DraftMessageType } from './email-editor/types'
 import MessageDisplay from './message-display'
@@ -162,6 +164,15 @@ export function ThreadMessages() {
     enabled: !!thread,
   })
 
+  // Chat thread lifecycle events (taken_over, returned_to_ai, archived,
+  // reopened, assignee:changed, visitor:identified). Only loaded for chat
+  // threads — email threads return an empty list and pay no realtime cost.
+  const isChatChannel = channel?.provider === 'chat'
+  const { events: threadEvents } = useChatThreadEvents({
+    threadId: thread?.id ?? null,
+    enabled: !!thread && isChatChannel,
+  })
+
   if (!thread) return null
 
   // Loading state
@@ -208,7 +219,10 @@ export function ThreadMessages() {
         )}
         {/* Email messages */}
         <div className={`flex flex-col gap-4 px-4 py-2 ${isMuted ? 'opacity-50' : ''}`}>
-          {buildRenderItems(messages).map((item) => {
+          {buildChatTimeline(messages, threadEvents).map((item) => {
+            if (item.kind === 'event') {
+              return <SystemLine key={`evt:${item.event.id}`} event={item.event} />
+            }
             if (item.kind === 'chat-group') {
               const groupIsLast =
                 item.endIndex === messages.length - 1 && scheduledMessages.length === 0
@@ -294,49 +308,4 @@ function MessageSkeleton() {
       <Skeleton className='h-20 w-full' />
     </div>
   )
-}
-
-type RenderItem =
-  | { kind: 'single'; message: MessageMeta; index: number }
-  | { kind: 'chat-group'; messages: MessageMeta[]; startIndex: number; endIndex: number }
-
-const CHAT_GROUP_WINDOW_MS = 5 * 60_000
-
-/**
- * Collapse consecutive same-sender CHAT messages (within 60s) into render
- * groups; everything else stays as a single render item carrying its original
- * index so existing per-message logic (latest-message check, animation delay)
- * keeps working.
- */
-function buildRenderItems(messages: MessageMeta[]): RenderItem[] {
-  const items: RenderItem[] = []
-  for (let i = 0; i < messages.length; i++) {
-    const m = messages[i]!
-    if (m.messageType !== 'CHAT') {
-      items.push({ kind: 'single', message: m, index: i })
-      continue
-    }
-    const startIndex = i
-    const run: MessageMeta[] = [m]
-    while (i + 1 < messages.length && canGroupChat(run[run.length - 1]!, messages[i + 1]!)) {
-      i++
-      run.push(messages[i]!)
-    }
-    items.push({ kind: 'chat-group', messages: run, startIndex, endIndex: i })
-  }
-  return items
-}
-
-function canGroupChat(a: MessageMeta, b: MessageMeta): boolean {
-  if (b.messageType !== 'CHAT') return false
-  if (a.isInbound !== b.isInbound) return false
-  if (fromParticipant(a) !== fromParticipant(b)) return false
-  const aT = a.sentAt ? new Date(a.sentAt).getTime() : null
-  const bT = b.sentAt ? new Date(b.sentAt).getTime() : null
-  if (aT === null || bT === null) return true
-  return Math.abs(bT - aT) <= CHAT_GROUP_WINDOW_MS
-}
-
-function fromParticipant(m: MessageMeta): string | null {
-  return m.participants.find((p) => p.startsWith('from:')) ?? null
 }

--- a/apps/web/src/server/api/routers/thread.ts
+++ b/apps/web/src/server/api/routers/thread.ts
@@ -29,7 +29,7 @@ import {
 import { createScopedLogger } from '@auxx/logger'
 import { recordIdSchema } from '@auxx/types/resource'
 import { TRPCError } from '@trpc/server'
-import { and, eq } from 'drizzle-orm'
+import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import { z } from 'zod'
 import { createTRPCRouter, notDemo, protectedProcedure } from '~/server/api/trpc'
 
@@ -925,5 +925,55 @@ export const threadRouter = createTRPCRouter({
       })
 
       return { success: true }
+    }),
+
+  // ═══════════════════════════════════════════════════════════════
+  // CHAT THREAD LIFECYCLE EVENTS (P4b-i)
+  // Centered system-line feed for the admin chat panel: takeover,
+  // return-to-AI, archive, reopen, assignee changed, visitor identified.
+  // Uses the `Event_threadId_expr_idx` expression index on
+  // `(Event.data->>'threadId')` added in #664.
+  // ═══════════════════════════════════════════════════════════════
+  listEvents: protectedProcedure
+    .input(z.object({ threadId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const { organizationId } = getServiceDependencies(ctx)
+      const rows = await ctx.db
+        .select({
+          id: schema.Event.id,
+          type: schema.Event.type,
+          createdAt: schema.Event.createdAt,
+          data: schema.Event.data,
+        })
+        .from(schema.Event)
+        .where(
+          and(
+            eq(schema.Event.organizationId, organizationId),
+            inArray(schema.Event.type, [
+              'thread:taken_over',
+              'thread:returned_to_ai',
+              'thread:archived',
+              'thread:reopened',
+              'thread:assignee:changed',
+              'thread:visitor:identified',
+            ]),
+            sql`(${schema.Event.data}->>'threadId') = ${input.threadId}`
+          )
+        )
+        .orderBy(asc(schema.Event.createdAt))
+        .limit(50)
+
+      return rows.map((r) => ({
+        id: r.id,
+        type: r.type as
+          | 'thread:taken_over'
+          | 'thread:returned_to_ai'
+          | 'thread:archived'
+          | 'thread:reopened'
+          | 'thread:assignee:changed'
+          | 'thread:visitor:identified',
+        createdAt: r.createdAt.toISOString(),
+        data: (r.data ?? {}) as Record<string, unknown>,
+      }))
     }),
 })

--- a/apps/worker/src/workers/worker-definitions/events-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/events-worker.ts
@@ -4,6 +4,7 @@ import {
   handleEntityTriggers,
   handleFieldTriggerJob,
   publishEventJob,
+  publishThreadEventToRealtime,
   publishToAnalyticsJob,
   sendInvitationUserJob,
   triggerAgents,
@@ -29,6 +30,7 @@ const eventHandlersJobMappings = {
   triggerAgents,
   handleFieldTriggerJob,
   handleEntityTriggers,
+  publishThreadEventToRealtime,
 }
 
 export function startEventsWorker() {

--- a/packages/lib/src/events/handlers/create-event-job.ts
+++ b/packages/lib/src/events/handlers/create-event-job.ts
@@ -3,9 +3,14 @@
 import { database, schema } from '@auxx/database'
 import type { Job } from 'bullmq'
 import type { AuxxEvent } from '../types'
+import { THREAD_REALTIME_EVENT_TYPES } from './publish-thread-event-to-realtime'
 
 export const createEventJob = async (job: Job<AuxxEvent>) => {
   const event = job.data
+  // Thread lifecycle events are persisted by `publishThreadEventToRealtime`
+  // so the realtime payload can carry the row id + createdAt for client-side
+  // dedupe. Skip here to avoid double-insert.
+  if (THREAD_REALTIME_EVENT_TYPES.has(event.type)) return
   await createEvent(event)
 }
 

--- a/packages/lib/src/events/handlers/index.ts
+++ b/packages/lib/src/events/handlers/index.ts
@@ -5,6 +5,10 @@ export { handleFieldTriggerJob } from '../../field-hooks/field-hook-job'
 export { createEventJob } from './create-event-job'
 export { createTimelineEvent } from './create-timeline-event'
 export { EventHandlers, publishEventJob } from './publish-event-job'
+export {
+  publishThreadEventToRealtime,
+  THREAD_REALTIME_EVENT_TYPES,
+} from './publish-thread-event-to-realtime'
 export { publishToAnalyticsJob } from './publish-to-analytics-job'
 export { sendInvitationUserJob } from './send-invitation-user-job'
 export { triggerAgents } from './trigger-agents'

--- a/packages/lib/src/events/handlers/publish-thread-event-to-realtime.ts
+++ b/packages/lib/src/events/handlers/publish-thread-event-to-realtime.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/events/handlers/publish-thread-event-to-realtime.ts
 
+import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
 import { getRealtimeService, rooms } from '../../realtime'
@@ -23,7 +24,13 @@ type RealtimeThreadEvent =
   | ThreadAssigneeChangedEvent
   | ThreadVisitorIdentifiedEvent
 
-const SUPPORTED_TYPES = new Set<AuxxEvent['type']>([
+/**
+ * Thread lifecycle event types this handler owns end-to-end (persistence +
+ * realtime fan-out). The generic `createEventJob` skips these types so this
+ * handler is the single writer — that way the Pusher payload can carry the
+ * row's `id` and `createdAt` for stable client-side dedupe.
+ */
+export const THREAD_REALTIME_EVENT_TYPES = new Set<AuxxEvent['type']>([
   'thread:archived',
   'thread:reopened',
   'thread:taken_over',
@@ -33,13 +40,15 @@ const SUPPORTED_TYPES = new Set<AuxxEvent['type']>([
 ])
 
 /**
- * Push thread lifecycle events onto the per-thread realtime room so widget
- * and admin clients can render centered system lines without polling. Runs
- * as a sibling of `createEventJob` — audit-log persistence is unaffected.
+ * Persist the thread lifecycle event AND push it onto the per-thread realtime
+ * room so widget and admin clients can render centered system lines without
+ * polling. Owns the `Event` row insert for these types — the generic
+ * `createEventJob` skips them so the inserted `id` and `createdAt` can be
+ * included in the Pusher payload (downstream clients dedupe on `id`).
  */
 export const publishThreadEventToRealtime = async (job: Job<AuxxEvent>) => {
   const event = job.data
-  if (!SUPPORTED_TYPES.has(event.type)) return
+  if (!THREAD_REALTIME_EVENT_TYPES.has(event.type)) return
 
   const typed = event as RealtimeThreadEvent
   const threadId = typed.data.threadId
@@ -48,8 +57,34 @@ export const publishThreadEventToRealtime = async (job: Job<AuxxEvent>) => {
     return
   }
 
+  // Persist first — the realtime payload carries the row id so clients can
+  // dedupe against the rows they load via the history endpoint.
+  let row: { id: string; createdAt: Date } | undefined
   try {
-    await getRealtimeService().publish(rooms.chatThread(threadId), event.type, typed.data)
+    const [inserted] = await database
+      .insert(schema.Event)
+      .values({
+        organizationId: typed.data.organizationId,
+        type: event.type,
+        data: typed.data,
+        updatedAt: new Date(),
+      })
+      .returning({ id: schema.Event.id, createdAt: schema.Event.createdAt })
+    row = inserted
+  } catch (error) {
+    logger.error('Failed to persist thread event row', {
+      type: event.type,
+      threadId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  try {
+    await getRealtimeService().publish(rooms.chatThread(threadId), event.type, {
+      ...typed.data,
+      id: row?.id,
+      createdAt: row?.createdAt?.toISOString() ?? new Date().toISOString(),
+    })
   } catch (error) {
     logger.error('Failed to publish thread event to realtime', {
       type: event.type,


### PR DESCRIPTION
## Summary
Builds the admin mirror of the take-over loop the widget got in #665.

### Thread list (`mail-thread-item.tsx` + `compact-thread-item.tsx`)
- Chat-bubble icon for chat threads
- Handoff pill: **AI** / **You** / **Human** (replaces default assignee chip on chat rows)
- "Live" pulsing dot + bolded subject when last inbound message is < 5min old

### Thread header banner (new `chat-handoff-banner.tsx`, replaces #663's placeholder buttons in `thread-header.tsx`)
- **State 1** — AI driving: "🤖 Our AI is replying to this chat. [Take over]"
- **State 2** — teammate driving (not me): "👤 {name} is on this chat. [Take over]" with `useConfirm` steal dialog
- **State 3** — I'm driving: "You're on this chat. [Return to AI]"
- Wired to `api.thread.takeOver` / `returnToAi` from #663
- Gracefully renders without presence dots / on-duty counts (those are 4b-ii / 4c)

### Centered system lines in the admin message list
- New `api.thread.listEvents` query + `useRealtimeRoom(rooms.chatThread)` subscription
- All 6 event types render with operator-facing copy (e.g. "Markus joined the chat", "Chat ended", "Visitor identified as markus@…")
- Actor names resolved via `useActor`; falls back to "A teammate" if member resolution lags
- `buildChatTimeline` util factored out, reused by `chat-panel/messages.tsx` and `thread-messages.tsx`

## Side fixes uncovered during implementation

### Bug in #664: live realtime push never fired

`publishThreadEventToRealtime` was added to the `EventHandlers` map but **never registered in the worker's `eventHandlersJobMappings`**. So the worker never invoked it when events were published. The widget in #665 only worked on hydration; the live take-over experience didn't actually update without a reload.

Fixed in `apps/worker/src/workers/worker-definitions/events-worker.ts`.

### Architectural deviation: realtime handler now writes the Event row

To carry `{id, createdAt}` in the live Pusher payload (avoiding the synthetic-id workaround #665 had to do), the realtime handler now writes the Event row itself via `returning({ id, createdAt })`. `createEventJob` early-returns for `thread:*` types to avoid double-insert.

This deviates from the plan's "audit-log persistence and realtime push stay siblings, never coupled" — we now have one writer for these 6 event types. Tradeoff: live payloads get accurate ids/timestamps + dedupe is deterministic. If we want to revisit, the cleaner-but-more-complex alternative is having `createEventJob` write first and pass `{id, createdAt}` via shared handler context.

## Out of scope (intentional)

- Presence dots / availability — separate plan [`plans/presence/agent-presence.md`](../plans/presence/agent-presence.md)
- "N teammates on chat duty" copy + headset badge — Phase 4c chat duty
- Sort "Active chats first" — explicitly skipped per spec
- Live open-chat surface for proactive outreach — 4b-iii, deferred post-v3
- Welcome bubble — P4.1 (Step 2)

## Plan
[`plans/chat/v3/phase-4b-handoff-presence-proactive.md`](../plans/chat/v3/phase-4b-handoff-presence-proactive.md) — 4b-i section.

## Test plan
- [ ] Chat threads in inbox list show chat icon + AI/You/Human pill (not default assignee chip)
- [ ] Chat row with inbound message < 5min ago shows bold subject + pulsing dot
- [ ] Email rows unchanged
- [ ] Thread view: AI-state banner appears with "🤖 Our AI is replying" + Take over button
- [ ] Take over → banner flips to "You're on this chat" + Return to AI button, no reload
- [ ] Have another teammate take a thread → my banner shows "👤 {name} is on this chat" + Take over
- [ ] My "Take over" on someone else's thread shows steal confirm dialog
- [ ] Return to AI → banner flips back to AI state
- [ ] Centered system lines render in the message list: "{name} joined the chat", "Chat ended", etc.
- [ ] Live: when another admin takes over, my open thread view renders the system line without reload (verifies the worker fix)
- [ ] System line `assignee:changed` renders sensibly (or hides if same actor as the take-over within a few seconds)
- [ ] No dual-rendering after reload (dedupe by event id works)