### PR TITLE
feat(billing): shopify billing follow-ups — expiring tokens, webhooks, agent limit

### DIFF
--- a/apps/web/src/app/(auth)/shopify/claim/page.tsx
+++ b/apps/web/src/app/(auth)/shopify/claim/page.tsx
@@ -1,8 +1,11 @@
 // apps/web/src/app/(auth)/shopify/claim/page.tsx
 
+import { database, schema } from '@auxx/database'
 import { getOrgCache, getUserCache } from '@auxx/lib/cache'
+import { DehydrationService } from '@auxx/lib/dehydration'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
+import { eq } from 'drizzle-orm'
 import { cookies, headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { auth } from '~/auth/server'
@@ -59,20 +62,70 @@ export default async function ShopifyClaimPage({ searchParams }: PageProps) {
 
   const claim = JSON.parse(raw) as { shop: string }
 
-  // Cached user→org memberships (one Redis lookup) + per-org profile (cached).
-  // A Shopify store can be attached to more than one Auxx org, so we always show
-  // the picker with every workspace the user is in.
+  // Cached user→org memberships (one Redis lookup).
   const memberships = await getUserCache().get(session.user.id, 'userMemberships')
   const activeMemberships = memberships.filter((m) => m.status === 'ACTIVE')
+
+  const defaultOrgId =
+    (session.user as { defaultOrganizationId?: string | null }).defaultOrganizationId ?? null
+
+  // Short-circuit the picker when this shop is already linked to a single *live*
+  // workspace. Shopify's "Open app" re-runs the install → OAuth → claim round-trip on
+  // every open, so an already-billed merchant lands here repeatedly; drop them straight
+  // into that workspace instead of re-picking it. `incomplete`/`canceled` rows are
+  // excluded — those still belong in the picker → finalizeAppStoreInstall flow (resume
+  // plan selection / fresh link). A shop attached to >1 live org stays ambiguous → picker.
+  const liveLinkedOrgIds: string[] = []
+  for (const m of activeMemberships) {
+    const sub = await getOrgCache().get(m.organizationId, 'subscription')
+    const isLiveLink =
+      sub?.billingProvider === 'shopify' &&
+      sub.shopifyShopDomain === claim.shop &&
+      sub.status !== 'canceled' &&
+      sub.status !== 'incomplete'
+    logger.info('Claim short-circuit eval', {
+      claimShop: claim.shop,
+      organizationId: m.organizationId,
+      billingProvider: sub?.billingProvider ?? null,
+      shopifyShopDomain: sub?.shopifyShopDomain ?? null,
+      status: sub?.status ?? null,
+      isLiveLink,
+    })
+    if (isLiveLink) {
+      liveLinkedOrgIds.push(m.organizationId)
+    }
+  }
+
+  logger.info('Claim short-circuit decision', {
+    claimShop: claim.shop,
+    userId: session.user.id,
+    activeMembershipCount: activeMemberships.length,
+    liveLinkedOrgIds,
+    willRedirect: liveLinkedOrgIds.length === 1,
+  })
+
+  if (liveLinkedOrgIds.length === 1) {
+    const targetOrgId = liveLinkedOrgIds[0]
+    // Make the linked workspace active before bouncing into the app, otherwise `/app`
+    // would open whatever the user's current default org is.
+    if (defaultOrgId !== targetOrgId) {
+      await database
+        .update(schema.User)
+        .set({ defaultOrganizationId: targetOrgId, updatedAt: new Date() })
+        .where(eq(schema.User.id, session.user.id))
+      await new DehydrationService(database).invalidateUser(session.user.id)
+    }
+    redirect('/app')
+  }
+
+  // A Shopify store can be attached to more than one Auxx org, so show the picker with
+  // every workspace the user is in (per-org profile is cached).
   const orgs = await Promise.all(
     activeMemberships.map(async (m) => {
       const profile = await getOrgCache().get(m.organizationId, 'orgProfile')
       return { id: profile.id, name: profile.name, handle: profile.handle }
     })
   )
-
-  const defaultOrgId =
-    (session.user as { defaultOrganizationId?: string | null }).defaultOrganizationId ?? null
 
   return (
     <ClaimFlow

--- a/apps/web/src/app/(protected)/app/settings/plans/_components/billing-details-section.tsx
+++ b/apps/web/src/app/(protected)/app/settings/plans/_components/billing-details-section.tsx
@@ -1,0 +1,64 @@
+// app/(protected)/app/settings/plans/_components/billing-details-section.tsx
+'use client'
+
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { Wallet } from 'lucide-react'
+import { Suspense } from 'react'
+import { BillingAddressCard } from '~/components/subscriptions/billing-address-card'
+import { PaymentMethodsCard } from '~/components/subscriptions/payment-methods-card'
+import { api } from '~/trpc/react'
+
+/**
+ * Client wrapper for the Billing Details block. Hidden for providers that don't manage
+ * payment methods in-app (Shopify) — the card on file lives in Shopify Admin, so the
+ * section header would otherwise render with no cards beneath it.
+ */
+export function BillingDetailsSection() {
+  const { data: subscription } = api.billing.getCurrentSubscription.useQuery()
+
+  // Gate on the same capability the cards use; hide while cache is cold to avoid a flash.
+  if (subscription && !subscription.capabilities?.managedPaymentMethods) return null
+
+  return (
+    <div id='billing-details' className='@container space-y-3'>
+      <div className='space-y-1'>
+        <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
+          <Wallet className='size-4' /> Billing Details
+        </div>
+        <div className='text-sm text-muted-foreground mb-4'>
+          Manage your payment methods and billing information
+        </div>
+      </div>
+      <div className='grid grid-cols-1 @lg:grid-cols-2 gap-6'>
+        <Suspense fallback={<BillingCardSkeleton />}>
+          <BillingAddressCard />
+        </Suspense>
+        <Suspense fallback={<BillingCardSkeleton />}>
+          <PaymentMethodsCard />
+        </Suspense>
+      </div>
+    </div>
+  )
+}
+
+function BillingCardSkeleton() {
+  return (
+    <div className='rounded-2xl border p-6 space-y-4'>
+      <div className='flex items-center justify-between'>
+        <div className='space-y-2'>
+          <Skeleton className='h-5 w-24' />
+          <Skeleton className='h-4 w-48' />
+        </div>
+        <Skeleton className='size-8 rounded' />
+      </div>
+      <div className='space-y-3'>
+        {[1, 2, 3].map((i) => (
+          <div key={i} className='grid grid-cols-[100px_1fr] gap-4'>
+            <Skeleton className='h-4 w-20' />
+            <Skeleton className='h-4 w-full' />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(protected)/app/settings/plans/_components/shopify-admin-billing-banner-wrapper.tsx
+++ b/apps/web/src/app/(protected)/app/settings/plans/_components/shopify-admin-billing-banner-wrapper.tsx
@@ -1,16 +1,32 @@
 // app/(protected)/app/settings/plans/_components/shopify-admin-billing-banner-wrapper.tsx
 'use client'
 
+import { Wallet } from 'lucide-react'
 import { ShopifyAdminBillingBanner } from '~/components/subscriptions/shopify-admin-billing-banner'
 import { api } from '~/trpc/react'
 
 /**
  * Client wrapper that reads the cached subscription via tRPC and conditionally
- * renders the Shopify Admin billing banner. Keeps the parent page server-rendered.
+ * renders the Shopify Admin billing banner. Stands in for the hidden Billing Details
+ * section on Shopify-billed orgs, so it carries the same section header.
+ * Keeps the parent page server-rendered.
  */
 export function ShopifyAdminBillingBannerWrapper() {
   const { data: subscription } = api.billing.getCurrentSubscription.useQuery()
 
   if (subscription?.billingProvider !== 'shopify') return null
-  return <ShopifyAdminBillingBanner shopDomain={subscription.shopifyShopDomain} />
+
+  return (
+    <div id='billing-details' className='space-y-3'>
+      <div className='space-y-1'>
+        <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
+          <Wallet className='size-4' /> Billing Details
+        </div>
+        <div className='text-sm text-muted-foreground mb-4'>
+          Manage your payment methods and billing information
+        </div>
+      </div>
+      <ShopifyAdminBillingBanner shopDomain={subscription.shopifyShopDomain} />
+    </div>
+  )
 }

--- a/apps/web/src/app/(protected)/app/settings/plans/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/plans/page.tsx
@@ -2,19 +2,18 @@
 
 import { isSelfHosted } from '@auxx/deployment'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import { Receipt, Wallet } from 'lucide-react'
+import { Receipt } from 'lucide-react'
 import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
 import SettingsPage from '~/components/global/settings-page'
-import { BillingAddressCard } from '~/components/subscriptions/billing-address-card'
 import {
   BillingCycleAlert,
   BillingCycleAlertSkeleton,
 } from '~/components/subscriptions/billing-cycle-alert'
 import { CancelSubscriptionDialog } from '~/components/subscriptions/cancel-subscription-dialog'
 import { InvoiceList } from '~/components/subscriptions/invoice-list'
-import { PaymentMethodsCard } from '~/components/subscriptions/payment-methods-card'
 import { PlanChangeCard } from '~/components/subscriptions/plan-change-card'
+import { BillingDetailsSection } from './_components/billing-details-section'
 import { DemoBillingCycleGuard } from './_components/demo-billing-cycle-guard'
 import { PlanViewTracker } from './_components/plan-view-tracker'
 import { ShopifyAdminBillingBannerWrapper } from './_components/shopify-admin-billing-banner-wrapper'
@@ -44,24 +43,7 @@ export default function PlansPage() {
 
         <ShopifyAdminBillingBannerWrapper />
 
-        <div id='billing-details' className='@container space-y-3'>
-          <div className='space-y-1'>
-            <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
-              <Wallet className='size-4' /> Billing Details
-            </div>
-            <div className='text-sm text-muted-foreground mb-4'>
-              Manage your payment methods and billing information
-            </div>
-          </div>
-          <div className='grid grid-cols-1 @lg:grid-cols-2 gap-6'>
-            <Suspense fallback={<BillingCardSkeleton />}>
-              <BillingAddressCard />
-            </Suspense>
-            <Suspense fallback={<BillingCardSkeleton />}>
-              <PaymentMethodsCard />
-            </Suspense>
-          </div>
-        </div>
+        <BillingDetailsSection />
 
         <div className='space-y-3'>
           <div className='space-y-1'>
@@ -120,28 +102,6 @@ function InvoiceListSkeleton() {
               <Skeleton className='h-3 w-24' />
             </div>
             <Skeleton className='h-4 w-20' />
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
-
-function BillingCardSkeleton() {
-  return (
-    <div className='rounded-2xl border p-6 space-y-4'>
-      <div className='flex items-center justify-between'>
-        <div className='space-y-2'>
-          <Skeleton className='h-5 w-24' />
-          <Skeleton className='h-4 w-48' />
-        </div>
-        <Skeleton className='size-8 rounded' />
-      </div>
-      <div className='space-y-3'>
-        {[1, 2, 3].map((i) => (
-          <div key={i} className='grid grid-cols-[100px_1fr] gap-4'>
-            <Skeleton className='h-4 w-20' />
-            <Skeleton className='h-4 w-full' />
           </div>
         ))}
       </div>

--- a/apps/web/src/app/api/apps/shopify/billing-webhook/route.ts
+++ b/apps/web/src/app/api/apps/shopify/billing-webhook/route.ts
@@ -2,6 +2,7 @@
 
 import { getProvider, verifyShopifyHmac } from '@auxx/billing'
 import { database } from '@auxx/database'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { createScopedLogger } from '@auxx/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 
@@ -19,12 +20,17 @@ export async function POST(req: NextRequest) {
   const shopDomain = req.headers.get('x-shopify-shop-domain') ?? ''
 
   try {
-    await getProvider('shopify').processWebhook({
+    const result = await getProvider('shopify').processWebhook({
       db: database,
       rawBody,
       topic,
       shopDomain,
     })
+    // Refresh the org's cached subscription/features after a billing state change so the
+    // app (and the claim-page short-circuit) sees the new status without waiting on TTL.
+    if (result.organizationId) {
+      await onCacheEvent('plan.changed', { orgId: result.organizationId })
+    }
     return new NextResponse('ok', { status: 200 })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)

--- a/apps/web/src/app/api/apps/shopify/install/callback/route.ts
+++ b/apps/web/src/app/api/apps/shopify/install/callback/route.ts
@@ -102,7 +102,10 @@ export async function GET(request: NextRequest) {
     const resolved = interpolateConnectionFields(connDef, { shop: shopSubdomain })
 
     // Exchange code for token. Shopify accepts both form-encoded and JSON; use JSON to
-    // match Shopify's documented example and the legacy route.
+    // match Shopify's documented example and the legacy route. `expiring: '1'` opts into
+    // expiring offline access tokens — Shopify no longer accepts non-expiring offline
+    // tokens for the Admin API, so the response now carries a refresh_token + expires_in.
+    // https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens
     const tokenResponse = await fetch(resolved.accessTokenUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
@@ -110,6 +113,7 @@ export async function GET(request: NextRequest) {
         client_id: resolved.clientId,
         client_secret: resolved.clientSecret,
         code,
+        expiring: '1',
       }),
     })
 
@@ -122,10 +126,27 @@ export async function GET(request: NextRequest) {
     const tokens = (await tokenResponse.json()) as {
       access_token?: string
       scope?: string
+      refresh_token?: string
+      expires_in?: number
+      refresh_token_expires_in?: number
     }
     if (!tokens.access_token) {
       throw new Error('Token response missing access_token')
     }
+
+    // Surface whether Shopify honored the expiring-token opt-in — if refresh_token is
+    // absent the app is still on a non-expiring token and Admin API calls will 403.
+    logger.info('Shopify token exchange result', {
+      shop,
+      hasAccessToken: !!tokens.access_token,
+      hasRefreshToken: !!tokens.refresh_token,
+      expiresIn: tokens.expires_in ?? null,
+      refreshTokenExpiresIn: tokens.refresh_token_expires_in ?? null,
+    })
+
+    const expiresAtIso = tokens.expires_in
+      ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+      : undefined
 
     // Park pending claim. claimToken is independent of the OAuth state to avoid
     // ever exposing the state value past callback termination. A shop can be
@@ -134,6 +155,8 @@ export async function GET(request: NextRequest) {
     const claimPayload = {
       shop,
       accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresAt: expiresAtIso,
       scope: tokens.scope,
       connectionDefinitionId: connDef.id,
       createdAt: new Date().toISOString(),

--- a/apps/web/src/components/agents/ui/list/create-agent-button.tsx
+++ b/apps/web/src/components/agents/ui/list/create-agent-button.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/agents/ui/list/create-agent-button.tsx
 'use client'
 
+import { FeatureKey } from '@auxx/lib/permissions/client'
 import { AnimatedGradientText } from '@auxx/ui/components/animated-gradient-text'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -12,7 +13,10 @@ import {
 import { Bot, LayoutTemplate, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useState } from 'react'
+import { LimitReachedDialog } from '~/components/subscriptions/limit-reached-dialog'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { useAgentMutations } from '../../hooks/use-agent-mutations'
+import { useAgentStore } from '../../store/agent-store'
 import { AgentTemplateDialog } from '../dialogs/agent-template-dialog'
 
 /**
@@ -26,6 +30,14 @@ export function CreateAgentButton() {
   const { createAgent, isCreating } = useAgentMutations()
   const [isRedirecting, setIsRedirecting] = useState(false)
   const [templateDialogOpen, setTemplateDialogOpen] = useState(false)
+  const [limitDialogOpen, setLimitDialogOpen] = useState(false)
+
+  const { isAtLimit, getLimit } = useFeatureFlags()
+  const agentCount = useAgentStore(
+    (s) => s.agents.filter((a) => !s.optimisticArchived.has(a.id)).length
+  )
+  const atLimit = isAtLimit(FeatureKey.agentsLimit, agentCount)
+  const agentLimit = getLimit(FeatureKey.agentsLimit)
 
   const isBusy = isCreating || isRedirecting
 
@@ -41,6 +53,30 @@ export function CreateAgentButton() {
     // this one tears down the state. Clearing it now would flash the
     // button back to idle while the next route bootstraps.
   }, [createAgent, router])
+
+  // No allowance on the current plan — gate creation behind an upgrade prompt.
+  if (atLimit) {
+    const hasNoAllowance = agentLimit === 0 || agentLimit === false
+    return (
+      <>
+        <Button size='sm' onClick={() => setLimitDialogOpen(true)}>
+          <Plus />
+          Create agent
+        </Button>
+        <LimitReachedDialog
+          open={limitDialogOpen}
+          onOpenChange={setLimitDialogOpen}
+          icon={Bot}
+          title={hasNoAllowance ? 'Agents Not Available' : 'Agent Limit Reached'}
+          description={
+            hasNoAllowance
+              ? 'Creating AI agents isn’t included in your current plan. Upgrade to build your own agents.'
+              : `You've reached the maximum of ${agentLimit} agents on your current plan.`
+          }
+        />
+      </>
+    )
+  }
 
   return (
     <>

--- a/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
@@ -66,6 +66,7 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
   const update = api.channel.updateChatWidgetIntegration.useMutation({
     onSuccess: () => {
       utils.channel.getChatWidgetIntegration.invalidate({ integrationId: channelId })
+      utils.channel.getChatIdentityState.invalidate({ channelId })
       utils.channel.list.invalidate()
     },
     onError: (e) => toastError({ title: 'Failed to save', description: e.message }),
@@ -284,7 +285,13 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
               <>
                 <RadioTab
                   value={field.value}
-                  onValueChange={(v) => field.onChange(v as ChatAudience)}
+                  onValueChange={(v) => {
+                    const next = v as ChatAudience
+                    field.onChange(next)
+                    // Persist immediately (like inbox/privacy/domains) so the
+                    // Identity tab unlocks without a separate "Save Changes".
+                    update.mutate({ integrationId: channelId, chatAudience: next })
+                  }}
                   size='sm'
                   radioGroupClassName='grid w-full grid-cols-3'
                   className='border border-primary-200 flex w-full mb-3'>

--- a/apps/web/src/components/chat-widget/ui/settings/sections/identity-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/identity-section.tsx
@@ -149,9 +149,12 @@ export function IdentitySection({ widget, channelId }: IdentitySectionProps) {
             stateLabel={stateLabel}
             stateBadgeVariant={stateBadgeVariant}
             canEnforce={canEnforce}
+            hasKeys={chatKeys.length > 0}
+            creatingKey={createKey.isPending}
             isPending={updateChannel.isPending}
             disabled={audienceDisabled}
             onOpenGeneral={() => setActiveSection('general')}
+            onCreateKey={handleCreate}
             onTransition={(next) =>
               updateChannel.mutate({ integrationId: channelId, identityVerification: next })
             }
@@ -308,10 +311,13 @@ interface EnforcementCardProps {
   stateLabel: string
   stateBadgeVariant: 'gray' | 'amber' | 'green'
   canEnforce: boolean
+  hasKeys: boolean
+  creatingKey: boolean
   isPending: boolean
   disabled?: boolean
   onTransition: (next: EnforcementState) => void
   onOpenSetup: () => void
+  onCreateKey: () => void
   onOpenGeneral?: () => void
 }
 
@@ -320,10 +326,13 @@ function EnforcementCard({
   stateLabel,
   stateBadgeVariant,
   canEnforce,
+  hasKeys,
+  creatingKey,
   isPending,
   disabled,
   onTransition,
   onOpenSetup,
+  onCreateKey,
   onOpenGeneral,
 }: EnforcementCardProps) {
   return (
@@ -345,38 +354,57 @@ function EnforcementCard({
             'All chat write requests must carry a valid JWT. Visitors without one are rejected.'}
         </p>
 
-        <div className='mt-4 flex items-center gap-3 rounded-md border border-border bg-background px-3 py-2 text-xs'>
-          <div
-            className={
-              canEnforce
-                ? 'flex size-6 shrink-0 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-700 ring-1 ring-emerald-500/20 dark:text-emerald-400'
-                : 'flex size-6 shrink-0 items-center justify-center rounded-full bg-background text-xs font-medium ring-1 ring-border'
-            }>
-            {canEnforce ? <Check className='size-3.5' /> : '1'}
-          </div>
-          <div className='flex-1'>
-            <div className='text-sm font-medium text-foreground'>
-              {canEnforce ? 'JWT-signed traffic seen' : 'Wire up your widget with a userJwt'}
+        <div className='mt-4 space-y-2'>
+          <div className='flex items-center gap-3 rounded-md border border-border bg-background px-3 py-2 text-xs'>
+            <StepBadge done={hasKeys} index={1} />
+            <div className='flex-1'>
+              <div className='text-sm font-medium text-foreground'>
+                {hasKeys ? 'Signing key created' : 'Create a signing key'}
+              </div>
+              <div className='text-muted-foreground'>
+                {hasKeys
+                  ? 'Your server can sign JWTs with this per-channel secret.'
+                  : 'Create a per-channel secret your server signs JWTs with.'}
+              </div>
             </div>
-            <div className='text-muted-foreground'>
-              {canEnforce
-                ? 'Your widget is sending signed visitors. Safe to enforce.'
-                : 'Use the Verified setup snippet — server signs a JWT, widget boots with it.'}
-            </div>
+            {!hasKeys && (
+              <button
+                type='button'
+                onClick={onCreateKey}
+                disabled={creatingKey}
+                className='inline-flex shrink-0 items-center gap-1 font-medium text-primary hover:underline disabled:opacity-50'>
+                {creatingKey ? 'Creating…' : 'Create key'}
+              </button>
+            )}
           </div>
-          <button
-            type='button'
-            onClick={onOpenSetup}
-            className='inline-flex shrink-0 items-center gap-1 font-medium text-primary hover:underline'>
-            Open Setup
-            <ArrowUpRight className='size-3' />
-          </button>
+
+          <div className='flex items-center gap-3 rounded-md border border-border bg-background px-3 py-2 text-xs'>
+            <StepBadge done={canEnforce} index={2} />
+            <div className='flex-1'>
+              <div className='text-sm font-medium text-foreground'>
+                {canEnforce ? 'JWT-signed traffic seen' : 'Wire up your widget with a userJwt'}
+              </div>
+              <div className='text-muted-foreground'>
+                {canEnforce
+                  ? 'Your widget is sending signed visitors. Safe to enforce.'
+                  : 'Use the Verified setup snippet — server signs a JWT, widget boots with it.'}
+              </div>
+            </div>
+            <button
+              type='button'
+              onClick={onOpenSetup}
+              className='inline-flex shrink-0 items-center gap-1 font-medium text-primary hover:underline'>
+              Open Setup
+              <ArrowUpRight className='size-3' />
+            </button>
+          </div>
         </div>
 
         <div className='mt-3 flex items-center justify-end'>
           <EnforceActions
             state={state}
             canEnforce={canEnforce}
+            hasKeys={hasKeys}
             isPending={isPending}
             onTransition={onTransition}
           />
@@ -396,13 +424,38 @@ function EnforcementCard({
   )
 }
 
+function StepBadge({ done, index }: { done: boolean; index: number }) {
+  return (
+    <div
+      className={
+        done
+          ? 'flex size-6 shrink-0 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-700 ring-1 ring-emerald-500/20 dark:text-emerald-400'
+          : 'flex size-6 shrink-0 items-center justify-center rounded-full bg-background text-xs font-medium ring-1 ring-border'
+      }>
+      {done ? <Check className='size-3.5' /> : index}
+    </div>
+  )
+}
+
 function EnforceActions({
   state,
   canEnforce,
+  hasKeys,
   isPending,
   onTransition,
-}: Pick<EnforcementCardProps, 'state' | 'canEnforce' | 'isPending' | 'onTransition'>) {
+}: Pick<EnforcementCardProps, 'state' | 'canEnforce' | 'hasKeys' | 'isPending' | 'onTransition'>) {
   if (state === 'off') {
+    if (!hasKeys) {
+      return (
+        <Tooltip content='Create a signing key first — rollout signs JWTs with it.'>
+          <span>
+            <Button size='xs' variant='outline' disabled>
+              Start rollout
+            </Button>
+          </span>
+        </Tooltip>
+      )
+    }
     return (
       <Button
         size='xs'

--- a/apps/web/src/components/kb/ui/articles/articles-view.tsx
+++ b/apps/web/src/components/kb/ui/articles/articles-view.tsx
@@ -11,6 +11,7 @@
 
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { converters } from '@auxx/lib/field-values/client'
+import { FeatureKey } from '@auxx/lib/permissions/client'
 import type { RecordId, ResourceField } from '@auxx/lib/resources/client'
 import { toFieldId, toResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
@@ -45,7 +46,9 @@ import { type RecordMeta, toRecordId, useResource } from '~/components/resources
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useRelationshipStore } from '~/components/resources/store/relationship-store'
 import { useResourceStore } from '~/components/resources/store/resource-store'
+import { LimitReachedDialog } from '~/components/subscriptions/limit-reached-dialog'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 import { useKnowledgeBaseMutations } from '../../hooks/use-knowledge-base-mutations'
 import {
@@ -131,7 +134,25 @@ export function ArticlesView() {
 
   const [confirm, ConfirmDialog] = useConfirm()
   const [isCreateKBOpen, setIsCreateKBOpen] = useState(false)
+  const [limitDialogOpen, setLimitDialogOpen] = useState(false)
   const { createKnowledgeBase, isCreating } = useKnowledgeBaseMutations()
+
+  const { isAtLimit, getLimit } = useFeatureFlags()
+  // The /app/kb route doesn't hydrate the KB store, so read the count straight
+  // from kb.list (warmed server-side by page.tsx).
+  const kbList = api.kb.list.useQuery(undefined, { staleTime: 5 * 60 * 1000 })
+  const kbCount = kbList.data?.length ?? 0
+  const atLimit = isAtLimit(FeatureKey.knowledgeBases, kbCount)
+  const kbLimit = getLimit(FeatureKey.knowledgeBases)
+
+  // No allowance on the current plan — gate creation behind an upgrade prompt.
+  const handleCreateClick = useCallback(() => {
+    if (atLimit) {
+      setLimitDialogOpen(true)
+    } else {
+      setIsCreateKBOpen(true)
+    }
+  }, [atLimit])
 
   const handleCreateKB = useCallback(
     async (values: KnowledgeBaseFormValues) => {
@@ -433,8 +454,8 @@ export function ArticlesView() {
       <MainPage>
         <MainPageHeader
           action={
-            <Button size='sm' className='h-7 rounded-lg' onClick={() => setIsCreateKBOpen(true)}>
-              <Plus className='size-4' />
+            <Button size='sm' className='h-7 rounded-lg' onClick={handleCreateClick}>
+              <Plus />
               Create Knowledge Base
             </Button>
           }>
@@ -472,6 +493,21 @@ export function ArticlesView() {
         onSubmit={handleCreateKB}
         isSubmitting={isCreating}
         mode='create'
+      />
+      <LimitReachedDialog
+        open={limitDialogOpen}
+        onOpenChange={setLimitDialogOpen}
+        icon={Book}
+        title={
+          kbLimit === 0 || kbLimit === false
+            ? 'Knowledge Bases Not Available'
+            : 'Knowledge Base Limit Reached'
+        }
+        description={
+          kbLimit === 0 || kbLimit === false
+            ? 'Creating knowledge bases isn’t included in your current plan. Upgrade to start building one.'
+            : `You've reached the maximum of ${kbLimit} knowledge bases on your current plan.`
+        }
       />
       <ConfirmDialog />
     </>

--- a/apps/web/src/components/kb/ui/dialogs/kb-empty-state.tsx
+++ b/apps/web/src/components/kb/ui/dialogs/kb-empty-state.tsx
@@ -49,7 +49,7 @@ export function KBEmptyState() {
             for your customers.
           </p>
           <Button className='mt-6' onClick={() => setShowDialog(true)} loading={isCreating}>
-            <Plus className='mr-2 h-4 w-4' />
+            <Plus />
             Create Knowledge Base
           </Button>
         </div>

--- a/apps/web/src/components/subscriptions/billing-cycle-alert.tsx
+++ b/apps/web/src/components/subscriptions/billing-cycle-alert.tsx
@@ -35,6 +35,11 @@ export function BillingCycleAlert() {
     return null
   }
 
+  // Shopify Admin owns the billing schedule — no in-app billing-cycle banner.
+  if (subscription.billingProvider === 'shopify') {
+    return null
+  }
+
   const isTrial = subscription.status === 'trialing'
   const now = new Date()
   const hasPaymentMethod = Boolean(paymentMethods && paymentMethods.length > 0)

--- a/apps/web/src/components/subscriptions/plan-change-summary.tsx
+++ b/apps/web/src/components/subscriptions/plan-change-summary.tsx
@@ -646,7 +646,7 @@ function PlanChangeSummaryContent({
             <div className='space-y-2 text-sm'>
               {/* Seat change indicator */}
               {currentSubscription && seats !== currentSubscription.seats && (
-                <div className='flex justify-between text-xs text-muted-foreground'>
+                <div className='flex h-4 items-center justify-between text-xs text-muted-foreground'>
                   <span>Seat change</span>
                   <span>
                     {currentSubscription.seats} → {seats} (
@@ -657,10 +657,10 @@ function PlanChangeSummaryContent({
               )}
 
               {/* Line item */}
-              <div className='flex justify-between'>
+              <div className='flex min-h-5 items-center justify-between'>
                 <span className='text-muted-foreground'>
                   {isLoadingPreview ? (
-                    <Skeleton className='h-[20px] w-32' />
+                    <Skeleton className='h-3.5 w-32' />
                   ) : (
                     <>
                       {seats} seat × {selectedPlan.name}
@@ -668,14 +668,14 @@ function PlanChangeSummaryContent({
                   )}
                 </span>
                 {isLoadingPreview ? (
-                  <Skeleton className='h-[20px] w-16' />
+                  <Skeleton className='h-3.5 w-16' />
                 ) : (
                   <span className='font-medium'>${subtotal.toFixed(2)}</span>
                 )}
               </div>
-              <div className='text-xs text-muted-foreground'>
+              <div className='flex min-h-4 items-center text-xs text-muted-foreground'>
                 {isLoadingPreview ? (
-                  <Skeleton className='h-[16px] w-24' />
+                  <Skeleton className='h-3 w-24' />
                 ) : (
                   <>
                     at ${(selectedPrice / 100).toFixed(2)} /{' '}
@@ -685,30 +685,30 @@ function PlanChangeSummaryContent({
               </div>
 
               {/* Subtotal */}
-              <div className='border-t pt-2 flex justify-between'>
+              <div className='border-t pt-2 flex items-center justify-between'>
                 <span className='text-muted-foreground'>Subtotal</span>
                 {isLoadingPreview ? (
-                  <Skeleton className='h-[20px] w-16' />
+                  <Skeleton className='h-3.5 w-16' />
                 ) : (
                   <span className='font-medium'>${subtotal.toFixed(2)}</span>
                 )}
               </div>
 
               {/* Tax */}
-              <div className='flex justify-between'>
+              <div className='flex items-center justify-between'>
                 <span className='text-muted-foreground'>Tax</span>
                 {isLoadingPreview ? (
-                  <Skeleton className='h-[20px] w-16' />
+                  <Skeleton className='h-3.5 w-16' />
                 ) : (
                   <span className='font-medium'>${tax.toFixed(2)}</span>
                 )}
               </div>
 
               {/* Total at renewal */}
-              <div className='border-t pt-2 flex justify-between font-semibold'>
+              <div className='border-t pt-2 flex items-center justify-between font-semibold'>
                 <span>Total at renewal</span>
                 {isLoadingPreview ? (
-                  <Skeleton className='h-[20px] w-16' />
+                  <Skeleton className='h-3.5 w-16' />
                 ) : (
                   <span>${total.toFixed(2)}</span>
                 )}
@@ -721,7 +721,7 @@ function PlanChangeSummaryContent({
                 </div>
               ) : (
                 <>
-                  <div className='flex justify-between text-xs'>
+                  <div className='flex h-4 items-center justify-between text-xs'>
                     <span className='text-muted-foreground'>
                       {preview?.transition === 'seat_addition' && 'Prorated seat addition'}
                       {preview?.transition === 'seat_reduction' && 'Prorated seat reduction'}
@@ -731,7 +731,7 @@ function PlanChangeSummaryContent({
                         'Adjustment due today'}
                     </span>
                     {isLoadingPreview ? (
-                      <Skeleton className='h-[16px] w-12' />
+                      <Skeleton className='h-3 w-12' />
                     ) : (
                       <span>${adjustmentDueToday.toFixed(2)}</span>
                     )}

--- a/apps/web/src/components/subscriptions/shopify-admin-billing-banner.tsx
+++ b/apps/web/src/components/subscriptions/shopify-admin-billing-banner.tsx
@@ -2,7 +2,9 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
-import { ExternalLink } from 'lucide-react'
+import { ExternalLink, Wallet } from 'lucide-react'
+import { useEnv } from '~/providers/dehydrated-state-provider'
+import { shopifyAppUrl } from './shopify-admin-url'
 
 interface ShopifyAdminBillingBannerProps {
   shopDomain: string | null
@@ -11,25 +13,31 @@ interface ShopifyAdminBillingBannerProps {
 /**
  * Banner shown above Billing Details for Shopify-billed orgs. Clarifies that only
  * payment method + invoice history live in Shopify Admin — plan changes and
- * cancellation still work from this page.
+ * cancellation still work from this page. "Open Shopify Admin" deep-links to the app's
+ * own page (Settings → Apps → Auxx). Mirrors the plan-change-card row design.
  */
 export function ShopifyAdminBillingBanner({ shopDomain }: ShopifyAdminBillingBannerProps) {
-  if (!shopDomain) return null
+  const { shopifyAppHandle } = useEnv()
+  const appUrl = shopDomain ? shopifyAppUrl(shopDomain, shopifyAppHandle) : null
+  if (!appUrl) return null
 
   return (
-    <div className='rounded-2xl border p-4 flex items-center justify-between gap-4'>
-      <div className='space-y-1'>
-        <div className='font-medium text-foreground'>
-          Payment method and invoices are managed in Shopify
+    <div className='group flex items-center justify-between rounded-2xl border py-2 px-3 hover:bg-muted transition-colors duration-200'>
+      <div className='flex flex-row items-center gap-2'>
+        <div className='size-8 border bg-muted rounded-lg flex items-center justify-center group-hover:bg-secondary transition-colors shrink-0'>
+          <Wallet className='size-4 shrink-0' />
         </div>
-        <div className='text-sm text-muted-foreground'>
-          Your card on file, past charges, and invoice history are handled by Shopify Admin. Plan
-          changes and cancellation work from this page.
+        <div className='flex flex-col'>
+          <span className='text-sm'>Billing is managed in Shopify</span>
+          <span className='text-xs text-muted-foreground'>
+            Your payment method and subscription are handled by Shopify Admin. Plan changes and
+            cancellation work from this page.
+          </span>
         </div>
       </div>
-      <Button variant='outline' asChild>
-        <a href={`https://${shopDomain}/admin/charges`} target='_blank' rel='noopener noreferrer'>
-          Open Shopify Admin
+      <Button variant='outline' size='sm' asChild>
+        <a href={appUrl} target='_blank' rel='noopener noreferrer'>
+          Open in Shopify Admin
           <ExternalLink />
         </a>
       </Button>

--- a/apps/web/src/components/subscriptions/shopify-admin-url.ts
+++ b/apps/web/src/components/subscriptions/shopify-admin-url.ts
@@ -1,0 +1,34 @@
+// apps/web/src/components/subscriptions/shopify-admin-url.ts
+
+/**
+ * Builds Shopify Admin deep-links from a shop domain (`cool-shop.myshopify.com`).
+ * The merchant-facing Admin UI lives at `admin.shopify.com/store/<handle>`, not on the
+ * `*.myshopify.com` domain — linking to `https://<shop>/admin/charges` 404s.
+ */
+
+/** `'cool-shop.myshopify.com'` → `'cool-shop'`. Returns null for non-myshopify domains. */
+function storeHandle(shopDomain: string): string | null {
+  const m = shopDomain.match(/^([^.]+)\.myshopify\.com$/)
+  return m ? m[1] : null
+}
+
+/**
+ * Org-level billing page: payment method on file + invoice/charge history.
+ * Returns null when the shop domain can't be parsed (caller hides the link).
+ */
+export function shopifyBillingUrl(shopDomain: string): string | null {
+  const handle = storeHandle(shopDomain)
+  return handle ? `https://admin.shopify.com/store/${handle}/settings/organization-billing` : null
+}
+
+/**
+ * The app's own page in Shopify Admin (Settings → Apps → Auxx) — where the merchant
+ * manages the app subscription itself. Needs the app slug (`SHOPIFY_APP_HANDLE`),
+ * surfaced to the client via the dehydrated environment. Returns null when either the
+ * shop domain can't be parsed or the app handle is unset (caller hides the link).
+ */
+export function shopifyAppUrl(shopDomain: string, appHandle: string): string | null {
+  const handle = storeHandle(shopDomain)
+  if (!handle || !appHandle) return null
+  return `https://admin.shopify.com/store/${handle}/settings/apps/app_installations/app/${appHandle}`
+}

--- a/apps/web/src/components/subscriptions/shopify-invoices-link.tsx
+++ b/apps/web/src/components/subscriptions/shopify-invoices-link.tsx
@@ -3,6 +3,7 @@
 
 import { Button } from '@auxx/ui/components/button'
 import { ExternalLink, FileText } from 'lucide-react'
+import { shopifyBillingUrl } from './shopify-admin-url'
 
 interface ShopifyInvoicesLinkProps {
   shopDomain: string | null
@@ -10,23 +11,24 @@ interface ShopifyInvoicesLinkProps {
 
 /** Replaces the invoice ledger for Shopify-billed orgs — deeplinks to Shopify Admin charges. */
 export function ShopifyInvoicesLink({ shopDomain }: ShopifyInvoicesLinkProps) {
-  if (!shopDomain) return null
+  const billingUrl = shopDomain ? shopifyBillingUrl(shopDomain) : null
+  if (!billingUrl) return null
 
   return (
-    <div className='flex items-center justify-between p-6'>
-      <div className='flex items-center gap-3'>
-        <div className='size-10 rounded bg-muted flex items-center justify-center'>
-          <FileText className='size-5 text-muted-foreground' />
+    <div className='flex items-center justify-between gap-2 p-3'>
+      <div className='flex flex-row items-center gap-2'>
+        <div className='size-8 border bg-muted rounded-lg flex items-center justify-center shrink-0'>
+          <FileText className='size-4 shrink-0 text-muted-foreground' />
         </div>
-        <div>
-          <div className='text-sm font-medium'>Invoices are in Shopify Admin</div>
-          <p className='text-xs text-muted-foreground'>
+        <div className='flex flex-col'>
+          <span className='text-sm'>Invoices are in Shopify Admin</span>
+          <span className='text-xs text-muted-foreground'>
             Past charges and invoice history are managed by Shopify for this organization.
-          </p>
+          </span>
         </div>
       </div>
       <Button variant='outline' size='sm' asChild>
-        <a href={`https://${shopDomain}/admin/charges`} target='_blank' rel='noopener noreferrer'>
+        <a href={billingUrl} target='_blank' rel='noopener noreferrer'>
           View in Shopify
           <ExternalLink />
         </a>

--- a/apps/web/src/server/api/routers/agent.ts
+++ b/apps/web/src/server/api/routers/agent.ts
@@ -11,6 +11,7 @@ import {
   listAgents,
   updateAgent as updateAgentService,
 } from '@auxx/lib/agents'
+import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
@@ -78,6 +79,13 @@ export const agentRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
       const args = input ?? {}
+
+      // Gate creation on the plan's agent allowance (0 on Free).
+      await new FeaturePermissionService().requireLimit(
+        organizationId,
+        FeatureKey.agentsLimit,
+        async () => (await listAgents(organizationId)).length
+      )
 
       if (args.slug && (await isAgentSlugTaken(organizationId, args.slug))) {
         throw new TRPCError({ code: 'CONFLICT', message: 'Slug already in use' })

--- a/apps/web/src/server/api/routers/billing.ts
+++ b/apps/web/src/server/api/routers/billing.ts
@@ -550,9 +550,9 @@ export const billingRouter = createTRPCRouter({
 
       const provider = await resolveBillingProvider(ctx.db, organizationId)
       if (!provider.capabilities.managedPaymentMethods) {
-        throw new BadRequestError(
-          'Payment methods are managed in Shopify Admin for this organization.'
-        )
+        // Provider manages payment methods externally (e.g. Shopify Admin).
+        // The UI gates the card on this capability — degrade to empty, don't throw.
+        return []
       }
       return await provider.listPaymentMethods!(organizationId)
     } catch (error: unknown) {

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -6,6 +6,7 @@ import { onCacheEvent, storeOAuthCsrfToken } from '@auxx/lib/cache'
 import {
   addExcludedSender as addExcludedSenderToChannel,
   addOpenPhoneChannel,
+  countBillableChannels,
   createChannel,
   disconnect as disconnectChannel,
   getAllStats,
@@ -51,15 +52,7 @@ async function checkChannelLimit(db: Database, organizationId: string) {
   const featureService = new FeaturePermissionService(db)
   const limit = await featureService.getLimit(organizationId, FeatureKey.channels)
   if (typeof limit === 'number' && limit >= 0) {
-    const [{ value: current }] = await db
-      .select({ value: count() })
-      .from(schema.Integration)
-      .where(
-        and(
-          eq(schema.Integration.organizationId, organizationId),
-          isNull(schema.Integration.deletedAt)
-        )
-      )
+    const current = await countBillableChannels(db, organizationId)
     if (current >= limit) {
       throw new TRPCError({
         code: 'FORBIDDEN',

--- a/apps/web/src/server/api/routers/shopify.ts
+++ b/apps/web/src/server/api/routers/shopify.ts
@@ -2,6 +2,7 @@ import { getProvider, type ShopifyBillingProvider, stripeClient } from '@auxx/bi
 import { WEBAPP_URL } from '@auxx/config/server'
 import { database as db, schema } from '@auxx/database'
 import { getOrgCache, isOrgMember, onCacheEvent, resolveAppSlug } from '@auxx/lib/cache'
+import { DehydrationService } from '@auxx/lib/dehydration'
 import { BadRequestError, ConflictError } from '@auxx/lib/errors'
 import { getQueue, Queues } from '@auxx/lib/jobs/queues'
 import { OrganizationService } from '@auxx/lib/organizations'
@@ -476,6 +477,8 @@ export const shopifyRouter = createTRPCRouter({
       const claim = JSON.parse(raw) as {
         shop: string
         accessToken: string
+        refreshToken?: string
+        expiresAt?: string
         scope?: string
         connectionDefinitionId: string
       }
@@ -532,6 +535,24 @@ export const shopifyRouter = createTRPCRouter({
         seed: claim.shop,
       })
 
+      // Reuse the single org-scoped Shopify connection if one already exists. Without
+      // this, every App Store (re)install inserts a fresh WorkflowCredentials row — and
+      // since Shopify revokes the old token whenever it issues a new one, getAppConnection
+      // can hand a stale (revoked) row to the Admin API read, 401-ing the billing sync so
+      // the PlanSubscription never leaves `incomplete`. One shop = one org-scoped token,
+      // updated in place.
+      const existingConn = await db.query.WorkflowCredentials.findFirst({
+        where: (c, { eq: e, and: a, isNull }) =>
+          a(
+            e(c.appId, appId),
+            e(c.organizationId, organizationId),
+            isNull(c.userId),
+            e(c.type, 'app-connection')
+          ),
+        orderBy: (c, { desc: d }) => d(c.createdAt),
+        columns: { id: true },
+      })
+
       const saveResult = await saveAppConnection(
         appId,
         installationId,
@@ -541,11 +562,14 @@ export const shopifyRouter = createTRPCRouter({
         null, // org-scoped
         {
           accessToken: claim.accessToken,
+          refreshToken: claim.refreshToken,
+          expiresAt: claim.expiresAt,
           metadata: {
             scope: claim.scope,
             shopDomain: claim.shop,
           },
-        }
+        },
+        existingConn ? { connectionId: existingConn.id } : undefined
       )
 
       if (saveResult.isErr()) {
@@ -626,9 +650,34 @@ export const shopifyRouter = createTRPCRouter({
         }
         await db.delete(schema.PlanSubscription).where(eq(schema.PlanSubscription.id, existing.id))
       } else if (existing?.billingProvider === 'shopify' && existing.status !== 'canceled') {
-        throw new ConflictError(
-          'This organization already has an active Shopify subscription. Contact support if this is unexpected.'
-        )
+        // The selected workspace is already billed through Shopify. Don't try to
+        // re-link it — decide where to send the merchant based on the existing row.
+        if (existing.shopifyShopDomain !== claim.shop) {
+          // One org bills exactly one shop. Re-claiming a *different* shop into an
+          // already-billed workspace is a genuine conflict — name the shop that holds it.
+          throw new ConflictError(
+            `This workspace already bills through Shopify for ${existing.shopifyShopDomain}. Choose a different workspace for this shop.`
+          )
+        }
+
+        // Same shop, already linked. An `incomplete` row means the merchant never
+        // approved a plan on Shopify's hosted page — resume plan selection. Any live
+        // status (active/trialing/past_due/paused) just opens their workspace.
+        if (existing.status === 'incomplete') {
+          const provider = getProvider('shopify') as ShopifyBillingProvider
+          const redirectUrl = await provider.getPlanSelectionUrl(organizationId)
+          return { redirectUrl, shop: claim.shop }
+        }
+        // Activate the picked workspace before sending them in, so `/app` opens it
+        // rather than the user's current default org.
+        if (ctx.session.user.defaultOrganizationId !== organizationId) {
+          await db
+            .update(schema.User)
+            .set({ defaultOrganizationId: organizationId, updatedAt: new Date() })
+            .where(eq(schema.User.id, userId))
+          await new DehydrationService(db).invalidateUser(userId)
+        }
+        return { redirectUrl: '/app', shop: claim.shop }
       }
       // 'shopify' + 'canceled' (reinstall) falls through to the upsert below — the
       // merchant re-enters Shopify's picker and we observe the fresh contract on return.

--- a/packages/billing/src/providers/shopify/provider.ts
+++ b/packages/billing/src/providers/shopify/provider.ts
@@ -3,6 +3,7 @@
 import { configService } from '@auxx/credentials'
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
 import { computePlanPreviewBase } from '../../services/preview-base'
 import { BillingError, ErrorCode } from '../../utils/error-codes'
@@ -20,7 +21,9 @@ import type {
 } from '../types'
 import { type ActiveSubscription, getActiveSubscription } from './active-subscription'
 import { mapActiveSubscriptionToStatus } from './status-mapping'
-import { dispatchShopifyBillingWebhook } from './webhook'
+import { cancelSubscriptionByShop, resolveOrgIdByShopDomain } from './webhook'
+
+const logger = createScopedLogger('billing/shopify/provider')
 
 /**
  * Shopify App Pricing adapter. Plans live in the Partner Dashboard; Shopify hosts the
@@ -33,7 +36,7 @@ export class ShopifyBillingProvider implements BillingProvider {
   readonly id = 'shopify' as const
   readonly capabilities: BillingCapabilities = {
     managedPaymentMethods: false, // Shopify Admin owns the card
-    selfServeBillingPortal: false, // No portal URL — we deep-link to /admin/charges
+    selfServeBillingPortal: false, // No portal API — we deep-link to Shopify Admin org billing
     prorationPreview: false, // Shopify prorates but does not preview
     arbitraryBillingCycles: false, // Monthly + annual only
     trialWithoutPaymentMethod: true, // Per-plan trial in Partner Dashboard
@@ -80,7 +83,7 @@ export class ShopifyBillingProvider implements BillingProvider {
     throw new BillingError(
       ErrorCode.OPERATION_NOT_SUPPORTED,
       'Shopify subscriptions are canceled by the merchant from Shopify Admin. ' +
-        'Direct them to https://{shop}/admin/charges to manage.'
+        'Direct them to Settings → Apps → Auxx to manage the subscription.'
     )
   }
 
@@ -99,7 +102,8 @@ export class ShopifyBillingProvider implements BillingProvider {
     if (!row?.shopifyShopDomain) {
       throw new BillingError(ErrorCode.NO_CUSTOMER_FOUND, 'No Shopify shop linked to this org')
     }
-    return { url: `https://${row.shopifyShopDomain}/admin/charges` }
+    const storeHandle = extractStoreHandle(row.shopifyShopDomain)
+    return { url: `https://admin.shopify.com/store/${storeHandle}/settings/organization-billing` }
   }
 
   async calculatePreview(input: PreviewInput): Promise<PreviewResult> {
@@ -128,16 +132,51 @@ export class ShopifyBillingProvider implements BillingProvider {
     }
   }
 
-  async processWebhook(input: ProcessWebhookInput): Promise<{ success: boolean }> {
+  /**
+   * Dispatches a Shopify billing webhook by topic. Contrary to the original App Pricing
+   * assumption, Shopify DOES deliver `app_subscriptions/update` (on approve/change/cancel)
+   * and `app/uninstalled`. Topics arrive in the REST header form (lowercase + slash), not
+   * the GraphQL enum. HMAC is pre-verified by the route. Returns the affected
+   * `organizationId` so the caller can invalidate org cache.
+   */
+  async processWebhook(
+    input: ProcessWebhookInput
+  ): Promise<{ success: boolean; organizationId?: string | null }> {
     if (input.rawBody == null || input.topic == null) {
       throw new Error('Shopify webhook requires rawBody and topic')
     }
-    return dispatchShopifyBillingWebhook({
-      db: input.db,
-      rawBody: input.rawBody,
-      topic: input.topic,
-      shopDomain: input.shopDomain ?? '',
-    })
+    const shopDomain = input.shopDomain ?? ''
+    const organizationId = await resolveOrgIdByShopDomain(input.db, shopDomain)
+
+    switch (input.topic) {
+      // Subscription created/approved/changed/cancelled on Shopify. Re-read the Admin API
+      // for the authoritative contract + plan resolution (reuses syncFromAdminApi).
+      case 'app_subscriptions/update':
+        if (organizationId) {
+          // Don't 500 the webhook on a transient Admin API failure (e.g. token mid-
+          // rotation) — Shopify would retry noisily and the 15-min worker poll backstops.
+          try {
+            await this.syncFromAdminApi(organizationId)
+          } catch (err) {
+            logger.error('syncFromAdminApi failed handling app_subscriptions/update', {
+              organizationId,
+              error: err instanceof Error ? err.message : String(err),
+            })
+          }
+        } else {
+          logger.warn('app_subscriptions/update for unknown shop', { shopDomain })
+        }
+        return { success: true, organizationId }
+
+      // Token is revoked at uninstall, so cancel directly rather than via the Admin API.
+      case 'app/uninstalled':
+        await cancelSubscriptionByShop(input.db, shopDomain)
+        return { success: true, organizationId }
+
+      default:
+        logger.info('Unhandled Shopify billing webhook topic', { topic: input.topic })
+        return { success: true, organizationId }
+    }
   }
 
   /**

--- a/packages/billing/src/providers/shopify/webhook.ts
+++ b/packages/billing/src/providers/shopify/webhook.ts
@@ -26,37 +26,28 @@ export function verifyShopifyHmac(rawBody: string, hmacHeader: string | null | u
   }
 }
 
-export interface DispatchShopifyWebhookInput {
-  db: Database
-  rawBody: string
-  topic: string
-  shopDomain: string
-}
-
-export async function dispatchShopifyBillingWebhook(
-  input: DispatchShopifyWebhookInput
-): Promise<{ success: boolean }> {
-  const { db, topic, shopDomain } = input
-
-  switch (topic) {
-    case 'APP_UNINSTALLED':
-      return handleAppUninstalled(db, shopDomain)
-    default:
-      // App Pricing delivers no billing webhooks to apps enrolled after April 2026.
-      // Subscription state changes are read from the Admin API (see provider's
-      // syncFromAdminApi + the worker poll). Uninstall is the only kept webhook.
-      logger.info('Unhandled Shopify billing webhook topic', { topic })
-      return { success: true }
-  }
-}
-
-async function handleAppUninstalled(
+/** Resolves the org that owns a shop from the denormalized PlanSubscription row. */
+export async function resolveOrgIdByShopDomain(
   db: Database,
   shopDomain: string
-): Promise<{ success: boolean }> {
+): Promise<string | null> {
+  if (!shopDomain) return null
+  const row = await db.query.PlanSubscription.findFirst({
+    where: (s, { eq: e }) => e(s.shopifyShopDomain, shopDomain),
+    columns: { organizationId: true },
+  })
+  return row?.organizationId ?? null
+}
+
+/**
+ * Cancels the Shopify subscription for a shop. Used on `app/uninstalled` — the access
+ * token is revoked at uninstall, so we cannot read the Admin API and must mark the row
+ * canceled directly.
+ */
+export async function cancelSubscriptionByShop(db: Database, shopDomain: string): Promise<void> {
   if (!shopDomain) {
-    logger.warn('APP_UNINSTALLED with no shopDomain header')
-    return { success: true }
+    logger.warn('Uninstall webhook with no shopDomain header')
+    return
   }
   const now = new Date()
   const result = await db
@@ -65,6 +56,8 @@ async function handleAppUninstalled(
     .where(eq(schema.PlanSubscription.shopifyShopDomain, shopDomain))
     .returning({ id: schema.PlanSubscription.id })
 
-  logger.info('APP_UNINSTALLED fan-out applied', { shopDomain, rowsUpdated: result.length })
-  return { success: true }
+  logger.info('Shopify subscription canceled on uninstall', {
+    shopDomain,
+    rowsUpdated: result.length,
+  })
 }

--- a/packages/billing/src/providers/types.ts
+++ b/packages/billing/src/providers/types.ts
@@ -135,7 +135,9 @@ export interface BillingProvider {
   createSubscription(input: CreateSubscriptionInput): Promise<CreateSubscriptionResult>
   cancelSubscription(input: CancelSubscriptionInput): Promise<void>
   restoreSubscription(input: RestoreSubscriptionInput): Promise<void>
-  processWebhook(input: ProcessWebhookInput): Promise<{ success: boolean }>
+  processWebhook(
+    input: ProcessWebhookInput
+  ): Promise<{ success: boolean; organizationId?: string | null }>
 
   updateSubscriptionDirect?(
     input: UpdateSubscriptionDirectInput

--- a/packages/lib/src/channels/index.ts
+++ b/packages/lib/src/channels/index.ts
@@ -9,7 +9,7 @@ export {
   createChannel,
   linkChannelToInbox,
 } from './lifecycle'
-export { getProviderType, list } from './list'
+export { countBillableChannels, getProviderType, list } from './list'
 export { getAuthUrl } from './oauth'
 export {
   addExcludedSender,

--- a/packages/lib/src/channels/list.ts
+++ b/packages/lib/src/channels/list.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/channels/list.ts
 
-import { schema } from '@auxx/database'
-import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { type Database, schema } from '@auxx/database'
+import { and, count, eq, inArray, isNull, sql } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
 import { getImportCacheSize } from '../email/polling-import-cache'
 import { NotFoundError } from '../errors'
@@ -80,6 +80,30 @@ export async function list(ctx: ChannelCtx) {
   })
 
   return { channels }
+}
+
+/**
+ * Count channels that consume the org's `channels` plan limit.
+ *
+ * Excludes auto-provisioned channels the user didn't create and shouldn't be
+ * billed for: the system-managed `*@mail.auxx.ai` forwarding address
+ * (`metadata.systemManaged === true`) and seeded example integrations
+ * (`isExample`). Soft-deleted rows are excluded too. Used by both the
+ * channel-create guard and overage detection so the two stay in sync.
+ */
+export async function countBillableChannels(db: Database, organizationId: string): Promise<number> {
+  const [result] = await db
+    .select({ value: count() })
+    .from(schema.Integration)
+    .where(
+      and(
+        eq(schema.Integration.organizationId, organizationId),
+        isNull(schema.Integration.deletedAt),
+        eq(schema.Integration.isExample, false),
+        sql`coalesce(${schema.Integration.metadata}->>'systemManaged', 'false') <> 'true'`
+      )
+    )
+  return result?.value ?? 0
 }
 
 /**

--- a/packages/lib/src/dehydration/service.ts
+++ b/packages/lib/src/dehydration/service.ts
@@ -51,6 +51,7 @@ export function buildEnvironment(): DehydratedEnvironment {
     kbUrl: KB_URL || '',
     cdnUrl: configService.get<string>('CDN_URL') || '',
     turnstileSiteKey: configService.get<string>('TURNSTILE_SITE_KEY') || '',
+    shopifyAppHandle: configService.get<string>('SHOPIFY_APP_HANDLE') || '',
     stripe: {
       publishableKey: configService.get<string>('STRIPE_PUBLISHABLE_KEY') || '',
     },

--- a/packages/lib/src/dehydration/types.ts
+++ b/packages/lib/src/dehydration/types.ts
@@ -39,6 +39,9 @@ export interface DehydratedEnvironment {
   // Captcha
   turnstileSiteKey: string
 
+  /** Shopify app slug — builds Admin deep-links (e.g. the app subscription page). */
+  shopifyAppHandle: string
+
   // External services
   stripe: {
     publishableKey: string

--- a/packages/lib/src/permissions/overage-detection-service.ts
+++ b/packages/lib/src/permissions/overage-detection-service.ts
@@ -5,6 +5,7 @@ import { isSelfHosted } from '@auxx/deployment'
 import { and, count, eq, isNull } from 'drizzle-orm'
 import { getAppCache } from '../cache'
 import { getOrgCache } from '../cache/singletons'
+import { countBillableChannels } from '../channels'
 import { createScopedLogger } from '../logger'
 import type { FeatureDefinition } from './types'
 import { FEATURE_REGISTRY_MAP, FeatureKey, parseFeatureLimits } from './types'
@@ -230,18 +231,8 @@ export class OverageDetectionService {
         return result?.value ?? 0
       }
 
-      case FeatureKey.channels: {
-        const [result] = await this.db
-          .select({ value: count() })
-          .from(schema.Integration)
-          .where(
-            and(
-              eq(schema.Integration.organizationId, organizationId),
-              isNull(schema.Integration.deletedAt)
-            )
-          )
-        return result?.value ?? 0
-      }
+      case FeatureKey.channels:
+        return countBillableChannels(this.db, organizationId)
 
       case FeatureKey.workflowsLimit: {
         const [result] = await this.db

--- a/packages/lib/src/permissions/types.ts
+++ b/packages/lib/src/permissions/types.ts
@@ -56,6 +56,7 @@ export enum FeatureKey {
   datasetsLimit = 'datasetsLimit',
   entities = 'entities',
   importRowsLimit = 'importRowsLimit',
+  agentsLimit = 'agentsLimit',
   monthlyAiCredits = 'monthlyAiCredits',
 
   // ── Usage limits (per billing cycle, Soft + Hard) ──
@@ -215,6 +216,13 @@ export const FEATURE_REGISTRY: FeatureMetadata[] = [
     group: 'Data',
     unit: 'rows',
     perOperation: true,
+  },
+  {
+    key: FeatureKey.agentsLimit,
+    type: 'static',
+    label: 'Agents',
+    group: 'AI',
+    unit: 'agents',
   },
   {
     key: FeatureKey.monthlyAiCredits,

--- a/packages/seed/src/domains/billing.domain.ts
+++ b/packages/seed/src/domains/billing.domain.ts
@@ -55,17 +55,19 @@ const STATIC_LIMITS = {
     datasetsLimit: 1,
     entities: 5,
     importRowsLimit: 50,
+    agentsLimit: 2,
   },
   free: {
     teammates: 1,
     channels: 1,
     workflowsLimit: 3,
     savedViews: 10,
-    knowledgeBases: 0,
-    kbPublishedArticles: 0,
+    knowledgeBases: 1,
+    kbPublishedArticles: 8,
     datasetsLimit: 0,
     entities: 3,
     importRowsLimit: 50,
+    agentsLimit: 0,
   },
   starter: {
     teammates: -1,
@@ -77,6 +79,7 @@ const STATIC_LIMITS = {
     datasetsLimit: 5,
     entities: 10,
     importRowsLimit: 500,
+    agentsLimit: 5,
   },
   growth: {
     teammates: -1,
@@ -88,6 +91,7 @@ const STATIC_LIMITS = {
     datasetsLimit: -1,
     entities: -1,
     importRowsLimit: 1000,
+    agentsLimit: -1,
   },
   enterprise: {
     teammates: -1,
@@ -99,6 +103,7 @@ const STATIC_LIMITS = {
     datasetsLimit: -1,
     entities: -1,
     importRowsLimit: -1,
+    agentsLimit: -1,
   },
 } as const
 
@@ -123,7 +128,7 @@ const BOOLEAN_GATES = {
     agents: true,
   },
   free: {
-    knowledgeBase: false,
+    knowledgeBase: true,
     apiAccess: false,
     workflows: true,
     aiAgent: false,

--- a/packages/services/src/app-connections/get-app-connection.ts
+++ b/packages/services/src/app-connections/get-app-connection.ts
@@ -59,7 +59,9 @@ import { fromDatabase } from '../shared/utils'
  * }
  */
 export async function getAppConnection(appId: string, organizationId: string, userId: string) {
-  // Try user-scoped connection first
+  // Try user-scoped connection first. Newest wins — duplicates can accumulate (e.g. an
+  // OAuth provider that issues a fresh token per (re)connect), and an older row's token
+  // is typically revoked once a newer one is issued.
   const userConnectionResult = await fromDatabase(
     database.query.WorkflowCredentials.findFirst({
       where: (creds, { eq, and }) =>
@@ -69,6 +71,7 @@ export async function getAppConnection(appId: string, organizationId: string, us
           eq(creds.userId, userId),
           eq(creds.type, 'app-connection')
         ),
+      orderBy: (creds, { desc }) => desc(creds.createdAt),
     }),
     'get-user-connection'
   )
@@ -84,7 +87,7 @@ export async function getAppConnection(appId: string, organizationId: string, us
     return ok(credentialData)
   }
 
-  // Fall back to organization-scoped connection
+  // Fall back to organization-scoped connection. Newest wins — see note above.
   const organizationConnectionResult = await fromDatabase(
     database.query.WorkflowCredentials.findFirst({
       where: (creds, { eq, and, isNull }) =>
@@ -94,6 +97,7 @@ export async function getAppConnection(appId: string, organizationId: string, us
           isNull(creds.userId), // Organization connection has no userId
           eq(creds.type, 'app-connection')
         ),
+      orderBy: (creds, { desc }) => desc(creds.createdAt),
     }),
     'get-org-connection'
   )


### PR DESCRIPTION
## Summary

Follow-ups to the Shopify App Billing provider (#701), hardening the install → claim → billing-sync round-trip and filling in plan gating.

- **Expiring OAuth tokens** — opt into Shopify's expiring offline access tokens (`expiring: '1'`), persist `refresh_token` + `expires_at` on the claim, and reuse the single org-scoped Shopify connection **in place**. Shopify revokes the previous token whenever it issues a new one, so inserting a fresh `WorkflowCredentials` row per (re)install was leaving the Admin API read on a stale/revoked token and stranding `PlanSubscription` in `incomplete`. One shop = one org-scoped token.
- **Webhooks** — handle `app_subscriptions/update` (re-read Admin API for the authoritative contract) and `app/uninstalled` (cancel directly, since the token is gone) by REST topic header. Failures in the sync are logged rather than 500'd; the 15-min worker poll backstops. Org cache is invalidated on plan change so the app reflects new status without waiting on TTL.
- **Claim page** — short-circuit the workspace picker straight into `/app` when the shop is already linked to exactly one *live* workspace (Shopify re-runs the whole install→claim flow on every "Open app"). `incomplete` resumes plan selection; a *different* shop in an already-billed workspace is the only hard conflict.
- **Admin deep-links** — link to `admin.shopify.com/store/<handle>/...` for billing + the app subscription page; the old `*.myshopify.com/admin/charges` URL 404s. `SHOPIFY_APP_HANDLE` is plumbed through the dehydrated environment for the app-page link.
- **Billing Details** — hide the payment-method/address cards for providers that manage cards externally (Shopify Admin owns the card); `listPaymentMethods` degrades to `[]` instead of throwing.
- **Agent limit** — new `agentsLimit` static feature with per-plan allowances (Free 0, Starter 5, Growth/Enterprise unlimited). Creation is gated server-side in the agent router and behind an upgrade prompt in the UI.
- **Billable channels** — limit + overage checks now exclude example and system-managed integrations via a shared `countBillableChannels`.
- **Free plan** — now includes 1 knowledge base / 8 published articles.

## Notes

- No schema changes.
- A few `logger.info` breadcrumbs were added around the claim short-circuit / token exchange to make production billing debugging tractable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)