### PR TITLE
feat(ui): reusable dialog nav header + animated wizard pages

### DIFF
--- a/apps/web/src/components/agents/ui/dialogs/agent-template-dialog.tsx
+++ b/apps/web/src/components/agents/ui/dialogs/agent-template-dialog.tsx
@@ -8,14 +8,8 @@ import {
   agentTemplates,
 } from '@auxx/lib/agents/client'
 import { Badge } from '@auxx/ui/components/badge'
-import { Button } from '@auxx/ui/components/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@auxx/ui/components/dialog'
+import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
+import { DialogNav } from '@auxx/ui/components/dialog-nav'
 import {
   Empty,
   EmptyDescription,
@@ -148,17 +142,11 @@ export function AgentTemplateDialog({ open, onOpenChange, kind }: AgentTemplateD
           searchInputRef.current?.focus()
         }}>
         <div className='flex flex-col flex-1 min-h-0'>
-          <DialogHeader className='border-b px-3 h-10 flex flex-row items-center justify-start mb-0'>
-            <div>
-              <Button variant='ghost' size='sm'>
-                Agent templates
-              </Button>
-              <DialogTitle className='sr-only'>Create from template</DialogTitle>
-              <DialogDescription className='sr-only'>
-                Select an agent template to scaffold
-              </DialogDescription>
-            </div>
-          </DialogHeader>
+          <DialogNav
+            title='Create from template'
+            description='Select an agent template to scaffold'
+            crumbs={[{ label: 'Agent templates' }]}
+          />
 
           <div className='flex flex-1 flex-col sm:flex-row justify-start w-full min-h-0'>
             {/* Sidebar */}

--- a/apps/web/src/components/custom-fields/ui/entity-template-dialog.tsx
+++ b/apps/web/src/components/custom-fields/ui/entity-template-dialog.tsx
@@ -9,13 +9,8 @@ import { getRelatedEntityDefinitionId, type RelationshipConfig } from '@auxx/typ
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@auxx/ui/components/dialog'
+import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
+import { DialogNav } from '@auxx/ui/components/dialog-nav'
 import {
   Empty,
   EmptyDescription,
@@ -28,11 +23,9 @@ import { InputSearch } from '@auxx/ui/components/input-search'
 import { RadioGroup } from '@auxx/ui/components/radio-group'
 import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
-import { Separator } from '@auxx/ui/components/separator'
 import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
 import {
-  ChevronLeft,
   Headphones,
   LayoutGrid,
   Link2,
@@ -502,17 +495,11 @@ export function EntityTemplateDialog({
             {viewMode === 'list' ? (
               <>
                 {/* LIST VIEW */}
-                <DialogHeader className='border-b px-3 h-10 flex flex-row items-center justify-start mb-0'>
-                  <div>
-                    <Button variant='ghost' size='sm'>
-                      Entity templates
-                    </Button>
-                    <DialogTitle className='sr-only'>Create from template</DialogTitle>
-                    <DialogDescription className='sr-only'>
-                      Select an entity template to scaffold
-                    </DialogDescription>
-                  </div>
-                </DialogHeader>
+                <DialogNav
+                  title='Create from template'
+                  description='Select an entity template to scaffold'
+                  crumbs={[{ label: 'Entity templates' }]}
+                />
 
                 <div className='flex flex-1 flex-col sm:flex-row justify-start w-full min-h-0'>
                   {/* Sidebar */}
@@ -650,26 +637,16 @@ export function EntityTemplateDialog({
             ) : (
               <>
                 {/* DETAIL VIEW */}
-                <DialogHeader className='border-b px-3 py-2 mb-0 h-10'>
-                  <div className='flex items-center gap-1'>
-                    <Button
-                      variant='ghost'
-                      size='sm'
-                      onClick={handleBackToList}
-                      disabled={installTemplates.isPending}>
-                      <ChevronLeft />
-                      Back
-                    </Button>
-                    <Separator orientation='vertical' className='h-5' />
-                    <Button variant='ghost' size='sm'>
-                      {templateDetail?.name ?? 'Loading...'}
-                    </Button>
-                    <DialogTitle className='sr-only'>Template Detail</DialogTitle>
-                    <DialogDescription className='sr-only'>
-                      Preview and install template
-                    </DialogDescription>
-                  </div>
-                </DialogHeader>
+                <DialogNav
+                  title='Template Detail'
+                  description='Preview and install template'
+                  onBack={handleBackToList}
+                  backDisabled={installTemplates.isPending}
+                  crumbs={[
+                    { label: 'Entity templates', onClick: handleBackToList },
+                    { label: templateDetail?.name ?? 'Loading...' },
+                  ]}
+                />
 
                 <div className='flex flex-col sm:flex-row flex-1 min-h-0 overflow-hidden'>
                   {/* Left: Preview cards — horizontally scrollable */}

--- a/apps/web/src/components/kb/ui/editor/crawl-website-wizard.tsx
+++ b/apps/web/src/components/kb/ui/editor/crawl-website-wizard.tsx
@@ -2,23 +2,15 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@auxx/ui/components/dialog'
+import { Dialog, DialogContent, DialogFooter } from '@auxx/ui/components/dialog'
+import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
 import { Input } from '@auxx/ui/components/input'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { Label } from '@auxx/ui/components/label'
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
-import { Separator } from '@auxx/ui/components/separator'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
 import { ToggleCard } from '@auxx/ui/components/toggle-card'
-import { Check, ChevronLeft, Globe } from 'lucide-react'
+import { Check, Globe } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { api } from '~/trpc/react'
 import { CrawlSectionTree, countPages, type SitemapNode } from './crawl-section-picker'
@@ -190,148 +182,131 @@ export function CrawlWebsiteWizard({
 
   return (
     <Dialog open={open} onOpenChange={close}>
-      <DialogContent className='h-dvh sm:h-[560px]' innerClassName='p-0' position='tc' size='sm'>
-        <div className='flex flex-1 flex-col min-h-0'>
-          {/* Header bar — Back + breadcrumb */}
-          <DialogHeader className='mb-0 flex h-10 flex-row items-center justify-start border-b px-3'>
-            <div className='flex items-center gap-1'>
-              {step !== 'connect' && (
-                <>
-                  <Button variant='ghost' size='sm' onClick={goBack} disabled={isSubmitting}>
-                    <ChevronLeft />
-                    Back
-                  </Button>
-                  <Separator orientation='vertical' className='h-5' />
-                </>
-              )}
-              <Button variant='ghost' size='sm'>
-                <Globe />
-                {STEP_TITLES[step]}
-              </Button>
-              <DialogTitle className='sr-only'>Crawl a website</DialogTitle>
-              <DialogDescription className='sr-only'>
-                Discover a site, pick the sections to ingest, and the crawler files each page as a
-                locked, source-managed article in its own source — optionally linked into your
-                knowledge bases.
-              </DialogDescription>
-            </div>
-          </DialogHeader>
+      <DialogContent innerClassName='p-0' position='tc' size='content'>
+        <div className='flex flex-col'>
+          <DialogNav
+            title='Crawl a website'
+            description='Discover a site, pick the sections to ingest, and the crawler files each page as a locked, source-managed article in its own source — optionally linked into your knowledge bases.'
+            onBack={step === 'connect' ? undefined : goBack}
+            backDisabled={isSubmitting}
+            crumbs={[{ label: STEP_TITLES[step], icon: <Globe /> }]}
+          />
 
-          {/* Body */}
-          <ScrollArea className='flex-1'>
-            <div className='flex flex-col gap-4 p-3'>
-              {step === 'connect' && (
+          {/* Body — width/height springs between steps */}
+          <DialogNavPages value={step}>
+            <DialogNavPage value='connect' size='sm'>
+              <div className='flex flex-col gap-1.5 p-3'>
+                <Label htmlFor='crawl-url'>Website URL</Label>
+                <Input
+                  id='crawl-url'
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  placeholder='https://docs.example.com'
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') void handleConnect()
+                  }}
+                />
+                <p className='text-muted-foreground text-xs'>
+                  We map the site and show its sections — no pages are ingested yet.
+                </p>
+              </div>
+            </DialogNavPage>
+
+            <DialogNavPage value='pages' size='lg'>
+              <div className='flex flex-col gap-4 p-3'>
                 <div className='flex flex-col gap-1.5'>
-                  <Label htmlFor='crawl-url'>Website URL</Label>
-                  <Input
-                    id='crawl-url'
-                    value={url}
-                    onChange={(e) => setUrl(e.target.value)}
-                    placeholder='https://docs.example.com'
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') void handleConnect()
-                    }}
+                  <div className='flex items-center justify-between'>
+                    <Label>Sections to crawl</Label>
+                    <span className='text-muted-foreground text-xs'>
+                      {selectedPageCount} page{selectedPageCount === 1 ? '' : 's'} selected
+                    </span>
+                  </div>
+                  <CrawlSectionTree
+                    sections={sections}
+                    selectedPaths={selectedPaths}
+                    onToggle={toggleSection}
+                  />
+                </div>
+
+                <ToggleCard
+                  title='Only main page content'
+                  description='Strip nav, headers, and footers.'
+                  checked={mainContentOnly}
+                  onCheckedChange={setMainContentOnly}
+                />
+
+                <div className='flex flex-col gap-1.5'>
+                  <Label htmlFor='exclude'>Exclude URLs (optional)</Label>
+                  <Textarea
+                    id='exclude'
+                    value={excludeText}
+                    onChange={(e) => setExcludeText(e.target.value)}
+                    placeholder='/blog&#10;/changelog'
+                    rows={2}
+                    className='font-mono text-sm'
                   />
                   <p className='text-muted-foreground text-xs'>
-                    We map the site and show its sections — no pages are ingested yet.
+                    One path or URL per line — these are never ingested.
                   </p>
                 </div>
-              )}
+              </div>
+            </DialogNavPage>
 
-              {step === 'pages' && (
-                <>
-                  <div className='flex flex-col gap-1.5'>
-                    <div className='flex items-center justify-between'>
-                      <Label>Sections to crawl</Label>
-                      <span className='text-muted-foreground text-xs'>
-                        {selectedPageCount} page{selectedPageCount === 1 ? '' : 's'} selected
-                      </span>
-                    </div>
-                    <CrawlSectionTree
-                      sections={sections}
-                      selectedPaths={selectedPaths}
-                      onToggle={toggleSection}
-                    />
-                  </div>
-
-                  <ToggleCard
-                    title='Only main page content'
-                    description='Strip nav, headers, and footers.'
-                    checked={mainContentOnly}
-                    onCheckedChange={setMainContentOnly}
+            <DialogNavPage value='target' size='lg'>
+              <div className='flex flex-col gap-4 p-3'>
+                <div className='flex flex-col gap-1.5'>
+                  <Label htmlFor='source-name'>Source name</Label>
+                  <Input
+                    id='source-name'
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder='e.g. Docs site'
                   />
-
-                  <div className='flex flex-col gap-1.5'>
-                    <Label htmlFor='exclude'>Exclude URLs (optional)</Label>
-                    <Textarea
-                      id='exclude'
-                      value={excludeText}
-                      onChange={(e) => setExcludeText(e.target.value)}
-                      placeholder='/blog&#10;/changelog'
-                      rows={2}
-                      className='font-mono text-sm'
-                    />
-                    <p className='text-muted-foreground text-xs'>
-                      One path or URL per line — these are never ingested.
-                    </p>
+                </div>
+                <div className='flex flex-col gap-1.5'>
+                  <Label>Link into knowledge bases (optional)</Label>
+                  <p className='text-muted-foreground text-xs'>
+                    The crawl becomes its own source. Pick any knowledge bases to surface it in —
+                    you can change this anytime in the source settings.
+                  </p>
+                  <div className='flex max-h-48 flex-col gap-0.5 overflow-auto rounded-md border p-1'>
+                    {(knowledgeBases.data ?? []).length === 0 ? (
+                      <p className='px-2 py-1.5 text-muted-foreground text-xs'>
+                        No knowledge bases yet.
+                      </p>
+                    ) : (
+                      (knowledgeBases.data ?? []).map((kb) => {
+                        const checked = linkKbIds.includes(kb.id)
+                        return (
+                          <button
+                            key={kb.id}
+                            type='button'
+                            onClick={() => toggleLink(kb.id)}
+                            className={`flex items-center justify-between rounded px-2 py-1.5 text-left text-sm hover:bg-muted ${
+                              checked ? 'bg-muted' : ''
+                            }`}>
+                            <span className='truncate'>{kb.name}</span>
+                            {checked && <Check className='size-4 text-info' />}
+                          </button>
+                        )
+                      })
+                    )}
                   </div>
-                </>
-              )}
+                </div>
+                <SyncFrequencyPicker value={schedule} onChange={setSchedule} />
+                <ToggleCard
+                  title='AI-only (catalog)'
+                  description='Embed without tree articles — coming in a later phase.'
+                  checked={false}
+                  onCheckedChange={() => {}}
+                  disabled
+                  className='border-dashed opacity-70'
+                />
+              </div>
+            </DialogNavPage>
 
-              {step === 'target' && (
-                <>
-                  <div className='flex flex-col gap-1.5'>
-                    <Label htmlFor='source-name'>Source name</Label>
-                    <Input
-                      id='source-name'
-                      value={name}
-                      onChange={(e) => setName(e.target.value)}
-                      placeholder='e.g. Docs site'
-                    />
-                  </div>
-                  <div className='flex flex-col gap-1.5'>
-                    <Label>Link into knowledge bases (optional)</Label>
-                    <p className='text-muted-foreground text-xs'>
-                      The crawl becomes its own source. Pick any knowledge bases to surface it in —
-                      you can change this anytime in the source settings.
-                    </p>
-                    <div className='flex max-h-48 flex-col gap-0.5 overflow-auto rounded-md border p-1'>
-                      {(knowledgeBases.data ?? []).length === 0 ? (
-                        <p className='px-2 py-1.5 text-muted-foreground text-xs'>
-                          No knowledge bases yet.
-                        </p>
-                      ) : (
-                        (knowledgeBases.data ?? []).map((kb) => {
-                          const checked = linkKbIds.includes(kb.id)
-                          return (
-                            <button
-                              key={kb.id}
-                              type='button'
-                              onClick={() => toggleLink(kb.id)}
-                              className={`flex items-center justify-between rounded px-2 py-1.5 text-left text-sm hover:bg-muted ${
-                                checked ? 'bg-muted' : ''
-                              }`}>
-                              <span className='truncate'>{kb.name}</span>
-                              {checked && <Check className='size-4 text-info' />}
-                            </button>
-                          )
-                        })
-                      )}
-                    </div>
-                  </div>
-                  <SyncFrequencyPicker value={schedule} onChange={setSchedule} />
-                  <ToggleCard
-                    title='AI-only (catalog)'
-                    description='Embed without tree articles — coming in a later phase.'
-                    checked={false}
-                    onCheckedChange={() => {}}
-                    disabled
-                    className='border-dashed opacity-70'
-                  />
-                </>
-              )}
-
-              {step === 'review' && (
+            <DialogNavPage value='review' size='sm'>
+              <div className='p-3'>
                 <div className='flex flex-col gap-2 rounded-md border p-4 text-sm'>
                   <Row label='URL' value={url.trim()} />
                   <Row label='Name' value={name.trim()} />
@@ -352,9 +327,9 @@ export function CrawlWebsiteWizard({
                     worker finishes.
                   </p>
                 </div>
-              )}
-            </div>
-          </ScrollArea>
+              </div>
+            </DialogNavPage>
+          </DialogNavPages>
 
           {/* Footer */}
           <DialogFooter className='mt-0 border-t p-3'>

--- a/apps/web/src/components/kopilot/ui/dialogs/prompt-template-dialog.tsx
+++ b/apps/web/src/components/kopilot/ui/dialogs/prompt-template-dialog.tsx
@@ -7,13 +7,8 @@ import type { DocJSON } from '@auxx/lib/kb/markdown'
 import type { SystemTemplateGalleryItem } from '@auxx/lib/prompt-templates'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@auxx/ui/components/dialog'
+import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
+import { DialogNav } from '@auxx/ui/components/dialog-nav'
 import {
   Empty,
   EmptyDescription,
@@ -28,7 +23,6 @@ import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import {
   Check,
-  ChevronLeft,
   Handshake,
   Headphones,
   LayoutGrid,
@@ -152,17 +146,11 @@ export function PromptTemplateDialog({ open, onOpenChange }: PromptTemplateDialo
           {viewMode === 'list' ? (
             <>
               {/* LIST VIEW */}
-              <DialogHeader className='border-b px-3 h-10 flex flex-row items-center justify-start mb-0'>
-                <div>
-                  <Button variant='ghost' size='sm'>
-                    Prompt templates
-                  </Button>
-                  <DialogTitle className='sr-only'>Prompt Templates</DialogTitle>
-                  <DialogDescription className='sr-only'>
-                    Browse and install prompt templates
-                  </DialogDescription>
-                </div>
-              </DialogHeader>
+              <DialogNav
+                title='Prompt Templates'
+                description='Browse and install prompt templates'
+                crumbs={[{ label: 'Prompt templates' }]}
+              />
 
               <div className='flex flex-1 flex-row justify-start w-full min-h-0'>
                 {/* Sidebar */}
@@ -293,20 +281,15 @@ export function PromptTemplateDialog({ open, onOpenChange }: PromptTemplateDialo
           ) : (
             <>
               {/* DETAIL VIEW */}
-              <DialogHeader className='border-b px-3 h-10 flex flex-row items-center justify-start mb-0'>
-                <div className='flex items-center gap-1'>
-                  <Button variant='ghost' size='sm' onClick={handleBack}>
-                    <ChevronLeft className='size-4' />
-                    Back
-                  </Button>
-                  <span className='text-muted-foreground'>/</span>
-                  <span className='text-sm font-medium truncate max-w-[300px]'>
-                    {selectedTemplate?.name}
-                  </span>
-                  <DialogTitle className='sr-only'>{selectedTemplate?.name}</DialogTitle>
-                  <DialogDescription className='sr-only'>Prompt template details</DialogDescription>
-                </div>
-              </DialogHeader>
+              <DialogNav
+                title={selectedTemplate?.name ?? 'Prompt template'}
+                description='Prompt template details'
+                onBack={handleBack}
+                crumbs={[
+                  { label: 'Prompt templates', onClick: handleBack },
+                  { label: selectedTemplate?.name ?? 'Template' },
+                ]}
+              />
 
               {selectedTemplate && (
                 <div className='flex flex-col flex-1 min-h-0'>

--- a/apps/web/src/components/workflow/dialogs/workflow-template-dialog.tsx
+++ b/apps/web/src/components/workflow/dialogs/workflow-template-dialog.tsx
@@ -4,13 +4,8 @@
 import { constants } from '@auxx/config/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@auxx/ui/components/dialog'
+import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
+import { DialogNav } from '@auxx/ui/components/dialog-nav'
 import {
   Empty,
   EmptyDescription,
@@ -24,12 +19,10 @@ import { Label } from '@auxx/ui/components/label'
 import { RadioGroup } from '@auxx/ui/components/radio-group'
 import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
-import { Separator } from '@auxx/ui/components/separator'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
 import {
   AlertTriangle,
-  ChevronLeft,
   GitBranch,
   Headphones,
   Image as ImageIcon,
@@ -299,16 +292,11 @@ export function WorkflowTemplateDialog({
             {viewMode === 'list' ? (
               <>
                 {/* LIST VIEW */}
-                <DialogHeader className='border-b px-3 h-10 flex flex-row items-center justify-start mb-0'>
-                  <div>
-                    <Button variant='ghost' size='sm'>
-                      Template selector
-                    </Button>
-
-                    <DialogTitle className='sr-only'>Use Template</DialogTitle>
-                    <DialogDescription className='sr-only'>Template selector</DialogDescription>
-                  </div>
-                </DialogHeader>
+                <DialogNav
+                  title='Use Template'
+                  description='Template selector'
+                  crumbs={[{ label: 'Template selector' }]}
+                />
 
                 {/* Search Bar */}
 
@@ -459,27 +447,16 @@ export function WorkflowTemplateDialog({
             ) : (
               <>
                 {/* DETAIL VIEW */}
-                <DialogHeader className='border-b px-3 py-2 mb-0 h-10 '>
-                  <div className='flex items-center gap-1'>
-                    <Button
-                      variant='ghost'
-                      size='sm'
-                      onClick={handleBackToList}
-                      disabled={createWorkflow.isPending}>
-                      <ChevronLeft />
-                      Back
-                    </Button>
-                    <Separator orientation='vertical' className='h-5' />
-                    <Button variant='ghost' size='sm'>
-                      {selectedTemplate.name}
-                    </Button>
-
-                    <div>
-                      <DialogTitle className='sr-only'>Use Template</DialogTitle>
-                      <DialogDescription className='sr-only'>Template selector</DialogDescription>
-                    </div>
-                  </div>
-                </DialogHeader>
+                <DialogNav
+                  title='Use Template'
+                  description='Template selector'
+                  onBack={handleBackToList}
+                  backDisabled={createWorkflow.isPending}
+                  crumbs={[
+                    { label: 'Template selector', onClick: handleBackToList },
+                    { label: selectedTemplate.name },
+                  ]}
+                />
 
                 <div className='flex flex-col sm:flex-row flex-1 overflow-hidden min-h-0'>
                   {/* Preview (top on mobile, left 2/3 on desktop) */}

--- a/packages/ui/src/components/dialog-nav.tsx
+++ b/packages/ui/src/components/dialog-nav.tsx
@@ -1,0 +1,197 @@
+// packages/ui/src/components/dialog-nav.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  DialogDescription,
+  DialogHeader,
+  type DialogSize,
+  DialogTitle,
+  dialogSizeRem,
+} from '@auxx/ui/components/dialog'
+import { Separator } from '@auxx/ui/components/separator'
+import { cn } from '@auxx/ui/lib/utils'
+import { ChevronLeft } from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+import {
+  Children,
+  Fragment,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
+
+/** App-wide spring used for dialog page transitions (matches tree-row/collapsible). */
+const SPRING = { type: 'spring', stiffness: 300, damping: 30 } as const
+
+// ── DialogNav (breadcrumb + back header) ─────────────────────────────────────
+
+export interface DialogNavCrumb {
+  label: ReactNode
+  /** Omit on the last/current crumb; set to make it a clickable jump-back. */
+  onClick?: () => void
+  icon?: ReactNode
+}
+
+export interface DialogNavProps {
+  /** sr-only DialogTitle (required by Radix Dialog for a11y). */
+  title: string
+  /** sr-only DialogDescription. */
+  description?: string
+  crumbs: DialogNavCrumb[]
+  /** Renders the leading "‹ Back" button when provided. */
+  onBack?: () => void
+  backDisabled?: boolean
+  /** Right-aligned slot — e.g. a step indicator. */
+  actions?: ReactNode
+  className?: string
+}
+
+/**
+ * Standard dialog navigation header: an optional Back button + a breadcrumb
+ * trail, in the `h-10 border-b` bar shared by the template/gallery dialogs and
+ * the wizard flows. Replaces the hand-rolled headers so they stay consistent.
+ * The last crumb renders as the current (non-interactive) page.
+ */
+export function DialogNav({
+  title,
+  description,
+  crumbs,
+  onBack,
+  backDisabled,
+  actions,
+  className,
+}: DialogNavProps) {
+  return (
+    <DialogHeader
+      className={cn(
+        'mb-0 flex h-10 flex-row items-center justify-between border-b px-3',
+        className
+      )}>
+      <div className='flex items-center gap-1'>
+        {onBack && (
+          <>
+            <Button variant='ghost' size='sm' onClick={onBack} disabled={backDisabled}>
+              <ChevronLeft />
+              Back
+            </Button>
+            <Separator orientation='vertical' className='h-5' />
+          </>
+        )}
+        {crumbs.map((crumb, i) => {
+          const isLast = i === crumbs.length - 1
+          return (
+            <Fragment key={i}>
+              {i > 0 && <Separator orientation='vertical' className='h-5' />}
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={crumb.onClick}
+                disabled={isLast || !crumb.onClick}
+                className={isLast ? 'pointer-events-none' : undefined}>
+                {crumb.icon}
+                {crumb.label}
+              </Button>
+            </Fragment>
+          )
+        })}
+        <DialogTitle className='sr-only'>{title}</DialogTitle>
+        {description && <DialogDescription className='sr-only'>{description}</DialogDescription>}
+      </div>
+      {actions && <div className='flex items-center'>{actions}</div>}
+    </DialogHeader>
+  )
+}
+
+// ── DialogNavPages (controlled, size-animated page switcher) ──────────────────
+
+export interface DialogNavPageProps {
+  value: string
+  /**
+   * Declared page width, reusing the `DialogContent` size tokens (`max-w-*`). The
+   * wrapper springs to the matching rem width; defaults to `'sm'`. Because the
+   * tokens are max-widths, the page still shrinks on mobile (capped at 95vw).
+   */
+  size?: DialogSize
+  children: ReactNode
+}
+
+/** A single page within `DialogNavPages`. Rendered only when active. */
+export function DialogNavPage({ children }: DialogNavPageProps) {
+  return <>{children}</>
+}
+
+export interface DialogNavPagesProps {
+  /** Active page key (controlled by the parent). */
+  value: string
+  children: ReactNode
+  className?: string
+}
+
+/**
+ * Controlled page switcher that springs the dialog body between steps in both
+ * dimensions: width is declared per page (`DialogNavPage size`) and animated to
+ * the matching rem; height is measured and animated to fit the active page's
+ * content. The active page crossfades in. Pair with a `DialogContent
+ * size='content'` shell so the card width follows the animating body.
+ */
+export function DialogNavPages({ value, children, className }: DialogNavPagesProps) {
+  const [height, setHeight] = useState<number | 'auto'>('auto')
+  const ref = useRef<HTMLDivElement>(null)
+  // The first measured height (from the observer, post-paint) must snap, not
+  // spring — otherwise the `'auto' → measured` delta settles visibly on open.
+  // Flipped true after the first numeric height commits; every change after springs.
+  const measuredOnce = useRef(false)
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const ro = new ResizeObserver(([entry]) => {
+      if (entry) setHeight(entry.contentRect.height)
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (typeof height === 'number') measuredOnce.current = true
+  }, [height])
+
+  const pages = Children.toArray(children).filter(
+    isValidElement
+  ) as ReactElement<DialogNavPageProps>[]
+  const active = pages.find((page) => page.props.value === value)
+  const widthRem = dialogSizeRem[active?.props.size ?? 'sm']
+
+  return (
+    <motion.div
+      // Start at the first page's size — without this the body tweens open on
+      // mount (on top of the dialog's own open animation). Step changes still spring.
+      initial={false}
+      animate={{ width: `${widthRem}rem`, height }}
+      transition={{ width: SPRING, height: measuredOnce.current ? SPRING : { duration: 0 } }}
+      style={{ maxWidth: '95vw' }}
+      className={cn('relative overflow-hidden', className)}>
+      {/* Stable measuring wrapper: the keyed page below remounts on every change,
+          so the ResizeObserver can't live on it. The exiting page is positioned
+          absolutely, so this wrapper's height tracks the active page. */}
+      <div ref={ref}>
+        <AnimatePresence mode='popLayout' initial={false}>
+          <motion.div
+            key={value}
+            className='w-full'
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0, position: 'absolute', inset: 0 }}
+            transition={{ duration: 0.15 }}>
+            {active}
+          </motion.div>
+        </AnimatePresence>
+      </div>
+    </motion.div>
+  )
+}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -59,7 +59,7 @@ function DialogOverlay({
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const dialogVariants = cva(
-  'relative z-50 grid w-full p-[4px] focus:ring-ring/20 focus:outline-none shadow-xl dark:shadow-black/40 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:rounded-[20px]',
+  'relative z-50 grid p-[4px] focus:ring-ring/20 focus:outline-none shadow-xl dark:shadow-black/40 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:rounded-[20px]',
   {
     variants: {
       variant: {
@@ -74,22 +74,46 @@ const dialogVariants = cva(
         br: 'right-6 bottom-6 data-[state=closed]:slide-out-to-bottom-16 data-[state=open]:slide-in-from-bottom-16',
         tc: 'left-[50%] top-[10%] translate-x-[-50%] data-[state=closed]:slide-out-to-top-16  data-[state=open]:slide-in-from-top-16  data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
       },
+      // `w-full` lives on each size token (not the cva base) so the content-sized
+      // `content` token can use `w-fit` without a conflicting `w-full`.
       size: {
-        default: 'max-w-lg',
-        xs: 'max-w-sm',
-        sm: 'max-w-md',
-        md: 'max-w-lg',
-        lg: 'max-w-xl',
-        xl: 'max-w-2xl',
-        xxl: 'max-w-3xl',
-        '3xl': 'max-w-4xl',
+        default: 'w-full max-w-lg',
+        xs: 'w-full max-w-sm',
+        sm: 'w-full max-w-md',
+        md: 'w-full max-w-lg',
+        lg: 'w-full max-w-xl',
+        xl: 'w-full max-w-2xl',
+        xxl: 'w-full max-w-3xl',
+        '3xl': 'w-full max-w-4xl',
         fullscreen: 'w-screen h-screen',
+        // Shrink-wraps to the widest child (capped at 95vw). Use for dialogs whose
+        // width is driven by their content — e.g. an animated `DialogNavPages` body.
+        content: 'w-fit max-w-[95vw]',
       },
     },
     defaultVariants: { variant: 'default', position: 'default', size: 'default' },
   }
 )
 //before:content-[''] before:absolute before:-top-[5%] before:left-[10%] before:w-[80%] before:h-[30%] before:-z-0 before:rounded-full before:bg-linear-to-r before:from-[#ffc58b] before:via-[#e1a6ff] before:to-[#352cee] before:opacity-100 before:blur-2xl before:mix-blend-color-dodge before:transition-opacity before:duration-1000 before:delay-1000
+
+/** Fixed, max-width dialog size tokens (excludes `fullscreen`/`content`). */
+export type DialogSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | '3xl'
+
+/**
+ * rem widths matching each `DialogSize` token's `max-w-*` class in
+ * `dialogVariants` above. Hand-synced — Tailwind JIT needs the literal class
+ * strings, so these can't be derived from the map. Keep the two in step.
+ */
+export const dialogSizeRem: Record<DialogSize, number> = {
+  xs: 24, // max-w-sm
+  sm: 28, // max-w-md
+  md: 32, // max-w-lg
+  lg: 36, // max-w-xl
+  xl: 42, // max-w-2xl
+  xxl: 48, // max-w-3xl
+  '3xl': 56, // max-w-4xl
+}
+
 export interface DialogContentProps
   extends React.ComponentProps<typeof DialogPrimitive.Content>,
     VariantProps<typeof dialogVariants> {


### PR DESCRIPTION
## What

Extracts the repeated "back/breadcrumb" dialog header into a reusable primitive and adds an animated, content-driven body for multi-step wizard dialogs.

### New primitives (`@auxx/ui`)
- **`DialogNav`** — the shared `h-10 border-b` header bar: optional Back button + breadcrumb trail + sr-only title/description. Non-last crumbs are clickable jump-backs.
- **`DialogNavPages` / `DialogNavPage`** — controlled page switcher that springs the body between steps in **both** dimensions:
  - **width** is *declared* per page via the `DialogContent` size tokens (`xs…3xl` → `max-w-*`), animated to the matching rem; `maxWidth: 95vw` keeps it responsive on mobile.
  - **height** is *measured* (`ResizeObserver` on a stable wrapper) and sprung.
- **`dialog.tsx`** — adds a content-sized `size='content'` variant (`w-fit max-w-[95vw]`); moves `w-full` into the existing size tokens; exports `DialogSize` + `dialogSizeRem`.

### Migrations
- **crawl-website-wizard** — now `DialogContent size='content'` + `DialogNav` + `DialogNavPages` with per-step sizes (connect/review `sm`, pages/target `lg`). Fixed height removed; the dialog springs wider+taller into the section step and back. No more empty space on the first step.
- **entity / workflow / prompt / agent template dialogs** — header swapped to `DialogNav` only; bodies, `size='3xl'`, and fixed heights untouched. prompt-template's slash/span header standardized to the separator+ghost look.

## Notes
- Gallery dialogs keep their fixed `size`/height — `size='content'` and `DialogNavPages` are wizard-only (width animation requires the content-sized shell).
- Mount polish: `initial={false}` on the size container + first measured height snaps (not springs), so the body doesn't tween open or settle on first render.
- Verified via lint (`biome`); not yet visually QA'd in-browser.