### PR TITLE
feat(chat): lazy attachment URLs, paginated history, visitor label cleanup

### DIFF
--- a/apps/api/src/routes/chat/attachments.ts
+++ b/apps/api/src/routes/chat/attachments.ts
@@ -1,8 +1,11 @@
 // apps/api/src/routes/chat/attachments.ts
 
 import { randomBytes } from 'node:crypto'
-import { createStorageManager, MediaAssetService } from '@auxx/lib/files'
+import { database, schema } from '@auxx/database'
+import { AttachmentService, createStorageManager, MediaAssetService } from '@auxx/lib/files'
+import type { ChatThreadMetadata } from '@auxx/lib/threads/types'
 import { createScopedLogger } from '@auxx/logger'
+import { and, eq, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { applyChatCorsHeaders } from './lib'
 
@@ -121,6 +124,88 @@ attachmentsRoute.post('/', async (c) => {
     })
     return c.json(
       { success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to upload attachment' } },
+      500
+    )
+  }
+})
+
+attachmentsRoute.options('/:attachmentId/url', (c) => {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+  return c.body(null, 204)
+})
+
+/**
+ * GET /api/chat/attachments/:attachmentId/url
+ *
+ * Resolve a short-lived presigned download URL for a single Attachment row.
+ * Used by the widget to render attachment thumbnails / download chips lazily —
+ * the URL never ships in initialize/history responses or Pusher payloads (so
+ * the TTL doesn't outlive a long-lived frame).
+ *
+ * Keyed off `Attachment.id` rather than `MediaAsset.id` because agent-side
+ * file-manager picks produce `Attachment.fileId` (→ FolderFile) rows with
+ * `assetId = NULL`. Resolution delegates to `AttachmentService.getDownloadUrl`
+ * which handles both backings.
+ *
+ * ACL: passport is org-scoped + visitor-scoped via `visitorParticipantId`. We
+ * verify the attachment hangs off a message in a thread the passport owns.
+ *
+ * Returns 404 (not 403) on ACL miss so we don't leak asset existence.
+ */
+attachmentsRoute.get('/:attachmentId/url', async (c) => {
+  applyChatCorsHeaders(c, { allowCredentials: true })
+
+  const chat = c.get('chat')
+  const attachmentId = c.req.param('attachmentId')
+
+  try {
+    const [hit] = await database
+      .select({ one: sql`1` })
+      .from(schema.Attachment)
+      .innerJoin(schema.Message, eq(schema.Message.id, schema.Attachment.entityId))
+      .innerJoin(schema.Thread, eq(schema.Thread.id, schema.Message.threadId))
+      .where(
+        and(
+          eq(schema.Attachment.id, attachmentId),
+          eq(schema.Attachment.organizationId, chat.organizationId),
+          eq(schema.Attachment.entityType, 'MESSAGE'),
+          eq(schema.Thread.integrationId, chat.channelId),
+          sql`(${schema.Thread.metadata}->>'visitorParticipantId') = ${chat.visitorParticipantId}`
+        )
+      )
+      .limit(1)
+
+    if (!hit) {
+      return c.json(
+        { success: false, error: { code: 'NOT_FOUND', message: 'Attachment not found' } },
+        404
+      )
+    }
+
+    // Visitor uploads have no User id — pass `undefined` for userId.
+    const attachmentService = new AttachmentService(chat.organizationId, undefined)
+    let url: string
+    try {
+      url = await attachmentService.getDownloadUrl(attachmentId)
+    } catch {
+      return c.json(
+        { success: false, error: { code: 'NOT_FOUND', message: 'Attachment not found' } },
+        404
+      )
+    }
+
+    // 1h TTL — long enough that paint + clicks succeed without a refetch,
+    // short enough to limit damage if a URL leaks.
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    return c.json({ success: true, data: { url, expiresAt } })
+  } catch (error) {
+    log.error('Failed to resolve chat attachment URL', {
+      channelId: chat.channelId,
+      attachmentId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return c.json(
+      { success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to resolve URL' } },
       500
     )
   }

--- a/apps/api/src/routes/chat/initialize.ts
+++ b/apps/api/src/routes/chat/initialize.ts
@@ -7,12 +7,16 @@ import { initializeOrResumeChatThread, publishVisitorThreadCreated } from '@auxx
 import { publisher } from '@auxx/lib/events'
 import { getRealtimeService, publishThreadCreated } from '@auxx/lib/realtime'
 import { createScopedLogger } from '@auxx/logger'
-import { asc, eq } from 'drizzle-orm'
+import { desc, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { parseIdentifyPayload } from './identify'
-import { applyChatCorsHeaders, loadThreadEvents } from './lib'
+import { applyChatCorsHeaders, loadChatAttachmentsForMessages, loadThreadEvents } from './lib'
 
 const log = createScopedLogger('chat-initialize-route')
+
+/** Most recent page of messages returned on initialize. Older pages load via
+ * `GET /api/chat/threads/:threadId/messages?cursor=…` as the visitor scrolls. */
+const INITIAL_MESSAGE_PAGE = 50
 
 const initializeRoute = new Hono()
 
@@ -109,8 +113,9 @@ initializeRoute.post('/', async (c) => {
       ])
     }
 
-    // Load existing messages on resume so the widget can rehydrate.
-    const rows = isNew
+    // Load the most recent page of messages on resume so the widget can
+    // rehydrate. Older messages page in via `getHistory` on scroll.
+    const recentRows = isNew
       ? []
       : await database
           .select({
@@ -124,16 +129,34 @@ initializeRoute.post('/', async (c) => {
           })
           .from(schema.Message)
           .where(eq(schema.Message.threadId, thread.id))
-          .orderBy(asc(schema.Message.sentAt))
+          .orderBy(desc(schema.Message.sentAt))
+          .limit(INITIAL_MESSAGE_PAGE)
 
-    const messages = rows.map((m) => ({
-      id: m.id,
-      threadId: m.threadId,
-      content: m.textPlain ?? m.textHtml ?? '',
-      sender: m.isInbound ? 'USER' : 'AGENT',
-      createdAt: m.sentAt ?? m.createdAt,
-      status: 'DELIVERED',
-    }))
+    // Flip back to chronological for render. The widget appends bubbles top-
+    // to-bottom; reversing in JS keeps the SQL plan simple (uses the existing
+    // sentAt desc index).
+    const rows = recentRows.slice().reverse()
+
+    const attachmentsByMessage =
+      rows.length > 0
+        ? await loadChatAttachmentsForMessages(
+            chat.organizationId,
+            rows.map((r) => r.id)
+          )
+        : new Map()
+
+    const messages = rows.map((m) => {
+      const attachments = attachmentsByMessage.get(m.id)
+      return {
+        id: m.id,
+        threadId: m.threadId,
+        content: m.textPlain ?? m.textHtml ?? '',
+        sender: m.isInbound ? 'USER' : 'AGENT',
+        createdAt: m.sentAt ?? m.createdAt,
+        status: 'DELIVERED',
+        ...(attachments?.length ? { attachments } : {}),
+      }
+    })
 
     // Hydrate thread lifecycle events so the widget can render centered
     // system lines (taken_over / returned_to_ai / archived / reopened / …)
@@ -174,6 +197,14 @@ initializeRoute.post('/', async (c) => {
       }
     }
 
+    // `recentRows` has the newest page in descending order; if we filled the
+    // page, expose the oldest entry's timestamp as the cursor so the widget
+    // can request older messages on scroll up.
+    const nextCursor =
+      recentRows.length === INITIAL_MESSAGE_PAGE
+        ? (recentRows[recentRows.length - 1]?.sentAt?.toISOString() ?? null)
+        : null
+
     return c.json({
       success: true,
       data: {
@@ -181,6 +212,7 @@ initializeRoute.post('/', async (c) => {
         visitorId: chat.sessionId,
         isNewSession: isNew,
         messages,
+        nextCursor,
         threadEvents,
         pusherChannel: `chat-${visitorChatSessionId}`,
         threadPusherChannel: `private-thread-${thread.id}`,

--- a/apps/api/src/routes/chat/lib.ts
+++ b/apps/api/src/routes/chat/lib.ts
@@ -2,6 +2,7 @@
 
 import { database, schema } from '@auxx/database'
 import { getCachedAgentById, getCachedOrgProfile } from '@auxx/lib/cache'
+import type { ChatAttachment } from '@auxx/lib/chat'
 import { listOnDutyUserIds } from '@auxx/lib/chat-duty'
 import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import type { Context } from 'hono'
@@ -69,6 +70,64 @@ export async function loadThreadEvents(
     createdAt: r.createdAt,
     data: (r.data ?? {}) as Record<string, unknown>,
   }))
+}
+
+/**
+ * Load non-inline attachment metadata for a batch of message ids, grouped by
+ * message. Returns metadata only — no presigned URLs. The widget resolves URLs
+ * lazily via `GET /api/chat/attachments/:attachmentId/url` per attachment.
+ *
+ * `role = 'ATTACHMENT'` filter keeps cid-referenced inline images out of the
+ * bubble (those are handled separately by the email path).
+ *
+ * Joins both `MediaAsset` and `FolderFile` because agent-side picks from the
+ * file manager produce `Attachment.fileId` rows, while fresh uploads produce
+ * `Attachment.assetId` rows. The widget treats the returned `id` as opaque —
+ * it's actually `Attachment.id` so the URL endpoint can resolve either backing.
+ */
+export async function loadChatAttachmentsForMessages(
+  organizationId: string,
+  messageIds: string[]
+): Promise<Map<string, ChatAttachment[]>> {
+  if (messageIds.length === 0) return new Map()
+
+  const rows = await database
+    .select({
+      messageId: schema.Attachment.entityId,
+      id: schema.Attachment.id,
+      assetName: schema.MediaAsset.name,
+      assetMimeType: schema.MediaAsset.mimeType,
+      assetSize: schema.MediaAsset.size,
+      fileName: schema.FolderFile.name,
+      fileMimeType: schema.FolderFile.mimeType,
+      fileSize: schema.FolderFile.size,
+      title: schema.Attachment.title,
+    })
+    .from(schema.Attachment)
+    .leftJoin(schema.MediaAsset, eq(schema.MediaAsset.id, schema.Attachment.assetId))
+    .leftJoin(schema.FolderFile, eq(schema.FolderFile.id, schema.Attachment.fileId))
+    .where(
+      and(
+        eq(schema.Attachment.organizationId, organizationId),
+        eq(schema.Attachment.entityType, 'MESSAGE'),
+        inArray(schema.Attachment.entityId, messageIds),
+        eq(schema.Attachment.role, 'ATTACHMENT')
+      )
+    )
+    .orderBy(asc(schema.Attachment.entityId), asc(schema.Attachment.sort))
+
+  const out = new Map<string, ChatAttachment[]>()
+  for (const r of rows) {
+    const list = out.get(r.messageId) ?? []
+    list.push({
+      id: r.id,
+      name: r.title ?? r.assetName ?? r.fileName ?? 'attachment',
+      mimeType: r.assetMimeType ?? r.fileMimeType ?? 'application/octet-stream',
+      size: Number(r.assetSize ?? r.fileSize ?? 0),
+    })
+    out.set(r.messageId, list)
+  }
+  return out
 }
 
 export interface LoadedChatWidget {

--- a/apps/api/src/routes/chat/threads.ts
+++ b/apps/api/src/routes/chat/threads.ts
@@ -8,13 +8,19 @@ import type { ChatThreadMetadata } from '@auxx/lib/threads/types'
 import { createScopedLogger } from '@auxx/logger'
 import { and, asc, desc, eq, isNotNull, lt, or, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
-import { applyChatCorsHeaders, loadChatWidgetByChannelId, loadThreadEvents } from './lib'
+import {
+  applyChatCorsHeaders,
+  loadChatAttachmentsForMessages,
+  loadChatWidgetByChannelId,
+  loadThreadEvents,
+} from './lib'
 
 const log = createScopedLogger('chat-threads-route')
 
 const threadsRoute = new Hono()
 
 const LIST_PAGE_SIZE = 20
+const MESSAGE_PAGE_SIZE = 50
 
 threadsRoute.options('/', (c) => {
   applyChatCorsHeaders(c, { allowCredentials: true })
@@ -221,7 +227,14 @@ threadsRoute.get('/:threadId/messages', async (c) => {
       )
     }
 
-    const rows = await database
+    const cursorParam = c.req.query('cursor') ?? null
+    const cursorDate = cursorParam ? parseHistoryCursor(cursorParam) : null
+    const limitRaw = Number(c.req.query('limit') ?? MESSAGE_PAGE_SIZE)
+    const limit = Number.isFinite(limitRaw)
+      ? Math.max(1, Math.min(100, limitRaw))
+      : MESSAGE_PAGE_SIZE
+
+    const recentRows = await database
       .select({
         id: schema.Message.id,
         threadId: schema.Message.threadId,
@@ -232,23 +245,50 @@ threadsRoute.get('/:threadId/messages', async (c) => {
         createdAt: schema.Message.createdAt,
       })
       .from(schema.Message)
-      .where(eq(schema.Message.threadId, threadId))
-      .orderBy(asc(schema.Message.sentAt))
+      .where(
+        and(
+          eq(schema.Message.threadId, threadId),
+          cursorDate ? lt(schema.Message.sentAt, cursorDate) : undefined
+        )
+      )
+      .orderBy(desc(schema.Message.sentAt))
+      .limit(limit)
 
-    const messages = rows.map((m) => ({
-      id: m.id,
-      threadId: m.threadId,
-      content: m.textPlain ?? m.textHtml ?? '',
-      sender: m.isInbound ? 'USER' : 'AGENT',
-      createdAt: m.sentAt ?? m.createdAt,
-      status: 'DELIVERED',
-    }))
+    // Render chronologically; cursor logic still uses the desc-sorted page.
+    const rows = recentRows.slice().reverse()
+
+    const attachmentsByMessage =
+      rows.length > 0
+        ? await loadChatAttachmentsForMessages(
+            chat.organizationId,
+            rows.map((r) => r.id)
+          )
+        : new Map()
+
+    const messages = rows.map((m) => {
+      const attachments = attachmentsByMessage.get(m.id)
+      return {
+        id: m.id,
+        threadId: m.threadId,
+        content: m.textPlain ?? m.textHtml ?? '',
+        sender: m.isInbound ? 'USER' : 'AGENT',
+        createdAt: m.sentAt ?? m.createdAt,
+        status: 'DELIVERED',
+        ...(attachments?.length ? { attachments } : {}),
+      }
+    })
 
     // Hydrate the thread's lifecycle events so the widget can interleave
-    // centered system lines with the message transcript on reload.
-    const threadEvents = await loadThreadEvents(chat.organizationId, threadId)
+    // centered system lines with the message transcript on reload. Only on
+    // the initial page — older pages reuse what the widget already has.
+    const threadEvents = cursorDate ? [] : await loadThreadEvents(chat.organizationId, threadId)
 
-    return c.json({ success: true, data: { messages, threadEvents, nextCursor: null } })
+    const nextCursor =
+      recentRows.length === limit
+        ? (recentRows[recentRows.length - 1]?.sentAt?.toISOString() ?? null)
+        : null
+
+    return c.json({ success: true, data: { messages, threadEvents, nextCursor } })
   } catch (error) {
     log.error('Failed to load chat history', {
       threadId,
@@ -544,6 +584,11 @@ threadsRoute.post('/:threadId/transcript', async (c) => {
     )
   }
 })
+
+function parseHistoryCursor(cursor: string): Date | null {
+  const d = new Date(cursor)
+  return Number.isNaN(d.getTime()) ? null : d
+}
 
 function parseCursor(cursor: string): { lastMessageAt: Date; id: string } | null {
   const [iso, id] = cursor.split('__')

--- a/apps/chat-widget/src/hooks/use-attachment-url.ts
+++ b/apps/chat-widget/src/hooks/use-attachment-url.ts
@@ -1,0 +1,75 @@
+// apps/chat-widget/src/hooks/use-attachment-url.ts
+//
+// Per-asset URL resolver for chat attachments. Hits
+// `GET /api/chat/attachments/:attachmentId/url` lazily as bubbles render. Module-
+// scoped cache + inflight dedup so the same asset doesn't issue parallel
+// fetches across remounts or duplicate renders.
+//
+// URLs come back with a server-controlled `expiresAt` (1h TTL today). We
+// refresh ~1 minute before that to avoid serving a stale URL that 403s mid-
+// render.
+
+import { useEffect, useState } from 'preact/hooks'
+import { chatApi } from '~/transport/chat-api'
+
+interface CacheEntry {
+  url: string
+  expiresAt: number
+}
+
+const cache = new Map<string, CacheEntry>()
+const inflight = new Map<string, Promise<string>>()
+
+export interface AttachmentUrlState {
+  url: string | null
+  loading: boolean
+  error: boolean
+}
+
+export function useAttachmentUrl(channelId: string, attachmentId: string): AttachmentUrlState {
+  const [state, setState] = useState<AttachmentUrlState>(() => {
+    const cached = cache.get(attachmentId)
+    if (cached && cached.expiresAt > Date.now() + 60_000) {
+      return { url: cached.url, loading: false, error: false }
+    }
+    return { url: null, loading: true, error: false }
+  })
+
+  useEffect(() => {
+    const cached = cache.get(attachmentId)
+    if (cached && cached.expiresAt > Date.now() + 60_000) {
+      if (state.url !== cached.url) setState({ url: cached.url, loading: false, error: false })
+      return
+    }
+
+    let cancelled = false
+    let promise = inflight.get(attachmentId)
+    if (!promise) {
+      promise = chatApi(channelId)
+        .getAttachmentUrl(attachmentId)
+        .then(({ url, expiresAt }) => {
+          cache.set(attachmentId, { url, expiresAt: new Date(expiresAt).getTime() })
+          inflight.delete(attachmentId)
+          return url
+        })
+        .catch((err) => {
+          inflight.delete(attachmentId)
+          throw err
+        })
+      inflight.set(attachmentId, promise)
+    }
+    promise
+      .then((url) => {
+        if (!cancelled) setState({ url, loading: false, error: false })
+      })
+      .catch(() => {
+        if (!cancelled) setState({ url: null, loading: false, error: true })
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [channelId, attachmentId])
+
+  return state
+}

--- a/apps/chat-widget/src/transport/chat-api.ts
+++ b/apps/chat-widget/src/transport/chat-api.ts
@@ -3,6 +3,23 @@
 import { authedFetch } from './api-client'
 import type { ThreadEvent } from './thread-events'
 
+/**
+ * Per-attachment metadata shipped from the API and on Pusher frames. Never
+ * carries a presigned URL — the widget resolves URLs lazily via
+ * `getAttachmentUrl(attachmentId)` as bubbles render.
+ *
+ * `objectUrl` is widget-local: set on optimistic sends from a
+ * `URL.createObjectURL(file)` and skipped on reconcile when the server payload
+ * arrives. Revoke it on unmount.
+ */
+export interface ChatAttachment {
+  id: string
+  name: string
+  mimeType: string
+  size: number
+  objectUrl?: string
+}
+
 export interface ChatMessage {
   id: string
   content: string
@@ -10,6 +27,7 @@ export interface ChatMessage {
   createdAt: string
   status?: string
   agent?: { id?: string; name?: string; image?: string | null }
+  attachments?: ChatAttachment[]
 }
 
 export interface InitializeResponse {
@@ -18,6 +36,8 @@ export interface InitializeResponse {
   visitorId: string
   isNewSession: boolean
   messages: ChatMessage[]
+  /** Cursor for fetching older messages via `getHistory`. Null = no more. */
+  nextCursor: string | null
   /** Persisted thread lifecycle events (taken_over / archived / …). */
   threadEvents: ThreadEvent[]
   pusherChannel: string
@@ -62,6 +82,7 @@ export function chatApi(channelId: string) {
       threadId: string
       content: string
       clientMessageId?: string
+      attachmentIds?: string[]
     }) => {
       const { threadId, ...rest } = body
       return authedFetch<{ messageId: string; status: string; createdAt: string }>(
@@ -71,15 +92,30 @@ export function chatApi(channelId: string) {
       )
     },
 
-    getHistory: (threadId: string, sessionId: string) =>
-      authedFetch<{
+    getAttachmentUrl: (attachmentId: string) =>
+      authedFetch<{ url: string; expiresAt: string }>(
+        channelId,
+        `/api/chat/attachments/${attachmentId}/url`,
+        { method: 'GET' }
+      ),
+
+    getHistory: (
+      threadId: string,
+      sessionId: string,
+      opts: { cursor?: string | null; limit?: number } = {}
+    ) => {
+      const query: Record<string, string> = { sessionId }
+      if (opts.cursor) query.cursor = opts.cursor
+      if (opts.limit) query.limit = String(opts.limit)
+      return authedFetch<{
         messages: ChatMessage[]
         threadEvents: ThreadEvent[]
         nextCursor: string | null
       }>(channelId, `/api/chat/threads/${threadId}/messages`, {
         method: 'GET',
-        query: { sessionId },
-      }),
+        query,
+      })
+    },
 
     setTyping: (sessionId: string, isTyping: boolean) =>
       authedFetch<Record<string, never>>(channelId, '/api/chat/typing', {

--- a/apps/chat-widget/src/views/conversation/attachment-list.tsx
+++ b/apps/chat-widget/src/views/conversation/attachment-list.tsx
@@ -1,0 +1,155 @@
+// apps/chat-widget/src/views/conversation/attachment-list.tsx
+//
+// Renders the attachment chips / image previews under a chat bubble. Each
+// attachment carries metadata only; the download URL is resolved on render via
+// `useAttachmentUrl`. Optimistic sends pass `objectUrl` so the visitor's own
+// image previews instantly without a round trip.
+
+import { File as FileIcon, FileImage, FileText, FileVideo } from 'lucide-react'
+import { useAttachmentUrl } from '~/hooks/use-attachment-url'
+import { cn } from '~/lib/cn'
+import type { ChatAttachment } from '~/transport/chat-api'
+
+interface AttachmentListProps {
+  channelId: string
+  items: ChatAttachment[]
+  isUser: boolean
+}
+
+export function AttachmentList({ channelId, items, isUser }: AttachmentListProps) {
+  if (items.length === 0) return null
+  const images = items.filter((a) => isImage(a.mimeType))
+  const files = items.filter((a) => !isImage(a.mimeType))
+  return (
+    <div className='mt-1 flex flex-col gap-1.5'>
+      {images.length > 0 ? (
+        <div className='flex flex-wrap gap-1.5'>
+          {images.map((a) => (
+            <AttachmentImage key={a.id} channelId={channelId} attachment={a} />
+          ))}
+        </div>
+      ) : null}
+      {files.length > 0 ? (
+        <div className='flex flex-col gap-1.5'>
+          {files.map((a) => (
+            <AttachmentChip key={a.id} channelId={channelId} attachment={a} isUser={isUser} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function AttachmentImage({
+  channelId,
+  attachment,
+}: {
+  channelId: string
+  attachment: ChatAttachment
+}) {
+  const { url, loading, error } = useAttachmentUrl(channelId, attachment.id)
+  const effectiveUrl = attachment.objectUrl ?? url
+  if (effectiveUrl) {
+    return (
+      <a
+        href={effectiveUrl}
+        target='_blank'
+        rel='noopener noreferrer'
+        className='block overflow-hidden rounded-md'>
+        <img
+          src={effectiveUrl}
+          alt={attachment.name}
+          className='max-h-[200px] max-w-[200px] rounded-md object-cover'
+        />
+      </a>
+    )
+  }
+  if (error) {
+    return (
+      <div className='rounded-md border border-destructive/40 bg-background/20 px-2 py-1 text-[11px]'>
+        Couldn’t load image — refresh to retry.
+      </div>
+    )
+  }
+  return (
+    <div
+      className={cn('h-[120px] w-[160px] rounded-md bg-muted', loading ? 'animate-pulse' : '')}
+      aria-label={`Loading ${attachment.name}`}
+    />
+  )
+}
+
+function AttachmentChip({
+  channelId,
+  attachment,
+  isUser,
+}: {
+  channelId: string
+  attachment: ChatAttachment
+  isUser: boolean
+}) {
+  const { url, loading, error } = useAttachmentUrl(channelId, attachment.id)
+  const effectiveUrl = attachment.objectUrl ?? url
+  const Icon = iconForMime(attachment.mimeType)
+
+  const body = (
+    <>
+      <Icon className='size-4 shrink-0' aria-hidden='true' />
+      <div className='flex min-w-0 flex-col text-left'>
+        <span className='truncate text-xs font-medium'>{attachment.name}</span>
+        <span className='text-[10px] opacity-70'>
+          {formatBytes(attachment.size)}
+          {error ? ' · couldn’t load' : loading && !effectiveUrl ? ' · loading…' : ''}
+        </span>
+      </div>
+    </>
+  )
+
+  const classes = cn(
+    'flex max-w-[260px] items-center gap-2 rounded-md px-2 py-1.5 transition-colors',
+    isUser
+      ? 'bg-background/15 text-current hover:bg-background/25'
+      : 'bg-background text-foreground hover:bg-muted'
+  )
+
+  if (!effectiveUrl) {
+    return (
+      <div className={cn(classes, 'cursor-default opacity-80')} aria-busy={loading}>
+        {body}
+      </div>
+    )
+  }
+  return (
+    <a
+      href={effectiveUrl}
+      target='_blank'
+      rel='noopener noreferrer'
+      download={attachment.name}
+      className={classes}>
+      {body}
+    </a>
+  )
+}
+
+function isImage(mimeType: string): boolean {
+  return mimeType.startsWith('image/')
+}
+
+function iconForMime(mimeType: string) {
+  if (mimeType.startsWith('image/')) return FileImage
+  if (mimeType.startsWith('video/')) return FileVideo
+  if (mimeType.startsWith('text/') || mimeType === 'application/pdf') return FileText
+  return FileIcon
+}
+
+function formatBytes(size: number): string {
+  if (!Number.isFinite(size) || size <= 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  let i = 0
+  let n = size
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024
+    i += 1
+  }
+  return `${n < 10 && i > 0 ? n.toFixed(1) : Math.round(n)} ${units[i]}`
+}

--- a/apps/chat-widget/src/views/conversation/bubble.tsx
+++ b/apps/chat-widget/src/views/conversation/bubble.tsx
@@ -12,6 +12,7 @@ import { User } from 'lucide-react'
 import type { ComponentChildren } from 'preact'
 import { cn } from '~/lib/cn'
 import type { ChatMessage } from '~/transport/chat-api'
+import { AttachmentList } from './attachment-list'
 
 export type BubbleSender = 'USER' | 'AGENT' | 'SYSTEM'
 
@@ -36,9 +37,11 @@ interface BubbleProps {
   group?: MessageGroup
   /** Single-pill body for synthetic bubbles when neither `group` nor `typing`. */
   children?: ComponentChildren
+  /** Channel id, needed to resolve attachment URLs lazily per message. */
+  channelId?: string
 }
 
-export function Bubble({ sender, avatar, typing, group, children }: BubbleProps) {
+export function Bubble({ sender, avatar, typing, group, children, channelId }: BubbleProps) {
   const effectiveSender: BubbleSender = sender ?? group?.sender ?? 'AGENT'
   const isUser = effectiveSender === 'USER'
   const isSystem = effectiveSender === 'SYSTEM'
@@ -61,11 +64,20 @@ export function Bubble({ sender, avatar, typing, group, children }: BubbleProps)
             <TypingDots />
           </div>
         ) : group ? (
-          group.messages.map((m, i) => (
-            <div key={m.id} className={pillClass(isUser, i === 0, i === group.messages.length - 1)}>
-              {m.content}
-            </div>
-          ))
+          group.messages.map((m, i) => {
+            const hasAttachments = m.attachments && m.attachments.length > 0
+            const hasContent = m.content && m.content.length > 0
+            return (
+              <div
+                key={m.id}
+                className={pillClass(isUser, i === 0, i === group.messages.length - 1)}>
+                {hasContent ? <div>{m.content}</div> : null}
+                {hasAttachments && channelId ? (
+                  <AttachmentList channelId={channelId} items={m.attachments!} isUser={isUser} />
+                ) : null}
+              </div>
+            )
+          })
         ) : (
           <div className={pillClass(isUser, true, true)}>{children}</div>
         )}

--- a/apps/chat-widget/src/views/conversation/composer/attach-button.tsx
+++ b/apps/chat-widget/src/views/conversation/composer/attach-button.tsx
@@ -24,6 +24,8 @@ export interface InflightAttachment {
   type: string
   /** Asset id once the upload settles. */
   assetId?: string
+  /** Local blob URL for instant image preview pre-upload. Caller revokes. */
+  objectUrl?: string
   error?: string
 }
 
@@ -46,6 +48,7 @@ export function AttachButton({ channelId, inflight, onChange, disabled }: Attach
         name: f.name,
         size: f.size,
         type: f.type,
+        objectUrl: f.type.startsWith('image/') ? URL.createObjectURL(f) : undefined,
       }))
       const start = [...inflight, ...additions]
       onChange(start)

--- a/apps/chat-widget/src/views/conversation/composer/composer.tsx
+++ b/apps/chat-widget/src/views/conversation/composer/composer.tsx
@@ -14,6 +14,12 @@ import { SendButton } from './send-button'
 export interface ComposerSendArgs {
   content: string
   attachmentIds: string[]
+  /**
+   * Inflight attachment metadata for the uploaded ids, in send order. Lets
+   * the caller render an optimistic bubble (chip + image preview) without
+   * waiting for a server payload to reconcile.
+   */
+  inflight: InflightAttachment[]
 }
 
 interface ComposerProps {
@@ -30,7 +36,8 @@ export function Composer({ channelId, onSend, disabled, placeholder }: ComposerP
   const [dragOver, setDragOver] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
-  const uploaded = attachments.filter((a) => a.assetId).map((a) => a.assetId!) as string[]
+  const uploadedInflight = attachments.filter((a) => a.assetId && !a.error)
+  const uploaded = uploadedInflight.map((a) => a.assetId!) as string[]
   const hasInflight = attachments.some((a) => !a.assetId && !a.error)
   const canSend = !sending && !hasInflight && (value.trim().length > 0 || uploaded.length > 0)
 
@@ -38,13 +45,20 @@ export function Composer({ channelId, onSend, disabled, placeholder }: ComposerP
     if (!canSend) return
     setSending(true)
     try {
-      await onSend({ content: value.trim(), attachmentIds: uploaded })
+      await onSend({
+        content: value.trim(),
+        attachmentIds: uploaded,
+        inflight: uploadedInflight,
+      })
       setValue('')
+      // Don't revoke objectUrls here — ownership transfers to the caller via
+      // `inflight`. The conversation view tracks them and revokes on Pusher
+      // reconcile or unmount.
       setAttachments([])
     } finally {
       setSending(false)
     }
-  }, [canSend, onSend, uploaded, value])
+  }, [canSend, onSend, uploaded, uploadedInflight, value])
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -79,7 +93,17 @@ export function Composer({ channelId, onSend, disabled, placeholder }: ComposerP
   )
 
   const handleRemoveAttachment = useCallback((localId: string) => {
-    setAttachments((prev) => prev.filter((a) => a.localId !== localId))
+    setAttachments((prev) => {
+      const removed = prev.find((a) => a.localId === localId)
+      if (removed?.objectUrl) {
+        try {
+          URL.revokeObjectURL(removed.objectUrl)
+        } catch {
+          /* ignore */
+        }
+      }
+      return prev.filter((a) => a.localId !== localId)
+    })
   }, [])
 
   // Drag-and-drop handoff to AttachButton's upload pipeline.
@@ -147,6 +171,7 @@ async function uploadFiles(
     name: f.name,
     size: f.size,
     type: f.type,
+    objectUrl: f.type.startsWith('image/') ? URL.createObjectURL(f) : undefined,
   }))
   const start = [...current, ...additions]
   setState(start)

--- a/apps/chat-widget/src/views/conversation/conversation-view.tsx
+++ b/apps/chat-widget/src/views/conversation/conversation-view.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { getStoredIdentify, type IdentifyPayload, onIdentify } from '~/identify'
 import { dismissPrivacyBanner, isPrivacyBannerDismissed } from '~/persistence/privacy-banner'
 import { markThreadRead } from '~/persistence/unread'
-import { type ChatMessage, chatApi } from '~/transport/chat-api'
+import { type ChatAttachment, type ChatMessage, chatApi } from '~/transport/chat-api'
 import type { ChatConfig } from '~/transport/config'
 import { connectPrivatePusher, connectPusher } from '~/transport/pusher'
 import {
@@ -48,10 +48,29 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
     getStoredIdentify(channelId)
   )
   const bodyRef = useRef<HTMLDivElement | null>(null)
+  // Track every `URL.createObjectURL(...)` we hand off as an optimistic
+  // preview so we can revoke them on Pusher reconcile or widget unmount. A
+  // missed revoke leaks memory per send.
+  const objectUrlsRef = useRef<Set<string>>(new Set())
 
   // Pick up later identify() calls so the welcome bubble's `visitor:*`
   // placeholders refresh in place.
   useEffect(() => onIdentify(setIdentify), [])
+
+  // Revoke any outstanding optimistic blob URLs on unmount.
+  useEffect(
+    () => () => {
+      for (const url of objectUrlsRef.current) {
+        try {
+          URL.revokeObjectURL(url)
+        } catch {
+          /* ignore */
+        }
+      }
+      objectUrlsRef.current.clear()
+    },
+    []
+  )
 
   // Bootstrap: call initialize so we always have a sessionId + pusherChannel
   // matched to the visitor's current passport. The endpoint resumes when a
@@ -115,10 +134,35 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
       content: string
       sender: string
       createdAt: string
+      clientMessageId?: string
+      attachments?: ChatAttachment[]
     }) => {
       if (data.threadId !== threadId) return
       setMessages((prev) => {
-        if (prev.some((m) => m.id === data.id)) return prev
+        // Match against either the server id (echo on a second tab) or the
+        // optimistic clientMessageId (own send round-tripping back). Merge
+        // server attachments onto the optimistic entry rather than replacing,
+        // so the local objectUrl previews don't flash. Once the merge lands
+        // we revoke the optimistic blob URLs — we know the server payload
+        // is now driving the render.
+        const idx = prev.findIndex(
+          (m) => m.id === data.id || (data.clientMessageId && m.id === data.clientMessageId)
+        )
+        if (idx >= 0) {
+          const existing = prev[idx]!
+          const mergedAttachments = mergeAttachments(existing.attachments, data.attachments)
+          revokeOptimisticUrls(existing.attachments, objectUrlsRef.current)
+          const next = prev.slice()
+          next[idx] = {
+            ...existing,
+            id: data.id,
+            content: data.content || existing.content,
+            createdAt: data.createdAt || existing.createdAt,
+            status: 'delivered',
+            ...(mergedAttachments ? { attachments: mergedAttachments } : {}),
+          }
+          return next
+        }
         return [
           ...prev,
           {
@@ -126,6 +170,7 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
             content: data.content,
             sender: (data.sender as ChatMessage['sender']) ?? 'AGENT',
             createdAt: data.createdAt,
+            ...(data.attachments?.length ? { attachments: data.attachments } : {}),
           },
         ]
       })
@@ -204,15 +249,31 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
   }, [messages.length, threadEvents.length])
 
   const handleSend = useCallback(
-    async ({ content, attachmentIds }: ComposerSendArgs) => {
+    async ({ content, attachmentIds, inflight }: ComposerSendArgs) => {
       if (!init) return
       const clientMessageId = `c-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      const optimisticAttachments: ChatAttachment[] | undefined =
+        inflight && inflight.length > 0
+          ? inflight
+              .filter((a) => a.assetId)
+              .map((a) => {
+                if (a.objectUrl) objectUrlsRef.current.add(a.objectUrl)
+                return {
+                  id: a.assetId!,
+                  name: a.name,
+                  mimeType: a.type,
+                  size: a.size,
+                  ...(a.objectUrl ? { objectUrl: a.objectUrl } : {}),
+                }
+              })
+          : undefined
       const optimistic: ChatMessage = {
         id: clientMessageId,
         content,
         sender: 'USER',
         createdAt: new Date().toISOString(),
         status: 'sending',
+        ...(optimisticAttachments?.length ? { attachments: optimisticAttachments } : {}),
       }
       setMessages((prev) => [...prev, optimistic])
       try {
@@ -222,7 +283,7 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
           content,
           clientMessageId,
           ...(attachmentIds.length > 0 ? { attachmentIds } : {}),
-        } as any)
+        })
       } catch (e) {
         setMessages((prev) =>
           prev.map((m) => (m.id === clientMessageId ? { ...m, status: 'error' } : m))
@@ -257,7 +318,7 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
           item.kind === 'event' ? (
             <SystemLine key={`e-${item.event.id}`} event={item.event} />
           ) : (
-            <Bubble key={`g-${i}`} group={item.group} />
+            <Bubble key={`g-${i}`} group={item.group} channelId={channelId} />
           )
         )}
       </div>
@@ -276,7 +337,7 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
             {init && messages.length === 0 ? (
               <SuggestedReplies
                 replies={config.suggestedReplies ?? []}
-                onSelect={(text) => handleSend({ content: text, attachmentIds: [] })}
+                onSelect={(text) => handleSend({ content: text, attachmentIds: [], inflight: [] })}
               />
             ) : null}
             <Composer channelId={channelId} onSend={handleSend} />
@@ -309,6 +370,54 @@ function OfflineNotice({ message }: { message: string | null }) {
       {text}
     </div>
   )
+}
+
+/**
+ * Merge attachments from a server payload onto an existing optimistic entry.
+ * The server is canonical for ids/order; optimistic entries only contribute
+ * `objectUrl` so the visitor doesn't see a flash on reconcile.
+ *
+ * Optimistic ids are MediaAsset ids (from the upload POST response); server
+ * ids are Attachment ids, so id-based matching fails on reconcile. When
+ * counts match, fall back to position-based zipping — the visitor sends in
+ * the order they picked, server preserves it via `Attachment.sort`.
+ */
+function mergeAttachments(
+  optimistic: ChatAttachment[] | undefined,
+  server: ChatAttachment[] | undefined
+): ChatAttachment[] | undefined {
+  if (!server || server.length === 0)
+    return optimistic && optimistic.length > 0 ? optimistic : undefined
+  if (!optimistic || optimistic.length === 0) return server
+  if (optimistic.length === server.length) {
+    return server.map((s, i) => {
+      const o = optimistic[i]
+      return o?.objectUrl ? { ...s, objectUrl: o.objectUrl } : s
+    })
+  }
+  const byId = new Map(optimistic.map((a) => [a.id, a]))
+  return server.map((s) => {
+    const o = byId.get(s.id)
+    return o?.objectUrl ? { ...s, objectUrl: o.objectUrl } : s
+  })
+}
+
+/** Revoke any blob URLs we created for the optimistic preview. */
+function revokeOptimisticUrls(
+  attachments: ChatAttachment[] | undefined,
+  tracked: Set<string>
+): void {
+  if (!attachments) return
+  for (const a of attachments) {
+    if (a.objectUrl && tracked.has(a.objectUrl)) {
+      try {
+        URL.revokeObjectURL(a.objectUrl)
+      } catch {
+        /* ignore */
+      }
+      tracked.delete(a.objectUrl)
+    }
+  }
 }
 
 type TimelineItem =

--- a/apps/web/src/components/mail/chat-composer/index.tsx
+++ b/apps/web/src/components/mail/chat-composer/index.tsx
@@ -67,7 +67,7 @@ function ChatComposerInner({
   const [attachments, setAttachments] = useState<FileAttachment[]>([])
 
   const tempEntityId = useMemo(
-    () => `chat-message-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+    () => `temp-message-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
     []
   )
   const fileSelect = useFileSelect({

--- a/apps/web/src/components/mail/chat-message-display.tsx
+++ b/apps/web/src/components/mail/chat-message-display.tsx
@@ -1,7 +1,6 @@
 // apps/web/src/components/mail/chat-message-display.tsx
 'use client'
 
-import { formatVisitorLabel } from '@auxx/lib/chat/labels'
 import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -17,8 +16,9 @@ import { cn } from '@auxx/ui/lib/utils'
 import { formatDistanceToNow } from 'date-fns'
 import { Check, CheckCheck, CopyPlusIcon, EllipsisVertical, Mail, Trash } from 'lucide-react'
 import { useMessage, useMessageParticipants, useThreadReadStatus } from '~/components/threads/hooks'
-import type { MessageMeta } from '~/components/threads/store'
+import type { AttachmentMeta, MessageMeta } from '~/components/threads/store'
 import { ContactHoverCard } from '../contacts/contact-hover-card'
+import { AttachmentDisplay } from '../files/utils/attachment-display'
 import { Tooltip } from '../global/tooltip'
 import type { EmailActions } from './email-actions'
 import { SendStatusIndicator } from './send-status-indicator'
@@ -68,17 +68,12 @@ const ChatMessageDisplay = ({
   if (!message) return null
 
   const isInbound = message.isInbound
-  const senderName = (() => {
-    if (!sender) return 'Unknown'
-    if (sender.displayName) return sender.displayName
-    if (sender.name) return sender.name
-    if (sender.identifierType === 'CHAT_VISITOR') return formatVisitorLabel(sender.identifier)
-    return sender.identifier || 'Unknown'
-  })()
+  const senderName = sender?.displayName ?? 'Unknown'
   const senderInitials = sender?.initials ?? senderName.charAt(0).toUpperCase()
   const contactId = sender?.entityInstanceId
   const content = message.textPlain ?? message.snippet ?? ''
   const isSending = !!message.sendStatus && message.sendStatus !== 'SENT'
+  const nonInlineAttachments = (message.attachments ?? []).filter((a) => !a.inline)
 
   const isGrouped = groupPosition !== 'solo'
   const isSoloLike = groupPosition === 'solo' || isExpanded
@@ -125,9 +120,22 @@ const ChatMessageDisplay = ({
             topRound ? 'rounded-t-2xl' : 'rounded-t-sm',
             bottomRound ? 'rounded-b-2xl' : 'rounded-b-sm'
           )}>
-          <div className='cursor-text select-text whitespace-pre-wrap break-words font-sans'>
-            {content}
-          </div>
+          {content ? (
+            <div className='cursor-text select-text whitespace-pre-wrap break-words font-sans'>
+              {content}
+            </div>
+          ) : null}
+          {nonInlineAttachments.length > 0 ? (
+            <div className={cn('flex flex-col gap-1.5', content ? 'mt-2' : '')}>
+              {nonInlineAttachments.map((a) => (
+                <AttachmentDisplay
+                  key={a.id}
+                  attachment={toAttachmentInfo(a)}
+                  showRemoveButton={false}
+                />
+              ))}
+            </div>
+          ) : null}
         </div>
         <FloatingDropdown
           message={message}
@@ -210,6 +218,29 @@ function ReceiptIndicator({ message }: { message: MessageMeta }) {
       <span>Sent</span>
     </div>
   )
+}
+
+/**
+ * Bridge from `AttachmentMeta` (the store's display shape, already loaded for
+ * every message) to the `GroupedAttachmentInfo` shape `AttachmentDisplay`
+ * expects. At runtime the component only reads id/name/mimeType/size — the
+ * extra fields are just to satisfy the prop type. We download via
+ * `/api/attachments/{id}/download` like the email path, so no presigned URL
+ * resolution is needed here.
+ */
+function toAttachmentInfo(a: AttachmentMeta) {
+  return {
+    id: a.id,
+    role: 'ATTACHMENT',
+    title: null,
+    sort: 0,
+    createdAt: new Date(),
+    type: 'asset' as const,
+    fileId: a.id,
+    name: a.name,
+    mimeType: a.mimeType,
+    size: a.size != null ? BigInt(a.size) : null,
+  }
 }
 
 function ChatMessageSkeleton() {

--- a/apps/web/src/components/mail/chat-visitor-sidebar.tsx
+++ b/apps/web/src/components/mail/chat-visitor-sidebar.tsx
@@ -1,7 +1,6 @@
 // apps/web/src/components/mail/chat-visitor-sidebar.tsx
 'use client'
 
-import { formatVisitorLabel } from '@auxx/lib/chat/labels'
 import { Separator } from '@auxx/ui/components/separator'
 import { User } from 'lucide-react'
 import { useParticipant } from '~/components/threads/hooks'
@@ -28,21 +27,11 @@ interface ChatThreadMetadata {
  */
 export function ChatVisitorSidebar({ metadata }: { metadata: ChatThreadMetadata }) {
   const visit = metadata.visit ?? {}
-  // Fetch the visitor participant from the store so the sidebar label is derived
-  // from the sticky session identifier (same suffix every other site shows),
-  // not the participant row PK.
   const { participant: visitor } = useParticipant({
     participantId: metadata.visitorParticipantId ?? null,
     enabled: !!metadata.visitorParticipantId,
   })
-  const visitorLabel =
-    visitor?.displayName ??
-    metadata.visitorLabel ??
-    (visitor?.identifier
-      ? formatVisitorLabel(visitor.identifier)
-      : metadata.visitorParticipantId
-        ? formatVisitorLabel(metadata.visitorParticipantId)
-        : null)
+  const visitorLabel = visitor?.displayName ?? metadata.visitorLabel ?? null
   return (
     <aside className='w-64 shrink-0 space-y-3 overflow-y-auto border-l bg-muted/30 p-4 text-xs'>
       <h3 className='flex items-center gap-1.5 text-sm font-semibold'>

--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -151,10 +151,7 @@ export const CompactThreadItem = memo(function CompactThreadItem({
       : ''
   }, [thread?.lastMessageAt])
 
-  const senderName = useMemo(
-    () => senderParticipant?.name || senderParticipant?.identifier || null,
-    [senderParticipant]
-  )
+  const senderName = senderParticipant?.displayName ?? null
 
   const snippet = useMemo(() => {
     if (typeof window !== 'undefined' && latestMessage?.snippet) {

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -1,7 +1,6 @@
 // apps/web/src/components/mail/mail-thread-item.tsx
 'use client'
 
-import { formatVisitorLabel } from '@auxx/lib/chat/labels'
 import { evaluateConditions, normalizeStatusConditions } from '@auxx/lib/conditions/client'
 import type { ActorId } from '@auxx/types/actor'
 import { toRecordId } from '@auxx/types/resource'
@@ -306,15 +305,7 @@ export const MailThreadItem = memo(function MailThreadItem({
       : ''
   }, [thread?.lastMessageAt])
 
-  const senderName = useMemo(() => {
-    if (!senderParticipant) return 'Unknown'
-    if (senderParticipant.displayName) return senderParticipant.displayName
-    if (senderParticipant.name) return senderParticipant.name
-    if (senderParticipant.identifierType === 'CHAT_VISITOR') {
-      return formatVisitorLabel(senderParticipant.identifier)
-    }
-    return senderParticipant.identifier || 'Unknown'
-  }, [senderParticipant])
+  const senderName = senderParticipant?.displayName ?? 'Unknown'
 
   const snippet = useMemo(() => {
     if (typeof window !== 'undefined' && latestMessage?.snippet) {

--- a/apps/web/src/components/mail/participant-display.tsx
+++ b/apps/web/src/components/mail/participant-display.tsx
@@ -1,7 +1,6 @@
 // apps/web/src/components/mail/participant-display.tsx
 'use client'
 
-import { formatVisitorLabel } from '@auxx/lib/chat/labels'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -88,13 +87,7 @@ export const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({
 
   const { identifier, identifierType, name, displayName, entityInstanceId, isInternal } =
     participant
-  // Belt-and-braces for anonymous chat visitors: if displayName/name weren't
-  // backfilled (pre-friendly-label rows), derive the friendly handle from
-  // the sticky session identifier so the FROM never falls back to a raw UUID.
-  const displayLabel =
-    displayName ||
-    name ||
-    (identifierType === 'CHAT_VISITOR' ? formatVisitorLabel(identifier) : identifier)
+  const displayLabel = displayName || identifier
 
   const senderDomain =
     identifierType === 'EMAIL' ? (identifier.split('@')[1] ?? undefined) : undefined

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -154,12 +154,6 @@
       "import": "./dist/chat-widget/visitor.mjs",
       "default": "./src/chat-widget/visitor.ts"
     },
-    "./chat/labels": {
-      "types": "./src/chat/labels.ts",
-      "source": "./src/chat/labels.ts",
-      "import": "./dist/chat/labels.mjs",
-      "default": "./src/chat/labels.ts"
-    },
     "./comments": {
       "types": "./src/comments/index.ts",
       "source": "./src/comments/index.ts",

--- a/packages/lib/src/chat-widget/config.ts
+++ b/packages/lib/src/chat-widget/config.ts
@@ -2,6 +2,7 @@
 
 import { type Database, schema } from '@auxx/database'
 import { desc, eq } from 'drizzle-orm'
+import { onCacheEvent } from '../cache'
 import { getOrgChannelProviderMap } from '../channels/cache'
 import { BadRequestError, ConflictError, databaseErrorCodes, NotFoundError } from '../errors'
 import { InboxService } from '../inboxes/inbox-service'
@@ -199,6 +200,10 @@ export async function updateChatWidget(
     logger.error('Failed to update chat widget', { error, channelId })
     throw error
   }
+
+  // Invalidate the `channels` org cache so ChatProvider.maybeEnqueueAgentRun
+  // and other hot paths pick up the new agentId / name / settings.
+  await onCacheEvent('channel.settings_updated', { orgId: ctx.organizationId })
 
   return Result.nil()
 }

--- a/packages/lib/src/chat/index.ts
+++ b/packages/lib/src/chat/index.ts
@@ -17,5 +17,5 @@ export type {
   InitializeChatThreadResult,
 } from './session'
 export { initializeOrResumeChatThread } from './session'
-export type { ServiceContext, VisitInfo } from './types'
+export type { ChatAttachment, ServiceContext, VisitInfo } from './types'
 export { findOrCreateVisitorParticipant, updateVisitorClaimedIdentity } from './visitor-identity'

--- a/packages/lib/src/chat/realtime.ts
+++ b/packages/lib/src/chat/realtime.ts
@@ -7,6 +7,7 @@ import {
 } from '../realtime/publish-helpers'
 import type { RealtimeService } from '../realtime/realtime-service'
 import { rooms } from '../realtime/rooms'
+import type { ChatAttachment } from './types'
 
 /**
  * Shape of a chat message frame the embedded widget renders. Loose typing —
@@ -21,6 +22,8 @@ export interface ChatVisitorMessagePayload {
   status: 'sending' | 'sent' | 'delivered' | 'read' | 'error'
   clientMessageId?: string
   agent?: { id?: string; name?: string; image?: string }
+  /** Metadata only — no presigned URLs. Widget resolves URLs lazily. */
+  attachments?: ChatAttachment[]
 }
 
 /**

--- a/packages/lib/src/chat/session.ts
+++ b/packages/lib/src/chat/session.ts
@@ -125,12 +125,33 @@ export async function initializeOrResumeChatThread(
       })
     }
 
-    // Try to resume an open thread for this visitor on this channel.
+    // Try to resume an open thread for this visitor on this channel. Use
+    // `Message.fromId` as the linkage rather than scanning the most recent 20
+    // threads and filtering on `Thread.metadata->>visitorParticipantId`:
+    //
+    //   1. Correctness — on a busy public widget, 20 newer threads from other
+    //      visitors mask this visitor's own thread, so we'd silently spawn a
+    //      new one instead of resuming.
+    //   2. Performance — `Message.fromId` is already indexed; this is a
+    //      single indexed lookup vs. fetching 20 rows to keep at most 1.
+    //
+    // Empty-thread edge case: a brand-new thread the visitor hasn't sent into
+    // yet won't match here. That's fine — `resumeThreadId` already handles
+    // explicit reopen above, and a thread with zero messages has nothing to
+    // resume into.
     const candidateThreads = input.forceNewThread
       ? []
       : await ctx.db
-          .select()
+          .selectDistinct({ thread: schema.Thread })
           .from(schema.Thread)
+          .innerJoin(
+            schema.Message,
+            and(
+              eq(schema.Message.threadId, schema.Thread.id),
+              eq(schema.Message.isInbound, true),
+              eq(schema.Message.fromId, visitor.id)
+            )
+          )
           .where(
             and(
               eq(schema.Thread.organizationId, ctx.organizationId),
@@ -139,12 +160,9 @@ export async function initializeOrResumeChatThread(
             )
           )
           .orderBy(desc(schema.Thread.lastMessageAt))
-          .limit(20)
+          .limit(1)
 
-    const resumable = candidateThreads.find((t) => {
-      const meta = (t.metadata ?? {}) as Partial<ChatThreadMetadata>
-      return meta.channel === 'chat' && meta.visitorParticipantId === visitor.id
-    })
+    const resumable = candidateThreads[0]?.thread
 
     if (resumable) {
       // Patch metadata with the latest visit info / claimed identity.

--- a/packages/lib/src/chat/types.ts
+++ b/packages/lib/src/chat/types.ts
@@ -14,3 +14,21 @@ export interface VisitInfo {
   referrer?: string
   url?: string
 }
+
+/**
+ * Per-attachment metadata shipped to the chat widget. Never includes a
+ * presigned URL — the widget resolves URLs lazily via
+ * `GET /api/chat/attachments/:attachmentId/url` so the URL TTL doesn't outlive
+ * a long-lived Pusher payload and we keep frames under the 10KB cap.
+ *
+ * `id` is the `Attachment.id` (not `MediaAsset.id`) — chat attachments can be
+ * either `MediaAsset`-backed (visitor uploads, fresh agent uploads) or
+ * `FolderFile`-backed (agent picks from the file manager). The URL endpoint
+ * resolves either via `AttachmentService.getDownloadUrl`.
+ */
+export interface ChatAttachment {
+  id: string
+  name: string
+  mimeType: string
+  size: number
+}

--- a/packages/lib/src/files/upload/processors/entity-processors.ts
+++ b/packages/lib/src/files/upload/processors/entity-processors.ts
@@ -2,7 +2,7 @@
 import { database as db, schema } from '@auxx/database'
 import type { MediaAsset } from '@auxx/database/types'
 import { and, desc, eq } from 'drizzle-orm'
-import { getOrgCache, isAgentUser } from '../../../cache'
+import { getOrgCache, isAgentUser, onCacheEvent } from '../../../cache'
 import { isAdminOrOwner } from '../../../members/member-queries'
 import { MemberService } from '../../../members/member-service'
 import { ensureThumbnailPresets } from '../../core/thumbnail-batch'
@@ -737,6 +737,7 @@ export class ChatWidgetProcessor extends BaseAttachmentProcessor {
     session: PresignedUploadSession,
     storageLocationId: string
   ): Promise<ProcessorResult> {
+    let logoUpdated = false
     const result = await this.mediaAssetService.getTx(async (tx) => {
       const { assetId, externalUrl } = await this.createAsset(session, storageLocationId, tx)
       await this.createAttachment(assetId, session, tx)
@@ -754,9 +755,15 @@ export class ChatWidgetProcessor extends BaseAttachmentProcessor {
           variant,
           url: externalUrl,
         })
+        logoUpdated = true
       }
       return { assetId, storageLocationId }
     })
+    // Logo lives on the cached ChatWidget row inside `channels`. Bust the
+    // cache so the next read returns the new URL.
+    if (logoUpdated && session.organizationId) {
+      await onCacheEvent('channel.settings_updated', { orgId: session.organizationId })
+    }
     return result
   }
 }

--- a/packages/lib/src/participants/participant-service.ts
+++ b/packages/lib/src/participants/participant-service.ts
@@ -4,6 +4,7 @@ import { type Database, database, schema } from '@auxx/database'
 import type { IdentifierType, ParticipantEntity } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, inArray } from 'drizzle-orm'
+import { formatVisitorLabel } from '../chat/labels'
 import {
   extractRegistrableDomain,
   getOwnDomains,
@@ -57,16 +58,30 @@ export class ParticipantService {
     return ownDomains.has(normalizeDomain(domain))
   }
 
-  /** Calculates display name and initials for a participant. */
+  /**
+   * Calculates display name and initials for a participant.
+   *
+   * For anonymous chat visitors the raw identifier is an opaque session UUID,
+   * so when there's no name we surface the friendly `Chat user #xxxx` handle
+   * instead. This is the single source of truth — every consumer that reads
+   * `ParticipantMeta.displayName` gets the correct label without needing its
+   * own fallback chain.
+   */
   private _calculateDisplayInfo(
     name?: string | null,
-    identifier?: string | null
+    identifier?: string | null,
+    identifierType?: IdentifierType | null
   ): {
     displayName: string
     initials: string
   } {
     const validName = name?.trim()
-    const validIdentifier = identifier?.trim() ?? 'Unknown'
+    const trimmedIdentifier = identifier?.trim()
+    const identifierFallback =
+      identifierType === 'CHAT_VISITOR' && trimmedIdentifier
+        ? formatVisitorLabel(trimmedIdentifier)
+        : (trimmedIdentifier ?? 'Unknown')
+    const validIdentifier = identifierFallback
     const displayName = validName || validIdentifier
     let initials = '?'
     if (validName) {
@@ -114,7 +129,7 @@ export class ParticipantService {
       organizationId: this.organizationId,
     })
     try {
-      const { displayName, initials } = this._calculateDisplayInfo(name, identifier)
+      const { displayName, initials } = this._calculateDisplayInfo(name, identifier, identifierType)
       const isInternal = await this._classifyIsInternal(identifier, identifierType)
       const updateValues: Record<string, unknown> = {
         ...(name !== undefined && { name: name }),
@@ -261,14 +276,21 @@ export class ParticipantService {
 
     const participantMap = new Map(
       participants.map((p) => {
-        const { displayName, initials } = this._calculateDisplayInfo(p.name, p.identifier)
+        // Trust the recomputed values over whatever's persisted: legacy
+        // CHAT_VISITOR rows have the raw session UUID stored in `displayName`,
+        // and `_calculateDisplayInfo` now produces the friendly handle.
+        const { displayName, initials } = this._calculateDisplayInfo(
+          p.name,
+          p.identifier,
+          p.identifierType
+        )
 
         const meta: ParticipantMeta = {
           id: p.id,
           name: p.name,
           identifier: p.identifier,
           identifierType: p.identifierType as ParticipantIdentifierType,
-          displayName: p.displayName || displayName,
+          displayName,
           initials: p.initials || initials,
           avatarUrl: null,
           entityInstanceId: p.entityInstanceId,

--- a/packages/lib/src/providers/chat/chat-provider.ts
+++ b/packages/lib/src/providers/chat/chat-provider.ts
@@ -3,8 +3,10 @@
 import { database as db, schema } from '@auxx/database'
 import { IntegrationProviderType, ThreadStatus } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, inArray, sql } from 'drizzle-orm'
+import { and, asc, eq, inArray, sql } from 'drizzle-orm'
+import { getOrgCache } from '../../cache'
 import { publishChatMessageCreated, publishChatMessageReceiptUpdated } from '../../chat/realtime'
+import type { ChatAttachment } from '../../chat/types'
 import { getRealtimeService } from '../../realtime'
 import { Result, type TypedResult } from '../../result'
 import type { ChatThreadMetadata } from '../../threads/types'
@@ -19,6 +21,47 @@ import {
 import { getProviderCapabilities, type ProviderCapabilities } from '../provider-capabilities'
 
 const logger = createScopedLogger('chat-provider')
+
+/**
+ * Load non-inline attachment metadata for a single agent-sent message before
+ * we publish the realtime frame. Gate the call site on
+ * `Message.hasAttachments` — most replies are text-only.
+ */
+async function loadChatAttachmentsForMessage(
+  organizationId: string,
+  messageId: string
+): Promise<ChatAttachment[]> {
+  const rows = await db
+    .select({
+      id: schema.Attachment.id,
+      title: schema.Attachment.title,
+      assetName: schema.MediaAsset.name,
+      assetMimeType: schema.MediaAsset.mimeType,
+      assetSize: schema.MediaAsset.size,
+      fileName: schema.FolderFile.name,
+      fileMimeType: schema.FolderFile.mimeType,
+      fileSize: schema.FolderFile.size,
+    })
+    .from(schema.Attachment)
+    .leftJoin(schema.MediaAsset, eq(schema.MediaAsset.id, schema.Attachment.assetId))
+    .leftJoin(schema.FolderFile, eq(schema.FolderFile.id, schema.Attachment.fileId))
+    .where(
+      and(
+        eq(schema.Attachment.organizationId, organizationId),
+        eq(schema.Attachment.entityType, 'MESSAGE'),
+        eq(schema.Attachment.entityId, messageId),
+        eq(schema.Attachment.role, 'ATTACHMENT')
+      )
+    )
+    .orderBy(asc(schema.Attachment.sort))
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.title ?? r.assetName ?? r.fileName ?? 'attachment',
+    mimeType: r.assetMimeType ?? r.fileMimeType ?? 'application/octet-stream',
+    size: Number(r.assetSize ?? r.fileSize ?? 0),
+  }))
+}
 
 /**
  * Provider for the embedded chat widget. Handles both directions of a chat:
@@ -81,6 +124,7 @@ export class ChatProvider extends BaseMessageProvider implements MessageProvider
         textHtml: schema.Message.textHtml,
         sentAt: schema.Message.sentAt,
         fromId: schema.Message.fromId,
+        hasAttachments: schema.Message.hasAttachments,
       })
       .from(schema.Message)
       .where(eq(schema.Message.id, internalMessageId))
@@ -121,6 +165,13 @@ export class ChatProvider extends BaseMessageProvider implements MessageProvider
         .onConflictDoNothing()
     }
 
+    // Most agent replies are text-only; only join Attachment when the
+    // composer flipped `hasAttachments`. Phase 5.5 — avoids one query per
+    // reply on the common path.
+    const attachments = message.hasAttachments
+      ? await loadChatAttachmentsForMessage(this.organizationId, message.id)
+      : undefined
+
     await publishChatMessageCreated(getRealtimeService(), {
       organizationId: this.organizationId,
       inboxId: thread.inboxId,
@@ -135,6 +186,7 @@ export class ChatProvider extends BaseMessageProvider implements MessageProvider
         sender: 'AGENT',
         createdAt: message.sentAt ?? new Date(),
         status: 'delivered',
+        ...(attachments?.length ? { attachments } : {}),
       },
     })
 
@@ -171,6 +223,7 @@ export class ChatProvider extends BaseMessageProvider implements MessageProvider
           organizationId: schema.Thread.organizationId,
           integrationId: schema.Thread.integrationId,
           inboxId: schema.Thread.inboxId,
+          handoffState: schema.Thread.handoffState,
         })
         .from(schema.Thread)
         .where(
@@ -252,6 +305,18 @@ export class ChatProvider extends BaseMessageProvider implements MessageProvider
         return { messageRowId: finalId }
       })
 
+      // Load attachment metadata for the realtime payload. The transaction
+      // above already inserted Attachment rows for `params.attachmentIds`;
+      // re-read by joining Attachment → MediaAsset so the publish carries
+      // `Attachment.id` (the opaque id the URL endpoint resolves against).
+      let attachments: ChatAttachment[] | undefined
+      if (params.attachmentIds && params.attachmentIds.length > 0) {
+        const rows = await loadChatAttachmentsForMessage(this.organizationId, messageRowId)
+        if (rows.length > 0) {
+          attachments = rows
+        }
+      }
+
       // Realtime — inbox channel for agents, visitor channel for echo.
       // The inbound sender IS the visitor, so their fromParticipantId is the
       // visitorParticipantId we publish per-visitor updates against.
@@ -270,6 +335,7 @@ export class ChatProvider extends BaseMessageProvider implements MessageProvider
           createdAt: now,
           status: 'delivered',
           clientMessageId: params.clientMessageId,
+          ...(attachments?.length ? { attachments } : {}),
         },
       })
 
@@ -278,6 +344,7 @@ export class ChatProvider extends BaseMessageProvider implements MessageProvider
         threadId: thread.id,
         messageId: messageRowId,
         integrationId,
+        handoffState: thread.handoffState,
       })
 
       return Result.ok({ messageId: messageRowId, threadId: thread.id })
@@ -297,17 +364,14 @@ export class ChatProvider extends BaseMessageProvider implements MessageProvider
     threadId: string
     messageId: string
     integrationId: string
+    /** Read from the same Thread row receiveMessage already loaded. */
+    handoffState: 'ai' | 'human'
   }): Promise<void> {
     try {
       // P4.2 gate — if a human took over this thread, never run the AI agent.
       // This is the earliest point we can short-circuit: before the widget
       // lookup, before any agent-framework work, before any draft/compose.
-      const [thread] = await db
-        .select({ handoffState: schema.Thread.handoffState })
-        .from(schema.Thread)
-        .where(eq(schema.Thread.id, args.threadId))
-        .limit(1)
-      if (thread?.handoffState === 'human') {
+      if (args.handoffState === 'human') {
         logger.debug('Chat thread is in human handoff — skipping agent run', {
           threadId: args.threadId,
           messageId: args.messageId,
@@ -315,19 +379,21 @@ export class ChatProvider extends BaseMessageProvider implements MessageProvider
         return
       }
 
-      const [widget] = await db
-        .select({ agentId: schema.ChatWidget.agentId })
-        .from(schema.ChatWidget)
-        .where(eq(schema.ChatWidget.integrationId, args.integrationId))
-        .limit(1)
-      if (!widget?.agentId) return
+      // Read agentId from the org `channels` cache instead of querying
+      // ChatWidget on every inbound message. The cache already includes the
+      // joined ChatWidget row and is invalidated on channel.connected /
+      // channel.settings_updated / chat-widget edits.
+      const channels = await getOrgCache().get(this.organizationId, 'channels')
+      const channel = channels.find((c) => c.id === args.integrationId)
+      const agentId = channel?.chatWidget?.agentId ?? null
+      if (!agentId) return
 
       // TODO(chat-agent): enqueueAgentJob expects an AgentSession id. The chat
       // → agent run path needs a session creation step (or a chat-specific
       // engine entry point). For phase 4a, leave this as a logged TODO so the
       // unblock work is visible.
       logger.warn('Chat widget has agentId but agent enqueue path not yet wired', {
-        agentId: widget.agentId,
+        agentId,
         threadId: args.threadId,
         messageId: args.messageId,
       })


### PR DESCRIPTION
## Summary
- **Widget attachments end-to-end.** New `GET /api/chat/attachments/:attachmentId/url` returns a 1h presigned URL per attachment, keyed off `Attachment.id` so both `MediaAsset` (visitor upload) and `FolderFile` (agent file-manager pick) backings resolve through `AttachmentService.getDownloadUrl`. Initialize/history responses + Pusher frames carry metadata only (id/name/mimeType/size) so URL TTLs don't outlive long-lived payloads and frames stay under the 10KB cap.
- **Optimistic image previews.** Composer creates a `URL.createObjectURL(file)` blob for image uploads, hands it off to the conversation view via `inflight`, and the view tracks every blob in a ref so reconcile (or unmount) revokes them — no leaks per send. Reconcile matches by id first, falls back to position-based zip (optimistic ids are MediaAsset, server ids are Attachment).
- **Paginated history.** Initialize + `GET /threads/:id/messages` now page at 50 and return a `nextCursor`; previously each reopen loaded the entire thread.
- **Thread resume fix.** Visitor's existing thread is now resumed via an indexed `Message.fromId` join instead of scanning the last 20 threads and filtering on `metadata->>visitorParticipantId` — on a busy widget that filter was getting masked and silently spawning new threads.
- **Chat agent enqueue is cache-backed.** `ChatProvider.maybeEnqueueAgentRun` reads `agentId` from the `channels` org cache instead of querying `ChatWidget` per inbound message; chat-widget edits and logo uploads now publish `channel.settings_updated` so the cache stays fresh.
- **Visitor labels centralized.** `ParticipantService._calculateDisplayInfo` now produces the `Chat user #xxxx` handle for `CHAT_VISITOR` identifiers, so the inbox/sidebar/thread-item components drop their own fallback chains and the `@auxx/lib/chat/labels` subpath export is removed.

## Test plan
- [ ] Visitor sends an image + text from the widget — local preview shows instantly, reconcile after Pusher echo doesn't flash the image, blob URL is revoked.
- [ ] Agent replies with a file-manager pick — bubble renders the attachment, click resolves URL via `/url` endpoint, download works.
- [ ] Reopen a long thread (>50 messages) — initial page renders, scrolling up requests `cursor=…` and prepends older messages.
- [ ] Two visitor sessions on the same widget — neither one resumes the other's thread.
- [ ] Edit chat-widget settings (e.g. change agentId, change name, upload new logo) — next inbound chat picks up the new values without a server restart.
- [ ] Inbox view of a chat thread — sender, sidebar, list item, and participant chip all show `Chat user #xxxx`, never the raw UUID.