### PR TITLE
feat(chat): org presence + widget polish

### DIFF
--- a/apps/api/src/routes/chat/config.ts
+++ b/apps/api/src/routes/chat/config.ts
@@ -61,6 +61,7 @@ configRoute.get('/:channelId', async (c) => {
     allowDownloadTranscript: widget.allowDownloadTranscript,
     suggestedReplies: widget.suggestedReplies,
     privacyPolicyUrl: widget.privacyPolicyUrl,
+    isOffline: widget.isOffline,
     realtime: {
       provider: 'pusher' as const,
       key: configService.get<string>('PUSHER_KEY') ?? '',

--- a/apps/api/src/routes/chat/lib.ts
+++ b/apps/api/src/routes/chat/lib.ts
@@ -2,6 +2,7 @@
 
 import { database, schema } from '@auxx/database'
 import { getCachedAgentById, getCachedOrgProfile } from '@auxx/lib/cache'
+import { listOnDutyUserIds } from '@auxx/lib/chat-duty'
 import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import type { Context } from 'hono'
 
@@ -121,6 +122,13 @@ export interface LoadedChatWidget {
   allowDownloadTranscript: boolean
   suggestedReplies: string[]
   privacyPolicyUrl: string | null
+  /**
+   * Derived: true when nobody is on chat duty AND the widget has no AI agent
+   * bound. In that state the widget renders `appearance.offlineMessage` and
+   * disables sending. Snapshotted at config-fetch time — visitors with an open
+   * session won't see this flip mid-conversation until they reconnect.
+   */
+  isOffline: boolean
 }
 
 /**
@@ -139,7 +147,12 @@ export async function loadChatWidgetByChannelId(
   })
   if (!row?.chatWidget) return null
 
-  const agent = await resolveAgentIdentity(row.organizationId, row.chatWidget.agentId ?? null)
+  const agentId = row.chatWidget.agentId ?? null
+  const [agent, onDutyUserIds] = await Promise.all([
+    resolveAgentIdentity(row.organizationId, agentId),
+    listOnDutyUserIds(row.organizationId),
+  ])
+  const isOffline = agentId === null && onDutyUserIds.length === 0
 
   return {
     channelId: row.id,
@@ -179,6 +192,7 @@ export async function loadChatWidgetByChannelId(
     allowDownloadTranscript: row.chatWidget.allowDownloadTranscript,
     suggestedReplies: row.chatWidget.suggestedReplies ?? [],
     privacyPolicyUrl: row.chatWidget.privacyPolicyUrl ?? null,
+    isOffline,
   }
 }
 

--- a/apps/api/src/routes/chat/threads.ts
+++ b/apps/api/src/routes/chat/threads.ts
@@ -113,9 +113,12 @@ threadsRoute.post('/', async (c) => {
 /**
  * GET /api/chat/threads/recent
  *
- * Return the visitor's most recently active thread + a one-line preview for
- * the Home "Recent message" card. Returns `{ thread: null }` when the visitor
- * has no threads on this channel.
+ * Return the visitor's most recently active thread for the Home "Recent
+ * message" card and the "Send us a message" reuse rule. Includes threads
+ * with no messages yet so the widget can reuse the empty thread instead of
+ * spawning a new one on every tap. `lastMessage` is null when the thread
+ * has no messages. Returns `{ thread: null }` when the visitor has no
+ * threads on this channel.
  */
 threadsRoute.get('/recent', async (c) => {
   applyChatCorsHeaders(c, { allowCredentials: true })
@@ -128,14 +131,10 @@ threadsRoute.get('/recent', async (c) => {
       .where(
         and(
           eq(schema.Thread.organizationId, chat.organizationId),
-          eq(schema.Thread.integrationId, chat.channelId),
-          // Skip empty threads — earlier widget builds created threads
-          // eagerly on every "Send us a message" tap, so an empty thread
-          // could otherwise mask an older one that actually has messages.
-          isNotNull(schema.Thread.latestMessageId)
+          eq(schema.Thread.integrationId, chat.channelId)
         )
       )
-      .orderBy(desc(schema.Thread.lastMessageAt))
+      .orderBy(desc(schema.Thread.lastMessageAt), desc(schema.Thread.createdAt))
       .limit(20)
 
     const recent = threads.find((t) => {
@@ -147,22 +146,20 @@ threadsRoute.get('/recent', async (c) => {
       return c.json({ success: true, data: { thread: null } })
     }
 
-    const [lastMessage] = await database
-      .select({
-        textPlain: schema.Message.textPlain,
-        textHtml: schema.Message.textHtml,
-        isInbound: schema.Message.isInbound,
-        sentAt: schema.Message.sentAt,
-        createdAt: schema.Message.createdAt,
-      })
-      .from(schema.Message)
-      .where(eq(schema.Message.threadId, recent.id))
-      .orderBy(desc(schema.Message.sentAt))
-      .limit(1)
-
-    if (!lastMessage) {
-      return c.json({ success: true, data: { thread: null } })
-    }
+    const [lastMessage] = recent.latestMessageId
+      ? await database
+          .select({
+            textPlain: schema.Message.textPlain,
+            textHtml: schema.Message.textHtml,
+            isInbound: schema.Message.isInbound,
+            sentAt: schema.Message.sentAt,
+            createdAt: schema.Message.createdAt,
+          })
+          .from(schema.Message)
+          .where(eq(schema.Message.threadId, recent.id))
+          .orderBy(desc(schema.Message.sentAt))
+          .limit(1)
+      : []
 
     return c.json({
       success: true,
@@ -170,11 +167,13 @@ threadsRoute.get('/recent', async (c) => {
         thread: {
           id: recent.id,
           subject: recent.subject,
-          lastMessage: {
-            preview: (lastMessage.textPlain ?? lastMessage.textHtml ?? '').slice(0, 160),
-            isInbound: lastMessage.isInbound,
-            timestamp: lastMessage.sentAt ?? lastMessage.createdAt,
-          },
+          lastMessage: lastMessage
+            ? {
+                preview: (lastMessage.textPlain ?? lastMessage.textHtml ?? '').slice(0, 160),
+                isInbound: lastMessage.isInbound,
+                timestamp: lastMessage.sentAt ?? lastMessage.createdAt,
+              }
+            : null,
         },
       },
     })

--- a/apps/chat-widget/src/components/frame-transition.tsx
+++ b/apps/chat-widget/src/components/frame-transition.tsx
@@ -1,0 +1,74 @@
+// apps/chat-widget/src/components/frame-transition.tsx
+//
+// Cross-fade / slide between two panel frames. The shell renders its current
+// frame as `children`; when `viewKey` changes, the previous render is frozen
+// as an "exiting" layer that slides off while the new render slides in. The
+// snapshot uses Preact vnode reuse — when the keyed wrapper for the previous
+// viewKey stays mounted across the swap, the underlying PanelShell is not
+// remounted, so its subscriptions (Pusher, thread fetches) survive the
+// animation.
+
+import type { ComponentChildren, VNode } from 'preact'
+import { useLayoutEffect, useRef, useState } from 'preact/hooks'
+
+export type SlideDirection = 'from-right' | 'from-left'
+
+interface Exiting {
+  key: string
+  children: ComponentChildren
+  direction: SlideDirection
+}
+
+interface FrameTransitionProps {
+  viewKey: string
+  direction: SlideDirection
+  children: VNode | ComponentChildren
+}
+
+export function FrameTransition({ viewKey, direction, children }: FrameTransitionProps) {
+  const lastKeyRef = useRef(viewKey)
+  const lastChildrenRef = useRef<ComponentChildren>(children)
+  const [exiting, setExiting] = useState<Exiting | null>(null)
+
+  // Detect viewKey change during render so the entering+exiting layers are
+  // committed in the same paint — avoids a one-frame flash where the new
+  // content shows without its slide-in animation.
+  if (lastKeyRef.current !== viewKey && (!exiting || exiting.key !== lastKeyRef.current)) {
+    setExiting({
+      key: lastKeyRef.current,
+      children: lastChildrenRef.current,
+      direction,
+    })
+  }
+
+  useLayoutEffect(() => {
+    lastKeyRef.current = viewKey
+    lastChildrenRef.current = children
+  })
+
+  const handleExitEnd = (e: AnimationEvent) => {
+    if (e.target !== e.currentTarget) return
+    setExiting(null)
+  }
+
+  return (
+    <div
+      className={`auxx-chat-frame-transition ${exiting ? 'auxx-chat-frame-transition--animating' : ''}`}>
+      {exiting ? (
+        <div
+          key={exiting.key}
+          className='auxx-chat-frame-layer auxx-chat-frame--exiting'
+          data-direction={exiting.direction}
+          onAnimationEnd={handleExitEnd}>
+          {exiting.children}
+        </div>
+      ) : null}
+      <div
+        key={viewKey}
+        className={`auxx-chat-frame-layer ${exiting ? 'auxx-chat-frame--entering' : ''}`}
+        data-direction={direction}>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/apps/chat-widget/src/components/tab-bar.tsx
+++ b/apps/chat-widget/src/components/tab-bar.tsx
@@ -21,7 +21,7 @@ const TABS: { id: TabId; label: string; icon: typeof Home }[] = [
 export function TabBar({ activeTab, onChange }: TabBarProps) {
   return (
     <nav
-      className='flex shrink-0 items-stretch justify-around divide-x divide-[color:var(--auxx-chat-hairline)] border-t border-[color:var(--auxx-chat-hairline)] bg-transparent'
+      className='auxx-chat-clip-bottom flex shrink-0 items-stretch justify-around divide-x divide-[color:var(--auxx-chat-hairline)] border-t border-[color:var(--auxx-chat-hairline)] bg-transparent'
       aria-label='Widget sections'>
       {TABS.map((tab) => {
         const isActive = tab.id === activeTab

--- a/apps/chat-widget/src/styles.css
+++ b/apps/chat-widget/src/styles.css
@@ -313,6 +313,11 @@
      * Alpha ladder: 40/70/86/90/96 — sparse subset of a full neutral ramp,
      * sized to the surface tiers we actually use (glass overlay → loud →
      * raised). */
+    /* Brand color defaults. widget.tsx overrides these inline on `.auxx-root`
+     * when the channel config loads — declared here so derived tokens that
+     * reference them (including `--primary` and the closed-launcher shadow)
+     * still resolve to something sane while the config is in-flight. */
+    --auxx-chat-primary: var(--color-indigo-500);
     --auxx-chat-tint-h: 250;
     --auxx-chat-tint-c: 0.012;
     --auxx-chat-neutral-base: oklch(98% var(--auxx-chat-tint-c) var(--auxx-chat-tint-h));
@@ -472,7 +477,13 @@
     --auxx-chat-shell-radius-bottom: 1.75rem;
     --auxx-chat-shell-edge-gap: 20px;
 
-    --auxx-chat-primary: #4f46e5;
+    /* `--auxx-chat-primary` (and `--auxx-chat-primary-dark`) are set inline
+     * on `.auxx-root` by widget.tsx when the brand config loads, so derived
+     * tokens declared on `.auxx-root` (e.g. `--primary`, `--auxx-chat-glass-
+     * overlay`, etc.) can substitute them at computed-value time on the right
+     * element. Do NOT default `--auxx-chat-primary` here — that declaration
+     * would beat the inherited inline value for every descendant of
+     * `.auxx-chat-root` (including the closed launcher's tinted shadow). */
     --auxx-chat-closed-outer-border: color-mix(in oklab, var(--auxx-chat-primary), black 22%);
     --auxx-chat-closed-inner-border: color-mix(in oklab, var(--auxx-chat-primary), white 20%);
     --auxx-chat-shell-closed-shadow:
@@ -761,6 +772,82 @@
       0 0 0 2px var(--primary),
       var(--auxx-chat-shadow-raised);
   }
+
+  /* Frame swipe transition — wraps the active PanelShell and slides between
+   * frames when the visitor switches tabs or pushes/pops a navigation frame.
+   * Two layers (entering + exiting) stack absolutely; `overflow:hidden` is
+   * only set during an animation so portaled popovers aren't clipped at
+   * rest. iOS-style parallax: entering layer slides the full panel width
+   * while the exiting layer drifts 30% off with a fade. */
+  .auxx-chat-frame-transition {
+    position: relative;
+    flex: 1 1 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .auxx-chat-frame-transition--animating {
+    overflow: hidden;
+  }
+  .auxx-chat-frame-layer {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    flex: 1 1 0;
+  }
+  .auxx-chat-frame-transition--animating .auxx-chat-frame-layer {
+    position: absolute;
+    inset: 0;
+    flex: none;
+  }
+  .auxx-chat-frame--entering[data-direction='from-right'] {
+    animation: auxx-frame-slide-in-right 280ms var(--auxx-chat-shell-ease) both;
+  }
+  .auxx-chat-frame--entering[data-direction='from-left'] {
+    animation: auxx-frame-slide-in-left 280ms var(--auxx-chat-shell-ease) both;
+  }
+  .auxx-chat-frame--exiting[data-direction='from-right'] {
+    animation: auxx-frame-slide-out-left 280ms var(--auxx-chat-shell-ease) both;
+  }
+  .auxx-chat-frame--exiting[data-direction='from-left'] {
+    animation: auxx-frame-slide-out-right 280ms var(--auxx-chat-shell-ease) both;
+  }
+  @keyframes auxx-frame-slide-in-right {
+    from {
+      transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+  @keyframes auxx-frame-slide-in-left {
+    from {
+      transform: translateX(-100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+  @keyframes auxx-frame-slide-out-left {
+    from {
+      transform: translateX(0);
+      opacity: 1;
+    }
+    to {
+      transform: translateX(-30%);
+      opacity: 0;
+    }
+  }
+  @keyframes auxx-frame-slide-out-right {
+    from {
+      transform: translateX(0);
+      opacity: 1;
+    }
+    to {
+      transform: translateX(30%);
+      opacity: 0;
+    }
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -771,5 +858,31 @@
   }
   .auxx-chat-shell--bobbing {
     animation: none;
+  }
+  .auxx-chat-frame--entering,
+  .auxx-chat-frame--entering[data-direction='from-right'],
+  .auxx-chat-frame--entering[data-direction='from-left'] {
+    animation: auxx-frame-fade-in 120ms ease-out both;
+  }
+  .auxx-chat-frame--exiting,
+  .auxx-chat-frame--exiting[data-direction='from-right'],
+  .auxx-chat-frame--exiting[data-direction='from-left'] {
+    animation: auxx-frame-fade-out 120ms ease-out both;
+  }
+  @keyframes auxx-frame-fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @keyframes auxx-frame-fade-out {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
   }
 }

--- a/apps/chat-widget/src/transport/chat-api.ts
+++ b/apps/chat-widget/src/transport/chat-api.ts
@@ -110,7 +110,7 @@ export function chatApi(channelId: string) {
         thread: {
           id: string
           subject: string | null
-          lastMessage: { preview: string; isInbound: boolean; timestamp: string }
+          lastMessage: { preview: string; isInbound: boolean; timestamp: string } | null
         } | null
       }>(channelId, '/api/chat/threads/recent', { method: 'GET' }),
 

--- a/apps/chat-widget/src/transport/config.ts
+++ b/apps/chat-widget/src/transport/config.ts
@@ -66,6 +66,10 @@ export interface ChatConfig {
   /** When non-null, the conversation composer shows a privacy consent banner
    * linking to this URL. Sanitized server-side to http/https only. */
   privacyPolicyUrl: string | null
+  /** Server-derived: true when nobody is on chat duty AND the widget has no AI
+   * agent bound. Snapshot taken at config-fetch time. When true, the
+   * conversation view replaces the composer with `appearance.offlineMessage`. */
+  isOffline: boolean
   realtime: { provider: 'pusher'; key: string; cluster: string }
 }
 

--- a/apps/chat-widget/src/views/conversation/conversation-view.tsx
+++ b/apps/chat-widget/src/views/conversation/conversation-view.tsx
@@ -263,30 +263,50 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
       </div>
       {/* "Loud" plinth — suggested replies, composer, privacy banner sit on a
        * tinted surface strip. The plinth's ::before pseudo feathers the body's
-       * bottom edge into the plinth so there's no hard seam. */}
+       * bottom edge into the plinth so there's no hard seam.
+       *
+       * Offline mode (no AI agent bound AND nobody on duty): swap the composer
+       * for a muted notice. Suggested replies + privacy banner would have
+       * nothing to act on so we drop them too. */}
       <div className='auxx-chat-composer-plinth'>
-        {init && messages.length === 0 ? (
-          <SuggestedReplies
-            replies={config.suggestedReplies ?? []}
-            onSelect={(text) => handleSend({ content: text, attachmentIds: [] })}
-          />
-        ) : null}
-        <Composer channelId={channelId} onSend={handleSend} />
-        {config.privacyPolicyUrl && !privacyDismissed ? (
-          <PrivacyBanner
-            url={config.privacyPolicyUrl}
-            onDismiss={() => {
-              dismissPrivacyBanner(channelId)
-              setPrivacyDismissed(true)
-            }}
-          />
-        ) : null}
+        {config.isOffline ? (
+          <OfflineNotice message={config.appearance.offlineMessage} />
+        ) : (
+          <>
+            {init && messages.length === 0 ? (
+              <SuggestedReplies
+                replies={config.suggestedReplies ?? []}
+                onSelect={(text) => handleSend({ content: text, attachmentIds: [] })}
+              />
+            ) : null}
+            <Composer channelId={channelId} onSend={handleSend} />
+            {config.privacyPolicyUrl && !privacyDismissed ? (
+              <PrivacyBanner
+                url={config.privacyPolicyUrl}
+                onDismiss={() => {
+                  dismissPrivacyBanner(channelId)
+                  setPrivacyDismissed(true)
+                }}
+              />
+            ) : null}
+          </>
+        )}
       </div>
       {config.branding.footerEnabled ? (
         <div className='border-t border-[color:var(--auxx-chat-hairline)] bg-transparent py-2 text-center text-[10px] uppercase tracking-wide text-muted-foreground'>
           Powered by Auxx
         </div>
       ) : null}
+    </div>
+  )
+}
+
+function OfflineNotice({ message }: { message: string | null }) {
+  const text =
+    message?.trim() || 'No one is available right now. Leave a message and we’ll reply by email.'
+  return (
+    <div className='mx-1 mb-1 rounded-md border border-[color:var(--auxx-chat-hairline)] bg-background/60 px-3 py-3 text-center text-xs text-muted-foreground'>
+      {text}
     </div>
   )
 }

--- a/apps/chat-widget/src/views/home/home-view.tsx
+++ b/apps/chat-widget/src/views/home/home-view.tsx
@@ -52,7 +52,7 @@ function pickContrastText(hex: string): string {
 interface RecentThread {
   id: string
   subject: string | null
-  lastMessage: { preview: string; isInbound: boolean; timestamp: string }
+  lastMessage: { preview: string; isInbound: boolean; timestamp: string } | null
 }
 
 export function HomeView({
@@ -107,12 +107,11 @@ export function HomeView({
   const handleSendMessage = useCallback(async () => {
     setCreating(true)
     try {
-      // Reuse the visitor's existing thread if one exists — a single ongoing
-      // conversation rather than a new thread per click. `recent` is already
-      // loaded when the admin enabled the Recent card; otherwise fetch on
-      // demand.
+      // Reuse only the visitor's most-recent thread when it has no messages
+      // yet — otherwise every tap should land in a fresh conversation. The
+      // recent endpoint includes empty threads so we can spot the reuse case.
       const existing = recent ?? (await api.getRecentThread().catch(() => null))?.thread ?? null
-      if (existing) {
+      if (existing && !existing.lastMessage) {
         openThread(existing.id, existing.subject || 'Conversation')
         return
       }
@@ -130,7 +129,7 @@ export function HomeView({
   }, [api, openThread, recent])
 
   const cards = [
-    home.showRecentMessage && recent ? (
+    home.showRecentMessage && recent && recent.lastMessage ? (
       <RecentMessageCard
         key='recent'
         subject={recent.subject}

--- a/apps/chat-widget/src/views/messages/messages-view.tsx
+++ b/apps/chat-widget/src/views/messages/messages-view.tsx
@@ -144,16 +144,17 @@ export function MessagesView({ channelId, config, subscribe }: MessagesViewProps
 
   const handleNewThread = useCallback(async () => {
     if (creating) return
-    // Reuse the most recent existing thread if there is one — we only want
-    // visitors to accumulate a single ongoing conversation, not a new thread
-    // per click.
-    if (threads.length > 0) {
-      const top = threads[0]
-      openThread(top.id, top.agent?.name ?? fallbackAgentName)
-      return
-    }
     setCreating(true)
     try {
+      // Reuse only the visitor's most-recent thread when it has no messages
+      // yet — otherwise every tap should land in a fresh conversation. The
+      // /recent endpoint surfaces empty threads (the listing above filters
+      // them out), so this is the one place we can spot the reuse case.
+      const existing = (await api.getRecentThread().catch(() => null))?.thread ?? null
+      if (existing && !existing.lastMessage) {
+        openThread(existing.id, existing.subject || fallbackAgentName)
+        return
+      }
       const { threadId } = await api.createThread({
         url: typeof window !== 'undefined' ? window.location.href : undefined,
         referrer: typeof document !== 'undefined' ? document.referrer || undefined : undefined,
@@ -163,7 +164,7 @@ export function MessagesView({ channelId, config, subscribe }: MessagesViewProps
     } finally {
       setCreating(false)
     }
-  }, [api, creating, openThread, threads, fallbackAgentName])
+  }, [api, creating, openThread, fallbackAgentName])
 
   if (loading && threads.length === 0) {
     return (

--- a/apps/chat-widget/src/widget.tsx
+++ b/apps/chat-widget/src/widget.tsx
@@ -10,8 +10,9 @@
 //   - tracks an `expanded` state per channel for the wide-window mode.
 
 import type { Ref } from 'preact'
-import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks'
 import { FrameHeader, type FrameHeaderVariant } from './components/frame-header'
+import { FrameTransition, type SlideDirection } from './components/frame-transition'
 import { TabBar } from './components/tab-bar'
 import { NavStackProvider } from './navigation/nav-stack-context'
 import type { NavFrame, NavView } from './navigation/use-navigation-stack'
@@ -42,6 +43,36 @@ interface WidgetProps {
 }
 
 const EXPANDED_PREFIX = 'auxx-chat-expanded:'
+
+const TAB_ORDER: TabId[] = ['home', 'messages']
+
+interface NavSignature {
+  activeTab: TabId
+  stackLength: number
+  currentId: string | null
+}
+
+// Picks the slide direction for the next FrameTransition swap by diffing the
+// previous nav signature against the current one. Tab swaps use TAB_ORDER to
+// determine which side the new tab slides in from; stack pushes always slide
+// in from the right, pops from the left. Same-stack-length identity changes
+// (replace) are treated as a forward slide.
+function useTransitionDirection(signature: NavSignature): SlideDirection {
+  const prevRef = useRef<NavSignature>(signature)
+  let direction: SlideDirection = 'from-right'
+  const prev = prevRef.current
+  if (prev.activeTab !== signature.activeTab) {
+    const prevIdx = TAB_ORDER.indexOf(prev.activeTab)
+    const nextIdx = TAB_ORDER.indexOf(signature.activeTab)
+    direction = nextIdx > prevIdx ? 'from-right' : 'from-left'
+  } else if (signature.stackLength < prev.stackLength) {
+    direction = 'from-left'
+  }
+  useLayoutEffect(() => {
+    prevRef.current = signature
+  })
+  return direction
+}
 
 function readExpanded(channelId: string): boolean {
   try {
@@ -79,8 +110,18 @@ export function Widget({ channelId, cacheBust = null, scriptTheme }: WidgetProps
   const shellRefCallback = useCallback((el: HTMLDivElement | null) => {
     setShellEl(el)
   }, [])
+  // Multiple PanelShells share this callback during a frame transition (the
+  // exiting + entering layers both render a header). On mount, the latest
+  // header wins. On unmount, the callback fires with `null` — but we can't
+  // tell which element triggered it. Only clear if the currently-tracked
+  // header is no longer in the DOM; otherwise the entering layer's freshly
+  // set ref would get clobbered when the exiting layer tears down.
   const headerRefCallback = useCallback((el: HTMLElement | null) => {
-    setHeaderEl(el)
+    if (el) {
+      setHeaderEl(el)
+    } else {
+      setHeaderEl((current) => (current && current.isConnected ? current : null))
+    }
   }, [])
 
   const shadowRoot = useShadowRoot()
@@ -89,12 +130,47 @@ export function Widget({ channelId, cacheBust = null, scriptTheme }: WidgetProps
     adminTheme: config?.appearance.theme ?? 'light',
   })
 
-  // Apply data-theme to the .auxx-root element inside the shadow root so the
-  // CSS token scopes (`[data-theme='light']`, `[data-theme='dark']`) activate.
+  // Apply data-theme + brand custom properties to the .auxx-root element
+  // inside the shadow root.
+  //
+  // Why brand vars must live on `.auxx-root`, not the JSX `.auxx-chat-root`
+  // below: unregistered custom properties substitute their `var()` references
+  // at *declaration* time, not at use time. Every derived token
+  // (`--primary`, `--auxx-chat-primary-band`, glass overlay, loud, raised,
+  // shadow tints) is declared on `.auxx-root` in styles.css and references
+  // `--auxx-chat-primary` / `--auxx-chat-tint-h`. If those inputs are only
+  // set inline on a descendant, the derived tokens resolve against the
+  // defaults on `.auxx-root` and descendants inherit the already-frozen
+  // (defaulted) values. Setting the inputs on `.auxx-root` itself fixes the
+  // whole derivation chain.
+  const tintHue = config
+    ? hexToOklchHue(config.appearance.primaryColorDark ?? config.appearance.primaryColor)
+    : null
+  const primaryColor = config?.appearance.primaryColor ?? null
+  const primaryColorDark = config?.appearance.primaryColorDark ?? null
+  const headerColor = config?.appearance.headerColor ?? null
+  const headerColorDark = config?.appearance.headerColorDark ?? null
   useEffect(() => {
-    const rootEl = shadowRoot?.querySelector('.auxx-root')
-    if (rootEl) rootEl.setAttribute('data-theme', resolvedTheme)
-  }, [shadowRoot, resolvedTheme])
+    const rootEl = shadowRoot?.querySelector('.auxx-root') as HTMLElement | null
+    if (!rootEl) return
+    rootEl.setAttribute('data-theme', resolvedTheme)
+    if (primaryColor) rootEl.style.setProperty('--auxx-chat-primary', primaryColor)
+    if (tintHue !== null) rootEl.style.setProperty('--auxx-chat-tint-h', String(tintHue))
+    if (primaryColorDark) rootEl.style.setProperty('--auxx-chat-primary-dark', primaryColorDark)
+    else rootEl.style.removeProperty('--auxx-chat-primary-dark')
+    if (headerColor) rootEl.style.setProperty('--auxx-chat-header', headerColor)
+    else rootEl.style.removeProperty('--auxx-chat-header')
+    if (headerColorDark) rootEl.style.setProperty('--auxx-chat-header-dark', headerColorDark)
+    else rootEl.style.removeProperty('--auxx-chat-header-dark')
+  }, [
+    shadowRoot,
+    resolvedTheme,
+    primaryColor,
+    tintHue,
+    primaryColorDark,
+    headerColor,
+    headerColorDark,
+  ])
 
   const router = useTabRouter(channelId)
   const subscribeRef = useRef<{
@@ -279,6 +355,12 @@ export function Widget({ channelId, cacheBust = null, scriptTheme }: WidgetProps
     onPositionChange: setFloatPosition,
   })
 
+  const direction = useTransitionDirection({
+    activeTab: router.activeTab,
+    stackLength: router.currentStack.stack.length,
+    currentId: router.currentStack.current?.id ?? null,
+  })
+
   if (!config) return null
 
   const positionClass = isFloating
@@ -290,22 +372,6 @@ export function Widget({ channelId, cacheBust = null, scriptTheme }: WidgetProps
   const expandedClass = open && expanded && !isFloating ? 'auxx-chat-shell--expanded' : ''
   const bobbingClass = bobbing && isFloating ? 'auxx-chat-shell--bobbing' : ''
   const dockingClass = docking ? 'auxx-chat-shell--docking' : ''
-  const rootStyle: Record<string, string> = {
-    '--auxx-chat-primary': config.appearance.primaryColor,
-    '--auxx-chat-header': config.appearance.headerColor,
-    // Derive the OKLCH hue from the brand color and feed it to every
-    // tinted surface (glass overlay, loud/raised plinth, shadow tints).
-    // Indigo brand → cool tint; orange brand → warm tint.
-    '--auxx-chat-tint-h': String(
-      hexToOklchHue(config.appearance.primaryColorDark ?? config.appearance.primaryColor)
-    ),
-  }
-  if (config.appearance.primaryColorDark) {
-    rootStyle['--auxx-chat-primary-dark'] = config.appearance.primaryColorDark
-  }
-  if (config.appearance.headerColorDark) {
-    rootStyle['--auxx-chat-header-dark'] = config.appearance.headerColorDark
-  }
   const shellStyle: Record<string, string> = {}
   if (isFloating && floatPosition) {
     shellStyle.left = `${floatPosition.x}px`
@@ -315,7 +381,7 @@ export function Widget({ channelId, cacheBust = null, scriptTheme }: WidgetProps
   }
 
   return (
-    <div className='auxx-chat-root' data-theme={resolvedTheme} style={rootStyle}>
+    <div className='auxx-chat-root' data-theme={resolvedTheme}>
       <div
         ref={shellRefCallback}
         className={`auxx-chat-shell ${stateClass} ${positionClass} ${expandedClass} ${bobbingClass} ${dockingClass}`}
@@ -345,24 +411,30 @@ export function Widget({ channelId, cacheBust = null, scriptTheme }: WidgetProps
           aria-label={config.appearance.title}
           aria-hidden={!open}>
           <NavStackProvider value={router.currentStack}>
-            <PanelShell
-              channelId={channelId}
-              config={config}
-              resolvedTheme={resolvedTheme}
-              activeTab={router.activeTab}
-              onTabChange={router.setActiveTab}
-              currentFrame={router.currentStack.current}
-              isAtRoot={router.currentStack.isAtRoot}
-              onBack={router.currentStack.pop}
-              onClose={handleClose}
-              error={error}
-              subscribe={subscribeRef.current ?? undefined}
-              expanded={expanded}
-              onToggleExpanded={toggleExpanded}
-              floating={isFloating}
-              onToggleFloating={toggleFloating}
-              headerRef={headerRefCallback}
-            />
+            <FrameTransition
+              viewKey={`${router.activeTab}|${router.currentStack.current?.id ?? 'root'}`}
+              direction={direction}>
+              <PanelShell
+                channelId={channelId}
+                config={config}
+                resolvedTheme={resolvedTheme}
+                activeTab={router.activeTab}
+                currentFrame={router.currentStack.current}
+                isAtRoot={router.currentStack.isAtRoot}
+                onBack={router.currentStack.pop}
+                onClose={handleClose}
+                error={error}
+                subscribe={subscribeRef.current ?? undefined}
+                expanded={expanded}
+                onToggleExpanded={toggleExpanded}
+                floating={isFloating}
+                onToggleFloating={toggleFloating}
+                headerRef={headerRefCallback}
+              />
+            </FrameTransition>
+            {router.currentStack.isAtRoot ? (
+              <TabBar activeTab={router.activeTab} onChange={router.setActiveTab} />
+            ) : null}
           </NavStackProvider>
         </div>
       </div>
@@ -375,7 +447,6 @@ interface PanelShellProps {
   config: ChatConfig
   resolvedTheme: 'light' | 'dark'
   activeTab: TabId
-  onTabChange: (tab: TabId) => void
   currentFrame: NavFrame | null
   isAtRoot: boolean
   onBack: () => void
@@ -397,7 +468,6 @@ function PanelShell({
   config,
   resolvedTheme,
   activeTab,
-  onTabChange,
   currentFrame,
   isAtRoot,
   onBack,
@@ -467,7 +537,6 @@ function PanelShell({
           headerRef
         )}
       </div>
-      {isAtRoot ? <TabBar activeTab={activeTab} onChange={onTabChange} /> : null}
     </div>
   )
 }

--- a/apps/web/src/components/global/auxx-app-providers.tsx
+++ b/apps/web/src/components/global/auxx-app-providers.tsx
@@ -8,6 +8,7 @@ import { FilesystemProvider } from '~/components/files/provider/filesystem-provi
 import { ResourceProvider } from '~/components/resources'
 import { useResourceSync } from '~/components/resources/hooks/use-resource-sync'
 import { useMailSync } from '~/components/threads/realtime'
+import { usePresenceHeartbeat } from '~/hooks/use-presence-heartbeat'
 import { useRealtimeLifecycle } from '~/realtime/use-realtime-lifecycle'
 
 interface AuxxAppProvidersProps {
@@ -29,6 +30,7 @@ interface AuxxAppProvidersProps {
  */
 export function AuxxAppProviders({ children }: AuxxAppProvidersProps) {
   useRealtimeLifecycle()
+  usePresenceHeartbeat()
   useResourceSync()
   useMailSync()
 

--- a/apps/web/src/components/global/sidebar/nav-user.tsx
+++ b/apps/web/src/components/global/sidebar/nav-user.tsx
@@ -50,8 +50,10 @@ import { useCallback, useEffect, useState } from 'react'
 import { client } from '~/auth/auth-client' // Use the correct import for your auth library
 import { Tooltip } from '~/components/global/tooltip'
 import { useKopilotStore } from '~/components/kopilot/stores/kopilot-store'
+import { PresenceDot } from '~/components/users/presence-dot'
 import { useAnalytics } from '~/hooks/use-analytics'
 import { useIsSelfHosted } from '~/hooks/use-deployment-mode'
+import { useOrgPresence } from '~/hooks/use-org-presence'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
@@ -126,6 +128,11 @@ export function NavUser({ user }: Prop) {
     },
   })
   const isOnDuty = !!userData?.id && (onDutyQuery.data ?? []).includes(userData.id)
+
+  const { getState } = useOrgPresence()
+  const myPresence = getState(userData?.id)
+  const presenceLabel =
+    myPresence === 'online' ? 'Online' : myPresence === 'away' ? 'Away' : 'Offline'
   const handleToggleDuty = useCallback(
     (next: boolean) => {
       setSelfDuty.mutate({ onDuty: next })
@@ -144,10 +151,21 @@ export function NavUser({ user }: Prop) {
               <SidebarMenuButton
                 size='lg'
                 className='ps-1 w-auto pe-1.5  h-8 rounded-2xl ring-0 ring-ring/20  data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:pe-0'>
-                <Avatar className='size-6 rounded-full ring-1 ring-ring/20 group-data-[collapsible=icon]:mx-auto'>
-                  <AvatarImage src={displayImage!} alt={displayName} />
-                  <AvatarFallback className='rounded-lg'>{initials}</AvatarFallback>
-                </Avatar>
+                <span className='relative inline-flex shrink-0 group-data-[collapsible=icon]:mx-auto'>
+                  <Avatar className='size-6 rounded-full ring-1 ring-ring/20'>
+                    <AvatarImage src={displayImage!} alt={displayName} />
+                    <AvatarFallback className='rounded-lg'>{initials}</AvatarFallback>
+                  </Avatar>
+                  {/* Inset positioning — the surrounding SidebarMenuButton has
+                   * `overflow-hidden` so the dot must stay within the avatar's
+                   * bounding box (otherwise it gets clipped in icon-collapsed
+                   * mode where the button shrinks to exactly fit the avatar). */}
+                  <PresenceDot
+                    state={myPresence}
+                    hideOffline
+                    className='absolute bottom-0 right-0 size-2'
+                  />
+                </span>
                 <div className='grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden pe-2'>
                   <span className='truncate'>{displayName}</span>
                 </div>
@@ -160,13 +178,21 @@ export function NavUser({ user }: Prop) {
               sideOffset={-32}>
               <DropdownMenuLabel className='p-0 font-normal'>
                 <div className='flex items-center gap-2 px-1 py-1.5 text-left text-sm'>
-                  <Avatar className='size-7 rounded-full ring-1 ring-ring/20'>
-                    <AvatarImage src={displayImage!} alt={displayName} />
-                    <AvatarFallback className='rounded-lg'>{initials}</AvatarFallback>
-                  </Avatar>
+                  <span className='relative inline-flex shrink-0'>
+                    <Avatar className='size-7 rounded-full ring-1 ring-ring/20'>
+                      <AvatarImage src={displayImage!} alt={displayName} />
+                      <AvatarFallback className='rounded-lg'>{initials}</AvatarFallback>
+                    </Avatar>
+                    <PresenceDot
+                      state={myPresence}
+                      className='absolute -bottom-0.5 -right-0.5 size-2.5'
+                    />
+                  </span>
                   <div className='grid flex-1 text-left text-sm leading-tight'>
                     <span className='truncate font-semibold'>{displayName}</span>
-                    <span className='truncate text-xs'>{displayEmail}</span>
+                    <span className='truncate text-xs text-muted-foreground'>
+                      {presenceLabel} · {displayEmail}
+                    </span>
                   </div>
                 </div>
               </DropdownMenuLabel>

--- a/apps/web/src/components/mail/chat-assignee-chip.tsx
+++ b/apps/web/src/components/mail/chat-assignee-chip.tsx
@@ -1,0 +1,76 @@
+// apps/web/src/components/mail/chat-assignee-chip.tsx
+'use client'
+
+import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
+import { useActor } from '~/components/resources/hooks'
+import { AvatarWithStatusIcon } from '~/components/users/avatar-with-status-icon'
+import { PresenceDot } from '~/components/users/presence-dot'
+import { useOrgPresence } from '~/hooks/use-org-presence'
+import { api } from '~/trpc/react'
+
+interface ChatAssigneeChipProps {
+  assigneeId: ActorId
+}
+
+/**
+ * Compact assignee chip rendered on chat threads in the inbox list when a
+ * teammate (not the current user) is on the chat. Shows the teammate's avatar
+ * with the on-duty headset overlay when they're currently flagged on chat
+ * duty — same component the handoff banner uses, just sized for a list row.
+ *
+ * Reads `chatDuty.listOnDuty` via React Query: every chat-thread row in the
+ * list shares the same query key, so this is one network call regardless of
+ * how many rows mount.
+ */
+export function ChatAssigneeChip({ assigneeId }: ChatAssigneeChipProps) {
+  const assigneeUserId = (() => {
+    try {
+      return parseActorId(assigneeId).id
+    } catch {
+      return null
+    }
+  })()
+
+  const { actor: assignee } = useActor({
+    actorId: assigneeUserId ? toActorId('user', assigneeUserId) : null,
+    enabled: !!assigneeUserId,
+  })
+
+  const onDutyQuery = api.chatDuty.listOnDuty.useQuery(undefined, {
+    enabled: !!assigneeUserId,
+  })
+  const assigneeOnDuty = !!assigneeUserId && (onDutyQuery.data ?? []).includes(assigneeUserId)
+
+  const { getState } = useOrgPresence()
+  const presence = getState(assigneeUserId)
+
+  if (!assigneeUserId) return null
+
+  const name = assignee?.name || 'A teammate'
+  const initials =
+    name
+      .split(' ')
+      .map((p) => p[0])
+      .join('')
+      .toUpperCase()
+      .substring(0, 2) || '?'
+
+  return (
+    <span
+      className='relative inline-flex shrink-0'
+      title={`${name} — ${presence}${assigneeOnDuty ? ' · on chat duty' : ''}`}>
+      <AvatarWithStatusIcon
+        className='size-5'
+        status={assigneeOnDuty ? 'on_duty' : 'none'}
+        src={assignee?.image}
+        alt={name}
+        fallback={initials}
+      />
+      <PresenceDot
+        state={presence}
+        hideOffline
+        className='absolute -bottom-0.5 -left-0.5 size-1.5'
+      />
+    </span>
+  )
+}

--- a/apps/web/src/components/mail/chat-handoff-banner.tsx
+++ b/apps/web/src/components/mail/chat-handoff-banner.tsx
@@ -10,7 +10,9 @@ import { useSession } from '~/auth/auth-client'
 import { useActor } from '~/components/resources/hooks'
 import { useThreadStore } from '~/components/threads/store'
 import { AvatarWithStatusIcon } from '~/components/users/avatar-with-status-icon'
+import { PresenceDot } from '~/components/users/presence-dot'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useOrgPresence } from '~/hooks/use-org-presence'
 import { api } from '~/trpc/react'
 
 interface ChatHandoffBannerProps {
@@ -60,6 +62,9 @@ export function ChatHandoffBanner({ threadId, handoffState, assigneeId }: ChatHa
   const onDutyUserIds = onDutyQuery.data ?? []
   const onDutyCount = onDutyUserIds.length
   const assigneeOnDuty = !!assigneeUserId && onDutyUserIds.includes(assigneeUserId)
+
+  const { getState } = useOrgPresence()
+  const assigneePresence = getState(assigneeUserId)
 
   const takeOver = api.thread.takeOver.useMutation()
   const returnToAi = api.thread.returnToAi.useMutation()
@@ -196,14 +201,29 @@ export function ChatHandoffBanner({ threadId, handoffState, assigneeId }: ChatHa
       <ConfirmDialog />
       <div className='mx-4 mt-2 flex items-center justify-between gap-3 rounded-md border bg-muted/40 px-3 py-2 text-sm'>
         <div className='flex items-center gap-2 text-muted-foreground'>
-          <AvatarWithStatusIcon
-            className='size-5'
-            status={assigneeOnDuty ? 'on_duty' : 'none'}
-            src={assignee?.image}
-            alt={assigneeName}
-            fallback={assigneeInitials}
-          />
-          <span>{assigneeName} is on this chat.</span>
+          <span className='relative inline-flex'>
+            <AvatarWithStatusIcon
+              className='size-5'
+              status={assigneeOnDuty ? 'on_duty' : 'none'}
+              src={assignee?.image}
+              alt={assigneeName}
+              fallback={assigneeInitials}
+            />
+            <PresenceDot
+              state={assigneePresence}
+              hideOffline
+              className='absolute -bottom-0.5 -left-0.5 size-1.5'
+            />
+          </span>
+          <span>
+            {assigneeName} is on this chat
+            {assigneePresence === 'away'
+              ? ' (away)'
+              : assigneePresence === 'offline'
+                ? ' (offline)'
+                : ''}
+            .
+          </span>
         </div>
         <Button
           variant='outline'

--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { evaluateConditions, normalizeStatusConditions } from '@auxx/lib/conditions/client'
+import type { ActorId } from '@auxx/types/actor'
 import { toRecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
@@ -37,6 +38,7 @@ import {
 import { useSelectionAnchorId, useThreadSelectionStore } from '~/components/threads/store'
 import { threadFieldResolver } from '~/components/threads/utils/thread-field-resolver'
 import { useIsRecordProcessing } from '~/components/workflow/use-is-record-processing'
+import { ChatAssigneeChip } from './chat-assignee-chip'
 import { useMailFilter } from './mail-filter-context'
 import { getIntegrationIcon } from './mail-status-config'
 import { ProcessingMenu } from './mail-thread-item'
@@ -309,16 +311,21 @@ export const CompactThreadItem = memo(function CompactThreadItem({
               </span>
               {isChatThread &&
                 (handoffState === 'human' ? (
-                  <span
-                    className={cn(
-                      'shrink-0 rounded-full border px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide',
-                      isAssignedToMe
-                        ? 'border-blue-500/40 bg-blue-500/10 text-blue-700 dark:text-blue-300'
-                        : 'border-muted-foreground/20 bg-muted text-muted-foreground'
-                    )}
-                    title={isAssignedToMe ? 'You are on this chat' : 'A teammate is on this chat'}>
-                    {isAssignedToMe ? 'You' : 'Human'}
-                  </span>
+                  isAssignedToMe ? (
+                    <span
+                      className='shrink-0 rounded-full border border-blue-500/40 bg-blue-500/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-blue-700 dark:text-blue-300'
+                      title='You are on this chat'>
+                      You
+                    </span>
+                  ) : thread.assigneeId ? (
+                    <ChatAssigneeChip assigneeId={thread.assigneeId as ActorId} />
+                  ) : (
+                    <span
+                      className='shrink-0 rounded-full border border-muted-foreground/20 bg-muted px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground'
+                      title='A teammate is on this chat'>
+                      Human
+                    </span>
+                  )
                 ) : (
                   <span
                     className='shrink-0 inline-flex items-center gap-0.5 rounded-full border border-muted-foreground/20 bg-muted/60 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground'

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { evaluateConditions, normalizeStatusConditions } from '@auxx/lib/conditions/client'
+import type { ActorId } from '@auxx/types/actor'
 import { toRecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
@@ -56,6 +57,7 @@ import { threadFieldResolver } from '~/components/threads/utils/thread-field-res
 import { useIsRecordProcessing } from '~/components/workflow/use-is-record-processing'
 import { WorkflowSubMenu } from '~/components/workflow/workflow-submenu'
 import { api } from '~/trpc/react'
+import { ChatAssigneeChip } from './chat-assignee-chip'
 import { useMailFilter } from './mail-filter-context'
 import { getIntegrationIcon } from './mail-status-config'
 
@@ -454,18 +456,21 @@ export const MailThreadItem = memo(function MailThreadItem({
                 </div>
                 {isChatThread &&
                   (handoffState === 'human' ? (
-                    <span
-                      className={cn(
-                        'shrink-0 rounded-full border px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide',
-                        isAssignedToMe
-                          ? 'border-blue-500/40 bg-blue-500/10 text-blue-700 dark:text-blue-300'
-                          : 'border-muted-foreground/20 bg-muted text-muted-foreground'
-                      )}
-                      title={
-                        isAssignedToMe ? 'You are on this chat' : 'A teammate is on this chat'
-                      }>
-                      {isAssignedToMe ? 'You' : 'Human'}
-                    </span>
+                    isAssignedToMe ? (
+                      <span
+                        className='shrink-0 rounded-full border border-blue-500/40 bg-blue-500/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-blue-700 dark:text-blue-300'
+                        title='You are on this chat'>
+                        You
+                      </span>
+                    ) : thread.assigneeId ? (
+                      <ChatAssigneeChip assigneeId={thread.assigneeId as ActorId} />
+                    ) : (
+                      <span
+                        className='shrink-0 rounded-full border border-muted-foreground/20 bg-muted px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground'
+                        title='A teammate is on this chat'>
+                        Human
+                      </span>
+                    )
                   ) : (
                     <span
                       className='shrink-0 inline-flex items-center gap-0.5 rounded-full border border-muted-foreground/20 bg-muted/60 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground'

--- a/apps/web/src/components/users/presence-dot.tsx
+++ b/apps/web/src/components/users/presence-dot.tsx
@@ -1,0 +1,41 @@
+// apps/web/src/components/users/presence-dot.tsx
+'use client'
+
+import type { PresenceState } from '@auxx/lib/presence'
+import { cn } from '@auxx/ui/lib/utils'
+
+/**
+ * Small colored dot reflecting auto-derived presence. Compose alongside any
+ * user avatar — `AvatarWithStatusIcon` already owns the bottom-right corner
+ * (chat-duty headset), so this lives bottom-left by default.
+ *
+ *  - online  → emerald
+ *  - away    → amber
+ *  - offline → neutral grey (or hidden when `hideOffline` is true)
+ */
+interface PresenceDotProps {
+  state: PresenceState
+  /** Hide the dot entirely when state is `offline`. */
+  hideOffline?: boolean
+  className?: string
+}
+
+const STATE_COLOR: Record<PresenceState, string> = {
+  online: 'bg-emerald-500',
+  away: 'bg-amber-500',
+  offline: 'bg-muted-foreground/40',
+}
+
+export function PresenceDot({ state, hideOffline = false, className }: PresenceDotProps) {
+  if (hideOffline && state === 'offline') return null
+  return (
+    <span
+      aria-label={state}
+      className={cn(
+        'inline-flex size-2 shrink-0 rounded-full ring-2 ring-background',
+        STATE_COLOR[state],
+        className
+      )}
+    />
+  )
+}

--- a/apps/web/src/hooks/use-org-presence.ts
+++ b/apps/web/src/hooks/use-org-presence.ts
@@ -1,0 +1,100 @@
+// apps/web/src/hooks/use-org-presence.ts
+'use client'
+
+import { type PresenceState, resolvePresence } from '@auxx/lib/presence'
+import type { PresenceMember } from '@auxx/lib/realtime/client'
+import { rooms } from '@auxx/lib/realtime/client'
+import { useEffect, useMemo, useState } from 'react'
+import { useUser } from '~/hooks/use-user'
+import { realtimeAdapter } from '~/realtime/adapter'
+
+/**
+ * Hydrates a `userId → PresenceState` map for every member currently in the
+ * org presence room. Members not in the map are absent — treat that as
+ * `'offline'` at the call site (the returned `getState` helper does this).
+ *
+ * Subscribes via the shared `realtimeAdapter`, so multiple call sites
+ * refcount onto the same Pusher channel. Stays mounted across the consumer's
+ * lifetime — unmount tears the subscription down only when refcount hits zero.
+ *
+ * `meta.idle` arrives via two paths:
+ *  - initial subscribe: Pusher delivers `user_info` from the auth route,
+ *    which doesn't carry `idle` — first sample is "online" until the user's
+ *    heartbeat flips them.
+ *  - subsequent `member-update` events: merged into the existing meta so
+ *    name/avatar info from the initial join isn't clobbered.
+ */
+export function useOrgPresence(): {
+  /** Live map. Use `getState(userId)` for the safe lookup. */
+  map: Record<string, PresenceState>
+  /** Convenience: returns `'offline'` for unknown users. */
+  getState: (userId: string | null | undefined) => PresenceState
+} {
+  const { organizationId } = useUser()
+  const [members, setMembers] = useState<Map<string, PresenceMember>>(() => new Map())
+
+  useEffect(() => {
+    if (!organizationId) {
+      setMembers((prev) => (prev.size === 0 ? prev : new Map()))
+      return
+    }
+    const roomKey = rooms.orgPresence(organizationId)
+    const sub = realtimeAdapter.subscribePresence(
+      roomKey,
+      // `self` is informational — Pusher derives the real self from the auth
+      // response. Empty meta keeps payload small.
+      { id: 'self', meta: {} },
+      {
+        onMembers: (list) => {
+          setMembers(new Map(list.map((m) => [m.id, m])))
+        },
+        onJoin: (m) => {
+          setMembers((prev) => {
+            const next = new Map(prev)
+            next.set(m.id, m)
+            return next
+          })
+        },
+        onLeave: (id) => {
+          setMembers((prev) => {
+            if (!prev.has(id)) return prev
+            const next = new Map(prev)
+            next.delete(id)
+            return next
+          })
+        },
+        onMemberUpdate: (m) => {
+          setMembers((prev) => {
+            const existing = prev.get(m.id)
+            const next = new Map(prev)
+            next.set(m.id, {
+              id: m.id,
+              meta: { ...(existing?.meta ?? {}), ...(m.meta ?? {}) },
+            })
+            return next
+          })
+        },
+      }
+    )
+    return () => {
+      sub.unsubscribe()
+    }
+  }, [organizationId])
+
+  const map = useMemo(() => {
+    const out: Record<string, PresenceState> = {}
+    for (const [id, m] of members) {
+      out[id] = resolvePresence({ subscribed: true, idle: m.meta?.idle === true })
+    }
+    return out
+  }, [members])
+
+  const getState = useMemo(() => {
+    return (userId: string | null | undefined): PresenceState => {
+      if (!userId) return 'offline'
+      return map[userId] ?? 'offline'
+    }
+  }, [map])
+
+  return { map, getState }
+}

--- a/apps/web/src/hooks/use-presence-heartbeat.ts
+++ b/apps/web/src/hooks/use-presence-heartbeat.ts
@@ -1,0 +1,83 @@
+// apps/web/src/hooks/use-presence-heartbeat.ts
+'use client'
+
+import { PRESENCE_IDLE_MS } from '@auxx/lib/presence'
+import { rooms } from '@auxx/lib/realtime/client'
+import { useEffect } from 'react'
+import { useUser } from '~/hooks/use-user'
+import { realtimeAdapter } from '~/realtime/adapter'
+
+/**
+ * Mount-once tracker that flips the current user's `meta.idle` flag on the
+ * org presence room when the tab is hidden or interaction stalls past
+ * `PRESENCE_IDLE_MS`.
+ *
+ * Only emits on edge transitions — mouse-jiggling while already-active is a
+ * no-op. On tab close / network drop, Pusher's connection drops and the
+ * `pusher:member_removed` event handles "offline" via the presence channel;
+ * no explicit "going offline" message is needed.
+ */
+export function usePresenceHeartbeat(): void {
+  const { organizationId } = useUser()
+
+  useEffect(() => {
+    if (!organizationId || typeof window === 'undefined') return
+    const roomKey = rooms.orgPresence(organizationId)
+
+    // Subscribing puts this user in the presence channel's member list — every
+    // other admin watching the room will see them via `pusher:member_added`.
+    // Without this, `updateSelf` would still publish member-update events but
+    // the user would never have joined, so observers wouldn't track them.
+    // Refcounted with `useOrgPresence` consumers, so this is cheap.
+    const sub = realtimeAdapter.subscribePresence(roomKey, { id: 'self', meta: {} }, {})
+
+    let isIdle: boolean | null = null
+    let lastInteraction = Date.now()
+    let timer: ReturnType<typeof setInterval> | null = null
+
+    const flip = (next: boolean) => {
+      if (next === isIdle) return
+      isIdle = next
+      // Fire-and-forget — the adapter's `updateSelf` already swallows errors.
+      void realtimeAdapter.updateSelf(roomKey, { idle: next })
+    }
+
+    const recompute = () => {
+      const idle = document.hidden || Date.now() - lastInteraction > PRESENCE_IDLE_MS
+      flip(idle)
+    }
+
+    const onActivity = () => {
+      lastInteraction = Date.now()
+      // Cheap path — if we're already not-idle, this is a no-op.
+      if (isIdle !== false) recompute()
+    }
+
+    const onVisibility = () => {
+      if (!document.hidden) lastInteraction = Date.now()
+      recompute()
+    }
+
+    // Initial sample so other clients see "online" right after subscribe.
+    recompute()
+
+    // Poll every 5s for the online → away transition. mousemove/keydown handle
+    // the reverse direction (away → online) immediately.
+    timer = setInterval(recompute, 5_000)
+
+    // `passive: true` keeps these listeners off the scrolling critical path.
+    document.addEventListener('mousemove', onActivity, { passive: true })
+    document.addEventListener('keydown', onActivity, { passive: true })
+    document.addEventListener('click', onActivity, { passive: true })
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      if (timer) clearInterval(timer)
+      document.removeEventListener('mousemove', onActivity)
+      document.removeEventListener('keydown', onActivity)
+      document.removeEventListener('click', onActivity)
+      document.removeEventListener('visibilitychange', onVisibility)
+      sub.unsubscribe()
+    }
+  }, [organizationId])
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -550,6 +550,12 @@
       "import": "./dist/posthog/posthog-client.mjs",
       "default": "./src/posthog/posthog-client.ts"
     },
+    "./presence": {
+      "types": "./src/presence/index.ts",
+      "source": "./src/presence/index.ts",
+      "import": "./dist/presence/index.mjs",
+      "default": "./src/presence/index.ts"
+    },
     "./prompt-templates": {
       "types": "./src/prompt-templates/index.ts",
       "source": "./src/prompt-templates/index.ts",

--- a/packages/lib/src/presence/index.ts
+++ b/packages/lib/src/presence/index.ts
@@ -1,0 +1,3 @@
+// packages/lib/src/presence/index.ts
+
+export { PRESENCE_IDLE_MS, type PresenceState, resolvePresence } from './presence-types'

--- a/packages/lib/src/presence/presence-types.ts
+++ b/packages/lib/src/presence/presence-types.ts
@@ -1,0 +1,27 @@
+// packages/lib/src/presence/presence-types.ts
+
+/**
+ * Three-state observational presence. Auto-derived from the realtime
+ * connection + an idle heartbeat — never set manually.
+ *
+ *  - `online`  — subscribed to the org presence room and not idle.
+ *  - `away`    — subscribed but the client flipped `meta.idle = true`
+ *    (tab hidden or no interaction for the idle threshold).
+ *  - `offline` — not currently subscribed (tab closed / network gone).
+ *
+ * Intent (chat duty, future user status) lives in separate features.
+ */
+export type PresenceState = 'online' | 'away' | 'offline'
+
+/** Idle threshold the heartbeat uses to flip online → away. */
+export const PRESENCE_IDLE_MS = 60_000
+
+/**
+ * Resolve a presence state from raw signals. `subscribed` is true when the
+ * user is currently in the org presence room; `idle` reflects their latest
+ * `meta.idle` flag from the heartbeat. Missing `idle` is treated as not-idle.
+ */
+export function resolvePresence(opts: { subscribed: boolean; idle?: boolean }): PresenceState {
+  if (!opts.subscribed) return 'offline'
+  return opts.idle ? 'away' : 'online'
+}


### PR DESCRIPTION
## Summary

- **Org presence**: new `@auxx/lib/presence` package + `usePresenceHeartbeat` / `useOrgPresence` hooks. Renders green/amber dots on the nav-user avatar, the chat handoff banner, and a new `ChatAssigneeChip` that replaces the generic "Human" pill on chat thread rows with the assigned teammate's avatar.
- **Widget frame transitions**: iOS-style slide animations between tabs and nav-stack pushes/pops. Falls back to a quick fade under `prefers-reduced-motion`.
- **Widget offline mode**: API derives `isOffline = no AI agent bound && nobody on chat duty`. Conversation view swaps the composer for `appearance.offlineMessage` when set.
- **Widget thread reuse fix**: reuse the visitor's most recent thread only when it has no messages yet; otherwise every tap starts a fresh conversation. Server returns empty threads in `/recent` so the widget can detect the reuse case.
- **Widget theming fix**: move brand color custom properties onto `.auxx-root` so derived tokens (`--primary`, glass overlay, closed-launcher shadow) substitute the live config instead of frozen defaults.

## Test plan

- [ ] Open inbox in two browsers as two different teammates — presence dots flip green/amber on tab hide and after 60s idle, and offline when the tab closes
- [ ] Chat thread row shows the assigned teammate's avatar (with on-duty headset if applicable) when someone other than me has taken the chat
- [ ] Handoff banner shows presence dot + appends "(away)" / "(offline)" when the assignee isn't online
- [ ] Widget tab swap (Home ↔ Messages) animates with a slide; pushing/popping a conversation slides right/left
- [ ] Widget with no AI agent and nobody on duty shows the offline notice instead of the composer
- [ ] Tapping "Send us a message" on Home twice in a row reuses the first (empty) thread, then creates a new one after sending
- [ ] Brand color set in widget config takes effect immediately (closed launcher shadow + suggested-reply chips tinted correctly)