### PR TITLE
fix(build): resolve container build failures across homepage, build, chat

### DIFF
--- a/apps/build/next.config.ts
+++ b/apps/build/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   output: 'standalone',
-  serverExternalPackages: ['sharp'],
+  serverExternalPackages: ['sharp', 'imapflow', 'pino', 'thread-stream'],
   transpilePackages: [
     '@auxx/config',
     '@auxx/credentials',

--- a/apps/homepage/src/app/_components/sections/hero-v2/kopilot-mock.tsx
+++ b/apps/homepage/src/app/_components/sections/hero-v2/kopilot-mock.tsx
@@ -74,7 +74,7 @@ export function KopilotMock() {
       ? {}
       : {
           animate: { y: [0, -amplitude, 0] },
-          transition: { duration: 7, repeat: Infinity, ease: 'easeInOut', delay },
+          transition: { duration: 7, repeat: Infinity, ease: 'easeInOut' as const, delay },
         }
 
   return (

--- a/packages/chat/src/transport/passport.ts
+++ b/packages/chat/src/transport/passport.ts
@@ -1,6 +1,6 @@
 // packages/chat/src/transport/passport.ts
 
-import { buildUserDataEnvelope, getApiBase } from '~/shared/runtime-config'
+import { buildUserDataEnvelope, getApiBase } from '../shared/runtime-config'
 
 const STORAGE_PREFIX = 'auxx_passport_chat_'
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000


### PR DESCRIPTION
## Summary

Three independent fixes that each broke a Docker/container build (homepage, build app, and the web → chat chain).

### `apps/homepage` — framer-motion type error
The `float()` helper's `ease: 'easeInOut'` was inferred as `string`, which doesn't satisfy framer-motion's `Transition.ease` (`Easing | Easing[]`). Pinned it `as const`, matching the existing `DROP_TRANSITION` pattern in the same file.

### `apps/build` — Turbopack bundling pino's worker deps
`@auxx/lib` pulls in `imapflow → pino → thread-stream` transitively. Turbopack tried to bundle `thread-stream` and crawled its `test/` fixtures, `LICENSE`, `bench.js`, etc., failing on 20 unparseable/unresolvable files. Added `imapflow`, `pino`, `thread-stream` to `serverExternalPackages` — the exact set `apps/web` already declares for the same reason.

### `packages/chat` — `~` alias leaking into emitted package entrypoint
A recent change added `import … from '~/shared/runtime-config'` to `transport/passport.ts`. That file is the only transport module reachable from the `build:entries` tsc programs (via `client/index.ts`), and the build tsconfigs don't define the `~` alias — so the build failed. Critically, `tsc` doesn't rewrite path aliases in emitted JS, so aliasing it in the tsconfig would have shipped a literal `~/…` import into `dist`, breaking `@auxx/chat/server` resolution in `web` at runtime. Fixed with a relative import instead. The sibling transport files keep `~` since they're only ever bundled by vite (which aliases it).

This also fixes the downstream `web` error `Can't resolve '@auxx/chat/server'` — that was just the missing `dist/server` artifact from the broken chat build.

## Test plan
- [x] `pnpm --filter @auxx/chat run build:entries` passes; emitted `passport.js` uses `../shared/runtime-config`, no `~/` leaks into `dist`
- [x] `import('@auxx/chat/server')` resolves `signUserJwt` from `apps/web`
- [ ] Full container builds for homepage / build / web green in CI