### PR TITLE
feat(mail): participant drawer + thread-header participant chip

### DIFF
--- a/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
+++ b/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
@@ -58,6 +58,7 @@ import { ThreadDisplay } from '~/components/mail/thread-display'
 import { ThreadNavToolbar } from '~/components/mail/thread-nav-toolbar'
 import { NestedThreadProvider } from '~/components/mail/thread-provider'
 import type { ThreadsFilterInput } from '~/components/mail/types'
+import { ParticipantDrawer } from '~/components/participants/drawer/participant-drawer'
 import { RecordDrawer } from '~/components/records/record-drawer'
 import {
   useActiveThreadId,
@@ -200,6 +201,8 @@ function MailboxInner({
   const isContactDrawerOpen = !!contactId
   const [openTicketId, setOpenTicketId] = useQueryState('ticketId', { defaultValue: '' })
   const isTicketDrawerOpen = !!openTicketId
+  const [participantId, setParticipantId] = useQueryState('participantId', { defaultValue: '' })
+  const isParticipantDrawerOpen = !!participantId
 
   // Kopilot — page-level mount lives in the JSX below. Active-thread/contact/
   // ticket context is contributed by their respective drawer components.
@@ -439,6 +442,14 @@ function MailboxInner({
     [openTicketId, setOpenTicketId]
   )
 
+  // Handle closing participant drawer
+  const handleParticipantDrawerClose = useCallback(
+    (open: boolean) => {
+      void setParticipantId(open ? participantId : '')
+    },
+    [participantId, setParticipantId]
+  )
+
   // Build docked panels for contact + ticket drawers
   const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
     const panels: DockedPanelConfig[] = []
@@ -479,6 +490,23 @@ function MailboxInner({
       })
     }
 
+    if (isDocked && isParticipantDrawerOpen) {
+      panels.push({
+        key: 'participant',
+        content: (
+          <ParticipantDrawer
+            participantId={participantId}
+            open={isParticipantDrawerOpen}
+            onOpenChange={handleParticipantDrawerClose}
+          />
+        ),
+        width: dockedWidth,
+        onWidthChange: setDockedWidth,
+        minWidth,
+        maxWidth,
+      })
+    }
+
     return panels
   }, [
     isDocked,
@@ -488,6 +516,9 @@ function MailboxInner({
     isTicketDrawerOpen,
     openTicketId,
     handleTicketDrawerClose,
+    isParticipantDrawerOpen,
+    participantId,
+    handleParticipantDrawerClose,
     dockedWidth,
     setDockedWidth,
     minWidth,
@@ -697,6 +728,15 @@ function MailboxInner({
             onOpenChange={handleTicketDrawerClose}
           />
         </NestedThreadProvider>
+      )}
+
+      {/* Overlay participant drawer when NOT docked */}
+      {!isDocked && (
+        <ParticipantDrawer
+          participantId={participantId}
+          open={isParticipantDrawerOpen}
+          onOpenChange={handleParticipantDrawerClose}
+        />
       )}
     </MailFilterProvider>
   )

--- a/apps/web/src/components/mail/participant-display.tsx
+++ b/apps/web/src/components/mail/participant-display.tsx
@@ -67,6 +67,7 @@ export const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({
   const isPrimary = role === 'FROM'
 
   const [, setContactId] = useQueryState('contactId', { defaultValue: '' })
+  const [, setParticipantId] = useQueryState('participantId', { defaultValue: '' })
   const { update } = useThreadMutation()
 
   const addExcludedSender = api.channel.addExcludedSender.useMutation({
@@ -85,7 +86,7 @@ export const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({
     return null
   }
 
-  const { identifier, identifierType, name, displayName, entityInstanceId, isInternal } =
+  const { id, identifier, identifierType, name, displayName, entityInstanceId, isInternal } =
     participant
   const displayLabel = displayName || identifier
 
@@ -99,8 +100,13 @@ export const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({
     !isInternal
 
   function handleShowDetails() {
-    if (!entityInstanceId) return
-    void setContactId(entityInstanceId)
+    if (entityInstanceId) {
+      void setParticipantId('')
+      void setContactId(entityInstanceId)
+    } else {
+      void setContactId('')
+      void setParticipantId(id)
+    }
   }
 
   return (
@@ -126,7 +132,7 @@ export const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({
               Copy '{name}'
             </DropdownMenuItem>
           )}
-          <DropdownMenuItem onSelect={handleShowDetails} disabled={!entityInstanceId}>
+          <DropdownMenuItem onSelect={handleShowDetails}>
             <User />
             Show details
           </DropdownMenuItem>

--- a/apps/web/src/components/mail/thread-header.tsx
+++ b/apps/web/src/components/mail/thread-header.tsx
@@ -40,6 +40,7 @@ import { InboxPicker } from '../pickers/inbox-picker'
 import { TagPicker } from '../pickers/tag-picker'
 import { RecordBadge } from '../resources/ui'
 import { ThreadHandoffControl } from './thread-handoff-control'
+import { ThreadParticipantButton } from './thread-participant-button'
 import { useThreadContext } from './thread-provider'
 import { ThreadTag } from './thread-tag'
 import { ThreadTicketControl } from './thread-ticket-control'
@@ -241,6 +242,7 @@ export function ThreadHeader() {
               <ThreadTicketControl />
             </div>
             {isChatChannel && <ThreadHandoffControl />}
+            <ThreadParticipantButton threadId={threadId} />
           </div>
           <div data-slot='thread-header-actions' className=' flex items-center '>
             <Tooltip content={isDone ? 'Unarchive' : 'Archive'} shortcut='D'>

--- a/apps/web/src/components/mail/thread-participant-button.tsx
+++ b/apps/web/src/components/mail/thread-participant-button.tsx
@@ -1,0 +1,92 @@
+// apps/web/src/components/mail/thread-participant-button.tsx
+'use client'
+
+import { groupParticipantsByRole } from '@auxx/types'
+import { toRecordId } from '@auxx/types/resource'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { cn } from '@auxx/ui/lib/utils'
+import { User } from 'lucide-react'
+import { useQueryState } from 'nuqs'
+import * as React from 'react'
+import { RecordBadge, recordBadgeVariants } from '~/components/resources/ui'
+import { useMessages, useParticipant } from '~/components/threads/hooks'
+
+interface ThreadParticipantButtonProps {
+  threadId: string
+}
+
+/**
+ * Compact chip in the thread header that opens the thread's primary
+ * participant (the `from` of the first message) in a drawer.
+ *
+ * Routing rule:
+ * - Linked contact (`entityInstanceId` set) → opens `?contactId=` and renders
+ *   a `RecordBadge` so it matches every other record chip in the app.
+ * - No linked contact → opens `?participantId=` and renders a chip styled with
+ *   the same `recordBadgeVariants` cva so the visual stays consistent
+ *   before/after promotion.
+ *
+ * Reads everything from the existing thread stores (`useMessages` +
+ * `useParticipant`); no extra network call.
+ */
+export function ThreadParticipantButton({ threadId }: ThreadParticipantButtonProps) {
+  const [, setContactId] = useQueryState('contactId', { defaultValue: '' })
+  const [, setParticipantId] = useQueryState('participantId', { defaultValue: '' })
+
+  const { messages, isLoading: messagesLoading } = useMessages({ threadId })
+  const fromId = React.useMemo(() => {
+    const first = messages[0]
+    if (!first) return null
+    return groupParticipantsByRole(first.participants).from
+  }, [messages])
+
+  const { participant } = useParticipant({ participantId: fromId, enabled: !!fromId })
+
+  const handleClick = React.useCallback(() => {
+    if (!participant) return
+    if (participant.entityInstanceId) {
+      void setParticipantId('')
+      void setContactId(participant.entityInstanceId)
+    } else {
+      void setContactId('')
+      void setParticipantId(participant.id)
+    }
+  }, [participant, setContactId, setParticipantId])
+
+  if (messagesLoading && !participant) {
+    return (
+      <span className={cn(recordBadgeVariants({ variant: 'default' }))}>
+        <Skeleton />
+        <Skeleton />
+      </span>
+    )
+  }
+
+  if (!participant) return null
+
+  if (participant.entityInstanceId) {
+    return (
+      <button type='button' onClick={handleClick} className='cursor-pointer'>
+        <RecordBadge
+          recordId={toRecordId('contact', participant.entityInstanceId)}
+          variant='link'
+          hoverCard={false}
+        />
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type='button'
+      onClick={handleClick}
+      className={cn(recordBadgeVariants({ variant: 'link' }))}>
+      <span className='flex size-4 items-center justify-center rounded-full bg-neutral-200 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-200'>
+        <User className='size-2.5' />
+      </span>
+      <span data-slot='record-display' className='truncate'>
+        {participant.displayName}
+      </span>
+    </button>
+  )
+}

--- a/apps/web/src/components/participants/drawer/participant-drawer.tsx
+++ b/apps/web/src/components/participants/drawer/participant-drawer.tsx
@@ -1,0 +1,179 @@
+// apps/web/src/components/participants/drawer/participant-drawer.tsx
+'use client'
+
+import { Avatar, AvatarFallback } from '@auxx/ui/components/avatar'
+import { Button } from '@auxx/ui/components/button'
+import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
+import { DrawerHeader } from '@auxx/ui/components/drawer'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { Mail, MessageSquare, Phone, UserPlus } from 'lucide-react'
+import { useQueryState } from 'nuqs'
+import * as React from 'react'
+import { DockToggleButton } from '~/components/global/dock-toggle-button'
+import { useParticipant } from '~/components/threads/hooks'
+import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useDockStore } from '~/stores/dock-store'
+import { api } from '~/trpc/react'
+
+interface ParticipantDrawerProps {
+  participantId: string | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Drawer for a Participant that has no linked Contact yet.
+ *
+ * When the participant *does* have a linked contact (`entityInstanceId` is
+ * set), the drawer auto-redirects to the contact drawer by swapping the URL
+ * params (`?participantId=` → `?contactId=`). Otherwise it renders a slim
+ * detail view with a "Create Contact" action.
+ */
+export function ParticipantDrawer({ participantId, open, onOpenChange }: ParticipantDrawerProps) {
+  const isDocked = useEffectiveDockState()
+  const dockedWidth = useDockStore((s) => s.dockedWidth)
+  const setDockedWidth = useDockStore((s) => s.setDockedWidth)
+
+  const [, setParticipantIdParam] = useQueryState('participantId', { defaultValue: '' })
+  const [, setContactIdParam] = useQueryState('contactId', { defaultValue: '' })
+
+  const { participant, isLoading, isNotFound } = useParticipant({
+    participantId,
+    enabled: open && !!participantId,
+  })
+
+  // Auto-redirect: once we know the participant has a linked contact, swap
+  // params to open the richer contact drawer instead.
+  React.useEffect(() => {
+    if (!open || !participant?.entityInstanceId) return
+    const contactId = participant.entityInstanceId
+    void setParticipantIdParam('')
+    void setContactIdParam(contactId)
+  }, [open, participant?.entityInstanceId, setParticipantIdParam, setContactIdParam])
+
+  const ensureContact = api.participant.ensureContact.useMutation({
+    onSuccess: ({ entityInstanceId }) => {
+      void setParticipantIdParam('')
+      void setContactIdParam(entityInstanceId)
+    },
+    onError: (error) => {
+      toastError({ title: 'Failed to create contact', description: error.message })
+    },
+  })
+
+  const handleClose = React.useCallback(() => {
+    onOpenChange(false)
+  }, [onOpenChange])
+
+  const handleCreateContact = React.useCallback(() => {
+    if (!participantId) return
+    ensureContact.mutate({ participantId })
+  }, [participantId, ensureContact])
+
+  if (!open || !participantId) return null
+
+  return (
+    <DockableDrawer
+      open={open}
+      onOpenChange={onOpenChange}
+      isDocked={isDocked}
+      width={dockedWidth}
+      onWidthChange={setDockedWidth}
+      minWidth={400}
+      maxWidth={800}
+      title='Participant'>
+      <div className='flex flex-col h-full overflow-hidden'>
+        <DrawerHeader
+          icon={<EntityIcon iconId='circle-user' color='neutral' className='size-6' />}
+          title='Participant'
+          actions={<DockToggleButton />}
+          onClose={handleClose}
+        />
+
+        {isNotFound ? (
+          <div className='flex-1 flex items-center justify-center p-6 text-sm text-muted-foreground'>
+            Participant not found.
+          </div>
+        ) : (
+          <div className='flex-1 overflow-y-auto'>
+            <ParticipantCard
+              displayName={participant?.displayName ?? null}
+              identifier={participant?.identifier ?? null}
+              identifierType={participant?.identifierType ?? null}
+              initials={participant?.initials ?? null}
+              isLoading={isLoading && !participant}
+            />
+
+            <div className='px-3 py-3 border-b'>
+              <Button
+                variant='info'
+                size='sm'
+                className='w-full'
+                loading={ensureContact.isPending}
+                loadingText='Creating contact...'
+                disabled={!participant || ensureContact.isPending}
+                onClick={handleCreateContact}>
+                <UserPlus />
+                Create Contact
+              </Button>
+              <p className='mt-2 text-xs text-muted-foreground'>
+                Promote this participant to a contact to assign owners, add notes, and track
+                conversations across channels.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </DockableDrawer>
+  )
+}
+
+/**
+ * Top card showing participant identity (name, identifier, channel icon).
+ */
+function ParticipantCard({
+  displayName,
+  identifier,
+  identifierType,
+  initials,
+  isLoading,
+}: {
+  displayName: string | null
+  identifier: string | null
+  identifierType: 'EMAIL' | 'PHONE' | 'CHAT_VISITOR' | null
+  initials: string | null
+  isLoading: boolean
+}) {
+  const IdentifierIcon =
+    identifierType === 'PHONE' ? Phone : identifierType === 'CHAT_VISITOR' ? MessageSquare : Mail
+
+  return (
+    <div className='flex gap-3 py-3 px-3 flex-row items-center justify-start border-b'>
+      <Avatar className='size-10'>
+        <AvatarFallback className='text-sm'>
+          {isLoading ? <Skeleton className='size-10 rounded-full' /> : (initials ?? '?')}
+        </AvatarFallback>
+      </Avatar>
+      <div className='flex flex-col align-start w-full min-w-0'>
+        <div className='text-lg font-medium text-neutral-900 dark:text-neutral-400 truncate'>
+          {isLoading ? <Skeleton className='h-6 w-60 mb-1' /> : (displayName ?? 'Unknown')}
+        </div>
+        <div className='flex items-center gap-1.5 text-xs text-muted-foreground min-w-0'>
+          {isLoading ? (
+            <Skeleton className='h-4 w-48' />
+          ) : (
+            <>
+              <IdentifierIcon className='size-3.5 shrink-0' />
+              <span className='truncate'>{identifier ?? '—'}</span>
+              <span className='ms-1 px-1.5 py-0.5 rounded bg-muted text-[10px] uppercase tracking-wide shrink-0'>
+                Not a contact
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/resources/hooks/use-all-records.ts
+++ b/apps/web/src/components/resources/hooks/use-all-records.ts
@@ -14,7 +14,7 @@ import {
   type StoredFieldValue,
   useFieldValueStore,
 } from '../store/field-value-store'
-import { type RecordMeta, useRecordStore } from '../store/record-store'
+import { type RecordMeta, type RecordStoreState, useRecordStore } from '../store/record-store'
 
 /**
  * Options for useAllRecords hook
@@ -139,6 +139,32 @@ export function useAllRecords<T extends RecordMeta = RecordMeta>(
   // Stable string key for selector memoization
   const keysKey = fieldValueKeys.join(',')
 
+  // Stable list of record ids for the current page (for meta overlay below)
+  const recordIds = useMemo(() => (data?.items ?? []).map((item) => item.id), [data?.items])
+  const idsKey = recordIds.join(',')
+
+  // Subscribe to the per-record meta (displayName / secondaryDisplayValue / avatarUrl)
+  // from the record store. Realtime keeps these fresh via use-resource-sync; the
+  // listAll React Query payload doesn't. Reading from the store here lets denormalized
+  // columns flow through to consumers the same way fieldValues already do.
+  const storeMetas = useRecordStore(
+    useShallow(
+      // biome-ignore lint/correctness/useExhaustiveDependencies: recordIds is captured from the same render as idsKey; idsKey serves as the stable content key
+      useCallback(
+        (state: RecordStoreState): Record<string, RecordMeta | undefined> => {
+          if (!resolvedEntityDefId) return {}
+          const bucket = state.records[resolvedEntityDefId]
+          if (!bucket) return {}
+          const result: Record<string, RecordMeta | undefined> = {}
+          for (const id of recordIds) result[id] = bucket.get(id)
+          return result
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [resolvedEntityDefId, idsKey]
+      )
+    )
+  )
+
   // Subscribe to ONLY the field values we need (prevents re-renders from unrelated changes)
   const relevantFieldValues = useFieldValueStore(
     useShallow(
@@ -194,6 +220,7 @@ export function useAllRecords<T extends RecordMeta = RecordMeta>(
 
     return data.items.map((item) => {
       const recordId = toRecordId(resolvedEntityDefId, item.id)
+      const storeMeta = storeMetas[item.id]
 
       // Build field values by reading from store (includes optimistic updates)
       const composedFieldValues: Record<string, unknown> = {}
@@ -211,12 +238,26 @@ export function useAllRecords<T extends RecordMeta = RecordMeta>(
         }
       }
 
+      // Overlay denormalized columns from the record store. Realtime keeps these
+      // fresh after every record:updated event; falls back to the listAll payload
+      // on the first render before the store is populated.
       return {
         ...item,
+        displayName: (storeMeta?.displayName as string | undefined) ?? item.displayName,
+        secondaryDisplayValue:
+          (storeMeta?.secondaryDisplayValue as string | undefined) ?? item.secondaryDisplayValue,
+        avatarUrl: (storeMeta?.avatarUrl as string | undefined) ?? item.avatarUrl,
         fieldValues: composedFieldValues,
       }
     })
-  }, [data?.items, data?.fields, resolvedEntityDefId, relevantFieldValues, resolveFieldId])
+  }, [
+    data?.items,
+    data?.fields,
+    resolvedEntityDefId,
+    relevantFieldValues,
+    resolveFieldId,
+    storeMetas,
+  ])
 
   return {
     records: records as T[],

--- a/apps/web/src/components/resources/store/record-store.ts
+++ b/apps/web/src/components/resources/store/record-store.ts
@@ -44,7 +44,7 @@ interface ListCache {
   nextCursor: string | null
 }
 
-interface RecordStoreState {
+export interface RecordStoreState {
   // ─────────────────────────────────────────────────────────────────
   // STATE
   // ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/components/threads/hooks/use-thread-keyboard-nav.ts
+++ b/apps/web/src/components/threads/hooks/use-thread-keyboard-nav.ts
@@ -152,11 +152,16 @@ export function useThreadKeyboardNav({
     conflictBehavior: 'allow',
   })
 
-  // Escape - clear selection
-  useHotkey('Escape', () => useThreadSelectionStore.getState().clearSelection(), {
-    enabled,
-    conflictBehavior: 'allow',
-  })
+  // Escape - clear selection. Defer to open Radix popovers/dropdowns so they
+  // can dismiss themselves first (Dialog/Drawer stop propagation on their own).
+  useHotkey(
+    'Escape',
+    () => {
+      if (document.querySelector('[data-radix-popper-content-wrapper]')) return
+      useThreadSelectionStore.getState().clearSelection()
+    },
+    { enabled, conflictBehavior: 'allow' }
+  )
 
   // Toggle view mode (view/edit)
   useHotkey(

--- a/packages/lib/src/realtime/events.ts
+++ b/packages/lib/src/realtime/events.ts
@@ -147,6 +147,12 @@ export interface ThreadMeta {
   updatedAt?: string
   /** Chat-only: AI vs human handoff state. Drives the take-over button UI. */
   handoffState?: 'ai' | 'human'
+  /**
+   * Channel-specific extras (`Thread.metadata` JSONB). Patch semantics: omit =
+   * unchanged; `null` = clear; object = full replacement. Chat threads carry
+   * `ChatThreadMetadata`; other channels may carry `{ importance }`.
+   */
+  metadata?: Record<string, unknown> | null
 }
 
 /**

--- a/packages/lib/src/threads/thread-query.service.ts
+++ b/packages/lib/src/threads/thread-query.service.ts
@@ -880,6 +880,7 @@ export class ThreadQueryService {
           draftIds: draftIdsByThread.get(id) ?? [],
           scheduledMessageCount: scheduledCountMap.get(id) ?? 0,
           handoffState: t.handoffState,
+          metadata: (t.metadata as Record<string, unknown> | null) ?? null,
         } satisfies ThreadMeta
       })
       .filter(Boolean) as ThreadMeta[]

--- a/packages/lib/src/threads/types.ts
+++ b/packages/lib/src/threads/types.ts
@@ -142,6 +142,13 @@ export interface ThreadMeta {
    * happens regardless). Drives the take-over / return-to-AI buttons.
    */
   handoffState: 'ai' | 'human'
+
+  /**
+   * Channel-specific extras stored on `Thread.metadata` (JSONB). Chat threads
+   * carry `ChatThreadMetadata` here; other channels may carry `{ importance }`
+   * or be null. Loose shape — not enforced at the DB level.
+   */
+  metadata: Record<string, unknown> | null
 }
 
 /**


### PR DESCRIPTION
## Summary
- New `ParticipantDrawer` opened via `?participantId=` for thread participants that don't have a linked contact yet. Docks alongside the existing contact/ticket drawers and falls back to an overlay when undocked.
- Thread header gains a `ThreadParticipantButton` chip (primary `from` of the thread). Linked contact → opens the contact drawer via `RecordBadge`; otherwise opens the new participant drawer. The participant-message dropdown's "Show details" follows the same routing.
- `useAllRecords` now overlays `displayName` / `secondaryDisplayValue` / `avatarUrl` from the record store so realtime `record:updated` events flow through to list consumers (previously only `fieldValues` did).
- `ThreadMeta` carries channel-specific `metadata` (JSONB) through both the list query and realtime events so chat/inbox extras don't get dropped.
- Escape in thread keyboard nav defers to any open Radix popover/dropdown before clearing the selection — fixes Escape eating the first dismiss for menus inside the thread view.

## Test plan
- [ ] Open a thread whose `from` is linked to a contact → header chip renders as a contact `RecordBadge`; clicking opens the contact drawer.
- [ ] Open a thread whose `from` has no linked contact → header chip renders with a generic user icon; clicking opens the participant drawer.
- [ ] In a message header, the participant dropdown's "Show details" routes to the same drawer as the chip (no longer disabled when the contact link is missing).
- [ ] Toggle dock mode — participant drawer renders as a docked panel when docked, overlay when not.
- [ ] In a record list, trigger a realtime update that changes `displayName` / `avatarUrl` and confirm the row updates without a refetch.
- [ ] With a dropdown open in the thread view, press Escape once → dropdown closes, selection persists. Second Escape clears the selection.