### PR TITLE
feat(kb): add concurrency guard to Kopilot write tools

### DIFF
--- a/apps/web/src/components/kb/ui/editor/article-diff-pane.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-diff-pane.tsx
@@ -8,11 +8,15 @@ import { useEffect, useMemo } from 'react'
 import { api } from '~/trpc/react'
 import { useArticleContent } from '../../hooks/use-article-content'
 import type { ArticleMeta } from '../../store/article-store'
+import type { KnowledgeBase } from '../../store/knowledge-base-store'
+import { mapKBForPreview } from '../preview/map-kb-for-preview'
 import { ArticleDiffView } from './article-diff-view'
 
 interface ArticleDiffPaneProps {
   article: ArticleMeta
   knowledgeBaseId: string
+  /** KB whose theme tokens style the rendered blocks (matches the published article). */
+  knowledgeBase: KnowledgeBase
   /** The raw `?diff=` value: `review` | `v:<revisionId>` | `kopilot`. */
   diffValue: string
   onClose: () => void
@@ -27,9 +31,11 @@ interface ArticleDiffPaneProps {
 export function ArticleDiffPane({
   article,
   knowledgeBaseId,
+  knowledgeBase,
   diffValue,
   onClose,
 }: ArticleDiffPaneProps) {
+  const kbTheme = useMemo(() => mapKBForPreview(knowledgeBase), [knowledgeBase])
   const isVersion = diffValue.startsWith('v:')
   const revisionId = isVersion ? diffValue.slice(2) : null
   const isKopilot = diffValue === 'kopilot'
@@ -138,6 +144,7 @@ export function ArticleDiffPane({
       diff={diff}
       baseLabel={resolved.baseLabel}
       compareLabel={resolved.compareLabel}
+      kbTheme={kbTheme}
       onClose={onClose}
     />
   )

--- a/apps/web/src/components/kb/ui/editor/article-diff-view.module.css
+++ b/apps/web/src/components/kb/ui/editor/article-diff-view.module.css
@@ -1,80 +1,67 @@
 /* apps/web/src/components/kb/ui/editor/article-diff-view.module.css */
 
 /*
- * The diff body renders through the shared KB `BlockRenderer` (same components
- * as the public site), but we restyle its output to match the Tiptap *editor*
- * the user edits in — same font size, heading scale, and tight line spacing —
- * rather than the looser published-article look. Metrics mirror
- * `editor/kb-article/block-node-view.module.css`.
+ * The diff body renders through the shared KB renderer. The `<article>` carries
+ * the renderer's own container class (`kbArticleContainerClass`) and sits inside
+ * a `KBThemeProvider`, so base typography, links, inline code, callouts, tables,
+ * and code blocks all match the *published* article — no styling is duplicated
+ * here. This file only adds the diff layer: per-block decorators and the
+ * word-level ins/del marks baked into modified text.
  */
-.body {
-  font-size: 0.875rem;
-  line-height: 24px;
-  letter-spacing: -0.01em;
-  color: var(--color-foreground);
-}
-
-/* Paragraphs: no inter-block margin — blocks stack tightly like the editor. */
-.body :global(p) {
-  margin: 0;
-}
-
-/* Headings — BlockRenderer maps level 1/2/3 to <h2>/<h3>/<h4>. Values match the
-   editor's h1/h2/h3 density vars. */
-.body :global(h2) {
-  font-size: 24px;
-  line-height: 28px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  margin: 1.5rem 0 0.5rem;
-}
-.body :global(h3) {
-  font-size: 20px;
-  line-height: 24px;
-  font-weight: 600;
-  letter-spacing: -0.015em;
-  margin: 1.25rem 0 0.375rem;
-}
-.body :global(h4) {
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 600;
-  letter-spacing: -0.015em;
-  margin: 1rem 0 0.25rem;
-}
-
-/* Collapse the leading block's top margin so it hugs the diff bar. */
-.body > .block:first-child :global(h2),
-.body > .block:first-child :global(h3),
-.body > .block:first-child :global(h4) {
-  margin-top: 0;
-}
-
-/* Links + inline code: editor tokens, not the undefined --kb-* renderer vars. */
-.body :global(.kb-link),
-.body :global(a) {
-  color: var(--color-primary);
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-.body :global(.kb-inline-code) {
-  font-size: 0.8125rem;
-  background-color: var(--color-muted);
-  border: 1px solid var(--color-border);
-  padding: 0.125rem 0.375rem;
-  border-radius: 0.375rem;
-}
-.body :global(blockquote) {
-  color: var(--color-muted-foreground);
-}
 
 /* ── Block-level diff decorators ──────────────────────────────────────── */
 
+/*
+ * Each block is wrapped for its colored gutter, but the wrapper must stay
+ * transparent to vertical margins: the shared renderer spaces blocks via
+ * collapsing top/bottom margins (`.text { margin: 0.5em 0 }` etc.), and any
+ * top/bottom padding or border here would block that collapse and double the
+ * gaps. So we decorate with a left border + left padding only (pulled into the
+ * gutter with a negative left margin) and leave the vertical edges open.
+ */
 .block {
   position: relative;
-  padding: 1px 0 1px 0.75rem;
+  padding-left: 0.75rem;
   margin-left: -0.75rem;
   border-left: 3px solid transparent;
+  /*
+   * Render at the editor's block density (14px) rather than the renderer's
+   * 16px published scale — the diff lives in the editor pane and should match
+   * what the user authors. Set on the wrapper (an ancestor of every block) so
+   * it wins by proximity over `.article`'s base size without specificity hacks;
+   * em-based heading sizes scale down proportionally.
+   */
+  font-size: 0.875rem;
+}
+
+/*
+ * Spacing only — match the editor's tight, line-height-driven block rhythm
+ * instead of the renderer's looser published margins (`.text { margin: 0.5em }`,
+ * heading `1.25em` etc. would add gaps the editor doesn't have). Colors,
+ * callouts, tables, and code still come from the renderer + `--kb-*` tokens;
+ * these rules only reset the vertical margins. Element selectors scoped under
+ * `.block` outweigh the renderer's single-class rules regardless of CSS order.
+ */
+.block :global(p),
+.block :global(.kb-diff-block) {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.block :global(h2) {
+  margin: 1.5rem 0 0.5rem;
+}
+.block :global(h3) {
+  margin: 1.25rem 0 0.375rem;
+}
+.block :global(h4) {
+  margin: 1rem 0 0.25rem;
+}
+
+/* Collapse the leading block's top margin so it hugs the diff bar (the shared
+   renderer's own `:first-child` reset is scoped to direct `.article` children,
+   which our wrapper breaks). */
+.body > .block:first-child > :global(*) {
+  margin-top: 0;
 }
 
 .added {
@@ -96,9 +83,11 @@
 /*
  * Within a modified block the inline content is rebuilt from the word diff:
  * inserted words carry a `highlight` mark (<mark class="kb-mark">), deleted
- * words a `strike` mark (<s>). Restyle those specifically as ins/del.
+ * words a `strike` mark (<s>). Restyle those specifically as ins/del. The
+ * compound `.block.modified` selector outweighs the renderer's
+ * `.article .kb-mark` highlight so the ins color wins regardless of CSS order.
  */
-.modified :global(.kb-mark) {
+.block.modified :global(.kb-mark) {
   background-color: color-mix(in srgb, var(--color-emerald-500, #10b981) 22%, transparent);
   color: inherit;
   text-decoration: underline;
@@ -107,7 +96,7 @@
   padding: 0 1px;
 }
 
-.modified s {
+.block.modified s {
   color: var(--color-red-600, #dc2626);
   text-decoration-color: var(--color-red-500, #ef4444);
   opacity: 0.85;

--- a/apps/web/src/components/kb/ui/editor/article-diff-view.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-diff-view.tsx
@@ -3,8 +3,9 @@
 
 import type { ArticleDiff, BlockDiff } from '@auxx/lib/kb/blocks'
 import { Button } from '@auxx/ui/components/button'
+import { KBThemeProvider, type KBThemeProviderProps } from '@auxx/ui/components/kb'
 import type { ArticleNodeJSON, DiffDecorations, DocJSON } from '@auxx/ui/components/kb/article'
-import { KBArticleNode } from '@auxx/ui/components/kb/article'
+import { KBArticleNode, kbArticleContainerClass } from '@auxx/ui/components/kb/article'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { cn } from '@auxx/ui/lib/utils'
 import { ArrowLeft } from 'lucide-react'
@@ -18,6 +19,12 @@ interface ArticleDiffViewProps {
   baseLabel?: string
   /** Newer side label, e.g. "Draft" / "Kopilot". */
   compareLabel?: string
+  /**
+   * KB theme to render the blocks under, so callouts/tables/code/links match
+   * the published article (their colors come from `--kb-*` tokens injected by
+   * `KBThemeProvider`). Map a store KnowledgeBase with `mapKBForPreview`.
+   */
+  kbTheme: KBThemeProviderProps['kb']
   /** Clears the `?diff=` param and returns to the editor. */
   onClose: () => void
 }
@@ -33,6 +40,7 @@ export function ArticleDiffView({
   diff,
   baseLabel = 'Before',
   compareLabel = 'After',
+  kbTheme,
   onClose,
 }: ArticleDiffViewProps) {
   // The nodes to render, with modified text blocks rebuilt to carry their word
@@ -49,7 +57,7 @@ export function ArticleDiffView({
   const hasChanges = added + removed + modified + moved > 0
 
   return (
-    <div className='flex min-h-0 flex-1 flex-col'>
+    <KBThemeProvider kb={kbTheme}>
       <div className='flex w-full items-center gap-3 border-b bg-primary-150 px-3 py-1.5'>
         <Button variant='outline' size='xs' onClick={onClose}>
           <ArrowLeft /> Back
@@ -67,7 +75,7 @@ export function ArticleDiffView({
       <ScrollArea className='flex-1'>
         <div className='mx-auto w-full max-w-3xl px-7 py-6'>
           {hasChanges ? (
-            <article className={styles.body}>
+            <article className={cn(kbArticleContainerClass, styles.body)}>
               {diff.blocks.map((d, idx) => (
                 <DiffBlock
                   key={d.id || idx}
@@ -86,7 +94,7 @@ export function ArticleDiffView({
           )}
         </div>
       </ScrollArea>
-    </div>
+    </KBThemeProvider>
   )
 }
 

--- a/apps/web/src/components/kb/ui/editor/article-versions-dialog.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-versions-dialog.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/kb/ui/editor/article-versions-dialog.tsx
 'use client'
 
+import { AutosizeInput, type AutosizeInputRef } from '@auxx/ui/components/autosize-input'
 import { Button } from '@auxx/ui/components/button'
 import {
   Dialog,
@@ -9,12 +10,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@auxx/ui/components/dialog'
-import { Input } from '@auxx/ui/components/input'
 import { getFullSlugPath } from '@auxx/ui/components/kb'
 import { getKbPreviewHref } from '@auxx/ui/components/kb/utils'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
-import { Check, ExternalLink, GitCompare, Loader2, Pencil, Undo2, X } from 'lucide-react'
-import { useState } from 'react'
+import { cn } from '@auxx/ui/lib/utils'
+import { ExternalLink, GitCompare, Loader2, Pencil, Trash2, Undo2, X } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { Tooltip } from '~/components/global/tooltip'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { useArticleList } from '../../hooks/use-article-list'
@@ -72,27 +75,17 @@ export function ArticleVersionsDialog({
 
   const renameMutation = api.kb.renameArticleVersion.useMutation()
   const [editingId, setEditingId] = useState<string | null>(null)
-  const [editingLabel, setEditingLabel] = useState('')
 
   const versions = versionsQuery.data ?? []
   const currentPublishedRevisionId = article.data?.publishedRevisionId ?? null
 
-  const startRename = (versionId: string, currentLabel: string | null) => {
-    setEditingId(versionId)
-    setEditingLabel(currentLabel ?? '')
-  }
-  const cancelRename = () => {
+  const startRename = (versionId: string) => setEditingId(versionId)
+  const cancelRename = () => setEditingId(null)
+  const saveLabel = async (versionId: string, label: string | null) => {
     setEditingId(null)
-    setEditingLabel('')
-  }
-  const submitRename = async (versionId: string) => {
     try {
-      await renameMutation.mutateAsync({
-        versionId,
-        label: editingLabel.trim() || null,
-      })
+      await renameMutation.mutateAsync({ versionId, label: label?.trim() || null })
       utils.kb.getArticleVersions.invalidate({ articleId })
-      cancelRename()
     } catch (error) {
       toastError({
         title: 'Failed to rename version',
@@ -118,7 +111,7 @@ export function ArticleVersionsDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent size='md' position='tc'>
+        <DialogContent size='md' position='tc' innerClassName='pr-1'>
           <DialogHeader>
             <DialogTitle>Version history</DialogTitle>
             <DialogDescription>
@@ -127,7 +120,7 @@ export function ArticleVersionsDialog({
             </DialogDescription>
           </DialogHeader>
 
-          <div className='max-h-[60vh] overflow-y-auto'>
+          <ScrollArea className='max-h-[60vh]' scrollbarClassName='w-1'>
             {versionsQuery.isLoading ? (
               <div className='flex justify-center py-12'>
                 <Loader2 className='size-5 animate-spin text-muted-foreground' />
@@ -137,114 +130,207 @@ export function ArticleVersionsDialog({
                 No published versions yet. Publish this article to create the first one.
               </p>
             ) : (
-              <ul className='space-y-3'>
+              <ul className='space-y-3 pr-4'>
                 {versions.map((v) => {
                   const isCurrent = v.id === currentPublishedRevisionId
                   const isEditing = editingId === v.id
                   return (
-                    <li key={v.id} className='rounded-md border p-3 hover:border-primary/30'>
-                      <div className='flex items-center justify-between gap-2'>
-                        <div className='flex items-center gap-2'>
-                          <span
-                            className={
-                              isCurrent
-                                ? 'inline-flex size-2 rounded-full bg-emerald-500'
-                                : 'inline-flex size-2 rounded-full bg-muted-foreground/40'
-                            }
-                          />
-                          <span className='text-sm font-medium'>v{v.versionNumber}</span>
-                          {isCurrent && (
-                            <span className='rounded bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-700'>
-                              Current
-                            </span>
+                    <li
+                      key={v.id}
+                      className='rounded-2xl border px-3 pt-1 pb-2 transition-colors hover:border-primary/30'>
+                      <div className='mb-3 flex items-center gap-2'>
+                        <span
+                          className={cn(
+                            'flex size-6 shrink-0 items-center justify-center rounded-md text-[11px] font-semibold inset-shadow-xs inset-shadow-black/20',
+                            isCurrent
+                              ? 'bg-emerald-500 text-white'
+                              : 'bg-muted text-muted-foreground'
+                          )}>
+                          v{v.versionNumber}
+                        </span>
+                        <div className='min-w-0 flex-1'>
+                          <h3 className='truncate text-sm font-semibold'>{v.title}</h3>
+                          <p className='flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground'>
+                            <span className='truncate'>{v.editor?.name ?? 'System'}</span>
+                            <span className='shrink-0'>&middot;</span>
+                            <span className='shrink-0'>{relativeTime(v.createdAt)}</span>
+                            {isCurrent && (
+                              <span className='shrink-0 rounded bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-700'>
+                                Current
+                              </span>
+                            )}
+                          </p>
+                        </div>
+                        <div className='flex shrink-0 items-center gap-1'>
+                          {v.versionNumber !== null && slugPath ? (
+                            <Tooltip content='View this version'>
+                              <Button size='icon-xs' variant='ghost' asChild>
+                                <a
+                                  href={getKbPreviewHref(knowledgeBaseId, slugPath, {
+                                    versionNumber: v.versionNumber,
+                                  })}
+                                  target='_blank'
+                                  rel='noopener'>
+                                  <ExternalLink />
+                                </a>
+                              </Button>
+                            </Tooltip>
+                          ) : null}
+                          {!isCurrent && (
+                            <Tooltip content='Compare with current'>
+                              <Button
+                                size='icon-xs'
+                                variant='ghost'
+                                onClick={() => handleDiff(v.id)}>
+                                <GitCompare />
+                              </Button>
+                            </Tooltip>
+                          )}
+                          {!isCurrent && (
+                            <Tooltip content='Restore as draft'>
+                              <Button
+                                size='icon-xs'
+                                variant='outline'
+                                onClick={() => handleRestore(v.id, v.versionNumber)}>
+                                <Undo2 />
+                              </Button>
+                            </Tooltip>
                           )}
                         </div>
-                        <span className='text-xs text-muted-foreground'>
-                          {relativeTime(v.createdAt)}
-                        </span>
                       </div>
-                      <div className='mt-1 text-sm'>{v.title}</div>
-                      {isEditing ? (
-                        <div className='mt-2 flex items-center gap-2'>
-                          <Input
-                            autoFocus
-                            value={editingLabel}
-                            onChange={(e) => setEditingLabel(e.target.value)}
-                            placeholder='e.g. v2 — pricing update'
-                            className='h-7 text-xs'
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') submitRename(v.id)
-                              if (e.key === 'Escape') cancelRename()
-                            }}
-                          />
-                          <Button
-                            size='icon-xs'
-                            variant='outline'
-                            onClick={() => submitRename(v.id)}
-                            disabled={renameMutation.isPending}>
-                            <Check />
-                          </Button>
-                          <Button size='icon-xs' variant='ghost' onClick={cancelRename}>
-                            <X />
-                          </Button>
-                        </div>
-                      ) : v.label ? (
-                        <div className='mt-1 flex items-center gap-2 text-xs italic text-muted-foreground'>
-                          “{v.label}”
-                          <button
-                            type='button'
-                            className='opacity-60 hover:opacity-100'
-                            onClick={() => startRename(v.id, v.label)}>
-                            <Pencil className='size-3' />
-                          </button>
-                        </div>
-                      ) : (
-                        <button
-                          type='button'
-                          className='mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground'
-                          onClick={() => startRename(v.id, v.label)}>
-                          <Pencil className='size-3' /> Add label
-                        </button>
-                      )}
-                      <div className='mt-3 flex items-center gap-2'>
-                        <span className='flex-1 text-xs text-muted-foreground'>
-                          {v.editor?.name ?? 'System'}
-                        </span>
-                        {v.versionNumber !== null && slugPath ? (
-                          <Button size='sm' variant='ghost' asChild>
-                            <a
-                              href={getKbPreviewHref(knowledgeBaseId, slugPath, {
-                                versionNumber: v.versionNumber,
-                              })}
-                              target='_blank'
-                              rel='noopener'>
-                              <ExternalLink /> View
-                            </a>
-                          </Button>
-                        ) : null}
-                        {!isCurrent && (
-                          <Button size='sm' variant='ghost' onClick={() => handleDiff(v.id)}>
-                            <GitCompare /> Diff
-                          </Button>
-                        )}
-                        {!isCurrent && (
-                          <Button
-                            size='sm'
-                            variant='outline'
-                            onClick={() => handleRestore(v.id, v.versionNumber)}>
-                            <Undo2 /> Restore as draft
-                          </Button>
-                        )}
-                      </div>
+
+                      <VersionLabelRow
+                        label={v.label}
+                        isEditing={isEditing}
+                        isPending={renameMutation.isPending && editingId === v.id}
+                        onStartEdit={() => startRename(v.id)}
+                        onSave={(value) => saveLabel(v.id, value)}
+                        onCancel={cancelRename}
+                        onClear={() => saveLabel(v.id, null)}
+                      />
                     </li>
                   )
                 })}
               </ul>
             )}
-          </div>
+          </ScrollArea>
         </DialogContent>
       </Dialog>
       <ConfirmDialog />
     </>
+  )
+}
+
+interface VersionLabelRowProps {
+  label: string | null
+  isEditing: boolean
+  isPending: boolean
+  onStartEdit: () => void
+  onSave: (value: string) => void
+  onCancel: () => void
+  onClear: () => void
+}
+
+/** TemplateFieldRow-style inline-editable label pill for a version. */
+function VersionLabelRow({
+  label,
+  isEditing,
+  isPending,
+  onStartEdit,
+  onSave,
+  onCancel,
+  onClear,
+}: VersionLabelRowProps) {
+  const inputRef = useRef<AutosizeInputRef>(null)
+  const [editValue, setEditValue] = useState('')
+  const hasLabel = label != null && label !== ''
+
+  useEffect(() => {
+    if (isEditing) {
+      setEditValue(label ?? '')
+      requestAnimationFrame(() => inputRef.current?.focus())
+    }
+  }, [isEditing, label])
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      onSave(editValue)
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      e.stopPropagation()
+      onCancel()
+    }
+  }
+
+  return (
+    <div
+      onClick={!isEditing ? onStartEdit : undefined}
+      className={cn(
+        'group relative flex h-7 items-center gap-1 rounded-md bg-primary-100 px-2 transition-opacity',
+        !isEditing && 'cursor-pointer',
+        isPending && 'opacity-50'
+      )}>
+      {isEditing ? (
+        <AutosizeInput
+          ref={inputRef}
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onBlur={() => onSave(editValue)}
+          onKeyDown={handleKeyDown}
+          placeholder='e.g. pricing update'
+          inputClassName='bg-transparent text-sm text-foreground outline-none'
+          minWidth={40}
+          maxWidth={240}
+        />
+      ) : hasLabel ? (
+        <span className='truncate text-sm text-foreground'>{label}</span>
+      ) : (
+        <span className='text-sm text-muted-foreground'>Add label</span>
+      )}
+
+      {/* Actions — fade in on hover, always shown while editing */}
+      <div
+        className={cn(
+          'absolute right-1 flex items-center gap-0.5 transition-opacity duration-150',
+          isEditing ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+        )}>
+        {isEditing ? (
+          <button
+            type='button'
+            onMouseDown={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              onCancel()
+            }}
+            className='flex size-5.5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-primary-200 hover:text-foreground'>
+            <X className='size-3' />
+          </button>
+        ) : (
+          <>
+            <button
+              type='button'
+              onClick={(e) => {
+                e.stopPropagation()
+                onStartEdit()
+              }}
+              className='flex size-5.5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-primary-200 hover:text-foreground'>
+              <Pencil className='size-3' />
+            </button>
+            {hasLabel && (
+              <button
+                type='button'
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onClear()
+                }}
+                className='flex size-5.5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-primary-200 hover:text-foreground'>
+                <Trash2 className='size-3' />
+              </button>
+            )}
+          </>
+        )}
+      </div>
+    </div>
   )
 }

--- a/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
@@ -71,11 +71,12 @@ function KBEditorBody({ knowledgeBaseId, slug, hasArticlesLoaded }: KBEditorBody
         <ContainerArticlePlaceholder article={currentArticle} knowledgeBaseId={knowledgeBaseId} />
       )
     }
-    if (diffValue) {
+    if (diffValue && knowledgeBase) {
       return (
         <ArticleDiffPane
           article={currentArticle}
           knowledgeBaseId={knowledgeBaseId}
+          knowledgeBase={knowledgeBase}
           diffValue={diffValue}
           onClose={() => setDiff(null)}
         />

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/update-block-text.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/update-block-text.test.ts
@@ -1,0 +1,41 @@
+// packages/lib/src/ai/kopilot/capabilities/kb/tools/__tests__/update-block-text.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { ToolContext } from '../../../../../agent-framework/tool-context'
+import type { GetToolDeps } from '../../../types'
+import { createUpdateBlockTextTool } from '../update-block-text'
+
+// Stub deps — the multi-block guard returns before runBlockCrudOp touches the
+// db, so a never-typed stub is enough for these cases.
+const FAKE_DEPS: GetToolDeps = () =>
+  ({
+    db: {} as never,
+    organizationId: 'org-1',
+    userId: 'user-1',
+    sessionId: 'sess-1',
+  }) as ReturnType<GetToolDeps>
+
+const FAKE_CTX = {} as ToolContext
+
+describe('update_block_text multi-block guard', () => {
+  const tool = createUpdateBlockTextTool(FAKE_DEPS)
+
+  it('rejects markdown that parses to multiple blocks instead of dropping content', async () => {
+    const result = await tool.execute(
+      { blockId: 'b1', markdown: 'First paragraph.\n\nSecond paragraph.' },
+      FAKE_CTX
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/single block/i)
+    expect(result.error).toMatch(/replace_block|insert_blocks/)
+  })
+
+  it('rejects structural/container markdown (e.g. a table)', async () => {
+    const result = await tool.execute(
+      { blockId: 'b1', markdown: '| a | b |\n| --- | --- |\n| 1 | 2 |' },
+      FAKE_CTX
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/single block/i)
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/delete-blocks.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/delete-blocks.ts
@@ -1,8 +1,9 @@
 // packages/lib/src/ai/kopilot/capabilities/kb/tools/delete-blocks.ts
 
+import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
-import { buildOpToolResult, runBlockCrudOp } from './write-helpers'
+import { buildOpToolResult, EXPECTED_HASH_PARAM, runBlockCrudOp } from './write-helpers'
 
 export function createDeleteBlocksTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -19,6 +20,7 @@ export function createDeleteBlocksTool(getDeps: GetToolDeps): AgentToolDefinitio
           items: { type: 'string' },
           description: 'Block ids to delete',
         },
+        expectedHash: EXPECTED_HASH_PARAM,
       },
       required: ['blockIds'],
       additionalProperties: false,
@@ -33,7 +35,9 @@ export function createDeleteBlocksTool(getDeps: GetToolDeps): AgentToolDefinitio
           return { ok: false, error: `blockIds[${i}] must be a non-empty string` }
         }
       }
-      return { ok: true, args }
+      const expectedHash = parseStringArg(args.expectedHash, { name: 'expectedHash', max: 200 })
+      if (!expectedHash.ok) return { ok: false, error: expectedHash.error }
+      return { ok: true, args: { ...args, expectedHash: expectedHash.value } }
     },
     execute: async (args, agentDeps) => {
       const toolDeps = getDeps()
@@ -43,6 +47,7 @@ export function createDeleteBlocksTool(getDeps: GetToolDeps): AgentToolDefinitio
         toolDeps,
         patch: { op: 'delete', blockIds },
         opIndex: 0,
+        expectedHash: args.expectedHash as string | undefined,
       })
       return buildOpToolResult('delete', result)
     },

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/insert-blocks.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/insert-blocks.ts
@@ -1,10 +1,12 @@
 // packages/lib/src/ai/kopilot/capabilities/kb/tools/insert-blocks.ts
 
 import type { BlockAnchor } from '../../../../../kb/blocks/patch-types'
+import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
 import {
   buildOpToolResult,
+  EXPECTED_HASH_PARAM,
   expandBlockInputs,
   parseBlockInputs,
   runBlockCrudOp,
@@ -32,6 +34,7 @@ export function createInsertBlocksTool(getDeps: GetToolDeps): AgentToolDefinitio
             "Block payloads — { kind: 'markdown', markdown } or { kind: 'block', block: BlockJSON }",
           items: { type: 'object', additionalProperties: true },
         },
+        expectedHash: EXPECTED_HASH_PARAM,
       },
       required: ['anchor', 'blocks'],
       additionalProperties: false,
@@ -43,9 +46,15 @@ export function createInsertBlocksTool(getDeps: GetToolDeps): AgentToolDefinitio
       if (!anchor || typeof anchor !== 'object' || typeof anchor.at !== 'string') {
         return { ok: false, error: 'anchor must be { at, blockId? | containerId? }' }
       }
+      const expectedHash = parseStringArg(args.expectedHash, { name: 'expectedHash', max: 200 })
+      if (!expectedHash.ok) return { ok: false, error: expectedHash.error }
       return {
         ok: true,
-        args: { ...args, blocks: blocks.value as unknown as Record<string, unknown>[] },
+        args: {
+          ...args,
+          blocks: blocks.value as unknown as Record<string, unknown>[],
+          expectedHash: expectedHash.value,
+        },
       }
     },
     execute: async (args, agentDeps) => {
@@ -61,6 +70,7 @@ export function createInsertBlocksTool(getDeps: GetToolDeps): AgentToolDefinitio
         toolDeps,
         patch: { op: 'insert', anchor, blocks },
         opIndex: 0,
+        expectedHash: args.expectedHash as string | undefined,
       })
       return buildOpToolResult('insert', result)
     },

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/move-blocks.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/move-blocks.ts
@@ -1,9 +1,10 @@
 // packages/lib/src/ai/kopilot/capabilities/kb/tools/move-blocks.ts
 
 import type { BlockAnchor } from '../../../../../kb/blocks/patch-types'
+import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
-import { buildOpToolResult, runBlockCrudOp } from './write-helpers'
+import { buildOpToolResult, EXPECTED_HASH_PARAM, runBlockCrudOp } from './write-helpers'
 
 export function createMoveBlocksTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -26,6 +27,7 @@ export function createMoveBlocksTool(getDeps: GetToolDeps): AgentToolDefinition 
             "Where to drop them: { at: 'start'|'end' } | { at: 'before'|'after', blockId } | { at: 'startOf'|'endOf', containerId }",
           additionalProperties: true,
         },
+        expectedHash: EXPECTED_HASH_PARAM,
       },
       required: ['blockIds', 'anchor'],
       additionalProperties: false,
@@ -44,7 +46,9 @@ export function createMoveBlocksTool(getDeps: GetToolDeps): AgentToolDefinition 
       if (!anchor || typeof anchor !== 'object' || typeof anchor.at !== 'string') {
         return { ok: false, error: 'anchor must be { at, blockId? | containerId? }' }
       }
-      return { ok: true, args }
+      const expectedHash = parseStringArg(args.expectedHash, { name: 'expectedHash', max: 200 })
+      if (!expectedHash.ok) return { ok: false, error: expectedHash.error }
+      return { ok: true, args: { ...args, expectedHash: expectedHash.value } }
     },
     execute: async (args, agentDeps) => {
       const toolDeps = getDeps()
@@ -55,6 +59,7 @@ export function createMoveBlocksTool(getDeps: GetToolDeps): AgentToolDefinition 
         toolDeps,
         patch: { op: 'move', blockIds, anchor },
         opIndex: 0,
+        expectedHash: args.expectedHash as string | undefined,
       })
       return buildOpToolResult('move', result)
     },

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/replace-block.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/replace-block.ts
@@ -3,7 +3,12 @@
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
-import { buildOpToolResult, parseSingleBlock, runBlockCrudOp } from './write-helpers'
+import {
+  buildOpToolResult,
+  EXPECTED_HASH_PARAM,
+  parseSingleBlock,
+  runBlockCrudOp,
+} from './write-helpers'
 
 export function createReplaceBlockTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -21,6 +26,7 @@ export function createReplaceBlockTool(getDeps: GetToolDeps): AgentToolDefinitio
           description: 'BlockJSON replacement (id is overwritten with blockId on the server)',
           additionalProperties: true,
         },
+        expectedHash: EXPECTED_HASH_PARAM,
       },
       required: ['blockId', 'block'],
       additionalProperties: false,
@@ -30,12 +36,15 @@ export function createReplaceBlockTool(getDeps: GetToolDeps): AgentToolDefinitio
       if (!id.ok) return { ok: false, error: id.error }
       const block = parseSingleBlock(args.block, 'block')
       if (!block.ok) return { ok: false, error: block.error }
+      const expectedHash = parseStringArg(args.expectedHash, { name: 'expectedHash', max: 200 })
+      if (!expectedHash.ok) return { ok: false, error: expectedHash.error }
       return {
         ok: true,
         args: {
           ...args,
           blockId: id.value,
           block: block.value as unknown as Record<string, unknown>,
+          expectedHash: expectedHash.value,
         },
       }
     },
@@ -50,6 +59,7 @@ export function createReplaceBlockTool(getDeps: GetToolDeps): AgentToolDefinitio
         toolDeps,
         patch: { op: 'replace', blockId, block: parsed.value },
         opIndex: 0,
+        expectedHash: args.expectedHash as string | undefined,
       })
       return buildOpToolResult('replace', result)
     },

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/update-block-attrs.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/update-block-attrs.ts
@@ -3,7 +3,7 @@
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
-import { buildOpToolResult, runBlockCrudOp } from './write-helpers'
+import { buildOpToolResult, EXPECTED_HASH_PARAM, runBlockCrudOp } from './write-helpers'
 
 export function createUpdateBlockAttrsTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -21,6 +21,7 @@ export function createUpdateBlockAttrsTool(getDeps: GetToolDeps): AgentToolDefin
           description: 'Partial attrs to merge (id is silently dropped)',
           additionalProperties: true,
         },
+        expectedHash: EXPECTED_HASH_PARAM,
       },
       required: ['blockId', 'attrs'],
       additionalProperties: false,
@@ -31,7 +32,9 @@ export function createUpdateBlockAttrsTool(getDeps: GetToolDeps): AgentToolDefin
       if (!args.attrs || typeof args.attrs !== 'object') {
         return { ok: false, error: 'attrs must be an object' }
       }
-      return { ok: true, args: { ...args, blockId: id.value } }
+      const expectedHash = parseStringArg(args.expectedHash, { name: 'expectedHash', max: 200 })
+      if (!expectedHash.ok) return { ok: false, error: expectedHash.error }
+      return { ok: true, args: { ...args, blockId: id.value, expectedHash: expectedHash.value } }
     },
     execute: async (args, agentDeps) => {
       const toolDeps = getDeps()
@@ -42,6 +45,7 @@ export function createUpdateBlockAttrsTool(getDeps: GetToolDeps): AgentToolDefin
         toolDeps,
         patch: { op: 'updateAttrs', blockId, attrs },
         opIndex: 0,
+        expectedHash: args.expectedHash as string | undefined,
       })
       return buildOpToolResult('updateAttrs', result)
     },

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/update-block-text.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/update-block-text.ts
@@ -5,7 +5,7 @@ import type { InlineJSON } from '../../../../../kb/markdown/types'
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
-import { buildOpToolResult, runBlockCrudOp } from './write-helpers'
+import { buildOpToolResult, EXPECTED_HASH_PARAM, runBlockCrudOp } from './write-helpers'
 
 /**
  * Convenience write tool for prose blocks: pass markdown text, server
@@ -24,6 +24,7 @@ export function createUpdateBlockTextTool(getDeps: GetToolDeps): AgentToolDefini
       properties: {
         blockId: { type: 'string', description: 'Id of the block to edit' },
         markdown: { type: 'string', description: 'New inline content (markdown)' },
+        expectedHash: EXPECTED_HASH_PARAM,
       },
       required: ['blockId', 'markdown'],
       additionalProperties: false,
@@ -33,23 +34,38 @@ export function createUpdateBlockTextTool(getDeps: GetToolDeps): AgentToolDefini
       if (!id.ok) return { ok: false, error: id.error }
       const md = parseStringArg(args.markdown, { name: 'markdown', required: true, max: 50_000 })
       if (!md.ok) return { ok: false, error: md.error }
-      return { ok: true, args: { ...args, blockId: id.value, markdown: md.value } }
+      const expectedHash = parseStringArg(args.expectedHash, { name: 'expectedHash', max: 200 })
+      if (!expectedHash.ok) return { ok: false, error: expectedHash.error }
+      return {
+        ok: true,
+        args: { ...args, blockId: id.value, markdown: md.value, expectedHash: expectedHash.value },
+      }
     },
     execute: async (args, agentDeps) => {
       const toolDeps = getDeps()
       const blockId = args.blockId as string
       const markdown = args.markdown as string
       const nodes = mdToBlocks(markdown)
-      // Take inline content from the first block of the parsed nodes; if
-      // the markdown produces multiple blocks, the agent should use
-      // replace_block / insert_blocks instead.
-      const first = nodes.find((n) => n.type === 'block')
-      const inline = (first && first.type === 'block' ? first.content : []) as InlineJSON[]
+      // This tool edits a SINGLE block's inline text. If the markdown parses
+      // to more than one block (or to a structural/container node), bail with
+      // guidance instead of silently dropping the extra content.
+      const first = nodes[0]
+      if (nodes.length !== 1 || !first || first.type !== 'block') {
+        return {
+          success: false,
+          output: null,
+          error:
+            `update_block_text edits a single block's inline text, but the markdown parsed to ${nodes.length} ` +
+            'block(s)/structural content. Use replace_block to rewrite this block, or insert_blocks to add new blocks.',
+        }
+      }
+      const inline = first.content as InlineJSON[]
       const result = await runBlockCrudOp({
         agentDeps,
         toolDeps,
         patch: { op: 'updateText', blockId, content: inline },
         opIndex: 0,
+        expectedHash: args.expectedHash as string | undefined,
       })
       return buildOpToolResult('updateText', result)
     },

--- a/packages/lib/src/ai/kopilot/capabilities/kb/tools/write-helpers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/tools/write-helpers.ts
@@ -36,6 +36,19 @@ export type BlockInput =
 const ALLOWED_NODE_TYPES = new Set(['block', 'table', 'tabs', 'accordion'])
 
 /**
+ * Optional concurrency guard shared by every KB write tool. The agent passes
+ * back the `postHash` it received from its previous edit on the same article;
+ * `runBlockCrudOp` rejects the op if the draft changed since (a concurrent
+ * write), so the agent re-reads instead of patching stale content. Omit on the
+ * first edit of a turn.
+ */
+export const EXPECTED_HASH_PARAM = {
+  type: 'string',
+  description:
+    'Optional concurrency guard. Pass the `postHash` returned by your previous edit to this article; if the article changed since then, the edit is rejected so you can re-read (get_article / get_article_section) and retry. Omit on your first edit of a turn.',
+} as const
+
+/**
  * Expand a list of BlockInput into a flat ArticleNodeJSON[] with ids
  * stamped. Used by insert / replace tools that accept the mixed payload
  * shape. Containers (table/tabs/accordion) flow through as-is so they
@@ -76,21 +89,25 @@ export interface KopilotWriteContext {
  *  6. Publish the kb-article-patch event.
  *  7. Return the new content hash so the agent can validate.
  *
- * Hash discipline: we don't enforce a `turnExpectedHash` precondition
- * here yet (the lock prevents user races; future work adds it for
- * cross-session safety). Manual edits clear the snapshot and the next
- * write fails-soft via the apply-patch error path.
+ * Hash discipline (CAS): when the caller passes `expectedHash` (the
+ * `postHash` the agent last saw for this article), we compare it against the
+ * live draft hash BEFORE applying. On mismatch the op is rejected fail-soft
+ * with a re-read instruction — a concurrent write won't get clobbered. The
+ * lock still guards in-turn races; this adds cross-session safety. Omitting
+ * `expectedHash` preserves the old unconditional behavior (e.g. the first
+ * write of a turn, which has no prior hash to chain from).
  */
 export async function runBlockCrudOp(args: {
   agentDeps: AgentDeps
   toolDeps: ToolDeps
   patch: ArticlePatch
   opIndex: number
+  expectedHash?: string
 }): Promise<
   | { ok: true; ctx: KopilotWriteContext; effect: { blockIds: string[] } }
   | { ok: false; error: string }
 > {
-  const { agentDeps, toolDeps, patch, opIndex } = args
+  const { agentDeps, toolDeps, patch, opIndex, expectedHash } = args
   const articleId = findRef(toolDeps.sessionContext, 'article')?.id
   if (!articleId) {
     return { ok: false, error: 'no active article' }
@@ -113,6 +130,18 @@ export async function runBlockCrudOp(args: {
   const knowledgeBaseId = article.knowledgeBaseId
   const draftJson = (article.draftRevision.contentJson as ArticleNodeJSON[] | null) ?? []
   const preHash = computeArticleJsonHash(draftJson)
+
+  // CAS precondition: if the agent told us the hash it last observed and the
+  // draft has since changed (a concurrent edit), reject before capturing a
+  // snapshot, locking, or applying — so we never patch stale content.
+  if (expectedHash && expectedHash !== preHash) {
+    return {
+      ok: false,
+      error:
+        `stale_content: the article changed since your last edit (you expected hash ${expectedHash}, current is ${preHash}). ` +
+        'Re-read it with get_article or get_article_section, then retry your edit against the fresh content.',
+    }
+  }
 
   // First-write-of-turn: capture snapshot + emit lock event. We use the
   // existing snapshot key as a soft idempotency guard — if a snapshot

--- a/packages/ui/src/components/kb/article/index.ts
+++ b/packages/ui/src/components/kb/article/index.ts
@@ -8,7 +8,7 @@ export { InlineRenderer } from './inline-renderer'
 export { KBArticleCopyMenu } from './kb-article-copy-menu'
 export { KBArticleNode } from './kb-article-node'
 export { KBArticlePager } from './kb-article-pager'
-export { KBArticleRenderer } from './kb-article-renderer'
+export { KBArticleRenderer, kbArticleContainerClass } from './kb-article-renderer'
 export { KBArticleWithToc } from './kb-article-with-toc'
 export { KBTableOfContents } from './kb-toc'
 export type {

--- a/packages/ui/src/components/kb/article/kb-article-renderer.tsx
+++ b/packages/ui/src/components/kb/article/kb-article-renderer.tsx
@@ -9,6 +9,15 @@ import styles from './kb-article-renderer.module.css'
 import { KBTableOfContentsDrawer } from './kb-toc-drawer'
 import type { DocJSON, ResolveAuxxHref } from './types'
 
+/**
+ * The container class that establishes KB article base typography (font,
+ * size, color via `--kb-*` tokens) and the descendant `.kb-link` /
+ * `.kb-inline-code` / `.kb-mark` styling. Apply it to any element that renders
+ * `KBArticleNode` children outside of `KBArticleRenderer` (e.g. the diff view)
+ * so the output matches the published article instead of inheriting nothing.
+ */
+export const kbArticleContainerClass = styles.article
+
 export interface KBArticleRendererProps {
   doc: DocJSON | null | undefined
   /** Optional title rendered as <h1>; the doc's heading levels start at <h2>. */


### PR DESCRIPTION
## Summary

- Adds an optional **`expectedHash` CAS precondition** to every KB block write tool (`insert_blocks`, `replace_block`, `delete_blocks`, `move_blocks`, `update_block_attrs`, `update_block_text`). The agent passes back the `postHash` it received from its previous edit on the same article; `runBlockCrudOp` compares it against the live draft hash before applying and rejects the op fail-soft on mismatch (a concurrent write), instructing the agent to re-read (`get_article` / `get_article_section`) and retry. Omitting the hash preserves the old unconditional behavior — e.g. the first write of a turn, which has no prior hash to chain from.
- Hardens **`update_block_text`**: it edits a single block's inline text, so when the markdown parses to more than one block (or to a structural/container node like a table) it now bails with guidance to use `replace_block`/`insert_blocks` instead of silently dropping the extra content.
- Includes the article **version diff / versions-dialog** UI and `kb-article-renderer` tweaks.

## Test plan

- New unit test `update-block-text.test.ts` covers the multi-block and structural-markdown guards.
- `pnpm test` for the KB tool suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)