### PR TITLE
feat(chat-widget): framework-specific setup snippets + JWT middleware fix

### DIFF
--- a/apps/api/src/middleware/chat-jwt.ts
+++ b/apps/api/src/middleware/chat-jwt.ts
@@ -47,11 +47,28 @@ export const chatUserJwtMiddleware: MiddlewareHandler = async (c, next) => {
     return next()
   }
 
+  // Only JSON bodies carry the user_data envelope. Reading any other
+  // content type (e.g. application/x-www-form-urlencoded from
+  // /pusher/auth) would consume the stream before the route handler can
+  // parse it, breaking the downstream handler.
+  const contentType = c.req.header('content-type') ?? ''
+  if (!contentType.toLowerCase().includes('application/json')) {
+    c.set('chatJwt', { verified: false, reason: 'absent' })
+    if (enforced) {
+      log.warn('Chat request rejected — enforced channel, non-JSON body', {
+        channelId: passport.channelId,
+        contentType,
+      })
+      return rejectEnforced('IDENTITY_REQUIRED', 'This chat channel requires a signed user JWT')
+    }
+    return next()
+  }
+
   let body: unknown = null
   try {
     body = await c.req.json()
   } catch {
-    // Not JSON or empty body — treat as absent.
+    // Empty / malformed JSON — treat as absent.
     c.set('chatJwt', { verified: false, reason: 'absent' })
     if (enforced) {
       log.warn('Chat request rejected — enforced channel, no JWT body', {

--- a/apps/docs/content/docs/help/channels/chat-widget.mdx
+++ b/apps/docs/content/docs/help/channels/chat-widget.mdx
@@ -3,43 +3,226 @@ title: Chat Widget
 description: Embed the Auxx chat widget on your site to route live conversations and AI replies into your inbox.
 ---
 
-The chat widget is a small script you drop into your site's HTML. Visitors get a launcher in the corner of the page; messages land in the inbox you've connected to the widget and can be answered by your team or an AI agent.
+The chat widget runs in your visitors' browsers and routes their messages into the inbox you've connected to the widget. Pick the install path that matches your stack — every option ends up in the same place.
 
 ## Prerequisites
 
 - A chat widget created in **Settings → Channels → Chat Widget**.
 - An inbox the widget routes conversations into (set on the widget's **General** tab).
-- Access to your site's HTML or template — the snippet needs to run on every page where the widget should appear.
+- Your widget's **channel id** — find it in **Settings → Channels → your widget → Setup**. Every snippet on this page uses `<channelId>` as a placeholder.
 
-## 1. Paste the install snippet
+## 1. Install the widget
 
-Open your widget in **Settings → Channels**, go to the **General** tab, and find the **Install** section. Copy the snippet — it looks like:
+Open your widget in **Settings → Channels → Setup** and copy the snippet that matches your stack. The Setup tab generates the exact same snippets shown here, with your real channel id pre-filled.
+
+<Tabs items={['Basic JS', 'npm', 'SPA', 'React', 'Vue', 'Angular']}>
+
+<Tab value="Basic JS">
+
+Paste this just before `</body>` on every page that should show the widget. No build step, no framework — works on any HTML page.
 
 ```html
-<script src="https://app.auxx.ai/api/integrations/chat/INTEGRATION_ID/script.js" async defer></script>
+<script
+  src="https://app.auxx.ai/scripts/chat-widget.js"
+  data-channel-id="<channelId>"
+  async defer></script>
 ```
 
-Paste it into your site's HTML just before the closing `</body>` tag, on every page the widget should appear on.
+The bundle is a single static asset served from our CDN. The `data-channel-id` attribute is the only piece that's customer-specific.
+
+</Tab>
+
+<Tab value="npm">
+
+Install the package and call `boot` once after the page loads.
+
+```bash
+npm install @auxx/chat
+```
+
+```ts
+import Auxx from '@auxx/chat'
+
+Auxx.boot({ channelId: '<channelId>' })
+```
+
+To pass visitor info or a verified-identity JWT, call `Auxx.boot` again with the same `channelId` — same-channel re-boots are a soft refresh.
+
+</Tab>
+
+<Tab value="SPA">
+
+In a single-page app you usually want full control over the widget lifecycle: boot on login, push attribute updates without a re-init, shut down on logout so the next user starts cold.
+
+```ts
+import Auxx from '@auxx/chat'
+
+// On app start / login
+Auxx.boot({ channelId: '<channelId>', userJwt })
+
+// On user data change (no reboot)
+Auxx.update({ plan: 'pro' })
+
+// On logout
+Auxx.shutdown()
+```
+
+Same package as the npm install — this snippet is about how to drive its `boot` / `update` / `shutdown` API across your app's lifecycle.
+
+</Tab>
+
+<Tab value="React">
+
+```bash
+npm install @auxx/chat
+```
+
+```tsx
+import { AuxxChat } from '@auxx/chat/react'
+
+export function AppRoot() {
+  return (
+    <>
+      {/* … your app … */}
+      <AuxxChat channelId="<channelId>" userJwt={token} />
+    </>
+  )
+}
+```
+
+Mount once at your app root. The component runs `Auxx.boot` on mount, `Auxx.update` when its serialized attributes change, and `Auxx.shutdown` on unmount.
+
+</Tab>
+
+<Tab value="Vue">
+
+```bash
+npm install @auxx/chat
+```
+
+Create a thin wrapper component:
+
+```vue
+<!-- components/AuxxChat.vue -->
+<script setup lang="ts">
+import { onMounted, onUnmounted, watch } from 'vue'
+import Auxx from '@auxx/chat'
+
+const props = defineProps<{
+  channelId: string
+  userJwt?: string
+  attributes?: Record<string, unknown>
+}>()
+
+onMounted(() => {
+  Auxx.boot({
+    channelId: props.channelId,
+    userJwt: props.userJwt,
+    attributes: props.attributes,
+  })
+})
+onUnmounted(() => {
+  Auxx.shutdown()
+})
+watch(
+  () => props.attributes,
+  (next) => next && Auxx.update(next),
+  { deep: true }
+)
+</script>
+
+<template></template>
+```
+
+Then mount it once at your app root:
+
+```vue
+<!-- App.vue -->
+<script setup lang="ts">
+import AuxxChat from './components/AuxxChat.vue'
+</script>
+
+<template>
+  <!-- … your app … -->
+  <AuxxChat channel-id="<channelId>" :user-jwt="token" />
+</template>
+```
+
+</Tab>
+
+<Tab value="Angular">
+
+```bash
+npm install @auxx/chat
+```
+
+Create a thin wrapper component:
+
+```ts
+// auxx-chat.component.ts
+import { Component, Input, OnDestroy, OnInit } from '@angular/core'
+import Auxx from '@auxx/chat'
+
+@Component({ selector: 'auxx-chat', template: '' })
+export class AuxxChatComponent implements OnInit, OnDestroy {
+  @Input() channelId!: string
+  @Input() userJwt?: string
+
+  ngOnInit() {
+    Auxx.boot({ channelId: this.channelId, userJwt: this.userJwt })
+  }
+  ngOnDestroy() {
+    Auxx.shutdown()
+  }
+}
+```
+
+Declare it in your app module, then drop it in once at the root:
+
+```html
+<!-- app.component.html -->
+<!-- … your app … -->
+<auxx-chat channelId="<channelId>" [userJwt]="token"></auxx-chat>
+```
+
+</Tab>
+
+</Tabs>
 
 ## 2. Configure allowed domains (optional)
 
 By default the widget loads on any site you embed it on. To restrict that:
 
-1. Open the widget's **Domains** tab.
+1. Open the widget's **Identity** tab.
 2. Add each domain that should be allowed to embed the widget — bare hostnames only, no protocol (`example.com`, not `https://example.com`).
 3. Subdomains of an allowed domain pass automatically — adding `example.com` also allows `app.example.com`.
 
-Leave the list empty if you want the widget to load anywhere.
+Leave the list empty to allow the widget to load anywhere.
 
 ## 3. Identify the visitor (optional)
 
-If you know who's on the page — for example after a user signs in — pass their info to the widget so the conversation is attached to a known visitor instead of an anonymous one.
+If you know who's on the page — typically after a user signs in — pass their info to the widget so the conversation attaches to a known visitor instead of an anonymous one.
 
-There are two patterns, pick whichever fits your setup.
+### Pass identity at boot
 
-### Queue-style — call before the bundle loads
+When using the npm package, React, Vue, or Angular install paths, pass an identity payload directly to `Auxx.boot`:
 
-Push commands onto a `window.AuxxChat` array before the script tag. The widget drains the queue once it boots.
+```ts
+import Auxx from '@auxx/chat'
+
+Auxx.boot({
+  channelId: '<channelId>',
+  attributes: {
+    name: 'Jane Doe',
+    email: 'jane@acme.com',
+    externalId: 'cus_123',
+  },
+})
+```
+
+### Queue-style identify
+
+If your visitor data is rendered into the page server-side (e.g. a Rails or Django template), push commands onto a `window.AuxxChat` array before the script tag. The widget drains the queue once it boots — works with any install path, but it's most natural with the Basic JS snippet.
 
 ```html
 <script>
@@ -50,42 +233,56 @@ Push commands onto a `window.AuxxChat` array before the script tag. The widget d
     externalId: 'cus_123'
   }]);
 </script>
-<script src="https://app.auxx.ai/api/integrations/chat/INTEGRATION_ID/script.js" async defer></script>
+<script
+  src="https://app.auxx.ai/scripts/chat-widget.js"
+  data-channel-id="<channelId>"
+  async defer></script>
 ```
 
-### Direct call — after the bundle has loaded
-
-Call `identify` directly after the widget script is on the page (typical in single-page apps after a login event):
+Or call `identify` directly after the bundle has loaded:
 
 ```js
 window.AuxxChat.identify({
   email: 'jane@acme.com',
-  externalId: 'cus_123'
+  externalId: 'cus_123',
 })
 ```
 
 ### Payload reference
 
-| Field        | Type     | Notes                                                                |
-| ------------ | -------- | -------------------------------------------------------------------- |
-| `name`       | string   | Display name shown in the inbox.                                     |
-| `email`      | string   | Used to match or create a contact.                                   |
-| `externalId` | string   | Your stable visitor key (e.g. your user id). Recommended for matching. |
+| Field        | Type   | Notes                                                                  |
+| ------------ | ------ | ---------------------------------------------------------------------- |
+| `name`       | string | Display name shown in the inbox.                                       |
+| `email`      | string | Used to match or create a contact.                                     |
+| `externalId` | string | Your stable visitor key (e.g. your user id). Recommended for matching. |
 
 All three fields are optional, but at least one must be non-empty for the call to register. Empty strings are dropped, and the most recent payload is persisted to `sessionStorage` so calling `identify` on every page load is safe.
 
-## 4. Verify the install
+## 4. Verify identity with a JWT (recommended)
+
+Anyone can call `identify` from the browser, so the email or external id you pass is only as trustworthy as the visitor's tab. For sensitive surfaces (account info, billing, support history), sign a short-lived JWT on your server with one of your widget's signing keys and pass it as `userJwt`.
+
+1. Open the widget's **Identity** tab.
+2. Click **Create signing key** and copy the secret — it's only shown once.
+3. Sign a JWT for the current visitor on your server using that secret.
+4. Pass the token to `Auxx.boot({ channelId, userJwt })`.
+5. Once your server reliably signs every visitor, click **Enforce** to reject anonymous traffic.
+
+The Identity tab walks through this end-to-end with the exact code snippets to paste on your server.
+
+## 5. Verify the install
 
 Open a page that includes the snippet — you should see the launcher in the configured corner. If it doesn't appear:
 
-- Check the **Domains** tab — if you've restricted domains, the current page's hostname must be in the list (or be a subdomain of one).
+- Check **Identity → Allowed Domains** — if you've restricted domains, the current page's hostname must be in the list (or be a subdomain of one).
 - Open the browser console and look for Content Security Policy errors blocking the script src.
 - Confirm the snippet is actually in the rendered HTML (some CMS templates strip script tags).
 
-You can also use the **Open preview** button at the top of the widget settings to load a live preview in a popup — useful for smoke-testing settings without touching your live site.
+You can also use the **Open preview** button at the top of widget settings to load a live preview in a popup — useful for smoke-testing settings without touching your live site.
 
 ## Troubleshooting
 
-- **Launcher doesn't appear** — check domain allowlist, browser console errors, and that the snippet is in the rendered HTML.
+- **Launcher doesn't appear** — check the allowed-domain list, browser console errors, and that the snippet is in the rendered HTML.
 - **`identify` doesn't take effect** — confirm at least one field is non-empty and that the command string is exactly `'identify'`.
+- **Identity enforcement rejects requests** — the JWT may be expired or signed with a revoked key. Mint a new signing key, sign with the new secret, then revoke the old key once the rollout is complete.
 - **AI auto-reply isn't firing** — verify an agent is selected in **General → AI Auto-Reply** and that auto-reply behaviour is enabled in the **Behavior** tab.

--- a/apps/web/src/components/chat-widget/ui/settings/chat-widget-settings.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/chat-widget-settings.tsx
@@ -175,7 +175,7 @@ export function ChatWidgetSettings({ channelId }: ChatWidgetSettingsProps) {
         </Button>
       }>
       <ConfirmDialog />
-      <div className='sticky top-[68px] z-10 border-b border-border bg-background/90 p-3 backdrop-blur-sm'>
+      <div className='sticky top-[68px] z-20 border-b border-border bg-background/90 p-3 backdrop-blur-sm'>
         <RadioTab
           value={activeSection}
           onValueChange={setActiveSection}

--- a/apps/web/src/components/chat-widget/ui/settings/sections/identity-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/identity-section.tsx
@@ -21,6 +21,7 @@ import {
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { useCopy } from '@auxx/ui/hooks/use-copy'
 import {
+  ArrowUpRight,
   Check,
   Copy,
   Globe,
@@ -30,6 +31,7 @@ import {
   Terminal,
   Trash2,
 } from 'lucide-react'
+import { useQueryState } from 'nuqs'
 import { useCallback, useState } from 'react'
 import { EmailFilterSection } from '~/app/(protected)/app/settings/channels/_components/email-list-dialog'
 import { Tooltip } from '~/components/global/tooltip'
@@ -44,6 +46,7 @@ interface IdentitySectionProps {
 export function IdentitySection({ widget, channelId }: IdentitySectionProps) {
   const utils = api.useUtils()
   const [confirm, ConfirmDialog] = useConfirm()
+  const [, setActiveSection] = useQueryState('s')
   const [newlyCreatedKey, setNewlyCreatedKey] = useState<string | null>(null)
   const {
     copied: copiedKey,
@@ -145,6 +148,16 @@ export function IdentitySection({ widget, channelId }: IdentitySectionProps) {
               widget can prove who the visitor is. Phase 3 wires verification end-to-end; for now,
               you can mint and rotate keys here.
             </p>
+          </div>
+
+          <div className='mb-2 flex justify-end'>
+            <button
+              type='button'
+              onClick={() => setActiveSection('setup')}
+              className='inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline'>
+              See Setup for framework-specific install instructions
+              <ArrowUpRight className='size-3' />
+            </button>
           </div>
 
           <EnforcementCard

--- a/apps/web/src/components/chat-widget/ui/settings/sections/setup-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/setup-section.tsx
@@ -1,33 +1,44 @@
 // apps/web/src/components/chat-widget/ui/settings/sections/setup-section.tsx
 'use client'
 import type { ChatWidgetWithIntegration } from '@auxx/lib/chat-widget/config'
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-  InputGroupText,
-} from '@auxx/ui/components/input-group'
-import { Skeleton } from '@auxx/ui/components/skeleton'
-import { useCopy } from '@auxx/ui/hooks/use-copy'
-import { ArrowUpRight, Check, Code, Copy, ExternalLink } from 'lucide-react'
-import { Tooltip } from '~/components/global/tooltip'
+import { AngularIcon } from '@auxx/ui/components/icons/angular-icon'
+import { NpmIcon } from '@auxx/ui/components/icons/npm-icon'
+import { ReactIcon } from '@auxx/ui/components/icons/react-icon'
+import { VueIcon } from '@auxx/ui/components/icons/vue-icon'
+import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
+import { ArrowUpRight, Code, ExternalLink } from 'lucide-react'
+import { parseAsStringLiteral, useQueryState } from 'nuqs'
+import { useMemo } from 'react'
+import CodeEditor from '~/components/workflow/ui/code-editor'
+import { CodeLanguage } from '~/components/workflow/ui/code-editor/types'
 import { useEnv } from '~/providers/dehydrated-state-provider'
-import { api } from '~/trpc/react'
+import {
+  getSetupSnippets,
+  type SetupCodeFlavor,
+  type SetupFramework,
+  type SetupSnippet,
+} from './setup-snippets'
 
 interface SetupSectionProps {
   widget: ChatWidgetWithIntegration
   channelId: string
 }
 
+const FRAMEWORKS = ['code', 'react', 'vue', 'angular'] as const
+const FLAVORS = ['basic-js', 'npm', 'spa'] as const
+
 export function SetupSection({ channelId }: SetupSectionProps) {
   const { docsUrl } = useEnv()
-  const { data: installCode, isLoading: installLoading } = api.channel.getInstallationCode.useQuery(
-    { integrationId: channelId }
+  const [framework, setFramework] = useQueryState(
+    'framework',
+    parseAsStringLiteral(FRAMEWORKS).withDefault('code')
   )
-  const { copied: copiedLink, copy: copyLink } = useCopy({
-    toastMessage: 'Install snippet copied to clipboard',
-  })
+  const [flavor, setFlavor] = useQueryState(
+    'flavor',
+    parseAsStringLiteral(FLAVORS).withDefault('basic-js')
+  )
+
+  const snippets = useMemo(() => getSetupSnippets(channelId), [channelId])
 
   const openFullPreview = () => {
     const width = 900
@@ -51,6 +62,15 @@ export function SetupSection({ channelId }: SetupSectionProps) {
     }
   }
 
+  const activeSnippet: SetupSnippet =
+    framework === 'code'
+      ? snippets.code[flavor]
+      : framework === 'react'
+        ? snippets.react
+        : framework === 'vue'
+          ? snippets.vue
+          : snippets.angular
+
   return (
     <div className='p-6 space-y-8'>
       <div>
@@ -59,59 +79,75 @@ export function SetupSection({ channelId }: SetupSectionProps) {
             <Code className='size-4' /> Install
           </div>
           <p className='text-sm text-muted-foreground'>
-            Paste this snippet into your site's HTML, ideally just before <code>&lt;/body&gt;</code>
-            .
+            Choose your stack — the snippet below is ready to paste.
           </p>
         </div>
-        <InputGroup>
-          <InputGroupAddon align='inline-start'>
-            <Code />
-          </InputGroupAddon>
-          {installLoading ? (
-            <InputGroupText className='flex-1'>
-              <Skeleton className='h-4 w-full' />
-            </InputGroupText>
-          ) : installCode?.script ? (
-            <InputGroupInput
-              type='text'
-              value={installCode.script}
-              readOnly
-              className='font-mono text-xs'
-              onFocus={(e) => e.target.select()}
-            />
-          ) : (
-            <InputGroupText className='text-destructive'>
-              Could not load installation code.
-            </InputGroupText>
-          )}
-          <InputGroupAddon align='inline-end' className='gap-0.5'>
-            <Tooltip content='Copy'>
-              <InputGroupButton
-                aria-label='Copy install snippet'
-                className='rounded-full'
-                size='icon-xs'
-                disabled={!installCode?.script}
-                onClick={() => installCode?.script && copyLink(installCode.script)}>
-                {copiedLink ? <Check /> : <Copy />}
-              </InputGroupButton>
-            </Tooltip>
-          </InputGroupAddon>
-        </InputGroup>
 
-        <ul className='mt-4 space-y-1.5 pl-5 text-sm text-muted-foreground list-disc marker:text-muted-foreground/60'>
-          <li>
-            Paste the snippet just before <code>&lt;/body&gt;</code> on every page that should show
-            the widget.
-          </li>
-          <li>
-            Pass visitor info via <code>window.AuxxChat.identify(…)</code> so conversations attach
-            to a known contact.
-          </li>
-          <li>
-            For verified identity, see the <strong>Identity</strong> tab — sign a per-session JWT on
-            your server and pass it to <code>Auxx.boot()</code>.
-          </li>
-        </ul>
+        <RadioTab
+          value={framework}
+          onValueChange={(v) => setFramework(v as SetupFramework)}
+          size='sm'
+          radioGroupClassName='grid w-full grid-cols-4'
+          className='border border-primary-200 flex w-full mb-3'>
+          <RadioTabItem value='code' size='sm'>
+            <Code />
+            Code snippet
+          </RadioTabItem>
+          <RadioTabItem value='react' size='sm'>
+            <ReactIcon />
+            React
+          </RadioTabItem>
+          <RadioTabItem value='vue' size='sm'>
+            <VueIcon />
+            Vue
+          </RadioTabItem>
+          <RadioTabItem value='angular' size='sm'>
+            <AngularIcon />
+            Angular
+          </RadioTabItem>
+        </RadioTab>
+
+        {framework === 'code' && (
+          <RadioTab
+            value={flavor}
+            onValueChange={(v) => setFlavor(v as SetupCodeFlavor)}
+            size='sm'
+            radioGroupClassName='grid w-full grid-cols-3'
+            className='border border-primary-200 flex w-full mb-4'>
+            <RadioTabItem value='basic-js' size='sm'>
+              <Code />
+              Basic JS
+            </RadioTabItem>
+            <RadioTabItem value='npm' size='sm'>
+              <NpmIcon />
+              npm package
+            </RadioTabItem>
+            <RadioTabItem value='spa' size='sm'>
+              <Code />
+              Single page app
+            </RadioTabItem>
+          </RadioTab>
+        )}
+
+        <div className='space-y-3'>
+          {activeSnippet.blocks.map((block, i) => {
+            const lines = block.value.split('\n').length
+            const isShell = block.language === CodeLanguage.shell
+            // header (28) + lines * 18 (CODE_EDITOR_LINE_HEIGHT) + 24px padding
+            const minHeight = isShell ? 56 : 28 + lines * 18 + 24
+            return (
+              <CodeEditor
+                key={`${framework}-${flavor}-${i}`}
+                language={block.language}
+                value={block.value}
+                readOnly
+                title={block.title ?? activeSnippet.label}
+                minHeight={minHeight}
+              />
+            )
+          })}
+          <p className='text-sm text-muted-foreground'>{activeSnippet.note}</p>
+        </div>
 
         <div className='mt-4 flex items-center gap-4'>
           <a

--- a/apps/web/src/components/chat-widget/ui/settings/sections/setup-snippets.ts
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/setup-snippets.ts
@@ -1,0 +1,193 @@
+// apps/web/src/components/chat-widget/ui/settings/sections/setup-snippets.ts
+import { CodeLanguage } from '~/components/workflow/ui/code-editor/types'
+
+export type SetupFramework = 'code' | 'react' | 'vue' | 'angular'
+export type SetupCodeFlavor = 'basic-js' | 'npm' | 'spa'
+
+export interface SetupSnippetBlock {
+  language: CodeLanguage
+  value: string
+  title?: string
+}
+
+export interface SetupSnippet {
+  label: string
+  blocks: SetupSnippetBlock[]
+  note: string
+}
+
+const installBlock: SetupSnippetBlock = {
+  language: CodeLanguage.shell,
+  value: 'npm install @auxx/chat',
+  title: 'Install',
+}
+
+export function getSetupSnippets(channelId: string): {
+  code: Record<SetupCodeFlavor, SetupSnippet>
+  react: SetupSnippet
+  vue: SetupSnippet
+  angular: SetupSnippet
+} {
+  const id = channelId || '<channelId>'
+  return {
+    code: {
+      'basic-js': {
+        label: 'Basic JS',
+        blocks: [
+          {
+            language: CodeLanguage.html,
+            value: `<script
+  src="https://app.auxx.ai/scripts/chat-widget.js"
+  data-channel-id="${id}"
+  async defer></script>`,
+            title: 'Basic JS',
+          },
+        ],
+        note: 'Paste just before </body> on every page that should show the widget. Zero build step — works on any HTML page.',
+      },
+      npm: {
+        label: 'npm package',
+        blocks: [
+          installBlock,
+          {
+            language: CodeLanguage.typescript,
+            value: `import Auxx from '@auxx/chat'
+
+Auxx.boot({ channelId: '${id}' })`,
+            title: 'Boot',
+          },
+        ],
+        note: 'Call once after the page loads. Pass userJwt or attributes later by calling Auxx.boot again with the same channelId — same-channel re-boots are a soft refresh.',
+      },
+      spa: {
+        label: 'Single page app',
+        blocks: [
+          installBlock,
+          {
+            language: CodeLanguage.typescript,
+            value: `import Auxx from '@auxx/chat'
+
+// On app start / login:
+Auxx.boot({ channelId: '${id}', userJwt })
+
+// On user data change (no reboot):
+Auxx.update({ plan: 'pro' })
+
+// On logout:
+Auxx.shutdown()`,
+            title: 'Lifecycle',
+          },
+        ],
+        note: 'Same package as npm. Use shutdown so the next user starts cold, update for in-place attribute pushes, and boot again for full re-init.',
+      },
+    },
+    react: {
+      label: 'React',
+      blocks: [
+        installBlock,
+        {
+          language: CodeLanguage.typescript,
+          value: `import { AuxxChat } from '@auxx/chat/react'
+
+export function AppRoot() {
+  return (
+    <>
+      {/* … your app … */}
+      <AuxxChat channelId="${id}" userJwt={token} />
+    </>
+  )
+}`,
+          title: 'React',
+        },
+      ],
+      note: 'Mount once at your app root. The component handles boot, update, and shutdown for you.',
+    },
+    vue: {
+      label: 'Vue',
+      blocks: [
+        installBlock,
+        {
+          language: CodeLanguage.html,
+          value: `<!-- components/AuxxChat.vue -->
+<script setup lang="ts">
+import { onMounted, onUnmounted, watch } from 'vue'
+import Auxx from '@auxx/chat'
+
+const props = defineProps<{
+  channelId: string
+  userJwt?: string
+  attributes?: Record<string, unknown>
+}>()
+
+onMounted(() => {
+  Auxx.boot({
+    channelId: props.channelId,
+    userJwt: props.userJwt,
+    attributes: props.attributes,
+  })
+})
+onUnmounted(() => {
+  Auxx.shutdown()
+})
+watch(
+  () => props.attributes,
+  (next) => next && Auxx.update(next),
+  { deep: true }
+)
+</script>
+
+<template></template>`,
+          title: 'Vue SFC',
+        },
+        {
+          language: CodeLanguage.html,
+          value: `<!-- App.vue -->
+<script setup lang="ts">
+import AuxxChat from './components/AuxxChat.vue'
+</script>
+
+<template>
+  <!-- … your app … -->
+  <AuxxChat channel-id="${id}" :user-jwt="token" />
+</template>`,
+          title: 'Usage',
+        },
+      ],
+      note: 'Drop the component into your app root once. It boots on mount, syncs attribute changes via watch, and shuts down on unmount.',
+    },
+    angular: {
+      label: 'Angular',
+      blocks: [
+        installBlock,
+        {
+          language: CodeLanguage.typescript,
+          value: `// auxx-chat.component.ts
+import { Component, Input, OnDestroy, OnInit } from '@angular/core'
+import Auxx from '@auxx/chat'
+
+@Component({ selector: 'auxx-chat', template: '' })
+export class AuxxChatComponent implements OnInit, OnDestroy {
+  @Input() channelId!: string
+  @Input() userJwt?: string
+
+  ngOnInit() {
+    Auxx.boot({ channelId: this.channelId, userJwt: this.userJwt })
+  }
+  ngOnDestroy() {
+    Auxx.shutdown()
+  }
+}`,
+          title: 'Angular component',
+        },
+        {
+          language: CodeLanguage.html,
+          value: `<!-- app.component.html -->
+<!-- … your app … -->
+<auxx-chat channelId="${id}" [userJwt]="token"></auxx-chat>`,
+          title: 'Usage',
+        },
+      ],
+      note: 'Declare the component in your app module and drop it in once at the root. It boots on init and shuts down on destroy.',
+    },
+  }
+}

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -23,7 +23,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { useDraggable } from '@dnd-kit/core'
 import { formatDistanceToNowStrict } from 'date-fns'
 import DOMPurify from 'dompurify'
-import { Archive, Ban, Clock, MailWarning, MoreVertical, Trash2 } from 'lucide-react'
+import { Archive, Ban, Clock, MailWarning, MoreHorizontal, Trash2 } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import type React from 'react'
 import { memo, useCallback, useMemo } from 'react'
@@ -89,8 +89,11 @@ export function ProcessingMenu({
   return (
     <DropdownMenu onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
-        <Button variant='ghost' size='icon-sm' className='rounded-[8px]!'>
-          <MoreVertical />
+        <Button
+          variant='ghost'
+          size='icon-xs'
+          className='rounded-[8px]! hover:bg-background/50 group-aria-selected:text-background/50'>
+          <MoreHorizontal />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align='end'>
@@ -346,7 +349,7 @@ export const MailThreadItem = memo(function MailThreadItem({
             className={cn(
               'z-2 hover:bg-accent hover:text-accent-foreground dark:border-[#1e2227] group relative flex w-full cursor-grab flex-col items-start gap-1 rounded-lg border bg-background ps-6 pe-2 py-3 text-left text-sm active:cursor-grabbing dark:bg-[#2c313c] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:focus-visible:ring-0 dark:focus-visible:ring-offset-0',
               isHighlighted &&
-                'bg-info hover:bg-info-100! text-background shadow-md dark:bg-info dark:hover:bg-info-100 border-info/50'
+                'bg-info hover:bg-info-100! text-background shadow dark:bg-info dark:hover:bg-info-100 border-info/50'
             )}
             aria-selected={isHighlighted}
             onClick={handleClick}
@@ -419,8 +422,23 @@ export const MailThreadItem = memo(function MailThreadItem({
                     </div>
                   )}
                 </div>
-                <div className='ml-auto shrink-0 whitespace-nowrap pl-2 text-xs text-muted-foreground group-aria-selected:text-background/50'>
-                  {formattedDate}
+                <div className='ml-auto shrink-0 whitespace-nowrap pl-2 text-xs text-right min-w-[2.5rem] group/menu relative'>
+                  <span className='text-muted-foreground group-aria-selected:text-background/50 group-hover:hidden group-has-data-[state=open]/menu:hidden'>
+                    {formattedDate}
+                  </span>
+                  <div className='hidden absolute -right-1 -top-4 group-hover:flex group-has-data-[state=open]/menu:flex'>
+                    <ProcessingMenu
+                      threadId={threadId}
+                      integrationId={thread?.integrationId}
+                      senderEmail={
+                        senderParticipant?.identifierType === 'EMAIL'
+                          ? senderParticipant.identifier
+                          : undefined
+                      }
+                      update={update}
+                      isUpdating={isUpdating}
+                    />
+                  </div>
                 </div>
               </div>
 
@@ -459,26 +477,7 @@ export const MailThreadItem = memo(function MailThreadItem({
             />
           </div>
 
-          {/* Processing menu — desktop: right panel, mobile: bottom-right corner */}
-          <div className='hidden sm:flex z-1 me-0.5 relative border-primary-500 rounded-r-lg -ms-1.5 ps-2 py-0.5 pe-0.5 bg-primary-200 dark:bg-[#252931] flex-row shrink-0'>
-            <div
-              className='absolute inset-0 rounded-r-lg pointer-events-none mask-y-from-98% mask-y-to-100%'
-              style={{ boxShadow: 'inset 25px 0 25px -25px #000, 1px 1px 3px rgba(0,0,0,0.2)' }}
-            />
-            <div className='flex flex-col justify-start h-full'>
-              <ProcessingMenu
-                threadId={threadId}
-                integrationId={thread?.integrationId}
-                senderEmail={
-                  senderParticipant?.identifierType === 'EMAIL'
-                    ? senderParticipant.identifier
-                    : undefined
-                }
-                update={update}
-                isUpdating={isUpdating}
-              />
-            </div>
-          </div>
+          {/* Processing menu — mobile: bottom-right corner (desktop uses hover swap in header) */}
           <div className='sm:hidden absolute bottom-1.5 right-1.5 z-3'>
             <ProcessingMenu
               threadId={threadId}

--- a/apps/web/src/components/workflow/ui/code-editor/code-editor-header.tsx
+++ b/apps/web/src/components/workflow/ui/code-editor/code-editor-header.tsx
@@ -36,15 +36,19 @@ const ToggleExpandBtn: React.FC<{
 /**
  * Language badge component
  */
-const LanguageBadge: React.FC<{ language: CodeLanguage }> = ({ language }) => {
-  const displayName = language === CodeLanguage.javascript ? 'JS' : 'JSON'
-
-  return (
-    <span className='inline-flex items-center rounded bg-primary-100 px-1.5 py-0.5 text-xs font-medium text-primary-700'>
-      {displayName}
-    </span>
-  )
+const LANGUAGE_BADGE: Record<CodeLanguage, string> = {
+  [CodeLanguage.javascript]: 'JS',
+  [CodeLanguage.json]: 'JSON',
+  [CodeLanguage.html]: 'HTML',
+  [CodeLanguage.shell]: 'Bash',
+  [CodeLanguage.typescript]: 'TS',
 }
+
+const LanguageBadge: React.FC<{ language: CodeLanguage }> = ({ language }) => (
+  <span className='inline-flex items-center rounded bg-primary-100 px-1.5 py-0.5 text-xs font-medium text-primary-700'>
+    {LANGUAGE_BADGE[language]}
+  </span>
+)
 
 /**
  * CodeEditor Header Component

--- a/apps/web/src/components/workflow/ui/code-editor/constants.ts
+++ b/apps/web/src/components/workflow/ui/code-editor/constants.ts
@@ -17,6 +17,7 @@ export const DEFAULT_EDITOR_OPTIONS = {
     horizontal: 'auto' as const,
     verticalScrollbarSize: 6,
     horizontalScrollbarSize: 6,
+    alwaysConsumeMouseWheel: false,
   },
   // Disable bracket guides on the right side
   guides: {

--- a/apps/web/src/components/workflow/ui/code-editor/types.ts
+++ b/apps/web/src/components/workflow/ui/code-editor/types.ts
@@ -5,11 +5,17 @@ import type React from 'react'
 export enum CodeLanguage {
   javascript = 'javascript',
   json = 'json',
+  html = 'html',
+  shell = 'shell',
+  typescript = 'typescript',
 }
 
 export const languageMap: Record<CodeLanguage, string> = {
   [CodeLanguage.javascript]: 'javascript',
   [CodeLanguage.json]: 'json',
+  [CodeLanguage.html]: 'html',
+  [CodeLanguage.shell]: 'shell',
+  [CodeLanguage.typescript]: 'typescript',
 }
 
 /** Input variable for code generation */

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -1,6 +1,5 @@
 // src/server/api/routers/channel.ts
 
-import { WEBAPP_URL } from '@auxx/config/server'
 import { ConfigStorage, CredentialService, configService } from '@auxx/credentials'
 import { type Database, database, schema } from '@auxx/database'
 import { onCacheEvent, storeOAuthCsrfToken } from '@auxx/lib/cache'
@@ -540,19 +539,6 @@ export const channelRouter = createTRPCRouter({
       const result = await getChatWidget({ db: ctx.db, organizationId }, input.integrationId)
       if (!result.ok) throw result.error
       return result.value
-    }),
-
-  /**
-   * Get widget installation code.
-   */
-  getInstallationCode: protectedProcedure
-    .input(z.object({ integrationId: z.string() }))
-    .query(async ({ ctx, input }) => {
-      const organizationId = getUserOrganizationId(ctx.session)
-      const result = await getChatWidget({ db: ctx.db, organizationId }, input.integrationId)
-      if (!result.ok) throw result.error
-      const scriptSrc = `${WEBAPP_URL}/api/integrations/chat/${result.value.id}/script.js`
-      return { script: `<script src="${scriptSrc}" async defer></script>` }
     }),
 
   getProviderType: protectedProcedure


### PR DESCRIPTION
## Summary

- **Chat widget Setup tab** — framework picker (Code / React / Vue / Angular) with Basic JS, npm, and SPA variants under the Code path. Snippets render via `CodeEditor` (with new shell/html/ts highlighting) and selection persists in the URL via nuqs.
- **Identity tab** — links out to Setup for framework-specific install instructions.
- **Docs** — rewrite `help/channels/chat-widget.mdx` install section to match the new tabs and document `Auxx.boot` / `update` / `shutdown` across stacks.
- **API** — `chat-jwt` middleware now only attempts JSON body parsing for `application/json`. Other content types (e.g. the `application/x-www-form-urlencoded` body from `/pusher/auth`) were getting their request stream consumed before the route could parse them.
- **Mail thread** — desktop swaps date for the `ProcessingMenu` on hover; mobile keeps the menu pinned bottom-right.
- **CodeEditor** — adds `html` / `shell` / `typescript` languages and disables `alwaysConsumeMouseWheel` so the page scrolls through read-only snippets.
- Drops the now-unused `channel.getInstallationCode` tRPC procedure.

## Test plan

- [ ] Open Settings → Channels → Chat Widget → Setup; cycle through Code/React/Vue/Angular and the Basic JS / npm / SPA flavors — URL updates, snippets render, copy works.
- [ ] Identity tab shows the "See Setup" link and it switches sections.
- [ ] Embed widget with the Basic JS snippet on a test page; launcher appears.
- [ ] Hit `/pusher/auth` while chat-jwt middleware is mounted — request still authorizes (no stream-already-consumed errors).
- [ ] Mail inbox: hover a thread; date swaps to processing menu; mobile width keeps bottom-right menu.