### PR TITLE
fix(field-values): static-key aliases + safe display formatting

### DIFF
--- a/apps/web/src/components/dynamic-table/cells/primary-field-cell.tsx
+++ b/apps/web/src/components/dynamic-table/cells/primary-field-cell.tsx
@@ -3,7 +3,7 @@
 
 import { formatToDisplayValue } from '@auxx/lib/field-values/client'
 import { parseResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
-import type { TypedFieldValue } from '@auxx/types/field-value'
+import { extractValue, type TypedFieldValue } from '@auxx/types/field-value'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { memo, type ReactNode, useMemo } from 'react'
 import { toRecordId, useRecord, useResource } from '~/components/resources'
@@ -64,13 +64,19 @@ export const PrimaryFieldCell = memo(function PrimaryFieldCell({
   // Format value for display
   const displayValue: string | null = useMemo(() => {
     if (value == null) return null
-    if (!fieldType) return String(value)
-    // Handle TypedFieldValue from store using centralized formatter
+    // TypedFieldValue from store: format with the field type when known. If the field
+    // metadata hasn't resolved yet (fieldType undefined), fall back to the value's own
+    // primitive so we never stringify the object into "[object Object]".
     if (typeof value === 'object' && 'type' in value) {
-      const formatted = formatToDisplayValue(value as TypedFieldValue, fieldType)
-      return typeof formatted === 'string' ? formatted : null
+      if (fieldType) {
+        const formatted = formatToDisplayValue(value as TypedFieldValue, fieldType)
+        return typeof formatted === 'string' ? formatted : null
+      }
+      const raw = extractValue(value as TypedFieldValue)
+      return typeof raw === 'object' ? null : String(raw)
     }
-    // Handle raw value (fallback)
+    // Arrays (multi-value) or other objects: avoid "[object Object]"
+    if (typeof value === 'object') return null
     return String(value)
   }, [value, fieldType])
 

--- a/apps/web/src/components/resources/store/hydrate-field-values.ts
+++ b/apps/web/src/components/resources/store/hydrate-field-values.ts
@@ -118,13 +118,6 @@ export function hydrateMultipleRecords(
         const valueKey = field.dbColumn || getFieldOutputKey(field)
         rawValue = record.data[valueKey]
       }
-      // console.log('Hydrating field', {
-      //   recordId: record.recordId,
-      //   fieldKey: field.key,
-      //   rawValue,
-      //   'record.data': record.data,
-      //   field,
-      // })
       if (rawValue === undefined) continue
 
       if (Array.isArray(rawValue) && field.relationship) {

--- a/apps/web/src/components/resources/store/resource-store.ts
+++ b/apps/web/src/components/resources/store/resource-store.ts
@@ -267,6 +267,26 @@ function isFieldContentEqual(a: ResourceField, b: ResourceField): boolean {
 }
 
 /**
+ * For a system field whose canonical id is the DB row id (post #734), compute the
+ * static-key form `<entity>:<key>` so callers addressing fields by their stable static
+ * key still resolve. Returns undefined when the canonical id already equals the key
+ * (custom fields, or system fields without a DB CustomField row).
+ *
+ * This mirrors the server-side interchangeable resolution (`f.id || f.key`): the
+ * canonical key stays the row id, the static-key form is registered as an alias to
+ * the same field object.
+ */
+function staticKeyAliasId(
+  canonicalKey: ResourceFieldId,
+  field: ResourceField
+): ResourceFieldId | undefined {
+  if (!field.key) return undefined
+  const { entityDefinitionId, fieldId } = parseResourceFieldId(canonicalKey)
+  if (field.key === fieldId) return undefined
+  return toResourceFieldId(entityDefinitionId, field.key)
+}
+
+/**
  * Build fieldMap with optimistic overlay applied.
  * This is the effective view of all fields (server + pending changes).
  */
@@ -311,6 +331,19 @@ function buildEffectiveFieldMap(
   >) {
     if (!optimisticDeletedFields.has(key)) {
       newFieldMap[key] = field
+    }
+  }
+
+  // Register static-key aliases so a field resolves by either its canonical row id or
+  // its `<entity>:<key>` form. Second pass over the resolved entries (not serverFieldMap)
+  // so the alias points at the effective, overlay-applied object. Never overwrite a real
+  // canonical entry.
+  for (const [key, field] of Object.entries(newFieldMap) as Array<
+    [ResourceFieldId, ResourceField]
+  >) {
+    const aliasKey = staticKeyAliasId(key, field)
+    if (aliasKey && !newFieldMap[aliasKey]) {
+      newFieldMap[aliasKey] = field
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #734 (row-id canonical field identity). Fixes two field-value resolution/display gaps and removes stale debug output.

- **`resource-store.ts`** — Register `<entity>:<key>` static-key aliases in the effective field map. After #734 a system field's canonical id is its DB row id, so callers addressing fields by their stable static key stopped resolving. A second pass over the resolved (overlay-applied) entries registers each static-key form as an alias to the same field object, mirroring the server-side interchangeable resolution (`f.id || f.key`). Never overwrites a real canonical entry.
- **`primary-field-cell.tsx`** — Harden display formatting. When field metadata hasn't resolved yet (`fieldType` undefined), fall back to the `TypedFieldValue`'s own primitive via `extractValue`, and return `null` for arrays/objects, so a value never stringifies into `"[object Object]"`.
- **`hydrate-field-values.ts`** — Drop a stale commented-out debug `console.log`.

## Testing

- Verified new symbols are imported/exported: `parseResourceFieldId`/`toResourceFieldId` (`@auxx/types/field`), `extractValue` (`@auxx/types/field-value`).
- Biome lint ran clean on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)