### PR TITLE
fix(chat): make geo entrypoint reachable in api and drop root via gosu for Railway volume

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -94,7 +94,10 @@ ENV GIT_SHA=$GIT_SHA
 ENV APP_VERSION=$APP_VERSION
 ENV BUILD_TIME=$BUILD_TIME
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
+# curl: healthcheck + GeoLite2 download. gosu: drop root → api before exec'ing
+# node when Railway starts us as root (RAILWAY_RUN_UID=0) so the geo block can
+# write to a root-owned volume mount. See docker-entrypoint.sh Block 2.
+RUN apt-get update && apt-get install -y --no-install-recommends curl gosu \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --system --gid 1001 nodejs && \

--- a/apps/web/src/app/(auth)/shopify/claim/page.tsx
+++ b/apps/web/src/app/(auth)/shopify/claim/page.tsx
@@ -2,13 +2,14 @@
 
 import { database, schema } from '@auxx/database'
 import { getOrgCache, getUserCache } from '@auxx/lib/cache'
-import { DehydrationService } from '@auxx/lib/dehydration'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { cookies, headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { auth } from '~/auth/server'
+import { setUserDefaultOrganization } from '~/server/auth/set-default-organization'
+import { confirmAndSyncShopifySubscription } from '~/server/billing/confirm-shopify-subscription'
 import { ClaimExpired } from './_components/claim-expired'
 import { ClaimFlow } from './_components/claim-flow'
 
@@ -62,6 +63,34 @@ export default async function ShopifyClaimPage({ searchParams }: PageProps) {
 
   const claim = JSON.parse(raw) as { shop: string }
 
+  // Shopify returns the merchant here (via install → OAuth → claim) right after they approve a
+  // plan on the hosted Managed Pricing page. The `app_subscriptions/update` webhook that flips the
+  // row `incomplete → active` may not have arrived yet, so the short-circuit below would read a
+  // stale `incomplete` from cache and re-show the picker. Confirm + sync against the Admin API
+  // first (busts the org cache) so the short-circuit sees the live status on the first return.
+  const [shopSub] = await database
+    .select({
+      organizationId: schema.PlanSubscription.organizationId,
+      status: schema.PlanSubscription.status,
+    })
+    .from(schema.PlanSubscription)
+    .where(
+      and(
+        eq(schema.PlanSubscription.shopifyShopDomain, claim.shop),
+        eq(schema.PlanSubscription.billingProvider, 'shopify')
+      )
+    )
+    .limit(1)
+  if (shopSub?.status === 'incomplete') {
+    // Short poll: right after approval the Admin API already reflects the contract, so a couple
+    // of attempts catch it without making a not-yet-approved merchant wait the full window.
+    await confirmAndSyncShopifySubscription({
+      organizationId: shopSub.organizationId,
+      shopDomain: claim.shop,
+      maxAttempts: 2,
+    })
+  }
+
   // Cached user→org memberships (one Redis lookup).
   const memberships = await getUserCache().get(session.user.id, 'userMemberships')
   const activeMemberships = memberships.filter((m) => m.status === 'ACTIVE')
@@ -93,11 +122,7 @@ export default async function ShopifyClaimPage({ searchParams }: PageProps) {
     // Make the linked workspace active before bouncing into the app, otherwise `/app`
     // would open whatever the user's current default org is.
     if (defaultOrgId !== targetOrgId) {
-      await database
-        .update(schema.User)
-        .set({ defaultOrganizationId: targetOrgId, updatedAt: new Date() })
-        .where(eq(schema.User.id, session.user.id))
-      await new DehydrationService(database).invalidateUser(session.user.id)
+      await setUserDefaultOrganization(database, session.user.id, targetOrgId)
     }
     redirect('/app')
   }

--- a/apps/web/src/app/(protected)/billing/subscription/activated/page.tsx
+++ b/apps/web/src/app/(protected)/billing/subscription/activated/page.tsx
@@ -1,13 +1,12 @@
 // apps/web/src/app/(protected)/billing/subscription/activated/page.tsx
 
-import { getActiveSubscription, getProvider, type ShopifyBillingProvider } from '@auxx/billing'
 import { database, schema } from '@auxx/database'
-import { onCacheEvent } from '@auxx/lib/cache'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { auth } from '~/auth/server'
+import { confirmAndSyncShopifySubscription } from '~/server/billing/confirm-shopify-subscription'
 
 const logger = createScopedLogger('shopify-billing-activated')
 
@@ -17,15 +16,12 @@ interface PageProps {
   searchParams: Promise<{ plan_handle?: string; shop?: string; org?: string }>
 }
 
-const MAX_ATTEMPTS = 5
-const RETRY_DELAY_MS = 1500
-
 /**
  * Post-approval landing route for Shopify App Pricing. The redirect itself isn't signed,
- * so we confirm against the Admin API: resolve the org from `?shop=` (or the session),
- * poll `activeSubscriptions` briefly for propagation lag, then mirror the live contract
- * onto the PlanSubscription row via the provider's `syncFromAdminApi`. If the contract
- * hasn't propagated within the window, the 15-minute worker poll backstops it.
+ * so we confirm against the Admin API: resolve the org from `?shop=` (or the session), then
+ * confirm + sync the live contract onto the PlanSubscription row (shared
+ * `confirmAndSyncShopifySubscription`). If the contract hasn't propagated within the window,
+ * the 15-minute worker poll backstops it.
  */
 export default async function ShopifySubscriptionActivatedPage({ searchParams }: PageProps) {
   const { plan_handle: planHandle, shop, org } = await searchParams
@@ -36,40 +32,13 @@ export default async function ShopifySubscriptionActivatedPage({ searchParams }:
     redirect('/app/settings/plans?billing=pending')
   }
 
-  // Poll the Admin API for the contract (handles post-approval propagation lag).
-  let confirmed = false
-  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-    try {
-      const sub = await getActiveSubscription({
-        shopDomain: orgRow.shopifyShopDomain,
-        organizationId: orgRow.organizationId,
-      })
-      if (sub) {
-        confirmed = true
-        break
-      }
-    } catch (err) {
-      logger.warn('getActiveSubscription failed on landing', {
-        organizationId: orgRow.organizationId,
-        error: err instanceof Error ? err.message : String(err),
-      })
-    }
-    if (attempt < MAX_ATTEMPTS - 1) {
-      await new Promise((r) => setTimeout(r, RETRY_DELAY_MS))
-    }
-  }
+  const confirmed = await confirmAndSyncShopifySubscription({
+    organizationId: orgRow.organizationId,
+    shopDomain: orgRow.shopifyShopDomain,
+    planHandle,
+  })
 
   if (confirmed) {
-    try {
-      const provider = getProvider('shopify') as ShopifyBillingProvider
-      await provider.syncFromAdminApi(orgRow.organizationId, { planHandleHint: planHandle })
-      await onCacheEvent('plan.changed', { orgId: orgRow.organizationId })
-    } catch (err) {
-      logger.error('syncFromAdminApi failed on landing', {
-        organizationId: orgRow.organizationId,
-        error: err instanceof Error ? err.message : String(err),
-      })
-    }
     logger.info('Shopify billing activated', {
       organizationId: orgRow.organizationId,
       planHandle: planHandle ?? null,

--- a/apps/web/src/auth/server.ts
+++ b/apps/web/src/auth/server.ts
@@ -634,10 +634,11 @@ export const auth = betterAuth({
         return null
       }
 
-      // Hydrate org id from the profile when the cookie session predates it (rare cold path).
-      if (!extendedUser.defaultOrganizationId) {
-        extendedUser.defaultOrganizationId = userProfile.defaultOrganizationId
-      }
+      // `userProfile` (Redis-backed, invalidated on every default-org change via
+      // `setUserDefaultOrganization`) is the source of truth for the active org. Always take it
+      // from the profile rather than the better-auth session, whose 5-min cookie cache otherwise
+      // serves a stale `defaultOrganizationId` for up to 5 minutes after an org switch.
+      extendedUser.defaultOrganizationId = userProfile.defaultOrganizationId
 
       // Track the "active login" signal (lastLoginAt write + auth.login audit) at most
       // once/hour per user. Gate on a dedicated Redis NX key, NOT a cached/cookie

--- a/apps/web/src/components/apps/ui/credential-badge.tsx
+++ b/apps/web/src/components/apps/ui/credential-badge.tsx
@@ -74,7 +74,7 @@ function renderLabel(status: BoundCredentialStatus, label: string | null): strin
     case 'connected':
       return label ?? 'Connected'
     case 'expired':
-      return `${label ?? 'Connection'} (expired)`
+      return 'Expired'
     case 'gone':
     case 'not_connected':
       return 'Disconnected'

--- a/apps/web/src/server/api/routers/organization.ts
+++ b/apps/web/src/server/api/routers/organization.ts
@@ -13,6 +13,7 @@ import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
 import { createTRPCRouter, notDemo, protectedProcedure, publicProcedure } from '~/server/api/trpc'
+import { setUserDefaultOrganization } from '~/server/auth/set-default-organization'
 
 const logger = createScopedLogger('api-organization')
 
@@ -329,15 +330,9 @@ export const organizationRouter = createTRPCRouter({
         throw new TRPCError({ code: 'FORBIDDEN', message: 'Not a member of this organization' })
       }
 
-      // Update default organization
-      await ctx.db
-        .update(schema.User)
-        .set({ defaultOrganizationId: organizationId, updatedAt: new Date() })
-        .where(eq(schema.User.id, userId))
-
-      // Invalidate dehydration cache so client gets fresh data on reload
-      const dehydrationService = new DehydrationService(ctx.db)
-      await dehydrationService.invalidateUser(userId)
+      // Update default organization + bust the user cache so the next session read
+      // (customSession derives defaultOrganizationId from the cached userProfile) reflects it.
+      await setUserDefaultOrganization(ctx.db, userId, organizationId)
 
       await recordAuditFromCtx(ctx, {
         category: 'auth',

--- a/apps/web/src/server/api/routers/shopify.ts
+++ b/apps/web/src/server/api/routers/shopify.ts
@@ -2,7 +2,6 @@ import { getProvider, type ShopifyBillingProvider, stripeClient } from '@auxx/bi
 import { WEBAPP_URL } from '@auxx/config/server'
 import { database as db, schema } from '@auxx/database'
 import { getOrgCache, isOrgMember, onCacheEvent, resolveAppSlug } from '@auxx/lib/cache'
-import { DehydrationService } from '@auxx/lib/dehydration'
 import { BadRequestError, ConflictError } from '@auxx/lib/errors'
 import { getQueue, Queues } from '@auxx/lib/jobs/queues'
 import { OrganizationService } from '@auxx/lib/organizations'
@@ -15,6 +14,7 @@ import { TRPCError } from '@trpc/server'
 import { and, count, desc, eq } from 'drizzle-orm'
 import { cookies } from 'next/headers'
 import { z } from 'zod'
+import { setUserDefaultOrganization } from '~/server/auth/set-default-organization'
 import { adminProcedure, createTRPCRouter, notDemo, protectedProcedure } from '../trpc'
 
 const CLAIM_COOKIE_NAME = 'shopify_claim_token'
@@ -671,11 +671,7 @@ export const shopifyRouter = createTRPCRouter({
         // Activate the picked workspace before sending them in, so `/app` opens it
         // rather than the user's current default org.
         if (ctx.session.user.defaultOrganizationId !== organizationId) {
-          await db
-            .update(schema.User)
-            .set({ defaultOrganizationId: organizationId, updatedAt: new Date() })
-            .where(eq(schema.User.id, userId))
-          await new DehydrationService(db).invalidateUser(userId)
+          await setUserDefaultOrganization(db, userId, organizationId)
         }
         return { redirectUrl: '/app', shop: claim.shop }
       }

--- a/apps/web/src/server/auth/set-default-organization.ts
+++ b/apps/web/src/server/auth/set-default-organization.ts
@@ -1,0 +1,27 @@
+// apps/web/src/server/auth/set-default-organization.ts
+
+import { type Database, schema } from '@auxx/database'
+import { getUserCache } from '@auxx/lib/cache'
+import { eq } from 'drizzle-orm'
+
+/**
+ * Sets a user's default organization and busts their user cache.
+ *
+ * `customSession` (`auth/server.ts`) derives `defaultOrganizationId` from the cached `userProfile`.
+ * Because better-auth's 5-minute session cookie cache holds the previous value, simply writing the
+ * DB row isn't enough — the next `getSession` would re-serve the stale org until the cookie expires.
+ * Flushing the user cache here forces `userProfile` to recompute from the DB on the next session
+ * read, which `customSession` then treats as authoritative. Use this at every default-org write
+ * site so session/identity stays consistent immediately after an org switch.
+ */
+export async function setUserDefaultOrganization(
+  db: Database,
+  userId: string,
+  organizationId: string
+): Promise<void> {
+  await db
+    .update(schema.User)
+    .set({ defaultOrganizationId: organizationId, updatedAt: new Date() })
+    .where(eq(schema.User.id, userId))
+  await getUserCache().invalidateUser(userId)
+}

--- a/apps/web/src/server/billing/confirm-shopify-subscription.ts
+++ b/apps/web/src/server/billing/confirm-shopify-subscription.ts
@@ -1,0 +1,75 @@
+// apps/web/src/server/billing/confirm-shopify-subscription.ts
+
+import { getActiveSubscription, getProvider, type ShopifyBillingProvider } from '@auxx/billing'
+import { onCacheEvent } from '@auxx/lib/cache'
+import { createScopedLogger } from '@auxx/logger'
+
+const logger = createScopedLogger('shopify-confirm-subscription')
+
+const DEFAULT_MAX_ATTEMPTS = 5
+const RETRY_DELAY_MS = 1500
+
+/**
+ * Confirms a Shopify subscription against the Admin API and mirrors it onto the local
+ * PlanSubscription row, then busts the org cache.
+ *
+ * The Managed-Pricing redirect back into the app isn't signed and the `app_subscriptions/update`
+ * webhook may not have arrived yet, so we poll `activeSubscriptions` briefly for propagation lag,
+ * call `syncFromAdminApi` to write the live contract, and fire `onCacheEvent('plan.changed')` so
+ * the org `subscription`/`features`/`overages` caches reflect the new status immediately.
+ *
+ * Shared by the post-approval landing page (`/billing/subscription/activated`) and the Shopify
+ * claim page short-circuit — both need authoritative state right after approval rather than
+ * trusting a possibly-stale cached `incomplete`.
+ *
+ * `maxAttempts` bounds the propagation-lag poll: the landing page can afford the full window, but
+ * the claim page passes a smaller value so a merchant who linked-but-hasn't-approved (also an
+ * `incomplete` row) doesn't eat the full delay on every app open.
+ *
+ * @returns `true` when a live contract was confirmed + synced, `false` if it hadn't propagated
+ *   within the poll window (the 15-minute worker poll backstops it).
+ */
+export async function confirmAndSyncShopifySubscription(input: {
+  organizationId: string
+  shopDomain: string
+  planHandle?: string | null
+  maxAttempts?: number
+}): Promise<boolean> {
+  const maxAttempts = input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+  let confirmed = false
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const sub = await getActiveSubscription({
+        shopDomain: input.shopDomain,
+        organizationId: input.organizationId,
+      })
+      if (sub) {
+        confirmed = true
+        break
+      }
+    } catch (err) {
+      logger.warn('getActiveSubscription failed', {
+        organizationId: input.organizationId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+    if (attempt < maxAttempts - 1) {
+      await new Promise((r) => setTimeout(r, RETRY_DELAY_MS))
+    }
+  }
+
+  if (!confirmed) return false
+
+  try {
+    const provider = getProvider('shopify') as ShopifyBillingProvider
+    await provider.syncFromAdminApi(input.organizationId, { planHandleHint: input.planHandle })
+    await onCacheEvent('plan.changed', { orgId: input.organizationId })
+    return true
+  } catch (err) {
+    logger.error('syncFromAdminApi failed', {
+      organizationId: input.organizationId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return false
+  }
+}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,10 +50,11 @@ replace_in_next() {
     {} + 2>/dev/null || true
 }
 
-if [ ! -d "${NEXT_DIR}" ]; then
-  echo "[entrypoint] No .next directory found — skipping replacements."
-  exec "$@"
-fi
+# Block 1 only applies to Next.js images (web/homepage/docs/build). Non-Next
+# images (api, worker) have no .next dir — skip the URL replacements but FALL
+# THROUGH to Block 2 (geo) and the privilege drop below. (This previously
+# `exec`-ed here, which silently skipped the geo download in the api image.)
+if [ -d "${NEXT_DIR}" ]; then
 
 replaced=false
 
@@ -99,6 +100,10 @@ else
   echo "[entrypoint] No replacements needed (DOMAIN=${DOMAIN:-<unset>}, APP_URL=${APP_URL:-<unset>})."
 fi
 
+else
+  echo "[entrypoint] No .next directory found — skipping URL replacements."
+fi
+
 # ─────────────────────────────────────────────────────────────────────
 # Block 2 — Optional GeoLite2-City download
 # ─────────────────────────────────────────────────────────────────────
@@ -122,9 +127,13 @@ else
     if tar -xzf /tmp/geolite2.tar.gz -C /tmp 2>/dev/null; then
       mmdb=$(find /tmp -maxdepth 3 -name 'GeoLite2-City.mmdb' -print -quit)
       if [ -n "${mmdb}" ]; then
-        mv "${mmdb}" "${GEO_FILE}"
-        rm -rf /tmp/geolite2.tar.gz /tmp/GeoLite2-City_*
-        echo "[geo] installed at ${GEO_FILE}"
+        if mv "${mmdb}" "${GEO_FILE}"; then
+          rm -rf /tmp/geolite2.tar.gz /tmp/GeoLite2-City_*
+          echo "[geo] installed at ${GEO_FILE}"
+        else
+          echo "[geo] failed to write ${GEO_FILE} — geo lookups will be disabled"
+          rm -f /tmp/geolite2.tar.gz
+        fi
       else
         echo "[geo] mmdb not found inside archive — geo lookups will be disabled"
         rm -f /tmp/geolite2.tar.gz
@@ -135,6 +144,25 @@ else
     fi
   else
     echo "[geo] download failed — geo lookups will be disabled"
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Drop root → app user before exec'ing the app.
+# ─────────────────────────────────────────────────────────────────────
+# Railway mounts volumes owned by root, and a non-root image can't write to
+# the mount — so the api service sets RAILWAY_RUN_UID=0 to let the geo block
+# above download into /app/geo. The app itself must NOT run as root, so we
+# hand the geo dir to the app user and drop privileges here.
+#
+# Generic across every image: we drop to whoever owns /app (each image chowns
+# its files to its own app user). Images that already start non-root never
+# enter this branch, so it's a no-op for them.
+if [ "$(id -u)" = "0" ] && command -v gosu >/dev/null 2>&1; then
+  app_uid=$(stat -c '%u' /app 2>/dev/null || echo 0)
+  if [ "${app_uid}" != "0" ]; then
+    chown -R "${app_uid}" "${GEO_DIR}" 2>/dev/null || true
+    exec gosu "${app_uid}" "$@"
   fi
 fi
 

--- a/packages/lib/src/members/member-service.ts
+++ b/packages/lib/src/members/member-service.ts
@@ -814,6 +814,10 @@ export class MemberService {
           .update(schema.User)
           .set({ defaultOrganizationId: organizationId })
           .where(eq(schema.User.id, acceptingUserId))
+        // customSession derives defaultOrganizationId from the cached userProfile — flush the
+        // user cache so the new default org is reflected on the next session read.
+        const { getUserCache } = await import('../cache')
+        await getUserCache().invalidateUser(acceptingUserId)
         logger.info('Helper: Set default organization for user', {
           userId: acceptingUserId,
           organizationId,


### PR DESCRIPTION
## Geo entrypoint fix + Railway volume support (primary)

Fixes the chat-widget visitor geolocation Docker path and makes it work with a Railway volume **without running node as root**.

- **Bug fix:** the shared `docker-entrypoint.sh` `exec`-exited at the end of Block 1 (Next.js URL substitution) whenever there was no `.next` dir. The `api` image is Express (no `.next`), so it never reached Block 2 — the GeoLite2 download was **dead code in the api container**. Block 1 now falls through to Block 2 for non-Next images (api/worker).
- **Privilege drop:** when started as root (Railway `RAILWAY_RUN_UID=0`, required so the geo block can write to a root-owned volume mount), the entrypoint `chown`s `/app/geo` to the app user and `exec gosu`'s down to it — **node never serves traffic as root**. Generic across images (drops to whoever owns `/app`); no-op for images that already start non-root.
- Adds `gosu` to the api image.
- Error-checks the mmdb `mv` so a failed write no longer logs a misleading `[geo] installed`.

### Post-merge / post-release Railway setup (not done by this PR)
Once a release with this fix deploys to Railway, on the `api` service:
1. Add a volume mounted at `/app/geo`.
2. Set `MAXMIND_LICENSE_KEY`, `RAILWAY_RUN_UID=0`, `AUXX_GEO_PROVIDER=maxmind`.
3. Redeploy; expect `Geo lookup ready: provider=maxmind` and `id` → uid 1001.

## Also bundled (unrelated WIP)
Second commit (`chore:`) carries in-progress `apps/web` auth/billing/shopify working-tree changes (auth/server, server/auth + server/billing, billing activated page, shopify claim page + router, organization router, member-service, credential-badge). Bundled per request; split out if you'd rather land it separately.
