### PR TITLE
feat(chat+drawers): optimistic send refactor, attachment realtime, drawer action registry

### DIFF
--- a/apps/web/src/components/drawers/actions/contact-compose-action.tsx
+++ b/apps/web/src/components/drawers/actions/contact-compose-action.tsx
@@ -1,0 +1,62 @@
+// apps/web/src/components/drawers/actions/contact-compose-action.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Mail } from 'lucide-react'
+import * as React from 'react'
+import { useChannels } from '~/components/channels/hooks/use-channels'
+import { Tooltip } from '~/components/global/tooltip'
+import type { EditorPresetValues } from '~/components/mail/email-editor/types'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useCompose } from '~/hooks/use-compose'
+import type { DrawerActionProps } from '../drawer-action-registry'
+
+const CONTACT_FIELDS = ['primary_email', 'first_name', 'last_name'] as const
+
+/**
+ * Header action for contacts: opens the floating composer with the contact's
+ * primary email pre-filled in the To field. Does not close the drawer.
+ */
+export function ContactComposeAction({ recordId, record }: DrawerActionProps) {
+  const { openCompose } = useCompose()
+
+  const { values } = useSystemValues(recordId, [...CONTACT_FIELDS], { autoFetch: true })
+  const channels = useChannels()
+  const defaultIntegrationId = channels[0]?.id
+
+  const presetValues = React.useMemo<EditorPresetValues | undefined>(() => {
+    const email = values.primary_email as string | undefined
+    if (!email) return undefined
+
+    const firstName = values.first_name as string | undefined
+    const lastName = values.last_name as string | undefined
+    const name =
+      [firstName, lastName].filter(Boolean).join(' ').trim() ||
+      (record?.displayName as string | undefined) ||
+      undefined
+
+    return {
+      to: [
+        {
+          id: (record?.id as string | undefined) ?? email,
+          identifier: email,
+          identifierType: 'EMAIL',
+          name,
+        },
+      ],
+      integrationId: defaultIntegrationId,
+    }
+  }, [values, record?.id, record?.displayName, defaultIntegrationId])
+
+  return (
+    <Tooltip content='Compose email' allowInteraction>
+      <Button
+        variant='ghost'
+        size='icon-xs'
+        disabled={!presetValues}
+        onClick={() => presetValues && openCompose({ presetValues })}>
+        <Mail />
+      </Button>
+    </Tooltip>
+  )
+}

--- a/apps/web/src/components/drawers/actions/create-note-action.tsx
+++ b/apps/web/src/components/drawers/actions/create-note-action.tsx
@@ -1,0 +1,28 @@
+// apps/web/src/components/drawers/actions/create-note-action.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { MessagesSquare } from 'lucide-react'
+import { useQueryState } from 'nuqs'
+import { Tooltip } from '~/components/global/tooltip'
+import type { DrawerActionProps } from '../drawer-action-registry'
+
+/**
+ * Generic header action: switches to the Comments tab and focuses the composer.
+ */
+export function CreateNoteAction({ onCreateNote }: DrawerActionProps) {
+  const [, setActiveTab] = useQueryState('tab', { defaultValue: 'overview' })
+
+  const handleClick = () => {
+    void setActiveTab('comments')
+    onCreateNote()
+  }
+
+  return (
+    <Tooltip content='Create note' allowInteraction>
+      <Button variant='ghost' size='icon-xs' onClick={handleClick}>
+        <MessagesSquare />
+      </Button>
+    </Tooltip>
+  )
+}

--- a/apps/web/src/components/drawers/actions/ticket-reply-action.tsx
+++ b/apps/web/src/components/drawers/actions/ticket-reply-action.tsx
@@ -1,0 +1,44 @@
+// apps/web/src/components/drawers/actions/ticket-reply-action.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { MessageSquare } from 'lucide-react'
+import { useChannels } from '~/components/channels/hooks/use-channels'
+import { Tooltip } from '~/components/global/tooltip'
+import type { EditorPresetValues } from '~/components/mail/email-editor/types'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useCompose } from '~/hooks/use-compose'
+import type { DrawerActionProps } from '../drawer-action-registry'
+
+const TICKET_FIELDS = ['ticket_title'] as const
+
+/**
+ * Header action for tickets: opens the floating composer pre-filled with the
+ * ticket's subject and linked to this ticket on send. Does not close the drawer.
+ */
+export function TicketReplyAction({ recordId, entityInstanceId, record }: DrawerActionProps) {
+  const { openCompose } = useCompose()
+
+  const { values } = useSystemValues(recordId, [...TICKET_FIELDS], { autoFetch: true })
+  const channels = useChannels()
+  const defaultIntegrationId = channels[0]?.id
+
+  const handleClick = () => {
+    const title =
+      (values.ticket_title as string | undefined) ?? (record?.displayName as string | undefined)
+    const presetValues: EditorPresetValues = {
+      subject: title ? String(title) : '',
+      linkTicketId: entityInstanceId,
+      integrationId: defaultIntegrationId,
+    }
+    openCompose({ presetValues })
+  }
+
+  return (
+    <Tooltip content='Reply' allowInteraction>
+      <Button variant='ghost' size='icon-xs' onClick={handleClick}>
+        <MessageSquare />
+      </Button>
+    </Tooltip>
+  )
+}

--- a/apps/web/src/components/drawers/drawer-action-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-action-registry.tsx
@@ -1,0 +1,36 @@
+// apps/web/src/components/drawers/drawer-action-registry.tsx
+'use client'
+
+import type { Resource } from '@auxx/lib/resources/client'
+import type { RecordId } from '@auxx/types/resource'
+import type { ComponentType } from 'react'
+import { ContactComposeAction } from './actions/contact-compose-action'
+import { CreateNoteAction } from './actions/create-note-action'
+import { TicketReplyAction } from './actions/ticket-reply-action'
+
+/**
+ * Props passed to all drawer header-action components.
+ */
+export interface DrawerActionProps {
+  recordId: RecordId
+  entityInstanceId: string
+  entityType: string
+  record?: Record<string, unknown>
+  resource?: Resource
+  /** Bumps the Comments composer focus trigger. */
+  onCreateNote: () => void
+}
+
+/**
+ * Registry of header action components per entity type, rendered in order.
+ * Falls back to the generic [CreateNoteAction] when an entity type isn't registered.
+ */
+const DRAWER_HEADER_ACTIONS: Record<string, ComponentType<DrawerActionProps>[]> = {
+  contact: [ContactComposeAction, CreateNoteAction],
+  ticket: [TicketReplyAction, CreateNoteAction],
+  part: [CreateNoteAction],
+}
+
+export function getHeaderActions(entityType: string): ComponentType<DrawerActionProps>[] {
+  return DRAWER_HEADER_ACTIONS[entityType] ?? [CreateNoteAction]
+}

--- a/apps/web/src/components/editor/editor-button.tsx
+++ b/apps/web/src/components/editor/editor-button.tsx
@@ -495,7 +495,6 @@ export const EditorToolbar = ({
   showSend = true,
   showFormatting = true,
   allowSchedule = true,
-  showMetaShortcut = true,
   popoverClassName,
 }: Partial<EditorButtonsProps> & {
   fileSelect?: UseFileSelectReturn
@@ -504,8 +503,6 @@ export const EditorToolbar = ({
   showFormatting?: boolean
   /** When false, sends immediately (no schedule dropdown). */
   allowSchedule?: boolean
-  /** When false, hides the ⌘ glyph next to the Enter icon — used when plain Enter submits. */
-  showMetaShortcut?: boolean
   aiToolsProps?: {
     threadId?: string
     hasContent: boolean
@@ -712,7 +709,6 @@ export const EditorToolbar = ({
           disabled={disabled}
           popoverClassName={popoverClassName}
           allowSchedule={allowSchedule}
-          showMetaShortcut={showMetaShortcut}
         />
       )}
     </div>

--- a/apps/web/src/components/mail/chat-composer/index.tsx
+++ b/apps/web/src/components/mail/chat-composer/index.tsx
@@ -6,7 +6,7 @@ import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
 import { Upload } from 'lucide-react'
 import type React from 'react'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDropzone } from 'react-dropzone'
 import { EditorToolbar } from '~/components/editor/editor-button'
 import { EditorProvider, useEditorContext } from '~/components/editor/editor-context'
@@ -97,6 +97,21 @@ function ChatComposerInner({
     },
   })
 
+  // Keep focus in the editor across a send. The editor's `editable` flag
+  // flips false while `isSending` is true, which makes the browser blur the
+  // contenteditable element; calling `focus()` synchronously inside
+  // `onSendSuccess` is too early because the re-enable hasn't rendered yet.
+  // Watching the falling edge of `isSending` runs after the editor has flipped
+  // back to `editable`, so focus sticks. Critical for the chat experience —
+  // an agent typing rapid replies shouldn't have to click back into the box.
+  const wasSendingRef = useRef(false)
+  useEffect(() => {
+    if (wasSendingRef.current && !isSending) {
+      editor?.commands.focus('end')
+    }
+    wasSendingRef.current = isSending
+  }, [isSending, editor])
+
   const allAttachments = useMemo(() => {
     const filesFromSelect: FileAttachment[] = fileSelect.selectedItems
       .filter((item) => item.source === 'filesystem' || item.serverFileId)
@@ -121,13 +136,28 @@ function ChatComposerInner({
       toastError({ title: 'Missing channel', description: 'No chat channel for this thread.' })
       return
     }
-    const plainContent = editor?.getText()?.trim() ?? ''
-    if (!plainContent) {
-      toastError({ title: 'Empty message', description: 'Type something before sending.' })
+    const plainContent = editor?.getText() ?? ''
+    const hasAttachment = allAttachments.length > 0
+    if (!plainContent.trim() && !hasAttachment) {
+      toastError({
+        title: 'Empty message',
+        description: 'Type something or attach a file before sending.',
+      })
       return
     }
-    send({ textHtml: content, attachments: allAttachments })
+    send({ textHtml: content, textPlain: plainContent, attachments: allAttachments })
   }, [isSending, editor, integrationId, content, allAttachments, send])
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.metaKey && event.key === 'Enter') {
+        event.preventDefault()
+        event.stopPropagation()
+        handleSendClick()
+      }
+    },
+    [handleSendClick]
+  )
 
   const handleContentChange = useCallback((next: string) => {
     setContent((prev) => (prev === next ? prev : next))
@@ -232,7 +262,6 @@ function ChatComposerInner({
         <ChatPanelHeader
           threadId={thread.id}
           isDialogMode={isDialogMode}
-          onClose={onClose}
           onPopOut={onPopOut}
           onMinimize={onMinimize}
           onDockBack={onDockBack}
@@ -251,6 +280,7 @@ function ChatComposerInner({
           isDragActive && 'border-transparent bg-white hover:bg-white hover:border-transparent'
         )}
         onClick={handleWrapperClick}
+        onKeyDown={handleKeyDown}
         onFocus={(e) => {
           if (!e.currentTarget.contains(e.relatedTarget)) {
             activeState.setHasFocus(true)
@@ -285,7 +315,6 @@ function ChatComposerInner({
             placeholder='Type your reply...'
             editable={!aiToolsState.isProcessing && !isSending}
             popoverClassName={popoverZIndex}
-            onEnter={handleSendClick}
             contentClassName='sm:min-h-[60px] py-2 text-sm'
           />
 
@@ -341,7 +370,6 @@ function ChatComposerInner({
               fileSelect={fileSelect}
               showFormatting={false}
               allowSchedule={false}
-              showMetaShortcut={false}
               popoverClassName={popoverZIndex}
               aiToolsProps={{
                 threadId: thread.id,

--- a/apps/web/src/components/mail/chat-composer/use-chat-send.ts
+++ b/apps/web/src/components/mail/chat-composer/use-chat-send.ts
@@ -3,24 +3,13 @@
 
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { useCallback, useState } from 'react'
-import { useMessageListStore } from '~/components/threads/store/message-list-store'
-import { type MessageMeta, useMessageStore } from '~/components/threads/store/message-store'
-import { getThreadStoreState } from '~/components/threads/store/thread-store'
+import {
+  appendOptimisticMessage,
+  toAttachmentMeta,
+} from '~/components/threads/hooks/append-optimistic-message'
+import type { MessageMeta } from '~/components/threads/store/message-store'
 import { api } from '~/trpc/react'
 import type { FileAttachment } from '../email-editor/types'
-
-function htmlToSnippet(html: string, maxLen = 140): string {
-  const text = html
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/\s+/g, ' ')
-    .trim()
-  return text.length > maxLen ? `${text.slice(0, maxLen - 1)}…` : text
-}
 
 interface UseChatSendOptions {
   threadId: string
@@ -32,6 +21,10 @@ interface UseChatSendOptions {
 
 interface SendArgs {
   textHtml: string
+  /** Plain text counterpart (from `editor.getText()`) — preserves newlines and
+   *  drives the bubble render. Without this, the optimistic message falls back
+   *  to `snippet`, which is single-line and truncated at 140 chars. */
+  textPlain: string
   attachments: FileAttachment[]
 }
 
@@ -45,22 +38,27 @@ export function useChatSend({ threadId, integrationId, onSendSuccess }: UseChatS
       toastSuccess({ description: 'Message sent' })
 
       if (sentMessage.threadId && sentMessage.id) {
-        // Synthesize a MessageMeta entry so the inbox row's snippet/body
-        // updates in-place when `latestMessageId` flips — without it, the row
-        // renders empty for the ~50ms request batch window and visibly shifts.
         const sentAt = sentMessage.sentAt?.toISOString() ?? new Date().toISOString()
+        const textPlain = variables.textPlain ?? ''
+        const attachments = (variables.attachments ?? []).map(toAttachmentMeta)
+        const snippet =
+          textPlain.length > 0
+            ? textPlain.length > 140
+              ? `${textPlain.slice(0, 139)}…`
+              : textPlain
+            : (attachments[0]?.name ?? '')
         const optimistic: MessageMeta = {
           id: sentMessage.id,
           threadId: sentMessage.threadId,
           subject: sentMessage.subject ?? null,
-          snippet: htmlToSnippet(variables.textHtml ?? ''),
+          snippet,
           textHtml: variables.textHtml ?? null,
-          textPlain: null,
+          textPlain,
           isInbound: false,
           isFirstInThread: false,
-          hasAttachments: (variables.attachments?.length ?? 0) > 0,
+          hasAttachments: attachments.length > 0,
           hasHtmlBody: !!variables.textHtml,
-          hasTextBody: false,
+          hasTextBody: textPlain.length > 0,
           sentAt,
           receivedAt: null,
           createdAt: sentAt,
@@ -69,28 +67,10 @@ export function useChatSend({ threadId, integrationId, onSendSuccess }: UseChatS
           sendStatus: 'SENT',
           providerError: null,
           attempts: 1,
-          attachments: [],
+          attachments,
           messageType: 'CHAT',
         }
-        useMessageStore.getState().setMessages([optimistic])
-
-        // Optimistically append the new message ID to the local list. Avoid
-        // invalidating the cached list — that would wipe `messageIds` and
-        // unmount/remount every message in the thread (visible as a full
-        // slide-in animation replay).
-        useMessageListStore.getState().appendMessage(sentMessage.threadId, sentMessage.id)
-        // tRPC cache invalidate is safe — the local list cache stays intact, so
-        // useMessages remains disabled and no refetch happens. The next time
-        // the cache misses (e.g. cold load), the fresh data will be used.
-        utils.message.listByThread.invalidate({ threadId: sentMessage.threadId })
-
-        const currentThread = getThreadStoreState().getThread(sentMessage.threadId)
-        if (currentThread) {
-          getThreadStoreState().updateThread(sentMessage.threadId, {
-            lastMessageAt: sentAt,
-            latestMessageId: sentMessage.id,
-          })
-        }
+        appendOptimisticMessage(utils, sentMessage.threadId, optimistic)
       }
 
       onSendSuccess()
@@ -102,11 +82,12 @@ export function useChatSend({ threadId, integrationId, onSendSuccess }: UseChatS
   })
 
   const send = useCallback(
-    ({ textHtml, attachments }: SendArgs) => {
+    ({ textHtml, textPlain, attachments }: SendArgs) => {
       mutation.mutate({
         threadId,
         integrationId,
         textHtml,
+        textPlain,
         to: [],
         attachments: attachments.length > 0 ? attachments : undefined,
       })

--- a/apps/web/src/components/mail/chat-message-display.tsx
+++ b/apps/web/src/components/mail/chat-message-display.tsx
@@ -94,10 +94,7 @@ const ChatMessageDisplay = ({
 
   return (
     <div
-      className={cn(
-        'group/message flex w-full flex-col gap-1',
-        isInbound ? 'items-start' : 'items-end'
-      )}>
+      className={cn('group/message flex flex-col gap-1', isInbound ? 'items-start' : 'items-end')}>
       {showHeader && (
         <div className='flex items-center gap-2 pl-1'>
           <ContactHoverCard contactId={contactId ?? undefined}>
@@ -111,17 +108,29 @@ const ChatMessageDisplay = ({
           <span className='text-xs font-medium text-foreground'>{senderName}</span>
         </div>
       )}
-      <div className='relative w-full'>
+      <div className='relative w-fit max-w-full'>
         <div
           onClick={handleBubbleClick}
           className={cn(
-            'w-full border border-transparent px-3 py-2 text-sm/5 shadow transition-all duration-300',
+            'border border-transparent px-3 py-2 text-sm/5 shadow transition-all duration-300',
             isGrouped && 'cursor-pointer',
             isInbound
-              ? 'bg-illustration text-foreground ring-border-illustration shadow-black/10 ring-1'
-              : 'bg-primary text-primary-foreground inset-ring-foreground/10 inset-ring-1 shadow-black/15',
-            topRound ? 'rounded-t-2xl' : 'rounded-t-sm',
-            bottomRound ? 'rounded-b-2xl' : 'rounded-b-sm'
+              ? 'bg-illustration text-foreground ring-border-illustration shadow-black/10 ring-1 rounded-r-2xl'
+              : 'bg-primary text-primary-foreground inset-ring-foreground/10 inset-ring-1 shadow-black/15 rounded-l-2xl',
+            isInbound
+              ? topRound
+                ? 'rounded-tl-2xl'
+                : 'rounded-tl-sm'
+              : topRound
+                ? 'rounded-tr-2xl'
+                : 'rounded-tr-sm',
+            isInbound
+              ? bottomRound
+                ? 'rounded-bl-2xl'
+                : 'rounded-bl-sm'
+              : bottomRound
+                ? 'rounded-br-2xl'
+                : 'rounded-br-sm'
           )}>
           {content ? (
             <div className='cursor-text select-text whitespace-pre-wrap break-words font-sans'>

--- a/apps/web/src/components/mail/chat-message-group.tsx
+++ b/apps/web/src/components/mail/chat-message-group.tsx
@@ -19,10 +19,9 @@ interface ChatMessageGroupProps {
 
 /**
  * Renders a run of consecutive same-sender chat messages as a merged stack.
- * Inside the run, sibling bubbles are sized to the widest content via CSS
- * grid (`grid-cols-[minmax(0,max-content)]` + per-bubble `w-full`).
- * Clicking any bubble expands the whole group: every bubble gets full
- * rounding, the gap opens, and each shows its own timestamp/receipt.
+ * Each bubble sizes to its own content. Clicking any bubble expands the
+ * whole group: every bubble gets full rounding, the gap opens, and each
+ * shows its own timestamp/receipt.
  */
 export function ChatMessageGroup({
   messages,
@@ -51,8 +50,8 @@ export function ChatMessageGroup({
     <div ref={rootRef} className='mx-auto w-full max-w-2xl'>
       <div
         className={cn(
-          'grid w-fit max-w-[80%] grid-cols-[minmax(0,max-content)] transition-all duration-300',
-          isInbound ? 'mr-auto' : 'ml-auto',
+          'flex max-w-[80%] flex-col transition-all duration-300',
+          isInbound ? 'mr-auto items-start' : 'ml-auto items-end',
           expanded ? 'gap-2' : 'gap-0.5'
         )}>
         {messages.map((message, index) => {

--- a/apps/web/src/components/mail/chat-panel/header.tsx
+++ b/apps/web/src/components/mail/chat-panel/header.tsx
@@ -12,7 +12,8 @@ import { asChatThreadMetadata } from '../chat-visitor-sidebar'
 interface ChatPanelHeaderProps {
   threadId: string
   isDialogMode: boolean
-  onClose: () => void
+  /** When omitted, the close (X) button is not rendered. */
+  onClose?: () => void
   onPopOut?: () => void
   onMinimize?: () => void
   onDockBack?: () => void
@@ -96,13 +97,15 @@ export function ChatPanelHeader({
             <Minus />
           </Button>
         )}
-        <Button
-          size='icon-sm'
-          variant='ghost'
-          className='rounded-full text-muted-foreground hover:bg-gray-200 dark:hover:bg-gray-700'
-          onClick={onClose}>
-          <X />
-        </Button>
+        {onClose && (
+          <Button
+            size='icon-sm'
+            variant='ghost'
+            className='rounded-full text-muted-foreground hover:bg-gray-200 dark:hover:bg-gray-700'
+            onClick={onClose}>
+            <X />
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -31,8 +31,11 @@ import { useFileSelect } from '~/components/file-select/hooks/use-file-select'
 import { useCountUpdates } from '~/components/mail/hooks'
 import { useComposeStore } from '~/components/mail/store/compose-store'
 import { SignatureEditor } from '~/components/signatures/ui'
-import { getMessageListStoreState } from '~/components/threads/store/message-list-store'
-import { getMessageStoreState, type MessageMeta } from '~/components/threads/store/message-store'
+import {
+  appendOptimisticMessage,
+  toAttachmentMeta,
+} from '~/components/threads/hooks/append-optimistic-message'
+import type { MessageMeta } from '~/components/threads/store/message-store'
 import { getThreadStoreState } from '~/components/threads/store/thread-store'
 import { useAnalytics } from '~/hooks/use-analytics'
 import { useConfirm } from '~/hooks/use-confirm'
@@ -389,18 +392,9 @@ function ReplyComposeEditorComponent({
         onSendDraft()
       }
 
-      // Message list refresh — invalidate both Zustand and React Query caches
-      if (sentMessage.threadId) {
-        getMessageListStoreState().invalidate(sentMessage.threadId)
-        utils.message.listByThread.invalidate({ threadId: sentMessage.threadId })
-      }
-
-      // Thread metadata patch + optimistic MessageMeta — point the row's
-      // snippet/sender at the new message in the same render. Without the
-      // synthesized message entry, `useMessage` returns undefined for the
-      // ~50ms request batch window and the snippet line blanks out.
       if (sentMessage.threadId && sentMessage.id) {
         const sentAt = sentMessage.sentAt?.toISOString() ?? new Date().toISOString()
+        const attachments = (variables.attachments ?? []).map(toAttachmentMeta)
         const optimistic: MessageMeta = {
           id: sentMessage.id,
           threadId: sentMessage.threadId,
@@ -410,7 +404,7 @@ function ReplyComposeEditorComponent({
           textPlain: variables.textPlain ?? null,
           isInbound: false,
           isFirstInThread: false,
-          hasAttachments: (variables.attachments?.length ?? 0) > 0,
+          hasAttachments: attachments.length > 0,
           hasHtmlBody: !!variables.textHtml,
           hasTextBody: !!variables.textPlain,
           sentAt,
@@ -421,18 +415,10 @@ function ReplyComposeEditorComponent({
           sendStatus: 'SENT',
           providerError: null,
           attempts: 1,
-          attachments: [],
+          attachments,
           messageType: 'EMAIL',
         }
-        getMessageStoreState().setMessages([optimistic])
-
-        const currentThread = getThreadStoreState().getThread(sentMessage.threadId)
-        if (currentThread) {
-          getThreadStoreState().updateThread(sentMessage.threadId, {
-            lastMessageAt: sentAt,
-            latestMessageId: sentMessage.id,
-          })
-        }
+        appendOptimisticMessage(utils, sentMessage.threadId, optimistic)
       }
 
       onSendSuccess()

--- a/apps/web/src/components/mail/email-editor/schedule-send-button.tsx
+++ b/apps/web/src/components/mail/email-editor/schedule-send-button.tsx
@@ -28,8 +28,6 @@ interface ScheduleSendButtonProps {
   /** When false, omits the schedule-send dropdown — renders a plain Send button.
    *  Used for chat / messaging channels that don't support scheduling. */
   allowSchedule?: boolean
-  /** When false, hides the ⌘ glyph next to the Enter icon — used when plain Enter submits. */
-  showMetaShortcut?: boolean
 }
 
 interface TimePreset {
@@ -111,7 +109,6 @@ export function ScheduleSendButton({
   disabled,
   popoverClassName,
   allowSchedule = true,
-  showMetaShortcut = true,
 }: ScheduleSendButtonProps) {
   const [datePickerOpen, setDatePickerOpen] = useState(false)
   const [dropdownOpen, setDropdownOpen] = useState(false)
@@ -159,7 +156,7 @@ export function ScheduleSendButton({
           loadingText='Sending...'>
           Send
           <Separator orientation='vertical' className='mx-1.5 h-3 opacity-50' />
-          {showMetaShortcut && <MetaIcon className='size-3! opacity-80' />}
+          <MetaIcon className='size-3! opacity-80' />
           <CornerDownLeft className='size-3! opacity-80' />
         </Button>
       </div>
@@ -205,7 +202,7 @@ export function ScheduleSendButton({
           loadingText='Sending...'>
           Send
           <Separator orientation='vertical' className='mx-1.5 h-3 opacity-50' />
-          {showMetaShortcut && <MetaIcon className='size-3! opacity-80' />}
+          <MetaIcon className='size-3! opacity-80' />
           <CornerDownLeft className='size-3! opacity-80' />
         </Button>
       )}

--- a/apps/web/src/components/mail/thread-messages.tsx
+++ b/apps/web/src/components/mail/thread-messages.tsx
@@ -179,7 +179,7 @@ export function ThreadMessages() {
   if (isLoading && messages.length === 0) {
     return (
       <div className='flex flex-col gap-4 px-4 py-2'>
-        {[1, 2, 3].map((i) => (
+        {[1, 2].map((i) => (
           <MessageSkeleton key={i} />
         ))}
       </div>

--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -20,8 +20,6 @@ import {
   Expand,
   Link as LinkIcon,
   Merge,
-  MessageSquare,
-  MessagesSquare,
   MoreHorizontal,
   TextCursorInput,
   Trash,
@@ -31,6 +29,7 @@ import { useRouter } from 'next/navigation'
 import * as React from 'react'
 import { EntityInstanceDialog } from '~/components/custom-fields/ui/entity-instance-dialog'
 import { BaseEntityDrawer } from '~/components/drawers/base-entity-drawer'
+import { getHeaderActions } from '~/components/drawers/drawer-action-registry'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
 import { DockToggleButton } from '~/components/global/dock-toggle-button'
 import { Tooltip } from '~/components/global/tooltip'
@@ -85,12 +84,21 @@ export const RecordDrawer = React.memo(function RecordDrawer({
   // Get resource with fields
   const { resource } = useResource(entityDefinitionId ?? null)
 
+  // Resolve entity type once (used for both drawer config and action registry)
+  const entityType = React.useMemo(
+    () => resource?.entityType ?? (resource?.type === 'system' ? resource?.id : 'custom'),
+    [resource]
+  )
+
   // Get drawer config for entity-type-aware actions
   const drawerConfig = React.useMemo(() => {
-    const entityType =
-      resource?.entityType ?? (resource?.type === 'system' ? resource?.id : 'custom')
     return entityType ? getEntityDrawerConfig(entityType, entityDefinitionId || undefined) : null
-  }, [resource, entityDefinitionId])
+  }, [entityType, entityDefinitionId])
+
+  const headerActionComponents = React.useMemo(
+    () => (entityType ? getHeaderActions(entityType) : []),
+    [entityType]
+  )
 
   // Fetch entity record from cache (populated by batch fetcher when list loads)
   const { record: cachedRecord, isLoading: isRecordLoading } = useRecord({
@@ -190,14 +198,6 @@ export const RecordDrawer = React.memo(function RecordDrawer({
     setFocusComposerTrigger((prev) => prev + 1)
   }, [])
 
-  /** Handle reply - navigate to detail page */
-  const handleReply = React.useCallback(() => {
-    if (resource?.apiSlug && entityInstanceId) {
-      router.push(`/app/tickets/${entityInstanceId}#reply`)
-      onOpenChange?.(false)
-    }
-  }, [resource?.apiSlug, entityInstanceId, router, onOpenChange])
-
   /** Handle delete with confirmation */
   const handleDelete = React.useCallback(async () => {
     if (!onDeleteInstance || !entityInstanceId) return
@@ -268,21 +268,19 @@ export const RecordDrawer = React.memo(function RecordDrawer({
         headerTitle={resource?.label || 'Record'}
         headerActions={
           <>
-            {/* Reply button (ticket-specific) */}
-            {actions?.enableEmailCompose && (
-              <Tooltip content='Reply'>
-                <Button variant='ghost' size='icon-xs' onClick={handleReply}>
-                  <MessageSquare />
-                </Button>
-              </Tooltip>
-            )}
-
-            {/* Create note */}
-            <Tooltip content='Create note'>
-              <Button variant='ghost' size='icon-xs' onClick={handleCreateNoteClick}>
-                <MessagesSquare />
-              </Button>
-            </Tooltip>
+            {/* Entity-specific header actions (compose for contacts, reply for tickets, etc.) */}
+            {entityType &&
+              headerActionComponents.map((Action, i) => (
+                <Action
+                  key={i}
+                  recordId={recordId}
+                  entityInstanceId={entityInstanceId}
+                  entityType={entityType}
+                  record={cachedRecord}
+                  resource={resource}
+                  onCreateNote={handleCreateNoteClick}
+                />
+              ))}
 
             {/* Run workflow */}
             <ManualTriggerButton

--- a/apps/web/src/components/threads/hooks/append-optimistic-message.ts
+++ b/apps/web/src/components/threads/hooks/append-optimistic-message.ts
@@ -1,0 +1,69 @@
+// apps/web/src/components/threads/hooks/append-optimistic-message.ts
+
+import type { FileAttachment } from '~/components/mail/email-editor/types'
+import type { api } from '~/trpc/react'
+import {
+  type AttachmentMeta,
+  getMessageListStoreState,
+  getMessageStoreState,
+  getThreadStoreState,
+  type MessageMeta,
+} from '../store'
+
+type Utils = ReturnType<typeof api.useUtils>
+
+/**
+ * Project a staged composer `FileAttachment` onto the display-side
+ * `AttachmentMeta`. `url` stays null — downloads go through
+ * `/api/attachments/{id}/download`, so a null URL is harmless. When the
+ * post-send sync echoes back the server-authoritative attachment, ids match
+ * and React reconciles in place.
+ */
+export const toAttachmentMeta = (file: FileAttachment): AttachmentMeta => ({
+  id: file.id,
+  name: file.name,
+  mimeType: file.mimeType ?? null,
+  size: file.size ?? null,
+  url: null,
+  inline: false,
+  contentId: null,
+})
+
+/**
+ * Single point of truth for "I just sent a message; apply it everywhere a
+ * reader might look so the UI updates immediately."
+ *
+ * Writes to:
+ *  - Zustand message store (additive — never drops existing entries)
+ *  - Zustand message list store (appends id; no-op if the list isn't seeded yet)
+ *  - tRPC `message.listByThread` query cache (keeps any future direct consumer
+ *    of that query honest — `useMessages` itself goes through Zustand)
+ *  - Zustand thread store (bumps `lastMessageAt` + `latestMessageId` so the
+ *    inbox row re-sorts and the snippet updates without a roundtrip)
+ *
+ * Note: the realtime `message:created` echo is suppressed for the originating
+ * tab (via `excludeSocketId`), so this helper is the only thing that surfaces
+ * the new message locally until the post-send sync emits `message:updated`.
+ */
+export function appendOptimisticMessage(
+  utils: Utils,
+  threadId: string,
+  message: MessageMeta
+): void {
+  getMessageStoreState().setMessages([message])
+  getMessageListStoreState().appendMessage(threadId, message.id)
+
+  utils.message.listByThread.setData({ threadId }, (prev) => {
+    if (!prev) return prev
+    if (prev.messages.some((m) => m.id === message.id)) return prev
+    return { messages: [...prev.messages, message], total: prev.total + 1 }
+  })
+
+  const thread = getThreadStoreState().getThread(threadId)
+  if (thread) {
+    getThreadStoreState().updateThread(threadId, {
+      lastMessageAt: message.sentAt ?? message.createdAt,
+      latestMessageId: message.id,
+    })
+  }
+}

--- a/apps/web/src/components/threads/hooks/index.ts
+++ b/apps/web/src/components/threads/hooks/index.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/threads/hooks/index.ts
 
+export { appendOptimisticMessage } from './append-optimistic-message'
 export { useFocusedThreadShortcuts } from './use-focused-thread-shortcuts'
 export { type InboxItem, type InboxRecord, useInbox, useInboxes } from './use-inbox'
 export { useMessage } from './use-message'

--- a/apps/web/src/components/threads/hooks/use-messages.ts
+++ b/apps/web/src/components/threads/hooks/use-messages.ts
@@ -70,15 +70,25 @@ export function useMessages({ threadId, enabled = true }: UseMessagesOptions): U
   useEffect(() => {
     if (!data || !threadId) return
 
-    // Populate message store
+    // Populate message store. Additive — won't drop optimistic entries that
+    // aren't in `data` (e.g. a just-sent message whose mutation `onSuccess`
+    // wrote to the store before this effect re-fired from a stale cache).
     setMessages(data.messages)
 
-    // Populate list store
-    setList(threadId, {
-      messageIds: data.messages.map((m) => m.id),
-      total: data.total,
-      fetchedAt: Date.now(),
-    })
+    // Only seed the list when it hasn't been populated yet. On remount with
+    // a warm tRPC cache (e.g. a chat thread's compose instance popping out
+    // floating a second time → new `ChatPanelMessages` mount), `data` is
+    // synchronously available from queryClient and this effect would
+    // otherwise re-run and clobber `appendMessage`/`removeMessage` mutations
+    // applied since the original fetch — wiping the just-sent message from
+    // both the floating panel and the thread view.
+    if (!cachedList) {
+      setList(threadId, {
+        messageIds: data.messages.map((m) => m.id),
+        total: data.total,
+        fetchedAt: Date.now(),
+      })
+    }
 
     // Extract unique participant IDs and queue fetches
     const allParticipantIds = data.messages.flatMap((m) => m.participants)
@@ -86,7 +96,7 @@ export function useMessages({ threadId, enabled = true }: UseMessagesOptions): U
     for (const id of uniqueIds) {
       requestParticipant(id)
     }
-  }, [data, threadId, setList, setMessages, requestParticipant])
+  }, [data, threadId, cachedList, setList, setMessages, requestParticipant])
 
   return {
     messages,

--- a/apps/web/src/components/threads/store/message-store.ts
+++ b/apps/web/src/components/threads/store/message-store.ts
@@ -78,6 +78,13 @@ interface MessageStoreState {
   pendingIds: Set<string>
   loadingIds: Set<string>
   notFoundIds: Set<string>
+  /**
+   * Realtime `message:updated` patches that arrived before the message itself
+   * was written to the store (e.g. when the server publishes the patch during
+   * the mutation, ahead of the client's optimistic write in `onSuccess`).
+   * Drained by `setMessages` / `completeBatch` once the row appears.
+   */
+  pendingPatches: Map<string, Partial<MessageMeta>>
   batchTimer: ReturnType<typeof setTimeout> | null
 
   setMessages: (messages: MessageMeta[]) => void
@@ -104,15 +111,18 @@ export const useMessageStore = create<MessageStoreState>()(
       pendingIds: new Set(),
       loadingIds: new Set(),
       notFoundIds: new Set(),
+      pendingPatches: new Map(),
       batchTimer: null,
 
       setMessages: (messages) =>
         set((state) => {
           for (const msg of messages) {
-            state.messages.set(msg.id, msg)
+            const buffered = state.pendingPatches.get(msg.id)
+            state.messages.set(msg.id, buffered ? { ...msg, ...buffered } : msg)
             state.pendingIds.delete(msg.id)
             state.loadingIds.delete(msg.id)
             state.notFoundIds.delete(msg.id)
+            state.pendingPatches.delete(msg.id)
           }
         }),
 
@@ -121,6 +131,9 @@ export const useMessageStore = create<MessageStoreState>()(
           const existing = state.messages.get(id)
           if (existing) {
             state.messages.set(id, { ...existing, ...updates })
+          } else {
+            const prior = state.pendingPatches.get(id)
+            state.pendingPatches.set(id, prior ? { ...prior, ...updates } : updates)
           }
         }),
 
@@ -173,12 +186,15 @@ export const useMessageStore = create<MessageStoreState>()(
       completeBatch: (messages, notFoundIds) =>
         set((state) => {
           for (const msg of messages) {
-            state.messages.set(msg.id, msg)
+            const buffered = state.pendingPatches.get(msg.id)
+            state.messages.set(msg.id, buffered ? { ...msg, ...buffered } : msg)
             state.loadingIds.delete(msg.id)
+            state.pendingPatches.delete(msg.id)
           }
           for (const id of notFoundIds) {
             state.loadingIds.delete(id)
             state.notFoundIds.add(id)
+            state.pendingPatches.delete(id)
           }
         }),
 
@@ -195,6 +211,7 @@ export const useMessageStore = create<MessageStoreState>()(
           state.pendingIds.clear()
           state.loadingIds.clear()
           state.notFoundIds.clear()
+          state.pendingPatches.clear()
           state.batchTimer = null
         })
       },

--- a/packages/lib/src/cache/invalidation-graph.ts
+++ b/packages/lib/src/cache/invalidation-graph.ts
@@ -42,6 +42,7 @@ export const INVALIDATION_GRAPH: Record<string, InvalidationMapping> = {
   'channel.disconnected': ['channelProviders', 'inboxes', 'channels', 'overages'],
   'channel.toggled': ['channels'],
   'channel.settings_updated': ['channels'],
+  'channel.inbox-link.changed': ['channels', 'inboxes'],
 
   'group.created': ['groups'],
   'group.updated': ['groups'],

--- a/packages/lib/src/channels/list.ts
+++ b/packages/lib/src/channels/list.ts
@@ -9,6 +9,12 @@ import { Result, type TypedResult } from '../result'
 import { getIdentifier } from './internal/identifier'
 import type { ChannelCtx } from './types'
 
+// Org cache JSON-roundtrips, turning Date columns into ISO strings.
+function toDate<T extends Date | null>(v: T | string): T {
+  if (v === null || v instanceof Date) return v as T
+  return new Date(v) as T
+}
+
 /**
  * Get all channels for the org (admin Channels page payload).
  *
@@ -50,18 +56,18 @@ export async function list(ctx: ChannelCtx) {
       provider: c.provider,
       name: c.name,
       enabled: c.enabled,
-      updatedAt: c.updatedAt,
-      lastSyncedAt: c.lastSyncedAt,
+      updatedAt: toDate(c.updatedAt),
+      lastSyncedAt: toDate(c.lastSyncedAt),
       email: c.email || (c.metadata as any)?.email || undefined,
       identifier: getIdentifier({ ...c, chatWidget: c.chatWidget }),
       inboxId: c.inboxId,
       widgetSettings: c.provider === 'chat' ? c.chatWidget : undefined,
       authStatus: c.authStatus,
-      lastSuccessfulSync: c.lastSuccessfulSync,
+      lastSuccessfulSync: toDate(c.lastSuccessfulSync),
       metadata: c.metadata,
       requiresReauth: c.requiresReauth,
       lastAuthError: c.lastAuthError,
-      lastAuthErrorAt: c.lastAuthErrorAt,
+      lastAuthErrorAt: toDate(c.lastAuthErrorAt),
       settings: c.settings,
       isExample: c.isExample,
       syncStatus: live?.syncStatus ?? null,

--- a/packages/lib/src/inboxes/inbox-service.ts
+++ b/packages/lib/src/inboxes/inbox-service.ts
@@ -5,6 +5,7 @@ import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
 import { and, eq } from 'drizzle-orm'
+import { onCacheEvent } from '../cache'
 import {
   checkAccess,
   getUserAccessibleInstances,
@@ -280,7 +281,7 @@ export class InboxService {
     const instanceId = getInstanceId(recordId)
     logger.info('Adding integration to inbox', { instanceId, integrationId, isDefault })
 
-    return this.db.transaction(async (tx) => {
+    const result = await this.db.transaction(async (tx) => {
       // Check if integration already assigned somewhere
       const existing = await tx.query.InboxIntegration.findFirst({
         where: eq(schema.InboxIntegration.integrationId, integrationId),
@@ -335,6 +336,9 @@ export class InboxService {
 
       return created
     })
+
+    await onCacheEvent('channel.inbox-link.changed', { orgId: this.organizationId })
+    return result
   }
 
   /**
@@ -364,6 +368,8 @@ export class InboxService {
           eq(schema.InboxIntegration.integrationId, integrationId)
         )
       )
+
+    await onCacheEvent('channel.inbox-link.changed', { orgId: this.organizationId })
     return true
   }
 

--- a/packages/lib/src/ingest/contacts/find-or-create.ts
+++ b/packages/lib/src/ingest/contacts/find-or-create.ts
@@ -41,8 +41,18 @@ export async function findOrCreateContactForParticipant(
     const handler = ctx.crudHandler
     const force = options?.force ?? false
 
-    const systemAttr =
-      participant.identifierType === IdentifierTypeEnum.PHONE ? 'phone' : 'primary_email'
+    // Chat-widget visitors are identified by an opaque session id (cookie value),
+    // not an email/phone — `Participant.identifier` is a cuid, not addressable.
+    // The other identifier types all carry a real address we can use as a dedupe
+    // key on the contact (`primary_email` / `phone`); chat visitors don't, so we
+    // skip the identifier-keyed lookup and rely on `Participant.entityInstanceId`
+    // for dedupe on the caller side.
+    const isChatVisitor = participant.identifierType === 'CHAT_VISITOR'
+    const systemAttr = isChatVisitor
+      ? null
+      : participant.identifierType === IdentifierTypeEnum.PHONE
+        ? 'phone'
+        : 'primary_email'
 
     // Never auto-create a contact for the integration owner's own addresses.
     // `force` is the documented escape hatch for the user-initiated
@@ -56,13 +66,16 @@ export async function findOrCreateContactForParticipant(
     }
 
     if (!force && mode === 'none') {
+      if (!systemAttr) return null
       const existing = await handler.findByField('contact', systemAttr, participant.identifier)
       return existing?.id ?? null
     }
 
     if (!force && mode === 'selective' && messageContext) {
-      const existing = await handler.findByField('contact', systemAttr, participant.identifier)
-      if (existing) return existing.id
+      if (systemAttr) {
+        const existing = await handler.findByField('contact', systemAttr, participant.identifier)
+        if (existing) return existing.id
+      }
 
       const isOutboundRecipient =
         !messageContext.isInbound &&
@@ -86,7 +99,6 @@ export async function findOrCreateContactForParticipant(
     }
 
     const names = getNamesFromParticipant(participant)
-    const findBy: Record<string, unknown> = { [systemAttr]: participant.identifier }
     const createValues: Record<string, unknown> = {
       first_name: names.firstName,
       last_name: names.lastName,
@@ -97,8 +109,18 @@ export async function findOrCreateContactForParticipant(
       createValues.phone = participant.identifier
     }
 
-    const { instance } = await handler.findOrCreate('contact', findBy, createValues)
-    const contactId = instance.id
+    let contactId: string
+    if (isChatVisitor || !systemAttr) {
+      // No identifier-keyed dedupe — just create. The caller writes the new id
+      // back to `Participant.entityInstanceId`, which is the only stable dedupe
+      // key we have for chat visitors.
+      const { instance } = await handler.create('contact', createValues)
+      contactId = instance.id
+    } else {
+      const findBy: Record<string, unknown> = { [systemAttr]: participant.identifier }
+      const { instance } = await handler.findOrCreate('contact', findBy, createValues)
+      contactId = instance.id
+    }
 
     if (contactId) {
       const ownDomains = await resolveOwnDomains(ctx, ctx.organizationId)

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -279,7 +279,7 @@ export class MessageSenderService {
     if (capabilities.requiresRecipients && (!input.to || input.to.length === 0)) {
       throw new Error('At least one recipient is required')
     }
-    if (!input.textHtml && !input.textPlain) {
+    if (!input.textHtml && !input.textPlain && !input.attachmentIds?.length) {
       throw new Error('Message content is required')
     }
   }

--- a/packages/lib/src/providers/chat/chat-provider.ts
+++ b/packages/lib/src/providers/chat/chat-provider.ts
@@ -8,6 +8,7 @@ import { getOrgCache } from '../../cache'
 import { publishChatMessageCreated, publishChatMessageReceiptUpdated } from '../../chat/realtime'
 import type { ChatAttachment } from '../../chat/types'
 import { getRealtimeService } from '../../realtime'
+import { publishMessageUpdated } from '../../realtime/publish-helpers'
 import { Result, type TypedResult } from '../../result'
 import type { ChatThreadMetadata } from '../../threads/types'
 import {
@@ -194,6 +195,33 @@ export class ChatProvider extends BaseMessageProvider implements MessageProvider
       },
       skipInboxMessagePublish: true,
     })
+
+    // When the message has attachments, push the server-authoritative
+    // attachment metadata to the inbox channel as `message:updated`. The
+    // sender's optimistic write uses staged file-ids (FolderFile / MediaAsset),
+    // which don't resolve against `/api/attachments/{id}/{thumbnail,download}`
+    // — those endpoints expect `Attachment.id`. No `excludeSocketId` here:
+    // we *want* the sender to receive this patch and overwrite the optimistic
+    // attachment array with real ids. Chat has no post-send sync, so without
+    // this push the wrong ids stick.
+    if (attachments?.length) {
+      await publishMessageUpdated(getRealtimeService(), this.organizationId, {
+        messageId: message.id,
+        threadId: thread.id,
+        inboxId: thread.inboxId,
+        patch: {
+          attachments: attachments.map((a) => ({
+            id: a.id,
+            name: a.name,
+            mimeType: a.mimeType ?? null,
+            size: a.size ?? null,
+            url: null,
+            inline: false,
+            contentId: null,
+          })),
+        },
+      })
+    }
 
     return { success: true, id: message.id, externalId: undefined, threadId: thread.id }
   }

--- a/packages/lib/src/realtime/events.ts
+++ b/packages/lib/src/realtime/events.ts
@@ -149,6 +149,22 @@ export interface ThreadMeta {
 }
 
 /**
+ * Attachment shape used inside realtime message patches. Mirrors the
+ * client-side `AttachmentMeta` so a `message:updated` patch can fully replace
+ * a message's attachments array (e.g. swapping optimistic file-ids for the
+ * server-side `Attachment.id`s).
+ */
+export interface AttachmentMeta {
+  id: string
+  name: string
+  mimeType: string | null
+  size: number | null
+  url: string | null
+  inline: boolean
+  contentId: string | null
+}
+
+/**
  * Partial-by-design message metadata for mail realtime patches.
  */
 export interface MessageMeta {
@@ -160,6 +176,7 @@ export interface MessageMeta {
   receivedAt?: string | null
   isInbound?: boolean
   hasAttachments?: boolean
+  attachments?: AttachmentMeta[]
   fromId?: string | null
   sendStatus?: 'PENDING' | 'SENT' | 'FAILED' | null
   providerError?: string | null

--- a/packages/lib/src/resources/registry/drawer-config-types.ts
+++ b/packages/lib/src/resources/registry/drawer-config-types.ts
@@ -19,7 +19,6 @@ export interface DrawerTabDefinition {
  * Drawer action capabilities
  */
 export interface DrawerActions {
-  enableEmailCompose?: boolean
   enableMerge?: boolean
   enableGroups?: boolean
   enableAssign?: boolean

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -21,7 +21,6 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
       { value: 'parts', label: 'Parts', icon: 'package' },
     ],
     actions: {
-      enableEmailCompose: true,
       enableMerge: true,
       enableGroups: true,
       enableArchive: true,
@@ -33,7 +32,6 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     entityType: 'ticket',
     additionalTabs: [{ value: 'conversation', label: 'Conversation', icon: 'mail' }],
     actions: {
-      enableEmailCompose: true,
       enableEdit: true,
       enableRename: true,
       enableMerge: true,


### PR DESCRIPTION
## Summary
- Unify optimistic message append for email + chat composers via `appendOptimisticMessage`; buffer realtime patches that arrive before the row is in the store, and stop wiping the message list on remount with a warm tRPC cache.
- Chat composer polish: ⌘+Enter submit, refocus after send, attachment-only sends, snippet preserves plain text/newlines; bubbles size to content with asymmetric rounding.
- Push `message:updated` with server-authoritative attachment ids after a chat send so optimistic file ids swap in place against `/api/attachments/{id}` endpoints.
- Drawer header actions extracted into a per-entity-type registry — contact gets a compose action, ticket keeps reply, both keep create-note.
- Inbox link changes invalidate channels/inboxes caches; chat-visitor participants skip identifier-keyed contact dedupe and rely on `Participant.entityInstanceId`.

## Test plan
- [ ] Send an email reply: row snippet/sender updates immediately, no flicker, message persists after pop-out/dock.
- [ ] Send a chat message with text and with attachment-only; ⌘+Enter sends; focus stays in the composer.
- [ ] Send a chat message with an attachment: download/thumbnail links resolve once `message:updated` lands.
- [ ] Open contact drawer → compose icon opens the floating composer prefilled with the contact's email.
- [ ] Open ticket drawer → reply icon opens the floating composer prefilled with subject + ticket link.
- [ ] Link/unlink a channel to an inbox → channels & inboxes cache invalidates.
- [ ] New chat visitor with no email creates a new contact every session (no opaque-cuid dedupe collisions).