### PR TITLE
refactor(chat): move user-JWT signer into @auxx/lib/chat

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,7 +14,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@auxx/chat": "workspace:*",
     "@auxx/config": "workspace:*",
     "@auxx/credentials": "workspace:*",
     "@auxx/database": "workspace:*",

--- a/apps/api/src/routes/chat/shopify-proxy.ts
+++ b/apps/api/src/routes/chat/shopify-proxy.ts
@@ -1,9 +1,9 @@
 // apps/api/src/routes/chat/shopify-proxy.ts
 
 import { createHmac, timingSafeEqual } from 'node:crypto'
-import { signUserJwt } from '@auxx/chat/server'
 import { CredentialService } from '@auxx/credentials'
 import { database, schema } from '@auxx/database'
+import { signChannelUserJwt } from '@auxx/lib/chat'
 import { shopifyExternalId } from '@auxx/lib/ingest'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
@@ -173,7 +173,7 @@ shopifyProxyRoute.get('/jwt', async (c) => {
   }
 
   const expiresIn = '1h'
-  const userJwt = signUserJwt(
+  const userJwt = await signChannelUserJwt(
     {
       user_id: shopifyExternalId(shop, customerId),
       attributes: {

--- a/packages/lib/src/chat/index.ts
+++ b/packages/lib/src/chat/index.ts
@@ -23,6 +23,8 @@ export type {
   InitializeChatThreadResult,
 } from './session'
 export { initializeOrResumeChatThread } from './session'
+export type { SignChannelUserJwtOptions, SignChannelUserJwtPayload } from './sign-jwt'
+export { signChannelUserJwt } from './sign-jwt'
 export type { ChatAttachment, ServiceContext, VisitInfo } from './types'
 export type { ChatJwtError, VerifiedChatUserJwt } from './verify-jwt'
 export { hashChatUserJwt, verifyChannelUserJwt } from './verify-jwt'

--- a/packages/lib/src/chat/sign-jwt.ts
+++ b/packages/lib/src/chat/sign-jwt.ts
@@ -1,0 +1,56 @@
+// packages/lib/src/chat/sign-jwt.ts
+
+import { SignJWT } from 'jose'
+
+/**
+ * Payload for {@link signChannelUserJwt}. Mirrors what
+ * {@link verifyChannelUserJwt} expects: `user_id` is required, anything else
+ * passes through to the JWT body and surfaces in `verified.attributes`.
+ */
+export interface SignChannelUserJwtPayload {
+  /** Stable customer-side user id. Required. */
+  user_id: string
+  /** Optional signed email; enables the email-fold tier on contact resolve. */
+  email?: string
+  /** Convenience for visitor display name; verified consumers may pick it up. */
+  name?: string
+  /** Any additional sensitive claims the caller wants protected by the JWT. */
+  [key: string]: unknown
+}
+
+export interface SignChannelUserJwtOptions {
+  /** JWT lifetime. Accepts a jose duration string (e.g. `'1h'`). Default `'1h'`. */
+  expiresIn?: string
+}
+
+/**
+ * Sign an HS256 user JWT for a chat channel using the channel's signing
+ * secret. The matching verifier is {@link verifyChannelUserJwt}; using a
+ * shared module for both keeps the algorithm + claim shape in lockstep.
+ *
+ * Server-side entry point for internal mint paths (e.g. Shopify App Proxy).
+ * The customer-facing npm package `@auxx/chat/server` exposes its own
+ * `signUserJwt` for merchants signing on their own infrastructure — both
+ * produce interchangeable tokens since the spec is just HS256 + payload.
+ */
+export async function signChannelUserJwt(
+  payload: SignChannelUserJwtPayload,
+  secret: string,
+  options: SignChannelUserJwtOptions = {}
+): Promise<string> {
+  if (!payload || typeof payload.user_id !== 'string' || payload.user_id.length === 0) {
+    throw new Error('signChannelUserJwt: payload.user_id is required')
+  }
+  if (typeof secret !== 'string' || secret.length === 0) {
+    throw new Error('signChannelUserJwt: secret is required')
+  }
+
+  const secretKey = new TextEncoder().encode(secret)
+  const expiresIn = options.expiresIn ?? '1h'
+
+  return await new SignJWT(payload as Record<string, unknown>)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime(expiresIn)
+    .sign(secretKey)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@auxx/chat':
+        specifier: workspace:*
+        version: link:../../packages/chat
       '@auxx/config':
         specifier: workspace:*
         version: link:../../packages/config


### PR DESCRIPTION
## Summary
- Adds `signChannelUserJwt` to `@auxx/lib/chat` next to the existing `verifyChannelUserJwt` — both sides of the channel-user-JWT lifecycle now live in one module.
- Switches the Shopify App Proxy mint route (`apps/api/src/routes/chat/shopify-proxy.ts`) to use the new lib helper.
- Drops the `@auxx/chat` workspace dep from `apps/api` — that package is the customer-facing npm bundle, not something the API surface should depend on internally.

## Test plan
- [ ] `pnpm --filter @auxx/api dev` boots without `ERR_MODULE_NOT_FOUND` (previously failed because `@auxx/chat` wasn't materialized in node_modules)
- [ ] Curl `/api/chat/shopify-proxy/jwt` with a forged shop+channel param, missing signature → 403
- [ ] End-to-end through Shopify App Proxy returns a JWT that `verifyChannelUserJwt` accepts in the same request lifecycle