### PR TITLE
feat(kb): article version diff + Kopilot turn review

### DIFF
--- a/apps/api/src/routes/chat/passport.ts
+++ b/apps/api/src/routes/chat/passport.ts
@@ -338,7 +338,14 @@ passportRoute.post('/', async (c) => {
           email: claims.email,
         })
         const participantUpdates: Record<string, unknown> = { updatedAt: new Date() }
-        if (!participant.entityInstanceId) {
+        // Verified JWT wins: a Shopify-signed customer identity is higher-trust
+        // than any prior link (e.g. a stale OTP link), and a different
+        // `jwtUserId` is a different person who must not inherit the old link.
+        // Always overwrite so the issued passport's `contactId` and the
+        // Participant link can never diverge. (Anonymous/OTP linking — which
+        // only fills an empty `entityInstanceId` — lives outside this
+        // verified-JWT branch.)
+        if (participant.entityInstanceId !== resolved.contactId) {
           participantUpdates.entityInstanceId = resolved.contactId
         }
         if (displayName) {

--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -73,22 +73,6 @@ function renderDmInstructions(instructions: Record<string, unknown> | null): str
   return text.length > 0 ? text : null
 }
 
-/**
- * Pull the active article id out of the raw request context. Mirrors the
- * server-side `findRef(ctx, 'article')` precedence (mention wins) without
- * dragging the kopilot lib types into the route handler.
- */
-function findActiveArticleIdInContext(
-  context: Record<string, unknown> | undefined
-): string | undefined {
-  const refs = (context as { references?: SessionRefLike[] } | undefined)?.references
-  if (!Array.isArray(refs)) return undefined
-  const mention = refs.find((r) => r?.kind === 'article' && r?.origin === 'mention')
-  if (mention?.id) return mention.id
-  const any = refs.find((r) => r?.kind === 'article')
-  return any?.id
-}
-
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
@@ -393,46 +377,14 @@ export async function POST(request: NextRequest) {
           await runPath()
         }
 
-        // Kopilot KB turn finalization: if this turn touched the active
-        // article (a pre-turn snapshot exists in Redis), release the lock
-        // so the editor goes editable again. The snapshot stays for the
-        // user to click Undo.
-        const activeArticleId = findActiveArticleIdInContext(context)
-        if (activeArticleId && page === 'kb') {
-          const { finalizeKopilotKbTurn } = await import(
-            '@auxx/lib/ai/kopilot/capabilities/kb/tools/write-helpers'
-          )
-          await finalizeKopilotKbTurn({ articleId: activeArticleId })
-        }
-
-        // Send terminal event
+        // KB turn lifecycle (lock release on success, auto-revert on error)
+        // now runs inside the engine's onTurnEnd hook — for both the
+        // in-process and worker paths. The route no longer owns it.
         send({ type: 'done' })
       } catch (error) {
         logger.error('Kopilot stream error', {
           error: error instanceof Error ? error.message : String(error),
         })
-        // Auto-revert on agent failure: half-applied state is hostile.
-        // If the turn captured a snapshot, restore it before the editor
-        // releases its lock.
-        const activeArticleId = findActiveArticleIdInContext(context)
-        if (activeArticleId && page === 'kb') {
-          try {
-            const { revertKopilotKbTurn } = await import(
-              '@auxx/lib/ai/kopilot/capabilities/kb/tools/write-helpers'
-            )
-            await revertKopilotKbTurn({
-              db,
-              organizationId,
-              userId,
-              articleId: activeArticleId,
-            })
-          } catch (revertError) {
-            logger.error('Auto-revert failed', {
-              error: revertError instanceof Error ? revertError.message : String(revertError),
-              articleId: activeArticleId,
-            })
-          }
-        }
         const errName = error instanceof Error ? error.name : ''
         const isQuotaExhaustion = errName === 'QuotaExceededError'
         const isRateLimited = errName === 'UsageLimitError' || errName === 'RateLimitError'
@@ -645,6 +597,11 @@ async function runInProcessPath(params: {
     maxIterations: 30,
     agentConfig,
     triggerContext,
+    // Turn-end KB lifecycle (finalize on success, revert on failure) runs from
+    // the engine's onTurnEnd hook — these scope it.
+    db,
+    organizationId,
+    userId,
   })
 
   // Create LLM adapter

--- a/apps/web/src/components/kb/hooks/use-diff-param.ts
+++ b/apps/web/src/components/kb/hooks/use-diff-param.ts
@@ -1,0 +1,15 @@
+// apps/web/src/components/kb/hooks/use-diff-param.ts
+'use client'
+
+import { useQueryState } from 'nuqs'
+
+/**
+ * Shared `?diff=` query state that drives the inline diff view in the editor
+ * pane. Values: `review` (draft vs published), `v:<revisionId>` (a version vs
+ * published), `kopilot` (Kopilot turn review). `null` = editing normally.
+ *
+ * Returns `[value, setValue]`; call `setValue(null)` to close the diff.
+ */
+export function useDiffParam() {
+  return useQueryState('diff')
+}

--- a/apps/web/src/components/kb/hooks/use-kb-article-channel.ts
+++ b/apps/web/src/components/kb/hooks/use-kb-article-channel.ts
@@ -70,6 +70,12 @@ export function useKbArticleChannel({
 
       if (eventType === 'kb-article-lock' && event.type === 'kb-article-lock') {
         setLocked(event.locked)
+        // Liveness for the turn-review banner: a finalize unlock keeps the
+        // snapshot (reviewable), a revert unlock clears it. Either way refresh
+        // the recovery query so the banner appears/disappears without a poll.
+        if (!event.locked && articleId) {
+          void utils.kb.getKopilotTurnReview.invalidate({ articleId })
+        }
         return
       }
 
@@ -85,7 +91,13 @@ export function useKbArticleChannel({
 
       logger.debug('Unhandled KB article event', { eventType })
     },
-    [articleId, knowledgeBaseId, utils.kb.getArticleById, utils.kb.getArticles]
+    [
+      articleId,
+      knowledgeBaseId,
+      utils.kb.getArticleById,
+      utils.kb.getArticles,
+      utils.kb.getKopilotTurnReview,
+    ]
   )
 
   useSSE(config, onEvent)

--- a/apps/web/src/components/kb/hooks/use-kopilot-review.ts
+++ b/apps/web/src/components/kb/hooks/use-kopilot-review.ts
@@ -1,0 +1,87 @@
+// apps/web/src/components/kb/hooks/use-kopilot-review.ts
+'use client'
+
+import { diffBlocks } from '@auxx/lib/kb/blocks'
+import { toastError } from '@auxx/ui/components/toast'
+import { useMemo } from 'react'
+import { api } from '~/trpc/react'
+
+interface UseKopilotReviewArgs {
+  articleId: string
+  /** Current draft body — the diff's "after" side; the snapshot supplies "before". */
+  draftContentJson: unknown[] | null | undefined
+  /** True while Kopilot holds the write lock — the banner stays hidden mid-turn. */
+  locked: boolean
+}
+
+interface KopilotReview {
+  /** Show the turn-review banner: a snapshot is pending and we're not mid-turn. */
+  pending: boolean
+  /** Number of changed top-level blocks (added + removed + modified + moved). */
+  changeCount: number
+  /** Commit the turn — clears the snapshot, removes the Undo affordance. */
+  onKeep: () => Promise<void>
+  /** Roll the article back to the pre-turn snapshot. */
+  onUndo: () => Promise<void>
+  /** A Keep/Undo mutation is in flight. */
+  isBusy: boolean
+}
+
+/**
+ * Surfaces a pending Kopilot turn review for the editor banner. The recovery
+ * query (`getKopilotTurnReview`) is the source of truth — it runs on mount (so
+ * a review survives refresh) and is invalidated by `useKbArticleChannel` on
+ * each lock event for liveness. Keep/Undo clear the snapshot, then refresh the
+ * query so the banner disappears.
+ */
+export function useKopilotReview({
+  articleId,
+  draftContentJson,
+  locked,
+}: UseKopilotReviewArgs): KopilotReview {
+  const utils = api.useUtils()
+  const reviewQuery = api.kb.getKopilotTurnReview.useQuery({ articleId }, { enabled: !!articleId })
+  const review = reviewQuery.data ?? null
+
+  const changeCount = useMemo(() => {
+    if (!review) return 0
+    const { added, removed, modified, moved } = diffBlocks(
+      review.base,
+      (draftContentJson ?? []) as Parameters<typeof diffBlocks>[1]
+    ).stats
+    return added + removed + modified + moved
+  }, [review, draftContentJson])
+
+  const undo = api.kb.revertKopilotTurn.useMutation()
+  const keep = api.kb.keepKopilotTurn.useMutation()
+
+  const refresh = () => void utils.kb.getKopilotTurnReview.invalidate({ articleId })
+
+  const onUndo = async () => {
+    if (!review) return
+    const result = await undo.mutateAsync({ articleId, turnId: review.turnId })
+    // ok → the revert's resync repaints the editor and clears the snapshot;
+    // not ok (e.g. snapshot expired past the 24h TTL) → nothing to undo.
+    if (!result.ok) {
+      toastError({
+        title: 'Could not undo',
+        description: 'These changes are no longer available to undo.',
+      })
+    }
+    refresh()
+  }
+
+  const onKeep = async () => {
+    if (!review) return
+    await keep.mutateAsync({ articleId, turnId: review.turnId })
+    refresh()
+  }
+
+  return {
+    pending: !!review && !locked,
+    changeCount,
+    onKeep,
+    onUndo,
+    isBusy: undo.isPending || keep.isPending,
+  }
+}

--- a/apps/web/src/components/kb/ui/editor/article-diff-pane.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-diff-pane.tsx
@@ -1,0 +1,144 @@
+// apps/web/src/components/kb/ui/editor/article-diff-pane.tsx
+'use client'
+
+import { diffBlocks } from '@auxx/lib/kb/blocks'
+import { toastError } from '@auxx/ui/components/toast'
+import { Loader2 } from 'lucide-react'
+import { useEffect, useMemo } from 'react'
+import { api } from '~/trpc/react'
+import { useArticleContent } from '../../hooks/use-article-content'
+import type { ArticleMeta } from '../../store/article-store'
+import { ArticleDiffView } from './article-diff-view'
+
+interface ArticleDiffPaneProps {
+  article: ArticleMeta
+  knowledgeBaseId: string
+  /** The raw `?diff=` value: `review` | `v:<revisionId>` | `kopilot`. */
+  diffValue: string
+  onClose: () => void
+}
+
+/**
+ * Resolves the two sides of a diff for the current `?diff=` value and renders
+ * `<ArticleDiffView>` in the editor pane. Draft-vs-published reads operands
+ * already on the client (no roundtrip); version-vs-published fetches via
+ * `kb.getArticleDiff`.
+ */
+export function ArticleDiffPane({
+  article,
+  knowledgeBaseId,
+  diffValue,
+  onClose,
+}: ArticleDiffPaneProps) {
+  const isVersion = diffValue.startsWith('v:')
+  const revisionId = isVersion ? diffValue.slice(2) : null
+  const isKopilot = diffValue === 'kopilot'
+  const isSupported = diffValue === 'review' || isVersion || isKopilot
+
+  // Always called (hooks can't be conditional); the base query is the
+  // already-cached article content, so 'review' costs no extra roundtrip.
+  const {
+    draftContentJson,
+    publishedContentJson,
+    isLoading: contentLoading,
+  } = useArticleContent(article.id, knowledgeBaseId)
+
+  const versionQuery = api.kb.getArticleDiff.useQuery(
+    { articleId: article.id, base: revisionId ?? '', compare: 'published' },
+    { enabled: isVersion && !!revisionId }
+  )
+
+  // Kopilot turn review: base = pre-turn snapshot, compare = current draft.
+  const reviewQuery = api.kb.getKopilotTurnReview.useQuery(
+    { articleId: article.id },
+    { enabled: isKopilot }
+  )
+
+  // Bail on unsupported values or a failed/empty fetch (version gone, or the
+  // Kopilot snapshot already cleared/expired so there's nothing to review).
+  useEffect(() => {
+    if (!isSupported) {
+      onClose()
+      return
+    }
+    if (isVersion && versionQuery.isError) {
+      toastError({ title: 'Could not load diff', description: 'This version may no longer exist.' })
+      onClose()
+    }
+    if (isKopilot && !reviewQuery.isLoading && !reviewQuery.data) {
+      onClose()
+    }
+  }, [
+    isSupported,
+    isVersion,
+    versionQuery.isError,
+    isKopilot,
+    reviewQuery.isLoading,
+    reviewQuery.data,
+    onClose,
+  ])
+
+  const resolved = useMemo(() => {
+    if (isVersion) {
+      const d = versionQuery.data
+      if (!d) return null
+      return {
+        base: d.base?.contentJson ?? null,
+        compare: d.compare?.contentJson ?? null,
+        baseLabel: d.base?.versionNumber != null ? `v${d.base.versionNumber}` : 'Version',
+        compareLabel:
+          d.compare?.versionNumber != null ? `v${d.compare.versionNumber}` : 'Published',
+      }
+    }
+    if (isKopilot) {
+      const r = reviewQuery.data
+      if (!r) return null
+      return {
+        base: r.base,
+        compare: draftContentJson ?? null,
+        baseLabel: 'Before',
+        compareLabel: 'Kopilot',
+      }
+    }
+    return {
+      base: publishedContentJson,
+      compare: draftContentJson,
+      baseLabel: 'Published',
+      compareLabel: 'Draft',
+    }
+  }, [
+    isVersion,
+    isKopilot,
+    versionQuery.data,
+    reviewQuery.data,
+    publishedContentJson,
+    draftContentJson,
+  ])
+
+  const diff = useMemo(
+    () => (resolved ? diffBlocks(resolved.base, resolved.compare) : null),
+    [resolved]
+  )
+
+  const loading = isVersion
+    ? versionQuery.isLoading
+    : isKopilot
+      ? reviewQuery.isLoading
+      : contentLoading
+  if (!isSupported || loading || !diff || !resolved) {
+    return (
+      <div className='flex min-h-0 flex-1 items-center justify-center'>
+        <Loader2 className='size-5 animate-spin text-muted-foreground' />
+      </div>
+    )
+  }
+
+  return (
+    <ArticleDiffView
+      diff={diff}
+      baseLabel={resolved.baseLabel}
+      compareLabel={resolved.compareLabel}
+      onClose={onClose}
+    />
+  )
+}

--- a/apps/web/src/components/kb/ui/editor/article-diff-tree.ts
+++ b/apps/web/src/components/kb/ui/editor/article-diff-tree.ts
@@ -1,0 +1,237 @@
+// apps/web/src/components/kb/ui/editor/article-diff-tree.ts
+//
+// Turns the structural `BlockDiff[]` from `@auxx/lib/kb/blocks` into a render
+// plan for `<ArticleDiffView>`. Top-level text blocks get their word diff baked
+// into inline content (ins → highlight, del → strike). Modified containers
+// (tabs/accordion/table) are reconstructed: each panel/cell is re-diffed so
+// container-nested changes show inline — modified text carries its word diff,
+// added blocks stay, and removed blocks are reinserted in place — and every
+// nested leaf's status is recorded in a `decorations` map the renderer reads to
+// border-decorate it.
+
+import { type BlockDiff, diffBlockList, type InlineDiffSpan } from '@auxx/lib/kb/blocks'
+import type {
+  ArticleNodeJSON,
+  BlockJSON,
+  DiffStatus,
+  InlineJSON,
+  PanelJSON,
+  TableRowJSON,
+} from '@auxx/ui/components/kb/article'
+
+/** Block types whose visible text we rebuild from the word diff. */
+const TEXT_BLOCK_TYPES = new Set([
+  'text',
+  'heading',
+  'bulletListItem',
+  'numberedListItem',
+  'todoListItem',
+  'quote',
+  'callout',
+])
+
+export interface DiffRenderResult {
+  /** One render node per top-level diff entry (containers reconstructed with inner diffs baked in). */
+  nodes: ArticleNodeJSON[]
+  /** Container-nested leaf id → status, consumed by the renderer for border decoration. */
+  decorations: Map<string, DiffStatus>
+}
+
+/** Build the render plan for a top-level article diff. */
+export function buildDiffRender(blocks: BlockDiff[]): DiffRenderResult {
+  const decorations = new Map<string, DiffStatus>()
+  const nodes = blocks.map((d) => toRenderNode(d, decorations))
+  return { nodes, decorations }
+}
+
+/**
+ * The node to render for a top-level diff entry. Modified text blocks get their
+ * inline content rebuilt from the word diff; modified containers are
+ * reconstructed (and populate `decorations`); everything else renders its own
+ * side verbatim (`block` is the new side, or the old side for removals).
+ */
+function toRenderNode(diff: BlockDiff, decorations: Map<string, DiffStatus>): ArticleNodeJSON {
+  const node = diff.block as ArticleNodeJSON
+  const prev = diff.prevBlock as ArticleNodeJSON | undefined
+
+  if (diff.status === 'modified' || diff.status === 'moved') {
+    if (
+      node.type === 'block' &&
+      diff.inline?.length &&
+      TEXT_BLOCK_TYPES.has(node.attrs.blockType)
+    ) {
+      return withDiffInline(node, diff.inline)
+    }
+    if (prev && node.type !== 'block' && prev.type === node.type) {
+      return reconstructContainer(prev, node, decorations)
+    }
+  }
+  return node
+}
+
+/** Rebuild a modified container so its nested leaf diffs render inline. */
+function reconstructContainer(
+  oldNode: ArticleNodeJSON,
+  newNode: ArticleNodeJSON,
+  decorations: Map<string, DiffStatus>
+): ArticleNodeJSON {
+  if (newNode.type === 'tabs' && oldNode.type === 'tabs') {
+    return { ...newNode, content: mergePanels(oldNode.content, newNode.content, decorations) }
+  }
+  if (newNode.type === 'accordion' && oldNode.type === 'accordion') {
+    return { ...newNode, content: mergePanels(oldNode.content, newNode.content, decorations) }
+  }
+  if (newNode.type === 'table' && oldNode.type === 'table') {
+    return { ...newNode, content: mergeRows(oldNode.content, newNode.content, decorations) }
+  }
+  return newNode
+}
+
+// ─── tabs / accordion ────────────────────────────────────────────────
+
+/** Pair panels by stable id; re-diff each panel's blocks, keep removed panels visible. */
+function mergePanels(
+  oldPanels: PanelJSON[],
+  newPanels: PanelJSON[],
+  decorations: Map<string, DiffStatus>
+): PanelJSON[] {
+  const oldById = new Map(oldPanels.map((p) => [p.attrs.id, p]))
+  const newIds = new Set(newPanels.map((p) => p.attrs.id))
+
+  const result: PanelJSON[] = newPanels.map((panel) => ({
+    ...panel,
+    content: mergeBlocks(
+      diffBlockList(oldById.get(panel.attrs.id)?.content, panel.content),
+      decorations
+    ),
+  }))
+
+  // Whole panels removed on the new side: reinsert at their old position with
+  // all their blocks flagged removed.
+  oldPanels.forEach((panel, i) => {
+    if (newIds.has(panel.attrs.id)) return
+    result.splice(Math.min(i, result.length), 0, {
+      ...panel,
+      content: markAll(panel.content, 'removed', decorations),
+    })
+  })
+
+  return result
+}
+
+// ─── table ───────────────────────────────────────────────────────────
+
+/** Tables are grids: pair rows and cells positionally, re-diffing each cell's blocks. */
+function mergeRows(
+  oldRows: TableRowJSON[],
+  newRows: TableRowJSON[],
+  decorations: Map<string, DiffStatus>
+): TableRowJSON[] {
+  const result: TableRowJSON[] = newRows.map((row, ri) => {
+    const oldRow = oldRows[ri]
+    return {
+      ...row,
+      content: row.content.map((cell, ci) => ({
+        ...cell,
+        content: mergeBlocks(
+          diffBlockList(oldRow?.content[ci]?.content, cell.content),
+          decorations
+        ),
+      })),
+    }
+  })
+
+  // Rows removed on the new side (old table had more rows): reinsert, all removed.
+  for (let ri = newRows.length; ri < oldRows.length; ri++) {
+    const oldRow = oldRows[ri]
+    result.push({
+      ...oldRow,
+      content: oldRow.content.map((cell) => ({
+        ...cell,
+        content: markAll(cell.content, 'removed', decorations),
+      })),
+    })
+  }
+
+  return result
+}
+
+// ─── leaf merge ──────────────────────────────────────────────────────
+
+/**
+ * Turn a slot's `BlockDiff[]` into the blocks to render: modified text carries
+ * its word diff, removed blocks are kept in place, and each changed leaf's id
+ * is recorded in `decorations` for border styling. `diff.block` is the new side
+ * (or the old side for removals).
+ */
+function mergeBlocks(diffs: BlockDiff[], decorations: Map<string, DiffStatus>): BlockJSON[] {
+  const out: BlockJSON[] = []
+  for (const d of diffs) {
+    const block = d.block as BlockJSON
+    const id = block.type === 'block' ? block.attrs.id : undefined
+
+    switch (d.status) {
+      case 'added':
+      case 'removed':
+        out.push(block)
+        if (id) decorations.set(id, d.status)
+        break
+      case 'modified':
+        out.push(diffInlineNode(block, d.inline))
+        if (id) decorations.set(id, 'modified')
+        break
+      case 'moved':
+        // A pure reorder gets no inline change; only flag/bake when text edited too.
+        if (d.inline?.length) {
+          out.push(diffInlineNode(block, d.inline))
+          if (id) decorations.set(id, 'modified')
+        } else {
+          out.push(block)
+        }
+        break
+      default:
+        out.push(block)
+    }
+  }
+  return out
+}
+
+/** Bake the word diff into a text block; leave non-text blocks untouched. */
+function diffInlineNode(block: BlockJSON, inline: InlineDiffSpan[] | undefined): BlockJSON {
+  if (inline?.length && TEXT_BLOCK_TYPES.has(block.attrs.blockType)) {
+    return withDiffInline(block, inline)
+  }
+  return block
+}
+
+/** Flag every block in a list with one status (used for wholly removed panels/rows). */
+function markAll(
+  blocks: BlockJSON[],
+  status: DiffStatus,
+  decorations: Map<string, DiffStatus>
+): BlockJSON[] {
+  for (const block of blocks) {
+    if (block.attrs?.id) decorations.set(block.attrs.id, status)
+  }
+  return blocks
+}
+
+// ─── inline rebuild ──────────────────────────────────────────────────
+
+function withDiffInline(block: BlockJSON, spans: InlineDiffSpan[]): BlockJSON {
+  return { ...block, content: spansToInline(spans) }
+}
+
+function spansToInline(spans: InlineDiffSpan[]): InlineJSON[] {
+  return spans
+    .filter((s) => s.text.length > 0)
+    .map((s) =>
+      s.type === 'eq'
+        ? { type: 'text', text: s.text }
+        : {
+            type: 'text',
+            text: s.text,
+            marks: [{ type: s.type === 'ins' ? 'highlight' : 'strike' }],
+          }
+    )
+}

--- a/apps/web/src/components/kb/ui/editor/article-diff-view.module.css
+++ b/apps/web/src/components/kb/ui/editor/article-diff-view.module.css
@@ -1,0 +1,160 @@
+/* apps/web/src/components/kb/ui/editor/article-diff-view.module.css */
+
+/*
+ * The diff body renders through the shared KB `BlockRenderer` (same components
+ * as the public site), but we restyle its output to match the Tiptap *editor*
+ * the user edits in — same font size, heading scale, and tight line spacing —
+ * rather than the looser published-article look. Metrics mirror
+ * `editor/kb-article/block-node-view.module.css`.
+ */
+.body {
+  font-size: 0.875rem;
+  line-height: 24px;
+  letter-spacing: -0.01em;
+  color: var(--color-foreground);
+}
+
+/* Paragraphs: no inter-block margin — blocks stack tightly like the editor. */
+.body :global(p) {
+  margin: 0;
+}
+
+/* Headings — BlockRenderer maps level 1/2/3 to <h2>/<h3>/<h4>. Values match the
+   editor's h1/h2/h3 density vars. */
+.body :global(h2) {
+  font-size: 24px;
+  line-height: 28px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 1.5rem 0 0.5rem;
+}
+.body :global(h3) {
+  font-size: 20px;
+  line-height: 24px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin: 1.25rem 0 0.375rem;
+}
+.body :global(h4) {
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin: 1rem 0 0.25rem;
+}
+
+/* Collapse the leading block's top margin so it hugs the diff bar. */
+.body > .block:first-child :global(h2),
+.body > .block:first-child :global(h3),
+.body > .block:first-child :global(h4) {
+  margin-top: 0;
+}
+
+/* Links + inline code: editor tokens, not the undefined --kb-* renderer vars. */
+.body :global(.kb-link),
+.body :global(a) {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.body :global(.kb-inline-code) {
+  font-size: 0.8125rem;
+  background-color: var(--color-muted);
+  border: 1px solid var(--color-border);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.375rem;
+}
+.body :global(blockquote) {
+  color: var(--color-muted-foreground);
+}
+
+/* ── Block-level diff decorators ──────────────────────────────────────── */
+
+.block {
+  position: relative;
+  padding: 1px 0 1px 0.75rem;
+  margin-left: -0.75rem;
+  border-left: 3px solid transparent;
+}
+
+.added {
+  border-left-color: var(--color-emerald-500, #10b981);
+  background-color: color-mix(in srgb, var(--color-emerald-500, #10b981) 8%, transparent);
+}
+
+.removed {
+  border-left-color: var(--color-red-500, #ef4444);
+  background-color: color-mix(in srgb, var(--color-red-500, #ef4444) 6%, transparent);
+  opacity: 0.65;
+}
+
+.modified {
+  border-left-color: var(--color-amber-500, #f59e0b);
+  background-color: color-mix(in srgb, var(--color-amber-500, #f59e0b) 6%, transparent);
+}
+
+/*
+ * Within a modified block the inline content is rebuilt from the word diff:
+ * inserted words carry a `highlight` mark (<mark class="kb-mark">), deleted
+ * words a `strike` mark (<s>). Restyle those specifically as ins/del.
+ */
+.modified :global(.kb-mark) {
+  background-color: color-mix(in srgb, var(--color-emerald-500, #10b981) 22%, transparent);
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--color-emerald-600, #059669);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.modified s {
+  color: var(--color-red-600, #dc2626);
+  text-decoration-color: var(--color-red-500, #ef4444);
+  opacity: 0.85;
+}
+
+/* ── Container-nested leaf decorators ─────────────────────────────────── */
+
+/*
+ * Blocks inside a modified table/tabs/accordion are wrapped by BlockRenderer
+ * in `<div class="kb-diff-block" data-diff-status="…">` so changes show per
+ * leaf instead of only framing the whole container. Same colour language as
+ * the top-level decorators, scaled down to sit inside cells/panels.
+ */
+.body :global(.kb-diff-block) {
+  border-left: 3px solid transparent;
+  padding-left: 0.5rem;
+  margin-left: -0.5rem;
+}
+
+.body :global(.kb-diff-block[data-diff-status='added']) {
+  border-left-color: var(--color-emerald-500, #10b981);
+  background-color: color-mix(in srgb, var(--color-emerald-500, #10b981) 8%, transparent);
+}
+
+.body :global(.kb-diff-block[data-diff-status='removed']) {
+  border-left-color: var(--color-red-500, #ef4444);
+  background-color: color-mix(in srgb, var(--color-red-500, #ef4444) 6%, transparent);
+  opacity: 0.65;
+}
+
+.body :global(.kb-diff-block[data-diff-status='modified']) {
+  border-left-color: var(--color-amber-500, #f59e0b);
+  background-color: color-mix(in srgb, var(--color-amber-500, #f59e0b) 6%, transparent);
+}
+
+/* Word-level ins/del baked into modified nested text (same marks as top level). */
+.body :global(.kb-diff-block[data-diff-status='modified'] .kb-mark) {
+  background-color: color-mix(in srgb, var(--color-emerald-500, #10b981) 22%, transparent);
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--color-emerald-600, #059669);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.body :global(.kb-diff-block[data-diff-status='modified'] s) {
+  color: var(--color-red-600, #dc2626);
+  text-decoration-color: var(--color-red-500, #ef4444);
+  opacity: 0.85;
+}

--- a/apps/web/src/components/kb/ui/editor/article-diff-view.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-diff-view.tsx
@@ -1,0 +1,155 @@
+// apps/web/src/components/kb/ui/editor/article-diff-view.tsx
+'use client'
+
+import type { ArticleDiff, BlockDiff } from '@auxx/lib/kb/blocks'
+import { Button } from '@auxx/ui/components/button'
+import type { ArticleNodeJSON, DiffDecorations, DocJSON } from '@auxx/ui/components/kb/article'
+import { KBArticleNode } from '@auxx/ui/components/kb/article'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { cn } from '@auxx/ui/lib/utils'
+import { ArrowLeft } from 'lucide-react'
+import { useMemo } from 'react'
+import { buildDiffRender } from './article-diff-tree'
+import styles from './article-diff-view.module.css'
+
+interface ArticleDiffViewProps {
+  diff: ArticleDiff
+  /** Older side label, e.g. "Published" / "v3" / "Before". */
+  baseLabel?: string
+  /** Newer side label, e.g. "Draft" / "Kopilot". */
+  compareLabel?: string
+  /** Clears the `?diff=` param and returns to the editor. */
+  onClose: () => void
+}
+
+/**
+ * Inline-highlighted article diff. Fills the editor pane (in place of
+ * `<ArticleEditor>`): a slim diff bar on top, then the compare-side article
+ * rendered through the shared `KBArticleNode`, with added/removed/changed
+ * blocks decorated and word-level ins/del shown inside modified text blocks —
+ * including container-nested changes inside tables, tabs, and accordions.
+ */
+export function ArticleDiffView({
+  diff,
+  baseLabel = 'Before',
+  compareLabel = 'After',
+  onClose,
+}: ArticleDiffViewProps) {
+  // The nodes to render, with modified text blocks rebuilt to carry their word
+  // diff and modified containers reconstructed; `decorations` carries the status
+  // of every container-nested leaf. Assembled as one doc so ordered concerns
+  // (list numbering) resolve against the full sequence.
+  const { nodes: renderNodes, decorations } = useMemo(
+    () => buildDiffRender(diff.blocks),
+    [diff.blocks]
+  )
+  const renderDoc: DocJSON = useMemo(() => ({ type: 'doc', content: renderNodes }), [renderNodes])
+
+  const { added, removed, modified, moved } = diff.stats
+  const hasChanges = added + removed + modified + moved > 0
+
+  return (
+    <div className='flex min-h-0 flex-1 flex-col'>
+      <div className='flex w-full items-center gap-3 border-b bg-primary-150 px-3 py-1.5'>
+        <Button variant='outline' size='xs' onClick={onClose}>
+          <ArrowLeft /> Back
+        </Button>
+        <span className='text-xs text-muted-foreground'>
+          {baseLabel} <span className='px-1'>→</span> {compareLabel}
+        </span>
+        <div className='ml-auto flex items-center gap-3 text-xs text-muted-foreground'>
+          <LegendChip color='emerald' label='Added' count={added} />
+          <LegendChip color='red' label='Removed' count={removed} />
+          <LegendChip color='amber' label='Changed' count={modified} />
+        </div>
+      </div>
+
+      <ScrollArea className='flex-1'>
+        <div className='mx-auto w-full max-w-3xl px-7 py-6'>
+          {hasChanges ? (
+            <article className={styles.body}>
+              {diff.blocks.map((d, idx) => (
+                <DiffBlock
+                  key={d.id || idx}
+                  diff={d}
+                  node={renderNodes[idx]}
+                  idx={idx}
+                  doc={renderDoc}
+                  decorations={decorations}
+                />
+              ))}
+            </article>
+          ) : (
+            <p className='py-12 text-center text-sm text-muted-foreground'>
+              No changes between {baseLabel} and {compareLabel}.
+            </p>
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  )
+}
+
+function DiffBlock({
+  diff,
+  node,
+  idx,
+  doc,
+  decorations,
+}: {
+  diff: BlockDiff
+  node: ArticleNodeJSON
+  idx: number
+  doc: DocJSON
+  decorations: DiffDecorations
+}) {
+  const decorated = decoratorClass(diff)
+  return (
+    <div className={cn(styles.block, decorated)}>
+      <KBArticleNode node={node} idx={idx} doc={doc} decorations={decorations} />
+    </div>
+  )
+}
+
+function LegendChip({
+  color,
+  label,
+  count,
+}: {
+  color: 'emerald' | 'red' | 'amber'
+  label: string
+  count: number
+}) {
+  const dot =
+    color === 'emerald' ? 'bg-emerald-500' : color === 'red' ? 'bg-red-500' : 'bg-amber-500'
+  return (
+    <span className='inline-flex items-center gap-1.5'>
+      <span className={cn('inline-block size-2 rounded-full', dot)} />
+      {label}
+      {count > 0 ? <span className='font-medium text-foreground'>{count}</span> : null}
+    </span>
+  )
+}
+
+/**
+ * Pick the outer decorator class for a top-level block diff. Modified
+ * containers carry their detail on the nested leaves (via `decorations`), so we
+ * drop the outer frame for them to avoid double-bordering.
+ */
+function decoratorClass(diff: BlockDiff): string | undefined {
+  switch (diff.status) {
+    case 'added':
+      return styles.added
+    case 'removed':
+      return styles.removed
+    case 'modified':
+      return diff.children?.length ? undefined : styles.modified
+    case 'moved':
+      // Moved-block rendering is deferred (no badge yet); still surface a
+      // changed frame when the move also carried content edits.
+      if (diff.children?.length) return undefined
+      return diff.inline?.length ? styles.modified : undefined
+    default:
+      return undefined
+  }
+}

--- a/apps/web/src/components/kb/ui/editor/article-editor.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/kb/ui/editor/article-editor.tsx
 'use client'
 
+import { Button } from '@auxx/ui/components/button'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { toastSuccess } from '@auxx/ui/components/toast'
 import { useHotkey } from '@tanstack/react-hotkeys'
@@ -13,7 +14,9 @@ import { KopilotContext } from '~/components/kopilot/context/kopilot-context'
 import { KopilotSuggestion } from '~/components/kopilot/suggestions'
 import { useArticleContent } from '../../hooks/use-article-content'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
+import { useDiffParam } from '../../hooks/use-diff-param'
 import { useKbArticleChannel } from '../../hooks/use-kb-article-channel'
+import { useKopilotReview } from '../../hooks/use-kopilot-review'
 import type { ArticleMeta } from '../../store/article-store'
 import { ArticleEditorFooter } from './article-editor-footer'
 import { ArticleEditorHeader } from './article-editor-header'
@@ -38,6 +41,11 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
   // picks up the new doc. The `locked` flag flips while Kopilot holds a
   // write turn so the editor goes read-only.
   const { locked } = useKbArticleChannel({ articleId: article.id, knowledgeBaseId })
+
+  // Post-turn review: after Kopilot edits, offer Review / Keep / Undo until the
+  // user commits or rolls back.
+  const [, setDiff] = useDiffParam()
+  const review = useKopilotReview({ articleId: article.id, draftContentJson, locked })
 
   const bodyEditorRef = useRef<Editor | null>(null)
 
@@ -80,6 +88,24 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
       <KopilotSuggestion text='Suggest related articles' icon='list' autoSubmit />
       <KopilotSuggestion text='Improve this article' icon='sparkle' />
       <ArticleEditorHeader article={article} knowledgeBaseId={knowledgeBaseId} />
+      {review.pending && (
+        <div className='flex items-center gap-3 border-b bg-primary-150 px-7 py-2 text-sm'>
+          <span className='text-foreground'>
+            Kopilot changed {review.changeCount} {review.changeCount === 1 ? 'block' : 'blocks'}.
+          </span>
+          <div className='ml-auto flex items-center gap-2'>
+            <Button variant='outline' size='xs' onClick={() => setDiff('kopilot')}>
+              Review
+            </Button>
+            <Button variant='outline' size='xs' loading={review.isBusy} onClick={review.onKeep}>
+              Keep
+            </Button>
+            <Button variant='outline' size='xs' loading={review.isBusy} onClick={review.onUndo}>
+              Undo
+            </Button>
+          </div>
+        </div>
+      )}
       <ScrollArea className='flex-1'>
         <div className='flex min-h-min flex-1 flex-col'>
           <div className='relative mx-auto flex h-full w-full max-w-3xl flex-1 flex-col px-7'>

--- a/apps/web/src/components/kb/ui/editor/article-publish-cluster.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-publish-cluster.tsx
@@ -13,10 +13,20 @@ import {
 } from '@auxx/ui/components/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
-import { Archive, ArchiveRestore, ChevronDown, History, Send, Trash2, Undo2 } from 'lucide-react'
+import {
+  Archive,
+  ArchiveRestore,
+  ChevronDown,
+  GitCompare,
+  History,
+  Send,
+  Trash2,
+  Undo2,
+} from 'lucide-react'
 import { useState } from 'react'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
+import { useDiffParam } from '../../hooks/use-diff-param'
 import { usePublishWithConfirm } from '../../hooks/use-publish-with-confirm'
 import type { ArticleMeta } from '../../store/article-store'
 import { ArticleVersionsDialog } from './article-versions-dialog'
@@ -36,6 +46,7 @@ export function ArticlePublishCluster({ article, knowledgeBaseId }: ArticlePubli
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isVersionsOpen, setIsVersionsOpen] = useState(false)
   const [confirm, ConfirmDialog] = useConfirm()
+  const [, setDiff] = useDiffParam()
 
   const { archiveArticle, unarchiveArticle, discardArticleDraft, deleteArticle } =
     useArticleMutations(knowledgeBaseId)
@@ -127,6 +138,20 @@ export function ArticlePublishCluster({ article, knowledgeBaseId }: ArticlePubli
 
           {isPublished && hasUnsaved && (
             <>
+              <ButtonGroupSeparator />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size='xs'
+                    variant='outline'
+                    className='border-r-0 px-1.5'
+                    onClick={() => setDiff('review')}
+                    aria-label='Review changes'>
+                    <GitCompare />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Review changes</TooltipContent>
+              </Tooltip>
               <ButtonGroupSeparator />
               <Button
                 size='xs'

--- a/apps/web/src/components/kb/ui/editor/article-versions-dialog.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-versions-dialog.tsx
@@ -13,12 +13,13 @@ import { Input } from '@auxx/ui/components/input'
 import { getFullSlugPath } from '@auxx/ui/components/kb'
 import { getKbPreviewHref } from '@auxx/ui/components/kb/utils'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
-import { Check, ExternalLink, Loader2, Pencil, Undo2, X } from 'lucide-react'
+import { Check, ExternalLink, GitCompare, Loader2, Pencil, Undo2, X } from 'lucide-react'
 import { useState } from 'react'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { useArticleList } from '../../hooks/use-article-list'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
+import { useDiffParam } from '../../hooks/use-diff-param'
 
 interface ArticleVersionsDialogProps {
   open: boolean
@@ -50,6 +51,12 @@ export function ArticleVersionsDialog({
   const utils = api.useUtils()
   const { restoreArticleVersion } = useArticleMutations(knowledgeBaseId)
   const [confirm, ConfirmDialog] = useConfirm()
+  const [, setDiff] = useDiffParam()
+
+  const handleDiff = (versionId: string) => {
+    setDiff(`v:${versionId}`)
+    onOpenChange(false)
+  }
 
   const versionsQuery = api.kb.getArticleVersions.useQuery({ articleId }, { enabled: open })
   const article = api.kb.getArticleById.useQuery(
@@ -215,6 +222,11 @@ export function ArticleVersionsDialog({
                             </a>
                           </Button>
                         ) : null}
+                        {!isCurrent && (
+                          <Button size='sm' variant='ghost' onClick={() => handleDiff(v.id)}>
+                            <GitCompare /> Diff
+                          </Button>
+                        )}
                         {!isCurrent && (
                           <Button
                             size='sm'

--- a/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
@@ -8,8 +8,10 @@ import { useQueryState } from 'nuqs'
 import { useMemo } from 'react'
 import { LoadingSpinner } from '~/components/global/loading-content'
 import { useArticleList, useIsArticleListLoaded } from '../../hooks/use-article-list'
+import { useDiffParam } from '../../hooks/use-diff-param'
 import { useKnowledgeBase } from '../../hooks/use-knowledge-base'
 import { KBPreview } from '../preview/kb-preview'
+import { ArticleDiffPane } from './article-diff-pane'
 import { ArticleEditor } from './article-editor'
 import { ContainerArticlePlaceholder } from './container-article-placeholder'
 
@@ -53,6 +55,7 @@ interface KBEditorBodyProps {
 function KBEditorBody({ knowledgeBaseId, slug, hasArticlesLoaded }: KBEditorBodyProps) {
   const articles = useArticleList(knowledgeBaseId)
   const { knowledgeBase } = useKnowledgeBase(knowledgeBaseId)
+  const [diffValue, setDiff] = useDiffParam()
 
   const currentArticle = useMemo(() => {
     if (!articles || articles.length === 0 || !slug || slug.length === 0) return undefined
@@ -66,6 +69,16 @@ function KBEditorBody({ knowledgeBaseId, slug, hasArticlesLoaded }: KBEditorBody
     if (kind === ArticleKind.tab || kind === ArticleKind.header || kind === ArticleKind.link) {
       return (
         <ContainerArticlePlaceholder article={currentArticle} knowledgeBaseId={knowledgeBaseId} />
+      )
+    }
+    if (diffValue) {
+      return (
+        <ArticleDiffPane
+          article={currentArticle}
+          knowledgeBaseId={knowledgeBaseId}
+          diffValue={diffValue}
+          onClose={() => setDiff(null)}
+        />
       )
     }
     return <ArticleEditor article={currentArticle} knowledgeBaseId={knowledgeBaseId} />

--- a/apps/web/src/server/api/routers/kb.ts
+++ b/apps/web/src/server/api/routers/kb.ts
@@ -418,6 +418,67 @@ export const knowledgeBaseRouter = createTRPCRouter({
       return result
     }),
 
+  /**
+   * Recover a pending Kopilot turn review for an article. Returns the pre-turn
+   * snapshot's `base` content (the diff's "before" side; the editor already has
+   * the current draft as the "after") or `null` when nothing is pending. Backs
+   * the post-turn banner — both the live signal and recovery-on-mount after a
+   * refresh (the snapshot survives reload, the agent event does not).
+   */
+  getKopilotTurnReview: protectedProcedure
+    .input(z.object({ articleId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const organizationId = getUserOrganizationId(ctx.session)
+      // Snapshots are keyed by articleId alone in Redis — gate on org ownership
+      // so a guessed id can't read another org's draft content.
+      const article = await ctx.db.query.Article.findFirst({
+        where: and(
+          eq(schema.Article.id, input.articleId),
+          eq(schema.Article.organizationId, organizationId)
+        ),
+        columns: { id: true },
+      })
+      if (!article) return null
+      const { readKopilotSnapshot } = await import('@auxx/lib/kb')
+      const snapshot = await readKopilotSnapshot(input.articleId)
+      if (!snapshot) return null
+      return {
+        turnId: snapshot.turnId,
+        base: snapshot.contentJson,
+        capturedAt: snapshot.capturedAt,
+      }
+    }),
+
+  /**
+   * Commit a Kopilot turn — the user is happy with the edits. Clears the
+   * pre-turn snapshot (removes the Undo affordance); the lock was already
+   * released by `finalizeKopilotKbTurn`. Turn-pinned: a stale Keep button won't
+   * clobber a newer turn's snapshot.
+   */
+  keepKopilotTurn: protectedProcedure
+    .input(z.object({ articleId: z.string(), turnId: z.string().optional() }))
+    .mutation(async ({ ctx, input }) => {
+      const organizationId = getUserOrganizationId(ctx.session)
+      const article = await ctx.db.query.Article.findFirst({
+        where: and(
+          eq(schema.Article.id, input.articleId),
+          eq(schema.Article.organizationId, organizationId)
+        ),
+        columns: { id: true },
+      })
+      if (!article) return { ok: false as const, reason: 'not_found' as const }
+      const { readKopilotSnapshot, clearKopilotSnapshot } = await import('@auxx/lib/kb')
+      const snapshot = await readKopilotSnapshot(input.articleId, input.turnId)
+      if (!snapshot) {
+        return {
+          ok: false as const,
+          reason: input.turnId ? ('turn_mismatch' as const) : ('no_snapshot' as const),
+        }
+      }
+      await clearKopilotSnapshot(input.articleId)
+      return { ok: true as const }
+    }),
+
   moveArticle: protectedProcedure
     .input(
       z.object({
@@ -469,6 +530,19 @@ export const knowledgeBaseRouter = createTRPCRouter({
     .input(z.object({ articleId: z.string() }))
     .query(async ({ ctx, input }) => {
       return await getKBService(ctx).getArticleVersions(input.articleId)
+    }),
+
+  getArticleDiff: protectedProcedure
+    .input(
+      z.object({
+        articleId: z.string(),
+        // Older side and newer side. Sentinels 'draft'/'published' or a revision id.
+        base: z.string(),
+        compare: z.string(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      return await getKBService(ctx).getArticleDiff(input.articleId, input.base, input.compare)
     }),
 
   exportArticleMarkdown: protectedProcedure

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -448,6 +448,12 @@
       "import": "./dist/kb/index.mjs",
       "default": "./src/kb/index.ts"
     },
+    "./kb/blocks": {
+      "types": "./src/kb/blocks/index.ts",
+      "source": "./src/kb/blocks/index.ts",
+      "import": "./dist/kb/blocks/index.mjs",
+      "default": "./src/kb/blocks/index.ts"
+    },
     "./kb/client": {
       "types": "./src/kb/client.ts",
       "source": "./src/kb/client.ts",
@@ -907,6 +913,7 @@
     "date-fns-tz": "^3.2.0",
     "drizzle-orm": "catalog:",
     "email-reply-parser": "^1.9.4",
+    "fast-diff": "^1.3.0",
     "file-type": "^19.0.0",
     "form-data": "^4.0.2",
     "free-email-domains": "^1.2.26",

--- a/packages/lib/src/ai/agent-framework/engine.ts
+++ b/packages/lib/src/ai/agent-framework/engine.ts
@@ -93,6 +93,12 @@ export class AgentEngine {
       approvalsThisTurn: 0,
       turnSnapshots: createEmptyTurnSnapshots(),
       capturedActions: [],
+      // Clear per-turn domain state (e.g. KB articles touched this turn). Only
+      // on a fresh user turn — resume() continues the same turn and must keep it.
+      domainState:
+        this.config.domainConfig.resetTurnDomainState?.(
+          this.state.domainState as Record<string, unknown>
+        ) ?? this.state.domainState,
     }
 
     logger.info('Turn submitted', {
@@ -111,7 +117,7 @@ export class AgentEngine {
     }
 
     try {
-      yield* this.tagTurnId(this.runPipeline(configWithAbort))
+      yield* this.withTurnEnd(this.tagTurnId(this.runPipeline(configWithAbort)))
     } finally {
       this.abortController = null
     }
@@ -158,7 +164,7 @@ export class AgentEngine {
     }
 
     try {
-      yield* this.tagTurnId(this.runResume(opts, route, configWithAbort))
+      yield* this.withTurnEnd(this.tagTurnId(this.runResume(opts, route, configWithAbort)))
     } finally {
       this.abortController = null
     }
@@ -646,6 +652,50 @@ export class AgentEngine {
   private async *tagTurnId(gen: AsyncGenerator<AgentEvent>): AsyncGenerator<AgentEvent> {
     for await (const event of gen) {
       yield this.tagEvent(event)
+    }
+  }
+
+  /**
+   * Wrap a turn's event stream so the domain's `onTurnEnd` hook fires exactly
+   * once with the resolved outcome, before the terminal event is yielded.
+   *
+   * Terminal events drive the normal path (`turn-completed` → 'completed',
+   * `turn-error` → 'error'). An abnormal close that yields no terminal event —
+   * abort, client disconnect, a thrown error — fires 'error' from the finally
+   * guard so locks release and the turn rolls back. The one exception is an
+   * approval pause: it returns without a terminal event but the turn isn't
+   * over, so `waitingForApproval` suppresses the guard.
+   *
+   * A hook failure is logged and swallowed; it must never mask the turn result.
+   */
+  private async *withTurnEnd(gen: AsyncGenerator<AgentEvent>): AsyncGenerator<AgentEvent> {
+    const hook = this.config.domainConfig.onTurnEnd
+    if (!hook) {
+      yield* gen
+      return
+    }
+    let fired = false
+    const fire = async (outcome: 'completed' | 'error') => {
+      if (fired) return
+      fired = true
+      try {
+        await hook(this.getState(), outcome)
+      } catch (err) {
+        logger.error('onTurnEnd hook failed', {
+          turnId: this.turnId,
+          outcome,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+    try {
+      for await (const event of gen) {
+        if (event.type === 'turn-completed') await fire('completed')
+        else if (event.type === 'turn-error') await fire('error')
+        yield event
+      }
+    } finally {
+      if (!fired && !this.state.waitingForApproval) await fire('error')
     }
   }
 

--- a/packages/lib/src/ai/agent-framework/process-agent-job.ts
+++ b/packages/lib/src/ai/agent-framework/process-agent-job.ts
@@ -388,6 +388,11 @@ async function buildKopilotShapedConfig(
     // Long-running plans (≥30 steps × ~1–2 LLM rounds each) need
     // headroom past the framework's small-loop default.
     maxIterations: 30,
+    // Scope the turn-end KB lifecycle hook so the worker path finalizes/reverts
+    // too (the latent bug this de-hack fixes).
+    db: database,
+    organizationId: params.organizationId,
+    userId: params.userId,
   })
 }
 

--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -623,6 +623,26 @@ export interface AgentDomainConfig<TDomainState = Record<string, unknown>> {
   summarizeContext?: (
     context: Record<string, unknown> | undefined
   ) => Record<string, unknown> | undefined
+  /**
+   * Optional hook fired once at the end of a turn, after final state is
+   * computed and before the terminal event is yielded. Runs in whatever
+   * process executes the engine (web route for in-process, worker for the
+   * BullMQ path), so a domain can commit or roll back side-effects keyed off
+   * domain state regardless of where the turn ran.
+   *
+   * `outcome` is `'completed'` for a clean finish and `'error'` for a
+   * turn-error, an aborted run, or a client disconnect. It does NOT fire when
+   * a turn pauses for approval (the turn isn't over). Must not throw — the
+   * engine wraps it in try/catch so a hook failure can't mask the turn result.
+   */
+  onTurnEnd?: (state: AgentState, outcome: 'completed' | 'error') => Promise<void>
+  /**
+   * Optional hook to clear per-turn domain state at the start of a NEW user
+   * turn (`submitMessage`) — NOT on approval-resume, which continues the same
+   * turn. Mirrors the engine's reset of `turnSnapshots` / `capturedActions`.
+   * Return a fresh domainState (or the same reference when nothing to clear).
+   */
+  resetTurnDomainState?: (domainState: Record<string, unknown>) => Record<string, unknown>
 }
 
 /** Return shape from `postProcessFinalContent`. */

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/write-helpers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/write-helpers.ts
@@ -310,6 +310,8 @@ export async function finalizeKopilotKbTurn(args: { articleId: string }): Promis
     locked: false,
     by: 'kopilot',
     turnId: snapshot.turnId,
+    // Snapshot is kept (not cleared) so the user can review/undo this turn.
+    reviewable: true,
   })
 }
 

--- a/packages/lib/src/ai/kopilot/domain-config.ts
+++ b/packages/lib/src/ai/kopilot/domain-config.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/ai/kopilot/domain-config.ts
 
+import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { ResolvedAgentConfig } from '../../agents'
 import type {
@@ -54,6 +55,15 @@ export interface KopilotDomainConfigOptions {
    * prompt. Chat runs leave this undefined.
    */
   triggerContext?: TriggerContext
+  /**
+   * Scope + DB handle for the turn-end KB lifecycle hook (finalize on success,
+   * revert on failure). Both the web route and the worker job construct the
+   * config and pass these. When omitted, `onTurnEnd` finalize still runs but a
+   * failure can't roll back (logged).
+   */
+  db?: Database
+  organizationId?: string
+  userId?: string
 }
 
 /**
@@ -76,6 +86,9 @@ export function createKopilotDomainConfig(
     maxIterations = 30,
     agentConfig,
     triggerContext,
+    db,
+    organizationId,
+    userId,
   } = options
 
   // Resolve tools: if the caller passed `tools`, use them verbatim (pre-filtered
@@ -155,6 +168,21 @@ export function createKopilotDomainConfig(
         mineDocSnapshots(result.output, snapshots)
       }
       let next: AgentState = { ...state, turnSnapshots: snapshots }
+
+      // KB block-CRUD tools surface the article they wrote on their result
+      // output. Record it on domain state so `onTurnEnd` can finalize/revert
+      // the right article(s) without duck-typing the request context.
+      const touchedArticleId = kbTouchedArticleId(result)
+      if (touchedArticleId) {
+        const ds = next.domainState as KopilotDomainState
+        const touched = ds.kbTouchedArticleIds ?? []
+        if (!touched.includes(touchedArticleId)) {
+          next = {
+            ...next,
+            domainState: { ...ds, kbTouchedArticleIds: [...touched, touchedArticleId] },
+          }
+        }
+      }
 
       // Plan tools: mutate domainState.plan.
       if (toolName === 'plan_create') {
@@ -258,7 +286,59 @@ export function createKopilotDomainConfig(
         ? { content: next, linkSnapshots }
         : { content: next }
     },
+    resetTurnDomainState(domainState: Record<string, unknown>): Record<string, unknown> {
+      const ds = domainState as KopilotDomainState
+      if (!ds.kbTouchedArticleIds?.length) return domainState
+      return { ...ds, kbTouchedArticleIds: [] }
+    },
+    async onTurnEnd(state: AgentState, outcome: 'completed' | 'error'): Promise<void> {
+      const ids = (state.domainState as KopilotDomainState).kbTouchedArticleIds ?? []
+      if (ids.length === 0) return
+
+      // Lazy import keeps the framework→kb edge out of the module graph until a
+      // turn actually touched KB. `finalizeKopilotKbTurn` only releases the lock
+      // (snapshot kept for Undo); `revertKopilotKbTurn` restores the pre-turn
+      // snapshot and unlocks.
+      const { finalizeKopilotKbTurn, revertKopilotKbTurn } = await import(
+        './capabilities/kb/tools/write-helpers'
+      )
+      for (const articleId of ids) {
+        try {
+          if (outcome === 'completed') {
+            await finalizeKopilotKbTurn({ articleId })
+          } else if (db && organizationId && userId) {
+            await revertKopilotKbTurn({ db, organizationId, userId, articleId })
+          } else {
+            logger.warn('Kopilot turn failed but revert deps missing; lock may leak', {
+              articleId,
+            })
+          }
+        } catch (err) {
+          logger.error('Kopilot turn-end KB lifecycle failed', {
+            articleId,
+            outcome,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    },
   }
+}
+
+/**
+ * Extract the article id from a KB block-CRUD tool result. These tools return
+ * `{ ok, op, articleId, preHash, postHash, affectedBlockIds }` (see
+ * `buildOpToolResult`); shape-match on `op` + `affectedBlockIds` so an
+ * unrelated tool that happens to carry an `articleId` doesn't trip it.
+ */
+function kbTouchedArticleId(result: AgentToolResult): string | undefined {
+  if (!result.success) return undefined
+  const output = result.output as Record<string, unknown> | null
+  if (!output || typeof output !== 'object') return undefined
+  const articleId = output.articleId
+  if (typeof articleId !== 'string' || articleId.length === 0) return undefined
+  if (typeof output.op !== 'string' || !Array.isArray(output.affectedBlockIds)) return undefined
+  return articleId
 }
 
 /**

--- a/packages/lib/src/ai/kopilot/types.ts
+++ b/packages/lib/src/ai/kopilot/types.ts
@@ -84,4 +84,11 @@ export interface KopilotDomainState {
   capabilities?: string[]
   /** Active plan, persisted across iterations and turns until replaced */
   plan?: PlanState
+  /**
+   * KB article ids written by a tool this turn, recorded from block-CRUD tool
+   * results in `onToolResult`. Drives the turn-end finalize/revert in
+   * `onTurnEnd` without duck-typing the request context. Per-turn — cleared at
+   * the start of each new user turn via `resetTurnDomainState`.
+   */
+  kbTouchedArticleIds?: string[]
 }

--- a/packages/lib/src/kb/articles/article-versions.ts
+++ b/packages/lib/src/kb/articles/article-versions.ts
@@ -1,12 +1,13 @@
 // @auxx/lib/kb/articles/article-versions.ts
 import { schema } from '@auxx/database'
 import { TRPCError } from '@trpc/server'
-import { and, desc, eq, sql } from 'drizzle-orm'
+import { and, desc, eq, inArray, sql } from 'drizzle-orm'
 import { resolveDb } from '../internal/context'
 import { createNotFoundError, handleError } from '../internal/errors'
 import { reloadFlat } from '../internal/flatten-article'
 import { verifyArticleExists } from '../internal/validate-existence'
 import { clearKopilotSnapshot } from '../kopilot-snapshot'
+import type { ArticleNodeJSON } from '../markdown/types'
 import { syncArticleDenormalizedFields } from '../sync-article-denormalized-fields'
 import type { ArticleListItem, KBContext } from '../types'
 
@@ -27,6 +28,88 @@ export async function getArticleVersions(ctx: KBContext, articleId: string) {
     return handleError(error, ctx.organizationId, 'Error fetching article versions', {
       articleId,
     })
+  }
+}
+
+/** One side of a diff: a revision's body + identifying metadata. */
+export interface ArticleRevisionBody {
+  id: string
+  versionNumber: number | null
+  label: string | null
+  title: string
+  contentJson: ArticleNodeJSON[] | null
+  createdAt: Date
+}
+
+/**
+ * Resolve two revisions of an article for diffing. `base`/`compare` accept the
+ * sentinels `'draft'` / `'published'` (resolved against the article's current
+ * draft/published revision ids) or a literal revision id. Every revision is
+ * org-scoped and validated to belong to `articleId`, so an id from another
+ * article resolves to `null`.
+ */
+export async function getArticleDiff(
+  ctx: KBContext,
+  articleId: string,
+  base: string,
+  compare: string
+): Promise<{ base: ArticleRevisionBody | null; compare: ArticleRevisionBody | null }> {
+  const db = resolveDb(ctx)
+  try {
+    await verifyArticleExists(db, ctx.organizationId, articleId)
+    const article = await db.query.Article.findFirst({
+      where: and(
+        eq(schema.Article.id, articleId),
+        eq(schema.Article.organizationId, ctx.organizationId)
+      ),
+      columns: { draftRevisionId: true, publishedRevisionId: true },
+    })
+    if (!article) throw createNotFoundError(`Article with ID '${articleId}' not found`)
+
+    const resolveRef = (ref: string): string | null =>
+      ref === 'draft'
+        ? article.draftRevisionId
+        : ref === 'published'
+          ? article.publishedRevisionId
+          : ref
+    const baseId = resolveRef(base)
+    const compareId = resolveRef(compare)
+
+    const ids = [...new Set([baseId, compareId].filter((x): x is string => !!x))]
+    const rows = ids.length
+      ? await db.query.ArticleRevision.findMany({
+          where: and(
+            eq(schema.ArticleRevision.articleId, articleId),
+            eq(schema.ArticleRevision.organizationId, ctx.organizationId),
+            inArray(schema.ArticleRevision.id, ids)
+          ),
+          columns: {
+            id: true,
+            versionNumber: true,
+            label: true,
+            title: true,
+            contentJson: true,
+            createdAt: true,
+          },
+        })
+      : []
+
+    const byId = new Map(rows.map((r) => [r.id, r]))
+    const toBody = (id: string | null): ArticleRevisionBody | null => {
+      const r = id ? byId.get(id) : undefined
+      if (!r) return null
+      return {
+        id: r.id,
+        versionNumber: r.versionNumber,
+        label: r.label,
+        title: r.title,
+        contentJson: (r.contentJson as ArticleNodeJSON[] | null) ?? null,
+        createdAt: r.createdAt,
+      }
+    }
+    return { base: toBody(baseId), compare: toBody(compareId) }
+  } catch (error) {
+    return handleError(error, ctx.organizationId, 'Error fetching article diff', { articleId })
   }
 }
 

--- a/packages/lib/src/kb/blocks/__tests__/diff-blocks.test.ts
+++ b/packages/lib/src/kb/blocks/__tests__/diff-blocks.test.ts
@@ -1,0 +1,231 @@
+// packages/lib/src/kb/blocks/__tests__/diff-blocks.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type {
+  AccordionJSON,
+  ArticleNodeJSON,
+  BlockJSON,
+  TableJSON,
+  TabsJSON,
+} from '../../markdown/types'
+import { diffBlockList, diffBlocks } from '../diff-blocks'
+import { diffInline, inlineToText } from '../inline-diff'
+
+const block = (id: string, text = ''): BlockJSON => ({
+  type: 'block',
+  attrs: { id, blockType: 'text' },
+  content: text ? [{ type: 'text', text }] : [],
+})
+
+describe('diffBlocks — top level', () => {
+  it('detects added / removed / unchanged', () => {
+    const before: ArticleNodeJSON[] = [block('a', 'one'), block('b', 'two')]
+    const after: ArticleNodeJSON[] = [block('a', 'one'), block('c', 'three')]
+    const { blocks, stats } = diffBlocks(before, after)
+
+    expect(blocks.map((d) => [d.status, d.id])).toEqual([
+      ['unchanged', 'a'],
+      ['removed', 'b'],
+      ['added', 'c'],
+    ])
+    expect(stats).toEqual({ added: 1, removed: 1, modified: 0, moved: 0 })
+  })
+
+  it('keeps a removed block in its old position', () => {
+    const before: ArticleNodeJSON[] = [block('a'), block('b'), block('c')]
+    const after: ArticleNodeJSON[] = [block('a'), block('c')]
+    const { blocks } = diffBlocks(before, after)
+    expect(blocks.map((d) => [d.status, d.id])).toEqual([
+      ['unchanged', 'a'],
+      ['removed', 'b'],
+      ['unchanged', 'c'],
+    ])
+  })
+
+  it('classifies a modified leaf with word-level inline spans', () => {
+    const before: ArticleNodeJSON[] = [block('a', 'the quick brown fox')]
+    const after: ArticleNodeJSON[] = [block('a', 'the slow brown fox')]
+    const { blocks, stats } = diffBlocks(before, after)
+
+    expect(blocks).toHaveLength(1)
+    const d = blocks[0]
+    expect(d.status).toBe('modified')
+    expect(d.prevBlock).toBeDefined()
+    // 'quick' deleted, 'slow' inserted; surrounding words unchanged.
+    expect(d.inline).toBeDefined()
+    expect(d.inline?.filter((s) => s.type === 'del').map((s) => s.text)).toContain('quick')
+    expect(d.inline?.filter((s) => s.type === 'ins').map((s) => s.text)).toContain('slow')
+    // Reconstruct each side from the spans.
+    const oldText = d.inline
+      ?.filter((s) => s.type !== 'ins')
+      .map((s) => s.text)
+      .join('')
+    const newText = d.inline
+      ?.filter((s) => s.type !== 'del')
+      .map((s) => s.text)
+      .join('')
+    expect(oldText).toBe('the quick brown fox')
+    expect(newText).toBe('the slow brown fox')
+    expect(stats.modified).toBe(1)
+  })
+
+  it('treats a reordered block as moved with LCS ordering preserved', () => {
+    // 'a','b','c' stay in order on both sides (the unambiguous LCS); only 'd'
+    // jumps to the front, so it's the single moved block.
+    const before: ArticleNodeJSON[] = [block('a'), block('b'), block('c'), block('d')]
+    const after: ArticleNodeJSON[] = [block('d'), block('a'), block('b'), block('c')]
+    const { blocks, stats } = diffBlocks(before, after)
+
+    expect(blocks.map((d) => [d.status, d.id])).toEqual([
+      ['moved', 'd'],
+      ['unchanged', 'a'],
+      ['unchanged', 'b'],
+      ['unchanged', 'c'],
+    ])
+    expect(stats.moved).toBe(1)
+  })
+
+  it('treats delete-then-add (different ids) as remove + add, not modified', () => {
+    const before: ArticleNodeJSON[] = [block('a', 'gone')]
+    const after: ArticleNodeJSON[] = [block('b', 'fresh')]
+    const { blocks, stats } = diffBlocks(before, after)
+    expect(blocks.map((d) => d.status)).toEqual(['removed', 'added'])
+    expect(stats).toEqual({ added: 1, removed: 1, modified: 0, moved: 0 })
+  })
+
+  it('handles null / empty on either side', () => {
+    expect(diffBlocks(null, [block('a')]).blocks.map((d) => d.status)).toEqual(['added'])
+    expect(diffBlocks([block('a')], undefined).blocks.map((d) => d.status)).toEqual(['removed'])
+    expect(diffBlocks(null, null).blocks).toEqual([])
+  })
+
+  it('ignores a codeHighlightedHtml-only change', () => {
+    const codeBefore: BlockJSON = {
+      type: 'block',
+      attrs: { id: 'code1', blockType: 'codeBlock', codeLanguage: 'ts' },
+      content: [{ type: 'text', text: 'const x = 1' }],
+    }
+    const codeAfter: BlockJSON = {
+      ...codeBefore,
+      attrs: { ...codeBefore.attrs, codeHighlightedHtml: '<pre>highlighted</pre>' },
+    }
+    const { blocks, stats } = diffBlocks([codeBefore], [codeAfter])
+    expect(blocks.map((d) => d.status)).toEqual(['unchanged'])
+    expect(stats).toEqual({ added: 0, removed: 0, modified: 0, moved: 0 })
+  })
+
+  it('marks a marks-only change as modified with no inline spans', () => {
+    const before: BlockJSON = {
+      type: 'block',
+      attrs: { id: 'a', blockType: 'text' },
+      content: [{ type: 'text', text: 'hello' }],
+    }
+    const after: BlockJSON = {
+      type: 'block',
+      attrs: { id: 'a', blockType: 'text' },
+      content: [{ type: 'text', text: 'hello', marks: [{ type: 'bold' }] }],
+    }
+    const { blocks } = diffBlocks([before], [after])
+    expect(blocks[0].status).toBe('modified')
+    expect(blocks[0].inline).toEqual([])
+  })
+})
+
+describe('diffBlocks — nested containers', () => {
+  const tabs = (id: string, panelBlocks: BlockJSON[]): TabsJSON => ({
+    type: 'tabs',
+    attrs: { id },
+    content: [{ type: 'panel', attrs: { id: `${id}-p1`, label: 'Tab 1' }, content: panelBlocks }],
+  })
+
+  const accordion = (id: string, panelBlocks: BlockJSON[]): AccordionJSON => ({
+    type: 'accordion',
+    attrs: { id, allowMultiple: false },
+    content: [{ type: 'panel', attrs: { id: `${id}-p1`, label: 'Item' }, content: panelBlocks }],
+  })
+
+  const table = (id: string, cellBlocks: BlockJSON[]): TableJSON => ({
+    type: 'table',
+    attrs: { id },
+    content: [{ type: 'tableRow', content: [{ type: 'tableCell', content: cellBlocks }] }],
+  })
+
+  it('recurses into a tab panel and reports the modified leaf as a child', () => {
+    const before: ArticleNodeJSON[] = [tabs('t1', [block('leaf', 'before')])]
+    const after: ArticleNodeJSON[] = [tabs('t1', [block('leaf', 'after')])]
+    const { blocks, stats } = diffBlocks(before, after)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].status).toBe('modified')
+    expect(blocks[0].children?.map((c) => [c.status, c.id])).toEqual([['modified', 'leaf']])
+    // The container itself defers to its children for counting.
+    expect(stats.modified).toBe(1)
+  })
+
+  it('recurses into an accordion panel', () => {
+    const before: ArticleNodeJSON[] = [accordion('ac', [block('x', 'old')])]
+    const after: ArticleNodeJSON[] = [accordion('ac', [block('x', 'new')])]
+    const { blocks } = diffBlocks(before, after)
+    expect(blocks[0].children?.[0].status).toBe('modified')
+  })
+
+  it('recurses into a table cell', () => {
+    const before: ArticleNodeJSON[] = [table('tbl', [block('cellblk', 'v1')])]
+    const after: ArticleNodeJSON[] = [table('tbl', [block('cellblk', 'v2')])]
+    const { blocks } = diffBlocks(before, after)
+    expect(blocks[0].status).toBe('modified')
+    expect(blocks[0].children?.map((c) => [c.status, c.id])).toEqual([['modified', 'cellblk']])
+  })
+})
+
+describe('diffBlockList — single slot (cell / panel)', () => {
+  it('diffs a flat block list keeping removed blocks in place', () => {
+    const before: BlockJSON[] = [block('a', 'keep'), block('b', 'drop'), block('c', 'edit me')]
+    const after: BlockJSON[] = [block('a', 'keep'), block('c', 'edited')]
+    const diffs = diffBlockList(before, after)
+
+    expect(diffs.map((d) => [d.status, d.id])).toEqual([
+      ['unchanged', 'a'],
+      ['removed', 'b'],
+      ['modified', 'c'],
+    ])
+    // The removed block carries its old side; the modified one carries inline spans.
+    expect(diffs[1].block).toMatchObject({ attrs: { id: 'b' } })
+    expect(diffs[2].inline?.some((s) => s.type === 'ins' && s.text === 'edited')).toBe(true)
+  })
+
+  it('treats null / empty slot content as an empty list', () => {
+    expect(diffBlockList(null, [block('a')]).map((d) => d.status)).toEqual(['added'])
+    expect(diffBlockList([block('a')], undefined).map((d) => d.status)).toEqual(['removed'])
+    expect(diffBlockList(null, null)).toEqual([])
+  })
+})
+
+describe('inline diff helpers', () => {
+  it('flattens visible text including hard breaks', () => {
+    expect(
+      inlineToText([
+        { type: 'text', text: 'line one' },
+        { type: 'hardBreak' },
+        { type: 'text', text: 'line two' },
+      ])
+    ).toBe('line one\nline two')
+    expect(inlineToText(undefined)).toBe('')
+  })
+
+  it('returns no spans for identical text', () => {
+    expect(diffInline([{ type: 'text', text: 'same' }], [{ type: 'text', text: 'same' }])).toEqual(
+      []
+    )
+  })
+
+  it('produces word-level (not char-level) spans', () => {
+    const spans = diffInline(
+      [{ type: 'text', text: 'hello world' }],
+      [{ type: 'text', text: 'hello there' }]
+    )
+    // 'world' replaced by 'there' as whole tokens, not a 'w→t' char edit.
+    expect(spans.some((s) => s.type === 'del' && s.text === 'world')).toBe(true)
+    expect(spans.some((s) => s.type === 'ins' && s.text === 'there')).toBe(true)
+  })
+})

--- a/packages/lib/src/kb/blocks/diff-blocks.ts
+++ b/packages/lib/src/kb/blocks/diff-blocks.ts
@@ -1,0 +1,229 @@
+// packages/lib/src/kb/blocks/diff-blocks.ts
+//
+// Pure structural diff of two article bodies (`ArticleNodeJSON[]`). Block ids
+// are stable across versions (publish/restore copy `contentJson` verbatim), so
+// the diff is keyed on `attrs.id`: an id present on both sides with differing
+// content is `modified`; LCS over the id sequences classifies reorders as
+// `moved` and keeps removed blocks in their old position for rendering.
+//
+// Reused by the version diff (Phase 3) and the Kopilot turn review (Phase 5).
+// Must stay pure (types + ./inline-diff only) so client code can import it.
+
+import type { ArticleNodeJSON, BlockJSON, ContainerBlockJSON } from '../markdown/types'
+import { diffInline, type InlineDiffSpan } from './inline-diff'
+
+export type BlockDiffStatus = 'added' | 'removed' | 'modified' | 'moved' | 'unchanged'
+
+export interface BlockDiff {
+  status: BlockDiffStatus
+  id: string // attrs.id (stable across versions)
+  block: ArticleNodeJSON // new side; old side when status === 'removed'
+  prevBlock?: ArticleNodeJSON // present for 'modified' | 'moved'
+  inline?: InlineDiffSpan[] // word-level, leaf 'modified'/'moved' only
+  children?: BlockDiff[] // recursion for modified containers (tabs/accordion/table)
+}
+
+export interface ArticleDiff {
+  blocks: BlockDiff[]
+  stats: { added: number; removed: number; modified: number; moved: number }
+}
+
+/**
+ * Diff two article bodies into a renderable `ArticleDiff`. `null`/`undefined`
+ * is treated as an empty body.
+ */
+export function diffBlocks(
+  oldContent: ArticleNodeJSON[] | null | undefined,
+  newContent: ArticleNodeJSON[] | null | undefined
+): ArticleDiff {
+  const blocks = diffLevel(oldContent ?? [], newContent ?? [])
+  const stats = { added: 0, removed: 0, modified: 0, moved: 0 }
+  tally(blocks, stats)
+  return { blocks, stats }
+}
+
+/**
+ * Diff two flat block lists — the contents of a single table cell or a
+ * tab/accordion panel — into ordered `BlockDiff`s. Same engine as the
+ * top-level diff (LCS over stable ids, word-level inline diff on modified
+ * leaves), exposed so container-internal rendering can rebuild a slot's
+ * before/after sequence with removed blocks reinserted in place.
+ */
+export function diffBlockList(
+  oldBlocks: ArticleNodeJSON[] | null | undefined,
+  newBlocks: ArticleNodeJSON[] | null | undefined
+): BlockDiff[] {
+  return diffLevel(oldBlocks ?? [], newBlocks ?? [])
+}
+
+// ─── core ────────────────────────────────────────────────────────────
+
+function diffLevel(oldNodes: ArticleNodeJSON[], newNodes: ArticleNodeJSON[]): BlockDiff[] {
+  const oldIds = oldNodes.map(nodeId)
+  const newIds = newNodes.map(nodeId)
+  const oldMap = new Map(oldNodes.map((n, i) => [oldIds[i], n]))
+  const newMap = new Map(newNodes.map((n, i) => [newIds[i], n]))
+  const lcs = lcsIds(oldIds, newIds)
+
+  const result: BlockDiff[] = []
+  let oi = 0
+  let nj = 0
+  let li = 0
+
+  while (oi < oldNodes.length || nj < newNodes.length) {
+    const anchor = li < lcs.length ? lcs[li] : undefined
+
+    // Old block that isn't the next stable anchor → removed, or the source
+    // slot of a moved block (emitted at its new position, so skip here).
+    if (oi < oldNodes.length && oldIds[oi] !== anchor) {
+      if (newMap.has(oldIds[oi])) {
+        oi++
+        continue
+      }
+      result.push({ status: 'removed', id: oldIds[oi], block: oldNodes[oi] })
+      oi++
+      continue
+    }
+
+    // New block that isn't the next anchor → added, or a moved block's
+    // destination (present on both sides but out of stable order).
+    if (nj < newNodes.length && newIds[nj] !== anchor) {
+      const prev = oldMap.get(newIds[nj])
+      if (prev) {
+        result.push(classify(prev, newNodes[nj], true))
+        nj++
+        continue
+      }
+      result.push({ status: 'added', id: newIds[nj], block: newNodes[nj] })
+      nj++
+      continue
+    }
+
+    // Both sit on the stable anchor.
+    if (anchor !== undefined) {
+      result.push(classify(oldNodes[oi], newNodes[nj], false))
+      oi++
+      nj++
+      li++
+      continue
+    }
+    break
+  }
+
+  return result
+}
+
+function classify(oldNode: ArticleNodeJSON, newNode: ArticleNodeJSON, moved: boolean): BlockDiff {
+  const id = nodeId(newNode)
+  if (isEqualNode(oldNode, newNode)) {
+    return moved
+      ? { status: 'moved', id, block: newNode, prevBlock: oldNode }
+      : { status: 'unchanged', id, block: newNode }
+  }
+
+  const status: BlockDiffStatus = moved ? 'moved' : 'modified'
+
+  // Leaf block changed → word-level inline diff.
+  if (oldNode.type === 'block' && newNode.type === 'block') {
+    return {
+      status,
+      id,
+      block: newNode,
+      prevBlock: oldNode,
+      inline: diffInline(oldNode.content, newNode.content),
+    }
+  }
+
+  // Container of the same kind changed → recurse over its leaf blocks.
+  if (isContainer(oldNode) && isContainer(newNode) && oldNode.type === newNode.type) {
+    return {
+      status,
+      id,
+      block: newNode,
+      prevBlock: oldNode,
+      children: diffLevel(collectLeaves(oldNode), collectLeaves(newNode)),
+    }
+  }
+
+  // Type changed across the same id (rare) — surface as a plain modified frame.
+  return { status, id, block: newNode, prevBlock: oldNode }
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+function nodeId(node: ArticleNodeJSON): string {
+  return (node.type === 'block' ? node.attrs.id : node.attrs?.id) ?? ''
+}
+
+function isContainer(node: ArticleNodeJSON): node is ContainerBlockJSON {
+  return node.type !== 'block'
+}
+
+/** Leaf blocks held inside a container, in document order. */
+function collectLeaves(node: ContainerBlockJSON): BlockJSON[] {
+  if (node.type === 'tabs' || node.type === 'accordion') {
+    return node.content.flatMap((panel) => panel.content)
+  }
+  return node.content.flatMap((row) => row.content.flatMap((cell) => cell.content))
+}
+
+const VOLATILE_KEYS = new Set(['codeHighlightedHtml'])
+
+/** Structural deep-equal, ignoring derived keys and key order. */
+function isEqualNode(a: ArticleNodeJSON, b: ArticleNodeJSON): boolean {
+  return JSON.stringify(canonicalize(a)) === JSON.stringify(canonicalize(b))
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      if (VOLATILE_KEYS.has(key)) continue
+      out[key] = canonicalize((value as Record<string, unknown>)[key])
+    }
+    return out
+  }
+  return value
+}
+
+/** Longest common subsequence of two id sequences (unique ids per doc). */
+function lcsIds(a: string[], b: string[]): string[] {
+  const n = a.length
+  const m = b.length
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1])
+    }
+  }
+  const seq: string[] = []
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      seq.push(a[i])
+      i++
+      j++
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      i++
+    } else {
+      j++
+    }
+  }
+  return seq
+}
+
+/** Count changed leaves of the diff tree (a modified container defers to its children). */
+function tally(diffs: BlockDiff[], stats: ArticleDiff['stats']): void {
+  for (const d of diffs) {
+    if (d.children && d.children.length > 0) {
+      tally(d.children, stats)
+      continue
+    }
+    if (d.status === 'added') stats.added++
+    else if (d.status === 'removed') stats.removed++
+    else if (d.status === 'modified') stats.modified++
+    else if (d.status === 'moved') stats.moved++
+  }
+}

--- a/packages/lib/src/kb/blocks/index.ts
+++ b/packages/lib/src/kb/blocks/index.ts
@@ -1,4 +1,12 @@
 // packages/lib/src/kb/blocks/index.ts
 
 export { type ApplyPatchResult, applyPatch, PatchError } from './apply-patch'
+export {
+  type ArticleDiff,
+  type BlockDiff,
+  type BlockDiffStatus,
+  diffBlockList,
+  diffBlocks,
+} from './diff-blocks'
+export { diffInline, type InlineDiffSpan, inlineToText } from './inline-diff'
 export type { ArticlePatch, BlockAnchor, ContainerKind, PatchEffect } from './patch-types'

--- a/packages/lib/src/kb/blocks/inline-diff.ts
+++ b/packages/lib/src/kb/blocks/inline-diff.ts
@@ -1,0 +1,85 @@
+// packages/lib/src/kb/blocks/inline-diff.ts
+//
+// Pure word-level inline diff for a block's visible text. Built on `fast-diff`
+// (char-level Myers) but run over a token-encoded representation so the output
+// lands on word boundaries instead of mid-word character runs.
+//
+// Must stay pure (types + `fast-diff` only) so client code in `apps/web` can
+// import it without pulling server-only deps.
+
+import fastDiff from 'fast-diff'
+import type { BlockJSON } from '../markdown/types'
+
+export interface InlineDiffSpan {
+  type: 'eq' | 'ins' | 'del'
+  text: string
+}
+
+/**
+ * Flatten a block's inline content to its visible text. Marks and links are
+ * not represented — v1 diffs visible text only. `hardBreak` becomes a newline
+ * so line additions/removals are visible.
+ */
+export function inlineToText(content: BlockJSON['content']): string {
+  if (!content) return ''
+  let out = ''
+  for (const node of content) {
+    if (node.type === 'hardBreak') out += '\n'
+    else if (typeof node.text === 'string') out += node.text
+  }
+  return out
+}
+
+/**
+ * Word-level inline diff. Returns ordered `eq`/`ins`/`del` spans whose `text`
+ * fields concatenate (per side) back to the originals.
+ *
+ * Returns `[]` when the visible text is identical — a marks-only change still
+ * makes the block `modified` upstream, but produces no inline spans.
+ */
+export function diffInline(
+  prev: BlockJSON['content'],
+  next: BlockJSON['content']
+): InlineDiffSpan[] {
+  const a = inlineToText(prev)
+  const b = inlineToText(next)
+  if (a === b) return []
+
+  // Token-encode each side so fast-diff's char algorithm operates on whole
+  // tokens (words + whitespace runs), yielding word-level granularity.
+  const tokens: string[] = []
+  const codes = new Map<string, number>()
+  const encode = (text: string): string => {
+    let encoded = ''
+    for (const token of tokenize(text)) {
+      let code = codes.get(token)
+      if (code === undefined) {
+        code = tokens.length
+        tokens.push(token)
+        codes.set(token, code)
+      }
+      // +1 keeps us off the NUL code point.
+      encoded += String.fromCharCode(code + 1)
+    }
+    return encoded
+  }
+
+  const raw = fastDiff(encode(a), encode(b))
+  const spans: InlineDiffSpan[] = []
+  for (const [op, chunk] of raw) {
+    let text = ''
+    for (const ch of chunk) text += tokens[ch.charCodeAt(0) - 1]
+    if (!text) continue
+    const type: InlineDiffSpan['type'] =
+      op === fastDiff.INSERT ? 'ins' : op === fastDiff.DELETE ? 'del' : 'eq'
+    const last = spans[spans.length - 1]
+    if (last && last.type === type) last.text += text
+    else spans.push({ type, text })
+  }
+  return spans
+}
+
+/** Split into word and whitespace tokens; concatenation reconstructs the input. */
+function tokenize(text: string): string[] {
+  return text.split(/(\s+)/).filter((t) => t.length > 0)
+}

--- a/packages/lib/src/kb/kb-service.ts
+++ b/packages/lib/src/kb/kb-service.ts
@@ -8,6 +8,7 @@
 import type { Database } from '@auxx/database'
 import { archiveArticle, unarchiveArticle } from './articles/archive-article'
 import {
+  getArticleDiff,
   getArticleVersions,
   renameArticleVersion,
   restoreArticleVersion,
@@ -172,6 +173,9 @@ export class KBService {
 
   getArticleVersions(articleId: string) {
     return getArticleVersions(this.ctx, articleId)
+  }
+  getArticleDiff(articleId: string, base: string, compare: string) {
+    return getArticleDiff(this.ctx, articleId, base, compare)
   }
   renameArticleVersion(versionId: string, label: string | null) {
     return renameArticleVersion(this.ctx, versionId, label)

--- a/packages/lib/src/kb/realtime.ts
+++ b/packages/lib/src/kb/realtime.ts
@@ -47,6 +47,13 @@ export type KbArticleEvent =
       by: 'kopilot'
       turnId: string
       expiresAt?: number
+      /**
+       * Set on the unlock (`locked: false`) emitted by `finalizeKopilotKbTurn`:
+       * the pre-turn snapshot is kept, so the turn is reviewable (Keep / Undo).
+       * Absent/false on the revert unlock (snapshot already cleared). Clients
+       * use it as a liveness signal to refresh the turn-review state.
+       */
+      reviewable?: boolean
     }
 
 /**

--- a/packages/ui/src/components/kb/article/block-renderer.tsx
+++ b/packages/ui/src/components/kb/article/block-renderer.tsx
@@ -1,5 +1,6 @@
 // packages/ui/src/components/kb/article/block-renderer.tsx
 
+import type { ReactNode } from 'react'
 import { parseEmbedUrl } from '../utils/embed'
 import { walkInlineToText } from '../utils/inline-text'
 import { CalloutIcon } from './callout-icon'
@@ -7,7 +8,14 @@ import { CardItem } from './card-item'
 import { ImageZoomable } from './image-zoomable'
 import { InlineRenderer } from './inline-renderer'
 import styles from './kb-article-renderer.module.css'
-import type { BlockJSON, CalloutVariant, CardData, DocJSON, ResolveAuxxHref } from './types'
+import type {
+  BlockJSON,
+  CalloutVariant,
+  CardData,
+  DiffDecorations,
+  DocJSON,
+  ResolveAuxxHref,
+} from './types'
 
 interface BlockRendererProps {
   node: BlockJSON
@@ -15,9 +23,34 @@ interface BlockRendererProps {
   doc: DocJSON
   headingIds?: Record<number, string>
   resolveAuxxHref?: ResolveAuxxHref
+  /** Diff decorations for container-nested leaves; absent on the normal render path. */
+  decorations?: DiffDecorations
 }
 
-export function BlockRenderer({ node, idx, doc, headingIds, resolveAuxxHref }: BlockRendererProps) {
+/**
+ * Render a leaf block. When `decorations` flags this block's id (diff surface
+ * only), the output is wrapped with a `data-diff-status` attribute so the diff
+ * view can border-decorate container-nested changes.
+ */
+export function BlockRenderer(props: BlockRendererProps) {
+  const el = renderBlock(props)
+  const id = props.node.attrs?.id
+  const status = id && props.decorations ? props.decorations.get(id) : undefined
+  if (!status) return el
+  return (
+    <div className='kb-diff-block' data-diff-status={status}>
+      {el}
+    </div>
+  )
+}
+
+function renderBlock({
+  node,
+  idx,
+  doc,
+  headingIds,
+  resolveAuxxHref,
+}: BlockRendererProps): ReactNode {
   const inline = <InlineRenderer content={node.content} resolveAuxxHref={resolveAuxxHref} />
   const blockType = node.attrs?.blockType ?? 'text'
 

--- a/packages/ui/src/components/kb/article/index.ts
+++ b/packages/ui/src/components/kb/article/index.ts
@@ -6,6 +6,7 @@ export { extractKBHeadings, type KBHeading } from './extract-headings'
 export { ImageZoomable } from './image-zoomable'
 export { InlineRenderer } from './inline-renderer'
 export { KBArticleCopyMenu } from './kb-article-copy-menu'
+export { KBArticleNode } from './kb-article-node'
 export { KBArticlePager } from './kb-article-pager'
 export { KBArticleRenderer } from './kb-article-renderer'
 export { KBArticleWithToc } from './kb-article-with-toc'
@@ -19,6 +20,8 @@ export type {
   CalloutVariant,
   CardData,
   ContainerBlockJSON,
+  DiffDecorations,
+  DiffStatus,
   DocJSON,
   EmbedAspect,
   EmbedProvider,

--- a/packages/ui/src/components/kb/article/kb-article-node.tsx
+++ b/packages/ui/src/components/kb/article/kb-article-node.tsx
@@ -1,0 +1,130 @@
+// packages/ui/src/components/kb/article/kb-article-node.tsx
+
+import type { ReactNode } from 'react'
+import { AccordionBlock } from './accordion-block'
+import { BlockRenderer } from './block-renderer'
+import { TableBlock } from './table-block'
+import { TabsBlock } from './tabs-block'
+import type {
+  AccordionJSON,
+  ArticleNodeJSON,
+  BlockJSON,
+  DiffDecorations,
+  DocJSON,
+  PanelJSON,
+  ResolveAuxxHref,
+  TabsJSON,
+} from './types'
+
+interface KBArticleNodeProps {
+  node: ArticleNodeJSON
+  idx: number
+  /** The full doc the node belongs to — needed for ordered concerns like list numbering. */
+  doc: DocJSON
+  headingIds?: Record<number, string>
+  resolveAuxxHref?: ResolveAuxxHref
+  /** Diff decorations for container-nested leaves; absent on the normal render path. */
+  decorations?: DiffDecorations
+}
+
+/**
+ * Renders a single top-level article node (leaf block or container). The
+ * dispatch shared by `KBArticleRenderer` and the diff view so block/container
+ * rendering never diverges between the two surfaces.
+ */
+export function KBArticleNode({
+  node,
+  idx,
+  doc,
+  headingIds,
+  resolveAuxxHref,
+  decorations,
+}: KBArticleNodeProps) {
+  switch (node.type) {
+    case 'tabs':
+      return (
+        <ServerTabsBlock node={node} resolveAuxxHref={resolveAuxxHref} decorations={decorations} />
+      )
+    case 'accordion':
+      return (
+        <ServerAccordionBlock
+          node={node}
+          resolveAuxxHref={resolveAuxxHref}
+          decorations={decorations}
+        />
+      )
+    case 'table':
+      return <TableBlock node={node} resolveAuxxHref={resolveAuxxHref} decorations={decorations} />
+    case 'block':
+      return (
+        <BlockRenderer
+          node={node}
+          idx={idx}
+          doc={doc}
+          headingIds={headingIds}
+          resolveAuxxHref={resolveAuxxHref}
+          decorations={decorations}
+        />
+      )
+    default:
+      return null
+  }
+}
+
+function renderPanelBody(
+  panel: PanelJSON,
+  resolveAuxxHref: ResolveAuxxHref | undefined,
+  decorations: DiffDecorations | undefined
+): ReactNode {
+  // Panel bodies are flat block content; reuse BlockRenderer with a synthetic
+  // sub-doc so heading-id maps stay scoped. We intentionally don't pass a
+  // headingIds map — TOC headings are top-level only.
+  const subDoc: DocJSON = { type: 'doc', content: panel.content }
+  return panel.content.map((block: BlockJSON, i) => (
+    <BlockRenderer
+      key={i}
+      node={block}
+      idx={i}
+      doc={subDoc}
+      resolveAuxxHref={resolveAuxxHref}
+      decorations={decorations}
+    />
+  ))
+}
+
+function ServerTabsBlock({
+  node,
+  resolveAuxxHref,
+  decorations,
+}: {
+  node: TabsJSON
+  resolveAuxxHref?: ResolveAuxxHref
+  decorations?: DiffDecorations
+}) {
+  if (!Array.isArray(node.content) || node.content.length === 0) return null
+  const panels = node.content.map((panel) => ({
+    id: panel.attrs.id,
+    label: panel.attrs.label,
+    iconId: panel.attrs.iconId,
+    body: renderPanelBody(panel, resolveAuxxHref, decorations),
+  }))
+  return <TabsBlock panels={panels} />
+}
+
+function ServerAccordionBlock({
+  node,
+  resolveAuxxHref,
+  decorations,
+}: {
+  node: AccordionJSON
+  resolveAuxxHref?: ResolveAuxxHref
+  decorations?: DiffDecorations
+}) {
+  if (!Array.isArray(node.content) || node.content.length === 0) return null
+  const items = node.content.map((panel) => ({
+    id: panel.attrs.id,
+    label: panel.attrs.label,
+    body: renderPanelBody(panel, resolveAuxxHref, decorations),
+  }))
+  return <AccordionBlock items={items} allowMultiple={node.attrs.allowMultiple !== false} />
+}

--- a/packages/ui/src/components/kb/article/kb-article-renderer.tsx
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.tsx
@@ -3,23 +3,11 @@
 import { EntityIcon } from '@auxx/ui/components/icons'
 import Link from 'next/link'
 import type { ReactNode } from 'react'
-import { AccordionBlock } from './accordion-block'
-import { BlockRenderer } from './block-renderer'
 import { extractKBHeadings, type KBHeading } from './extract-headings'
+import { KBArticleNode } from './kb-article-node'
 import styles from './kb-article-renderer.module.css'
 import { KBTableOfContentsDrawer } from './kb-toc-drawer'
-import { TableBlock } from './table-block'
-import { TabsBlock } from './tabs-block'
-import type {
-  AccordionJSON,
-  ArticleNodeJSON,
-  BlockJSON,
-  DocJSON,
-  PanelJSON,
-  ResolveAuxxHref,
-  TableJSON,
-  TabsJSON,
-} from './types'
+import type { DocJSON, ResolveAuxxHref } from './types'
 
 export interface KBArticleRendererProps {
   doc: DocJSON | null | undefined
@@ -109,106 +97,18 @@ export function KBArticleRenderer({
           ) : null}
         </header>
       ) : null}
-      {doc?.content?.map((node, idx) => {
-        switch (node.type) {
-          case 'tabs':
-            return (
-              <ServerTabsBlock
-                // biome-ignore lint/suspicious/noArrayIndexKey: block order is stable per render
-                key={idx}
-                node={node}
-                resolveAuxxHref={resolveAuxxHref}
-              />
-            )
-          case 'accordion':
-            return (
-              <ServerAccordionBlock
-                // biome-ignore lint/suspicious/noArrayIndexKey: block order is stable per render
-                key={idx}
-                node={node}
-                resolveAuxxHref={resolveAuxxHref}
-              />
-            )
-          case 'table':
-            return (
-              <TableBlock
-                // biome-ignore lint/suspicious/noArrayIndexKey: block order is stable per render
-                key={idx}
-                node={node}
-                resolveAuxxHref={resolveAuxxHref}
-              />
-            )
-          case 'block':
-            return (
-              <BlockRenderer
-                // biome-ignore lint/suspicious/noArrayIndexKey: block order is stable per render
-                key={idx}
-                node={node}
-                idx={idx}
-                doc={doc}
-                headingIds={headingIds}
-                resolveAuxxHref={resolveAuxxHref}
-              />
-            )
-          default:
-            return null
-        }
-      })}
+      {doc?.content?.map((node, idx) => (
+        <KBArticleNode
+          key={idx}
+          node={node}
+          idx={idx}
+          doc={doc}
+          headingIds={headingIds}
+          resolveAuxxHref={resolveAuxxHref}
+        />
+      ))}
     </article>
   )
-}
-
-function renderPanelBody(
-  panel: PanelJSON,
-  resolveAuxxHref: ResolveAuxxHref | undefined
-): ReactNode {
-  // Panel bodies are flat block content; reuse BlockRenderer with a synthetic
-  // sub-doc so heading-id maps stay scoped. We intentionally don't pass a
-  // headingIds map — TOC headings are top-level only.
-  const subDoc: DocJSON = { type: 'doc', content: panel.content }
-  return panel.content.map((block: BlockJSON, i) => (
-    <BlockRenderer
-      // biome-ignore lint/suspicious/noArrayIndexKey: panel content order is stable per render
-      key={i}
-      node={block}
-      idx={i}
-      doc={subDoc}
-      resolveAuxxHref={resolveAuxxHref}
-    />
-  ))
-}
-
-function ServerTabsBlock({
-  node,
-  resolveAuxxHref,
-}: {
-  node: TabsJSON
-  resolveAuxxHref?: ResolveAuxxHref
-}) {
-  if (!Array.isArray(node.content) || node.content.length === 0) return null
-  const panels = node.content.map((panel) => ({
-    id: panel.attrs.id,
-    label: panel.attrs.label,
-    iconId: panel.attrs.iconId,
-    body: renderPanelBody(panel, resolveAuxxHref),
-  }))
-  return <TabsBlock panels={panels} />
-}
-
-function ServerAccordionBlock({
-  node,
-  resolveAuxxHref,
-}: {
-  node: AccordionJSON
-  resolveAuxxHref?: ResolveAuxxHref
-}) {
-  if (!Array.isArray(node.content) || node.content.length === 0) return null
-  const items = node.content.map((panel) => ({
-    id: panel.attrs.id,
-    label: panel.attrs.label,
-    body: renderPanelBody(panel, resolveAuxxHref),
-  }))
-  return <AccordionBlock items={items} allowMultiple={node.attrs.allowMultiple !== false} />
 }
 
 function buildHeadingIdMap(doc: DocJSON, headings: KBHeading[]): Record<number, string> {

--- a/packages/ui/src/components/kb/article/table-block.tsx
+++ b/packages/ui/src/components/kb/article/table-block.tsx
@@ -3,11 +3,20 @@
 import type { ReactNode } from 'react'
 import { BlockRenderer } from './block-renderer'
 import styles from './kb-article-renderer.module.css'
-import type { BlockJSON, DocJSON, ResolveAuxxHref, TableCellJSON, TableJSON } from './types'
+import type {
+  BlockJSON,
+  DiffDecorations,
+  DocJSON,
+  ResolveAuxxHref,
+  TableCellJSON,
+  TableJSON,
+} from './types'
 
 interface TableBlockProps {
   node: TableJSON
   resolveAuxxHref?: ResolveAuxxHref
+  /** Diff decorations for cell-nested leaves; absent on the normal render path. */
+  decorations?: DiffDecorations
 }
 
 /**
@@ -15,7 +24,7 @@ interface TableBlockProps {
  * `<thead>` (when the first row is all `tableHeader`) and `<tbody>`. Cell
  * content recurses through `BlockRenderer`.
  */
-export function TableBlock({ node, resolveAuxxHref }: TableBlockProps): ReactNode {
+export function TableBlock({ node, resolveAuxxHref, decorations }: TableBlockProps): ReactNode {
   if (!Array.isArray(node.content) || node.content.length === 0) return null
 
   const [firstRow, ...restRows] = node.content
@@ -39,6 +48,7 @@ export function TableBlock({ node, resolveAuxxHref }: TableBlockProps): ReactNod
             idx={i}
             doc={subDoc}
             resolveAuxxHref={resolveAuxxHref}
+            decorations={decorations}
           />
         ))}
       </Tag>

--- a/packages/ui/src/components/kb/article/types.ts
+++ b/packages/ui/src/components/kb/article/types.ts
@@ -32,6 +32,8 @@ export interface CardData {
 }
 
 export interface BlockAttrs {
+  /** Stable id, copied verbatim across versions; keys the version diff. */
+  id?: string | null
   blockType: BlockType
   level?: number | null
   checked?: boolean
@@ -145,3 +147,14 @@ export interface DocJSON {
  * their own URL prefix.
  */
 export type ResolveAuxxHref = (articleId: string) => string
+
+/** Diff status of a block, mirrored from `@auxx/lib/kb/blocks` to avoid a cross-package dep. */
+export type DiffStatus = 'added' | 'removed' | 'modified' | 'moved' | 'unchanged'
+
+/**
+ * Container-nested leaf decorations keyed by `attrs.id`. When provided to the
+ * renderer, leaf blocks whose id appears here are wrapped with a
+ * `data-diff-status` attribute so the diff surface can border-decorate them.
+ * Top-level block decoration is handled by the diff view, not this map.
+ */
+export type DiffDecorations = ReadonlyMap<string, DiffStatus>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1926,6 +1926,9 @@ importers:
       email-reply-parser:
         specifier: ^1.9.4
         version: 1.9.4
+      fast-diff:
+        specifier: ^1.3.0
+        version: 1.3.0
       file-type:
         specifier: ^19.0.0
         version: 19.6.0
@@ -10155,6 +10158,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
   fast-equals@2.0.4:
     resolution: {integrity: sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w==}
@@ -23310,6 +23316,8 @@ snapshots:
   fast-deep-equal@2.0.1: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-diff@1.3.0: {}
 
   fast-equals@2.0.4: {}
 


### PR DESCRIPTION
## Summary

Adds a rendered, word-level **diff** for KB article versions and a **Kopilot turn-review** (Keep / Undo) flow, sharing one diff engine and a cleaned-up agent turn lifecycle.

### Diff core — `@auxx/lib/kb/blocks`
- Pure `diffBlocks(old, new)`: LCS-by-id structural diff, classifies `added`/`removed`/`modified`/`moved`/`unchanged`, recurses into containers; word-level `inlineDiff` via `fast-diff`.
- `diffBlockList` for per-slot (cell/panel) container diffs.

### `<ArticleDiffView>` — inline in the editor pane
- Driven by the `?diff=` nuqs param (`review` / `v:<id>` / `kopilot`); replaces the editor in the pane, not a dialog. Slim diff bar + legend.
- Reuses the article renderer via a shared `<KBArticleNode>` so diff and render never diverge.
- **Container-internal diffs**: changes inside tables / tabs / accordions render per-leaf (inline ins/del, reinserted removed blocks), not just a framed container.

### Turn-lifecycle de-hack
- Engine-level `onTurnEnd` + `resetTurnDomainState` hooks on `AgentDomainConfig`. `onTurnEnd` fires finalize-on-success / revert-on-failure for **both** the in-process and worker paths (fixes a latent `USE_AGENT_WORKER=true` lock-leak / no-rollback bug).
- Kopilot records touched article ids off block-CRUD tool results in `onToolResult` — removes the SSE-route bolt-on and its request-context duck-typing.

### Kopilot turn review (Keep / Undo)
- Post-turn banner (**Kopilot changed N blocks** · Review · Keep · Undo) backed by the kept pre-turn snapshot.
- Liveness via the `kb-article-lock { reviewable }` unlock event + recovery-on-mount via the new `getKopilotTurnReview` query (survives refresh). `keepKopilotTurn` commits (clears snapshot); Undo reuses the existing `revertKopilotTurn`.

## Incidental
- `fix(api): overwrite participant link on verified Shopify JWT` — unrelated chat-passport identity-linking bug fix, included per request (separate commit).

## Testing
- `diff-blocks` unit tests: 16 passing (top-level + nested container + per-slot).
- Agent-framework / kopilot suites: behave identically to the base branch (2 pre-existing failures + 2 unrelated suite-load issues reproduce on a clean tree).
- Not yet exercised end-to-end in the browser (live SSE → banner → Keep/Undo loop).

## Out of scope (follow-ups)
- Phase 6 — reliability hardening (CAS hash precondition + `update_block_text` guard).
- Per-block accept/reject (turn-level only for v1).
- Mid-table row insert/delete pairs positionally (shows trailing rows as changed).