### PR TITLE
feat(agents): per-tool surfaces + externalSafe (replace chatSafe)

### DIFF
--- a/apps/web/src/components/agents/hooks/use-tool-catalog.ts
+++ b/apps/web/src/components/agents/hooks/use-tool-catalog.ts
@@ -2,20 +2,22 @@
 'use client'
 
 import {
+  type AgentSurface,
   buildCatalogTreeFromInstallations,
   type CatalogNode,
-  filterCatalogToChatSafe,
+  filterCatalogToSurface,
 } from '@auxx/lib/agents/client'
 import { useMemo } from 'react'
 import { useExtensionsContext } from '~/providers/extensions/extensions-context'
 
 interface UseToolCatalogOptions {
   /**
-   * Clamp the catalog to chat-safe tools only — set for chat-kind agents so
-   * the picker can't surface tools that aren't safe for an anonymous visitor.
-   * See plans/chat/v5 phase-2 §5.
+   * Clamp the catalog to tools offered on this surface — set to `'chat'` for
+   * chat-kind agents so the picker only shows what survives the runtime surface
+   * filter. Absent ⇒ the full catalog (admin/internal view). See
+   * plans/chat/v6/chat-tool-availability.md.
    */
-  chatSafeOnly?: boolean
+  surface?: AgentSurface
 }
 
 /**
@@ -29,11 +31,11 @@ export function useToolCatalog(options: UseToolCatalogOptions = {}): {
   catalog: CatalogNode[]
   isLoading: boolean
 } {
-  const { chatSafeOnly = false } = options
+  const { surface } = options
   const { appInstallations, isLoading } = useExtensionsContext()
   const catalog = useMemo(() => {
     const tree = buildCatalogTreeFromInstallations(appInstallations)
-    return chatSafeOnly ? filterCatalogToChatSafe(tree) : tree
-  }, [appInstallations, chatSafeOnly])
+    return surface ? filterCatalogToSurface(tree, surface) : tree
+  }, [appInstallations, surface])
   return { catalog, isLoading }
 }

--- a/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
@@ -184,15 +184,7 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
         </div>
 
         <div ref={assignRef('restrictions')}>
-          <Section
-            title='Restrictions'
-            icon={<ShieldCheck className='size-4' />}
-            className='[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
-            initialOpen
-            description='Pin or require tool arguments so this agent stays scoped — lock identity args for chat.'
-            collapsible={false}>
-            <RestrictionsSectionContent agent={agent} />
-          </Section>
+          <RestrictionsSection agent={agent} />
         </div>
 
         <div ref={assignRef('knowledge')}>
@@ -255,6 +247,45 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
   )
 }
 
+/**
+ * Restrictions tab wrapper. Owns the add/edit dialog state so the "Add
+ * restriction" trigger can sit in `<Section actions>` alongside Tools and
+ * Triggers, while the dialog itself renders inside the section content.
+ */
+function RestrictionsSection({ agent }: { agent: AgentDetail }) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editing, setEditing] = useState<{ registeredName: string; arg: string } | null>(null)
+  return (
+    <Section
+      title='Restrictions'
+      icon={<ShieldCheck className='size-4' />}
+      className='[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
+      initialOpen
+      description='Pin or require tool arguments so this agent stays scoped — lock identity args for chat.'
+      collapsible={false}
+      actions={
+        <Button
+          variant='ghost'
+          size='xs'
+          onClick={() => {
+            setEditing(null)
+            setDialogOpen(true)
+          }}>
+          <Plus />
+          Add restriction
+        </Button>
+      }>
+      <RestrictionsSectionContent
+        agent={agent}
+        dialogOpen={dialogOpen}
+        onDialogOpenChange={setDialogOpen}
+        editing={editing}
+        onEditingChange={setEditing}
+      />
+    </Section>
+  )
+}
+
 interface ToolsSectionProps {
   agent: AgentDetail
   onAutosaveChange?: (state: AutosaveState) => void
@@ -314,7 +345,7 @@ function ToolsSection({ agent, onAutosaveChange }: ToolsSectionProps) {
       <ToolSelectDialog
         installedToolsets={agent.toolsets}
         boundAppIds={boundAppIds}
-        chatSafeOnly={agent.kind === 'chat'}
+        surface={agent.kind === 'chat' ? 'chat' : undefined}
         onToggleToolset={toggleToolset}
         onToggleToolsets={toggleToolsets}
         open={dialogOpen}

--- a/apps/web/src/components/agents/ui/detail/restrictions/restrictions-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/restrictions/restrictions-section-content.tsx
@@ -2,12 +2,11 @@
 'use client'
 
 import type { ArgRestriction, ToolRestrictionMap } from '@auxx/lib/agents/restrictions/client'
-import { Button } from '@auxx/ui/components/button'
 import { EmptySection } from '@auxx/ui/components/section'
 import { TreeRow } from '@auxx/ui/components/tree-row'
 import { pluralize } from '@auxx/utils/strings'
-import { AlertTriangle, Plus, ShieldCheck } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { AlertTriangle, ShieldCheck } from 'lucide-react'
+import { useMemo } from 'react'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { Tooltip } from '~/components/global/tooltip'
 import { useConfirm } from '~/hooks/use-confirm'
@@ -20,6 +19,12 @@ import { RestrictionRow } from './restriction-row'
 
 interface RestrictionsSectionContentProps {
   agent: AgentDetail
+  /** Controlled add/edit dialog open state — the "Add restriction" trigger lives in `<Section actions>`. */
+  dialogOpen: boolean
+  onDialogOpenChange: (open: boolean) => void
+  /** Which restriction is being edited (`null` ⇒ adding a new one). */
+  editing: { registeredName: string; arg: string } | null
+  onEditingChange: (editing: { registeredName: string; arg: string } | null) => void
 }
 
 /** Render a restriction's bound value as a short label for the row secondary. */
@@ -42,10 +47,14 @@ function valueLabelFor(restriction: ArgRestriction, varLabelById: Map<string, st
  * identity arg is unbound (fail-closed). Disabled-tool entries are kept in the
  * map but hidden. See plans/chat/v6 phase-4.
  */
-export function RestrictionsSectionContent({ agent }: RestrictionsSectionContentProps) {
+export function RestrictionsSectionContent({
+  agent,
+  dialogOpen,
+  onDialogOpenChange,
+  editing,
+  onEditingChange,
+}: RestrictionsSectionContentProps) {
   const [confirm, ConfirmDialog] = useConfirm()
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [editing, setEditing] = useState<{ registeredName: string; arg: string } | null>(null)
 
   const toolMeta = useToolMeta(agent)
   const { restrictions, save } = useRestrictions(agent)
@@ -131,13 +140,9 @@ export function RestrictionsSectionContent({ agent }: RestrictionsSectionContent
     await save(next)
   }
 
-  const openAdd = () => {
-    setEditing(null)
-    setDialogOpen(true)
-  }
   const openEdit = (registeredName: string, arg: string) => {
-    setEditing({ registeredName, arg })
-    setDialogOpen(true)
+    onEditingChange({ registeredName, arg })
+    onDialogOpenChange(true)
   }
 
   const editingRestriction = editing
@@ -226,16 +231,9 @@ export function RestrictionsSectionContent({ agent }: RestrictionsSectionContent
         </p>
       ) : null}
 
-      <div className='px-3'>
-        <Button variant='ghost' size='xs' onClick={openAdd}>
-          <Plus />
-          Add restriction
-        </Button>
-      </div>
-
       <AddRestrictionDialog
         open={dialogOpen}
-        onOpenChange={setDialogOpen}
+        onOpenChange={onDialogOpenChange}
         agent={agent}
         toolMeta={toolMeta}
         editing={editing}

--- a/apps/web/src/components/agents/ui/detail/tools/catalog-node-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/catalog-node-row.tsx
@@ -4,7 +4,7 @@
 import type { CatalogNode, CatalogToolsetNode } from '@auxx/lib/agents/client'
 import { TreeRow } from '@auxx/ui/components/tree-row'
 import { pluralize } from '@auxx/utils/strings'
-import { Lock, Plus, Settings } from 'lucide-react'
+import { AlertTriangle, Lock, Plus, Settings } from 'lucide-react'
 import { useBoundCredential } from '~/components/apps/hooks/use-bound-credential'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { AppWithStatusIcon } from '~/components/apps/ui/app-with-status-icon'
@@ -59,6 +59,12 @@ interface CatalogNodeRowProps {
    * `AppWithStatusIcon`. See plans/kopilot/apps/agent-credentials.md §5.6.
    */
   boundCredIdByApp?: Record<string, string | undefined>
+  /**
+   * Flag toolsets containing tools not verified safe for an untrusted visitor
+   * (`externalSafe` absent). Set for chat-kind agents. See
+   * plans/chat/v6/chat-tool-availability.md.
+   */
+  warnNotExternalSafe?: boolean
 }
 
 /**
@@ -81,6 +87,7 @@ export function CatalogNodeRow({
   onAddToApp,
   onOpenAccountPicker,
   boundCredIdByApp,
+  warnNotExternalSafe,
 }: CatalogNodeRowProps) {
   const iconId = node.iconId ?? inheritedIconId
   const color = node.color ?? inheritedColor
@@ -97,6 +104,7 @@ export function CatalogNodeRow({
         toolCount={node.tools.length}
         source={state.source}
         restrictionCount={restrictionCountBySlug?.get(node.slug) ?? 0}
+        warn={Boolean(warnNotExternalSafe) && hasUnverifiedTool(node)}
         onRemove={onRemove ? () => onRemove(node) : undefined}
       />
     )
@@ -105,6 +113,7 @@ export function CatalogNodeRow({
   const isOpen = !collapsed.has(node.id)
   const stats = summarizeContainer(node, stateBySlug)
   const restrictionCount = countRestrictions(node, restrictionCountBySlug)
+  const containerWarn = Boolean(warnNotExternalSafe) && hasUnverifiedTool(node)
   const isApp = node.kind === 'app'
   const isInstalledApp = isApp && !node.isBuiltin
   // App container nodes carry the prefixed id `app:<appId>` so the tree can
@@ -131,6 +140,7 @@ export function CatalogNodeRow({
               {stats.enabled} {pluralize(stats.enabled, 'tool')}
             </span>
             {restrictionCount > 0 ? <RestrictionLockBadge count={restrictionCount} /> : null}
+            {containerWarn ? <ChatWarnBadge /> : null}
             <span className='text-muted-foreground'>·</span>
             <CredentialBadge
               credId={boundCredId}
@@ -143,6 +153,7 @@ export function CatalogNodeRow({
               {stats.enabled} {pluralize(stats.enabled, 'tool')}
             </span>
             {restrictionCount > 0 ? <RestrictionLockBadge count={restrictionCount} /> : null}
+            {containerWarn ? <ChatWarnBadge /> : null}
           </span>
         )
       }
@@ -174,9 +185,29 @@ export function CatalogNodeRow({
           onAddToApp={onAddToApp}
           onOpenAccountPicker={onOpenAccountPicker}
           boundCredIdByApp={boundCredIdByApp}
+          warnNotExternalSafe={warnNotExternalSafe}
         />
       ))}
     </TreeRow>
+  )
+}
+
+/** True when any toolset leaf under `node` has a tool that isn't `externalSafe`. */
+function hasUnverifiedTool(node: CatalogNode): boolean {
+  for (const leaf of collectLeaves(node)) {
+    if (leaf.tools.some((t) => t.externalSafe !== true)) return true
+  }
+  return false
+}
+
+/** Amber warning badge for toolsets not verified safe for visitor chat. */
+function ChatWarnBadge() {
+  return (
+    <Tooltip content='Not verified safe for visitor chat — scope its arguments under Restrictions.'>
+      <span className='inline-flex'>
+        <AlertTriangle className='size-3 text-amber-500' />
+      </span>
+    </Tooltip>
   )
 }
 

--- a/apps/web/src/components/agents/ui/detail/tools/tool-select-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tool-select-dialog.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/agents/ui/detail/tools/tool-select-dialog.tsx
 'use client'
 
-import type { CatalogContainerNode, CatalogNode } from '@auxx/lib/agents/client'
+import type { AgentSurface, CatalogContainerNode, CatalogNode } from '@auxx/lib/agents/client'
 import { flattenCatalogToToolsets } from '@auxx/lib/agents/client'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -44,8 +44,11 @@ interface ToolSelectDialogProps {
    * for this app id. The Back button still returns to the Apps list.
    */
   initialAppId?: string
-  /** Clamp the catalog to chat-safe tools (chat-kind agents). See plans/chat/v5 phase-2 §5. */
-  chatSafeOnly?: boolean
+  /**
+   * Clamp the catalog to one surface (e.g. `'chat'` for chat-kind agents). See
+   * plans/chat/v6/chat-tool-availability.md.
+   */
+  surface?: AgentSurface
 }
 
 type ViewMode = 'list' | 'app-detail'
@@ -71,9 +74,9 @@ export function ToolSelectDialog({
   open,
   onOpenChange,
   initialAppId,
-  chatSafeOnly = false,
+  surface,
 }: ToolSelectDialogProps) {
-  const { catalog: catalogData, isLoading: catalogIsLoading } = useToolCatalog({ chatSafeOnly })
+  const { catalog: catalogData, isLoading: catalogIsLoading } = useToolCatalog({ surface })
 
   const [viewMode, setViewMode] = useState<ViewMode>('list')
   const [tab, setTab] = useState<ListTab>('all')

--- a/apps/web/src/components/agents/ui/detail/tools/tools-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tools-section-content.tsx
@@ -42,7 +42,7 @@ export function ToolsSectionContent({
   onAddToApp,
 }: ToolsSectionContentProps) {
   const { catalog, isLoading: catalogIsLoading } = useToolCatalog({
-    chatSafeOnly: agent.kind === 'chat',
+    surface: agent.kind === 'chat' ? 'chat' : undefined,
   })
 
   const handleSavingChange = useCallback(
@@ -220,6 +220,7 @@ export function ToolsSectionContent({
           onAddToApp={onAddToApp}
           onOpenAccountPicker={setAccountPickerAppId}
           boundCredIdByApp={boundCredIdByApp}
+          warnNotExternalSafe={agent.kind === 'chat'}
         />
       ))}
       <AppAccountDialog

--- a/apps/web/src/components/agents/ui/detail/tools/toolset-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/toolset-row.tsx
@@ -3,7 +3,7 @@
 
 import { TreeRow } from '@auxx/ui/components/tree-row'
 import { pluralize } from '@auxx/utils/strings'
-import { Lock } from 'lucide-react'
+import { AlertTriangle, Lock } from 'lucide-react'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { Tooltip } from '~/components/global/tooltip'
 import { RemoveButton } from './remove-button'
@@ -19,6 +19,12 @@ export interface ToolsetRowProps {
   source: 'manual' | 'mention' | 'auto_default'
   /** Read-only restriction count for this toolset; ≥1 shows a lock badge. */
   restrictionCount?: number
+  /**
+   * Chat/email warning — this toolset has ≥1 tool not verified safe for an
+   * untrusted visitor (`externalSafe` absent). Shows an `AlertTriangle`. See
+   * plans/chat/v6/chat-tool-availability.md.
+   */
+  warn?: boolean
   depth?: number
   onRemove?: () => void
 }
@@ -37,6 +43,7 @@ export function ToolsetRow({
   toolCount,
   source,
   restrictionCount = 0,
+  warn = false,
   depth = 0,
   onRemove,
 }: ToolsetRowProps) {
@@ -54,6 +61,13 @@ export function ToolsetRow({
       secondary={
         <span className='inline-flex items-center gap-2'>
           <span>{`${toolCount} ${toolCount === 1 ? 'tool' : 'tools'}`}</span>
+          {warn ? (
+            <Tooltip content='Not verified safe for visitor chat — scope its arguments under Restrictions.'>
+              <span className='inline-flex'>
+                <AlertTriangle className='size-3 text-amber-500' />
+              </span>
+            </Tooltip>
+          ) : null}
           {restrictionCount > 0 ? (
             <Tooltip
               content={`${restrictionCount} ${pluralize(restrictionCount, 'restricted argument')}`}>

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -32,6 +32,9 @@ export interface CatalogTool {
   refs: Array<{ path: string[]; kind: string }>
 }
 
+/** Where an agent tool may run — mirrors `@auxx/lib` `AgentSurface`. */
+export type AgentSurface = 'internal' | 'chat' | 'email' | 'builder'
+
 export interface CatalogAgentTool extends CatalogTool {
   /** LLM-facing name (snake_case). May differ from CatalogTool.name. */
   agentName: string
@@ -40,13 +43,18 @@ export interface CatalogAgentTool extends CatalogTool {
   toolsetSlug: string
   idempotent?: boolean
   /**
-   * Soft hint surfaced to the chat-kind agent catalog (builder recommendations
-   * + picker declutter), carried verbatim from the SDK's `tool.agent.chatSafe`.
-   * Absent ⇒ not chat-safe. NOT a runtime gate. The installed-apps cache
-   * forwards it onto `CachedAgentTool.chatSafe` via spread. See plans/chat/v6
-   * phase-3.
+   * Surfaces this tool is offered on, carried verbatim from the SDK's
+   * `tool.agent.surfaces`. Absent ⇒ all surfaces. NOT a runtime gate. The
+   * installed-apps cache forwards it onto `CachedAgentTool` via spread. See
+   * plans/chat/v6/chat-tool-availability.md.
    */
-  chatSafe?: boolean
+  surfaces?: AgentSurface[]
+  /**
+   * Advisory chat/email-warning flag, carried verbatim from the SDK's
+   * `tool.agent.externalSafe`. Absent ⇒ warn. NOT a gate. See
+   * plans/chat/v6/chat-tool-availability.md.
+   */
+  externalSafe?: boolean
   /**
    * Identity/record-scope args the engine fail-closes on in a visitor turn —
    * carried verbatim from the SDK's `tool.agent.identityScopedInputs`. The

--- a/packages/lib/src/agents/__tests__/filter-catalog-to-surface.test.ts
+++ b/packages/lib/src/agents/__tests__/filter-catalog-to-surface.test.ts
@@ -1,0 +1,120 @@
+// packages/lib/src/agents/__tests__/filter-catalog-to-surface.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { CatalogNode } from '../client'
+import { filterCatalogToSurface } from '../client'
+
+/** Minimal app → toolset tree with three tools of varying `surfaces`/`externalSafe`. */
+function fixture(): CatalogNode[] {
+  return [
+    {
+      kind: 'app',
+      id: 'app:auxx',
+      label: 'Auxx.ai',
+      iconId: 'package',
+      color: null,
+      isBuiltin: true,
+      children: [
+        {
+          kind: 'toolset',
+          id: 'auxx:entities:search',
+          slug: 'auxx:entities:search',
+          label: 'Search',
+          fullLabel: 'Records · Search',
+          description: '',
+          isDefault: false,
+          isPopular: false,
+          tools: [
+            // default surfaces (absent ⇒ all), not externalSafe
+            { name: 'search_entities', displayName: 'Search records', description: '' },
+            // schema read, externalSafe
+            {
+              name: 'list_entities',
+              displayName: 'List entity types',
+              description: '',
+              externalSafe: true,
+            },
+          ],
+        },
+        {
+          kind: 'toolset',
+          id: 'auxx:builder',
+          slug: 'auxx:builder',
+          label: 'Builder',
+          fullLabel: 'Agent builder',
+          description: '',
+          isDefault: false,
+          isPopular: false,
+          tools: [
+            {
+              name: 'set_agent_prompt',
+              displayName: 'Set prompt',
+              description: '',
+              surfaces: ['builder'],
+            },
+          ],
+        },
+      ],
+    },
+  ]
+}
+
+describe('filterCatalogToSurface', () => {
+  it('keeps default-surface tools and drops surface-narrowed ones for chat', () => {
+    const out = filterCatalogToSurface(fixture(), 'chat')
+    const slugs = collectToolsetSlugs(out)
+    // The builder-only toolset has zero chat tools → dropped entirely.
+    expect(slugs).toEqual(['auxx:entities:search'])
+    const tools = toolNames(out, 'auxx:entities:search')
+    expect(tools).toEqual(['search_entities', 'list_entities'])
+  })
+
+  it('preserves externalSafe on surviving tools', () => {
+    const out = filterCatalogToSurface(fixture(), 'chat')
+    const search = findTool(out, 'search_entities')
+    const list = findTool(out, 'list_entities')
+    expect(search?.externalSafe).toBeUndefined()
+    expect(list?.externalSafe).toBe(true)
+  })
+
+  it('keeps the builder-only tool for the builder surface (alongside default-all reads)', () => {
+    const out = filterCatalogToSurface(fixture(), 'builder')
+    // Default-all reads are offered on every surface; the builder tool also
+    // survives here (page-gate, not `surfaces`, isolates the builder session).
+    expect(collectToolsetSlugs(out)).toEqual(['auxx:entities:search', 'auxx:builder'])
+    expect(toolNames(out, 'auxx:builder')).toEqual(['set_agent_prompt'])
+  })
+})
+
+function collectToolsetSlugs(nodes: CatalogNode[]): string[] {
+  const out: string[] = []
+  const walk = (n: CatalogNode) => {
+    if (n.kind === 'toolset') out.push(n.slug)
+    else n.children.forEach(walk)
+  }
+  nodes.forEach(walk)
+  return out
+}
+
+function toolNames(nodes: CatalogNode[], slug: string): string[] {
+  const out: string[] = []
+  const walk = (n: CatalogNode) => {
+    if (n.kind === 'toolset') {
+      if (n.slug === slug) out.push(...n.tools.map((t) => t.name))
+    } else n.children.forEach(walk)
+  }
+  nodes.forEach(walk)
+  return out
+}
+
+function findTool(nodes: CatalogNode[], name: string) {
+  let found: { name: string; externalSafe?: boolean } | undefined
+  const walk = (n: CatalogNode) => {
+    if (n.kind === 'toolset') {
+      const t = n.tools.find((x) => x.name === name)
+      if (t) found = t
+    } else n.children.forEach(walk)
+  }
+  nodes.forEach(walk)
+  return found
+}

--- a/packages/lib/src/agents/builtin-installed-row.ts
+++ b/packages/lib/src/agents/builtin-installed-row.ts
@@ -70,7 +70,8 @@ function buildBuiltinAgentTools(): CachedAgentTool[] {
         // the LLM actually invokes.
         registeredName: tool.name,
         iconId: lookupIconForSlug(tool.toolsetSlug),
-        chatSafe: tool.chatSafe,
+        surfaces: tool.surfaces,
+        externalSafe: tool.externalSafe,
         identityScopedInputs: tool.identityScopedInputs,
       })
     }

--- a/packages/lib/src/agents/client.ts
+++ b/packages/lib/src/agents/client.ts
@@ -8,19 +8,35 @@
 
 export type AgentScopeMode = 'include_descendants' | 'include_one' | 'exclude'
 
+/**
+ * Where a tool may run — mirrors `AgentKind` (`internal | chat`) plus the
+ * agent-builder Kopilot and the future email agent. A tool's `surfaces` is an
+ * allow-list; absent ⇒ {@link ALL_SURFACES} (offered everywhere). NOT a
+ * security boundary — adding a toolset to an agent (admin act) + the
+ * restriction engine are. See plans/chat/v6/chat-tool-availability.md.
+ */
+export type AgentSurface = 'internal' | 'chat' | 'email' | 'builder'
+
+/** Default `surfaces` when a tool declares none — offered on every surface. */
+export const ALL_SURFACES: readonly AgentSurface[] = ['internal', 'chat', 'email', 'builder']
+
 export interface ToolCatalogEntry {
   name: string
   /** Short, human-friendly label for chips, pickers, and audit UI. */
   displayName: string
   description: string
   /**
-   * Opt-in: this tool is safe to register on a chat-kind (visitor-facing)
-   * agent. Mirrors `AgentToolDefinition.chatSafe`. Absent / false ⇒ the tool
-   * is hidden from the chat-kind toolset catalog. Phase 4 is the first to
-   * populate this through the projection; until then the chat catalog is
-   * empty. See plans/chat/v5.
+   * Surfaces this tool is offered on. Absent ⇒ {@link ALL_SURFACES}. Mirrors
+   * `AgentToolDefinition.surfaces`; drives `filterCatalogToSurface`. Not a gate.
    */
-  chatSafe?: boolean
+  surfaces?: AgentSurface[]
+  /**
+   * Advisory: verified safe for an untrusted, externally-identified caller
+   * (anonymous/just-verified chat visitor, email sender). Absent ⇒ the
+   * chat/email Tools UI flags the tool with a warning. Replaces `chatSafe`.
+   * Not a gate. See plans/chat/v6/chat-tool-availability.md.
+   */
+  externalSafe?: boolean
 }
 
 /**
@@ -132,18 +148,17 @@ export function flattenCatalogToToolsets(roots: CatalogNode[]): FlatToolsetCatal
 }
 
 /**
- * Prune a catalog tree to only the tools that are `chatSafe`, dropping any
- * toolset left with zero tools and any container left with no children. Used
- * by the agent detail UI to clamp a chat-kind agent's toolset catalog to the
- * visitor-safe surface. Pure — returns fresh nodes, never mutates the input.
- *
- * Until the first `chatSafe` tool ships (phase 4) this returns `[]` for every
- * input, which is the intended phase-2 behavior. See plans/chat/v5 phase-2 §5.
+ * Prune a catalog tree to the tools offered on `surface`, dropping any toolset
+ * left with zero tools and any container left with no children. A tool with no
+ * `surfaces` defaults to {@link ALL_SURFACES} (offered everywhere), so with
+ * today's tools this only drops builder-only tools from non-builder surfaces.
+ * Pure — returns fresh nodes, never mutates the input. See
+ * plans/chat/v6/chat-tool-availability.md.
  */
-export function filterCatalogToChatSafe(roots: CatalogNode[]): CatalogNode[] {
+export function filterCatalogToSurface(roots: CatalogNode[], surface: AgentSurface): CatalogNode[] {
   const pruneNode = (node: CatalogNode): CatalogNode | null => {
     if (node.kind === 'toolset') {
-      const tools = node.tools.filter((t) => t.chatSafe === true)
+      const tools = node.tools.filter((t) => (t.surfaces ?? ALL_SURFACES).includes(surface))
       return tools.length > 0 ? { ...node, tools } : null
     }
     const children = node.children.map(pruneNode).filter((n): n is CatalogNode => n !== null)
@@ -184,8 +199,10 @@ export interface CachedInstalledAppLike {
     name: string
     description: string
     toolsetSlug: string
-    /** Mirrors `AgentToolDefinition.chatSafe` — surfaces the tool in the chat-kind catalog. */
-    chatSafe?: boolean
+    /** Mirrors `AgentToolDefinition.surfaces` — where the tool is offered. Absent ⇒ all. */
+    surfaces?: AgentSurface[]
+    /** Mirrors `AgentToolDefinition.externalSafe` — drives the chat/email warning. */
+    externalSafe?: boolean
     /**
      * Identity/record-scope args the engine fail-closes on in a visitor turn.
      * See plans/chat/v6 phase-3.
@@ -338,7 +355,8 @@ export function buildCatalogTreeFromInstallations(
         name: tool.id,
         displayName: tool.name,
         description: shortDescription(tool.description),
-        chatSafe: tool.chatSafe,
+        surfaces: tool.surfaces,
+        externalSafe: tool.externalSafe,
       })
       toolsBySlug.set(tool.toolsetSlug, arr)
     }

--- a/packages/lib/src/agents/toolset-catalog.ts
+++ b/packages/lib/src/agents/toolset-catalog.ts
@@ -2,11 +2,12 @@
 
 import { getOrgCache } from '../cache'
 import {
+  type AgentSurface,
   buildCatalogTreeFromInstallations,
   type CatalogContainerNode,
   type CatalogNode,
   type CatalogToolsetNode,
-  filterCatalogToChatSafe,
+  filterCatalogToSurface,
   type ToolCatalogEntry,
 } from './client'
 
@@ -79,17 +80,19 @@ export async function getOrgToolsetCatalog(organizationId: string): Promise<Tool
 }
 
 /**
- * Chat-safe flat toolset catalog — the same projection as
- * `getOrgToolsetCatalog`, clamped to `chatSafe` tools only (toolsets left with
- * zero safe tools are dropped). Used by the chat-kind agent builder so its
- * persona prompt advertises — and `set_agent_toolsets` validates against —
- * exactly the toolsets that survive `buildChatEngineConfig`'s runtime chat-safe
- * filter. See plans/chat/v5 phase-2b.
+ * Flat toolset catalog clamped to one surface — the same projection as
+ * `getOrgToolsetCatalog`, dropping tools not offered on `surface` (and toolsets
+ * left empty). Used by the agent builder so a chat agent's persona advertises —
+ * and `set_agent_toolsets` validates against — exactly the toolsets that survive
+ * `buildChatEngineConfig`'s runtime surface filter. With default-all `surfaces`,
+ * this only drops surface-narrowed tools (e.g. builder meta-tools). See
+ * plans/chat/v6/chat-tool-availability.md.
  */
-export async function getOrgChatSafeToolsetCatalog(
-  organizationId: string
+export async function getOrgToolsetCatalogForSurface(
+  organizationId: string,
+  surface: AgentSurface
 ): Promise<ToolsetCatalogEntry[]> {
-  const tree = filterCatalogToChatSafe(await getOrgCatalogTree(organizationId))
+  const tree = filterCatalogToSurface(await getOrgCatalogTree(organizationId), surface)
   return flattenToolsets(tree)
 }
 

--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -2,6 +2,7 @@
 
 import type { Database } from '@auxx/database'
 import type { z } from 'zod'
+import type { AgentSurface } from '../../agents/client'
 import type { Message, ModelParameters, Tool, ToolCall, UsageMetrics } from '../clients/base/types'
 import type { ChatInvocationContext, ToolContext, WorkflowToolContext } from './tool-context'
 
@@ -296,13 +297,21 @@ export interface AgentToolDefinition {
    */
   toolsetSlug?: string
   /**
-   * Opt-in: tool is safe to register on a chat-kind agent (visitor-facing).
-   * Defaults to false. The chat-kind agent toolset catalog filters by this
-   * flag (`tools.filter(t => t.chatSafe)`), so a tool that doesn't set it is
-   * never exposed to an anonymous visitor. New tools must explicitly opt in.
-   * See plans/chat/v5 — phase 4 ships the first `chatSafe` tool (`kb.search`).
+   * Surfaces this tool is offered on (allow-list). Absent ⇒ every surface
+   * (the permissive default). Narrow it only when a tool makes no sense in a
+   * context — e.g. the agent-builder meta-tools set `['builder']`. NOT a
+   * security boundary: the admin adding a toolset to an agent + the restriction
+   * engine are. See plans/chat/v6/chat-tool-availability.md.
    */
-  chatSafe?: boolean
+  surfaces?: AgentSurface[]
+  /**
+   * Advisory: verified safe for an untrusted, externally-identified caller
+   * (anonymous/just-verified chat visitor, email sender) — either self-clamps
+   * on a visitor turn (`search_knowledge`) or is identity-scoped. Absent ⇒ the
+   * chat/email Tools UI flags it with a warning. Replaces `chatSafe`; not a
+   * gate. See plans/chat/v6/chat-tool-availability.md.
+   */
+  externalSafe?: boolean
   /**
    * Input args carrying caller identity / record scope. In a visitor (chat)
    * invocation each MUST be bound to a restriction or the engine refuses the

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/index.ts
@@ -1,8 +1,8 @@
 // packages/lib/src/ai/kopilot/capabilities/agents-builder/index.ts
 
 import {
-  getOrgChatSafeToolsetCatalog,
   getOrgToolsetCatalog,
+  getOrgToolsetCatalogForSurface,
 } from '../../../../agents/toolset-catalog'
 import { getCachedAgentById } from '../../../../cache'
 import { findRef } from '../../context-refs'
@@ -48,7 +48,7 @@ export async function createAgentsBuilderCapabilities(
   const isChat = agent?.kind === 'chat'
 
   const catalog = isChat
-    ? await getOrgChatSafeToolsetCatalog(organizationId)
+    ? await getOrgToolsetCatalogForSurface(organizationId, 'chat')
     : await getOrgToolsetCatalog(organizationId)
 
   // Chat agents run on the inbound-message gate, never autonomously, and don't

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/complete-agent-setup.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/complete-agent-setup.ts
@@ -15,6 +15,8 @@ export function createCompleteAgentSetupTool(getDeps: GetToolDeps): AgentToolDef
   return {
     name: 'complete_agent_setup',
     displayName: 'Complete agent setup',
+    // Builder-only meta-tool. See plans/chat/v6/chat-tool-availability.md.
+    surfaces: ['builder'],
     description: `Mark this agent's chat-driven setup as complete.
 
 Call this as the LAST step of the three-phase build, after:

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-prompt.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-prompt.ts
@@ -22,6 +22,9 @@ export function createSetAgentPromptTool(getDeps: GetToolDeps): AgentToolDefinit
   return {
     name: 'set_agent_prompt',
     displayName: 'Set agent prompt',
+    // Builder-only meta-tool — configures another agent. Never offered on a
+    // chat/internal/email agent. See plans/chat/v6/chat-tool-availability.md.
+    surfaces: ['builder'],
     description: `Replace the agent's persona prompt with a markdown document.
 
 The persona prompt is the agent's instructions: tone, role, constraints,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-resource-scope.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-resource-scope.ts
@@ -23,6 +23,8 @@ export function createSetAgentResourceScopeTool(getDeps: GetToolDeps): AgentTool
   return {
     name: 'set_agent_resource_scope',
     displayName: 'Set agent resource scope',
+    // Builder-only meta-tool. See plans/chat/v6/chat-tool-availability.md.
+    surfaces: ['builder'],
     description: `Update the agent's resource-scope rows (which records / entity types it can read).
 
 Pass the FULL desired set of scopes. Rows in the DB that aren't in this list

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-restrictions.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-restrictions.ts
@@ -38,6 +38,8 @@ export function createSetAgentRestrictionsTool(getDeps: GetToolDeps): AgentToolD
   return {
     name: 'set_agent_restrictions',
     displayName: 'Set agent restrictions',
+    // Builder-only meta-tool. See plans/chat/v6/chat-tool-availability.md.
+    surfaces: ['builder'],
     description: `Lock individual tool arguments to a fixed value or a visitor/thread var. FULL REPLACE — send every restriction you want to keep; an empty array clears them all.
 
 Each row:

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-toolsets.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-toolsets.ts
@@ -2,8 +2,8 @@
 
 import { batchUpdateAgentToolsets } from '../../../../../agents/agent-toolset-service'
 import {
-  getOrgChatSafeToolsetCatalog,
   getOrgToolsetCatalog,
+  getOrgToolsetCatalogForSurface,
   type ToolsetCatalogEntry,
 } from '../../../../../agents/toolset-catalog'
 import { getCachedAgentById } from '../../../../../cache'
@@ -22,6 +22,8 @@ export function createSetAgentToolsetsTool(getDeps: GetToolDeps): AgentToolDefin
   return {
     name: 'set_agent_toolsets',
     displayName: 'Set agent toolsets',
+    // Builder-only meta-tool. See plans/chat/v6/chat-tool-availability.md.
+    surfaces: ['builder'],
     description: `Update the agent's toolset configuration.
 
 Each row patches the agent's record for one toolset slug:
@@ -78,15 +80,15 @@ to change; omitted slugs are left alone.`,
         return { success: false, output: null, error: 'toolsets array must have at least one row' }
       }
 
-      // Chat-kind agents validate against the chat-safe catalog only — the
-      // same surface their builder persona advertised and the only toolsets
-      // that survive `buildChatEngineConfig`'s runtime filter. A non-safe slug
-      // for a chat agent therefore errors here instead of being silently
-      // dropped at chat runtime. See plans/chat/v5 phase-2b.
+      // Chat-kind agents validate against the chat-surface catalog — the same
+      // toolsets their builder persona advertised and the only ones that survive
+      // `buildChatEngineConfig`'s runtime surface filter. A slug narrowed off
+      // chat therefore errors here instead of being silently dropped at runtime.
+      // See plans/chat/v6/chat-tool-availability.md.
       const agent = await getCachedAgentById(agentDeps.organizationId, agentRef.id)
       const catalog =
         agent?.kind === 'chat'
-          ? await getOrgChatSafeToolsetCatalog(agentDeps.organizationId)
+          ? await getOrgToolsetCatalogForSurface(agentDeps.organizationId, 'chat')
           : await getOrgToolsetCatalog(agentDeps.organizationId)
       const catalogBySlug = new Map<string, ToolsetCatalogEntry>(
         catalog.map((entry) => [entry.slug, entry])

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-triggers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/set-agent-triggers.ts
@@ -55,6 +55,8 @@ export function createSetAgentTriggersTool(getDeps: GetToolDeps): AgentToolDefin
   return {
     name: 'set_agent_triggers',
     displayName: 'Set agent triggers',
+    // Builder-only meta-tool. See plans/chat/v6/chat-tool-availability.md.
+    surfaces: ['builder'],
     description: `Replace the agent's trigger set with the provided list.
 
 Triggers tell the agent when to run autonomously. Default: no triggers — the

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-agent-identity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-agent-identity.ts
@@ -23,6 +23,8 @@ export function createUpdateAgentIdentityTool(getDeps: GetToolDeps): AgentToolDe
   return {
     name: 'update_agent_identity',
     displayName: 'Update agent identity',
+    // Builder-only meta-tool. See plans/chat/v6/chat-tool-availability.md.
+    surfaces: ['builder'],
     description: `Update the agent's identity — any subset of name, description, avatarSlug.
 
 Provide ONLY the fields you want to change; omitted fields are left alone. At

--- a/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
@@ -198,6 +198,12 @@ export async function createAppCapabilities(deps: {
         // plans/kopilot/agents/README.md §2 decision #12.
         requiresApproval: false,
         toolsetSlug: tool.toolsetSlug,
+        // Surface allow-list + chat/email warning flag (carried from the cached
+        // catalog) so the runtime surface filter honours an app that narrows a
+        // tool off chat. Absent ⇒ all surfaces. See
+        // plans/chat/v6/chat-tool-availability.md.
+        surfaces: tool.surfaces,
+        externalSafe: tool.externalSafe,
         // Author-floor: identity/record-scope args the engine fail-closes on in
         // a visitor turn (carried from the cached catalog). See plans/chat/v6
         // phase-3.

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entities.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entities.ts
@@ -11,6 +11,9 @@ export function createListEntitiesTool(_getDeps: GetToolDeps): AgentToolDefiniti
     displayName: 'List entity types',
     toolsetSlug: 'auxx:entities:search',
     idempotent: true,
+    // Schema only — entity TYPES, no record data — so safe for an external
+    // caller. See plans/chat/v6/chat-tool-availability.md.
+    externalSafe: true,
     outputDigestSchema: ListEntitiesDigest,
     buildDigest: (output) => {
       const out = (output ?? {}) as { entities?: Array<{ apiSlug?: string; label?: string }> }

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
@@ -12,6 +12,9 @@ export function createListEntityFieldsTool(_getDeps: GetToolDeps): AgentToolDefi
     displayName: 'List entity fields',
     toolsetSlug: 'auxx:entities:search',
     idempotent: true,
+    // Schema only — field definitions, no record data — so safe for an external
+    // caller. See plans/chat/v6/chat-tool-availability.md.
+    externalSafe: true,
     outputDigestSchema: ListEntityFieldsDigest,
     buildDigest: (output) => {
       const out = (output ?? {}) as { entityDefinitionId?: string; fields?: unknown[] }

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge.test.ts
@@ -42,9 +42,11 @@ beforeEach(() => {
 })
 
 describe('search_knowledge chat clamp', () => {
-  it('is marked chatSafe', () => {
+  it('is marked externalSafe (offered on chat by default)', () => {
     const tool = createSearchKnowledgeTool(() => ({}) as never)
-    expect(tool.chatSafe).toBe(true)
+    expect(tool.externalSafe).toBe(true)
+    // Default `surfaces` (absent) ⇒ offered everywhere, including chat.
+    expect(tool.surfaces).toBeUndefined()
   })
 
   it('with a chat invocation, searches only PUBLIC knowledge-base datasets (no RAG)', async () => {

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
@@ -25,10 +25,12 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
     displayName: 'Search knowledge',
     toolsetSlug: 'auxx:knowledge',
     idempotent: true,
-    // Safe for visitor-facing chat agents. In chat context (`ctx.invocation`
-    // set) the search is clamped to PUBLIC knowledge bases and RAG datasets
-    // are excluded — see the execute clamp below. See plans/chat/v5 phase-4.
-    chatSafe: true,
+    // Verified safe for an untrusted external caller: in chat context
+    // (`ctx.invocation` set) the search self-clamps to PUBLIC knowledge bases
+    // and excludes RAG datasets — see the execute clamp below. Offered on all
+    // surfaces (default); `externalSafe` drops the chat/email warning. See
+    // plans/chat/v6/chat-tool-availability.md.
+    externalSafe: true,
     outputDigestSchema: ArticleSearchDigest,
     buildDigest: (output) => {
       const out = (output ?? {}) as {

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -230,12 +230,9 @@ export interface CachedSystemModelDefault {
 export interface CachedAgentTool extends CatalogAgentTool {
   registeredName: string
   iconId: string
-  /**
-   * Mirrors `AgentToolDefinition.chatSafe`. Surfaces the tool in the chat-kind
-   * agent toolset catalog (the picker filters by it). Absent ⇒ not chat-safe.
-   * See plans/chat/v5.
-   */
-  chatSafe?: boolean
+  // `surfaces` + `externalSafe` are inherited from `CatalogAgentTool` (carried
+  // through from the SDK / built-in tool defs). See
+  // plans/chat/v6/chat-tool-availability.md.
 }
 
 /**

--- a/packages/lib/src/chat/agent/build-chat-engine-config.ts
+++ b/packages/lib/src/chat/agent/build-chat-engine-config.ts
@@ -2,6 +2,7 @@
 
 import { type Database, database } from '@auxx/database'
 import { filterToolsByToolsets, resolveAgentConfig } from '../../agents'
+import { ALL_SURFACES } from '../../agents/client'
 import { buildApplyToolRestrictions } from '../../agents/restrictions/apply'
 import { projectToolsSchemas } from '../../agents/restrictions/project-schema'
 import { buildResolveVar } from '../../agents/restrictions/var-registry'
@@ -51,10 +52,12 @@ export interface BuildChatEngineConfigInput {
  * kopilot-shaped config (`process-agent-job.ts`) with three chat-specific
  * differences (plans/chat/v5 phase-3b §3):
  *
- *   1. **Chat-safe tool gate** — the agent's enabled toolsets are further
- *      filtered to `chatSafe` tools only. Until phase 4 ships the first
- *      chat-safe tool this yields an empty toolset (a persona-only responder),
- *      which is the intended phase-3b behavior.
+ *   1. **Surface gate** — the agent's enabled toolsets are further filtered to
+ *      tools offered on the `chat` surface (`surfaces` absent ⇒ all surfaces,
+ *      so this only drops tools explicitly narrowed away from chat). The real
+ *      "is it available" gate is the admin enabling the toolset; tools that
+ *      aren't `externalSafe` run but are flagged in the UI. See
+ *      plans/chat/v6/chat-tool-availability.md.
  *   2. **`approvalMode: 'auto'`** — no admin is watching a visitor turn to
  *      approve tool calls; the chat-safe + row-level scope gate *is* the
  *      approval. Never `'pause'` (that would hang the turn forever).
@@ -118,10 +121,12 @@ export async function buildChatEngineConfig(
     })
   )
 
-  // Agent's enabled toolsets ∩ chat-safe tools. The chat-safe gate happens
-  // before the engine ever sees a non-safe tool.
+  // Agent's enabled toolsets ∩ tools offered on the `chat` surface. With the
+  // default-all `surfaces`, this only drops tools explicitly narrowed off chat
+  // (e.g. builder meta-tools — which aren't registered here anyway). `surfaces`
+  // is not the security boundary; the admin enabling the toolset is.
   const enabledTools = filterToolsByToolsets(registry.getTools('__none__'), agentConfig)
-  const chatSafeTools = enabledTools.filter((t) => t.chatSafe === true)
+  const chatTools = enabledTools.filter((t) => (t.surfaces ?? ALL_SURFACES).includes('chat'))
 
   // Escalation (`chat_handoff`) is always available to a chat agent — you never
   // want one unable to hand off to a human — so it's appended unconditionally
@@ -131,7 +136,7 @@ export async function buildChatEngineConfig(
   // visible, drop from `required`, and get an annotated description. Pure
   // comprehension hint; the runtime clamp below is the actual guarantee.
   const tools = projectToolsSchemas(
-    [...chatSafeTools, createChatHandoffTool()],
+    [...chatTools, createChatHandoffTool()],
     agentConfig.toolRestrictions
   )
 

--- a/packages/lib/src/chat/agent/tools/handoff.ts
+++ b/packages/lib/src/chat/agent/tools/handoff.ts
@@ -23,7 +23,10 @@ export function createChatHandoffTool(): AgentToolDefinition {
     name: 'chat_handoff',
     displayName: 'Hand off to a teammate',
     toolsetSlug: 'auxx:chat',
-    chatSafe: true,
+    // The escalation path — only meaningful on a visitor chat turn, and safe for
+    // an anonymous visitor (it just flags the thread for a human).
+    surfaces: ['chat'],
+    externalSafe: true,
     description:
       'Hand the conversation to a human teammate. Call this when you cannot ' +
       'help, when the visitor explicitly asks for a human, or when an ' +

--- a/packages/sdk/src/root/tools/types.ts
+++ b/packages/sdk/src/root/tools/types.ts
@@ -97,6 +97,14 @@ export interface ToolConfig {
 }
 
 /**
+ * Where an agent tool may run — mirrors the host's `AgentSurface`. An app tool
+ * is offered on every surface by default; narrow it only when it makes no sense
+ * in a context. NOT a security boundary. See
+ * plans/chat/v6/chat-tool-availability.md.
+ */
+export type AgentSurface = 'internal' | 'chat' | 'email' | 'builder'
+
+/**
  * Agent-surface projection of a tool — opt in by setting `tool.agent = {…}`.
  * Presence of this key exposes the tool to the LLM as a callable function.
  */
@@ -112,14 +120,20 @@ export interface ToolAgentSurface {
   /** LLM hint for read-only tools. */
   readonly idempotent?: boolean
   /**
-   * Soft hint: is this tool appropriate to *recommend* for a visitor-facing
-   * chat-kind agent? Default (absent) = false. NOT a security gate in v6 — the
-   * admin explicitly adding a tool is the coarse gate. Drives builder-Kopilot
-   * recommendations and picker decluttering only. Read-only customer-scoped
-   * reads set `true`; mutating/admin tools set `false`. See plans/chat/v6
-   * phase-3.
+   * Surfaces this tool is offered on (allow-list). Absent ⇒ every surface.
+   * Narrow it only when the tool makes no sense in a context. NOT a security
+   * gate — the admin adding the tool to an agent is. See
+   * plans/chat/v6/chat-tool-availability.md.
    */
-  readonly chatSafe?: boolean
+  readonly surfaces?: AgentSurface[]
+  /**
+   * Advisory: verified safe for an untrusted, externally-identified caller
+   * (anonymous chat visitor / email sender). Absent ⇒ the chat/email Tools UI
+   * flags it with a warning. Identity-scoped reads (see `identityScopedInputs`)
+   * are the typical opt-in. Replaces `chatSafe`; not a gate. See
+   * plans/chat/v6/chat-tool-availability.md.
+   */
+  readonly externalSafe?: boolean
   /**
    * Input args that carry caller identity / record scope. In a visitor (chat)
    * invocation each MUST be bound to a restriction or the engine refuses the

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -6,7 +6,12 @@ import path from 'path'
 import { fileURLToPath, pathToFileURL } from 'url'
 import { HIDDEN_AUXX_DIRECTORY } from '../constants/hidden-auxx-directory.js'
 import { complete, errored, type Result } from '../errors.js'
-import type { ToolActionSurface, ToolAgentSurface, ToolConfig } from '../root/tools/types.js'
+import type {
+  AgentSurface,
+  ToolActionSurface,
+  ToolAgentSurface,
+  ToolConfig,
+} from '../root/tools/types.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -46,11 +51,17 @@ export interface CatalogAgentTool extends CatalogTool {
   toolsetSlug: string
   idempotent?: boolean
   /**
-   * Soft hint surfaced to the chat-kind agent catalog (builder recommendations
-   * + picker declutter). Carried verbatim from `tool.agent.chatSafe`. Absent ⇒
-   * not chat-safe. NOT a runtime gate. See plans/chat/v6 phase-3.
+   * Surfaces this tool is offered on, carried verbatim from
+   * `tool.agent.surfaces`. Absent ⇒ all surfaces. NOT a runtime gate. See
+   * plans/chat/v6/chat-tool-availability.md.
    */
-  chatSafe?: boolean
+  surfaces?: AgentSurface[]
+  /**
+   * Advisory chat/email-warning flag, carried verbatim from
+   * `tool.agent.externalSafe`. Absent ⇒ warn. NOT a gate. See
+   * plans/chat/v6/chat-tool-availability.md.
+   */
+  externalSafe?: boolean
   /**
    * Identity/record-scope args the engine fail-closes on in a visitor turn.
    * Carried verbatim from `tool.agent.identityScopedInputs`. See plans/chat/v6
@@ -385,7 +396,8 @@ export async function compileAndExtractCatalog(): Promise<
         agentDescription: tool.agent.description ?? tool.description,
         toolsetSlug,
         idempotent: tool.agent.idempotent ?? tool.config?.idempotent,
-        chatSafe: tool.agent.chatSafe,
+        surfaces: tool.agent.surfaces,
+        externalSafe: tool.agent.externalSafe,
         identityScopedInputs: tool.agent.identityScopedInputs,
       })
     }


### PR DESCRIPTION
## Summary

Replaces the boolean `chatSafe` tool hint with a richer two-part model that lets a tool declare **which surfaces it is offered on** and **whether it's safe for an untrusted external caller**, carried verbatim from the SDK tool definitions through the installed-apps cache.

## Model

- `surfaces?: AgentSurface[]` — allow-list of surfaces a tool is offered on (`internal` / `chat` / `email` / `builder`). Absent ⇒ all surfaces. **Not** a runtime gate — picker/declutter only.
- `externalSafe?: boolean` — advisory chat/email warning flag. Absent ⇒ warn. **Not** a gate.

Both replace the old single `chatSafe?: boolean` and are inherited on `CachedAgentTool` from `CatalogAgentTool` via spread, so no separate plumbing.

## Changes

- **sdk**: tool-def types + `compile-and-extract-catalog` emit `surfaces` / `externalSafe`
- **schema**: `AgentSurface` type on `app-deployment` `CatalogAgentTool`
- **cache**: `CachedAgentTool` inherits the fields from `CatalogAgentTool`
- **kopilot**: apps / entities (`list-entities`, `list-entity-fields`) / knowledge (`search-knowledge`) tools set the new flags; agents-builder tools updated
- **lib/agents**: `filter-catalog-to-surface` (+ test), `client`, `toolset-catalog`
- **web**: agent detail tools/restrictions UI honours `surfaces`
- **chat**: `build-chat-engine-config` + `handoff` use the new model

## Test plan
- [ ] `pnpm test` for `filter-catalog-to-surface` and `search-knowledge`
- [ ] Open the agent tool picker and confirm surface filtering + external warning render
