### PR TITLE
feat(chat-widget): dedicated AI section in settings

### DIFF
--- a/apps/api/src/routes/chat/index.ts
+++ b/apps/api/src/routes/chat/index.ts
@@ -33,7 +33,14 @@ chatRoutes.use('/attachments/*', chatPassportMiddleware, chatUserJwtMiddleware)
 chatRoutes.use('/typing/*', chatPassportMiddleware, chatUserJwtMiddleware)
 chatRoutes.use('/receipts/*', chatPassportMiddleware, chatUserJwtMiddleware)
 chatRoutes.use('/visitor-info/*', chatPassportMiddleware, chatUserJwtMiddleware)
-chatRoutes.use('/pusher/*', chatPassportMiddleware, chatUserJwtMiddleware)
+// `/pusher/auth` is form-encoded (Pusher's client posts `socket_id`/`channel_name`
+// as application/x-www-form-urlencoded). The chat-jwt middleware can only read
+// the JWT envelope from JSON bodies, so re-verifying here would always 401 on
+// `users + enforced` channels. The passport mint already gates identity at
+// session start, and the pusher-auth handler ACL-checks channels against the
+// passport's visitorParticipantId — re-verifying per pusher-auth call adds no
+// security and breaks the request shape.
+chatRoutes.use('/pusher/*', chatPassportMiddleware)
 
 // /initialize — POST per page-load.
 chatRoutes.use(

--- a/apps/web/src/app/(protected)/preview/widget/[integrationId]/embed/page.tsx
+++ b/apps/web/src/app/(protected)/preview/widget/[integrationId]/embed/page.tsx
@@ -17,7 +17,7 @@ const VALID_THEMES: PreviewTheme[] = ['light', 'dark', 'system']
  * wants and the page itself blends with whatever theme is around it.
  *
  * Behavior is driven by query params:
- * - `intent` (one of: general, setup, appearance, behavior, identity) —
+ * - `intent` (one of: general, setup, appearance, behavior, ai, identity) —
  *   accepted today so the parent can re-key the iframe on tab change; the
  *   widget itself doesn't read it yet because it lives in a closed shadow
  *   root that the embed page can't poke at from outside. Reserved for a

--- a/apps/web/src/components/chat-widget/ui/settings/chat-widget-settings.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/chat-widget-settings.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import {
   AlertCircle,
+  Bot,
   Code,
   ExternalLink,
   Palette,
@@ -22,6 +23,7 @@ import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { useChatWidget } from '../../hooks/use-chat-widget'
 import { MobilePreviewLauncher, PreviewPane } from './preview-pane'
+import { AiSection } from './sections/ai-section'
 import { AppearanceSection } from './sections/appearance-section'
 import { BehaviorSection } from './sections/behavior-section'
 import { GeneralSection } from './sections/general-section'
@@ -32,13 +34,14 @@ interface ChatWidgetSettingsProps {
   channelId: string
 }
 
-type SectionId = 'general' | 'setup' | 'appearance' | 'behavior' | 'identity'
+type SectionId = 'general' | 'setup' | 'appearance' | 'behavior' | 'ai' | 'identity'
 
 const SETTINGS_SECTIONS: { id: SectionId; label: string; icon: typeof Settings }[] = [
   { id: 'general', label: 'General', icon: Settings },
   { id: 'setup', label: 'Setup', icon: Code },
   { id: 'appearance', label: 'Appearance', icon: Palette },
   { id: 'behavior', label: 'Behavior', icon: SlidersHorizontal },
+  { id: 'ai', label: 'AI', icon: Bot },
   { id: 'identity', label: 'Identity', icon: ShieldCheck },
 ]
 
@@ -152,6 +155,8 @@ export function ChatWidgetSettings({ channelId }: ChatWidgetSettingsProps) {
         return <AppearanceSection widget={widget} channelId={channelId} />
       case 'behavior':
         return <BehaviorSection widget={widget} channelId={channelId} />
+      case 'ai':
+        return <AiSection widget={widget} channelId={channelId} />
       case 'identity':
         return <IdentitySection widget={widget} channelId={channelId} />
       default:
@@ -180,7 +185,7 @@ export function ChatWidgetSettings({ channelId }: ChatWidgetSettingsProps) {
           value={activeSection}
           onValueChange={setActiveSection}
           size='sm'
-          radioGroupClassName='grid w-full grid-cols-5'
+          radioGroupClassName='grid w-full grid-cols-6'
           className='border border-primary-200 flex w-full'>
           {SETTINGS_SECTIONS.map((section) => {
             const Icon = section.icon

--- a/apps/web/src/components/chat-widget/ui/settings/preview-pane.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/preview-pane.tsx
@@ -6,7 +6,7 @@ import { Moon, Smartphone, Sun, SunMoon } from 'lucide-react'
 import { useState } from 'react'
 
 type PreviewTheme = 'light' | 'dark' | 'system'
-type PreviewIntent = 'general' | 'setup' | 'appearance' | 'behavior' | 'identity'
+type PreviewIntent = 'general' | 'setup' | 'appearance' | 'behavior' | 'ai' | 'identity'
 
 interface PreviewPaneProps {
   channelId: string

--- a/apps/web/src/components/chat-widget/ui/settings/sections/ai-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/ai-section.tsx
@@ -1,0 +1,217 @@
+// apps/web/src/components/chat-widget/ui/settings/sections/ai-section.tsx
+'use client'
+import type { ChatWidgetWithIntegration } from '@auxx/lib/chat-widget/config'
+import type { RecordId } from '@auxx/lib/resources/client'
+import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@auxx/ui/components/form'
+import { toastError } from '@auxx/ui/components/toast'
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
+import { BookOpen, Bot, Home, Sparkles } from 'lucide-react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { ActorPicker } from '~/components/pickers/actor-picker'
+import { MultiRelationInput } from '~/components/shared/multi-relation-input'
+import { BaseType } from '~/components/workflow/types'
+import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
+import { api } from '~/trpc/react'
+import { FeaturedArticlesField } from '../featured-articles-field'
+
+interface AiSectionProps {
+  widget: ChatWidgetWithIntegration
+  channelId: string
+}
+
+const aiSchema = z.object({
+  knowledgeBaseId: z.string().nullable(),
+  featuredArticleIds: z.array(z.string()),
+})
+
+type AiForm = z.infer<typeof aiSchema>
+
+function KbVisibilityWarning({ knowledgeBaseId }: { knowledgeBaseId: string | null }) {
+  const enabled = !!knowledgeBaseId
+  const { data } = api.kb.byId.useQuery(
+    { id: knowledgeBaseId ?? '' },
+    { enabled, staleTime: 60_000 }
+  )
+  if (!enabled || !data || data.visibility === 'PUBLIC') return null
+  return (
+    <p className='text-sm text-destructive'>
+      This knowledge base is set to INTERNAL. Switch it to PUBLIC before saving — chat widgets only
+      support PUBLIC knowledge bases.
+    </p>
+  )
+}
+
+export function AiSection({ widget, channelId }: AiSectionProps) {
+  const utils = api.useUtils()
+
+  const update = api.channel.updateChatWidgetIntegration.useMutation({
+    onSuccess: () => {
+      utils.channel.getChatWidgetIntegration.invalidate({ integrationId: channelId })
+      utils.channel.list.invalidate()
+    },
+    onError: (e) => toastError({ title: 'Failed to save', description: e.message }),
+  })
+
+  const cw = widget.chatWidget
+  const rawAgentId = cw?.agentId ?? null
+  const agentActorIds: ActorId[] = rawAgentId ? [toActorId('agent', rawAgentId)] : []
+
+  const handleAgentChange = (ids: ActorId[]) => {
+    const next = ids[0]
+    if (!next) {
+      update.mutate({ integrationId: channelId, agentId: null })
+      return
+    }
+    const { id } = parseActorId(next)
+    update.mutate({ integrationId: channelId, agentId: id })
+  }
+
+  const form = useForm<AiForm>({
+    resolver: standardSchemaResolver(aiSchema),
+    defaultValues: {
+      knowledgeBaseId: cw?.knowledgeBaseId ?? null,
+      featuredArticleIds: cw?.featuredArticleIds ?? [],
+    },
+  })
+
+  const onSubmit = (values: AiForm) => {
+    update.mutate({
+      integrationId: channelId,
+      knowledgeBaseId: values.knowledgeBaseId,
+      featuredArticleIds: values.featuredArticleIds,
+    })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <div className='p-6'>
+          <div className='space-y-1 mb-4'>
+            <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
+              <Bot className='size-4' /> Agent
+            </div>
+            <p className='text-sm text-muted-foreground'>
+              The AI agent that replies to incoming chat messages.
+            </p>
+          </div>
+
+          <VarEditorField orientation='responsive' className='p-0'>
+            <VarEditorFieldRow
+              title='AI Auto-Reply'
+              description='Pick an Agent that responds automatically to new chat messages. Leave unset to require a human reply.'
+              type={BaseType.ACTOR}
+              icon={<Sparkles className='size-3.5' />}
+              showIcon>
+              <ActorPicker
+                value={agentActorIds}
+                onChange={handleAgentChange}
+                multi={false}
+                target='agent'
+                emptyLabel='Choose an agent…'
+                disabled={update.isPending}
+                triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              />
+            </VarEditorFieldRow>
+          </VarEditorField>
+        </div>
+
+        <div className='border-t p-6 space-y-4'>
+          <div>
+            <div className='space-y-1 mb-4'>
+              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
+                <BookOpen className='size-4' /> Knowledge base
+              </div>
+              <p className='text-sm text-muted-foreground'>
+                Source articles for the widget's Home and Browse screens.
+              </p>
+            </div>
+
+            <VarEditorField orientation='responsive' className='p-0'>
+              <FormField
+                control={form.control}
+                name='knowledgeBaseId'
+                render={({ field, fieldState }) => {
+                  const recordId = field.value ? (`kb:${field.value}` as RecordId) : null
+                  return (
+                    <VarEditorFieldRow
+                      title='Knowledge base'
+                      description="Articles from this KB power the widget's featured cards and Browse all view."
+                      type={BaseType.RELATION}
+                      icon={<BookOpen className='size-3.5' />}
+                      showIcon
+                      validationError={fieldState.error?.message}>
+                      <MultiRelationInput
+                        entityDefinitionId='kb'
+                        value={recordId ? [recordId] : []}
+                        multi={false}
+                        placeholder='Link a knowledge base…'
+                        onChange={(ids) => {
+                          const first = ids[0]
+                          if (!first) {
+                            field.onChange(null)
+                            return
+                          }
+                          const instanceId = first.includes(':')
+                            ? first.split(':').slice(1).join(':')
+                            : first
+                          field.onChange(instanceId)
+                        }}
+                      />
+                      <KbVisibilityWarning knowledgeBaseId={field.value} />
+                    </VarEditorFieldRow>
+                  )
+                }}
+              />
+            </VarEditorField>
+          </div>
+
+          <div>
+            <FormField
+              control={form.control}
+              name='featuredArticleIds'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Featured articles</FormLabel>
+                  <FormControl>
+                    <FeaturedArticlesField
+                      knowledgeBaseId={form.watch('knowledgeBaseId')}
+                      value={field.value}
+                      onChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Pinned articles shown as cards on the Home screen. Drag to reorder.
+                  </FormDescription>
+                </FormItem>
+              )}
+            />
+          </div>
+        </div>
+
+        <div className='flex justify-end gap-2 border-t px-4 py-4'>
+          <Button type='button' variant='ghost' size='sm' onClick={() => form.reset()}>
+            Reset
+          </Button>
+          <Button
+            type='submit'
+            size='sm'
+            variant='outline'
+            loading={update.isPending}
+            loadingText='Saving…'>
+            Save Changes
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
@@ -2,7 +2,6 @@
 'use client'
 import { FieldType } from '@auxx/database/enums'
 import type { ChatWidgetWithIntegration } from '@auxx/lib/chat-widget/config'
-import type { RecordId } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
 import {
   Form,
@@ -29,11 +28,9 @@ import {
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
-import { MultiRelationInput } from '~/components/shared/multi-relation-input'
 import { BaseType } from '~/components/workflow/types'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
-import { FeaturedArticlesField } from '../featured-articles-field'
 
 interface BehaviorSectionProps {
   widget: ChatWidgetWithIntegration
@@ -49,32 +46,9 @@ const behaviorSchema = z.object({
   homeShowSendMessageCta: z.boolean(),
   allowDownloadTranscript: z.boolean(),
   brandingFooterEnabled: z.boolean(),
-  knowledgeBaseId: z.string().nullable(),
-  featuredArticleIds: z.array(z.string()),
 })
 
 type BehaviorForm = z.infer<typeof behaviorSchema>
-
-/**
- * Inline warning rendered under the KB picker when the selected KB is
- * INTERNAL. The widget reader only supports PUBLIC KBs in v1 — the server
- * also rejects the save, this just surfaces it before the click so the
- * admin doesn't waste the round-trip.
- */
-function KbVisibilityWarning({ knowledgeBaseId }: { knowledgeBaseId: string | null }) {
-  const enabled = !!knowledgeBaseId
-  const { data } = api.kb.byId.useQuery(
-    { id: knowledgeBaseId ?? '' },
-    { enabled, staleTime: 60_000 }
-  )
-  if (!enabled || !data || data.visibility === 'PUBLIC') return null
-  return (
-    <p className='text-sm text-destructive'>
-      This knowledge base is set to INTERNAL. Switch it to PUBLIC before saving — chat widgets only
-      support PUBLIC knowledge bases.
-    </p>
-  )
-}
 
 export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
   const utils = api.useUtils()
@@ -97,8 +71,6 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
       homeShowSendMessageCta: cw?.homeShowSendMessageCta ?? true,
       allowDownloadTranscript: cw?.allowDownloadTranscript ?? true,
       brandingFooterEnabled: cw?.brandingFooterEnabled ?? true,
-      knowledgeBaseId: cw?.knowledgeBaseId ?? null,
-      featuredArticleIds: cw?.featuredArticleIds ?? [],
     },
   })
 
@@ -112,8 +84,6 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
       homeShowSendMessageCta: values.homeShowSendMessageCta,
       allowDownloadTranscript: values.allowDownloadTranscript,
       brandingFooterEnabled: values.brandingFooterEnabled,
-      knowledgeBaseId: values.knowledgeBaseId,
-      featuredArticleIds: values.featuredArticleIds,
     })
   }
 
@@ -287,88 +257,6 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                     Leave blank to fall back to the default message.
                   </FormDescription>
                   <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-        </div>
-
-        <div className='border-t p-6 space-y-8'>
-          <div>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <BookOpen className='size-4' /> Knowledge base
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Source articles for the widget's Home and Browse screens.
-              </p>
-            </div>
-
-            <VarEditorField orientation='responsive' className='p-0'>
-              <FormField
-                control={form.control}
-                name='knowledgeBaseId'
-                render={({ field, fieldState }) => {
-                  const recordId = field.value ? (`kb:${field.value}` as RecordId) : null
-                  return (
-                    <VarEditorFieldRow
-                      title='Knowledge base'
-                      description="Articles from this KB power the widget's featured cards and Browse all view."
-                      type={BaseType.RELATION}
-                      icon={<BookOpen className='size-3.5' />}
-                      showIcon
-                      validationError={fieldState.error?.message}>
-                      <MultiRelationInput
-                        entityDefinitionId='kb'
-                        value={recordId ? [recordId] : []}
-                        multi={false}
-                        placeholder='Link a knowledge base…'
-                        onChange={(ids) => {
-                          const first = ids[0]
-                          if (!first) {
-                            field.onChange(null)
-                            return
-                          }
-                          const instanceId = first.includes(':')
-                            ? first.split(':').slice(1).join(':')
-                            : first
-                          field.onChange(instanceId)
-                        }}
-                      />
-                      <KbVisibilityWarning knowledgeBaseId={field.value} />
-                    </VarEditorFieldRow>
-                  )
-                }}
-              />
-            </VarEditorField>
-          </div>
-
-          <div>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <Home className='size-4' /> Featured articles
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Pinned articles shown as cards on the Home screen.
-              </p>
-            </div>
-
-            <FormField
-              control={form.control}
-              name='featuredArticleIds'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Featured articles</FormLabel>
-                  <FormControl>
-                    <FeaturedArticlesField
-                      knowledgeBaseId={form.watch('knowledgeBaseId')}
-                      value={field.value}
-                      onChange={field.onChange}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Pinned articles shown as cards on the Home screen. Drag to reorder.
-                  </FormDescription>
                 </FormItem>
               )}
             />

--- a/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
@@ -2,8 +2,8 @@
 'use client'
 import { FieldType } from '@auxx/database/enums'
 import type { ChatWidgetWithIntegration } from '@auxx/lib/chat-widget/config'
-import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
 import { getInstanceId, type RecordId, toRecordId } from '@auxx/types/resource'
+import { Alert } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { Form, FormField } from '@auxx/ui/components/form'
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
@@ -16,7 +16,6 @@ import {
   Power,
   Settings,
   ShieldCheck,
-  Sparkles,
   Tag,
   Trash2,
   Type as TypeIcon,
@@ -29,7 +28,6 @@ import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { InboxDialog } from '~/components/inbox/inbox-dialog'
-import { ActorPicker } from '~/components/pickers/actor-picker'
 import { useResource } from '~/components/resources/hooks/use-resource'
 import { MultiRelationInput } from '~/components/shared/multi-relation-input'
 import { BaseType } from '~/components/workflow/types'
@@ -123,18 +121,6 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
     update.mutate({ integrationId: channelId, inboxId: inbox.id })
   }
 
-  const rawAgentId = widget.chatWidget?.agentId ?? null
-  const agentActorIds: ActorId[] = rawAgentId ? [toActorId('agent', rawAgentId)] : []
-
-  const handleAgentChange = (ids: ActorId[]) => {
-    const next = ids[0]
-    if (!next) {
-      update.mutate({ integrationId: channelId, agentId: null })
-      return
-    }
-    const { id } = parseActorId(next)
-    update.mutate({ integrationId: channelId, agentId: id })
-  }
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
@@ -255,23 +241,6 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
             </VarEditorFieldRow>
 
             <VarEditorFieldRow
-              title='AI Auto-Reply'
-              description='Pick an Agent that responds automatically to new chat messages. Leave unset to require a human reply.'
-              type={BaseType.ACTOR}
-              icon={<Sparkles className='size-3.5' />}
-              showIcon>
-              <ActorPicker
-                value={agentActorIds}
-                onChange={handleAgentChange}
-                multi={false}
-                target='agent'
-                emptyLabel='Choose an agent…'
-                disabled={update.isPending}
-                triggerProps={{ className: 'w-full ps-0 pe-1' }}
-              />
-            </VarEditorFieldRow>
-
-            <VarEditorFieldRow
               title='Privacy URL'
               description='When set, the widget shows a consent banner under the composer linking to this URL. Leave blank to hide.'
               type={BaseType.STRING}
@@ -338,19 +307,21 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
                 </p>
 
                 {field.value === 'users' && identityVerification === 'off' && (
-                  <div className='mt-3 flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-900 dark:text-amber-200'>
-                    <AlertTriangle className='size-3.5 shrink-0' />
-                    <span className='flex-1'>
-                      Rollout is off — anonymous visitors can still chat. Start rollout on the
-                      Identity tab to lock down.
-                    </span>
-                    <button
-                      type='button'
-                      onClick={() => setActiveSection('identity')}
-                      className='shrink-0 font-medium underline'>
-                      Open Identity
-                    </button>
-                  </div>
+                  <Alert variant='warning' className='mt-3'>
+                    <AlertTriangle />
+                    <div className='flex items-center gap-2'>
+                      <span className='flex-1'>
+                        Rollout is off. Anonymous visitors can still chat. Start rollout on the
+                        Identity tab to lock down.
+                      </span>
+                      <button
+                        type='button'
+                        onClick={() => setActiveSection('identity')}
+                        className='shrink-0 font-medium underline'>
+                        Open Identity
+                      </button>
+                    </div>
+                  </Alert>
                 )}
               </>
             )}


### PR DESCRIPTION
## Summary
- Split a new **AI** tab out of the chat-widget settings, hosting the agent picker (moved from General) and knowledge base + featured articles (moved from Behavior).
- Wire the new section into `chat-widget-settings.tsx` (icon, tab grid bumped to 6 cols, `intent=ai` reserved on the preview embed page).
- Swap the inline amber rollout warning in General for the shared `<Alert variant='warning'>` component.
- Drop `chatUserJwtMiddleware` from `/pusher/*` — Pusher posts form-encoded `socket_id`/`channel_name`, which the JWT middleware can't read, so it always 401'd on `users + enforced` channels. Identity is still gated by the passport mint and per-channel ACL in the pusher-auth handler.

## Test plan
- [ ] Open a chat widget's settings — verify the new **AI** tab appears between Behavior and Identity and renders the agent + KB + featured articles controls.
- [ ] Save changes from the AI tab and confirm `agentId`, `knowledgeBaseId`, `featuredArticleIds` persist.
- [ ] Confirm General no longer shows the AI Auto-Reply row and Behavior no longer shows KB/featured articles.
- [ ] In `users + enforced` mode, load the widget and verify Pusher auth succeeds (no 401 on `/pusher/auth`).
- [ ] Verify the rollout warning Alert renders correctly when audience=`users` and identity verification is off.