### PR TITLE
feat(chat): floating, draggable widget window (P6)

### DIFF
--- a/apps/chat-widget/src/components/frame-header.tsx
+++ b/apps/chat-widget/src/components/frame-header.tsx
@@ -5,9 +5,13 @@
 //   - dark hero    → Home root: logo + greeting on a primary-colored band
 //   - plain title  → Messages root: centered "Messages" on a flat band
 //   - contextual   → deep frames: back chevron + custom title + actions slot
+//
+// v3 Phase 6 adds the floating-window toggle button immediately left of the
+// close button in every variant, and forwards a ref to the root `<header>`
+// element so the parent can attach a pointer-drag controller while floating.
 
-import { ArrowLeft, X } from 'lucide-react'
-import type { ComponentChildren } from 'preact'
+import { ArrowDownLeft, ArrowLeft, ArrowUpRight, X } from 'lucide-react'
+import type { ComponentChildren, Ref } from 'preact'
 import { cn } from '~/lib/cn'
 
 export type FrameHeaderVariant = 'dark-hero' | 'plain' | 'contextual'
@@ -23,6 +27,9 @@ interface FrameHeaderProps {
   onBack?: () => void
   actions?: ComponentChildren
   children?: ComponentChildren
+  floating?: boolean
+  onToggleFloating?: () => void
+  headerRef?: Ref<HTMLElement>
 }
 
 export function FrameHeader({
@@ -36,20 +43,30 @@ export function FrameHeader({
   onBack,
   actions,
   children,
+  floating,
+  onToggleFloating,
+  headerRef,
 }: FrameHeaderProps) {
   if (variant === 'dark-hero') {
     // dark-hero sits on the primary-colored band — always use the light logo
     // (white/transparent, designed for dark backgrounds).
     const heroLogo = logoLight
     return (
-      <header className='relative flex shrink-0 flex-col gap-4 bg-primary px-5 py-5 text-primary-foreground'>
+      <header
+        ref={headerRef}
+        className='relative flex shrink-0 flex-col gap-4 bg-primary px-5 py-5 text-primary-foreground'>
         <div className='flex items-start justify-between'>
           {heroLogo ? (
             <img src={heroLogo} alt='' className='h-8 w-auto' />
           ) : (
             <span className='h-8' />
           )}
-          <CloseButton onClose={onClose} tone='light' />
+          <div className='flex items-center gap-1'>
+            {onToggleFloating ? (
+              <FloatButton floating={floating ?? false} onToggle={onToggleFloating} tone='light' />
+            ) : null}
+            <CloseButton onClose={onClose} tone='light' />
+          </div>
         </div>
         {children ?? (
           <div className='flex flex-col gap-1'>
@@ -63,16 +80,25 @@ export function FrameHeader({
 
   if (variant === 'plain') {
     return (
-      <header className='relative flex shrink-0 items-center justify-between border-b border-border bg-transparent px-4 py-3'>
-        <span className='w-6' />
+      <header
+        ref={headerRef}
+        className='relative flex shrink-0 items-center justify-between border-b border-border bg-transparent px-4 py-3'>
+        <span aria-hidden className='size-7' />
         <h1 className='text-sm font-semibold'>{title}</h1>
-        <CloseButton onClose={onClose} tone='dark' />
+        <div className='flex items-center gap-1'>
+          {onToggleFloating ? (
+            <FloatButton floating={floating ?? false} onToggle={onToggleFloating} tone='dark' />
+          ) : null}
+          <CloseButton onClose={onClose} tone='dark' />
+        </div>
       </header>
     )
   }
 
   return (
-    <header className='relative flex shrink-0 items-center gap-2 border-b border-border bg-transparent px-3 py-2'>
+    <header
+      ref={headerRef}
+      className='relative flex shrink-0 items-center gap-2 border-b border-border bg-transparent px-3 py-2'>
       {onBack ? (
         <button
           type='button'
@@ -91,8 +117,40 @@ export function FrameHeader({
         ) : null}
       </div>
       {actions}
+      {onToggleFloating ? (
+        <FloatButton floating={floating ?? false} onToggle={onToggleFloating} tone='dark' />
+      ) : null}
       <CloseButton onClose={onClose} tone='dark' />
     </header>
+  )
+}
+
+function FloatButton({
+  floating,
+  onToggle,
+  tone,
+}: {
+  floating: boolean
+  onToggle: () => void
+  tone: 'light' | 'dark'
+}) {
+  const Icon = floating ? ArrowDownLeft : ArrowUpRight
+  return (
+    <button
+      type='button'
+      onClick={onToggle}
+      onPointerDown={(e) => e.stopPropagation()}
+      data-no-drag
+      aria-label={floating ? 'Dock chat' : 'Pop out chat'}
+      aria-pressed={floating}
+      className={cn(
+        'flex size-7 items-center justify-center rounded transition-colors',
+        tone === 'light'
+          ? 'text-white/90 hover:bg-white/10 hover:text-white'
+          : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+      )}>
+      <Icon className='size-4' aria-hidden='true' />
+    </button>
   )
 }
 
@@ -101,6 +159,8 @@ function CloseButton({ onClose, tone }: { onClose: () => void; tone: 'light' | '
     <button
       type='button'
       onClick={onClose}
+      onPointerDown={(e) => e.stopPropagation()}
+      data-no-drag
       aria-label='Close chat'
       className={cn(
         'flex size-7 items-center justify-center rounded transition-colors',

--- a/apps/chat-widget/src/styles.css
+++ b/apps/chat-widget/src/styles.css
@@ -420,6 +420,54 @@
     height: calc(100vh - var(--auxx-chat-shell-edge-gap));
     max-height: calc(100vh - var(--auxx-chat-shell-edge-gap));
   }
+  .auxx-chat-shell--floating {
+    right: auto;
+    bottom: auto;
+    transform-origin: top left;
+    /* Disable the docked size transitions while floating — left/top must
+       respond instantly to pointer movement. */
+    transition: none;
+  }
+  .auxx-chat-shell--floating .auxx-chat-shell__trigger,
+  .auxx-chat-shell--floating .auxx-chat-shell__icon {
+    display: none;
+  }
+  /* Entry bob — runs 2 slow cycles of a gentle up/down translate after
+     detaching. The keyframe-driven transform composes with the inline
+     left/top, so dragging during the bob still works (transform is layered
+     on top). */
+  .auxx-chat-shell--bobbing {
+    animation: auxx-float-bob 1600ms cubic-bezier(0.45, 0, 0.55, 1) 2;
+  }
+  @keyframes auxx-float-bob {
+    0% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-6px);
+    }
+    100% {
+      transform: translateY(0);
+    }
+  }
+  /* Dock-back transition — temporarily re-enables left/top tweening so the
+     panel slides back to its corner before snapping to the docked layout. */
+  .auxx-chat-shell--docking {
+    transition:
+      left 320ms cubic-bezier(0.32, 0.72, 0, 1),
+      top 320ms cubic-bezier(0.32, 0.72, 0, 1);
+  }
+  .auxx-chat-drag-handle {
+    cursor: grab;
+    touch-action: none;
+  }
+  .auxx-chat-drag-handle.is-dragging {
+    cursor: grabbing;
+    user-select: none;
+  }
+  .auxx-chat-drag-handle :is(button, a, input, textarea, select, [role='button']) {
+    cursor: pointer;
+  }
 
   .auxx-chat-shell__badge {
     position: absolute;
@@ -513,5 +561,8 @@
   .auxx-chat-shell__icon,
   .auxx-chat-shell__panel {
     transition: none;
+  }
+  .auxx-chat-shell--bobbing {
+    animation: none;
   }
 }

--- a/apps/chat-widget/src/views/conversation/menu.tsx
+++ b/apps/chat-widget/src/views/conversation/menu.tsx
@@ -19,6 +19,8 @@ interface ConversationMenuProps {
   expanded: boolean
   onToggleExpanded: () => void
   allowDownloadTranscript: boolean
+  /** When the widget is in floating-window mode, the expand/shrink row is hidden. */
+  floating?: boolean
 }
 
 export function ConversationMenu({
@@ -27,6 +29,7 @@ export function ConversationMenu({
   expanded,
   onToggleExpanded,
   allowDownloadTranscript,
+  floating = false,
 }: ConversationMenuProps) {
   const api = chatApi(channelId)
 
@@ -62,14 +65,16 @@ export function ConversationMenu({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align='end'>
-        <DropdownMenuItem onSelect={onToggleExpanded}>
-          {expanded ? (
-            <Minimize2 className='size-4' aria-hidden='true' />
-          ) : (
-            <Maximize2 className='size-4' aria-hidden='true' />
-          )}
-          {expanded ? 'Shrink window' : 'Expand window'}
-        </DropdownMenuItem>
+        {floating ? null : (
+          <DropdownMenuItem onSelect={onToggleExpanded}>
+            {expanded ? (
+              <Minimize2 className='size-4' aria-hidden='true' />
+            ) : (
+              <Maximize2 className='size-4' aria-hidden='true' />
+            )}
+            {expanded ? 'Shrink window' : 'Expand window'}
+          </DropdownMenuItem>
+        )}
         {allowDownloadTranscript ? (
           <DropdownMenuItem onSelect={handleDownload}>
             <Download className='size-4' aria-hidden='true' />

--- a/apps/chat-widget/src/views/home/home-view.tsx
+++ b/apps/chat-widget/src/views/home/home-view.tsx
@@ -9,7 +9,8 @@
 // Greeting + card visibility are driven by `config.home`. Identify claims
 // substitute into the greeting via the Tiptap-JSON walker in ./greeting.
 
-import { X } from 'lucide-react'
+import { ArrowDownLeft, ArrowUpRight, X } from 'lucide-react'
+import type { Ref } from 'preact'
 import { useCallback, useEffect, useState } from 'preact/hooks'
 import { getStoredIdentify, type IdentifyPayload, onIdentify } from '~/identify'
 import { useNavStack } from '~/navigation/nav-stack-context'
@@ -26,6 +27,9 @@ interface HomeViewProps {
   config: ChatConfig
   resolvedTheme: 'light' | 'dark'
   onClose?: () => void
+  floating?: boolean
+  onToggleFloating?: () => void
+  headerRef?: Ref<HTMLElement>
 }
 
 /**
@@ -52,7 +56,15 @@ interface RecentThread {
   lastMessage: { preview: string; isInbound: boolean; timestamp: string }
 }
 
-export function HomeView({ channelId, config, resolvedTheme, onClose }: HomeViewProps) {
+export function HomeView({
+  channelId,
+  config,
+  resolvedTheme,
+  onClose,
+  floating = false,
+  onToggleFloating,
+  headerRef,
+}: HomeViewProps) {
   const nav = useNavStack()
   const [identify, setIdentify] = useState<IdentifyPayload | null>(() =>
     getStoredIdentify(channelId)
@@ -182,23 +194,48 @@ export function HomeView({ channelId, config, resolvedTheme, onClose }: HomeView
         }}
       />
       <div
+        ref={headerRef}
         className='relative z-10 flex shrink-0 flex-col gap-8 ps-5 pe-3 pt-5 pb-6'
         style={{ color: headerText }}>
         <div className='flex items-start justify-between'>
           {logo ? <img src={logo} alt='' className='h-8 w-auto' /> : <span className='h-8' />}
-          {onClose ? (
-            <button
-              type='button'
-              onClick={onClose}
-              aria-label='Close chat'
-              className={
-                isLightHeader
-                  ? 'flex size-7 items-center justify-center rounded text-black/70 transition-colors hover:bg-black/5 hover:text-black'
-                  : 'flex size-7 items-center justify-center rounded text-white/90 transition-colors hover:bg-white/10 hover:text-white'
-              }>
-              <X className='size-4' aria-hidden='true' />
-            </button>
-          ) : null}
+          <div className='flex items-center gap-1'>
+            {onToggleFloating ? (
+              <button
+                type='button'
+                onClick={onToggleFloating}
+                onPointerDown={(e) => e.stopPropagation()}
+                data-no-drag
+                aria-label={floating ? 'Dock chat' : 'Pop out chat'}
+                aria-pressed={floating}
+                className={
+                  isLightHeader
+                    ? 'flex size-7 items-center justify-center rounded text-black/70 transition-colors hover:bg-black/5 hover:text-black'
+                    : 'flex size-7 items-center justify-center rounded text-white/90 transition-colors hover:bg-white/10 hover:text-white'
+                }>
+                {floating ? (
+                  <ArrowDownLeft className='size-4' aria-hidden='true' />
+                ) : (
+                  <ArrowUpRight className='size-4' aria-hidden='true' />
+                )}
+              </button>
+            ) : null}
+            {onClose ? (
+              <button
+                type='button'
+                onClick={onClose}
+                onPointerDown={(e) => e.stopPropagation()}
+                data-no-drag
+                aria-label='Close chat'
+                className={
+                  isLightHeader
+                    ? 'flex size-7 items-center justify-center rounded text-black/70 transition-colors hover:bg-black/5 hover:text-black'
+                    : 'flex size-7 items-center justify-center rounded text-white/90 transition-colors hover:bg-white/10 hover:text-white'
+                }>
+                <X className='size-4' aria-hidden='true' />
+              </button>
+            ) : null}
+          </div>
         </div>
         <Greeting doc={home.greetingTemplate ?? null} identify={identify} />
       </div>

--- a/apps/chat-widget/src/views/use-drag-shell.ts
+++ b/apps/chat-widget/src/views/use-drag-shell.ts
@@ -1,0 +1,159 @@
+// apps/chat-widget/src/views/use-drag-shell.ts
+//
+// Pointer-drag controller for the floating chat shell. While `enabled`, a
+// pointerdown on `headerEl` (anywhere that's not a button / link / form
+// control / `[data-no-drag]`) starts a drag — subsequent pointermove events
+// update the position via `onPositionChange`, clamped to the viewport.
+// Uses Pointer Events + `setPointerCapture` so the same path handles mouse,
+// touch, and pen across both shadow and light DOM.
+
+import { useEffect, useRef } from 'preact/hooks'
+
+interface Position {
+  x: number
+  y: number
+}
+
+interface UseDragShellArgs {
+  enabled: boolean
+  shellEl: HTMLElement | null
+  headerEl: HTMLElement | null
+  position: Position | null
+  onPositionChange: (next: Position) => void
+}
+
+const EDGE_GAP = 8
+
+function clampToViewport(pos: Position, width: number, height: number): Position {
+  const maxX = Math.max(EDGE_GAP, window.innerWidth - width - EDGE_GAP)
+  const maxY = Math.max(EDGE_GAP, window.innerHeight - height - EDGE_GAP)
+  return {
+    x: Math.min(Math.max(EDGE_GAP, pos.x), maxX),
+    y: Math.min(Math.max(EDGE_GAP, pos.y), maxY),
+  }
+}
+
+function isInteractiveTarget(target: EventTarget | null, header: HTMLElement): boolean {
+  let node: Node | null = target instanceof Node ? target : null
+  while (node && node !== header) {
+    if (node instanceof HTMLElement) {
+      if (node.dataset.noDrag !== undefined) return true
+      const tag = node.tagName
+      if (
+        tag === 'BUTTON' ||
+        tag === 'A' ||
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        tag === 'SELECT' ||
+        tag === 'LABEL'
+      ) {
+        return true
+      }
+      if (node.getAttribute('role') === 'button') return true
+    }
+    node = node.parentNode
+  }
+  return false
+}
+
+export function useDragShell({
+  enabled,
+  shellEl,
+  headerEl,
+  position,
+  onPositionChange,
+}: UseDragShellArgs): void {
+  const positionRef = useRef<Position | null>(position)
+  const callbackRef = useRef(onPositionChange)
+
+  useEffect(() => {
+    positionRef.current = position
+  }, [position])
+
+  useEffect(() => {
+    callbackRef.current = onPositionChange
+  }, [onPositionChange])
+
+  useEffect(() => {
+    if (!enabled || !headerEl || !shellEl) return
+
+    let dragging = false
+    let pointerId = -1
+    let startX = 0
+    let startY = 0
+    let startPosX = 0
+    let startPosY = 0
+    let width = 0
+    let height = 0
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.pointerType === 'mouse' && e.button !== 0) return
+      if (isInteractiveTarget(e.target, headerEl)) return
+      const current = positionRef.current
+      if (!current) return
+      const rect = shellEl.getBoundingClientRect()
+      width = rect.width
+      height = rect.height
+      startX = e.clientX
+      startY = e.clientY
+      startPosX = current.x
+      startPosY = current.y
+      pointerId = e.pointerId
+      dragging = true
+      headerEl.classList.add('is-dragging')
+      try {
+        headerEl.setPointerCapture(pointerId)
+      } catch {
+        /* ignore */
+      }
+      e.preventDefault()
+    }
+
+    const onPointerMove = (e: PointerEvent) => {
+      if (!dragging || e.pointerId !== pointerId) return
+      const next = clampToViewport(
+        { x: startPosX + (e.clientX - startX), y: startPosY + (e.clientY - startY) },
+        width,
+        height
+      )
+      callbackRef.current(next)
+    }
+
+    const endDrag = (e: PointerEvent) => {
+      if (!dragging || e.pointerId !== pointerId) return
+      dragging = false
+      headerEl.classList.remove('is-dragging')
+      try {
+        headerEl.releasePointerCapture(pointerId)
+      } catch {
+        /* ignore */
+      }
+    }
+
+    const onResize = () => {
+      const current = positionRef.current
+      if (!current) return
+      const rect = shellEl.getBoundingClientRect()
+      callbackRef.current(clampToViewport(current, rect.width, rect.height))
+    }
+
+    headerEl.classList.add('auxx-chat-drag-handle')
+    headerEl.addEventListener('pointerdown', onPointerDown)
+    headerEl.addEventListener('pointermove', onPointerMove)
+    headerEl.addEventListener('pointerup', endDrag)
+    headerEl.addEventListener('pointercancel', endDrag)
+    window.addEventListener('resize', onResize)
+
+    return () => {
+      headerEl.removeEventListener('pointerdown', onPointerDown)
+      headerEl.removeEventListener('pointermove', onPointerMove)
+      headerEl.removeEventListener('pointerup', endDrag)
+      headerEl.removeEventListener('pointercancel', endDrag)
+      window.removeEventListener('resize', onResize)
+      headerEl.classList.remove('is-dragging')
+      headerEl.classList.remove('auxx-chat-drag-handle')
+    }
+  }, [enabled, shellEl, headerEl])
+}
+
+export { clampToViewport }

--- a/apps/chat-widget/src/widget.tsx
+++ b/apps/chat-widget/src/widget.tsx
@@ -9,7 +9,8 @@
 //     issued, so the launcher unread badge updates while closed.
 //   - tracks an `expanded` state per channel for the wide-window mode.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import type { Ref } from 'preact'
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
 import { FrameHeader, type FrameHeaderVariant } from './components/frame-header'
 import { TabBar } from './components/tab-bar'
 import { NavStackProvider } from './navigation/nav-stack-context'
@@ -31,6 +32,7 @@ import { HomeView } from './views/home/home-view'
 import { KbArticleView } from './views/kb/kb-article-view'
 import { KbSectionView } from './views/kb/kb-section-view'
 import { MessagesView } from './views/messages/messages-view'
+import { clampToViewport, useDragShell } from './views/use-drag-shell'
 
 interface WidgetProps {
   channelId: string
@@ -65,6 +67,20 @@ export function Widget({ channelId, cacheBust = null, scriptTheme }: WidgetProps
   // localStorage. Start collapsed — the per-thread effect below restores the
   // preference whenever the visitor enters a thread.
   const [expanded, setExpanded] = useState(false)
+  // `floatPosition` is in-memory only. null = docked. Closing the widget or
+  // reloading the page resets to docked.
+  const [floatPosition, setFloatPosition] = useState<{ x: number; y: number } | null>(null)
+  // Track both elements as state so the drag effect re-runs when either swaps
+  // — the active header element changes as the visitor navigates views
+  // (contextual ↔ plain ↔ dark-hero ↔ home div).
+  const [shellEl, setShellEl] = useState<HTMLDivElement | null>(null)
+  const [headerEl, setHeaderEl] = useState<HTMLElement | null>(null)
+  const shellRefCallback = useCallback((el: HTMLDivElement | null) => {
+    setShellEl(el)
+  }, [])
+  const headerRefCallback = useCallback((el: HTMLElement | null) => {
+    setHeaderEl(el)
+  }, [])
 
   const shadowRoot = useShadowRoot()
   const resolvedTheme = useResolvedTheme({
@@ -166,23 +182,113 @@ export function Widget({ channelId, cacheBust = null, scriptTheme }: WidgetProps
 
   // Expand mode is thread-only. On entering a thread, restore the visitor's
   // sticky preference. On leaving, collapse visually but leave the preference
-  // untouched.
+  // untouched. Floating mode supersedes expanded — skip restoration while
+  // detached.
   const currentView = router.currentStack.current?.view ?? router.activeTab
   useEffect(() => {
+    if (floatPosition) return
     if (currentView === 'thread') {
       setExpanded(readExpanded(channelId))
     } else {
       setExpanded(false)
     }
-  }, [currentView, channelId])
+  }, [currentView, channelId, floatPosition])
+
+  // Visual flags for the float entry/exit animations:
+  //   `bobbing`   — 4-cycle up/down translate keyframe applied right after
+  //                 the panel detaches.
+  //   `docking`   — left/top transition re-enabled while we tween the panel
+  //                 back to its corner before clearing floatPosition.
+  const [bobbing, setBobbing] = useState(false)
+  const [docking, setDocking] = useState(false)
+  const dockTimerRef = useRef<number | null>(null)
+  const bobTimerRef = useRef<number | null>(null)
+
+  useEffect(
+    () => () => {
+      if (dockTimerRef.current !== null) window.clearTimeout(dockTimerRef.current)
+      if (bobTimerRef.current !== null) window.clearTimeout(bobTimerRef.current)
+    },
+    []
+  )
+
+  const toggleFloating = useCallback(() => {
+    if (docking) return
+    if (floatPosition) {
+      // Re-dock: tween left/top back to the corner, then drop floatPosition
+      // so the corner-anchored CSS takes over.
+      if (!shellEl) {
+        setFloatPosition(null)
+        return
+      }
+      const rect = shellEl.getBoundingClientRect()
+      const isLeft = config?.appearance.position.toLowerCase().includes('left') ?? false
+      const edgeGap = 20
+      const target = {
+        x: isLeft ? edgeGap : Math.max(edgeGap, window.innerWidth - rect.width - edgeGap),
+        y: Math.max(edgeGap, window.innerHeight - rect.height - edgeGap),
+      }
+      setDocking(true)
+      setFloatPosition(target)
+      if (dockTimerRef.current !== null) window.clearTimeout(dockTimerRef.current)
+      dockTimerRef.current = window.setTimeout(() => {
+        setFloatPosition(null)
+        setDocking(false)
+        dockTimerRef.current = null
+      }, 340)
+      return
+    }
+    // Detach: place the panel at its current location and bob for ~4 cycles.
+    const rect = shellEl?.getBoundingClientRect()
+    const next = rect
+      ? clampToViewport({ x: rect.left, y: rect.top }, rect.width, rect.height)
+      : { x: 20, y: 20 }
+    setExpanded(false)
+    setFloatPosition(next)
+    setBobbing(true)
+    if (bobTimerRef.current !== null) window.clearTimeout(bobTimerRef.current)
+    bobTimerRef.current = window.setTimeout(() => {
+      setBobbing(false)
+      bobTimerRef.current = null
+    }, 1600 * 2)
+  }, [docking, floatPosition, shellEl, config?.appearance.position])
+
+  const handleClose = useCallback(() => {
+    setOpen(false)
+    setFloatPosition(null)
+    setBobbing(false)
+    setDocking(false)
+    if (dockTimerRef.current !== null) {
+      window.clearTimeout(dockTimerRef.current)
+      dockTimerRef.current = null
+    }
+    if (bobTimerRef.current !== null) {
+      window.clearTimeout(bobTimerRef.current)
+      bobTimerRef.current = null
+    }
+  }, [])
+
+  const isFloating = open && floatPosition !== null
+
+  useDragShell({
+    enabled: isFloating && !docking,
+    shellEl,
+    headerEl,
+    position: floatPosition,
+    onPositionChange: setFloatPosition,
+  })
 
   if (!config) return null
 
-  const positionClass = config.appearance.position.toLowerCase().includes('left')
-    ? 'auxx-chat-shell--bottom-left'
-    : 'auxx-chat-shell--bottom-right'
+  const positionClass = isFloating
+    ? 'auxx-chat-shell--floating'
+    : config.appearance.position.toLowerCase().includes('left')
+      ? 'auxx-chat-shell--bottom-left'
+      : 'auxx-chat-shell--bottom-right'
   const stateClass = open ? 'auxx-chat-shell--open' : 'auxx-chat-shell--closed'
-  const expandedClass = open && expanded ? 'auxx-chat-shell--expanded' : ''
+  const expandedClass = open && expanded && !isFloating ? 'auxx-chat-shell--expanded' : ''
+  const bobbingClass = bobbing && isFloating ? 'auxx-chat-shell--bobbing' : ''
+  const dockingClass = docking ? 'auxx-chat-shell--docking' : ''
   const rootStyle: Record<string, string> = {
     '--auxx-chat-primary': config.appearance.primaryColor,
     '--auxx-chat-header': config.appearance.headerColor,
@@ -193,10 +299,20 @@ export function Widget({ channelId, cacheBust = null, scriptTheme }: WidgetProps
   if (config.appearance.headerColorDark) {
     rootStyle['--auxx-chat-header-dark'] = config.appearance.headerColorDark
   }
+  const shellStyle: Record<string, string> = {}
+  if (isFloating && floatPosition) {
+    shellStyle.left = `${floatPosition.x}px`
+    shellStyle.top = `${floatPosition.y}px`
+    shellStyle.right = 'auto'
+    shellStyle.bottom = 'auto'
+  }
 
   return (
     <div className='auxx-chat-root' data-theme={resolvedTheme} style={rootStyle}>
-      <div className={`auxx-chat-shell ${stateClass} ${positionClass} ${expandedClass}`}>
+      <div
+        ref={shellRefCallback}
+        className={`auxx-chat-shell ${stateClass} ${positionClass} ${expandedClass} ${bobbingClass} ${dockingClass}`}
+        style={shellStyle}>
         <button
           type='button'
           className='auxx-chat-shell__trigger'
@@ -231,11 +347,14 @@ export function Widget({ channelId, cacheBust = null, scriptTheme }: WidgetProps
               currentFrame={router.currentStack.current}
               isAtRoot={router.currentStack.isAtRoot}
               onBack={router.currentStack.pop}
-              onClose={() => setOpen(false)}
+              onClose={handleClose}
               error={error}
               subscribe={subscribeRef.current ?? undefined}
               expanded={expanded}
               onToggleExpanded={toggleExpanded}
+              floating={isFloating}
+              onToggleFloating={toggleFloating}
+              headerRef={headerRefCallback}
             />
           </NavStackProvider>
         </div>
@@ -261,6 +380,9 @@ interface PanelShellProps {
   }
   expanded: boolean
   onToggleExpanded: () => void
+  floating: boolean
+  onToggleFloating: () => void
+  headerRef: Ref<HTMLElement>
 }
 
 function PanelShell({
@@ -277,6 +399,9 @@ function PanelShell({
   subscribe,
   expanded,
   onToggleExpanded,
+  floating,
+  onToggleFloating,
+  headerRef,
 }: PanelShellProps) {
   const view: NavView = currentFrame?.view ?? activeTab
   const headerVariant = pickHeaderVariant(view, isAtRoot)
@@ -299,6 +424,9 @@ function PanelShell({
           resolvedTheme={resolvedTheme}
           onBack={isAtRoot ? undefined : onBack}
           onClose={onClose}
+          floating={floating}
+          onToggleFloating={onToggleFloating}
+          headerRef={headerRef}
           actions={
             threadId ? (
               <ConversationMenu
@@ -307,6 +435,7 @@ function PanelShell({
                 expanded={expanded}
                 onToggleExpanded={onToggleExpanded}
                 allowDownloadTranscript={config.allowDownloadTranscript}
+                floating={floating}
               />
             ) : undefined
           }
@@ -318,7 +447,18 @@ function PanelShell({
         </div>
       ) : null}
       <div className='flex min-h-0 flex-1 flex-col [&>*:last-child]:rounded-b-2xl'>
-        {renderFrame(view, currentFrame, channelId, config, resolvedTheme, subscribe, onClose)}
+        {renderFrame(
+          view,
+          currentFrame,
+          channelId,
+          config,
+          resolvedTheme,
+          subscribe,
+          onClose,
+          floating,
+          onToggleFloating,
+          headerRef
+        )}
       </div>
       {isAtRoot ? <TabBar activeTab={activeTab} onChange={onTabChange} /> : null}
     </div>
@@ -345,7 +485,10 @@ function renderFrame(
   config: ChatConfig,
   resolvedTheme: 'light' | 'dark',
   subscribe?: PanelShellProps['subscribe'],
-  onClose?: () => void
+  onClose?: () => void,
+  floating?: boolean,
+  onToggleFloating?: () => void,
+  headerRef?: Ref<HTMLElement>
 ) {
   switch (view) {
     case 'home':
@@ -355,6 +498,9 @@ function renderFrame(
           config={config}
           resolvedTheme={resolvedTheme}
           onClose={onClose}
+          floating={floating}
+          onToggleFloating={onToggleFloating}
+          headerRef={headerRef}
         />
       )
     case 'messages':


### PR DESCRIPTION
## Summary

- Adds an `ArrowUpRight` toggle next to the close `X` in every chat-widget header variant (`dark-hero`, `plain`, `contextual`, plus the home view's custom header). Clicking it detaches the panel from its bottom-right/-left corner into a free-floating, draggable window. The icon swaps to `ArrowDownLeft` while floating.
- Drag handle is the entire top bar, minus interactive children (`<button>`/`<a>`/inputs/`[role=button]`/`[data-no-drag]`). Uses Pointer Events + `setPointerCapture` so the same path covers mouse, touch, and pen. Position is clamped 8 px from each viewport edge and re-clamps on `window.resize`.
- Detach plays a slow 2-cycle vertical bob (`1600ms × 2`, gentle ease) — the keyframe drives `transform: translateY` so it composes with the inline `left/top` and dragging mid-bob still works. Dock-back tweens `left/top` 320 ms back to the configured corner, then clears float state without a snap.
- Float position is in-memory only — no `localStorage`/`sessionStorage`. Closing the widget always resets to docked. Floating supersedes the existing `expanded` mode (Conversation menu's "Expand/Shrink window" row hides while floating). `prefers-reduced-motion` disables the bob.

## Test plan

- [ ] Open the widget, click the pop-out arrow — panel detaches without a jump and bobs twice slowly.
- [ ] Drag the top bar to all four viewport corners — confirm clamping and that buttons (close, back, menu, float toggle) do not start a drag.
- [ ] In a conversation thread, open the `…` menu while floating — "Expand window" is hidden.
- [ ] Click the dock arrow — panel slides back to the configured corner (test both `bottom-right` and `bottom-left` channel configs).
- [ ] Close the widget while floating — reopening from the launcher starts docked.
- [ ] Resize the browser while floating — panel re-clamps to stay on-screen.
- [ ] Touch test on mobile (or DevTools touch emulation).
- [ ] Keyboard: Tab to the float button, Enter toggles cleanly.
- [ ] Light and dark themes — new button matches surrounding header controls.