### PR TITLE
feat(billing): shopify per-seat usage drip via app events

### DIFF
--- a/apps/web/src/components/subscriptions/plan-change-summary.tsx
+++ b/apps/web/src/components/subscriptions/plan-change-summary.tsx
@@ -20,6 +20,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { useAnalytics } from '~/hooks/use-analytics'
 import { getStripePromise } from '~/lib/stripe'
+import { useDehydratedSubscription } from '~/providers/dehydrated-state-provider'
 import { api } from '~/trpc/react'
 import { type Plan, PlanComparison } from './plan-comparison'
 
@@ -58,6 +59,9 @@ export function PlanChangeSummary({ open, onOpenChange, initialPlan }: PlanChang
   const [billingCycle, setBillingCycle] = useState<'MONTHLY' | 'ANNUAL'>('MONTHLY')
   const [seats, setSeats] = useState(1)
 
+  // Shopify is monthly-only; default a missing capability to `true` (Stripe/unknown). Plan 15.
+  const annualBillingCycle = useDehydratedSubscription()?.capabilities.annualBillingCycle ?? true
+
   const { data: subscription } = api.billing.getCurrentSubscription.useQuery(undefined, {
     enabled: open,
   })
@@ -74,8 +78,9 @@ export function PlanChangeSummary({ open, onOpenChange, initialPlan }: PlanChang
   // Set initial plan, billing cycle, and seats from current subscription
   useEffect(() => {
     if (subscription && plans) {
-      // Always update billing cycle and seats from subscription to prevent race conditions
-      setBillingCycle(subscription.billingCycle || 'MONTHLY')
+      // Always update billing cycle and seats from subscription to prevent race conditions.
+      // Monthly-only providers (Shopify) hard-pin MONTHLY so a stale ANNUAL row can't leak in.
+      setBillingCycle(annualBillingCycle ? subscription.billingCycle || 'MONTHLY' : 'MONTHLY')
       setSeats(subscription.seats || 1)
 
       // Only set plan if not already selected
@@ -86,7 +91,7 @@ export function PlanChangeSummary({ open, onOpenChange, initialPlan }: PlanChang
         }
       }
     }
-  }, [subscription, plans, selectedPlan])
+  }, [subscription, plans, selectedPlan, annualBillingCycle])
 
   /** Handle plan selection from PlanComparison */
   const handlePlanSelect = (plan: Plan) => {
@@ -168,6 +173,9 @@ function PlanChangeSummaryContent({
   const posthog = useAnalytics()
   const stripe = useStripe()
   const elements = useElements()
+
+  // Shopify is monthly-only; default a missing capability to `true` (Stripe/unknown). Plan 15.
+  const annualBillingCycle = useDehydratedSubscription()?.capabilities.annualBillingCycle ?? true
 
   const {
     register,
@@ -474,33 +482,42 @@ function PlanChangeSummaryContent({
           {/* Billing Period */}
           <div className='space-y-2'>
             <Label>Billing period</Label>
-            <div className='relative w-full'>
-              <RadioTab
-                className='w-full'
-                radioGroupClassName='w-full '
-                value={billingCycle}
-                onValueChange={(v) => setBillingCycle(v as any)}>
-                <RadioTabItem value='MONTHLY'>
-                  <span className='hidden sm:inline'>
-                    Monthly (${monthlyPricePerMonth.toFixed(0)} / user / month)
-                  </span>
-                  <span className='sm:hidden'>Monthly ${monthlyPricePerMonth.toFixed(0)}/mo</span>
-                </RadioTabItem>
-                <RadioTabItem value='ANNUAL'>
-                  <div className='flex items-center gap-2'>
+            {annualBillingCycle ? (
+              <div className='relative w-full'>
+                <RadioTab
+                  className='w-full'
+                  radioGroupClassName='w-full '
+                  value={billingCycle}
+                  onValueChange={(v) => setBillingCycle(v as any)}>
+                  <RadioTabItem value='MONTHLY'>
                     <span className='hidden sm:inline'>
-                      Annually (${annualPricePerMonth.toFixed(0)} / user / month)
+                      Monthly (${monthlyPricePerMonth.toFixed(0)} / user / month)
                     </span>
-                    <span className='sm:hidden'>Annual ${annualPricePerMonth.toFixed(0)}/mo</span>
-                    {savingsPercentage > 0 && (
-                      <Badge size='xs' variant='blue' className='absolute -right-4 -top-4'>
-                        {savingsPercentage}% off
-                      </Badge>
-                    )}
-                  </div>
-                </RadioTabItem>
-              </RadioTab>
-            </div>
+                    <span className='sm:hidden'>Monthly ${monthlyPricePerMonth.toFixed(0)}/mo</span>
+                  </RadioTabItem>
+                  <RadioTabItem value='ANNUAL'>
+                    <div className='flex items-center gap-2'>
+                      <span className='hidden sm:inline'>
+                        Annually (${annualPricePerMonth.toFixed(0)} / user / month)
+                      </span>
+                      <span className='sm:hidden'>Annual ${annualPricePerMonth.toFixed(0)}/mo</span>
+                      {savingsPercentage > 0 && (
+                        <Badge size='xs' variant='blue' className='absolute -right-4 -top-4'>
+                          {savingsPercentage}% off
+                        </Badge>
+                      )}
+                    </div>
+                  </RadioTabItem>
+                </RadioTab>
+              </div>
+            ) : (
+              <div className='rounded-2xl border py-2 px-3'>
+                <div className='text-sm font-medium'>Billed monthly</div>
+                <div className='text-xs text-muted-foreground'>
+                  Annual billing isn't available on Shopify plans
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Seats Card */}

--- a/apps/web/src/components/subscriptions/plan-comparison.tsx
+++ b/apps/web/src/components/subscriptions/plan-comparison.tsx
@@ -4,6 +4,7 @@
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { useEffect, useState } from 'react'
 import { useUser } from '~/hooks/use-user'
+import { useDehydratedSubscription } from '~/providers/dehydrated-state-provider'
 import { api } from '~/trpc/react'
 import { BillingCycleToggle } from './billing-cycle-toggle'
 import { HorizontalPlanCard } from './horizontal-plan-card'
@@ -54,6 +55,10 @@ export function PlanComparison({
 
   const [billingCycle, setBillingCycle] = useState<'MONTHLY' | 'ANNUAL'>('MONTHLY')
 
+  // Shopify is monthly-only (per-seat is billed as usage, which can't ride an annual cycle).
+  // Default a missing capability to `true` (Stripe/unknown → annual offered). See plan 15.
+  const annualBillingCycle = useDehydratedSubscription()?.capabilities.annualBillingCycle ?? true
+
   const [initialCycleSet, setInitialCycleSet] = useState(false) // Flag to set default only once
 
   const { data: plans, isLoading: plansLoading } = api.billing.getPlans.useQuery()
@@ -66,6 +71,12 @@ export function PlanComparison({
   useEffect(() => {
     // Only run if subscription data is loaded and we haven't set the initial cycle yet
     if (!subscriptionLoading && !initialCycleSet) {
+      // Monthly-only providers (Shopify) stay pinned to MONTHLY — never copy a cycle in.
+      if (!annualBillingCycle) {
+        setBillingCycle('MONTHLY')
+        setInitialCycleSet(true)
+        return
+      }
       // Check if there's an active, non-trial subscription with a billing cycle
       if (
         subscription?.billingCycle &&
@@ -81,7 +92,7 @@ export function PlanComparison({
       // Mark that we've attempted to set the initial state
       setInitialCycleSet(true)
     }
-  }, [subscription, subscriptionLoading, initialCycleSet]) // Dependencies
+  }, [subscription, subscriptionLoading, initialCycleSet, annualBillingCycle]) // Dependencies
 
   // Filter out internal plans (e.g. Demo), then separate free and paid
   const availablePlans = plans?.filter((plan) => plan.hierarchyLevel >= 0) ?? []
@@ -90,9 +101,11 @@ export function PlanComparison({
 
   return (
     <div className={inDialog ? '' : 'p-6'}>
-      <div className='flex flex-col gap-4 justify-center items-center'>
-        <BillingCycleToggle value={billingCycle} onChange={setBillingCycle} variant={variant} />
-      </div>
+      {annualBillingCycle && (
+        <div className='flex flex-col gap-4 justify-center items-center'>
+          <BillingCycleToggle value={billingCycle} onChange={setBillingCycle} variant={variant} />
+        </div>
+      )}
 
       {isLoading && !initialCycleSet ? (
         <div>

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -341,6 +341,25 @@ export async function setupSchedules() {
       }
     )
 
+    // Shopify per-seat usage drip
+    // Daily at 04:00 UTC - Report each Shopify-billed org's seat count to the App Events
+    // `seat_day` meter (value = PlanSubscription.seats). Idempotent per (org, day) with a
+    // lookback to self-heal a missed run. See plans/billing/v2/14-shopify-per-seat-usage-meter-hack.md.
+    await maintenanceQueue.upsertJobScheduler(
+      'shopifySeatUsageJob',
+      { pattern: '0 4 * * *', tz: 'UTC' },
+      {
+        data: { batchSize: 200, lookbackDays: 1 },
+        opts: {
+          attempts: 2,
+          backoff: { type: 'exponential', delay: 60000 },
+          priority: 6,
+          removeOnComplete: { count: 7 },
+          removeOnFail: { count: 30 },
+        },
+      }
+    )
+
     // Demo cleanup job
     // Every 15 minutes - Clean up expired demo organizations
     await maintenanceQueue.upsertJobScheduler(

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
@@ -25,6 +25,7 @@ import {
   sendMidTrialEmailsJob,
   sendTrialConversionEmailsJob,
   shopifyBillingSyncJob,
+  shopifySeatUsageJob,
   storageCleanupJob,
   stripeSubscriptionSyncJob,
   taskDeadlineScannerJob,
@@ -105,6 +106,7 @@ const jobMappings = {
   applyScheduledSubscriptionChangesJob: cloudOnly(applyScheduledSubscriptionChangesJob),
   stripeSubscriptionSyncJob: cloudOnly(stripeSubscriptionSyncJob),
   shopifyBillingSyncJob: cloudOnly(shopifyBillingSyncJob),
+  shopifySeatUsageJob: cloudOnly(shopifySeatUsageJob),
 
   // Account management jobs (cloud-only)
   demoCleanupJob: cloudOnly(demoCleanupJob),

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -13,6 +13,11 @@ export {
   getActiveSubscription,
   type LocalStatus as ShopifyLocalStatus,
   mapActiveSubscriptionToStatus,
+  postSeatDayEvent,
+  reportOrgSeatDay,
+  type SeatDayEvent,
+  type SeatDayEventStatus,
+  type SeatDayReport,
   ShopifyBillingProvider,
   verifyShopifyHmac,
 } from './providers/shopify'

--- a/packages/billing/src/providers/shopify/app-events-client.ts
+++ b/packages/billing/src/providers/shopify/app-events-client.ts
@@ -1,0 +1,148 @@
+// packages/billing/src/providers/shopify/app-events-client.ts
+
+import { configService } from '@auxx/credentials'
+import { createScopedLogger } from '@auxx/logger'
+
+const logger = createScopedLogger('billing/shopify/app-events')
+
+/**
+ * App Events (per-seat usage) billing API. Two pieces:
+ *
+ *  1. An **app-scoped** client-credentials token (NOT the per-shop Admin token used by
+ *     `active-subscription.ts`). One cached token serves every org's seat events — minted
+ *     from the app's client_id/client_secret (`SHOPIFY_API_KEY`/`SHOPIFY_API_SECRET`, the
+ *     same OAuth app credentials), lives 60 min, refreshed early.
+ *  2. A billing-event POST to `api.shopify.com/app/{version}/events`. The API is
+ *     additive-only and has **permanent** idempotency (a given `idempotency_key` bills at
+ *     most once, ever), which is what makes the daily seat drip safe against retries.
+ *
+ * See plans/billing/v2/14-shopify-per-seat-usage-meter-hack.md §3.1, §5.1.
+ */
+
+const APP_EVENTS_VERSION = '2026-04'
+const TOKEN_URL = 'https://api.shopify.com/auth/access_token'
+const EVENTS_URL = `https://api.shopify.com/app/${APP_EVENTS_VERSION}/events`
+
+/** Refresh the 60-min token this far before expiry so an in-flight POST never races a stale token. */
+const TOKEN_REFRESH_SKEW_MS = 5 * 60 * 1000
+
+let cachedToken: { token: string; expiresAt: number } | null = null
+
+/**
+ * Mints (or returns the cached) app-scoped client-credentials token. Pass `force` to
+ * bypass the cache — used to re-mint exactly once after a 401.
+ */
+async function getAppToken(force = false): Promise<string> {
+  const now = Date.now()
+  if (!force && cachedToken && cachedToken.expiresAt - TOKEN_REFRESH_SKEW_MS > now) {
+    return cachedToken.token
+  }
+
+  // The app's client_id/client_secret for the client-credentials grant are the same OAuth
+  // app credentials we already store as the Shopify API key/secret.
+  const clientId = configService.get<string>('SHOPIFY_API_KEY')
+  const clientSecret = configService.get<string>('SHOPIFY_API_SECRET')
+  if (!clientId || !clientSecret) {
+    throw new Error('SHOPIFY_API_KEY and SHOPIFY_API_SECRET must be configured')
+  }
+
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: 'client_credentials',
+    }),
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`Shopify app token mint failed (${res.status}): ${body}`)
+  }
+
+  const json = (await res.json()) as { access_token: string; expires_in: number }
+  cachedToken = {
+    token: json.access_token,
+    expiresAt: now + json.expires_in * 1000,
+  }
+  return cachedToken.token
+}
+
+/** Status of a single seat-day event POST. `duplicate` = already billed (idempotent no-op). */
+export type SeatDayEventStatus = 'accepted' | 'duplicate'
+
+export interface SeatDayEvent {
+  /** `gid://shopify/Shop/<id>` — the App Events API `shop_id`. */
+  shopGid: string
+  /** ISO8601 timestamp; must fall inside the shop's current billing cycle. */
+  timestamp: string
+  /** Permanent idempotency key — `seat_day:<orgId>:<YYYY-MM-DD>`. */
+  idempotencyKey: string
+  /** Quantity to ADD to the meter — the org's current `PlanSubscription.seats`. */
+  value: number
+  /** Meter handle configured in the Partner Dashboard. Defaults to `seat_day`. */
+  eventHandle?: string
+}
+
+function buildBody(event: SeatDayEvent): string {
+  return JSON.stringify({
+    shop_id: event.shopGid,
+    event_handle: event.eventHandle ?? 'seat_day',
+    timestamp: event.timestamp,
+    idempotency_key: event.idempotencyKey,
+    attributes: { value: event.value },
+  })
+}
+
+async function doPost(token: string, body: string): Promise<Response> {
+  return fetch(EVENTS_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body,
+  })
+}
+
+/**
+ * Posts one billing event to the seat-day meter.
+ *
+ * The API returns **202 for everything** — there is no synchronous billing-validation
+ * error; failures surface only in the Dev Dashboard logs. We rely on permanent idempotency
+ * + a daily lookback for correctness (§5.3/§5.4). Status handling:
+ *  - 202 → accepted
+ *  - 409 → an in-flight duplicate (idempotent) → treat as already-billed
+ *  - 401 → token expired → re-mint once and retry
+ *  - 429 → rate-limited (500 rps/app) → back off once and retry
+ */
+export async function postSeatDayEvent(event: SeatDayEvent): Promise<SeatDayEventStatus> {
+  const body = buildBody(event)
+  let token = await getAppToken()
+  let res = await doPost(token, body)
+
+  // Token expired between mint and POST — re-mint once and retry.
+  if (res.status === 401) {
+    token = await getAppToken(true)
+    res = await doPost(token, body)
+  }
+
+  // Rate-limited — single short backoff then retry. The daily lookback heals anything
+  // still failing, so we don't loop.
+  if (res.status === 429) {
+    const retryAfterMs = Number(res.headers.get('retry-after')) * 1000 || 1000
+    await new Promise((r) => setTimeout(r, retryAfterMs))
+    res = await doPost(token, body)
+  }
+
+  if (res.status === 202) return 'accepted'
+  if (res.status === 409) return 'duplicate'
+
+  const responseBody = await res.text().catch(() => '')
+  logger.error('App Events POST failed', {
+    status: res.status,
+    idempotencyKey: event.idempotencyKey,
+    body: responseBody,
+  })
+  throw new Error(`App Events POST failed (${res.status}): ${responseBody}`)
+}

--- a/packages/billing/src/providers/shopify/index.ts
+++ b/packages/billing/src/providers/shopify/index.ts
@@ -7,8 +7,14 @@ export type {
   AppSubscriptionStatus,
 } from './active-subscription'
 export { getActiveSubscription } from './active-subscription'
+export {
+  postSeatDayEvent,
+  type SeatDayEvent,
+  type SeatDayEventStatus,
+} from './app-events-client'
 export { createShopifyAdminClient } from './client'
 export { extractStoreHandle, ShopifyBillingProvider } from './provider'
+export { reportOrgSeatDay, type SeatDayReport } from './seat-usage'
 export type { LocalStatus } from './status-mapping'
 export { mapActiveSubscriptionToStatus } from './status-mapping'
 export { verifyShopifyHmac } from './webhook'

--- a/packages/billing/src/providers/shopify/provider.ts
+++ b/packages/billing/src/providers/shopify/provider.ts
@@ -38,7 +38,8 @@ export class ShopifyBillingProvider implements BillingProvider {
     managedPaymentMethods: false, // Shopify Admin owns the card
     selfServeBillingPortal: false, // No portal API — we deep-link to Shopify Admin org billing
     prorationPreview: false, // Shopify prorates but does not preview
-    arbitraryBillingCycles: false, // Monthly + annual only
+    arbitraryBillingCycles: false, // Monthly only — per-seat is billed as usage, which can't ride an annual cycle (plan 14 §6 Q3)
+    annualBillingCycle: false, // Usage charges must be tied to a monthly cycle; annual is Stripe-only
     trialWithoutPaymentMethod: true, // Per-plan trial in Partner Dashboard
     immediateCancellation: false, // Cancellations land at end of cycle
     scheduledDowngrade: true, // Downgrade-to-free is a scheduled cancel

--- a/packages/billing/src/providers/shopify/seat-usage.ts
+++ b/packages/billing/src/providers/shopify/seat-usage.ts
@@ -1,0 +1,133 @@
+// packages/billing/src/providers/shopify/seat-usage.ts
+
+import { configService } from '@auxx/credentials'
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getAppConnection } from '@auxx/services/app-connections'
+import { eq } from 'drizzle-orm'
+import { postSeatDayEvent } from './app-events-client'
+import { createShopifyAdminClient } from './client'
+
+const logger = createScopedLogger('billing/shopify/seat-usage')
+
+/** Outcome of a single (org, day) seat drip — fed into the daily job's structured log. */
+export interface SeatDayReport {
+  orgId: string
+  /** `YYYY-MM-DD` (UTC). */
+  date: string
+  seats: number
+  status: 'accepted' | 'duplicate' | 'skipped'
+  /** Set when `status === 'skipped'`. */
+  reason?: string
+}
+
+/** `Date` → `YYYY-MM-DD` in UTC, the granularity of the per-day idempotency key. */
+function toDayKey(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+/**
+ * Reports **one** idempotent `seat_day` usage event for an org on a given day, with
+ * `value = PlanSubscription.seats`. Per-org-per-day (not per-member) — idempotency is keyed
+ * on `(org, day)`, so cron retries / worker restarts / lookback re-sends never double-bill.
+ *
+ * Reads the seat count and Shop GID off the local row; lazily fetches+caches the GID from
+ * the Admin API (`query { shop { id } }`) the first time. No-ops (returns `skipped`) for
+ * non-Shopify or canceled orgs and rows missing a shop domain.
+ *
+ * See plans/billing/v2/14-shopify-per-seat-usage-meter-hack.md §3.2, §5.2.
+ */
+export async function reportOrgSeatDay(
+  db: Database,
+  input: { organizationId: string; date: Date }
+): Promise<SeatDayReport> {
+  const date = toDayKey(input.date)
+  const row = await db.query.PlanSubscription.findFirst({
+    where: (sub, { eq: e }) => e(sub.organizationId, input.organizationId),
+    columns: {
+      id: true,
+      seats: true,
+      status: true,
+      billingProvider: true,
+      shopifyShopDomain: true,
+      shopifyShopGid: true,
+    },
+  })
+
+  const skip = (reason: string): SeatDayReport => ({
+    orgId: input.organizationId,
+    date,
+    seats: row?.seats ?? 0,
+    status: 'skipped',
+    reason,
+  })
+
+  if (!row || row.billingProvider !== 'shopify') return skip('not_shopify')
+  if (!row.shopifyShopDomain) return skip('no_shop_domain')
+  if (row.status === 'canceled') return skip('canceled')
+
+  const shopGid = await resolveShopGid(db, {
+    subscriptionId: row.id,
+    organizationId: input.organizationId,
+    shopDomain: row.shopifyShopDomain,
+    cachedGid: row.shopifyShopGid,
+  })
+
+  const status = await postSeatDayEvent({
+    shopGid,
+    // Noon UTC keeps the timestamp comfortably inside the billing day regardless of tz.
+    timestamp: `${date}T12:00:00.000Z`,
+    idempotencyKey: `seat_day:${input.organizationId}:${date}`,
+    value: row.seats,
+  })
+
+  return { orgId: input.organizationId, date, seats: row.seats, status }
+}
+
+/**
+ * Returns the shop's `gid://shopify/Shop/<id>`, reading the cached value off the row when
+ * present, otherwise querying the Admin API once and persisting it. The GID is immutable, so
+ * a single fetch per shop suffices for the lifetime of the install.
+ */
+async function resolveShopGid(
+  db: Database,
+  input: {
+    subscriptionId: string
+    organizationId: string
+    shopDomain: string
+    cachedGid: string | null
+  }
+): Promise<string> {
+  if (input.cachedGid) return input.cachedGid
+
+  const appId = configService.get<string>('SHOPIFY_APP_ID')
+  if (!appId) throw new Error('SHOPIFY_APP_ID must be configured')
+
+  // Org-scoped Shopify connection (written at install). Empty userId falls through to the
+  // org-scoped row — same pattern as active-subscription.ts.
+  const conn = await getAppConnection(appId, input.organizationId, '')
+  if (conn.isErr()) throw conn.error
+  const accessToken = conn.value.accessToken
+  if (!accessToken) throw new Error('Shopify connection has no access token')
+
+  const client = createShopifyAdminClient({ shopDomain: input.shopDomain, accessToken })
+  const res = (await client.request('#graphql\n query ShopGid { shop { id } }')) as {
+    data?: { shop?: { id?: string } }
+    errors?: unknown
+  }
+  if (res.errors || !res.data?.shop?.id) {
+    throw new Error(
+      `Admin API shop GID query failed: ${JSON.stringify(res.errors ?? 'no shop id')}`
+    )
+  }
+  const gid = res.data.shop.id
+
+  await db
+    .update(schema.PlanSubscription)
+    .set({ shopifyShopGid: gid, updatedAt: new Date() })
+    .where(eq(schema.PlanSubscription.id, input.subscriptionId))
+  logger.info('Cached Shopify shop GID', { organizationId: input.organizationId, gid })
+
+  return gid
+}

--- a/packages/billing/src/providers/stripe.ts
+++ b/packages/billing/src/providers/stripe.ts
@@ -28,6 +28,7 @@ export class StripeBillingProvider implements BillingProvider {
     selfServeBillingPortal: true,
     prorationPreview: true,
     arbitraryBillingCycles: true,
+    annualBillingCycle: true,
     trialWithoutPaymentMethod: true,
     immediateCancellation: true,
     scheduledDowngrade: true,

--- a/packages/billing/src/providers/types.ts
+++ b/packages/billing/src/providers/types.ts
@@ -10,6 +10,8 @@ export interface BillingCapabilities {
   selfServeBillingPortal: boolean
   prorationPreview: boolean
   arbitraryBillingCycles: boolean
+  /** Whether annual billing is offered. Shopify is monthly-only (usage charges can't ride an annual cycle). */
+  annualBillingCycle: boolean
   trialWithoutPaymentMethod: boolean
   immediateCancellation: boolean
   scheduledDowngrade: boolean

--- a/packages/lib/src/jobs/billing/index.ts
+++ b/packages/lib/src/jobs/billing/index.ts
@@ -13,6 +13,12 @@ export {
 } from './shopify-billing-sync-job'
 
 export {
+  type ShopifySeatUsageJobData,
+  type ShopifySeatUsageResult,
+  shopifySeatUsageJob,
+} from './shopify-seat-usage-job'
+
+export {
   type StripeSubscriptionSyncJobData,
   type StripeSubscriptionSyncResult,
   stripeSubscriptionSyncJob,

--- a/packages/lib/src/jobs/billing/shopify-seat-usage-job.ts
+++ b/packages/lib/src/jobs/billing/shopify-seat-usage-job.ts
@@ -1,0 +1,118 @@
+// packages/lib/src/jobs/billing/shopify-seat-usage-job.ts
+
+import { reportOrgSeatDay, type SeatDayReport } from '@auxx/billing'
+import { database as db, schema } from '@auxx/database'
+import type { Job } from 'bullmq'
+import { and, eq, isNotNull, ne } from 'drizzle-orm'
+import { z } from 'zod'
+import { createScopedLogger } from '../../logger'
+
+const logger = createScopedLogger('shopify-seat-usage-job')
+
+const payloadSchema = z.object({
+  batchSize: z.number().int().positive().default(200),
+  /** How many prior days to re-send (idempotent) to self-heal a missed run. */
+  lookbackDays: z.number().int().min(0).max(7).default(1),
+})
+
+export type ShopifySeatUsageJobData = z.infer<typeof payloadSchema>
+
+export interface ShopifySeatUsageResult {
+  total: number
+  accepted: number
+  duplicate: number
+  skipped: number
+  errors: number
+}
+
+/** Midnight-UTC `Date` for `today - offsetDays`. */
+function utcDayMinus(offsetDays: number): Date {
+  const now = new Date()
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - offsetDays))
+}
+
+/**
+ * Drips the admin-managed seat count to Shopify's App Events meter, once per Shopify-billed
+ * org per day, with `value = PlanSubscription.seats`. Over a 30-day cycle this accrues
+ * `seats × 30 × (price/30) = seats × price`, matching Stripe's per-seat charge.
+ *
+ * Reports today plus a short lookback (default: yesterday too). Already-landed days dedupe
+ * on Shopify's **permanent** billing idempotency, so a skipped/crashed run self-heals on the
+ * next tick with no local ledger. Trialing orgs are skipped so we never bill mid-trial
+ * (§6 Q5); canceled/frozen rows are skipped via the query + per-row status guard.
+ *
+ * Out-of-cycle events reject, so the lookback only heals gaps inside the current cycle: a
+ * lookback day before `periodStart` is not sent.
+ *
+ * See plans/billing/v2/14-shopify-per-seat-usage-meter-hack.md §5.3.
+ */
+export async function shopifySeatUsageJob(
+  job: Job<ShopifySeatUsageJobData>
+): Promise<ShopifySeatUsageResult> {
+  const input = payloadSchema.parse(job.data ?? {})
+  const result: ShopifySeatUsageResult = {
+    total: 0,
+    accepted: 0,
+    duplicate: 0,
+    skipped: 0,
+    errors: 0,
+  }
+
+  const rows = await db.query.PlanSubscription.findMany({
+    where: and(
+      eq(schema.PlanSubscription.billingProvider, 'shopify'),
+      ne(schema.PlanSubscription.status, 'canceled'),
+      isNotNull(schema.PlanSubscription.shopifyShopDomain)
+    ),
+    columns: { organizationId: true, status: true, periodStart: true },
+    limit: input.batchSize,
+  })
+
+  result.total = rows.length
+  logger.info('Shopify seat-usage tick', { rowCount: rows.length })
+  if (rows.length === 0) return result
+
+  // today, then the lookback days (yesterday, …) — all at midnight UTC.
+  const dates = Array.from({ length: input.lookbackDays + 1 }, (_, i) => utcDayMinus(i))
+
+  const tally = (report: SeatDayReport) => {
+    if (report.status === 'accepted') result.accepted++
+    else if (report.status === 'duplicate') result.duplicate++
+    else result.skipped++
+  }
+
+  for (const row of rows) {
+    // Never bill during the free-trial window (§6 Q5 — a money bug if wrong).
+    if (row.status === 'trialing') {
+      result.skipped++
+      continue
+    }
+
+    for (const date of dates) {
+      // Out-of-cycle events reject — only send a lookback day that's within the current cycle.
+      if (row.periodStart && date < startOfUtcDay(row.periodStart)) {
+        result.skipped++
+        continue
+      }
+      try {
+        const report = await reportOrgSeatDay(db, { organizationId: row.organizationId, date })
+        tally(report)
+      } catch (err) {
+        result.errors++
+        logger.error('reportOrgSeatDay failed for org', {
+          orgId: row.organizationId,
+          date: date.toISOString().slice(0, 10),
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+  }
+
+  logger.info('Shopify seat-usage tick completed', { ...result })
+  return result
+}
+
+/** Midnight-UTC of the given timestamp, for same-granularity comparison with the drip dates. */
+function startOfUtcDay(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+}

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -50,6 +50,11 @@ export {
   shopifyBillingSyncJob,
 } from './billing/shopify-billing-sync-job'
 export {
+  type ShopifySeatUsageJobData,
+  type ShopifySeatUsageResult,
+  shopifySeatUsageJob,
+} from './billing/shopify-seat-usage-job'
+export {
   type StripeSubscriptionSyncJobData,
   type StripeSubscriptionSyncResult,
   stripeSubscriptionSyncJob,

--- a/packages/lib/src/members/member-service.ts
+++ b/packages/lib/src/members/member-service.ts
@@ -744,12 +744,16 @@ export class MemberService {
         where: (sub, { eq }) => eq(sub.organizationId, organizationId),
         columns: {
           stripeSubscriptionId: true,
+          billingProvider: true,
           plan: true,
           billingCycle: true,
         },
       })
 
-      if (subscription?.stripeSubscriptionId) {
+      // The seat bump above is provider-agnostic — Shopify bills it via the daily seat-day
+      // usage drip (no quantity line). Only push to Stripe for Stripe-billed orgs. Gate on
+      // billingProvider explicitly so a stray Stripe id on a Shopify row can't trigger a push.
+      if (subscription?.stripeSubscriptionId && subscription.billingProvider !== 'shopify') {
         const billingCycle = subscription.billingCycle
         if (billingCycle !== 'MONTHLY' && billingCycle !== 'ANNUAL') {
           logger.warn('Skipping Stripe seat update due to unsupported billing cycle', {


### PR DESCRIPTION
## Summary

Bills Shopify per-seat usage through the **App Events `seat_day` meter** rather than a quantity line. Shopify usage charges can't ride an annual cycle, so Shopify subscriptions are now treated as monthly-only end to end.

## Changes

**Billing package**
- New App Events client (`postSeatDayEvent`) + `reportOrgSeatDay` reporter.
- New `annualBillingCycle` capability — `true` for Stripe, `false` for Shopify (usage charges are monthly-only).

**Worker / lib**
- Daily `shopifySeatUsageJob` (cron `0 4 * * *` UTC) reports each Shopify-billed org's seat count to the meter. Idempotent per `(org, day)` with a lookback to self-heal a missed run.

**member-service**
- Seat bumps are provider-agnostic; the Stripe quantity push is now gated on `billingProvider !== 'shopify'` so Shopify rows only drip via usage (a stray Stripe id on a Shopify row can't trigger a push).

**Web**
- Hide the annual billing toggle and pin `MONTHLY` in plan comparison / plan-change summary when `annualBillingCycle` is unavailable (Shopify).

## ⚠️ Depends on #704
The seat-usage reporter reads/writes `PlanSubscription.shopifyShopGid`. That column (and its migration `0189`) ships in the audit-log PR #704, since Drizzle bundled the column into that migration. **Merge #704 first.**