### PR TITLE
fix(kb): externalize imapflow/pino/thread-stream in container build

### DIFF
--- a/apps/kb/next.config.ts
+++ b/apps/kb/next.config.ts
@@ -6,6 +6,7 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: 'standalone',
   cacheComponents: true,
+  serverExternalPackages: ['imapflow', 'pino', 'thread-stream'],
   transpilePackages: ['@auxx/database', '@auxx/config', '@auxx/lib', '@auxx/ui', '@auxx/utils'],
   images: {
     unoptimized: true,

--- a/apps/kb/package.json
+++ b/apps/kb/package.json
@@ -18,13 +18,16 @@
     "@auxx/redis": "workspace:*",
     "@auxx/ui": "workspace:*",
     "drizzle-orm": "catalog:",
+    "imapflow": "^1.2.13",
     "lucide-react": "catalog:",
     "minisearch": "catalog:",
     "next": "catalog:",
     "pg": "catalog:",
+    "pino": "^10.3.1",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "sharp": "catalog:"
+    "sharp": "catalog:",
+    "thread-stream": "^4.0.0"
   },
   "devDependencies": {
     "@types/react": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -775,6 +775,9 @@ importers:
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.44.5(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.19.0)(postgres@3.4.8)
+      imapflow:
+        specifier: ^1.2.13
+        version: 1.2.13
       lucide-react:
         specifier: 'catalog:'
         version: 0.575.0(react@19.2.3)
@@ -787,6 +790,9 @@ importers:
       pg:
         specifier: 'catalog:'
         version: 8.19.0
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
       react:
         specifier: 'catalog:'
         version: 19.2.3
@@ -796,6 +802,9 @@ importers:
       sharp:
         specifier: 'catalog:'
         version: 0.34.3
+      thread-stream:
+        specifier: ^4.0.0
+        version: 4.0.0
     devDependencies:
       '@auxx/typescript-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

`apps/kb` failed the container build with the same `thread-stream` bundling errors fixed for `apps/build` in #709 — but `kb` is a separate app with its own config, so it needed the same fix applied independently.

`apps/kb` imports `@auxx/lib`, whose cache/channels path pulls in `imapflow → pino → thread-stream`. Two things were missing:

1. `apps/kb/next.config.ts` had no `serverExternalPackages`, so Turbopack tried to bundle `pino` and crawled `thread-stream`'s package dir (`LICENSE`, `bench.js`, `test/*.ts`, etc.) → unparseable-module / "module not found" errors.
2. The three packages weren't direct deps of `apps/kb`. `serverExternalPackages` only externalizes packages Node can resolve from the app's own directory, and these are only transitive deps of `@auxx/lib`.

This matches `apps/web` and the merged `apps/build` fix:

- `next.config.ts`: `serverExternalPackages: ['imapflow', 'pino', 'thread-stream']`
- `package.json`: `imapflow ^1.2.13`, `pino ^10.3.1`, `thread-stream ^4.0.0`

## Test plan
- [x] All three resolve via `require.resolve` from `apps/kb`
- [x] `pnpm --filter @auxx/kb build` exits 0; routes generated; `thread-stream` errors gone (only the pre-existing non-fatal `shiki` warning remains)
- [ ] Container build for `@auxx/kb` green in CI