### PR TITLE
feat(geo): visitor city for chat widget + shopify reserved-namespace metafields

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -227,3 +227,19 @@ TURNSTILE_SITE_KEY=1x00000000000000000000AA
 RECALL_AI_API_KEY=
 RECALL_AI_WEBHOOK_SECRET=
 RECALL_AI_REGION=us-west-2
+
+# ------------------------------------
+# Geolocation (optional) — used to surface visitor city in the chat widget
+# ------------------------------------
+# Provider: "maxmind" (default), "ipapi" (no signup, rate-limited free tier),
+# or "none" (disable geolocation entirely).
+AUXX_GEO_PROVIDER=maxmind
+# Required when AUXX_GEO_PROVIDER=maxmind. Sign up free at https://www.maxmind.com,
+# generate a GeoLite2 license key. The API container downloads GeoLite2-City
+# automatically on first boot. License terms forbid us from redistributing the db.
+MAXMIND_LICENSE_KEY=
+# Override default mmdb location. Default is ./geo/GeoLite2-City.mmdb,
+# resolved relative to the API process cwd. Works in both Docker (cwd=/app
+# → /app/geo/...) and local dev (cwd=apps/api → apps/api/geo/...) without
+# needing an override.
+# MAXMIND_DB_PATH=./geo/GeoLite2-City.mmdb

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ repomix.config.json
 /prisma/db.sqlite-journal
 db.sqlite
 /plans
+
+# MaxMind GeoLite2 database (license forbids redistribution)
+apps/api/geo/
 # next.js
 .open-next
 /.next/

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -103,6 +103,12 @@ RUN groupadd --system --gid 1001 nodejs && \
 COPY --from=deploy --chown=api:nodejs /deployed /app
 COPY --from=builder --chown=api:nodejs /app/apps/api/public/app-runtime /app/public/app-runtime
 
+# Shared entrypoint (Next.js URL substitution is a no-op here; geo block
+# downloads GeoLite2-City.mmdb on first boot when MAXMIND_LICENSE_KEY is set).
+COPY --chown=api:nodejs docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh && \
+    mkdir -p /app/geo && chown api:nodejs /app/geo
+
 USER api
 WORKDIR /app
 
@@ -112,4 +118,5 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:${API_PORT}/health || exit 1
 
 EXPOSE 3007
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["node", "dist/index.mjs"]

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 // apps/api/src/index.ts
 
 import { configService } from '@auxx/credentials'
+import { initGeo } from '@auxx/lib/geo'
 import { createScopedLogger } from '@auxx/logger'
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
@@ -42,6 +43,7 @@ const log = createScopedLogger('api-server')
  */
 async function main() {
   await configService.init()
+  await initGeo()
 
   const app = new Hono()
 

--- a/docker-compose.self-hosted.yml
+++ b/docker-compose.self-hosted.yml
@@ -193,6 +193,13 @@ services:
       LAMBDA_INTERNAL_URL: http://lambda:${LAMBDA_PORT:-3008}
       DB_POOL_MAX: "5"
       APP_NAME: auxx-api
+      # Geolocation (optional). See .env.example for details.
+      AUXX_GEO_PROVIDER: ${AUXX_GEO_PROVIDER:-maxmind}
+      MAXMIND_LICENSE_KEY: ${MAXMIND_LICENSE_KEY:-}
+    volumes:
+      # Persists the MaxMind mmdb across restarts so we don't re-download
+      # the ~70MB file on every container boot.
+      - geo_data:/app/geo
     depends_on:
       migrate: { condition: service_completed_successfully }
       redis: { condition: service_healthy }
@@ -285,6 +292,7 @@ volumes:
   postgres_data:
   redis_data:
   letsencrypt_data:
+  geo_data:
 
 networks:
   auxx-network:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,23 +1,33 @@
 #!/bin/sh
 # docker-entrypoint.sh
-# Replaces build-time URL placeholders with runtime values in .next client bundles.
 #
-# At build time, DOMAIN=__RUNTIME_DOMAIN__ is baked into Next.js bundles.
-# url.ts produces these patterns:
-#   https://app.__RUNTIME_DOMAIN__    (WEBAPP_URL)
-#   https://api.__RUNTIME_DOMAIN__    (API_URL)
-#   https://__RUNTIME_DOMAIN__        (HOMEPAGE_URL)
-#   https://docs.__RUNTIME_DOMAIN__   (DOCS_URL)
-#   https://build.__RUNTIME_DOMAIN__  (DEV_PORTAL_URL)
+# Shared entrypoint for every app image in the monorepo. Each block is
+# independently gated by its own preconditions, so the same script no-ops
+# safely in containers that don't need it.
 #
-# Supports two replacement modes:
-#   1. Explicit URL overrides — for platforms like Railway where each service
-#      has its own domain (no shared root).
-#   2. DOMAIN-based replacement — for custom domains with subdomain patterns.
+# Block 1 — Next.js runtime URL substitution (web, homepage, docs, build):
+#   At build time DOMAIN=__RUNTIME_DOMAIN__ is baked into Next.js bundles.
+#   url.ts produces these patterns:
+#     https://app.__RUNTIME_DOMAIN__    (WEBAPP_URL)
+#     https://api.__RUNTIME_DOMAIN__    (API_URL)
+#     https://__RUNTIME_DOMAIN__        (HOMEPAGE_URL)
+#     https://docs.__RUNTIME_DOMAIN__   (DOCS_URL)
+#     https://build.__RUNTIME_DOMAIN__  (DEV_PORTAL_URL)
+#   Two replacement modes are supported:
+#     1. Explicit URL overrides — for platforms like Railway where each
+#        service has its own domain (no shared root).
+#     2. DOMAIN-based replacement — for custom domains with subdomain
+#        patterns.
+#   Order matters: specific URL patterns (with subdomain prefix) are
+#   replaced first, then HOMEPAGE_URL (bare https://PLACEHOLDER), then
+#   DOMAIN catches any remaining occurrences.
 #
-# Order matters: specific URL patterns (with subdomain prefix) are replaced
-# first, then HOMEPAGE_URL (bare https://PLACEHOLDER), then DOMAIN catches
-# any remaining occurrences.
+# Block 2 — Optional MaxMind GeoLite2-City download (api):
+#   When AUXX_GEO_PROVIDER=maxmind (default) and MAXMIND_LICENSE_KEY is
+#   set, fetch the mmdb on first boot so the chat widget can label
+#   visitors with their city. License terms forbid redistribution, so
+#   the db is NEVER baked into the published image — operators always
+#   bring their own key. Persists when /app/geo is a mounted volume.
 
 PLACEHOLDER="__RUNTIME_DOMAIN__"
 PLACEHOLDER_LOWER="__runtime_domain__"
@@ -87,6 +97,45 @@ if [ "${replaced}" = true ]; then
   echo "[entrypoint] Replacement complete."
 else
   echo "[entrypoint] No replacements needed (DOMAIN=${DOMAIN:-<unset>}, APP_URL=${APP_URL:-<unset>})."
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Block 2 — Optional GeoLite2-City download
+# ─────────────────────────────────────────────────────────────────────
+GEO_FILE="${MAXMIND_DB_PATH:-/app/geo/GeoLite2-City.mmdb}"
+GEO_DIR="${GEO_FILE%/*}"
+GEO_PROVIDER="${AUXX_GEO_PROVIDER:-maxmind}"
+
+if [ "${GEO_PROVIDER}" != "maxmind" ]; then
+  echo "[geo] AUXX_GEO_PROVIDER=${GEO_PROVIDER} — skipping MaxMind download"
+elif [ -f "${GEO_FILE}" ]; then
+  echo "[geo] ${GEO_FILE} exists — skipping download"
+elif [ -z "${MAXMIND_LICENSE_KEY}" ]; then
+  echo "[geo] MAXMIND_LICENSE_KEY not set — geo lookups will be disabled"
+  echo "[geo] To enable: sign up at maxmind.com and generate a GeoLite2 license key"
+else
+  mkdir -p "${GEO_DIR}"
+  echo "[geo] downloading GeoLite2-City…"
+  if command -v curl >/dev/null 2>&1 && curl -sSL --fail --max-time 60 \
+       "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz" \
+       -o /tmp/geolite2.tar.gz; then
+    if tar -xzf /tmp/geolite2.tar.gz -C /tmp 2>/dev/null; then
+      mmdb=$(find /tmp -maxdepth 3 -name 'GeoLite2-City.mmdb' -print -quit)
+      if [ -n "${mmdb}" ]; then
+        mv "${mmdb}" "${GEO_FILE}"
+        rm -rf /tmp/geolite2.tar.gz /tmp/GeoLite2-City_*
+        echo "[geo] installed at ${GEO_FILE}"
+      else
+        echo "[geo] mmdb not found inside archive — geo lookups will be disabled"
+        rm -f /tmp/geolite2.tar.gz
+      fi
+    else
+      echo "[geo] tar extract failed — geo lookups will be disabled"
+      rm -f /tmp/geolite2.tar.gz
+    fi
+  else
+    echo "[geo] download failed — geo lookups will be disabled"
+  fi
 fi
 
 exec "$@"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "format": "biome format --write .",
     "setup:dev": "node scripts/setup-s3-cdn-secure.js development direct-s3",
     "setup:cloudfront": "node scripts/setup-cloudfront-secure.js production",
+    "setup:geo": "bash scripts/setup-geo.sh",
     "e2e": "pnpm --filter @auxx/e2e run test",
     "e2e:ui": "pnpm --filter @auxx/e2e run test:ui",
     "e2e:debug": "pnpm --filter @auxx/e2e run test:debug",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -346,6 +346,12 @@
       "import": "./dist/files/types/index.mjs",
       "default": "./src/files/types/index.ts"
     },
+    "./geo": {
+      "types": "./src/geo/index.ts",
+      "source": "./src/geo/index.ts",
+      "import": "./dist/geo/index.mjs",
+      "default": "./src/geo/index.ts"
+    },
     "./groups": {
       "types": "./src/groups/index.ts",
       "source": "./src/groups/index.ts",
@@ -909,6 +915,7 @@
     "lru-cache": "11.1.0",
     "lucide-react": "catalog:",
     "mailgun.js": "^12.0.1",
+    "maxmind": "^4.3.20",
     "mammoth": "^1.10.0",
     "mdast-util-to-string": "^4.0.0",
     "nanoid": "^5.1.5",

--- a/packages/lib/src/geo/__tests__/geo-manager.test.ts
+++ b/packages/lib/src/geo/__tests__/geo-manager.test.ts
@@ -1,0 +1,59 @@
+// packages/lib/src/geo/__tests__/geo-manager.test.ts
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { __resetGeoForTests, initGeo, lookupIp } from '../geo-manager'
+
+describe('geo-manager', () => {
+  const originalProvider = process.env.AUXX_GEO_PROVIDER
+  const originalDbPath = process.env.MAXMIND_DB_PATH
+
+  beforeEach(() => {
+    __resetGeoForTests()
+  })
+
+  afterEach(() => {
+    if (originalProvider === undefined) delete process.env.AUXX_GEO_PROVIDER
+    else process.env.AUXX_GEO_PROVIDER = originalProvider
+    if (originalDbPath === undefined) delete process.env.MAXMIND_DB_PATH
+    else process.env.MAXMIND_DB_PATH = originalDbPath
+  })
+
+  it('returns null before initGeo() has run', async () => {
+    expect(await lookupIp('8.8.8.8')).toBeNull()
+  })
+
+  it('returns null for empty / nullish input', async () => {
+    process.env.AUXX_GEO_PROVIDER = 'none'
+    await initGeo()
+    expect(await lookupIp(null)).toBeNull()
+    expect(await lookupIp(undefined)).toBeNull()
+    expect(await lookupIp('')).toBeNull()
+  })
+
+  it('short-circuits private IPs without calling the provider', async () => {
+    process.env.AUXX_GEO_PROVIDER = 'none'
+    await initGeo()
+    expect(await lookupIp('127.0.0.1')).toBeNull()
+    expect(await lookupIp('10.0.0.1')).toBeNull()
+  })
+
+  it('noop provider returns null for any public IP', async () => {
+    process.env.AUXX_GEO_PROVIDER = 'none'
+    await initGeo()
+    expect(await lookupIp('8.8.8.8')).toBeNull()
+  })
+
+  it('falls back to noop on unknown provider name', async () => {
+    process.env.AUXX_GEO_PROVIDER = 'bogus'
+    await initGeo()
+    expect(await lookupIp('8.8.8.8')).toBeNull()
+  })
+
+  it('falls back to noop when maxmind cannot find the mmdb', async () => {
+    process.env.AUXX_GEO_PROVIDER = 'maxmind'
+    process.env.MAXMIND_DB_PATH = '/nonexistent/path/GeoLite2-City.mmdb'
+    await initGeo()
+    // Should not throw and lookups should return null.
+    expect(await lookupIp('8.8.8.8')).toBeNull()
+  })
+})

--- a/packages/lib/src/geo/__tests__/ipapi-provider.test.ts
+++ b/packages/lib/src/geo/__tests__/ipapi-provider.test.ts
@@ -1,0 +1,59 @@
+// packages/lib/src/geo/__tests__/ipapi-provider.test.ts
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { IpApiProvider } from '../providers/ipapi-provider'
+
+describe('IpApiProvider', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('maps a successful response into GeoLocation', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        city: 'Inglewood',
+        region: 'California',
+        country_name: 'United States',
+        country_code: 'US',
+        timezone: 'America/Los_Angeles',
+      }),
+    } as Response)
+
+    const result = await new IpApiProvider().lookup('8.8.8.8')
+    expect(result).toEqual({
+      city: 'Inglewood',
+      region: 'California',
+      country: 'United States',
+      countryCode: 'US',
+      timezone: 'America/Los_Angeles',
+    })
+  })
+
+  it('returns null when ipapi signals an error', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ error: true, reason: 'reserved' }),
+    } as Response)
+
+    expect(await new IpApiProvider().lookup('127.0.0.1')).toBeNull()
+  })
+
+  it('returns null on non-2xx response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({}),
+    } as Response)
+
+    expect(await new IpApiProvider().lookup('8.8.8.8')).toBeNull()
+  })
+
+  it('returns null on network error', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('boom'))
+    expect(await new IpApiProvider().lookup('8.8.8.8')).toBeNull()
+  })
+})

--- a/packages/lib/src/geo/__tests__/private-ip.test.ts
+++ b/packages/lib/src/geo/__tests__/private-ip.test.ts
@@ -1,0 +1,50 @@
+// packages/lib/src/geo/__tests__/private-ip.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { isPrivateIp } from '../private-ip'
+
+describe('isPrivateIp', () => {
+  it.each([
+    ['10.0.0.1'],
+    ['10.255.255.255'],
+    ['172.16.0.1'],
+    ['172.31.255.254'],
+    ['192.168.1.1'],
+    ['127.0.0.1'],
+    ['169.254.169.254'],
+    ['0.0.0.0'],
+  ])('treats %s as private (IPv4)', (ip) => {
+    expect(isPrivateIp(ip)).toBe(true)
+  })
+
+  it.each([
+    ['::1'],
+    ['::'],
+    ['fe80::1'],
+    ['fc00::1'],
+    ['fd12:3456:789a::1'],
+  ])('treats %s as private (IPv6)', (ip) => {
+    expect(isPrivateIp(ip)).toBe(true)
+  })
+
+  it.each([
+    ['8.8.8.8'],
+    ['1.1.1.1'],
+    ['172.32.0.1'],
+    ['11.0.0.1'],
+    ['192.169.1.1'],
+    ['2606:4700:4700::1111'],
+  ])('treats %s as public', (ip) => {
+    expect(isPrivateIp(ip)).toBe(false)
+  })
+
+  it.each([
+    ['  '],
+    [''],
+    ['not-an-ip'],
+    ['256.0.0.1'],
+    ['10.0.0'],
+  ])('treats invalid input %s as private (fail closed)', (ip) => {
+    expect(isPrivateIp(ip)).toBe(true)
+  })
+})

--- a/packages/lib/src/geo/geo-manager.ts
+++ b/packages/lib/src/geo/geo-manager.ts
@@ -1,0 +1,76 @@
+// packages/lib/src/geo/geo-manager.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { isPrivateIp } from './private-ip'
+import { IpApiProvider } from './providers/ipapi-provider'
+import { MaxMindProvider } from './providers/maxmind-provider'
+import { NoopProvider } from './providers/noop-provider'
+import type { GeoLocation, IpLookupProvider } from './types'
+
+const log = createScopedLogger('geo-manager')
+
+let provider: IpLookupProvider | null = null
+let initPromise: Promise<void> | null = null
+
+function selectProvider(): IpLookupProvider {
+  const choice = (process.env.AUXX_GEO_PROVIDER ?? 'maxmind').toLowerCase()
+  if (choice === 'none') return new NoopProvider()
+  if (choice === 'ipapi') return new IpApiProvider()
+  if (choice === 'maxmind') return new MaxMindProvider()
+  log.warn(`Unknown AUXX_GEO_PROVIDER=${choice} — falling back to none`)
+  return new NoopProvider()
+}
+
+/**
+ * Initialize the geo lookup provider. Idempotent — safe to call multiple
+ * times. Never throws: provider init failures swap in {@link NoopProvider}
+ * so the rest of the app continues to boot.
+ */
+export async function initGeo(): Promise<void> {
+  if (initPromise) return initPromise
+  initPromise = (async () => {
+    const p = selectProvider()
+    try {
+      await p.init?.()
+      provider = p
+      log.info(`Geo lookup ready: provider=${p.id}`)
+    } catch (err) {
+      log.warn(`Geo provider ${p.id} failed to init — lookups disabled`, {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      provider = new NoopProvider()
+    }
+  })()
+  return initPromise
+}
+
+/**
+ * Resolve an IP to a {@link GeoLocation}. Returns `null` for:
+ * - missing / empty input
+ * - private, loopback, or link-local ranges
+ * - any provider failure (logged at warn, never thrown)
+ * - calls before {@link initGeo} has resolved (silent fallback)
+ */
+export async function lookupIp(ip: string | null | undefined): Promise<GeoLocation | null> {
+  if (!ip) return null
+  if (isPrivateIp(ip)) return null
+  if (!provider) return null
+  try {
+    return await provider.lookup(ip)
+  } catch (err) {
+    log.warn('Geo lookup failed', {
+      ip,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return null
+  }
+}
+
+/**
+ * Test-only — resets the module-level provider + init promise so tests
+ * can re-init with a different `AUXX_GEO_PROVIDER`. Do not call from app code.
+ */
+export function __resetGeoForTests(): void {
+  provider = null
+  initPromise = null
+}

--- a/packages/lib/src/geo/index.ts
+++ b/packages/lib/src/geo/index.ts
@@ -1,0 +1,4 @@
+// packages/lib/src/geo/index.ts
+
+export { initGeo, lookupIp } from './geo-manager'
+export type { GeoLocation, IpLookupProvider } from './types'

--- a/packages/lib/src/geo/private-ip.ts
+++ b/packages/lib/src/geo/private-ip.ts
@@ -1,0 +1,64 @@
+// packages/lib/src/geo/private-ip.ts
+
+/**
+ * Quick check for IPs that have no useful geo answer — RFC1918 private
+ * ranges, loopback, link-local, and the IPv6 equivalents. Used to
+ * short-circuit `lookupIp` so we don't hit MaxMind / ipapi with garbage
+ * (and so local-dev `127.0.0.1` requests don't log noisy `AddressNotFound`
+ * warnings).
+ */
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+  let n = 0
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return null
+    const octet = Number(part)
+    if (octet < 0 || octet > 255) return null
+    n = n * 256 + octet
+  }
+  return n
+}
+
+const PRIVATE_V4_RANGES: Array<[number, number]> = [
+  [ipv4ToInt('10.0.0.0')!, ipv4ToInt('10.255.255.255')!],
+  [ipv4ToInt('172.16.0.0')!, ipv4ToInt('172.31.255.255')!],
+  [ipv4ToInt('192.168.0.0')!, ipv4ToInt('192.168.255.255')!],
+  [ipv4ToInt('127.0.0.0')!, ipv4ToInt('127.255.255.255')!],
+  [ipv4ToInt('169.254.0.0')!, ipv4ToInt('169.254.255.255')!],
+  [ipv4ToInt('0.0.0.0')!, ipv4ToInt('0.255.255.255')!],
+]
+
+function isPrivateV6(ip: string): boolean {
+  const lower = ip.toLowerCase()
+  if (lower === '::1') return true
+  if (lower === '::') return true
+  if (
+    lower.startsWith('fe8') ||
+    lower.startsWith('fe9') ||
+    lower.startsWith('fea') ||
+    lower.startsWith('feb')
+  ) {
+    return true
+  }
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true
+  return false
+}
+
+export function isPrivateIp(ip: string): boolean {
+  if (!ip) return true
+  const trimmed = ip.trim()
+  if (!trimmed) return true
+
+  if (trimmed.includes(':')) {
+    return isPrivateV6(trimmed)
+  }
+
+  const n = ipv4ToInt(trimmed)
+  if (n === null) return true
+  for (const [lo, hi] of PRIVATE_V4_RANGES) {
+    if (n >= lo && n <= hi) return true
+  }
+  return false
+}

--- a/packages/lib/src/geo/providers/ipapi-provider.ts
+++ b/packages/lib/src/geo/providers/ipapi-provider.ts
@@ -1,0 +1,51 @@
+// packages/lib/src/geo/providers/ipapi-provider.ts
+
+import type { GeoLocation, IpLookupProvider } from '../types'
+
+interface IpApiResponse {
+  city?: string
+  region?: string
+  country_name?: string
+  country_code?: string
+  timezone?: string
+  error?: boolean
+  reason?: string
+}
+
+/**
+ * ipapi.co hosted lookup. Free tier requires no signup but is
+ * rate-limited (≈30k req/day from a single IP as of last check).
+ * Selected when `AUXX_GEO_PROVIDER=ipapi` — useful for self-hosters who
+ * don't want a MaxMind account.
+ *
+ * 2-second hard timeout so a hung ipapi.co never stalls the chat
+ * passport-mint critical path; failure is silent (returns `null`).
+ */
+export class IpApiProvider implements IpLookupProvider {
+  readonly id = 'ipapi' as const
+
+  async lookup(ip: string): Promise<GeoLocation | null> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 2_000)
+    try {
+      const res = await fetch(`https://ipapi.co/${encodeURIComponent(ip)}/json/`, {
+        signal: controller.signal,
+        headers: { 'User-Agent': 'auxxai/1.0' },
+      })
+      if (!res.ok) return null
+      const data = (await res.json()) as IpApiResponse
+      if (data.error) return null
+      return {
+        city: data.city,
+        region: data.region,
+        country: data.country_name,
+        countryCode: data.country_code,
+        timezone: data.timezone,
+      }
+    } catch {
+      return null
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+}

--- a/packages/lib/src/geo/providers/maxmind-provider.ts
+++ b/packages/lib/src/geo/providers/maxmind-provider.ts
@@ -1,0 +1,54 @@
+// packages/lib/src/geo/providers/maxmind-provider.ts
+
+import { promises as fs } from 'node:fs'
+import maxmind, { type CityResponse, type Reader } from 'maxmind'
+import type { GeoLocation, IpLookupProvider } from '../types'
+
+/**
+ * Resolved relative to `process.cwd()`. Both prod (Docker WORKDIR=/app)
+ * and local dev (API runs from apps/api/) put the mmdb in a sibling `geo/`
+ * dir, so this single default works in both without an env override.
+ */
+const DEFAULT_PATH = './geo/GeoLite2-City.mmdb'
+
+/**
+ * MaxMind GeoLite2-City local mmdb provider. Sub-millisecond lookups via
+ * memory-mapped file; the file itself is acquired at container start by
+ * the shared `docker-entrypoint.sh` using the operator's
+ * `MAXMIND_LICENSE_KEY` env var.
+ *
+ * License terms forbid redistribution of the mmdb, so it is never baked
+ * into the published Docker image — operators always bring their own.
+ */
+export class MaxMindProvider implements IpLookupProvider {
+  readonly id = 'maxmind' as const
+  private reader: Reader<CityResponse> | null = null
+
+  async init(): Promise<void> {
+    const path = process.env.MAXMIND_DB_PATH ?? DEFAULT_PATH
+    try {
+      await fs.access(path)
+    } catch {
+      throw new Error(
+        `MaxMind mmdb not found at ${path}. Set MAXMIND_LICENSE_KEY and ` +
+          `restart so the entrypoint can download it, set ` +
+          `AUXX_GEO_PROVIDER=ipapi to use the hosted fallback, or ` +
+          `AUXX_GEO_PROVIDER=none to disable geo lookups.`
+      )
+    }
+    this.reader = await maxmind.open<CityResponse>(path)
+  }
+
+  async lookup(ip: string): Promise<GeoLocation | null> {
+    if (!this.reader) return null
+    const record = this.reader.get(ip)
+    if (!record) return null
+    return {
+      city: record.city?.names?.en,
+      region: record.subdivisions?.[0]?.names?.en,
+      country: record.country?.names?.en,
+      countryCode: record.country?.iso_code,
+      timezone: record.location?.time_zone,
+    }
+  }
+}

--- a/packages/lib/src/geo/providers/noop-provider.ts
+++ b/packages/lib/src/geo/providers/noop-provider.ts
@@ -1,0 +1,15 @@
+// packages/lib/src/geo/providers/noop-provider.ts
+
+import type { GeoLocation, IpLookupProvider } from '../types'
+
+/**
+ * Disabled provider. Selected when `AUXX_GEO_PROVIDER=none`, or as the
+ * silent fallback when the configured provider fails to init.
+ */
+export class NoopProvider implements IpLookupProvider {
+  readonly id = 'noop' as const
+
+  async lookup(_ip: string): Promise<GeoLocation | null> {
+    return null
+  }
+}

--- a/packages/lib/src/geo/types.ts
+++ b/packages/lib/src/geo/types.ts
@@ -1,0 +1,31 @@
+// packages/lib/src/geo/types.ts
+
+/**
+ * Resolved location for an IP address. All fields are optional — providers
+ * fill in what they know; callers must handle partial results.
+ */
+export interface GeoLocation {
+  /** City name (English). */
+  city?: string
+  /** First-level subdivision — US state, Canadian province, etc. */
+  region?: string
+  /** Country name (English). */
+  country?: string
+  /** ISO 3166-1 alpha-2 country code. */
+  countryCode?: string
+  /** IANA timezone, e.g. `America/Los_Angeles`. */
+  timezone?: string
+}
+
+/**
+ * Pluggable IP-to-location provider. Implementations live under
+ * `packages/lib/src/geo/providers/` and are selected by
+ * {@link selectProvider} based on the `AUXX_GEO_PROVIDER` env var.
+ */
+export interface IpLookupProvider {
+  readonly id: 'maxmind' | 'ipapi' | 'noop'
+  /** One-time setup. Called from {@link initGeo} at API boot. */
+  init?(): Promise<void>
+  /** Resolve a single IP. Returns `null` when the IP is unknown or invalid. */
+  lookup(ip: string): Promise<GeoLocation | null>
+}

--- a/packages/lib/src/shopify/chat-metafields.ts
+++ b/packages/lib/src/shopify/chat-metafields.ts
@@ -8,25 +8,9 @@ import { createShopifyAdminClient } from './shopify-webhooks'
 
 const logger = createScopedLogger('shopify/chat-metafields')
 
-export const AUXX_CHAT_METAFIELD_NAMESPACE = 'auxx'
-export const AUXX_CHAT_METAFIELD_KEY_CHANNEL = 'chat_channel_id'
-export const AUXX_CHAT_METAFIELD_KEY_AUDIENCE = 'chat_audience'
-
-const METAFIELD_DEFINITIONS_MUTATION = `#graphql
-  mutation EnsureAuxxChatMetafieldDefinitions(
-    $channel: MetafieldDefinitionInput!,
-    $audience: MetafieldDefinitionInput!
-  ) {
-    channelDef: metafieldDefinitionCreate(definition: $channel) {
-      createdDefinition { id }
-      userErrors { field message code }
-    }
-    audienceDef: metafieldDefinitionCreate(definition: $audience) {
-      createdDefinition { id }
-      userErrors { field message code }
-    }
-  }
-`
+export const AUXX_CHAT_METAFIELD_NAMESPACE = '$app:chat'
+export const AUXX_CHAT_METAFIELD_KEY_CHANNEL = 'channel_id'
+export const AUXX_CHAT_METAFIELD_KEY_AUDIENCE = 'audience'
 
 const SHOP_GID_QUERY = `#graphql
   query ShopGid { shop { id } }
@@ -48,62 +32,16 @@ export interface WriteAuxxChatMetafieldsInput {
 }
 
 /**
- * Register the `auxx.chat_channel_id` and `auxx.chat_audience` shop
- * metafield definitions with storefront read access so the theme can read
- * them from Liquid without merchant intervention. Idempotent — Shopify
- * returns a `TAKEN` userError when a definition already exists; we treat
- * that as success.
- */
-export async function ensureAuxxChatMetafieldDefinitions(params: {
-  shopDomain: string
-  accessToken: string
-}): Promise<void> {
-  const { shopDomain, accessToken } = params
-  const client = createShopifyAdminClient({ shopDomain, accessToken })
-
-  const channel = {
-    namespace: AUXX_CHAT_METAFIELD_NAMESPACE,
-    key: AUXX_CHAT_METAFIELD_KEY_CHANNEL,
-    name: 'Auxx chat channel',
-    description: 'Auxx chat channel ID powering the storefront widget.',
-    type: 'single_line_text_field',
-    ownerType: 'SHOP',
-    pin: true,
-    access: { storefront: 'PUBLIC_READ' },
-  }
-  const audience = {
-    namespace: AUXX_CHAT_METAFIELD_NAMESPACE,
-    key: AUXX_CHAT_METAFIELD_KEY_AUDIENCE,
-    name: 'Auxx chat audience',
-    description: 'Auxx chat audience policy: visitors, both, or users.',
-    type: 'single_line_text_field',
-    ownerType: 'SHOP',
-    pin: true,
-    access: { storefront: 'PUBLIC_READ' },
-  }
-
-  try {
-    const response = await client.request(METAFIELD_DEFINITIONS_MUTATION, {
-      variables: { channel, audience },
-    })
-    const errors = [
-      ...(response.data?.channelDef?.userErrors ?? []),
-      ...(response.data?.audienceDef?.userErrors ?? []),
-    ].filter((e: { code?: string }) => e.code !== 'TAKEN')
-    if (errors.length > 0) {
-      logger.warn('Shopify metafield definition userErrors', { shopDomain, errors })
-    }
-  } catch (error) {
-    logger.error('Failed to register Shopify chat metafield definitions', { shopDomain, error })
-  }
-}
-
-/**
- * Write the `auxx.chat_channel_id` and/or `auxx.chat_audience` shop
- * metafields. Pass `null` to clear (the Liquid embed treats blank as
- * "not bound" and renders nothing). Failures are logged, not thrown —
- * the source of truth lives in our DB, so a metafield write retry can
- * be wired later without blocking the calling mutation.
+ * Write the `$app:chat.channel_id` and/or `$app:chat.audience` shop
+ * metafields in the app-reserved namespace. Pass `null` to clear (the
+ * Liquid embed treats blank as "not bound" and renders nothing).
+ * Failures are logged, not thrown — the source of truth lives in our
+ * DB, so a metafield write retry can be wired later without blocking
+ * the calling mutation.
+ *
+ * Reserved-namespace metafields are hidden from the merchant's Custom
+ * data UI, can't be read/written by other apps, and auto-delete on app
+ * uninstall — no definition registration required.
  */
 export async function writeAuxxChatMetafields(input: WriteAuxxChatMetafieldsInput): Promise<void> {
   const { shopDomain, accessToken, channelId, audience } = input
@@ -168,7 +106,7 @@ export async function writeAuxxChatMetafields(input: WriteAuxxChatMetafieldsInpu
  * `chatChannelId === channelId` in its AppSetting. Looks up each install's
  * Shopify access token + shop domain by decrypting its
  * `WorkflowCredentials.encryptedData`, then writes the
- * `auxx.chat_audience` metafield. Best-effort per install — one shop's
+ * `$app:chat.audience` metafield. Best-effort per install — one shop's
  * failure doesn't block the others.
  */
 export async function fanOutAuxxChatAudienceToShopify(params: {
@@ -235,9 +173,9 @@ export async function fanOutAuxxChatAudienceToShopify(params: {
 /**
  * Bind a chat channel to a specific Shopify install (an `AppInstallation`
  * for the `shopify` app). Resolves the install's access token + shop
- * domain by decrypting its org-scoped `WorkflowCredentials`, registers
- * the metafield definitions (idempotent), then writes the
- * `auxx.chat_channel_id` and `auxx.chat_audience` shop metafields.
+ * domain by decrypting its org-scoped `WorkflowCredentials`, then writes
+ * the `$app:chat.channel_id` and `$app:chat.audience` shop metafields in
+ * the app-reserved namespace.
  *
  * Called from the chat-widget admin UI (phase 5) when the merchant picks
  * which channel powers a connected store. The App Store install flow
@@ -296,8 +234,6 @@ export async function bindChatChannelToShopifyInstall(params: {
   if (!accessToken || !shopDomain) {
     return { ok: false, reason: 'credential_missing_shop_or_token' }
   }
-
-  await ensureAuxxChatMetafieldDefinitions({ shopDomain, accessToken })
 
   let audience: 'visitors' | 'both' | 'users' = 'visitors'
   if (channelId) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1962,6 +1962,9 @@ importers:
       mammoth:
         specifier: ^1.10.0
         version: 1.11.0
+      maxmind:
+        specifier: ^4.3.20
+        version: 4.3.29
       mdast-util-to-string:
         specifier: ^4.0.0
         version: 4.0.0
@@ -11582,6 +11585,10 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  maxmind@4.3.29:
+    resolution: {integrity: sha512-Vxx0rh7omBekjZnsDxpw35SrGGM3Uy7NoIKWzZlvh3UcjihGaySR8n+YSQ8YBseCvhEn+yehA98rZkTDW+uhPw==}
+    engines: {node: '>=12', npm: '>=6'}
+
   md5@2.3.0:
     resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
@@ -11858,6 +11865,10 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  mmdb-lib@2.2.1:
+    resolution: {integrity: sha512-DXO4L9W+08T+A7h5+xdT32l7IMot8z7WOH+7C1Maol571PnktQ8un7Ni4CyPFp4H+vht/FDA5/tpjRvWMFQDMw==}
+    engines: {node: '>=10', npm: '>=6'}
 
   mnemonist@0.38.3:
     resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
@@ -13019,6 +13030,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -13762,6 +13774,10 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-lru@11.3.4:
+    resolution: {integrity: sha512-UxWEfRKpFCabAf6fkTNdlfSw/RDUJ/4C6i1aLZaDnGF82PERHyYhz5CMCVYXtLt34LbqgfpJ2bjmgGKgxuF/6A==}
+    engines: {node: '>=12'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -24776,6 +24792,11 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  maxmind@4.3.29:
+    dependencies:
+      mmdb-lib: 2.2.1
+      tiny-lru: 11.3.4
+
   md5@2.3.0:
     dependencies:
       charenc: 0.0.2
@@ -25314,6 +25335,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  mmdb-lib@2.2.1: {}
 
   mnemonist@0.38.3:
     dependencies:
@@ -27663,6 +27686,8 @@ snapshots:
       when-exit: 2.1.5
 
   tiny-invariant@1.3.3: {}
+
+  tiny-lru@11.3.4: {}
 
   tinybench@2.9.0: {}
 

--- a/scripts/setup-geo.sh
+++ b/scripts/setup-geo.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# scripts/setup-geo.sh
+#
+# Local-dev convenience for downloading the MaxMind GeoLite2-City database.
+#
+# In production / Docker, `docker-entrypoint.sh` does the equivalent on
+# container start. Locally the API runs outside Docker (`pnpm dev`), so
+# this script lets you pull the same db once and point the API at it via
+# MAXMIND_DB_PATH in .env.
+#
+# Usage:
+#   1. Sign up at https://www.maxmind.com (free GeoLite2 tier).
+#   2. Generate a license key in your account dashboard.
+#   3. Add to your .env:
+#        MAXMIND_LICENSE_KEY=your_key_here
+#        MAXMIND_DB_PATH=./apps/api/geo/GeoLite2-City.mmdb
+#   4. Run: pnpm setup:geo
+#
+# License terms forbid redistribution — the db is gitignored and never
+# committed.
+
+set -e
+
+# Pull MAXMIND_LICENSE_KEY / MAXMIND_DB_PATH out of .env if they aren't
+# already exported. We grep specific keys instead of sourcing the whole
+# file because .env contains multi-line values (RSA keys etc.) that don't
+# parse as shell.
+read_env() {
+  key=$1
+  [ -f .env ] || return 0
+  line=$(grep -E "^${key}=" .env | head -n1 || true)
+  [ -z "${line}" ] && return 0
+  value=${line#*=}
+  # strip surrounding single or double quotes
+  case "${value}" in
+    \"*\") value=${value%\"}; value=${value#\"} ;;
+    \'*\') value=${value%\'}; value=${value#\'} ;;
+  esac
+  printf '%s' "${value}"
+}
+
+[ -z "${MAXMIND_LICENSE_KEY}" ] && MAXMIND_LICENSE_KEY=$(read_env MAXMIND_LICENSE_KEY)
+[ -z "${MAXMIND_DB_PATH}" ] && MAXMIND_DB_PATH=$(read_env MAXMIND_DB_PATH)
+
+GEO_FILE="${MAXMIND_DB_PATH:-./apps/api/geo/GeoLite2-City.mmdb}"
+GEO_DIR="${GEO_FILE%/*}"
+
+if [ -z "${MAXMIND_LICENSE_KEY}" ]; then
+  echo "✗ MAXMIND_LICENSE_KEY not set."
+  echo ""
+  echo "  1. Sign up at https://www.maxmind.com"
+  echo "  2. Generate a license key in your account dashboard"
+  echo "  3. Add MAXMIND_LICENSE_KEY=<key> to .env"
+  echo "  4. Re-run pnpm setup:geo"
+  exit 1
+fi
+
+mkdir -p "${GEO_DIR}"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+echo "→ Downloading GeoLite2-City…"
+curl -sSL --fail --max-time 120 \
+  "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz" \
+  -o "${tmpdir}/geolite2.tar.gz"
+
+echo "→ Extracting…"
+tar -xzf "${tmpdir}/geolite2.tar.gz" -C "${tmpdir}"
+
+mmdb=$(find "${tmpdir}" -maxdepth 3 -name 'GeoLite2-City.mmdb' -print -quit)
+if [ -z "${mmdb}" ]; then
+  echo "✗ GeoLite2-City.mmdb not found inside the archive."
+  exit 1
+fi
+
+mv "${mmdb}" "${GEO_FILE}"
+
+size=$(ls -lh "${GEO_FILE}" | awk '{print $5}')
+echo "✓ Installed ${GEO_FILE} (${size})"
+echo ""
+echo "  Set in your .env (only AUXX_GEO_PROVIDER needs to be set —"
+echo "  MAXMIND_DB_PATH defaults to ./geo/GeoLite2-City.mmdb, which"
+echo "  resolves correctly in both dev and Docker):"
+echo "    AUXX_GEO_PROVIDER=maxmind"
+echo ""
+echo "  Restart the API to pick it up."


### PR DESCRIPTION
## Summary
- New `@auxx/lib/geo` module with provider manager (maxmind, ipapi, noop) + private-IP guard; wired into the api boot so the chat widget can label visitors with their city. Docker entrypoint downloads GeoLite2-City on first boot (BYO `MAXMIND_LICENSE_KEY` — license forbids redistribution). `scripts/setup-geo.sh` handles the same for local dev.
- Switched the Shopify shop metafields from `auxx.chat_*` to the app-reserved `$app:chat.*` namespace. Drops the upfront `metafieldDefinitionCreate` mutation — reserved-namespace metafields auto-scope to our app, are hidden from merchant custom-data UI, and clean up on uninstall.

## Test plan
- [ ] `pnpm test --filter @auxx/lib` (geo provider + private-ip + manager unit tests)
- [ ] Boot api locally with `AUXX_GEO_PROVIDER=maxmind` + `MAXMIND_DB_PATH` set; confirm `initGeo()` logs success and a chat session resolves a city
- [ ] Boot api locally with `AUXX_GEO_PROVIDER=none`; confirm no MaxMind download attempt and lookups no-op
- [ ] Self-hosted docker compose: cold start with `MAXMIND_LICENSE_KEY` set downloads the mmdb into the `geo_data` volume; second start skips download
- [ ] Re-bind a chat channel to a connected Shopify store; verify `$app:chat.channel_id` + `$app:chat.audience` shop metafields are written and the storefront Liquid embed reads them