### PR TITLE
fix(field-values): row-id canonical field identity

### DIFF
--- a/packages/lib/src/field-values/field-value-helpers.ts
+++ b/packages/lib/src/field-values/field-value-helpers.ts
@@ -1235,7 +1235,7 @@ export async function getFieldInfoFromRegistry(
   organizationId: string,
   entityDefinitionId: string,
   fieldId: string
-): Promise<{ fieldType: FieldType; fieldOptions?: FieldOptions }> {
+): Promise<{ fieldId: string; fieldType: FieldType; fieldOptions?: FieldOptions }> {
   const resource = await findCachedResource(organizationId, entityDefinitionId)
   if (!resource) {
     console.error('[getFieldInfoFromRegistry] entity not found', {
@@ -1272,5 +1272,8 @@ export async function getFieldInfoFromRegistry(
     throw new Error(`Field "${fieldId}" missing fieldType on entity "${entityDefinitionId}"`)
   }
 
-  return { fieldType: field.fieldType, fieldOptions: field.options }
+  // Return the canonical field id (`field.id`) — the DB CustomField row id for
+  // system fields. Callers key FieldValue queries / maps by this so a static-form
+  // ref (e.g. `contact:firstName`) resolves to the same id values are stored under.
+  return { fieldId: field.id, fieldType: field.fieldType, fieldOptions: field.options }
 }

--- a/packages/lib/src/field-values/field-value-queries.ts
+++ b/packages/lib/src/field-values/field-value-queries.ts
@@ -244,21 +244,21 @@ async function batchGetAllDirectFieldValues(
     instanceToRecordId.set(entityInstanceId, rid)
   }
 
-  // Parse all field refs to get fieldIds and build ref lookup
+  // Resolve each ref to its canonical field id (DB row id for system fields) and key
+  // every lookup by it. This is what lets a static-form ref (`contact:firstName`) and a
+  // row-id ref both query FieldValue under the id values are actually stored under.
+  // `fieldIdToRef` keeps the *original* ref as its value so the response echoes the form
+  // the client requested (its store key agrees).
   const fieldIdToRef = new Map<string, ResourceFieldId>()
   const allFieldIds: string[] = []
-  for (const ref of fieldRefs) {
-    const { fieldId } = parseResourceFieldId(ref)
-    fieldIdToRef.set(fieldId, ref)
-    allFieldIds.push(fieldId)
-  }
-
-  // Resolve field types + options from registry
   const fieldTypeMap = new Map<string, FieldType>()
   const fieldOptionsMap = new Map<string, FieldOptions | undefined>()
   for (const ref of fieldRefs) {
-    const { entityDefinitionId, fieldId } = parseResourceFieldId(ref)
-    const info = await getFieldInfoFromRegistry(ctx.organizationId, entityDefinitionId, fieldId)
+    const { entityDefinitionId, fieldId: rawFieldId } = parseResourceFieldId(ref)
+    const info = await getFieldInfoFromRegistry(ctx.organizationId, entityDefinitionId, rawFieldId)
+    const fieldId = info.fieldId // canonical
+    fieldIdToRef.set(fieldId, ref)
+    allFieldIds.push(fieldId)
     fieldTypeMap.set(fieldId, info.fieldType)
     fieldOptionsMap.set(fieldId, info.fieldOptions)
   }
@@ -365,10 +365,13 @@ async function categorizeFields(
   fieldTypeMap: Map<string, FieldType>,
   fieldOptionsMap: Map<string, FieldOptions | undefined>
 ): Promise<CategorizedFields> {
+  // `isSystem` (old system types: thread/user/…) gates the system-table (Layer 1) and
+  // virtual (Layer 2) categorization. But canonical-id resolution must run for ANY
+  // registered resource — including EntityDefinition-backed ones (contact/ticket), which
+  // are NOT `isSystemResourceId` yet still have system fields whose row id ≠ static key.
+  // So always load the cached resource to map a static-key ref → its canonical row id.
   const isSystem = isSystemResourceId(entityDefinitionId)
-  const cachedResource = isSystem
-    ? await findCachedResource(ctx.organizationId, entityDefinitionId)
-    : null
+  const cachedResource = await findCachedResource(ctx.organizationId, entityDefinitionId)
 
   const systemDbFields: SystemFieldDescriptor[] = []
   const virtualFields: CategorizedFields['virtualFields'] = []
@@ -376,39 +379,40 @@ async function categorizeFields(
   const fieldIdToKeyMap = new Map<string, string>()
 
   for (const ref of fieldRefs) {
-    const { fieldId } = parseResourceFieldId(ref)
+    const { fieldId: rawFieldId } = parseResourceFieldId(ref)
+    const cachedField = cachedResource?.fields.find(
+      (f) => f.id === rawFieldId || f.key === rawFieldId
+    )
+    // Canonical id: the DB row id (cachedField.id) where a CustomField row exists, else the
+    // parsed id. Static-key refs (e.g. `contact:firstName`) resolve to the row id values are
+    // stored under; all maps + the FieldValue query key by it.
+    const fieldId = cachedField?.id ?? rawFieldId
     const fieldType = fieldTypeMap.get(fieldId)
 
     // Skip NAME fields (handled separately)
     if (!fieldType || fieldType === FieldTypeEnum.NAME) continue
 
-    if (isSystem && cachedResource) {
-      const cachedField = cachedResource.fields.find((f) => f.id === fieldId || f.key === fieldId)
-
-      if (cachedField?.dbColumn) {
-        systemDbFields.push({
-          fieldKey: cachedField.key,
-          fieldId,
-          fieldRef: ref,
-          fieldType,
-          fieldOptions: fieldOptionsMap.get(fieldId),
-          dbColumn: cachedField.dbColumn,
-          relationship: cachedField.relationship,
-        })
-      } else if (cachedField && isVirtualField(entityDefinitionId, cachedField.key)) {
-        virtualFields.push({
-          fieldKey: cachedField.key,
-          fieldId,
-          fieldRef: ref,
-          fieldType,
-          fieldOptions: fieldOptionsMap.get(fieldId),
-        })
-        fieldIdToKeyMap.set(cachedField.key, fieldId)
-      } else {
-        // System field stored in FieldValue (e.g. tags) or unknown
-        fieldValueFieldIds.push(fieldId)
-      }
+    if (isSystem && cachedField?.dbColumn) {
+      systemDbFields.push({
+        fieldKey: cachedField.key,
+        fieldId,
+        fieldRef: ref,
+        fieldType,
+        fieldOptions: fieldOptionsMap.get(fieldId),
+        dbColumn: cachedField.dbColumn,
+        relationship: cachedField.relationship,
+      })
+    } else if (isSystem && cachedField && isVirtualField(entityDefinitionId, cachedField.key)) {
+      virtualFields.push({
+        fieldKey: cachedField.key,
+        fieldId,
+        fieldRef: ref,
+        fieldType,
+        fieldOptions: fieldOptionsMap.get(fieldId),
+      })
+      fieldIdToKeyMap.set(cachedField.key, fieldId)
     } else {
+      // System field stored in FieldValue (e.g. tags), or a custom/non-system field.
       fieldValueFieldIds.push(fieldId)
     }
   }
@@ -603,12 +607,19 @@ async function resolveFieldReference(
     terminalEntityId,
     terminalFieldId
   )
+  // Canonical id (row id for system fields) — query/compose values under the id they're
+  // stored under, even when the ref arrived in static-key form.
+  const canonicalTerminalFieldId = terminalFieldInfo.fieldId
   const terminalFieldType = terminalFieldInfo.fieldType
   const terminalFieldOptions = terminalFieldInfo.fieldOptions
 
   // Handle NAME fields
   if (terminalFieldType === FieldTypeEnum.NAME && currentRecordIds.length > 0) {
-    const terminalValues = await resolveNameFieldValues(ctx, currentRecordIds, terminalFieldId)
+    const terminalValues = await resolveNameFieldValues(
+      ctx,
+      currentRecordIds,
+      canonicalTerminalFieldId
+    )
     return mapResultsToSources(
       sourceRecordIds,
       traversalMaps,
@@ -625,7 +636,7 @@ async function resolveFieldReference(
           ctx,
           currentRecordIds,
           terminalEntityId,
-          terminalFieldId,
+          canonicalTerminalFieldId,
           terminalResourceFieldId,
           terminalFieldType,
           terminalFieldOptions
@@ -652,18 +663,23 @@ async function fetchRelationshipHop(
   recordIds: RecordId[],
   resourceFieldId: ResourceFieldId
 ): Promise<Map<RecordId, RecordId[]>> {
-  const { entityDefinitionId: hopEntityDefId, fieldId } = parseResourceFieldId(resourceFieldId)
+  const { entityDefinitionId: hopEntityDefId, fieldId: rawFieldId } =
+    parseResourceFieldId(resourceFieldId)
 
   if (isSystemResourceId(hopEntityDefId)) {
     const hopResource = await findCachedResource(ctx.organizationId, hopEntityDefId)
-    const cachedField = hopResource?.fields.find((f) => f.id === fieldId || f.key === fieldId)
+    const cachedField = hopResource?.fields.find((f) => f.id === rawFieldId || f.key === rawFieldId)
 
     if (cachedField?.dbColumn && cachedField.relationship) {
       return batchFetchSystemRelationships(ctx, recordIds, cachedField, hopEntityDefId)
     }
+
+    // FieldValue-backed system relationship — query by canonical row id so a
+    // static-key hop ref still finds the stored relationships.
+    return batchFetchRelationships(ctx, recordIds, cachedField?.id ?? rawFieldId)
   }
 
-  return batchFetchRelationships(ctx, recordIds, fieldId)
+  return batchFetchRelationships(ctx, recordIds, rawFieldId)
 }
 
 /**

--- a/packages/lib/src/resources/registry/resource-registry-service.ts
+++ b/packages/lib/src/resources/registry/resource-registry-service.ts
@@ -203,6 +203,36 @@ function toSystemResourceBase(tableId: TableId): Omit<SystemResource, 'fields'> 
 }
 
 /**
+ * Re-point a system resource's display-field ids at the MERGED field ids.
+ *
+ * The static display config (`RESOURCE_DISPLAY_CONFIG`) resolves display fields against the
+ * static registry, so each `DisplayFieldConfig.id` is the static field id (== the field key).
+ * After merging with DB CustomField rows a system field's canonical id becomes the DB row id,
+ * so the static display id no longer matches `fields[].id` — which silently breaks the
+ * primary-cell match in the table (`f.id === primaryDisplayField.id`). Re-point each display
+ * field to the merged field that shares its key, keeping display identity consistent with the
+ * merged field identity. No-op for system types whose fields keep the static id.
+ */
+function reconcileSystemDisplayFields(
+  display: Omit<SystemResource, 'fields'>['display'],
+  fields: ResourceField[]
+): Omit<SystemResource, 'fields'>['display'] {
+  const repoint = (cfg: DisplayFieldConfig | null): DisplayFieldConfig | null => {
+    if (!cfg) return cfg
+    // cfg.id is the static field id (== key for system registry fields). Prefer an exact
+    // id match (already consistent); else match by key (id became a row id after merge).
+    const merged = fields.find((f) => f.id === cfg.id) ?? fields.find((f) => f.key === cfg.id)
+    return merged ? { ...cfg, id: merged.id } : cfg
+  }
+  return {
+    ...display,
+    primaryDisplayField: repoint(display.primaryDisplayField),
+    secondaryDisplayField: repoint(display.secondaryDisplayField),
+    avatarField: repoint(display.avatarField),
+  }
+}
+
+/**
  * Build a SystemResource from registry entry and display config (with static fields only)
  * Used for synchronous access when custom fields are not needed
  */
@@ -310,15 +340,18 @@ export class ResourceRegistryService {
       const staticFields = fieldRegistry ? Object.values(fieldRegistry) : []
       const orgCustomFields = fieldsByModelType.get(tableId) ?? []
 
+      const fields = sortFieldsWithMetadataLast(
+        this.mergeSystemAndCustomFields(
+          staticFields,
+          orgCustomFields,
+          systemResourceBase.entityDefinitionId
+        )
+      )
+
       return {
         ...systemResourceBase,
-        fields: sortFieldsWithMetadataLast(
-          this.mergeSystemAndCustomFields(
-            staticFields,
-            orgCustomFields,
-            systemResourceBase.entityDefinitionId
-          )
-        ),
+        display: reconcileSystemDisplayFields(systemResourceBase.display, fields),
+        fields,
       }
     })
 
@@ -543,13 +576,15 @@ export class ResourceRegistryService {
         orderBy: (f, { asc }) => [asc(f.sortOrder)],
       })
 
+      const mergedFields = this.mergeSystemAndCustomFields(
+        staticFields,
+        customFields as CustomFieldRecord[],
+        systemResourceBase.entityDefinitionId
+      )
       resource = {
         ...systemResourceBase,
-        fields: this.mergeSystemAndCustomFields(
-          staticFields,
-          customFields as CustomFieldRecord[],
-          systemResourceBase.entityDefinitionId
-        ),
+        display: reconcileSystemDisplayFields(systemResourceBase.display, mergedFields),
+        fields: mergedFields,
       }
     } else {
       // Custom entity - treat as EntityDefinitionId (UUID) - no entity_ prefix needed
@@ -848,15 +883,13 @@ export class ResourceRegistryService {
 
       if (staticField) {
         matchedAttributes.add(dbField.systemAttribute!)
-        // DB field takes priority, enrich with static-only properties.
-        // System fields are addressed by their logical registry id everywhere
-        // (values, filters, display config, columns), so adopt the static id
-        // and resourceFieldId rather than keeping the DB CustomField row id —
-        // otherwise metadata lookups by `<entity>:<key>` miss the field.
+        // Identity stays the DB CustomField row id (`dbField.id`/`dbField.resourceFieldId`)
+        // so it matches `FieldValue.fieldId` — values, columns, and store keys all agree on
+        // one id. We adopt the static field's display/behaviour metadata only. Resolution by
+        // `<entity>:<key>` still works because every read site dual-matches `f.id || f.key`
+        // and `key` below stays the stable static key.
         return {
           ...dbField,
-          id: staticField.id,
-          resourceFieldId: toResourceFieldId(entityDefinitionId, staticField.id),
           key: staticField.key,
           dbColumn: staticField.dbColumn,
           dynamicOptionsKey: staticField.dynamicOptionsKey,


### PR DESCRIPTION
## Problem

System-table cells loaded empty and `fieldValue.batchGet` threw `Field "<rowId>" not found in "<entityDef>"`. The client sends field references in **row-id** form (derived from `field.resourceFieldId`), but the server kept the **static registry id** as a system field's identity (#719), so `FieldValue.fieldId` (always the CustomField row id) never matched the id the field was addressed by.

A second symptom surfaced once identity flipped: the KB **article title stopped rendering as the primary cell**, because the resource display config still pointed at the static field id.

## Fix — row id is canonical

A system field's `ResourceField.id` now equals its DB CustomField row id, so `ResourceField.id ≡ ResourceFieldId field part ≡ FieldValue.fieldId`. Identity comes from the DB row; the static registry contributes display/behaviour metadata (`key`, `dbColumn`, capabilities, …) only.

- **Revert the #719 identity override** in `mergeSystemAndCustomFields` — keep `dbField.id`/`resourceFieldId`, adopt static metadata.
- **Reconcile system display fields** — re-point `primary/secondary/avatar` display ids to the merged field ids (matched by key), so `display.primaryDisplayField.id === fields[].id` again. Fixes the article primary-cell regression.
- **`getFieldInfoFromRegistry`** returns the canonical `fieldId`.
- **Canonical resolution before every FieldValue query** (`batchGetValues` / `categorizeFields` / slow-path terminal + relationship fetches) so both row-id refs and static-key refs (e.g. a workflow's `contact:firstName`) hit the stored id. The response `fieldRef` echoes the requested form so client store keys agree.

`categorizeFields` now loads the cached resource unconditionally — `isSystemResourceId` is **false** for EntityDefinition resources (contact/ticket) even though they carry system fields; only the dbColumn/virtual categorization stays gated on `isSystem`.

Client needed no changes — it already derives column ids, batchGet refs, and store keys from `field.resourceFieldId`.

## Verification (live data, org `abgwpa1l81reht2zmwrcihfu`)

- Row-id ref `…:pfofjb…` (the throwing call) and static-key ref `…:firstName` both resolve to `"Brandon"`.
- Full contact panel populates: First/Last Name, Email, composed NAME, SINGLE_SELECT Status, multi-value Tickets relationship.
- Article `display.primaryDisplayField.id` now equals the merged title field id → primary cell renders.
- Workflow query builder unchanged (already resolves through `field.id`).
- Org cache (`resources` + `customFields`) invalidated + recomputed; `@auxx/lib` rebuilt.

No production users yet, so legacy static-form persisted view configs are handled by read-time canonical resolution rather than a migration.