### PR TITLE
fix(api): install ca-certificates in runner stage for GeoLite2 download

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -94,10 +94,12 @@ ENV GIT_SHA=$GIT_SHA
 ENV APP_VERSION=$APP_VERSION
 ENV BUILD_TIME=$BUILD_TIME
 
-# curl: healthcheck + GeoLite2 download. gosu: drop root → api before exec'ing
-# node when Railway starts us as root (RAILWAY_RUN_UID=0) so the geo block can
-# write to a root-owned volume mount. See docker-entrypoint.sh Block 2.
-RUN apt-get update && apt-get install -y --no-install-recommends curl gosu \
+# curl: healthcheck + GeoLite2 download. ca-certificates: system CA bundle so
+# curl can verify TLS for the HTTPS GeoLite2 download (bookworm-slim ships none,
+# and --no-install-recommends won't pull it in — without it the download fails
+# the TLS handshake). gosu: drop root → api before exec'ing node when Railway
+# starts us as root (RAILWAY_RUN_UID=0). See docker-entrypoint.sh Block 2.
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates gosu \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --system --gid 1001 nodejs && \


### PR DESCRIPTION
## Problem
On the live api image the GeoLite2 download fails at boot:
```
[geo] downloading GeoLite2-City…
[geo] download failed — geo lookups will be disabled
[geo-manager]: Geo provider maxmind failed to init — lookups disabled
```

## Root cause
The **runner stage** installed `curl` with `--no-install-recommends` on `bookworm-slim`, which does **not** include `ca-certificates`. curl then had no system CA bundle, so the HTTPS download (MaxMind 302 → Cloudflare R2) failed the TLS handshake. Verified: the exact URL + key downloads fine locally (HTTP 200, 31MB), and the builder stage already installs `ca-certificates` — only the runner was missing it. The Node app's HTTPS was unaffected (Node ships its own CA store) and the healthcheck is plain `http`, which masked the gap.

## Fix
Add `ca-certificates` to the runner-stage apt install.

## After deploy
With the `api` env already set (`MAXMIND_LICENSE_KEY`, `RAILWAY_RUN_UID=0`, `AUXX_GEO_PROVIDER=maxmind`) and the `/app/geo` volume attached, the next release should log `[geo] installed at …` and `Geo lookup ready: provider=maxmind`, with node running as uid 1001.