### PR TITLE
feat(chat): friendly visitor labels (Chat user #xxxx)

### DIFF
--- a/apps/api/src/routes/chat/visitor-info.ts
+++ b/apps/api/src/routes/chat/visitor-info.ts
@@ -2,7 +2,7 @@
 
 import { issueChatPassport } from '@auxx/credentials/passport'
 import { database } from '@auxx/database'
-import { patchChatThreadMetadata } from '@auxx/lib/chat'
+import { patchChatThreadMetadata, updateVisitorClaimedIdentity } from '@auxx/lib/chat'
 import { publisher } from '@auxx/lib/events'
 import { createScopedLogger } from '@auxx/logger'
 import { Hono } from 'hono'
@@ -49,15 +49,19 @@ visitorInfoRoute.patch('/', async (c) => {
   const claimedExternalId = identify?.externalId
 
   try {
-    await patchChatThreadMetadata(
-      { db: database, organizationId: chat.organizationId },
-      body.threadId,
-      {
-        claimedVisitorName,
-        claimedVisitorEmail,
-        claimedExternalId,
-      }
-    )
+    const ctx = { db: database, organizationId: chat.organizationId }
+    await patchChatThreadMetadata(ctx, body.threadId, {
+      claimedVisitorName,
+      claimedVisitorEmail,
+      claimedExternalId,
+    })
+
+    // Overwrite the synthetic `Chat user #xxxx` displayName so message FROM
+    // and future thread subjects pick up the real identity.
+    await updateVisitorClaimedIdentity(ctx, chat.visitorParticipantId, {
+      name: claimedVisitorName,
+      email: claimedVisitorEmail,
+    })
 
     // Emit `thread:visitor:identified` once an email is attached to an active
     // thread — admin + widget render this as a centered system line. Fired

--- a/apps/web/src/components/mail/chat-visitor-sidebar.tsx
+++ b/apps/web/src/components/mail/chat-visitor-sidebar.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/mail/chat-visitor-sidebar.tsx
 'use client'
 
+import { formatVisitorLabel } from '@auxx/lib/chat/labels'
 import { Separator } from '@auxx/ui/components/separator'
 import { User } from 'lucide-react'
 
@@ -16,6 +17,7 @@ interface ChatThreadMetadata {
   }
   claimedVisitorEmail?: string
   claimedVisitorName?: string
+  visitorLabel?: string
 }
 
 /**
@@ -52,8 +54,8 @@ export function ChatVisitorSidebar({ metadata }: { metadata: ChatThreadMetadata 
         {metadata.visitorParticipantId && (
           <p title={metadata.visitorParticipantId}>
             <strong className='font-medium'>Visitor ID:</strong>{' '}
-            <span className='font-mono text-muted-foreground'>
-              {metadata.visitorParticipantId.substring(0, 8)}...
+            <span className='text-muted-foreground'>
+              {metadata.visitorLabel ?? formatVisitorLabel(metadata.visitorParticipantId)}
             </span>
           </p>
         )}

--- a/apps/web/src/components/mail/participant-display.tsx
+++ b/apps/web/src/components/mail/participant-display.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/mail/participant-display.tsx
 'use client'
 
+import { formatVisitorLabel } from '@auxx/lib/chat/labels'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -87,7 +88,13 @@ export const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({
 
   const { identifier, identifierType, name, displayName, entityInstanceId, isInternal } =
     participant
-  const displayLabel = displayName || name || identifier
+  // Belt-and-braces for anonymous chat visitors: if displayName/name weren't
+  // backfilled (pre-friendly-label rows), derive the friendly handle from
+  // the sticky session identifier so the FROM never falls back to a raw UUID.
+  const displayLabel =
+    displayName ||
+    name ||
+    (identifierType === 'CHAT_VISITOR' ? formatVisitorLabel(identifier) : identifier)
 
   const senderDomain =
     identifierType === 'EMAIL' ? (identifier.split('@')[1] ?? undefined) : undefined

--- a/apps/web/src/components/threads/store/participant-store.ts
+++ b/apps/web/src/components/threads/store/participant-store.ts
@@ -10,7 +10,7 @@ const BATCH_DELAY = 50
 const MAX_BATCH_SIZE = 50
 
 /** Identifier type for participants */
-export type ParticipantIdentifierType = 'EMAIL' | 'PHONE'
+export type ParticipantIdentifierType = 'EMAIL' | 'PHONE' | 'CHAT_VISITOR'
 
 /**
  * ParticipantMeta - email/phone participant for display.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -154,6 +154,12 @@
       "import": "./dist/chat-widget/visitor.mjs",
       "default": "./src/chat-widget/visitor.ts"
     },
+    "./chat/labels": {
+      "types": "./src/chat/labels.ts",
+      "source": "./src/chat/labels.ts",
+      "import": "./dist/chat/labels.mjs",
+      "default": "./src/chat/labels.ts"
+    },
     "./comments": {
       "types": "./src/comments/index.ts",
       "source": "./src/comments/index.ts",

--- a/packages/lib/src/chat-widget/visitor.ts
+++ b/packages/lib/src/chat-widget/visitor.ts
@@ -3,6 +3,7 @@
 import { type Database, schema } from '@auxx/database'
 import type { ParticipantEntity } from '@auxx/database/types'
 import { and, eq } from 'drizzle-orm'
+import { formatVisitorLabel } from '../chat/labels'
 import { Result, type TypedResult } from '../result'
 
 export interface FindOrCreateVisitorOptions {
@@ -34,14 +35,15 @@ export async function findOrCreateVisitorParticipant(
     })
     if (existing) return Result.ok(existing)
 
+    const fallback = formatVisitorLabel(sessionId)
     const [created] = await db
       .insert(schema.Participant)
       .values({
         organizationId,
         identifier: sessionId,
         identifierType: 'CHAT_VISITOR',
-        name: name ?? null,
-        displayName: name ?? null,
+        name: name ?? fallback,
+        displayName: name ?? fallback,
         firstInteractionType: 'chat',
         firstInteractionDate: new Date(),
         updatedAt: new Date(),

--- a/packages/lib/src/chat/index.ts
+++ b/packages/lib/src/chat/index.ts
@@ -18,4 +18,4 @@ export type {
 } from './session'
 export { initializeOrResumeChatThread } from './session'
 export type { ServiceContext, VisitInfo } from './types'
-export { findOrCreateVisitorParticipant } from './visitor-identity'
+export { findOrCreateVisitorParticipant, updateVisitorClaimedIdentity } from './visitor-identity'

--- a/packages/lib/src/chat/labels.ts
+++ b/packages/lib/src/chat/labels.ts
@@ -1,0 +1,42 @@
+// packages/lib/src/chat/labels.ts
+
+/**
+ * Client-safe label helpers for anonymous chat visitors.
+ *
+ * The admin panel renders chat-widget visitors by the sticky
+ * `auxx_chat_session_id` cookie value (stored as `Participant.identifier`),
+ * which is an opaque UUID. These helpers derive a short, human-readable
+ * handle from the last 4 characters of that identifier so admins can
+ * distinguish anonymous visitors at a glance without leaking the full id.
+ *
+ * Pure string helpers — no DB or server deps, safe to import from the web
+ * client.
+ */
+
+const SUFFIX_LEN = 4
+
+/** Last 4 chars of the identifier (or the whole thing if shorter). */
+function suffix(identifier: string): string {
+  if (!identifier) return ''
+  return identifier.length > SUFFIX_LEN ? identifier.slice(-SUFFIX_LEN) : identifier
+}
+
+/**
+ * Friendly per-message label for an anonymous chat visitor.
+ *
+ * @example formatVisitorLabel('7c0e8605-0fa0-476f-9549-d1a566d4354b') → 'Chat user #354b'
+ */
+export function formatVisitorLabel(identifier: string): string {
+  return `Chat user #${suffix(identifier)}`
+}
+
+/**
+ * Friendly thread-subject label for an anonymous chat visitor's conversation.
+ * Shorter than the per-message label since the channel is already implied by
+ * the inbox filter.
+ *
+ * @example formatVisitorThreadSubject('7c0e8605-0fa0-476f-9549-d1a566d4354b') → 'Chat #354b'
+ */
+export function formatVisitorThreadSubject(identifier: string): string {
+  return `Chat #${suffix(identifier)}`
+}

--- a/packages/lib/src/chat/session.ts
+++ b/packages/lib/src/chat/session.ts
@@ -8,6 +8,7 @@ import { and, desc, eq } from 'drizzle-orm'
 import { BadRequestError, ForbiddenError, NotFoundError } from '../errors'
 import { Result, type TypedResult } from '../result'
 import type { ChatThreadMetadata } from '../threads/types'
+import { formatVisitorLabel, formatVisitorThreadSubject } from './labels'
 import { patchChatThreadMetadata } from './metadata'
 import type { ServiceContext, VisitInfo } from './types'
 import { findOrCreateVisitorParticipant } from './visitor-identity'
@@ -168,6 +169,7 @@ export async function initializeOrResumeChatThread(
 
     // Create a new thread.
     const now = new Date()
+    const visitorLabel = formatVisitorLabel(visitor.identifier)
     const metadata: ChatThreadMetadata = {
       channel: 'chat',
       channelId: integration.id,
@@ -176,12 +178,19 @@ export async function initializeOrResumeChatThread(
       claimedVisitorEmail: input.visitorEmail,
       claimedVisitorName: input.visitorName,
       claimedExternalId: input.visitorExternalId,
+      visitorLabel,
     }
+
+    // Subject: friendlier `Chat #354b` when the visitor is still anonymous;
+    // upgrade to `Chat with <claimed-name>` once the visitor identifies.
+    const subject = input.visitorName
+      ? `Chat with ${input.visitorName}`
+      : formatVisitorThreadSubject(visitor.identifier)
 
     const [thread] = await ctx.db
       .insert(schema.Thread)
       .values({
-        subject: `Chat with ${visitor.displayName || visitor.name || 'Visitor'}`,
+        subject,
         organizationId: ctx.organizationId,
         integrationId: integration.id,
         status: ThreadStatus.OPEN,

--- a/packages/lib/src/chat/visitor-identity.ts
+++ b/packages/lib/src/chat/visitor-identity.ts
@@ -5,6 +5,7 @@ import type { ParticipantEntity } from '@auxx/database/types'
 import { and, eq } from 'drizzle-orm'
 import { BadRequestError } from '../errors'
 import { Result, type TypedResult } from '../result'
+import { formatVisitorLabel } from './labels'
 import type { ServiceContext } from './types'
 
 /**
@@ -36,14 +37,15 @@ export async function findOrCreateVisitorParticipant(
       return Result.ok(existing)
     }
 
+    const fallback = formatVisitorLabel(visitorId)
     const [created] = await ctx.db
       .insert(schema.Participant)
       .values({
         organizationId: ctx.organizationId,
         identifier: visitorId,
         identifierType: 'CHAT_VISITOR',
-        name: opts?.displayName ?? null,
-        displayName: opts?.displayName ?? null,
+        name: opts?.displayName ?? fallback,
+        displayName: opts?.displayName ?? fallback,
         firstInteractionType: 'chat',
         firstInteractionDate: new Date(),
         updatedAt: new Date(),
@@ -54,6 +56,47 @@ export async function findOrCreateVisitorParticipant(
       return Result.error(new Error('Failed to create visitor participant'))
     }
     return Result.ok(created)
+  } catch (error) {
+    return Result.error(error instanceof Error ? error : new Error(String(error)))
+  }
+}
+
+/**
+ * Update a chat visitor's Participant row when the widget supplies a claimed
+ * identity (name/email). Overwrites the synthetic `Chat user #xxxx` label
+ * baked in at create time so message headers and threads start showing the
+ * real name. No-op if neither field is provided.
+ */
+export async function updateVisitorClaimedIdentity(
+  ctx: ServiceContext,
+  visitorParticipantId: string,
+  opts: { name?: string; email?: string }
+): Promise<TypedResult<undefined, Error>> {
+  const trimmedName = opts.name?.trim()
+  const trimmedEmail = opts.email?.trim()
+  if (!trimmedName && !trimmedEmail) return Result.nil()
+
+  try {
+    const updates: Record<string, unknown> = { updatedAt: new Date() }
+    if (trimmedName) {
+      updates.name = trimmedName
+      updates.displayName = trimmedName
+    } else if (trimmedEmail) {
+      // No name yet — fall back to email so the FROM stops showing the synthetic.
+      updates.displayName = trimmedEmail
+    }
+
+    await ctx.db
+      .update(schema.Participant)
+      .set(updates)
+      .where(
+        and(
+          eq(schema.Participant.id, visitorParticipantId),
+          eq(schema.Participant.organizationId, ctx.organizationId),
+          eq(schema.Participant.identifierType, 'CHAT_VISITOR')
+        )
+      )
+    return Result.nil()
   } catch (error) {
     return Result.error(error instanceof Error ? error : new Error(String(error)))
   }

--- a/packages/lib/src/participants/client.ts
+++ b/packages/lib/src/participants/client.ts
@@ -8,7 +8,7 @@
 /**
  * Identifier type for participants.
  */
-export type ParticipantIdentifierType = 'EMAIL' | 'PHONE'
+export type ParticipantIdentifierType = 'EMAIL' | 'PHONE' | 'CHAT_VISITOR'
 
 /**
  * Participant display data for frontend store.

--- a/packages/lib/src/threads/types.ts
+++ b/packages/lib/src/threads/types.ts
@@ -174,4 +174,10 @@ export interface ChatThreadMetadata {
   claimedVisitorName?: string
   /** Embedder-supplied external id (e.g. customer id in the host app). Unverified in v1. */
   claimedExternalId?: string
+  /**
+   * Friendly handle derived from the visitor's session identifier (e.g.
+   * `Chat user #354b`). Frozen at thread-creation time so the sidebar can
+   * render it without an extra Participant fetch.
+   */
+  visitorLabel?: string
 }


### PR DESCRIPTION
## Summary
- Replace raw UUID display for anonymous chat visitors with a friendly `Chat user #xxxx` handle (last 4 chars of the sticky session id)
- Backfill synthetic name/displayName on `Participant` create so message FROM and thread subjects render the handle instead of a truncated UUID
- Upgrade Participant `name`/`displayName` to the claimed name/email when the widget identifies the visitor (`PATCH /chat/visitor-info`)
- Add `visitorLabel` to `ChatThreadMetadata`, frozen at thread-creation time so the sidebar renders without an extra fetch
- Add `CHAT_VISITOR` to the client-side `ParticipantIdentifierType` union; client `ParticipantDisplay` falls back to `formatVisitorLabel` for pre-backfill rows
- New client-safe `@auxx/lib/chat/labels` subpath with pure `formatVisitorLabel` / `formatVisitorThreadSubject` helpers

## Test plan
- [ ] Start a fresh anonymous chat from the widget — admin inbox shows `Chat #xxxx` subject and `Chat user #xxxx` in the FROM
- [ ] Submit name+email via the widget identity form — Participant row updates, message FROM switches to the claimed name
- [ ] Open an old thread (pre-this-change) — sidebar/FROM still falls back to the friendly label via the client-side derivation
- [ ] Visitor sidebar shows the friendly label next to "Visitor ID"