### PR TITLE
fix(auth): resolve headers from ctx.headers in before hook

### DIFF
--- a/apps/web/src/app/api/demo/create-session/route.ts
+++ b/apps/web/src/app/api/demo/create-session/route.ts
@@ -59,7 +59,8 @@ export async function POST(request: NextRequest) {
       .from(schema.Organization)
       .where(gt(schema.Organization.demoExpiresAt, new Date()))
 
-    if ((activeDemoResult?.count ?? 0) >= 100) {
+    const activeDemoCount = activeDemoResult?.count ?? 0
+    if (activeDemoCount >= 100) {
       logger.warn('Demo concurrent limit reached', { activeDemoCount })
       return NextResponse.json(
         { error: 'Demo is currently at capacity. Please try again in a few minutes.' },

--- a/apps/web/src/auth/server.ts
+++ b/apps/web/src/auth/server.ts
@@ -135,10 +135,16 @@ export const auth = betterAuth({
   trustedOrigins,
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
+      // `ctx.request` is only populated for HTTP-driven calls. Server-side
+      // `auth.api.*` invocations (e.g. the demo create-session route) pass only
+      // `headers`, leaving `ctx.request` undefined — so resolve from `ctx.headers`.
+      const requestHeaders = ctx.headers ?? ctx.request?.headers
+      if (!requestHeaders) return
+
       // Agent guard: if a request resolves to an AGENT user OR targets a
       // path that mutates auth state, look up the resolved user and reject.
       if (AGENT_BLOCKED_AUTH_PATHS.has(ctx.path)) {
-        const session = await auth.api.getSession({ headers: ctx.request.headers })
+        const session = await auth.api.getSession({ headers: requestHeaders })
         const sessionUser = session?.user as
           | (typeof session extends null ? never : { id: string })
           | undefined
@@ -159,7 +165,7 @@ export const auth = betterAuth({
       if (!DEMO_BLOCKED_AUTH_PATHS.has(ctx.path)) return
 
       // Session isn't resolved yet in before hooks — resolve from request headers
-      const session = await auth.api.getSession({ headers: ctx.request.headers })
+      const session = await auth.api.getSession({ headers: requestHeaders })
       if (!session?.user) return
 
       const user = session.user as typeof session.user & {


### PR DESCRIPTION
## Problem

Demo session creation was 500ing with:

```
TypeError: Cannot read properties of undefined (reading 'headers')
    at ... runBeforeHooks ... at async POST (/api/demo/create-session)
```

The demo route (`apps/web/src/app/api/demo/create-session/route.ts`) calls `auth.api.signUpEmail(...)` / `signInEmail(...)` **server-side**, passing only `headers` — not a real HTTP `Request`. better-auth's `before` hook runs for `/sign-up/email` (it's in `AGENT_BLOCKED_AUTH_PATHS`) and dereferenced `ctx.request.headers`. But `ctx.request` is only populated for HTTP-driven calls; for direct `auth.api.*` invocations it's `undefined`, so the hook threw and the 500 bubbled up.

The `after` hook already guarded this with `ctx.request?.headers` — the `before` hook just hadn't been given the same treatment.

## Fix

- **`apps/web/src/auth/server.ts`** — the `before` hook resolves headers from `ctx.headers ?? ctx.request?.headers` (`ctx.headers` is populated for both HTTP and direct-API calls) and returns early if neither exists. Both `getSession` call sites in the hook use it.
- **`apps/web/src/app/api/demo/create-session/route.ts`** — fixed a latent `ReferenceError`: the concurrency-limit branch logged an undefined `activeDemoCount` variable. Now bound from `activeDemoResult?.count` before the check.

## Testing

- Lint passes.
- Recommend exercising the demo flow against a running server — both sign-up and the subsequent sign-in go through the hook.