### PR TITLE
feat(kb): reuse article editor header in diff pane

### DIFF
--- a/apps/web/src/components/kb/ui/editor/article-diff-pane.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-diff-pane.tsx
@@ -142,6 +142,8 @@ export function ArticleDiffPane({
   return (
     <ArticleDiffView
       diff={diff}
+      article={article}
+      knowledgeBaseId={knowledgeBaseId}
       baseLabel={resolved.baseLabel}
       compareLabel={resolved.compareLabel}
       kbTheme={kbTheme}

--- a/apps/web/src/components/kb/ui/editor/article-diff-view.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-diff-view.tsx
@@ -2,19 +2,22 @@
 'use client'
 
 import type { ArticleDiff, BlockDiff } from '@auxx/lib/kb/blocks'
-import { Button } from '@auxx/ui/components/button'
 import { KBThemeProvider, type KBThemeProviderProps } from '@auxx/ui/components/kb'
 import type { ArticleNodeJSON, DiffDecorations, DocJSON } from '@auxx/ui/components/kb/article'
 import { KBArticleNode, kbArticleContainerClass } from '@auxx/ui/components/kb/article'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { cn } from '@auxx/ui/lib/utils'
-import { ArrowLeft } from 'lucide-react'
 import { useMemo } from 'react'
+import type { ArticleMeta } from '../../store/article-store'
 import { buildDiffRender } from './article-diff-tree'
 import styles from './article-diff-view.module.css'
+import { ArticleEditorHeader } from './article-editor-header'
 
 interface ArticleDiffViewProps {
   diff: ArticleDiff
+  /** Article whose editor header is reused as the diff bar. */
+  article: ArticleMeta
+  knowledgeBaseId: string
   /** Older side label, e.g. "Published" / "v3" / "Before". */
   baseLabel?: string
   /** Newer side label, e.g. "Draft" / "Kopilot". */
@@ -38,6 +41,8 @@ interface ArticleDiffViewProps {
  */
 export function ArticleDiffView({
   diff,
+  article,
+  knowledgeBaseId,
   baseLabel = 'Before',
   compareLabel = 'After',
   kbTheme,
@@ -58,19 +63,11 @@ export function ArticleDiffView({
 
   return (
     <KBThemeProvider kb={kbTheme}>
-      <div className='flex w-full items-center gap-3 border-b bg-primary-150 px-3 py-1.5'>
-        <Button variant='outline' size='xs' onClick={onClose}>
-          <ArrowLeft /> Back
-        </Button>
-        <span className='text-xs text-muted-foreground'>
-          {baseLabel} <span className='px-1'>→</span> {compareLabel}
-        </span>
-        <div className='ml-auto flex items-center gap-3 text-xs text-muted-foreground'>
-          <LegendChip color='emerald' label='Added' count={added} />
-          <LegendChip color='red' label='Removed' count={removed} />
-          <LegendChip color='amber' label='Changed' count={modified} />
-        </div>
-      </div>
+      <ArticleEditorHeader
+        article={article}
+        knowledgeBaseId={knowledgeBaseId}
+        diff={{ baseLabel, compareLabel, stats: diff.stats, onClose }}
+      />
 
       <ScrollArea className='flex-1'>
         <div className='mx-auto w-full max-w-3xl px-7 py-6'>
@@ -116,26 +113,6 @@ function DiffBlock({
     <div className={cn(styles.block, decorated)}>
       <KBArticleNode node={node} idx={idx} doc={doc} decorations={decorations} />
     </div>
-  )
-}
-
-function LegendChip({
-  color,
-  label,
-  count,
-}: {
-  color: 'emerald' | 'red' | 'amber'
-  label: string
-  count: number
-}) {
-  const dot =
-    color === 'emerald' ? 'bg-emerald-500' : color === 'red' ? 'bg-red-500' : 'bg-amber-500'
-  return (
-    <span className='inline-flex items-center gap-1.5'>
-      <span className={cn('inline-block size-2 rounded-full', dot)} />
-      {label}
-      {count > 0 ? <span className='font-medium text-foreground'>{count}</span> : null}
-    </span>
   )
 }
 

--- a/apps/web/src/components/kb/ui/editor/article-editor-header.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor-header.tsx
@@ -1,9 +1,11 @@
 // apps/web/src/components/kb/ui/editor/article-editor-header.tsx
 'use client'
 
+import type { ArticleDiff } from '@auxx/lib/kb/blocks'
 import { Button } from '@auxx/ui/components/button'
 import { getFullSlugPath, getKbPreviewHref } from '@auxx/ui/components/kb/utils'
-import { Cog, Eye } from 'lucide-react'
+import { cn } from '@auxx/ui/lib/utils'
+import { Cog, Eye, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useArticleList } from '../../hooks/use-article-list'
 import type { ArticleMeta } from '../../store/article-store'
@@ -11,12 +13,30 @@ import { ArticlePublishCluster } from './article-publish-cluster'
 import { ArticleSettingsDialog } from './article-settings-dialog'
 import { HiddenParentBadge } from './hidden-parent-badge'
 
+interface DiffHeaderInfo {
+  /** Older side label, e.g. "Published" / "v3" / "Before". */
+  baseLabel: string
+  /** Newer side label, e.g. "Draft" / "Kopilot". */
+  compareLabel: string
+  /** Change counts driving the legend chips. */
+  stats: ArticleDiff['stats']
+  /** Clears the `?diff=` param and returns to the editor. */
+  onClose: () => void
+}
+
 interface ArticleEditorHeaderProps {
   article: ArticleMeta
   knowledgeBaseId: string
+  /**
+   * When present, the header renders in diff mode: a `base → compare` label and
+   * an X close button after the hidden-parent badge, and the change legend in
+   * place of the Preview button. The left cluster (Page settings, publish
+   * status, hidden-parent badge) stays unchanged.
+   */
+  diff?: DiffHeaderInfo
 }
 
-export function ArticleEditorHeader({ article, knowledgeBaseId }: ArticleEditorHeaderProps) {
+export function ArticleEditorHeader({ article, knowledgeBaseId, diff }: ArticleEditorHeaderProps) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const articles = useArticleList(knowledgeBaseId)
 
@@ -26,17 +46,42 @@ export function ArticleEditorHeader({ article, knowledgeBaseId }: ArticleEditorH
   )
 
   return (
-    <div className='flex w-full items-center gap-2 border-b bg-primary-150 px-3 py-1.5 rounded-b-none'>
-      <Button variant='outline' size='xs' onClick={() => setIsSettingsOpen(true)}>
+    <div className='flex w-full items-center gap-2 overflow-x-auto no-scrollbar border-b bg-primary-150 px-3 py-1.5 rounded-b-none'>
+      <Button
+        variant='outline'
+        size='xs'
+        className='shrink-0'
+        onClick={() => setIsSettingsOpen(true)}>
         <Cog /> Page settings
       </Button>
       <ArticlePublishCluster article={article} knowledgeBaseId={knowledgeBaseId} />
       <HiddenParentBadge article={article} knowledgeBaseId={knowledgeBaseId} />
-      <Button variant='outline' size='xs' className='ml-auto' asChild>
-        <a href={previewHref} target='_blank' rel='noopener'>
-          <Eye /> Preview
-        </a>
-      </Button>
+      {diff ? (
+        <>
+          <span className='shrink-0 text-xs text-muted-foreground'>
+            {diff.baseLabel} <span className='px-1'>→</span> {diff.compareLabel}
+          </span>
+          <Button
+            variant='destructive-hover'
+            size='icon-xs'
+            className='shrink-0'
+            onClick={diff.onClose}
+            aria-label='Close diff'>
+            <X />
+          </Button>
+          <div className='ml-auto flex shrink-0 items-center gap-3 text-xs text-muted-foreground'>
+            <LegendChip color='emerald' label='Added' count={diff.stats.added} />
+            <LegendChip color='red' label='Removed' count={diff.stats.removed} />
+            <LegendChip color='amber' label='Changed' count={diff.stats.modified} />
+          </div>
+        </>
+      ) : (
+        <Button variant='outline' size='xs' className='ml-auto shrink-0' asChild>
+          <a href={previewHref} target='_blank' rel='noopener'>
+            <Eye /> Preview
+          </a>
+        </Button>
+      )}
       <ArticleSettingsDialog
         open={isSettingsOpen}
         onOpenChange={setIsSettingsOpen}
@@ -44,5 +89,25 @@ export function ArticleEditorHeader({ article, knowledgeBaseId }: ArticleEditorH
         knowledgeBaseId={knowledgeBaseId}
       />
     </div>
+  )
+}
+
+function LegendChip({
+  color,
+  label,
+  count,
+}: {
+  color: 'emerald' | 'red' | 'amber'
+  label: string
+  count: number
+}) {
+  const dot =
+    color === 'emerald' ? 'bg-emerald-500' : color === 'red' ? 'bg-red-500' : 'bg-amber-500'
+  return (
+    <span className='inline-flex items-center gap-1.5'>
+      <span className={cn('inline-block size-2 rounded-full', dot)} />
+      {label}
+      {count > 0 ? <span className='font-medium text-foreground'>{count}</span> : null}
+    </span>
   )
 }

--- a/apps/web/src/components/kb/ui/editor/article-publish-cluster.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-publish-cluster.tsx
@@ -126,7 +126,7 @@ export function ArticlePublishCluster({ article, knowledgeBaseId }: ArticlePubli
   return (
     <>
       <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
-        <ButtonGroup>
+        <ButtonGroup className='shrink-0'>
           <Button
             size='xs'
             variant='outline'

--- a/apps/web/src/components/kb/ui/editor/hidden-parent-badge.tsx
+++ b/apps/web/src/components/kb/ui/editor/hidden-parent-badge.tsx
@@ -39,7 +39,7 @@ export function HiddenParentBadge({ article, knowledgeBaseId }: HiddenParentBadg
 
   return (
     <Tooltip content={message}>
-      <Badge variant='amber'>
+      <Badge variant='amber' className='shrink-0'>
         <TriangleAlert />
         Parent hidden
       </Badge>


### PR DESCRIPTION
## What

The KB article **diff pane** now reuses `ArticleEditorHeader` instead of its own bespoke bar.

- After the `HiddenParentBadge`: the `base → compare` label (e.g. `Published → Draft`, `v3 → Published`, `Before → Kopilot`) and an **X close** button.
- The change **legend** (Added / Removed / Changed) replaces the **Preview** button on the right.
- The left cluster (Page settings, publish status, hidden-parent badge) stays visible and interactive.
- Applies to all three diff modes: version (`v:<id>`), draft review (`review`), and Kopilot turn review (`kopilot`).

## Layout

- Header row is `overflow-x-auto no-scrollbar` so items scroll horizontally on narrow panes instead of compressing.
- `shrink-0` baked into `ArticlePublishCluster` and `HiddenParentBadge` (and applied to the header's own inline items) so nothing squishes.

## Files

- `article-diff-pane.tsx` — passes `article` + `knowledgeBaseId` through.
- `article-diff-view.tsx` — drops its own header bar; renders `ArticleEditorHeader` in diff mode.
- `article-editor-header.tsx` — optional `diff` prop drives the diff-mode rendering; `LegendChip` moved here.
- `article-publish-cluster.tsx`, `hidden-parent-badge.tsx` — `shrink-0` on their roots.