### PR TITLE
feat(homepage): hero v2 with kopilot mock + 3D overflow support

### DIFF
--- a/apps/homepage/src/app/_components/sections/hero-section-v2.tsx
+++ b/apps/homepage/src/app/_components/sections/hero-section-v2.tsx
@@ -1,0 +1,83 @@
+// apps/homepage/src/app/_components/sections/hero-section-v2.tsx
+'use client'
+
+import { Sparkles } from 'lucide-react'
+import { motion, useReducedMotion } from 'motion/react'
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { useConfig } from '~/lib/config-context'
+import { CyclingPill } from './hero-v2/cycling-pill'
+import { KopilotMock } from './hero-v2/kopilot-mock'
+
+export default function HeroSectionV2() {
+  const { urls } = useConfig()
+  const reduce = useReducedMotion()
+
+  return (
+    <main role='main' className='relative min-h-screen overflow-hidden bg-muted/30'>
+      {/* Soft brand glow behind the mock */}
+      <div
+        aria-hidden='true'
+        className='pointer-events-none absolute right-[-10%] top-[-10%] h-[700px] w-[700px] rounded-full bg-gradient-to-br from-blue-500/20 via-purple-500/15 to-pink-500/5 blur-3xl'
+      />
+
+      <section className='relative mx-auto flex min-h-screen max-w-7xl items-center px-6 pt-24 pb-16 lg:pt-28'>
+        <div className='grid w-full grid-cols-1 gap-16 lg:grid-cols-12 lg:gap-8'>
+          {/* Left column — copy */}
+          <div className='flex flex-col items-start justify-center lg:col-span-5 lg:pt-12 z-20'>
+            <motion.div
+              initial={reduce ? false : { opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, ease: 'easeOut' }}
+              className='mb-6 flex size-9 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-purple-500 text-white shadow-lg shadow-blue-500/20'>
+              <Sparkles className='size-4' />
+            </motion.div>
+
+            <motion.h1
+              initial={reduce ? false : { opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, ease: 'easeOut', delay: 0.05 }}
+              className='text-balance text-4xl font-semibold tracking-tight text-foreground lg:text-5xl'>
+              The AI agent that runs your inbox and CRM.
+            </motion.h1>
+
+            <motion.p
+              initial={reduce ? false : { opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, ease: 'easeOut', delay: 0.12 }}
+              className='mt-5 max-w-md text-lg leading-relaxed text-muted-foreground'>
+              Kopilot reads every ticket, drafts the reply, and updates your customer record — so
+              you sell, and the agent does the rest.
+            </motion.p>
+
+            <motion.div
+              initial={reduce ? false : { opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, ease: 'easeOut', delay: 0.2 }}
+              className='mt-8 flex flex-col gap-3 sm:flex-row sm:items-center'>
+              <Button asChild className='rounded-full px-6 text-base'>
+                <Link href={urls.signup}>Start free trial</Link>
+              </Button>
+              <Button asChild variant='outline' className='rounded-full px-6 text-base'>
+                <Link href={urls.demo}>Book a demo</Link>
+              </Button>
+            </motion.div>
+
+            <motion.div
+              initial={reduce ? false : { opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, ease: 'easeOut', delay: 0.3 }}
+              className='mt-12'>
+              <CyclingPill />
+            </motion.div>
+          </div>
+
+          {/* Right column — Kopilot mockup */}
+          <div className='relative lg:col-span-7'>
+            <KopilotMock />
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/apps/homepage/src/app/_components/sections/hero-v2/agent-log.tsx
+++ b/apps/homepage/src/app/_components/sections/hero-v2/agent-log.tsx
@@ -1,0 +1,32 @@
+// apps/homepage/src/app/_components/sections/hero-v2/agent-log.tsx
+import { Check, Search } from 'lucide-react'
+
+const rows = [
+  { label: 'Retrieved', detail: '12 open VIP tickets' },
+  { label: 'Analyzed', detail: '4 mention shipping delays' },
+  { label: 'Drafted', detail: '12 replies · 4 tagged shipping-delay' },
+]
+
+export function AgentLog() {
+  return (
+    <div className='w-[340px] max-w-full rounded-xl border border-foreground/10 bg-background/95 p-4 shadow-2xl shadow-black/10 backdrop-blur'>
+      <div className='mb-3 flex items-center gap-2 text-[11px] text-muted-foreground'>
+        <Search className='size-3' />
+        <span>Kopilot run · just now</span>
+      </div>
+      <div className='flex flex-col gap-2.5'>
+        {rows.map((r) => (
+          <div key={r.label} className='flex items-start gap-2.5'>
+            <div className='mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary'>
+              <Check className='size-2.5' strokeWidth={3} />
+            </div>
+            <div className='min-w-0 flex-1 text-xs'>
+              <span className='font-medium text-foreground'>{r.label}</span>
+              <span className='text-muted-foreground'> — {r.detail}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/_components/sections/hero-v2/cycling-pill.tsx
+++ b/apps/homepage/src/app/_components/sections/hero-v2/cycling-pill.tsx
@@ -1,0 +1,53 @@
+// apps/homepage/src/app/_components/sections/hero-v2/cycling-pill.tsx
+'use client'
+
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { useEffect, useState } from 'react'
+
+const messages = [
+  { label: 'Kopilot', body: 'the agent that runs your inbox' },
+  { label: 'Workflows', body: 'automate every repeatable reply' },
+  { label: 'Shared inbox', body: 'one place for every customer thread' },
+]
+
+const ROTATE_MS = 3500
+
+export function CyclingPill() {
+  const reduce = useReducedMotion()
+  const [index, setIndex] = useState(0)
+  const [paused, setPaused] = useState(false)
+
+  useEffect(() => {
+    if (reduce || paused) return
+    const id = window.setInterval(() => {
+      setIndex((i) => (i + 1) % messages.length)
+    }, ROTATE_MS)
+    return () => window.clearInterval(id)
+  }, [reduce, paused])
+
+  const current = messages[index]
+
+  return (
+    <div
+      className='inline-flex items-center gap-2 rounded-full border border-foreground/10 bg-background/70 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur'
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}>
+      <span className='relative flex size-1.5'>
+        <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-primary/60 opacity-75' />
+        <span className='relative inline-flex size-1.5 rounded-full bg-primary' />
+      </span>
+      <AnimatePresence mode='wait' initial={false}>
+        <motion.span
+          key={current.label}
+          initial={reduce ? false : { opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={reduce ? undefined : { opacity: 0, y: -4 }}
+          transition={{ duration: 0.25, ease: 'easeOut' }}
+          className='flex items-center gap-1.5'>
+          <span className='font-medium text-foreground'>{current.label}</span>
+          <span className='text-muted-foreground'>— {current.body}</span>
+        </motion.span>
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/_components/sections/hero-v2/kopilot-mock.tsx
+++ b/apps/homepage/src/app/_components/sections/hero-v2/kopilot-mock.tsx
@@ -1,0 +1,136 @@
+// apps/homepage/src/app/_components/sections/hero-v2/kopilot-mock.tsx
+'use client'
+
+import { Sparkles } from 'lucide-react'
+import { motion, useReducedMotion } from 'motion/react'
+import {
+  MockAppSidebar,
+  MockBrowserChrome,
+  MockKopilotWindow,
+  MockMainPage,
+} from '~/app/platform/ai/_mocks'
+import { KOPILOT_HERO_SCRIPT } from '~/app/platform/ai/kopilot/_components/kopilot-hero-script'
+import { AgentLog } from './agent-log'
+
+export function KopilotMock() {
+  const reduce = useReducedMotion()
+
+  const float = (delay: number) =>
+    reduce
+      ? {}
+      : {
+          animate: { y: [0, -6, 0] },
+          transition: { duration: 7, repeat: Infinity, ease: 'easeInOut', delay },
+        }
+
+  return (
+    <div className='pointer-events-none relative h-full min-h-[80vh] w-full select-none transform-3d'>
+      {/* Crosshatch mesh background — fades radially */}
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 mask-radial-from-55% mask-radial-to-75% opacity-60'
+        style={{
+          backgroundImage: `
+            repeating-linear-gradient(22.5deg, transparent, transparent 1px, rgba(120, 120, 140, 0.06) 1px, rgba(120, 120, 140, 0.06) 2px, transparent 2px, transparent 4px),
+            repeating-linear-gradient(67.5deg, transparent, transparent 1px, rgba(120, 120, 140, 0.05) 1px, rgba(120, 120, 140, 0.05) 2px, transparent 2px, transparent 4px),
+            repeating-linear-gradient(112.5deg, transparent, transparent 1px, rgba(120, 120, 140, 0.04) 1px, rgba(120, 120, 140, 0.04) 2px, transparent 2px, transparent 4px),
+            repeating-linear-gradient(157.5deg, transparent, transparent 1px, rgba(120, 120, 140, 0.03) 1px, rgba(120, 120, 140, 0.03) 2px, transparent 2px, transparent 4px)
+          `,
+        }}
+      />
+
+      {/* Back layer — chrome and the inner content (sidebar / main+kopilot) are SIBLINGS
+          under one relative wrapper. Each layer's Z is a direct world coordinate (no parent
+          transform compounding). Single float on the outer wrapper keeps the whole composition
+          moving as a unit. Entrance is Z-only: each layer starts ~40px closer to the viewer
+          than its resting Z, then settles back into its resting depth. */}
+      <motion.div
+        initial={reduce ? false : { opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.6, ease: 'easeOut' }}
+        className='absolute right-[-22vw] bottom-[-6vh] z-0 transform-3d'>
+        <div className='relative rotate-x-[30deg] rotate-y-[24deg] rotate-[344deg] mask-radial-from-65% mask-radial-at-top-right mask-radial-[200%_100%] perspective-[4000px] transform-3d'>
+          <motion.div {...float(0)} className='relative w-[1100px] max-w-none transform-3d'>
+            {/* Layer 1 — chrome frame (world z:-160). Static; outer wrapper handles fade. */}
+            <div className='transform-3d' style={{ transform: 'translateZ(-160px)' }}>
+              <MockBrowserChrome allowOverflow variant='regular' className='transform-3d'>
+                <div className='h-[620px]' />
+              </MockBrowserChrome>
+            </div>
+
+            {/* Content layers — absolutely positioned over chrome's content area.
+                Top offset (50px) matches chrome's outer p-2 + header height (~9 + 41). */}
+            <div
+              className='pointer-events-none absolute flex transform-3d'
+              style={{ top: '50px', left: '10px', right: '10px', height: '620px' }}>
+              {/* Layer 2 — sidebar (world z:-40). Static. */}
+              <div
+                className='hidden flex-shrink-0 shadow-2xl shadow-black/50 transform-3d md:flex'
+                style={{ transform: 'translateZ(-40px)' }}>
+                <MockAppSidebar activeKey='kopilot' />
+              </div>
+
+              {/* Layer 3 — main page (world z:80), kopilot window nested at relative z:140 (world 220). Static. */}
+              <div
+                className='flex flex-1 shadow-2xl shadow-black/60 transform-3d'
+                style={{ transform: 'translateZ(80px)' }}>
+                <MockMainPage allowOverflow>
+                  <div
+                    className='flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-[calc(var(--radius-2xl)-4px)] transform-3d'
+                    style={{ transform: 'translateZ(140px)' }}>
+                    <MockKopilotWindow
+                      breadcrumb={{
+                        trail: ['Chats'],
+                        title: 'Open Support Tickets Summary',
+                        titleMobile: 'Tickets',
+                      }}
+                      script={KOPILOT_HERO_SCRIPT}
+                      composerPlaceholder='Ask Kopilot...'
+                      modelLabel='GPT-5.4 Nano'
+                    />
+                  </div>
+                </MockMainPage>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      </motion.div>
+
+      {/* Mid layer — agent log. translateZ:340 keeps it above the back-layer Kopilot world z (220). */}
+      <motion.div
+        initial={reduce ? false : { opacity: 0, z: 340 }}
+        animate={{ opacity: 1, z: 340 }}
+        transition={{ duration: 0.5, ease: 'easeOut', delay: 0.15 }}
+        className='absolute right-[18%] top-[38%] z-10 perspective-[4000px] transform-3d'>
+        <motion.div {...float(1.2)} className='transform-3d'>
+          <div className='rotate-x-[30deg] rotate-y-[24deg] rotate-[344deg]'>
+            <AgentLog />
+          </div>
+        </motion.div>
+      </motion.div>
+
+      {/* Front layer — Kopilot prompt bubble, highest at translateZ:440. */}
+      <motion.div
+        initial={reduce ? false : { opacity: 0, z: 440 }}
+        animate={{ opacity: 1, z: 440 }}
+        transition={{ duration: 0.5, ease: 'easeOut', delay: 0.25 }}
+        className='absolute right-[10%] top-[18%] z-20 perspective-[4000px] transform-3d'>
+        <motion.div {...float(2.4)}>
+          <div className='rotate-x-[30deg] rotate-y-[24deg] rotate-[344deg]'>
+            <div className='w-[360px] max-w-full rounded-xl border border-foreground/10 bg-background/95 p-3.5 shadow-2xl shadow-black/25 backdrop-blur-md'>
+              <div className='mb-2 flex items-center gap-2'>
+                <div className='flex size-5 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-purple-500 text-white'>
+                  <Sparkles className='size-2.5' />
+                </div>
+                <span className='text-xs font-medium text-foreground'>Kopilot</span>
+              </div>
+              <p className='text-sm leading-relaxed text-foreground'>
+                Reply to the open VIP tickets and tag anything about shipping delays.
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      </motion.div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/_components/sections/hero-v2/ticket-card.tsx
+++ b/apps/homepage/src/app/_components/sections/hero-v2/ticket-card.tsx
@@ -1,0 +1,61 @@
+// apps/homepage/src/app/_components/sections/hero-v2/ticket-card.tsx
+import { Inbox, Sparkles } from 'lucide-react'
+
+const tickets = [
+  { name: 'Hannah W.', subject: 'Where is my order #4821?', time: '2m', unread: true },
+  { name: 'Marco L.', subject: 'Refund for damaged item', time: '14m', unread: true },
+  { name: 'Priya S.', subject: 'Can I change my shipping address?', time: '1h', unread: false },
+  { name: 'Devon K.', subject: 'Discount code not working', time: '3h', unread: false },
+]
+
+export function TicketCard() {
+  return (
+    <div className='w-[560px] max-w-full overflow-hidden rounded-xl border border-foreground/10 bg-background/95 shadow-2xl shadow-black/10 backdrop-blur'>
+      <div className='flex items-center gap-2 border-b border-foreground/10 bg-muted/40 px-4 py-2.5 text-xs text-muted-foreground'>
+        <Inbox className='size-3.5' />
+        <span className='font-medium text-foreground'>Inbox</span>
+        <span>·</span>
+        <span>12 open</span>
+      </div>
+      <div className='grid grid-cols-[220px_1fr]'>
+        <div className='border-r border-foreground/10 bg-muted/20'>
+          {tickets.map((t) => (
+            <div
+              key={t.name}
+              className='flex items-start gap-2 border-b border-foreground/5 px-3 py-2.5 last:border-b-0'>
+              <div
+                className='mt-1 size-1.5 shrink-0 rounded-full bg-primary data-[unread=false]:bg-transparent'
+                data-unread={t.unread}
+              />
+              <div className='min-w-0 flex-1'>
+                <div className='flex items-center justify-between gap-2'>
+                  <span className='truncate text-xs font-medium text-foreground'>{t.name}</span>
+                  <span className='text-[10px] text-muted-foreground'>{t.time}</span>
+                </div>
+                <div className='truncate text-[11px] text-muted-foreground'>{t.subject}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className='flex flex-col gap-3 p-4'>
+          <div>
+            <div className='text-xs font-medium text-foreground'>Hannah W.</div>
+            <div className='text-[11px] text-muted-foreground'>Where is my order #4821?</div>
+          </div>
+          <div className='rounded-md bg-muted/40 p-2.5 text-[11px] leading-relaxed text-muted-foreground'>
+            Hey — I placed an order last Tuesday but haven&apos;t seen any tracking yet. Can you
+            check what&apos;s going on?
+          </div>
+          <div className='rounded-md border border-primary/20 bg-primary/5 p-2.5 text-[11px] leading-relaxed text-foreground'>
+            <div className='mb-1 flex items-center gap-1 text-[10px] font-medium text-primary'>
+              <Sparkles className='size-3' />
+              Kopilot draft
+            </div>
+            Hi Hannah — order #4821 shipped Wednesday via UPS. Tracking: 1Z999AA10123456784.
+            Expected delivery Friday.
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/ai/_mocks/mock-browser-chrome.tsx
+++ b/apps/homepage/src/app/platform/ai/_mocks/mock-browser-chrome.tsx
@@ -6,6 +6,12 @@ interface MockBrowserChromeProps {
   variant?: 'regular' | 'compact'
   url?: string
   className?: string
+  /**
+   * When true, the inner content surface uses `overflow-visible` instead of
+   * `overflow-hidden`, allowing children that translate in 3D (translateZ) to
+   * render beyond the chrome bounds without being flattened. Default `false`.
+   */
+  allowOverflow?: boolean
   children: React.ReactNode
 }
 
@@ -21,6 +27,7 @@ export function MockBrowserChrome({
   variant = 'regular',
   url = 'app.auxx.ai/app/chats',
   className,
+  allowOverflow = false,
   children,
 }: MockBrowserChromeProps) {
   return (
@@ -30,7 +37,11 @@ export function MockBrowserChrome({
         className='pointer-events-none absolute inset-0 scale-100 opacity-75 blur-lg transition-all duration-300 dark:opacity-50'>
         <div className='bg-linear-to-r/increasing animate-hue-rotate absolute inset-x-6 bottom-0 top-12 -translate-y-3 from-pink-400 to-purple-400' />
       </div>
-      <div className='relative overflow-hidden rounded-2xl bg-card/85 backdrop-blur-md text-card-foreground shadow-xl shadow-black/[.065] ring-1 ring-border-illustration'>
+      <div
+        className={cn(
+          'relative rounded-2xl bg-card/85 backdrop-blur-md text-card-foreground shadow-xl shadow-black/[.065] ring-1 ring-border-illustration',
+          allowOverflow ? 'overflow-visible transform-3d' : 'overflow-hidden'
+        )}>
         {variant === 'regular' ? (
           <div className='relative grid grid-cols-[auto_1fr_auto] items-center gap-3 border-b border-border px-3 py-2'>
             <TrafficLights />

--- a/apps/homepage/src/app/platform/ai/_mocks/mock-main-page.tsx
+++ b/apps/homepage/src/app/platform/ai/_mocks/mock-main-page.tsx
@@ -5,6 +5,10 @@ import { MockPanelFrame } from './mock-panel-frame'
 
 interface MockMainPageProps {
   className?: string
+  /** When true, swaps `overflow-hidden` for `overflow-visible` and enables
+   *  `transform-3d` so 3D-translated children render beyond the panel bounds.
+   *  Forwarded to the inner `MockPanelFrame`. Default `false`. */
+  allowOverflow?: boolean
   children: React.ReactNode
 }
 
@@ -15,14 +19,17 @@ interface MockMainPageProps {
  * (`bg-neutral-100 dark:bg-background p-3 pt-0`) and wraps its content in a
  * `MockPanelFrame` for the nested-border depth effect.
  */
-export function MockMainPage({ className, children }: MockMainPageProps) {
+export function MockMainPage({ className, allowOverflow = false, children }: MockMainPageProps) {
   return (
     <div
       className={cn(
-        'flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-mock-page-bg p-3 pt-3',
+        'flex h-full min-h-0 flex-1 flex-col bg-mock-page-bg p-3 pt-3',
+        allowOverflow ? 'overflow-visible transform-3d' : 'overflow-hidden',
         className
       )}>
-      <MockPanelFrame flex>{children}</MockPanelFrame>
+      <MockPanelFrame flex allowOverflow={allowOverflow}>
+        {children}
+      </MockPanelFrame>
     </div>
   )
 }

--- a/apps/homepage/src/app/platform/ai/_mocks/mock-panel-frame.tsx
+++ b/apps/homepage/src/app/platform/ai/_mocks/mock-panel-frame.tsx
@@ -6,6 +6,9 @@ interface MockPanelFrameProps {
   width?: number | string
   flex?: boolean
   className?: string
+  /** When true, swaps overflow-hidden/clip for overflow-visible on every nested
+   *  ring + enables transform-3d so 3D-translated children aren't flattened. */
+  allowOverflow?: boolean
   children: React.ReactNode
 }
 
@@ -14,22 +17,47 @@ interface MockPanelFrameProps {
  * Reproduces the four-layer nested border depth effect (alternating
  * highlight/shadow rings) that wraps every main panel in the real app.
  */
-export function MockPanelFrame({ width, flex, className, children }: MockPanelFrameProps) {
+export function MockPanelFrame({
+  width,
+  flex,
+  className,
+  allowOverflow = false,
+  children,
+}: MockPanelFrameProps) {
   const inlineStyle =
     width !== undefined ? { width: typeof width === 'number' ? `${width}px` : width } : undefined
+  const overflowOuter = allowOverflow ? 'overflow-visible transform-3d' : 'overflow-hidden'
+  const overflowInner = allowOverflow ? 'overflow-visible transform-3d' : 'overflow-clip'
 
   return (
     <div
       style={inlineStyle}
       className={cn(
-        'relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border border-mock-panel-border-1 bg-mock-panel-bg',
+        'relative flex h-full min-h-0 min-w-0 flex-col rounded-2xl border border-mock-panel-border-1 bg-mock-panel-bg',
+        overflowOuter,
         flex ? 'flex-1' : 'shrink-0',
         className
       )}>
-      <div className='flex min-h-0 flex-1 flex-col rounded-[calc(var(--radius-2xl)-1px)] border border-mock-panel-border-2'>
-        <div className='flex min-h-0 flex-1 rounded-[calc(var(--radius-2xl)-2px)] border border-mock-panel-border-3'>
-          <div className='flex min-h-0 flex-1 rounded-[calc(var(--radius-2xl)-3px)] border border-mock-panel-border-4'>
-            <div className='flex min-h-0 flex-1 flex-col overflow-clip rounded-[calc(var(--radius-2xl)-4px)] bg-clip-padding'>
+      <div
+        className={cn(
+          'flex min-h-0 flex-1 flex-col rounded-[calc(var(--radius-2xl)-1px)] border border-mock-panel-border-2',
+          allowOverflow && 'transform-3d'
+        )}>
+        <div
+          className={cn(
+            'flex min-h-0 flex-1 rounded-[calc(var(--radius-2xl)-2px)] border border-mock-panel-border-3',
+            allowOverflow && 'transform-3d'
+          )}>
+          <div
+            className={cn(
+              'flex min-h-0 flex-1 rounded-[calc(var(--radius-2xl)-3px)] border border-mock-panel-border-4',
+              allowOverflow && 'transform-3d'
+            )}>
+            <div
+              className={cn(
+                'flex min-h-0 flex-1 flex-col rounded-[calc(var(--radius-2xl)-4px)] bg-clip-padding',
+                overflowInner
+              )}>
               {children}
             </div>
           </div>

--- a/apps/homepage/src/app/platform/data-model/_components/surfaces/auto-reply-hero.tsx
+++ b/apps/homepage/src/app/platform/data-model/_components/surfaces/auto-reply-hero.tsx
@@ -28,7 +28,6 @@ export function AutoReplyHero() {
     <>
       <div className='pointer-events-none absolute inset-x-0 top-0 bottom-[42%] overflow-hidden opacity-30 transition-opacity duration-500 ease-out group-hover/card:opacity-100'>
         <div className='absolute inset-x-0 top-0 z-10 h-20 bg-gradient-to-b from-[#EDFDED] via-[#EDFDED]/80 to-transparent dark:from-[#1A2A20] dark:via-[#1A2A20]/80' />
-        <div className='absolute inset-x-0 bottom-0 z-10 h-12 bg-gradient-to-t from-[#EDFDED] to-transparent dark:from-[#1A2A20]' />
         <div className='flex flex-col px-5 pt-12 [animation:scroll-code_25s_linear_infinite_paused] group-hover/card:[animation-play-state:running]'>
           {[0, 1].map((i) => (
             <pre


### PR DESCRIPTION
## Summary
- Adds new hero section v2 (`hero-section-v2.tsx`) with kopilot mock, agent log, ticket card, and cycling pill
- Extends `MockBrowserChrome`, `MockMainPage`, and `MockPanelFrame` with optional `allowOverflow` prop — swaps overflow-hidden for overflow-visible + `transform-3d` so 3D-translated children render beyond panel bounds
- Minor cleanup in `auto-reply-hero.tsx` (removes bottom fade gradient)

## Test plan
- [ ] Verify hero v2 renders correctly on homepage
- [ ] Check kopilot mock 3D translated children aren't flattened
- [ ] Confirm existing mock surfaces (default `allowOverflow=false`) still clip as before