### PR TITLE
fix(homepage): paginated mobile logo cloud, hero blur, looping kopilot

### DIFF
--- a/apps/homepage/src/app/_components/logo-cloud.tsx
+++ b/apps/homepage/src/app/_components/logo-cloud.tsx
@@ -42,21 +42,23 @@ const logos: Record<'ai' | 'messages', React.ReactNode[]> = {
 
 type LogoGroup = keyof typeof logos
 
+const mobilePages = (arr: React.ReactNode[]): React.ReactNode[][] => [
+  arr.slice(0, 3),
+  arr.slice(2, 5),
+]
+
 export default function LogoCloudTwo() {
-  const [currentGroup, setCurrentGroup] = useState<LogoGroup>('ai')
+  const [tick, setTick] = useState(0)
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrentGroup((prev) => {
-        const groups = Object.keys(logos) as LogoGroup[]
-        const currentIndex = groups.indexOf(prev)
-        const nextIndex = (currentIndex + 1) % groups.length
-        return groups[nextIndex]
-      })
-    }, 2500)
-
+    const interval = setInterval(() => setTick((t) => t + 1), 2500)
     return () => clearInterval(interval)
   }, [])
+
+  const groupKeys = Object.keys(logos) as LogoGroup[]
+  const currentGroup: LogoGroup = groupKeys[tick % groupKeys.length]
+  const mobilePageIndex = Math.floor(tick / groupKeys.length) % 2
+  const currentMobileLogos = mobilePages(logos[currentGroup])[mobilePageIndex]
 
   return (
     <section className='border-foreground/10 relative overflow-hidden border-b'>
@@ -78,7 +80,24 @@ export default function LogoCloudTwo() {
             </div>
             <div
               aria-hidden='true'
-              className='perspective-dramatic mx-auto grid max-w-5xl grid-cols-3 items-center gap-8 md:h-10 md:grid-cols-5'>
+              className='perspective-dramatic mx-auto grid max-w-5xl grid-cols-3 items-center gap-8 md:hidden'>
+              <AnimatePresence initial={false} mode='popLayout'>
+                {currentMobileLogos.map((logo, i) => (
+                  <motion.div
+                    key={`${currentGroup}-${mobilePageIndex}-${i}`}
+                    className='**:fill-foreground! flex items-center justify-center'
+                    initial={{ opacity: 0, y: 24, filter: 'blur(6px)' }}
+                    animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+                    exit={{ opacity: 0, y: -24, filter: 'blur(6px)', scale: 0.5 }}
+                    transition={{ delay: i * 0.05, duration: 0.4 }}>
+                    {logo}
+                  </motion.div>
+                ))}
+              </AnimatePresence>
+            </div>
+            <div
+              aria-hidden='true'
+              className='perspective-dramatic mx-auto hidden max-w-5xl grid-cols-5 items-center gap-8 md:grid md:h-10'>
               <AnimatePresence initial={false} mode='popLayout'>
                 {logos[currentGroup].map((logo, i) => (
                   <motion.div

--- a/apps/homepage/src/app/_components/sections/hero-section-v2.tsx
+++ b/apps/homepage/src/app/_components/sections/hero-section-v2.tsx
@@ -38,7 +38,7 @@ export default function HeroSectionV2() {
               initial={reduce ? false : { opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, ease: 'easeOut', delay: 0.05 }}
-              className='text-balance text-4xl font-semibold tracking-tight text-foreground lg:text-5xl'>
+              className='text-balance text-4xl font-semibold tracking-tight text-foreground lg:text-5xl backdrop-blur-xs rounded-xl'>
               The AI agent that runs your inbox and CRM.
             </motion.h1>
 
@@ -46,7 +46,7 @@ export default function HeroSectionV2() {
               initial={reduce ? false : { opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, ease: 'easeOut', delay: 0.12 }}
-              className='mt-5 max-w-md text-lg leading-relaxed text-muted-foreground'>
+              className='mt-5 max-w-md text-lg leading-relaxed text-muted-foreground backdrop-blur-xs rounded-xl'>
               Kopilot reads every ticket, drafts the reply, and updates your customer record — so
               you sell, and the agent does the rest.
             </motion.p>

--- a/apps/homepage/src/app/_components/sections/hero-v2/kopilot-mock.tsx
+++ b/apps/homepage/src/app/_components/sections/hero-v2/kopilot-mock.tsx
@@ -69,11 +69,11 @@ const dropIn = (reduce: boolean | null, delay: number, z?: number) => ({
 export function KopilotMock() {
   const reduce = useReducedMotion()
 
-  const float = (delay: number) =>
+  const float = (delay: number, amplitude = 6) =>
     reduce
       ? {}
       : {
-          animate: { y: [0, -6, 0] },
+          animate: { y: [0, -amplitude, 0] },
           transition: { duration: 7, repeat: Infinity, ease: 'easeInOut', delay },
         }
 
@@ -144,32 +144,34 @@ export function KopilotMock() {
           is in true screen-Y (not tilted local-Y). Inside the matching tilt, panel is
           absolutely positioned at the chrome interior offsets. */}
       <motion.div {...dropIn(reduce, 1)} className={cn(STAGE_ANCHOR, 'z-[1]')}>
-        <div className={TILT_STAGE}>
-          <motion.div className={MOCK_CANVAS}>
-            {/* Mirrors the chrome's outer size so the panel can position inside
+        <motion.div {...float(2.4, 24)} className='transform-3d'>
+          <div className={TILT_STAGE}>
+            <motion.div className={MOCK_CANVAS}>
+              {/* Mirrors the chrome's outer size so the panel can position inside
                 its main-page interior. Height matches chrome: header(~50) + 620. */}
-            <div className='relative h-[680px] w-full transform-3d'>
-              {/* Width is calc(100% − sidebar − chrome padding) so the panel fills
+              <div className='relative h-[680px] w-full transform-3d'>
+                {/* Width is calc(100% − sidebar − chrome padding) so the panel fills
                   the main-page area exactly: full chrome interior on mobile (no
                   sidebar), full minus the 220px sidebar on desktop.
                   29 = 8 (chrome p-2 left) + 21 (right offset).
                   249 = 228 (chrome p-2 + sidebar) + 21. */}
-              <div
-                className='absolute top-[180px] left-[8px] bottom-[21px] flex w-[calc(100%_-_29px)] transform-3d md:left-[228px] md:w-[calc(100%_-_320px)]'
-                style={{ transform: 'translateZ(120px)' }}>
-                <div className='flex h-full min-h-0 flex-1 flex-col rounded-2xl shadow-2xl shadow-black/40 transform-3d'>
-                  <MockPanelFrame>
-                    <MockKopilotWindow
-                      script={KOPILOT_HERO_SCRIPT}
-                      composerPlaceholder='Ask Kopilot...'
-                      modelLabel='GPT-5.4 Nano'
-                    />
-                  </MockPanelFrame>
+                <div
+                  className='absolute top-[180px] left-[8px] bottom-[21px] flex w-[calc(100%_-_29px)] transform-3d md:left-[228px] md:w-[calc(100%_-_320px)]'
+                  style={{ transform: 'translateZ(120px)' }}>
+                  <div className='flex h-full min-h-0 flex-1 flex-col rounded-2xl shadow-2xl shadow-black/40 transform-3d backdrop-blur-[2px]'>
+                    <MockPanelFrame>
+                      <MockKopilotWindow
+                        script={KOPILOT_HERO_SCRIPT}
+                        composerPlaceholder='Ask Kopilot...'
+                        modelLabel='GPT-5.4 Nano'
+                      />
+                    </MockPanelFrame>
+                  </div>
                 </div>
               </div>
-            </div>
-          </motion.div>
-        </div>
+            </motion.div>
+          </div>
+        </motion.div>
       </motion.div>
 
       {/* Mid layer — AgentLog. Root-level sibling with its own perspective + tilt + float

--- a/apps/homepage/src/app/globals.css
+++ b/apps/homepage/src/app/globals.css
@@ -429,7 +429,7 @@
   --color-card-foreground: var(--color-zinc-950);
   --color-popover: var(--color-white);
   --color-popover-foreground: var(--color-zinc-950);
-  --color-primary: lab(70% -7.01 -44.82);
+  --color-primary: var(--color-zinc-950);
 
   --color-primary-foreground: var(--color-white);
   --color-secondary: var(--color-sky-100);

--- a/apps/homepage/src/app/platform/ai/_mocks/use-kopilot-story.ts
+++ b/apps/homepage/src/app/platform/ai/_mocks/use-kopilot-story.ts
@@ -11,6 +11,10 @@ export interface KopilotStoryScript {
   turns: ScriptTurn[]
   /** Multiplier on all timings. 1 = realistic, <1 speeds up, >1 slows down. */
   speed?: number
+  /** When true, playback restarts after the last turn settles. */
+  loop?: boolean
+  /** Pause between loops in ms. Defaults to 2500. */
+  loopGapMs?: number
 }
 
 export interface ScriptTurn {
@@ -385,6 +389,8 @@ export function useKopilotStory<T extends Element = HTMLDivElement>(
     let cursor = 0
     let timeoutId: ReturnType<typeof setTimeout> | null = null
 
+    const loopGap = script.loopGapMs ?? 2500
+
     const tick = () => {
       if (cancelled) return
       const ev = events[cursor]
@@ -394,6 +400,13 @@ export function useKopilotStory<T extends Element = HTMLDivElement>(
       const next = events[cursor]
       if (next) {
         timeoutId = setTimeout(tick, next.delay)
+      } else if (script.loop) {
+        timeoutId = setTimeout(() => {
+          if (cancelled) return
+          cursor = 0
+          setState(initialState)
+          timeoutId = setTimeout(tick, events[0]!.delay)
+        }, loopGap)
       }
     }
 

--- a/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-hero-script.ts
+++ b/apps/homepage/src/app/platform/ai/kopilot/_components/kopilot-hero-script.ts
@@ -12,6 +12,8 @@ import type { KopilotStoryScript } from '../../_mocks/use-kopilot-story'
  */
 export const KOPILOT_HERO_SCRIPT: KopilotStoryScript = {
   speed: 1,
+  loop: true,
+  loopGapMs: 3000,
   turns: [
     {
       user: 'Summarize my open tickets',


### PR DESCRIPTION
## Summary
- Mobile logo cloud paginates between groups of 3 instead of cramming all 5 logos into a tight row
- Hero h1/subtitle get a subtle backdrop-blur so they read against the gradient
- Primary color switches to zinc-950 (was a teal-ish `lab()` value)
- Kopilot mock floats vertically and the hero script loops with a 3s gap so the demo keeps playing

## Test plan
- [ ] Homepage hero looks correct on mobile + desktop
- [ ] Logo cloud cycles smoothly between mobile pages
- [ ] Kopilot mock floats and loops without jank