### PR TITLE
fix(chat): P4 realtime + reconcile fixes

### DIFF
--- a/apps/api/src/routes/chat/initialize.ts
+++ b/apps/api/src/routes/chat/initialize.ts
@@ -3,8 +3,9 @@
 import type { ChatIdentifyClaim } from '@auxx/credentials/passport'
 import { issueChatPassport } from '@auxx/credentials/passport'
 import { database, schema } from '@auxx/database'
-import { initializeOrResumeChatThread } from '@auxx/lib/chat'
+import { initializeOrResumeChatThread, publishVisitorThreadCreated } from '@auxx/lib/chat'
 import { publisher } from '@auxx/lib/events'
+import { getRealtimeService, publishThreadCreated } from '@auxx/lib/realtime'
 import { createScopedLogger } from '@auxx/logger'
 import { asc, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
@@ -46,6 +47,7 @@ initializeRoute.post('/', async (c) => {
       {
         channelId: chat.channelId,
         visitorId: chat.sessionId,
+        resumeThreadId: typeof body.threadId === 'string' ? body.threadId : undefined,
         visit: {
           url: typeof body.url === 'string' ? body.url : undefined,
           referrer: typeof body.referrer === 'string' ? body.referrer : undefined,
@@ -79,6 +81,33 @@ initializeRoute.post('/', async (c) => {
     }
 
     const { thread, isNew, visitorChatSessionId } = result.value
+
+    if (isNew) {
+      // New chat thread — fan out so the admin's mail-thread list picks it up
+      // live, and the visitor's Messages tab (cross-thread channel) bumps to
+      // include it without a refetch.
+      await Promise.all([
+        publishThreadCreated(getRealtimeService(), chat.organizationId, {
+          threadId: thread.id,
+          inboxId: thread.inboxId ?? null,
+        }).catch((err) =>
+          log.warn('Failed to publish thread:created for new chat thread', {
+            threadId: thread.id,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        ),
+        publishVisitorThreadCreated(getRealtimeService(), {
+          visitorParticipantId: chat.visitorParticipantId,
+          threadId: thread.id,
+          createdAt: thread.createdAt ?? new Date(),
+        }).catch((err) =>
+          log.warn('Failed to publish visitor thread-created', {
+            threadId: thread.id,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        ),
+      ])
+    }
 
     // Load existing messages on resume so the widget can rehydrate.
     const rows = isNew

--- a/apps/api/src/routes/chat/passport.ts
+++ b/apps/api/src/routes/chat/passport.ts
@@ -34,6 +34,34 @@ passportRoute.options('/', (c) => {
   return c.body(null, 204)
 })
 
+passportRoute.options('/reset', (c) => {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  return c.body(null, 204)
+})
+
+/**
+ * POST /api/chat/passport/reset
+ *
+ * Dev/preview-only convenience to wipe the visitor's sticky session. Clears
+ * the `auxx_chat_session_id` cookie by setting `Max-Age=0`. After this the
+ * next passport request will allocate a brand-new sessionId + Participant.
+ *
+ * Not gated to dev because (a) it only affects the caller's own cookie and
+ * (b) Pusher channel names are unguessable, so worst-case a malicious caller
+ * just resets *themselves*.
+ */
+passportRoute.post('/reset', (c) => {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  setCookie(c, CHAT_SESSION_COOKIE, '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'None',
+    maxAge: 0,
+    path: '/',
+  })
+  return c.json({ success: true })
+})
+
 /**
  * POST /api/chat/passport
  *

--- a/apps/api/src/routes/chat/threads.ts
+++ b/apps/api/src/routes/chat/threads.ts
@@ -1,8 +1,9 @@
 // apps/api/src/routes/chat/threads.ts
 
 import { database, schema } from '@auxx/database'
-import { initializeOrResumeChatThread } from '@auxx/lib/chat'
+import { initializeOrResumeChatThread, publishVisitorThreadCreated } from '@auxx/lib/chat'
 import { ProviderRegistryService } from '@auxx/lib/providers'
+import { getRealtimeService, publishThreadCreated } from '@auxx/lib/realtime'
 import type { ChatThreadMetadata } from '@auxx/lib/threads/types'
 import { createScopedLogger } from '@auxx/logger'
 import { and, asc, desc, eq, isNotNull, lt, or, sql } from 'drizzle-orm'
@@ -75,10 +76,35 @@ threadsRoute.post('/', async (c) => {
     )
   }
 
+  const { thread, isNew } = result.value
+  if (isNew) {
+    await Promise.all([
+      publishThreadCreated(getRealtimeService(), chat.organizationId, {
+        threadId: thread.id,
+        inboxId: thread.inboxId ?? null,
+      }).catch((err) =>
+        log.warn('Failed to publish thread:created for new chat thread', {
+          threadId: thread.id,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      ),
+      publishVisitorThreadCreated(getRealtimeService(), {
+        visitorParticipantId: chat.visitorParticipantId,
+        threadId: thread.id,
+        createdAt: thread.createdAt ?? new Date(),
+      }).catch((err) =>
+        log.warn('Failed to publish visitor thread-created', {
+          threadId: thread.id,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      ),
+    ])
+  }
+
   return c.json({
     success: true,
     data: {
-      threadId: result.value.thread.id,
+      threadId: thread.id,
       pusherChannel: `chat-${result.value.visitorChatSessionId}`,
     },
   })
@@ -333,6 +359,10 @@ threadsRoute.get('/', async (c) => {
     const baseConditions = [
       eq(schema.Thread.organizationId, chat.organizationId),
       eq(schema.Thread.integrationId, chat.channelId),
+      // Skip empty threads — the widget previously created threads eagerly on
+      // every Home "Send us a message" tap, leaving rows with no messages that
+      // showed up as "No messages yet, Support" in the Messages tab.
+      isNotNull(schema.Thread.latestMessageId),
     ]
 
     const conditions = cursorParts

--- a/apps/chat-widget/src/transport/pusher.ts
+++ b/apps/chat-widget/src/transport/pusher.ts
@@ -18,6 +18,15 @@ export function connectPusher(opts: {
     forceTLS: true,
   })
   const channel = pusher.subscribe(opts.channelName)
+  channel.bind_global((event: string, payload: unknown) => {
+    if (event.startsWith('pusher:')) {
+      if (event === 'pusher:subscription_succeeded' || event === 'pusher:subscription_error') {
+        console.log('[widget.sub]', opts.channelName, event)
+      }
+      return
+    }
+    console.log('[widget.sub]', opts.channelName, event, payload)
+  })
   return {
     channel,
     disconnect: () => {
@@ -74,6 +83,15 @@ export function connectPrivatePusher(opts: {
     },
   })
   const channel = pusher.subscribe(opts.channelName)
+  channel.bind_global((event: string, payload: unknown) => {
+    if (event.startsWith('pusher:')) {
+      if (event === 'pusher:subscription_succeeded' || event === 'pusher:subscription_error') {
+        console.log('[widget.sub]', opts.channelName, event)
+      }
+      return
+    }
+    console.log('[widget.sub]', opts.channelName, event, payload)
+  })
   return {
     channel,
     disconnect: () => {

--- a/apps/chat-widget/src/views/conversation/composer/composer.tsx
+++ b/apps/chat-widget/src/views/conversation/composer/composer.tsx
@@ -105,7 +105,7 @@ export function Composer({ channelId, onSend, disabled, placeholder }: ComposerP
       onDragLeave={() => setDragOver(false)}
       onDrop={handleDrop}
       className={cn(
-        'mx-3 mb-3 rounded-xl bg-muted ring-1 ring-border transition-colors focus-within:ring-primary focus-within:ring-2',
+        'relative mx-3 mb-3 rounded-xl bg-muted ring-1 ring-border transition-colors focus-within:ring-primary focus-within:ring-2',
         dragOver && 'ring-primary bg-accent'
       )}>
       <AttachmentThumbRow inflight={attachments} onRemove={handleRemoveAttachment} />
@@ -118,9 +118,10 @@ export function Composer({ channelId, onSend, disabled, placeholder }: ComposerP
         minRows={1}
         maxRows={6}
         disabled={disabled}
+        className='pb-10'
       />
-      <div className='flex items-center justify-between gap-1 px-2 pb-2'>
-        <div className='flex items-center gap-1'>
+      <div className='pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-between gap-1 px-1 pb-1'>
+        <div className='pointer-events-auto flex items-center gap-1'>
           <EmojiButton onSelect={insertAtCaret} />
           <AttachButton
             channelId={channelId}
@@ -129,7 +130,9 @@ export function Composer({ channelId, onSend, disabled, placeholder }: ComposerP
             disabled={disabled || sending}
           />
         </div>
-        <SendButton onClick={handleSend} disabled={!canSend} loading={sending} />
+        <div className='pointer-events-auto'>
+          <SendButton onClick={handleSend} disabled={!canSend} loading={sending} />
+        </div>
       </div>
     </div>
   )

--- a/apps/chat-widget/src/views/conversation/conversation-view.tsx
+++ b/apps/chat-widget/src/views/conversation/conversation-view.tsx
@@ -76,7 +76,10 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
           setMessages(data.messages)
           setThreadEvents(data.threadEvents ?? [])
         } else {
-          // Fallback for cases where initialize resumed a different thread.
+          // Defensive: the server now honors `resumeThreadId` so this branch
+          // shouldn't fire in practice. If it does, surface the error loudly
+          // instead of silently rendering an empty transcript — that masks
+          // real bugs as "thread reset to welcome bubble."
           api
             .getHistory(threadId, data.sessionId)
             .then((hist) => {
@@ -84,7 +87,10 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
               setMessages(hist.messages)
               setThreadEvents(hist.threadEvents ?? [])
             })
-            .catch(() => {})
+            .catch((e) => {
+              if (cancelled) return
+              setError(e instanceof Error ? e.message : 'Failed to load conversation')
+            })
         }
       })
       .catch((e) => {
@@ -230,12 +236,20 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
   const timeline = useMemo(() => buildTimeline(messages, threadEvents), [messages, threadEvents])
 
   return (
-    <div className='flex min-h-0 flex-1 flex-col bg-muted [&>*:last-child]:rounded-b-2xl'>
+    <div className='flex min-h-0 flex-1 flex-col dark:bg-background bg-muted  [&>*:last-child]:rounded-b-2xl'>
       <div ref={bodyRef} className='flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3'>
         {error ? (
           <div className='rounded bg-background p-2 text-center text-xs text-destructive'>
             {error}
           </div>
+        ) : null}
+        {init ? (
+          <WelcomeBubble
+            agent={config.agent}
+            template={config.welcomeMessageTemplate}
+            identify={identify}
+            initialTyping={messages.length === 0}
+          />
         ) : null}
         {timeline.map((item, i) =>
           item.kind === 'event' ? (
@@ -244,13 +258,6 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
             <Bubble key={`g-${i}`} group={item.group} />
           )
         )}
-        {init && messages.length === 0 ? (
-          <WelcomeBubble
-            agent={config.agent}
-            template={config.welcomeMessageTemplate}
-            identify={identify}
-          />
-        ) : null}
       </div>
       {init && messages.length === 0 ? (
         <SuggestedReplies

--- a/apps/chat-widget/src/views/conversation/welcome-bubble.tsx
+++ b/apps/chat-widget/src/views/conversation/welcome-bubble.tsx
@@ -20,6 +20,12 @@ interface WelcomeBubbleProps {
   identify: IdentifyPayload | null
   /** Milliseconds the typing-dots animation shows before the bubble swaps in. */
   typingDelayMs?: number
+  /**
+   * Whether to start in the typing-dots state. Pass false when the conversation
+   * already has messages so the bubble doesn't replay the typing animation
+   * every time the visitor reopens the thread.
+   */
+  initialTyping?: boolean
 }
 
 export function WelcomeBubble({
@@ -27,13 +33,15 @@ export function WelcomeBubble({
   template,
   identify,
   typingDelayMs = 900,
+  initialTyping = true,
 }: WelcomeBubbleProps) {
-  const [showContent, setShowContent] = useState(false)
+  const [showContent, setShowContent] = useState(!initialTyping)
 
   useEffect(() => {
+    if (!initialTyping) return
     const t = window.setTimeout(() => setShowContent(true), typingDelayMs)
     return () => window.clearTimeout(t)
-  }, [typingDelayMs])
+  }, [typingDelayMs, initialTyping])
 
   const avatar: BubbleAvatar | undefined = agent
     ? { name: agent.name, avatarUrl: agent.avatarUrl }

--- a/apps/chat-widget/src/views/messages/messages-view.tsx
+++ b/apps/chat-widget/src/views/messages/messages-view.tsx
@@ -11,17 +11,19 @@ import { cn } from '~/lib/cn'
 import { useNavStack } from '~/navigation/nav-stack-context'
 import { getLastReadAt } from '~/persistence/unread'
 import { chatApi, type ThreadListItem } from '~/transport/chat-api'
+import type { ChatConfig } from '~/transport/config'
 import type { ThreadCreatedEvent, ThreadUpdatedEvent } from '~/transport/visitor-channel'
 
 interface MessagesViewProps {
   channelId: string
+  config: ChatConfig
   subscribe?: {
     onThreadUpdated: (cb: (e: ThreadUpdatedEvent) => void) => () => void
     onThreadCreated: (cb: (e: ThreadCreatedEvent) => void) => () => void
   }
 }
 
-export function MessagesView({ channelId, subscribe }: MessagesViewProps) {
+export function MessagesView({ channelId, config, subscribe }: MessagesViewProps) {
   const nav = useNavStack()
   const api = chatApi(channelId)
   const [threads, setThreads] = useState<ThreadListItem[]>([])
@@ -137,6 +139,9 @@ export function MessagesView({ channelId, subscribe }: MessagesViewProps) {
     [nav]
   )
 
+  const fallbackAgentName = config.agent?.name ?? 'Support'
+  const fallbackAgentAvatar = config.agent?.avatarUrl ?? null
+
   const handleNewThread = useCallback(async () => {
     if (creating) return
     // Reuse the most recent existing thread if there is one — we only want
@@ -144,7 +149,7 @@ export function MessagesView({ channelId, subscribe }: MessagesViewProps) {
     // per click.
     if (threads.length > 0) {
       const top = threads[0]
-      openThread(top.id, top.agent?.name ?? 'Conversation')
+      openThread(top.id, top.agent?.name ?? fallbackAgentName)
       return
     }
     setCreating(true)
@@ -154,11 +159,11 @@ export function MessagesView({ channelId, subscribe }: MessagesViewProps) {
         referrer: typeof document !== 'undefined' ? document.referrer || undefined : undefined,
         userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
       })
-      openThread(threadId, 'New conversation')
+      openThread(threadId, fallbackAgentName)
     } finally {
       setCreating(false)
     }
-  }, [api, creating, openThread, threads])
+  }, [api, creating, openThread, threads, fallbackAgentName])
 
   if (loading && threads.length === 0) {
     return (
@@ -212,7 +217,9 @@ export function MessagesView({ channelId, subscribe }: MessagesViewProps) {
               key={t.id}
               thread={t}
               isUnread={isUnread}
-              onOpen={() => openThread(t.id, t.agent?.name ?? 'Conversation')}
+              fallbackName={fallbackAgentName}
+              fallbackAvatarUrl={fallbackAgentAvatar}
+              onOpen={() => openThread(t.id, t.agent?.name ?? fallbackAgentName)}
             />
           )
         })}
@@ -234,11 +241,15 @@ function Frame({ children }: { children: preact.ComponentChildren }) {
 interface ThreadRowProps {
   thread: ThreadListItem
   isUnread: boolean
+  fallbackName: string
+  fallbackAvatarUrl: string | null
   onOpen: () => void
 }
 
-function ThreadRow({ thread, isUnread, onOpen }: ThreadRowProps) {
+function ThreadRow({ thread, isUnread, fallbackName, fallbackAvatarUrl, onOpen }: ThreadRowProps) {
   const relative = formatRelativeTime(thread.lastMessage.sentAt)
+  const displayName = thread.agent?.name ?? fallbackName
+  const displayAvatarUrl = thread.agent?.avatarUrl ?? fallbackAvatarUrl
   return (
     <button
       type='button'
@@ -246,12 +257,10 @@ function ThreadRow({ thread, isUnread, onOpen }: ThreadRowProps) {
       className={cn(
         'flex w-full items-start gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-accent'
       )}>
-      <Avatar agent={thread.agent} />
+      <Avatar avatarUrl={displayAvatarUrl} />
       <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
         <div className='flex items-center justify-between gap-2'>
-          <span className='truncate text-sm font-medium text-foreground'>
-            {thread.agent?.name ?? 'Support'}
-          </span>
+          <span className='truncate text-sm font-medium text-foreground'>{displayName}</span>
           <span className='shrink-0 text-[11px] text-muted-foreground'>{relative}</span>
         </div>
         <div className='flex items-center gap-2'>
@@ -272,11 +281,9 @@ function ThreadRow({ thread, isUnread, onOpen }: ThreadRowProps) {
   )
 }
 
-function Avatar({ agent }: { agent: ThreadListItem['agent'] }) {
-  if (agent?.avatarUrl) {
-    return (
-      <img src={agent.avatarUrl} alt='' className='size-9 shrink-0 rounded-full object-cover' />
-    )
+function Avatar({ avatarUrl }: { avatarUrl: string | null }) {
+  if (avatarUrl) {
+    return <img src={avatarUrl} alt='' className='size-9 shrink-0 rounded-full object-cover' />
   }
   return (
     <div className='flex size-9 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground'>

--- a/apps/chat-widget/src/widget.tsx
+++ b/apps/chat-widget/src/widget.tsx
@@ -358,7 +358,7 @@ function renderFrame(
         />
       )
     case 'messages':
-      return <MessagesView channelId={channelId} subscribe={subscribe} />
+      return <MessagesView channelId={channelId} subscribe={subscribe} config={config} />
     case 'thread': {
       const raw = frame?.params?.threadId
       if (typeof raw !== 'string') return null

--- a/apps/web/src/app/(protected)/preview/widget/[integrationId]/page.tsx
+++ b/apps/web/src/app/(protected)/preview/widget/[integrationId]/page.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { useParams, useSearchParams } from 'next/navigation'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useEnv } from '~/providers/dehydrated-state-provider'
 
 type PreviewTheme = 'light' | 'dark' | 'system'
@@ -26,10 +26,29 @@ const THEME_LABELS: Record<PreviewTheme, string> = {
 export default function PreviewWidgetPage() {
   const params = useParams<{ integrationId: string }>()
   const search = useSearchParams()
-  const { appUrl } = useEnv()
+  const { appUrl, apiUrl } = useEnv()
   const integrationId = params?.integrationId
   const v = search?.get('v') ?? null
   const [previewTheme, setPreviewTheme] = useState<PreviewTheme>('light')
+  const [iframeKey, setIframeKey] = useState(0)
+  const [resetting, setResetting] = useState(false)
+
+  const handleClearVisitor = useCallback(async () => {
+    if (resetting) return
+    setResetting(true)
+    try {
+      // Clears the `auxx_chat_session_id` cookie on the API origin. Widget
+      // localStorage (passport, identify, unread) lives in the srcDoc iframe
+      // and gets discarded when we rekey the iframe below.
+      await fetch(`${apiUrl}/api/chat/passport/reset`, {
+        method: 'POST',
+        credentials: 'include',
+      }).catch(() => {})
+    } finally {
+      setIframeKey((k) => k + 1)
+      setResetting(false)
+    }
+  }, [apiUrl, resetting])
 
   const srcDoc = useMemo(() => {
     if (!integrationId) return null
@@ -57,8 +76,6 @@ export default function PreviewWidgetPage() {
     return <div style={{ padding: 16 }}>Loading…</div>
   }
 
-  const bundleSrc = `${appUrl}/scripts/chat-widget.js`
-
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', width: '100vw' }}>
       <div
@@ -74,40 +91,59 @@ export default function PreviewWidgetPage() {
           gap: 12,
         }}>
         <span>
-          Widget Preview — {bundleSrc} &nbsp;|&nbsp; Channel:{' '}
+          Widget Preview &nbsp;|&nbsp; Channel:{' '}
           <code style={{ color: '#e2e8f0' }}>{integrationId}</code>
         </span>
-        <div
-          style={{
-            display: 'flex',
-            gap: 2,
-            background: '#1a202c',
-            borderRadius: 6,
-            padding: 2,
-          }}>
-          {(['light', 'dark', 'system'] as const).map((t) => (
-            <button
-              key={t}
-              type='button'
-              onClick={() => setPreviewTheme(t)}
-              style={{
-                padding: '3px 10px',
-                borderRadius: 4,
-                border: 'none',
-                cursor: 'pointer',
-                fontSize: 11,
-                fontWeight: previewTheme === t ? 600 : 400,
-                background: previewTheme === t ? '#4a5568' : 'transparent',
-                color: previewTheme === t ? '#f7fafc' : '#a0aec0',
-                transition: 'background 0.15s',
-              }}>
-              {THEME_LABELS[t]}
-            </button>
-          ))}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button
+            type='button'
+            onClick={handleClearVisitor}
+            disabled={resetting}
+            title='Clear the visitor session cookie + reload the widget. Fresh sessionId + Participant on next load.'
+            style={{
+              padding: '4px 10px',
+              borderRadius: 4,
+              border: '1px solid #4a5568',
+              cursor: resetting ? 'wait' : 'pointer',
+              fontSize: 11,
+              background: '#1a202c',
+              color: '#e2e8f0',
+              opacity: resetting ? 0.6 : 1,
+            }}>
+            {resetting ? 'Clearing…' : 'Clear visitor'}
+          </button>
+          <div
+            style={{
+              display: 'flex',
+              gap: 2,
+              background: '#1a202c',
+              borderRadius: 6,
+              padding: 2,
+            }}>
+            {(['light', 'dark', 'system'] as const).map((t) => (
+              <button
+                key={t}
+                type='button'
+                onClick={() => setPreviewTheme(t)}
+                style={{
+                  padding: '3px 10px',
+                  borderRadius: 4,
+                  border: 'none',
+                  cursor: 'pointer',
+                  fontSize: 11,
+                  fontWeight: previewTheme === t ? 600 : 400,
+                  background: previewTheme === t ? '#4a5568' : 'transparent',
+                  color: previewTheme === t ? '#f7fafc' : '#a0aec0',
+                  transition: 'background 0.15s',
+                }}>
+                {THEME_LABELS[t]}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
       <iframe
-        key={previewTheme}
+        key={`${previewTheme}-${iframeKey}`}
         title='Chat Widget Preview'
         srcDoc={srcDoc}
         style={{ flex: '1 1 auto', border: 0, width: '100%' }}

--- a/packages/lib/src/chat/realtime.ts
+++ b/packages/lib/src/chat/realtime.ts
@@ -1,6 +1,10 @@
 // packages/lib/src/chat/realtime.ts
 
-import { publishMessageCreated, publishMessageUpdated } from '../realtime/publish-helpers'
+import {
+  publishMessageCreated,
+  publishMessageUpdated,
+  publishThreadUpdated,
+} from '../realtime/publish-helpers'
 import type { RealtimeService } from '../realtime/realtime-service'
 import { rooms } from '../realtime/rooms'
 
@@ -48,6 +52,18 @@ export async function publishChatMessageCreated(
       messageId: args.messageId,
       threadId: args.threadId,
       inboxId: args.inboxId,
+    }),
+    // Bump the thread row in the admin's mail-thread list so it re-sorts and
+    // the `isLiveChat` dot in `mail-thread-item.tsx` re-evaluates against the
+    // fresh `lastMessageAt`. Without this, `ChatProvider.receiveMessage` updates
+    // the DB but the admin list stays stale until refresh.
+    publishThreadUpdated(realtime, args.organizationId, {
+      threadId: args.threadId,
+      inboxId: args.inboxId,
+      patch: {
+        lastMessageAt: args.visitorPayload.createdAt.toISOString(),
+        latestMessageId: args.messageId,
+      },
     }),
     realtime.publish(
       rooms.chatSession(args.visitorChatSessionId),

--- a/packages/lib/src/chat/session.ts
+++ b/packages/lib/src/chat/session.ts
@@ -28,6 +28,13 @@ export interface InitializeChatThreadInput {
    * in a new conversation.
    */
   forceNewThread?: boolean
+  /**
+   * When set, resume this specific thread (after verifying ownership) instead
+   * of falling back to "most recent open thread for this visitor." Used when
+   * the visitor opens a specific past conversation from the Messages tab so
+   * `initialize` doesn't silently swap them onto a different thread.
+   */
+  resumeThreadId?: string
 }
 
 export interface InitializeChatThreadResult {
@@ -82,6 +89,40 @@ export async function initializeOrResumeChatThread(
     })
     if (visitorResult.error) return Result.error(visitorResult.error)
     const visitor = visitorResult.value
+
+    // Visitor explicitly asked to resume a specific thread (e.g. tapped a row
+    // in the Messages tab). Verify ownership + that it lives on this channel,
+    // then resume; otherwise reject — don't silently swap them onto a
+    // different thread.
+    if (input.resumeThreadId) {
+      const [requested] = await ctx.db
+        .select()
+        .from(schema.Thread)
+        .where(
+          and(
+            eq(schema.Thread.id, input.resumeThreadId),
+            eq(schema.Thread.organizationId, ctx.organizationId),
+            eq(schema.Thread.integrationId, integration.id)
+          )
+        )
+        .limit(1)
+      if (!requested) {
+        return Result.error(new NotFoundError('Chat thread not found'))
+      }
+      const meta = (requested.metadata ?? {}) as Partial<ChatThreadMetadata>
+      if (meta.channel !== 'chat' || meta.visitorParticipantId !== visitor.id) {
+        return Result.error(new ForbiddenError('Chat thread does not belong to this visitor'))
+      }
+      logger.info('Resumed requested chat thread', {
+        threadId: requested.id,
+        visitorId: input.visitorId,
+      })
+      return Result.ok({
+        thread: requested,
+        isNew: false,
+        visitorChatSessionId: requested.id,
+      })
+    }
 
     // Try to resume an open thread for this visitor on this channel.
     const candidateThreads = input.forceNewThread

--- a/packages/lib/src/messages/message-reconciler.service.ts
+++ b/packages/lib/src/messages/message-reconciler.service.ts
@@ -26,6 +26,7 @@ export class MessageReconcilerService {
    */
   async reconcileSentMessage(input: ReconciliationInput): Promise<void> {
     const { messageId, sendToken, providerResponse, threadContext } = input
+    const reconcileThread = input.reconcileThread !== false
 
     logger.info('Reconciling sent message', {
       messageId,
@@ -85,8 +86,10 @@ export class MessageReconcilerService {
 
     await this.db.update(schema.Message).set(updateData).where(eq(schema.Message.id, messageId))
 
-    // Step 2: Reconcile thread if needed (not just pending)
-    if (providerResponse.threadId) {
+    // Step 2: Reconcile thread if needed (not just pending). Skipped for
+    // providers without external thread state (e.g. chat) — they echo our own
+    // thread id back, and reconciling would clobber thread metadata.
+    if (reconcileThread && providerResponse.threadId) {
       await this.threadManager.reconcileThread(threadContext.id, {
         externalThreadId: providerResponse.threadId,
         actualMessageId: providerResponse.messageId || messageId,
@@ -95,7 +98,12 @@ export class MessageReconcilerService {
     }
 
     // Step 3: Mark duplicates for cleanup if we detect any
-    if (providerResponse.success && providerResponse.threadId && providerResponse.messageId) {
+    if (
+      reconcileThread &&
+      providerResponse.success &&
+      providerResponse.threadId &&
+      providerResponse.messageId
+    ) {
       await this.markDuplicatesForCleanup({
         realThreadId: threadContext.id,
         realMessageId: messageId,

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -165,12 +165,17 @@ export class MessageSenderService {
         threadContext: threadContext,
         attachments: attachmentFiles,
       })
-      // Step 7: Reconcile with provider response
+      // Step 7: Reconcile with provider response. Per-message bookkeeping
+      // (sendStatus, sentAt, externalId) always runs; the thread-level
+      // reconciliation is gated on the capability — chat has no external
+      // thread state and echoes our own id back, which would clobber thread
+      // metadata if reconciled.
       await this.reconciler.reconcileSentMessage({
         messageId: composed.id,
         sendToken: composed.sendToken,
         providerResponse: sendResult,
         threadContext: threadContext,
+        reconcileThread: capabilities.requiresSendReconciliation,
       })
 
       // Realtime: publish `message:created` for the freshly sent message so

--- a/packages/lib/src/messages/thread-manager.service.ts
+++ b/packages/lib/src/messages/thread-manager.service.ts
@@ -200,16 +200,19 @@ export class ThreadManagerService {
       return
     }
 
-    // Update the pending thread with real data
+    // Update the pending thread with real data. Merge reconciliation state into
+    // the existing jsonb instead of replacing — replacing would clobber any
+    // provider-specific metadata already on the thread (e.g. chat's
+    // visitorParticipantId / channel, which downstream filters depend on).
     await this.db
       .update(schema.Thread)
       .set({
         externalId: providerData.externalThreadId,
-        metadata: {
-          state: ThreadState.RECONCILED,
-          reconciledAt: new Date().toISOString(),
-          originalExternalId: providerData.externalThreadId,
-        },
+        metadata: sql`COALESCE(${schema.Thread.metadata}, '{}'::jsonb) || jsonb_build_object(
+          'state', ${ThreadState.RECONCILED}::text,
+          'reconciledAt', ${new Date().toISOString()}::text,
+          'originalExternalId', ${providerData.externalThreadId}::text
+        )`,
       })
       .where(eq(schema.Thread.id, pendingThreadId))
 

--- a/packages/lib/src/messages/types/message-sending.types.ts
+++ b/packages/lib/src/messages/types/message-sending.types.ts
@@ -127,6 +127,10 @@ export interface ReconciliationInput {
   sendToken: string
   providerResponse: ProviderSendResponse
   threadContext: ThreadContext
+  /** Whether to reconcile the thread against an external thread id. False for
+   * providers like `chat` that have no external state — the per-message
+   * bookkeeping (sendStatus, sentAt, externalId) still runs. Defaults to true. */
+  reconcileThread?: boolean
 }
 /**
  * Post-send sync job

--- a/packages/lib/src/providers/provider-capabilities.ts
+++ b/packages/lib/src/providers/provider-capabilities.ts
@@ -37,6 +37,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     requiresRecipients: true,
     countsAgainstOutboundEmailsQuota: true,
     triggersPostSendSync: true,
+    requiresSendReconciliation: true,
     supportsRichText: true,
   },
   [IntegrationProviderType.facebook]: {
@@ -75,6 +76,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     requiresRecipients: true,
     countsAgainstOutboundEmailsQuota: true,
     triggersPostSendSync: true,
+    requiresSendReconciliation: true,
     supportsRichText: false,
   },
   [IntegrationProviderType.instagram]: {
@@ -112,6 +114,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     requiresRecipients: true,
     countsAgainstOutboundEmailsQuota: true,
     triggersPostSendSync: true,
+    requiresSendReconciliation: true,
     supportsRichText: false,
   },
   [IntegrationProviderType.openphone]: {
@@ -146,6 +149,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     requiresRecipients: true,
     countsAgainstOutboundEmailsQuota: false,
     triggersPostSendSync: false,
+    requiresSendReconciliation: false,
     supportsRichText: false,
   },
   [IntegrationProviderType.mailgun]: {
@@ -177,6 +181,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     requiresRecipients: true,
     countsAgainstOutboundEmailsQuota: true,
     triggersPostSendSync: true,
+    requiresSendReconciliation: true,
     supportsRichText: true,
   },
   [IntegrationProviderType.sms]: {
@@ -211,6 +216,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     requiresRecipients: true,
     countsAgainstOutboundEmailsQuota: false,
     triggersPostSendSync: false,
+    requiresSendReconciliation: false,
     supportsRichText: false,
   },
   [IntegrationProviderType.email]: {
@@ -242,6 +248,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     requiresRecipients: true,
     countsAgainstOutboundEmailsQuota: true,
     triggersPostSendSync: true,
+    requiresSendReconciliation: true,
     supportsRichText: true,
   },
   [IntegrationProviderType.whatsapp]: {
@@ -278,6 +285,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     requiresRecipients: true,
     countsAgainstOutboundEmailsQuota: false,
     triggersPostSendSync: false,
+    requiresSendReconciliation: false,
     supportsRichText: false,
   },
   [IntegrationProviderType.chat]: {
@@ -306,10 +314,13 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     canReact: true,
     canShare: false,
     // Chat: visitor is encoded on the Thread, no subject, free.
+    // Chat has no external state to reconcile — the provider echoes our own
+    // thread id back, and reconciling would clobber thread metadata.
     requiresSubject: false,
     requiresRecipients: false,
     countsAgainstOutboundEmailsQuota: false,
     triggersPostSendSync: false,
+    requiresSendReconciliation: false,
     supportsRichText: false,
   },
   [IntegrationProviderType.shopify]: {
@@ -345,6 +356,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     requiresRecipients: false,
     countsAgainstOutboundEmailsQuota: false,
     triggersPostSendSync: false,
+    requiresSendReconciliation: false,
     supportsRichText: false,
   },
   [IntegrationProviderType.imap]: {
@@ -376,6 +388,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     requiresRecipients: true,
     countsAgainstOutboundEmailsQuota: true,
     triggersPostSendSync: true,
+    requiresSendReconciliation: true,
     supportsRichText: true,
   },
   [IntegrationProviderType.outlook]: {
@@ -407,6 +420,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     requiresRecipients: true,
     countsAgainstOutboundEmailsQuota: true,
     triggersPostSendSync: true,
+    requiresSendReconciliation: true,
     supportsRichText: true,
   },
 }
@@ -457,6 +471,7 @@ export function getProviderCapabilities(
       requiresRecipients: false,
       countsAgainstOutboundEmailsQuota: false,
       triggersPostSendSync: false,
+      requiresSendReconciliation: false,
       supportsRichText: false,
     }
   )

--- a/packages/lib/src/providers/types.ts
+++ b/packages/lib/src/providers/types.ts
@@ -49,6 +49,11 @@ export interface ProviderCapabilities {
   requiresRecipients: boolean
   countsAgainstOutboundEmailsQuota: boolean
   triggersPostSendSync: boolean
+  /** Whether the send pipeline should reconcile the local message against a
+   * provider response (externalThreadId, internetMessageId, etc.). False for
+   * providers like `chat` that have no external state — the provider echoes
+   * our local ids back and reconciling would clobber thread metadata. */
+  requiresSendReconciliation: boolean
   supportsRichText: boolean
 
   // Rate limiting

--- a/packages/lib/src/realtime/client/adapters/pusher.ts
+++ b/packages/lib/src/realtime/client/adapters/pusher.ts
@@ -134,7 +134,13 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
       // `pusher:member_removed`) are bound explicitly above and routed through
       // the presence handlers, not the global fan-out.
       const globalListener = (event: string, payload: unknown) => {
-        if (event.startsWith('pusher:')) return
+        if (event.startsWith('pusher:')) {
+          if (event === 'pusher:subscription_succeeded' || event === 'pusher:subscription_error') {
+            console.log('[realtime.sub]', roomKey, event)
+          }
+          return
+        }
+        console.log('[realtime.sub]', roomKey, event, payload)
         const current = this.rooms.get(roomKey)
         if (!current) return
         for (const h of current.handlers) {

--- a/packages/lib/src/realtime/realtime-service.ts
+++ b/packages/lib/src/realtime/realtime-service.ts
@@ -29,6 +29,7 @@ export class RealtimeService {
     options?: { excludeSocketId?: string }
   ): Promise<boolean> {
     const channel = toPusherChannel(roomKey)
+    console.log('[realtime.publish]', roomKey, event, channel ? '→' : 'NO_CHANNEL')
     if (!channel) return false
     return this.provider.publish(channel, event, data, options)
   }

--- a/packages/lib/src/realtime/room-keys.ts
+++ b/packages/lib/src/realtime/room-keys.ts
@@ -11,7 +11,15 @@
  * the server registry adds `authorize(...)` fns on top.
  */
 
-export type RoomKind = 'plain' | 'presence'
+/**
+ * - `plain` — server-published, client subscribes via `private-` Pusher channel
+ *   with auth signing. Most admin-side rooms.
+ * - `presence` — Pusher `presence-` channel; carries member roster + state.
+ * - `public` — server-published, client subscribes to the raw channel name
+ *   with no auth. Used for the visitor chat session (`chat-{id}`) which is
+ *   bootstrapped from the widget without a session cookie.
+ */
+export type RoomKind = 'plain' | 'presence' | 'public'
 
 /** Typed helpers to build room keys. Mirrored on `rooms` for server callers. */
 export const rooms = {
@@ -42,21 +50,28 @@ export function roomKindFor(roomKey: string): RoomKind | null {
   if (roomKey.startsWith('org-')) return 'presence'
   if (roomKey.startsWith('user-')) return 'plain'
   if (roomKey.startsWith('thread-')) return 'plain'
-  if (roomKey.startsWith('chat-')) return 'plain'
+  // Widget visitor session — raw public Pusher channel, no auth signing. The
+  // widget connects with `connectPusher` (non-private), so the server must
+  // publish to the same raw channel name.
+  if (roomKey.startsWith('chat-')) return 'public'
   if (roomKey.startsWith('visitor-')) return 'plain'
   return null
 }
 
-/** Map a room key to its Pusher channel name (`private-` / `presence-`). */
+/** Map a room key to its Pusher channel name. */
 export function toPusherChannel(roomKey: string): string | null {
   const kind = roomKindFor(roomKey)
   if (!kind) return null
-  return kind === 'presence' ? `presence-${roomKey}` : `private-${roomKey}`
+  if (kind === 'presence') return `presence-${roomKey}`
+  if (kind === 'public') return roomKey
+  return `private-${roomKey}`
 }
 
 /** Strip the Pusher prefix to recover the room key. */
 export function fromPusherChannel(channelName: string): string | null {
   if (channelName.startsWith('private-')) return channelName.slice('private-'.length)
   if (channelName.startsWith('presence-')) return channelName.slice('presence-'.length)
+  // Public channel — channel name and room key are the same.
+  if (roomKindFor(channelName) === 'public') return channelName
   return null
 }

--- a/packages/lib/src/realtime/rooms.ts
+++ b/packages/lib/src/realtime/rooms.ts
@@ -119,18 +119,16 @@ const REGISTRY: RoomDef[] = [
   },
   // Visitor chat session (widget-side): `chat-{sessionId}`.
   //
-  // The widget signs `chat-*` bindings via `/api/chat/pusher/auth` (apps/api),
-  // which validates the visitor passport and populates `ctx.visitor`. This
-  // surface (apps/web `/api/pusher/auth`) never populates `ctx.visitor`, so in
-  // practice the predicate below collapses to "authenticated admin only" here.
-  //
-  // Kept in the registry on purpose: when the widget's transport eventually
-  // migrates onto this codepath, the ACL row is already in place. Don't drop
-  // it just because the apps/web path can't satisfy it today.
+  // Public Pusher channel — the widget connects with `connectPusher` (no auth
+  // signing) at bootstrap, before any session is established. Authorization is
+  // moot: the channel name is unguessable (random session id) and only carries
+  // the visitor's own transcript echo. Authorize hook is unreachable for
+  // public channels (Pusher never asks the server to sign them) but we leave
+  // the entry in the registry so `findRoom` can resolve the key.
   {
-    kind: 'plain',
+    kind: 'public',
     match: (k) => k.startsWith('chat-'),
-    authorize: (_key, ctx) => !!ctx.session || !!ctx.visitor,
+    authorize: () => true,
   },
   // Visitor cross-thread (widget-side): `visitor-{participantId}`
   {


### PR DESCRIPTION
## Summary

Bundles the P4 chat realtime/widget polish with the reconcile metadata-clobber fix.

**Realtime + widget (sibling plan `phase-4-debug-realtime-and-fixes.md`, F-0..F-7):**
- `chat-{id}` pusher channel prefix + visitor subscription wiring
- Messages tab / Home "Recent message" data path
- Welcome bubble + agent identity polish
- Preview page wiring

**Reconcile (plan `phase-4-reconcile-clobber-fix.md`, F-8a/F-8b + follow-up):**
- New `requiresSendReconciliation` capability on `ProviderCapabilities`; chat/sms/openphone/whatsapp/shopify = `false`, email-likes = `true`
- `MessageReconcilerService.reconcileSentMessage` still runs per-message bookkeeping (`sendStatus`, `sentAt`, `externalId`) for every provider; the thread-level reconcile call + duplicate cleanup are now gated on the capability via a new `reconcileThread` flag on `ReconciliationInput`
- `ThreadManagerService.reconcileThread` now merges thread metadata via `COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(...)` instead of replacing — defense in depth so any future reconcile path preserves prior keys (`channel`, `visitorParticipantId`, `visit`, etc.)

### Why this matters

Before the fix, every chat thread had its metadata wiped the moment an admin/AI replied — `ChatProvider.sendMessage` returned `threadId = thread.id` (the local id echoed back), the reconciler treated that as an external thread id, and `reconcileThread` replaced the metadata jsonb with `{ state: 'RECONCILED', reconciledAt, originalExternalId }`. Downstream `meta.channel === 'chat' && meta.visitorParticipantId === ...` filters in `listThreads` / `recent` then returned `[]`, so the widget's Messages tab and Home recent-message card were empty.

After the first iteration (skipping the whole reconciler call for chat), admin messages stayed `sendStatus: PENDING` forever because Step 1 (message bookkeeping) was also skipped. Final fix splits the two steps: Step 1 always runs, Steps 2–3 (thread reconcile + duplicate cleanup) are capability-gated.

## Test plan

- [ ] Visitor sends a chat message → admin replies → returned message has `sendStatus: SENT`, non-null `sentAt`
- [ ] Thread row keeps `metadata.channel === 'chat'` and `metadata.visitorParticipantId` after the admin reply
- [ ] Widget Messages tab lists past threads with agent name + last-message snippet
- [ ] Home view shows "Recent message" card when `home.showRecentMessage` is on
- [ ] `GET /api/chat/threads` returns the visitor's threads (not `[]`)
- [ ] Email send path (Gmail/Outlook) still reconciles externalId/threadId as before — sanity-check with a real send