### PR TITLE
feat(chat): chat-kind agent builder — v5 phase-2b

### DIFF
--- a/apps/web/src/components/agents/ui/list/agents-grid-view.tsx
+++ b/apps/web/src/components/agents/ui/list/agents-grid-view.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { useMemo } from 'react'
+import { LoadingSpinner } from '~/components/global/loading-content'
 import { useAgentSearch } from '../../hooks/use-agent-search'
 import { useAgents } from '../../hooks/use-agents'
 import type { AgentListItem } from '../../store/agent-store'
@@ -48,7 +49,7 @@ export function AgentsGridView() {
   }, [agents, search])
 
   if (!hasLoadedOnce) {
-    return <div className='p-6 text-sm text-muted-foreground'>Loading agents…</div>
+    return <LoadingSpinner />
   }
 
   // Truly empty (no agents in org) or no search matches — the onboarding /

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -148,12 +148,6 @@
       "import": "./dist/chat/index.mjs",
       "default": "./src/chat/index.ts"
     },
-    "./chat/agent": {
-      "types": "./src/chat/agent/index.ts",
-      "source": "./src/chat/agent/index.ts",
-      "import": "./dist/chat/agent/index.mjs",
-      "default": "./src/chat/agent/index.ts"
-    },
     "./chat-duty": {
       "types": "./src/chat-duty/index.ts",
       "source": "./src/chat-duty/index.ts",
@@ -171,6 +165,12 @@
       "source": "./src/chat-widget/visitor.ts",
       "import": "./dist/chat-widget/visitor.mjs",
       "default": "./src/chat-widget/visitor.ts"
+    },
+    "./chat/agent": {
+      "types": "./src/chat/agent/index.ts",
+      "source": "./src/chat/agent/index.ts",
+      "import": "./dist/chat/agent/index.mjs",
+      "default": "./src/chat/agent/index.ts"
     },
     "./comments": {
       "types": "./src/comments/index.ts",

--- a/packages/lib/src/agents/toolset-catalog.ts
+++ b/packages/lib/src/agents/toolset-catalog.ts
@@ -6,6 +6,7 @@ import {
   type CatalogContainerNode,
   type CatalogNode,
   type CatalogToolsetNode,
+  filterCatalogToChatSafe,
   type ToolCatalogEntry,
 } from './client'
 
@@ -74,6 +75,21 @@ export async function getOrgCatalogTree(organizationId: string): Promise<Catalog
  */
 export async function getOrgToolsetCatalog(organizationId: string): Promise<ToolsetCatalogEntry[]> {
   const tree = await getOrgCatalogTree(organizationId)
+  return flattenToolsets(tree)
+}
+
+/**
+ * Chat-safe flat toolset catalog — the same projection as
+ * `getOrgToolsetCatalog`, clamped to `chatSafe` tools only (toolsets left with
+ * zero safe tools are dropped). Used by the chat-kind agent builder so its
+ * persona prompt advertises — and `set_agent_toolsets` validates against —
+ * exactly the toolsets that survive `buildChatEngineConfig`'s runtime chat-safe
+ * filter. See plans/chat/v5 phase-2b.
+ */
+export async function getOrgChatSafeToolsetCatalog(
+  organizationId: string
+): Promise<ToolsetCatalogEntry[]> {
+  const tree = filterCatalogToChatSafe(await getOrgCatalogTree(organizationId))
   return flattenToolsets(tree)
 }
 

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/index.ts
@@ -1,8 +1,13 @@
 // packages/lib/src/ai/kopilot/capabilities/agents-builder/index.ts
 
-import { getOrgToolsetCatalog } from '../../../../agents/toolset-catalog'
+import {
+  getOrgChatSafeToolsetCatalog,
+  getOrgToolsetCatalog,
+} from '../../../../agents/toolset-catalog'
+import { getCachedAgentById } from '../../../../cache'
+import { findRef } from '../../context-refs'
 import type { GetToolDeps, PageCapability } from '../types'
-import { buildBuilderPersonaPrompt } from './persona-prompt'
+import { buildBuilderPersonaPrompt, buildChatBuilderPersonaPrompt } from './persona-prompt'
 import { createCompleteAgentSetupTool } from './tools/complete-agent-setup'
 import { createSetAgentPromptTool } from './tools/set-agent-prompt'
 import { createSetAgentResourceScopeTool } from './tools/set-agent-resource-scope'
@@ -20,28 +25,53 @@ export const AGENTS_BUILDER_PAGE = 'agents.builder'
  * `findRef(ctx, 'agent')` without taking an agentId argument.
  *
  * Persona prompt inlines the org's toolset catalog so the LLM can recommend
- * concrete toolsets by slug without needing a separate discovery tool. The
- * caller must pre-fetch the catalog via `getOrgToolsetCatalog` and pass it
- * in — keeps this factory synchronous to match the rest of the registry.
+ * concrete toolsets by slug without needing a separate discovery tool.
+ *
+ * Branches on the session agent's `kind` (resolved from the `agent` session
+ * ref): a `chat`-kind agent gets the chat-safe toolset catalog, a chat-shaped
+ * persona prompt, and a reduced tool set (no triggers / resource-scope);
+ * `internal` agents keep the full triage builder. See plans/chat/v5 phase-2b.
  */
 export async function createAgentsBuilderCapabilities(
   getDeps: GetToolDeps,
   organizationId: string
 ): Promise<PageCapability> {
-  const catalog = await getOrgToolsetCatalog(organizationId)
+  // Resolve the agent being built so the builder branches on `kind`. The agent
+  // is in the session refs (the same ref every setter tool resolves via
+  // `findRef`). `kind` is immutable, so resolving once per session build is
+  // safe. A chat-kind agent is visitor-facing: chat-safe toolsets only, a
+  // chat-shaped persona, and no triggers / resource-scope. See plans/chat/v5
+  // phase-2b.
+  const agentRef = findRef(getDeps().sessionContext, 'agent')
+  const agent = agentRef?.id ? await getCachedAgentById(organizationId, agentRef.id) : null
+  const isChat = agent?.kind === 'chat'
+
+  const catalog = isChat
+    ? await getOrgChatSafeToolsetCatalog(organizationId)
+    : await getOrgToolsetCatalog(organizationId)
+
+  // Chat agents run on the inbound-message gate, never autonomously, and don't
+  // read records — drop `set_agent_triggers` + `set_agent_resource_scope`.
+  const tools = [
+    createUpdateAgentIdentityTool(getDeps),
+    createSetAgentPromptTool(getDeps),
+    createSetAgentToolsetsTool(getDeps),
+    ...(isChat
+      ? []
+      : [createSetAgentResourceScopeTool(getDeps), createSetAgentTriggersTool(getDeps)]),
+    createCompleteAgentSetupTool(getDeps),
+  ]
+
   return {
     page: AGENTS_BUILDER_PAGE,
-    tools: [
-      createUpdateAgentIdentityTool(getDeps),
-      createSetAgentPromptTool(getDeps),
-      createSetAgentToolsetsTool(getDeps),
-      createSetAgentResourceScopeTool(getDeps),
-      createSetAgentTriggersTool(getDeps),
-      createCompleteAgentSetupTool(getDeps),
-    ],
+    tools,
     excludeGlobalTools: BUILDER_GLOBAL_TOOL_EXCLUDES,
-    systemPromptAddition: buildBuilderPersonaPrompt({ catalog }),
-    capabilities: ['Edit one agent in this workspace — name, prompt, tools, knowledge scope'],
+    systemPromptAddition: isChat
+      ? buildChatBuilderPersonaPrompt({ catalog })
+      : buildBuilderPersonaPrompt({ catalog }),
+    capabilities: isChat
+      ? ['Configure this visitor chat agent — name, persona, knowledge, escalation']
+      : ['Edit one agent in this workspace — name, prompt, tools, knowledge scope'],
   }
 }
 

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/persona-prompt.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/persona-prompt.ts
@@ -94,3 +94,105 @@ Default to none. If the admin wants autonomous runs, ask schedule vs event. \`sc
 - You don't switch the agent's model or archive/delete agents.
 `
 }
+
+/**
+ * Build the persona prompt addition for a **chat-kind** agent — a
+ * visitor-facing website-chat responder, not an internal triage agent. Differs
+ * from `buildBuilderPersonaPrompt`: no ticket/classification framing, no
+ * `@[field:…]` schema-chip rule, no triggers (chat agents run on the inbound
+ * gate, never autonomously), and the toolset surface is the chat-safe catalog.
+ * Escalation (`chat_handoff`) is always available at runtime and authored as
+ * prose in the persona. See plans/chat/v5 phase-2b.
+ */
+export function buildChatBuilderPersonaPrompt(deps: { catalog: ToolsetCatalogEntry[] }): string {
+  const { catalog } = deps
+
+  const catalogBlock = catalog.length
+    ? catalog
+        .map((entry) => {
+          const toolNames = entry.tools.map((t) => t.name).join(', ')
+          return `- \`${entry.slug}\` — ${entry.label}\n    tools: ${toolNames}`
+        })
+        .join('\n')
+    : '_(no optional toolsets available yet — the agent answers from its persona alone)_'
+
+  const avatarSlugs = BUILDER_AVATAR_POOL.map((a) => `\`${a.slug}\``).join(', ')
+
+  return `# Auxx Chat Agent Builder
+
+You configure a **visitor-facing website-chat agent** in this session's active references (it appears as an \`@agent\` reference). Every mutator tool operates on that agent — you do NOT pass an agentId.
+
+This agent answers visitors on a website chat widget. Its job is to **answer questions from the organization's published knowledge** and **hand off to a human** when it can't. It is NOT an internal triage agent: it does not classify, tag, route, or write records, and it never runs autonomously on a schedule or on record events.
+
+## How you work
+
+Two flows. Pick based on the agent's current state.
+
+### Flow A — Fresh agent (no prompt)
+
+A short interview, not a one-shot. A seed like "build me a support chat agent" is the *start*. Stage:
+
+1. **Alignment turn** — call \`plan_create\` (3–5 ordered steps), ask 1–2 clarifying questions in prose (who the visitors are, what topics it should and shouldn't answer, tone), call \`suggest_replies\`. **No setter calls in turn 1.** Wait for the admin.
+2. **Knowledge** — a chat agent answers from your knowledge base. Confirm whether to enable knowledge search (see toolsets below); on confirm, \`set_agent_toolsets\`. If it matters which articles, call \`search_knowledge\` first to ground the persona in real titles.
+3. **Persona prompt** — \`set_agent_prompt\` (see rules below).
+4. **Identity** — \`update_agent_identity\` with name + description + avatar.
+5. **Complete** — \`complete_agent_setup\`. Server rejects until prompt + ≥1 toolset + name are set; don't call early.
+
+**Hard rules:** never bundle "prompt + complete" in one turn — let the admin see the prompt land first. At least one user reply must sit between the seed and \`complete_agent_setup\`. One topic per turn.
+
+### Flow B — Existing agent
+
+Skip the interview. Call setter tools directly on the admin's explicit request; confirm in one short sentence. Never re-call \`complete_agent_setup\`.
+
+### Either flow
+
+\`suggest_replies\` whenever you ask a 2–4-option question. One clarifying question per turn.
+
+## Toolsets you can give the agent
+
+Use \`set_agent_toolsets\`. These are the **visitor-safe** toolsets (slug → tools):
+
+${catalogBlock}
+
+Only these are available to a chat agent — the full internal toolset catalog (mail, tasks, entity writes, etc.) is intentionally not offered, because those tools don't run for an anonymous visitor. Don't propose toolsets that aren't listed here.
+
+## Escalation — always on
+
+The agent can **always** hand the conversation to a human (the \`chat_handoff\` capability is built in — you do NOT enable it as a toolset). Your job is to author **when** it should, in the persona prompt as prose. Cover at least: the visitor explicitly asks for a person, the agent can't answer from its knowledge, or the request needs account-specific/sensitive action the agent can't safely take.
+
+## Persona prompt — \`set_agent_prompt\`
+
+Pass the FULL prompt as markdown (headings, lists, fences). Replaces the previous prompt wholesale. Write it as the agent's own operating instructions for talking to website visitors.
+
+**Embed \`@[tool:<name>]\` chips for each tool the agent uses** (e.g. \`@[tool:search_knowledge]\`). Backtick names are plain text — they do not render as chips.
+
+A good chat persona covers:
+- **Voice & scope** — who it's talking to, tone, what it does and doesn't help with.
+- **How it answers** — search the knowledge base with @[tool:search_knowledge] and answer from what it finds; cite KB articles inline as \`[Title](auxx://doc/<docSlug>)\` (docSlug is on each result). Don't invent facts that aren't in the knowledge base.
+- **When to hand off to a human** — the escalation conditions above, in prose.
+
+Do NOT write ticket-classification, tagging, routing, or record-update steps, and do NOT use \`@[field:…]\` chips — a chat agent doesn't touch records.
+
+Example shape:
+
+\`\`\`markdown
+# Support Chat Assistant
+
+## Voice & Scope
+You're the friendly support assistant on our website. Answer visitor questions about our products and policies. Keep replies short and warm.
+
+## How you answer
+1. Search the knowledge base with @[tool:search_knowledge] and answer from what you find.
+2. Cite the article you used inline as [Title](auxx://doc/<docSlug>).
+3. If you're unsure or it's not in the knowledge base, say so — don't guess.
+
+## When to bring in a human
+Hand off to a teammate if the visitor asks for a person, you can't answer from the knowledge base, or they need help with a specific order or account. Tell them a teammate will follow up, then stop.
+\`\`\`
+
+## Identity & limits
+
+- \`update_agent_identity\` sets name (1–100 chars), one-line description, and avatar — one slug from: ${avatarSlugs}.
+- You don't switch the agent's model, set triggers, or archive/delete agents.
+`
+}

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-toolsets.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-toolsets.ts
@@ -2,9 +2,11 @@
 
 import { batchUpdateAgentToolsets } from '../../../../../agents/agent-toolset-service'
 import {
+  getOrgChatSafeToolsetCatalog,
   getOrgToolsetCatalog,
   type ToolsetCatalogEntry,
 } from '../../../../../agents/toolset-catalog'
+import { getCachedAgentById } from '../../../../../cache'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import { findRef } from '../../../context-refs'
 import type { GetToolDeps } from '../../types'
@@ -76,7 +78,16 @@ to change; omitted slugs are left alone.`,
         return { success: false, output: null, error: 'toolsets array must have at least one row' }
       }
 
-      const catalog = await getOrgToolsetCatalog(agentDeps.organizationId)
+      // Chat-kind agents validate against the chat-safe catalog only — the
+      // same surface their builder persona advertised and the only toolsets
+      // that survive `buildChatEngineConfig`'s runtime filter. A non-safe slug
+      // for a chat agent therefore errors here instead of being silently
+      // dropped at chat runtime. See plans/chat/v5 phase-2b.
+      const agent = await getCachedAgentById(agentDeps.organizationId, agentRef.id)
+      const catalog =
+        agent?.kind === 'chat'
+          ? await getOrgChatSafeToolsetCatalog(agentDeps.organizationId)
+          : await getOrgToolsetCatalog(agentDeps.organizationId)
       const catalogBySlug = new Map<string, ToolsetCatalogEntry>(
         catalog.map((entry) => [entry.slug, entry])
       )

--- a/packages/sdk/__fixtures__/tool-app/src/app.ts
+++ b/packages/sdk/__fixtures__/tool-app/src/app.ts
@@ -9,6 +9,7 @@
 // Consumed by `src/util/__tests__/compile-and-extract-catalog.test.ts` to pin
 // the catalog projection per impl plan §5.6.
 
+import { defineFields } from '@auxx/sdk/fields'
 import { z } from 'zod/v4'
 import sendMessage from './send-message.tool.server'
 
@@ -94,7 +95,10 @@ export const app = {
       },
     ],
   },
-  fields: [
+  // Imported via `@auxx/sdk/fields` (not inlined) so catalog extraction
+  // exercises the real `defineFields` runtime — guards the esbuild resolver
+  // mapping for `@auxx/sdk/fields` (see compile-and-extract-catalog.ts).
+  fields: defineFields([
     {
       appFieldKey: 'customerId',
       type: 'TEXT',
@@ -114,5 +118,5 @@ export const app = {
         { value: 'silver', label: 'Silver' },
       ],
     },
-  ],
+  ]),
 }

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -215,11 +215,12 @@ export async function compileAndExtractCatalog(): Promise<
   // map most subpaths to types-only (e.g. `@auxx/sdk/client`, `@auxx/sdk/server`),
   // so there's no runtime file to load. We resolve the real entry points we
   // need (bare + `/tools` + `/workflow`) and stub the rest with an empty
-  // module — the catalog extractor only reads `app.{tools,toolsets,workflow}`,
+  // module — the catalog extractor only reads `app.{tools,toolsets,workflow,fields}`,
   // so other surfaces don't need real runtime.
   const SDK_REAL_BARE = path.join(SDK_ROOT, 'lib', 'root', 'index.js')
   const SDK_REAL_TOOLS = path.join(SDK_ROOT, 'lib', 'root', 'tools', 'index.js')
   const SDK_REAL_WORKFLOW = path.join(SDK_ROOT, 'lib', 'root', 'workflow', 'index.js')
+  const SDK_REAL_FIELDS = path.join(SDK_ROOT, 'lib', 'root', 'fields', 'index.js')
   const stubSdkSubpaths: esbuild.Plugin = {
     name: 'auxx-stub-sdk-subpaths',
     setup(build) {
@@ -227,6 +228,11 @@ export async function compileAndExtractCatalog(): Promise<
         if (args.path === '@auxx/sdk') return { path: SDK_REAL_BARE }
         if (args.path === '@auxx/sdk/tools') return { path: SDK_REAL_TOOLS }
         if (args.path === '@auxx/sdk/workflow') return { path: SDK_REAL_WORKFLOW }
+        // `defineFields` runs at module load to build the catalog, so it must
+        // resolve to real runtime — the no-op stub Proxy has no own enumerable
+        // keys, so esbuild's CJS→ESM interop drops the named export and the
+        // call throws `defineFields is not a function`.
+        if (args.path === '@auxx/sdk/fields') return { path: SDK_REAL_FIELDS }
         return { path: args.path, namespace: 'auxx-sdk-stub' }
       })
       // CJS module shape with a Proxy: any named import becomes a no-op


### PR DESCRIPTION
## Summary

Branches the Kopilot **agents-builder** capability on the session agent's `kind`, so a chat-kind (visitor-facing website chat) agent gets a builder tailored to its runtime, while internal triage agents keep the existing full builder.

For a `chat`-kind agent, the builder now:

- Uses the **chat-safe toolset catalog** (`getOrgChatSafeToolsetCatalog`) — the same projection as `getOrgToolsetCatalog`, clamped to `chatSafe` tools. The persona prompt advertises, and `set_agent_toolsets` validates against, exactly the toolsets that survive `buildChatEngineConfig`'s runtime chat-safe filter. A non-safe slug now errors at config time instead of being silently dropped at chat runtime.
- Renders a **chat-shaped persona prompt** (`buildChatBuilderPersonaPrompt`): no ticket/classification framing, no `@[field:…]` schema chips, escalation authored as prose. `chat_handoff` is always-on (not a toolset).
- Exposes a **reduced tool set** — drops `set_agent_triggers` and `set_agent_resource_scope` (chat agents run on the inbound-message gate, never autonomously, and don't read records).

## Also in this PR

- **sdk**: catalog extraction now exercises the real `defineFields` runtime. The esbuild stub plugin resolves `@auxx/sdk/fields` to real runtime so the named export isn't dropped by CJS→ESM interop (`defineFields is not a function`). Fixture `app.ts` imports `defineFields` instead of inlining the array.
- **agents**: swap the `Loading agents…` text for `LoadingSpinner` in the grid view.

## Test plan

- [ ] Build a chat-kind agent via Kopilot — confirm chat persona, chat-safe toolsets only, no triggers/resource-scope tools.
- [ ] Build an internal agent — confirm the full builder is unchanged.
- [ ] `set_agent_toolsets` with a non-chat-safe slug on a chat agent errors.
- [ ] SDK catalog extraction test passes (`compile-and-extract-catalog.test.ts`).