### PR TITLE
feat(kb): link individual articles into a KB from any KB

### DIFF
--- a/apps/web/src/app/(protected)/app/kb/[knowledgeBaseId]/editor/r/[articleId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/kb/[knowledgeBaseId]/editor/r/[articleId]/page.tsx
@@ -1,0 +1,72 @@
+// apps/web/src/app/(protected)/app/kb/[knowledgeBaseId]/editor/r/[articleId]/page.tsx
+//
+// Stable-id soft-redirect for the editor. The articles table only has an article's
+// id + home KB (slug lives on ArticlePlacement, not the row), so the primary-cell
+// click routes here. A *page* (not a route handler) so `router.push` performs a
+// soft RSC navigation and the `redirect()` is followed client-side without a full
+// reload. Resolves the id to its current slug path and forwards to the editor.
+
+import { ArticlePlacement, database } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import { headers } from 'next/headers'
+import { notFound, redirect } from 'next/navigation'
+import { auth } from '~/auth/server'
+
+interface PageProps {
+  params: Promise<{ knowledgeBaseId: string; articleId: string }>
+}
+
+export default async function ArticleIdRedirectPage({ params }: PageProps) {
+  const { knowledgeBaseId, articleId } = await params
+
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session?.user) {
+    redirect(`/login?callbackUrl=/app/kb/${knowledgeBaseId}/editor/r/${articleId}`)
+  }
+
+  // Resolve the article's placement — prefer the requested KB, else any.
+  const placements = await database
+    .select({
+      id: ArticlePlacement.id,
+      knowledgeBaseId: ArticlePlacement.knowledgeBaseId,
+      organizationId: ArticlePlacement.organizationId,
+    })
+    .from(ArticlePlacement)
+    .where(eq(ArticlePlacement.articleId, articleId))
+
+  const placement = placements.find((p) => p.knowledgeBaseId === knowledgeBaseId) ?? placements[0]
+  if (!placement) notFound()
+
+  const userOrgId = (session.user as { defaultOrganizationId?: string | null })
+    .defaultOrganizationId
+  if (userOrgId && userOrgId !== placement.organizationId) notFound()
+
+  const slugPath = await buildSlugPath(placement.id, placement.knowledgeBaseId)
+  redirect(`/app/kb/${placement.knowledgeBaseId}/editor/~/${slugPath}?panel=articles`)
+}
+
+/** Walk the placement tree up from `placementId`, collecting slugs root→leaf. */
+async function buildSlugPath(placementId: string, knowledgeBaseId: string): Promise<string> {
+  const rows = await database
+    .select({
+      id: ArticlePlacement.id,
+      slug: ArticlePlacement.slug,
+      parentId: ArticlePlacement.parentId,
+    })
+    .from(ArticlePlacement)
+    .where(eq(ArticlePlacement.knowledgeBaseId, knowledgeBaseId))
+
+  const byId = new Map(rows.map((r) => [r.id, r]))
+  const parts: string[] = []
+  const seen = new Set<string>()
+  let cursor: string | null = placementId
+  while (cursor) {
+    if (seen.has(cursor)) break
+    seen.add(cursor)
+    const row = byId.get(cursor)
+    if (!row) break
+    parts.unshift(row.slug)
+    cursor = row.parentId
+  }
+  return parts.join('/')
+}

--- a/apps/web/src/app/(protected)/app/kb/[knowledgeBaseId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/kb/[knowledgeBaseId]/page.tsx
@@ -1,0 +1,16 @@
+// app/kb/[knowledgeBaseId]/page.tsx
+
+import { redirect } from 'next/navigation'
+
+type KBIndexParams = {
+  params: Promise<{ knowledgeBaseId: string }>
+}
+
+/**
+ * The per-KB landing is the editor. The bare `/app/kb/<id>` URL has no page of
+ * its own, so forward it to the editor root (which resolves the home article).
+ */
+export default async function KBIndexPage({ params }: KBIndexParams) {
+  const { knowledgeBaseId } = await params
+  redirect(`/app/kb/${knowledgeBaseId}/editor`)
+}

--- a/apps/web/src/components/agents/ui/detail/restrictions/add-restriction-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/restrictions/add-restriction-dialog.tsx
@@ -4,17 +4,11 @@
 import type { ArgRestriction } from '@auxx/lib/agents/restrictions/client'
 import { fieldTypeOptions } from '@auxx/lib/custom-fields/types'
 import { Button } from '@auxx/ui/components/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@auxx/ui/components/dialog'
+import { Dialog, DialogContent, DialogFooter } from '@auxx/ui/components/dialog'
+import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
 import { EntityIcon } from '@auxx/ui/components/icons'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
-import { ChevronLeft } from 'lucide-react'
 import { type ReactNode, useEffect, useMemo, useState } from 'react'
 import { ToolReferenceList } from '~/components/pickers/tool-picker/tool-reference-list'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
@@ -163,109 +157,123 @@ export function AddRestrictionDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className='max-w-lg'>
-        <DialogHeader>
-          <DialogTitle className='flex items-center gap-2'>
-            {step === 'args' && !editing ? (
-              <button
-                type='button'
-                aria-label='Back'
-                className='rounded-md p-0.5 hover:bg-primary/5'
-                onClick={() => setStep('tool')}>
-                <ChevronLeft className='size-4 text-muted-foreground' />
-              </button>
-            ) : null}
-            {step === 'tool' ? 'Add restriction' : (selectedTool?.displayName ?? 'Restrictions')}
-          </DialogTitle>
-          <DialogDescription>
-            {step === 'tool'
-              ? 'Pick a tool, then bind its arguments.'
-              : 'Pin each argument to a value, or leave it for the model to decide.'}
-          </DialogDescription>
-        </DialogHeader>
-
-        {step === 'tool' ? (
-          <ToolReferenceList
-            filterNames={toolMeta.enabledCatalogNames}
-            onSelectSingle={handleSelectTool}
-            className='border'
+      <DialogContent innerClassName='p-0' position='tc' size='content'>
+        <div className='flex flex-col'>
+          <DialogNav
+            title='Add restriction'
+            description='Pick a tool, then bind each of its arguments to a fixed value or leave it for the model to decide.'
+            onBack={step === 'args' && !editing ? () => setStep('tool') : undefined}
+            crumbs={[
+              {
+                label:
+                  step === 'tool'
+                    ? 'Add restriction'
+                    : (selectedTool?.displayName ?? 'Restrictions'),
+                icon:
+                  step === 'args' && selectedTool ? (
+                    <EntityIcon iconId={selectedTool.iconId} size='xs' />
+                  ) : undefined,
+              },
+            ]}
           />
-        ) : null}
 
-        {step === 'args' ? (
-          <ScrollArea className='max-h-[28rem]'>
-            <div className='pe-2'>
-              {args.length === 0 ? (
-                <p className='px-2 py-4 text-sm text-muted-foreground'>
-                  This tool has no top-level arguments.
-                </p>
-              ) : (
-                <VarEditorField className='p-0'>
-                  {args.map((arg) => {
-                    const mapped = argToFieldType(arg.schema)
-                    const isIdentity = identityArgNames.has(arg.name)
-                    const r = draft[arg.name] ?? MODEL_DECIDES
-                    const suggested = selectedTool?.identityScopedInputs.find(
-                      (i) => i.name === arg.name
-                    )?.suggestedVar
+          {/* Body — width/height springs between steps */}
+          <DialogNavPages value={step}>
+            <DialogNavPage value='tool' size='md'>
+              <div className='p-3'>
+                <ToolReferenceList
+                  filterNames={toolMeta.enabledCatalogNames}
+                  onSelectSingle={handleSelectTool}
+                  className='border'
+                />
+              </div>
+            </DialogNavPage>
 
-                    return (
-                      <VarEditorFieldRow
-                        key={arg.name}
-                        title={arg.name}
-                        description={arg.schema.description}
-                        icon={fieldTypeIcon(mapped.supported ? mapped.fieldType : undefined)}
-                        showIcon
-                        isRequired={r.required}
-                        onClear={
-                          !isIdentity && r.source !== 'model'
-                            ? () => setRow(arg.name, { source: 'model', required: r.required })
-                            : undefined
-                        }>
-                        {mapped.supported ? (
-                          <div className='relative'>
-                            <div className='absolute right-full top-1/2 z-10 -translate-y-1/2 me-0.5'>
-                              <RestrictionRequiredBadge
-                                required={!!r.required}
-                                isIdentityArg={isIdentity}
-                                onChange={(req) => setRow(arg.name, { ...r, required: req })}
-                              />
-                            </div>
-                            <RestrictionValueEditor
-                              restriction={r}
-                              onChange={(next) => setRow(arg.name, next)}
-                              argFieldType={mapped.fieldType}
-                              fieldOptions={mapped.options}
-                              agentId={agent.id}
-                              agentKind={agent.kind}
-                              isIdentityArg={isIdentity}
-                              suggestedVar={suggested}
-                            />
-                          </div>
-                        ) : (
-                          <p className='py-2 text-xs italic text-muted-foreground'>
-                            {mapped.reason}
-                          </p>
-                        )}
-                      </VarEditorFieldRow>
-                    )
-                  })}
-                </VarEditorField>
-              )}
-            </div>
-          </ScrollArea>
-        ) : null}
+            <DialogNavPage value='args' size='md'>
+              <ScrollArea className='max-h-[28rem]'>
+                <div className='p-3'>
+                  <p className='pb-2 text-muted-foreground text-xs'>
+                    Pin each argument to a value, or leave it for the model to decide.
+                  </p>
+                  {args.length === 0 ? (
+                    <p className='px-2 py-4 text-sm text-muted-foreground'>
+                      This tool has no top-level arguments.
+                    </p>
+                  ) : (
+                    <VarEditorField className='p-0'>
+                      {args.map((arg) => {
+                        const mapped = argToFieldType(arg.schema)
+                        const isIdentity = identityArgNames.has(arg.name)
+                        const r = draft[arg.name] ?? MODEL_DECIDES
+                        const suggested = selectedTool?.identityScopedInputs.find(
+                          (i) => i.name === arg.name
+                        )?.suggestedVar
 
-        {step === 'args' ? (
-          <DialogFooter>
-            <Button variant='ghost' onClick={() => onOpenChange(false)}>
-              Cancel
+                        return (
+                          <VarEditorFieldRow
+                            key={arg.name}
+                            title={arg.name}
+                            description={arg.schema.description}
+                            icon={fieldTypeIcon(mapped.supported ? mapped.fieldType : undefined)}
+                            showIcon
+                            isRequired={r.required}
+                            onClear={
+                              !isIdentity && r.source !== 'model'
+                                ? () => setRow(arg.name, { source: 'model', required: r.required })
+                                : undefined
+                            }>
+                            {mapped.supported ? (
+                              <div className='relative'>
+                                <div className='absolute right-full top-1/2 z-10 -translate-y-1/2 me-0.5'>
+                                  <RestrictionRequiredBadge
+                                    required={!!r.required}
+                                    isIdentityArg={isIdentity}
+                                    onChange={(req) => setRow(arg.name, { ...r, required: req })}
+                                  />
+                                </div>
+                                <RestrictionValueEditor
+                                  restriction={r}
+                                  onChange={(next) => setRow(arg.name, next)}
+                                  argFieldType={mapped.fieldType}
+                                  fieldOptions={mapped.options}
+                                  agentId={agent.id}
+                                  agentKind={agent.kind}
+                                  isIdentityArg={isIdentity}
+                                  suggestedVar={suggested}
+                                />
+                              </div>
+                            ) : (
+                              <p className='py-2 text-xs italic text-muted-foreground'>
+                                {mapped.reason}
+                              </p>
+                            )}
+                          </VarEditorFieldRow>
+                        )
+                      })}
+                    </VarEditorField>
+                  )}
+                </div>
+              </ScrollArea>
+            </DialogNavPage>
+          </DialogNavPages>
+
+          {/* Footer */}
+          <DialogFooter className='mt-0 p-3 pt-0'>
+            <Button size='sm' variant='ghost' onClick={() => onOpenChange(false)}>
+              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
             </Button>
-            <Button onClick={handleSave} disabled={!canSave}>
-              {editing ? 'Save' : 'Add restriction'}
-            </Button>
+            {step === 'args' && (
+              <Button
+                size='sm'
+                variant='outline'
+                onClick={handleSave}
+                disabled={!canSave}
+                data-dialog-submit>
+                {editing ? 'Save' : 'Add restriction'} <KbdSubmit variant='outline' size='sm' />
+              </Button>
+            )}
           </DialogFooter>
-        ) : null}
+        </div>
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/components/editor/editable-text.tsx
+++ b/apps/web/src/components/editor/editable-text.tsx
@@ -130,8 +130,9 @@ export const EditableText = forwardRef<EditableTextHandle, EditableTextProps>(fu
     }
   }
 
-  // Determine if the placeholder should be shown in the display view
-  const showPlaceholder = !text && placeholder
+  // Determine if the placeholder should be shown in the display view. A read-only
+  // field with no value renders nothing — the placeholder is an editing affordance.
+  const showPlaceholder = !text && placeholder && !readOnly
 
   return (
     <div className={cn('relative inline-block', containerClassName)}>

--- a/apps/web/src/components/editor/kb-article/block-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/block-node-view.tsx
@@ -236,6 +236,7 @@ export function BlockNodeView({
   const isEmpty = node.content.size === 0
   const isFirstBlock = pos === 0
   const showPlaceholder =
+    editor.isEditable &&
     isEmpty &&
     !isDivider &&
     !isImage &&

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
@@ -43,6 +43,13 @@ interface KBArticleEditorProps {
   onReady?: (editor: Editor) => void
   /** When true, switches the editor to read-only — used while Kopilot is in a write turn. */
   readOnly?: boolean
+  /**
+   * Collapse the left block gutter (numbers + drag handles) and its pull-left
+   * margin so the body lines up flush under the title. Set on read-only viewers
+   * like the source workspace where the gutter rail is never shown — without it
+   * the body sits left of the title.
+   */
+  hideGutter?: boolean
 }
 
 interface LinkPopoverState {
@@ -64,6 +71,7 @@ export function KBArticleEditor({
   knowledgeBaseId,
   onReady,
   readOnly,
+  hideGutter,
 }: KBArticleEditorProps) {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const referencePickerRef = useRef<ReferencePickerHandle | null>(null)
@@ -230,7 +238,9 @@ export function KBArticleEditor({
         onMouseDown={handleWrapperMouseDown}
         onContextMenu={handleContextMenu}
         style={
-          { '--editor-gutter-min-width': `calc(${gutterCharWidth}ch + 1rem)` } as CSSProperties
+          (hideGutter
+            ? { '--editor-gutter-min-width': '0px', '--editor-gutter-pull-left': '0' }
+            : { '--editor-gutter-min-width': `calc(${gutterCharWidth}ch + 1rem)` }) as CSSProperties
         }>
         <div className={styles.editorContainer}>
           <EditorContent editor={editor} className={styles.editorContent} />

--- a/apps/web/src/components/kb/ui/articles/article-picker.tsx
+++ b/apps/web/src/components/kb/ui/articles/article-picker.tsx
@@ -14,10 +14,12 @@ import {
   useCommandNavigation,
 } from '@auxx/ui/components/command'
 import { EntityIcon } from '@auxx/ui/components/icons'
-import { ChevronRight, CornerDownRight } from 'lucide-react'
+import { ChevronRight, CornerDownRight, Loader2 } from 'lucide-react'
 import { type KeyboardEvent, useCallback, useMemo, useState } from 'react'
+import { api } from '~/trpc/react'
 import { useArticleList } from '../../hooks/use-article-list'
 import { useKnowledgeBases } from '../../hooks/use-knowledge-bases'
+import { normalizeServerArticle } from '../../store/normalize-server-article'
 
 interface NavItem {
   /** When `kind` is omitted, this entry is a KB root (cross-KB picker). */
@@ -52,6 +54,14 @@ export interface ArticlePickerProps {
    * navigation still works when the search is empty.
    */
   flattenSearch?: boolean
+  /**
+   * Cross-KB mode only (no `knowledgeBaseId`): list these KBs at the root instead of
+   * `useKnowledgeBases()`. Lets callers include KBs the default list hides — e.g. sources'
+   * hidden KBs (`api.kb.list` only returns `kind='standard'`).
+   */
+  knowledgeBasesOverride?: { id: string; name: string }[]
+  /** Focus the search input on mount (e.g. when embedded in a morphing dropdown). */
+  autoFocusSearch?: boolean
   onPick: (articleId: string) => void
   onClose: () => void
 }
@@ -76,6 +86,8 @@ function ArticlePickerContent({
   rootLabel = 'Pick an article',
   searchPlaceholder,
   flattenSearch,
+  knowledgeBasesOverride,
+  autoFocusSearch,
   onPick,
   onClose,
 }: ArticlePickerProps) {
@@ -86,12 +98,27 @@ function ArticlePickerContent({
   // Cross-KB scope: when no `knowledgeBaseId` is provided, the root is a KB
   // list and we drill into a KB on select. Inside a KB, behave like the
   // single-KB form.
+  const isCrossKb = !knowledgeBaseId
   const { knowledgeBases } = useKnowledgeBases()
+  const kbList = knowledgeBasesOverride ?? knowledgeBases
   const activeKbId =
     knowledgeBaseId ??
     (stack[0]?.kind === 'kb' ? stack[0].id : isAtRoot ? null : (current?.id ?? null))
 
-  const articles = useArticleList(activeKbId)
+  // Single-KB mode reads the global store (reflects optimistic moves). Cross-KB mode
+  // fetches the drilled-into KB directly — loading a second KB into the shared store
+  // would clobber `parentId` for articles shared across KBs (see plan, constraint 2).
+  const storeArticles = useArticleList(knowledgeBaseId)
+  const crossKbArticles = api.kb.getArticles.useQuery(
+    { knowledgeBaseId: activeKbId ?? '', includeUnpublished: true },
+    { enabled: isCrossKb && !!activeKbId }
+  )
+  const fetchedArticles = useMemo(
+    () => ((crossKbArticles.data as unknown[]) ?? []).map(normalizeServerArticle),
+    [crossKbArticles.data]
+  )
+  const articles = isCrossKb ? fetchedArticles : storeArticles
+  const articlesLoading = isCrossKb && !!activeKbId && crossKbArticles.isLoading
 
   const allowedSet = useMemo(() => new Set(allowedKinds), [allowedKinds])
   const drillableSet = useMemo(() => new Set(drillableKinds), [drillableKinds])
@@ -139,8 +166,8 @@ function ArticlePickerContent({
 
   const visibleKbs = useMemo(() => {
     if (knowledgeBaseId || activeKbId) return []
-    return knowledgeBases.filter((kb) => !q || (kb.name ?? '').toLowerCase().includes(q))
-  }, [knowledgeBaseId, activeKbId, knowledgeBases, q])
+    return kbList.filter((kb) => !q || (kb.name ?? '').toLowerCase().includes(q))
+  }, [knowledgeBaseId, activeKbId, kbList, q])
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
@@ -176,9 +203,14 @@ function ArticlePickerContent({
   return (
     <Command className='w-72 overflow-hidden' shouldFilter={false} onKeyDown={handleKeyDown}>
       <CommandBreadcrumb rootLabel={rootLabel} />
-      <CommandInput placeholder={placeholder} value={search} onValueChange={setSearch} />
+      <CommandInput
+        placeholder={placeholder}
+        value={search}
+        onValueChange={setSearch}
+        autoFocus={autoFocusSearch}
+      />
       <CommandList>
-        <CommandEmpty>No matches.</CommandEmpty>
+        {!articlesLoading && <CommandEmpty>No matches.</CommandEmpty>}
 
         {!insideKb && visibleKbs.length > 0 && (
           <CommandGroup heading='Knowledge bases'>
@@ -201,7 +233,13 @@ function ArticlePickerContent({
           </CommandGroup>
         )}
 
-        {insideKb && (
+        {insideKb && articlesLoading && (
+          <div className='flex items-center justify-center py-6'>
+            <Loader2 className='size-4 animate-spin text-muted-foreground' />
+          </div>
+        )}
+
+        {insideKb && !articlesLoading && (
           <CommandGroup
             heading={
               current?.kind === 'tab' || current?.kind === 'category' ? current.label : 'Articles'

--- a/apps/web/src/components/kb/ui/articles/articles-view.tsx
+++ b/apps/web/src/components/kb/ui/articles/articles-view.tsx
@@ -52,9 +52,10 @@ const TAGS_COLUMN_ID = toResourceFieldId(ARTICLE_SLUG, toFieldId('tags'))
  * row into RecordMeta, so kb id / slug / publish state are top-level.
  */
 interface ArticleRow extends RecordMeta {
-  slug?: string
-  knowledgeBaseId?: string
-  isPublished?: boolean
+  /** The article's owning KB (Article.homeKnowledgeBaseId) — always present on the row. */
+  homeKnowledgeBaseId?: string
+  /** Article-level publish status (Article.status). */
+  status?: 'DRAFT' | 'PUBLISHED' | 'ARCHIVED'
   articleKind?: string
 }
 
@@ -149,8 +150,8 @@ export function ArticlesView() {
 
   const handlePublishToggle = useCallback(
     (row: ArticleRow) => {
-      const input = { id: row.id, knowledgeBaseId: row.knowledgeBaseId }
-      if (row.isPublished) {
+      const input = { id: row.id, knowledgeBaseId: row.homeKnowledgeBaseId }
+      if (row.status === 'PUBLISHED') {
         unpublishArticle.mutate(input)
       } else {
         publishArticle.mutate({ ...input, ancestorIds: [] })
@@ -168,14 +169,14 @@ export function ArticlesView() {
         destructive: true,
       })
       if (!ok) return
-      archiveArticle.mutate({ id: row.id, knowledgeBaseId: row.knowledgeBaseId })
+      archiveArticle.mutate({ id: row.id, knowledgeBaseId: row.homeKnowledgeBaseId })
     },
     [archiveArticle, confirm]
   )
 
   const handleDelete = useCallback(
     async (row: ArticleRow) => {
-      if (!row.knowledgeBaseId) return
+      if (!row.homeKnowledgeBaseId) return
       const ok = await confirm({
         title: 'Delete article?',
         description: 'This action cannot be undone.',
@@ -183,7 +184,7 @@ export function ArticlesView() {
         destructive: true,
       })
       if (!ok) return
-      deleteArticle.mutate({ id: row.id, knowledgeBaseId: row.knowledgeBaseId })
+      deleteArticle.mutate({ id: row.id, knowledgeBaseId: row.homeKnowledgeBaseId })
     },
     [deleteArticle, confirm]
   )
@@ -192,25 +193,26 @@ export function ArticlesView() {
   const primaryCellRender = useCallback(
     (row: ArticleRow) => {
       const resourceFieldId = toResourceFieldId(ARTICLE_SLUG, toFieldId('title'))
-      const canOpenEditor = !!row.knowledgeBaseId && !!row.slug
+      // The row carries the article's home KB but not its placement slug, so route by
+      // id through the editor's id→slug redirect handler.
       return (
         <PrimaryFieldCell
           resourceFieldId={resourceFieldId}
           rowId={row.id}
           onTitleClick={() => {
-            if (!canOpenEditor) return
-            router.push(`/app/kb/${row.knowledgeBaseId}/editor/${row.slug}`)
+            if (!row.homeKnowledgeBaseId) return
+            router.push(`/app/kb/${row.homeKnowledgeBaseId}/editor/r/${row.id}`)
           }}>
-          {row.knowledgeBaseId &&
+          {row.homeKnowledgeBaseId &&
             (row.articleKind === 'page' || row.articleKind === 'category') && (
               <FavoriteToggleMenuItem
                 targetType='ARTICLE'
-                targetIds={{ articleId: row.id, knowledgeBaseId: row.knowledgeBaseId }}
+                targetIds={{ articleId: row.id, knowledgeBaseId: row.homeKnowledgeBaseId }}
               />
             )}
           <DropdownMenuItem onSelect={() => handlePublishToggle(row)}>
-            {row.isPublished ? <GlobeLock /> : <Globe />}
-            {row.isPublished ? 'Unpublish' : 'Publish'}
+            {row.status === 'PUBLISHED' ? <GlobeLock /> : <Globe />}
+            {row.status === 'PUBLISHED' ? 'Unpublish' : 'Publish'}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => handleArchive(row)}>
             <Archive />

--- a/apps/web/src/components/kb/ui/editor/article-editor-footer.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor-footer.tsx
@@ -11,6 +11,7 @@ import Link from 'next/link'
 import { useMemo } from 'react'
 import { useArticleList } from '../../hooks/use-article-list'
 import type { ArticleMeta } from '../../store/article-store'
+import { useArticleEditorSurface } from './article-editor-surface'
 
 interface ArticleEditorFooterProps {
   article: ArticleMeta
@@ -19,6 +20,7 @@ interface ArticleEditorFooterProps {
 
 export function ArticleEditorFooter({ article, knowledgeBaseId }: ArticleEditorFooterProps) {
   const articles = useArticleList(knowledgeBaseId)
+  const { buildHref: hrefOverride } = useArticleEditorSurface()
 
   const { prevArticle, nextArticle } = useMemo(() => {
     const tree = buildArticleTree(articles)
@@ -31,12 +33,12 @@ export function ArticleEditorFooter({ article, knowledgeBaseId }: ArticleEditorF
   }, [articles, article.id])
 
   const basePath = `/app/kb/${knowledgeBaseId}`
-  const prevHref = prevArticle
-    ? `${basePath}/editor/~/${getFullSlugPath(prevArticle, articles)}?panel=articles`
-    : '#'
-  const nextHref = nextArticle
-    ? `${basePath}/editor/~/${getFullSlugPath(nextArticle, articles)}?panel=articles`
-    : '#'
+  const buildHref = (a: ArticleMeta) =>
+    hrefOverride
+      ? hrefOverride(a)
+      : `${basePath}/editor/~/${getFullSlugPath(a, articles)}?panel=articles`
+  const prevHref = prevArticle ? buildHref(prevArticle) : '#'
+  const nextHref = nextArticle ? buildHref(nextArticle) : '#'
 
   return (
     <div className='relative mx-auto mt-6 flex w-full max-w-3xl'>

--- a/apps/web/src/components/kb/ui/editor/article-editor-header.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor-header.tsx
@@ -9,6 +9,7 @@ import { Cog, Eye, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useArticleList } from '../../hooks/use-article-list'
 import type { ArticleMeta } from '../../store/article-store'
+import { useArticleEditorSurface } from './article-editor-surface'
 import { ArticlePublishCluster } from './article-publish-cluster'
 import { ArticleSettingsDialog } from './article-settings-dialog'
 import { HiddenParentBadge } from './hidden-parent-badge'
@@ -39,6 +40,9 @@ interface ArticleEditorHeaderProps {
 export function ArticleEditorHeader({ article, knowledgeBaseId, diff }: ArticleEditorHeaderProps) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const articles = useArticleList(knowledgeBaseId)
+  // Source-owned KBs aren't independently publishable, so the embedding surface
+  // hides the publish cluster + Preview link entirely.
+  const { hidePublishing } = useArticleEditorSurface()
 
   const previewHref = useMemo(
     () => getKbPreviewHref(knowledgeBaseId, getFullSlugPath(article, articles)),
@@ -54,7 +58,9 @@ export function ArticleEditorHeader({ article, knowledgeBaseId, diff }: ArticleE
         onClick={() => setIsSettingsOpen(true)}>
         <Cog /> Page settings
       </Button>
-      <ArticlePublishCluster article={article} knowledgeBaseId={knowledgeBaseId} />
+      {!hidePublishing && (
+        <ArticlePublishCluster article={article} knowledgeBaseId={knowledgeBaseId} />
+      )}
       <HiddenParentBadge article={article} knowledgeBaseId={knowledgeBaseId} />
       {diff ? (
         <>
@@ -75,7 +81,7 @@ export function ArticleEditorHeader({ article, knowledgeBaseId, diff }: ArticleE
             <LegendChip color='amber' label='Changed' count={diff.stats.modified} />
           </div>
         </>
-      ) : (
+      ) : hidePublishing ? null : (
         <Button variant='outline' size='xs' className='ml-auto shrink-0' asChild>
           <a href={previewHref} target='_blank' rel='noopener'>
             <Eye /> Preview

--- a/apps/web/src/components/kb/ui/editor/article-editor-surface.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor-surface.tsx
@@ -1,0 +1,56 @@
+// apps/web/src/components/kb/ui/editor/article-editor-surface.tsx
+'use client'
+
+import { createContext, useContext, useMemo } from 'react'
+import type { ArticleMeta } from '../../store/article-store'
+
+/** Builds the href an article link should point at. */
+export type ArticleHrefBuilder = (article: ArticleMeta) => string
+
+/** How an embedding surface customizes the shared article editor. */
+export interface ArticleEditorSurface {
+  /**
+   * Overrides where the editor's internal links (footer prev/next) point. The KB
+   * editor route uses its default slug-based href; surfaces that embed the editor
+   * elsewhere — e.g. the source workspace — keep navigation inside their route.
+   */
+  buildHref?: ArticleHrefBuilder
+  /**
+   * Hide the publish/unpublish cluster (status pill, publish, archive, delete) and
+   * the Preview link. Set by surfaces whose knowledge base isn't independently
+   * publishable, like the source workspace — a source's owned KB has no public site.
+   */
+  hidePublishing?: boolean
+}
+
+const ArticleEditorSurfaceContext = createContext<ArticleEditorSurface | null>(null)
+
+/**
+ * Provides surface-level overrides to a `ArticleEditor` embedded outside the KB
+ * editor route. Pass stable `buildHref` (hoist it to module scope) so the memo
+ * holds and the editor subtree doesn't re-render on every parent render.
+ */
+export function ArticleEditorSurfaceProvider({
+  buildHref,
+  hidePublishing = false,
+  children,
+}: {
+  buildHref?: ArticleHrefBuilder
+  hidePublishing?: boolean
+  children: React.ReactNode
+}) {
+  const value = useMemo<ArticleEditorSurface>(
+    () => ({ buildHref, hidePublishing }),
+    [buildHref, hidePublishing]
+  )
+  return (
+    <ArticleEditorSurfaceContext.Provider value={value}>
+      {children}
+    </ArticleEditorSurfaceContext.Provider>
+  )
+}
+
+/** Surface overrides for the current editor, or empty defaults on the KB route. */
+export function useArticleEditorSurface(): ArticleEditorSurface {
+  return useContext(ArticleEditorSurfaceContext) ?? {}
+}

--- a/apps/web/src/components/kb/ui/editor/article-editor.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-editor.tsx
@@ -177,6 +177,7 @@ export function ArticleEditor({ article, knowledgeBaseId }: ArticleEditorProps) 
                     knowledgeBaseId={knowledgeBaseId}
                     onReady={handleBodyEditorReady}
                     readOnly={bodyReadOnly}
+                    hideGutter={managed}
                   />
                 )}
                 {locked && (

--- a/apps/web/src/components/kb/ui/editor/container-article-placeholder.tsx
+++ b/apps/web/src/components/kb/ui/editor/container-article-placeholder.tsx
@@ -4,24 +4,20 @@
 import { ArticleKind } from '@auxx/database/enums'
 import type { ArticleKind as ArticleKindType } from '@auxx/database/types'
 import { Button } from '@auxx/ui/components/button'
-import {
-  Command,
-  CommandGroup,
-  CommandGroupLabel,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-} from '@auxx/ui/components/command'
 import { EntityIcon, getIcon } from '@auxx/ui/components/icons'
 import { getFullSlugPath } from '@auxx/ui/components/kb/utils'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
-import { ExternalLink, FileText, FolderClosed, Heading, Link2 } from 'lucide-react'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { Database, ExternalLink, FileText, FolderClosed, Heading, Link2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useCallback, useMemo, useRef } from 'react'
+import { forwardRef, useCallback, useMemo, useRef, useState } from 'react'
 import { useArticleList } from '../../hooks/use-article-list'
 import { useArticleMutations } from '../../hooks/use-article-mutations'
 import type { ArticleMeta } from '../../store/article-store'
 import { usePendingInsertStore } from '../../store/pending-insert-store'
+import { LinkArticlePicker } from '../sidebar/link-article-picker'
 import { ArticleEditorHeader } from './article-editor-header'
 import { ArticleEditorTop } from './article-editor-top'
 
@@ -54,7 +50,8 @@ const HEADER_OPTIONS: QuickCreateOption[] = [
  * container (`tab`, `header`, or `link`). Reuses the article editor's
  * header + top blocks so the surface matches a real article — same
  * page-settings cluster, same icon/title/description chrome — then
- * swaps the body for a quick-create Command list (tab/header) or an
+ * swaps the body for a quick-create list of tree rows (tab/header) — create
+ * actions, a "Link an article" popover, and the existing children — or an
  * Open-link CTA (link). `ArticleCoverStrip` self-gates for these
  * kinds, so the cover slot is hidden automatically.
  */
@@ -66,8 +63,9 @@ export function ContainerArticlePlaceholder({
   const articles = useArticleList(knowledgeBaseId)
   const { isCreating, updateArticleDraft } = useArticleMutations(knowledgeBaseId)
   const setPending = usePendingInsertStore((s) => s.setPending)
-  const commandWrapperRef = useRef<HTMLDivElement>(null)
+  const optionsRef = useRef<HTMLDivElement>(null)
   const linkButtonRef = useRef<HTMLAnchorElement>(null)
+  const [linkOpen, setLinkOpen] = useState(false)
 
   const children = useMemo(
     () =>
@@ -124,8 +122,7 @@ export function ContainerArticlePlaceholder({
       linkButtonRef.current?.focus()
       return
     }
-    const first = commandWrapperRef.current?.querySelector<HTMLElement>('[cmdk-item]')
-    first?.focus()
+    optionsRef.current?.querySelector<HTMLElement>('button')?.focus()
   }, [isLink])
 
   const handleCreate = (kind: ArticleKindType) => {
@@ -168,45 +165,57 @@ export function ContainerArticlePlaceholder({
                   )}
                 </div>
               ) : options ? (
-                <div ref={commandWrapperRef} className='mt-4 w-full text-left'>
-                  <Command className='overflow-hidden rounded-xl border'>
-                    <CommandList>
-                      <CommandGroup>
-                        <CommandGroupLabel>
-                          {article.articleKind === ArticleKind.tab
-                            ? 'Add to this tab'
-                            : 'Add to this section header'}
-                        </CommandGroupLabel>
-                        {options.map(({ kind, label, Icon }) => (
-                          <CommandItem
-                            key={kind}
-                            value={`create-${kind}`}
-                            disabled={isCreating}
-                            onSelect={() => handleCreate(kind)}>
-                            <Icon className='size-4 text-muted-foreground' />
-                            <span>{label}</span>
-                          </CommandItem>
+                <div
+                  ref={optionsRef}
+                  className='mt-4 w-full overflow-hidden rounded-xl border text-left'>
+                  <GroupLabel>
+                    {article.articleKind === ArticleKind.tab
+                      ? 'Add to this tab'
+                      : 'Add to this section header'}
+                  </GroupLabel>
+                  <div className='flex flex-col p-1'>
+                    {options.map(({ kind, label, Icon }) => (
+                      <RowButton
+                        key={kind}
+                        disabled={isCreating}
+                        onClick={() => handleCreate(kind)}>
+                        <TreeRow
+                          icon={<Icon className='size-4 text-muted-foreground' />}
+                          title={label}
+                        />
+                      </RowButton>
+                    ))}
+                    <Popover open={linkOpen} onOpenChange={setLinkOpen}>
+                      <PopoverTrigger asChild>
+                        <RowButton>
+                          <TreeRow
+                            icon={<Database className='size-4 text-muted-foreground' />}
+                            title='Link an article'
+                          />
+                        </RowButton>
+                      </PopoverTrigger>
+                      <PopoverContent align='start' className='w-72 p-0'>
+                        <LinkArticlePicker
+                          knowledgeBaseId={knowledgeBaseId}
+                          targetParentArticleId={article.id}
+                          onClose={() => setLinkOpen(false)}
+                        />
+                      </PopoverContent>
+                    </Popover>
+                  </div>
+                  {children.length > 0 && (
+                    <>
+                      <div className='border-t' />
+                      <GroupLabel>Inside</GroupLabel>
+                      <div className='flex flex-col p-1'>
+                        {children.map((child) => (
+                          <RowButton key={child.id} onClick={() => handleOpenChild(child)}>
+                            <TreeRow icon={childIcon(child)} title={child.title || 'Untitled'} />
+                          </RowButton>
                         ))}
-                      </CommandGroup>
-                      {children.length > 0 && (
-                        <>
-                          <CommandSeparator />
-                          <CommandGroup>
-                            <CommandGroupLabel>Inside</CommandGroupLabel>
-                            {children.map((child) => (
-                              <CommandItem
-                                key={child.id}
-                                value={`open-${child.id}`}
-                                onSelect={() => handleOpenChild(child)}>
-                                {childIcon(child)}
-                                <span className='truncate'>{child.title || 'Untitled'}</span>
-                              </CommandItem>
-                            ))}
-                          </CommandGroup>
-                        </>
-                      )}
-                    </CommandList>
-                  </Command>
+                      </div>
+                    </>
+                  )}
                 </div>
               ) : null}
             </div>
@@ -216,3 +225,27 @@ export function ContainerArticlePlaceholder({
     </div>
   )
 }
+
+/** Small uppercase-ish group heading, mirrors the old CommandGroup label. */
+function GroupLabel({ children }: { children: React.ReactNode }) {
+  return <div className='px-2 py-1.5 text-xs font-medium text-muted-foreground'>{children}</div>
+}
+
+/**
+ * Full-width clickable row wrapping a {@link TreeRow}. forwardRef so it can be a
+ * `PopoverTrigger asChild` (Radix needs the ref + click props on the trigger).
+ */
+const RowButton = forwardRef<HTMLButtonElement, React.ComponentProps<'button'>>(function RowButton(
+  { className, children, ...props },
+  ref
+) {
+  return (
+    <button
+      ref={ref}
+      type='button'
+      className={cn('block w-full rounded-md text-left disabled:opacity-50', className)}
+      {...props}>
+      {children}
+    </button>
+  )
+})

--- a/apps/web/src/components/kb/ui/editor/crawl-section-picker.tsx
+++ b/apps/web/src/components/kb/ui/editor/crawl-section-picker.tsx
@@ -1,10 +1,10 @@
 // apps/web/src/components/kb/ui/editor/crawl-section-picker.tsx
 'use client'
 
-import { Badge } from '@auxx/ui/components/badge'
-import { Checkbox } from '@auxx/ui/components/checkbox'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Switch } from '@auxx/ui/components/switch'
 import { TreeRow } from '@auxx/ui/components/tree-row'
+import { pluralize } from '@auxx/utils'
 
 /** Local mirror of the crawl provider's SitemapNode (recursive, render-only). */
 export interface SitemapNode {
@@ -39,37 +39,50 @@ export function CrawlSectionTree({
   onToggle,
   className = 'h-56',
 }: CrawlSectionTreeProps) {
+  const allSelected = sections.length > 0 && sections.every((s) => selectedPaths.includes(s.path))
+
+  const toggleAll = (checked: boolean) => {
+    for (const section of sections) onToggle(section.path, checked)
+  }
+
   return (
-    <ScrollArea className={`${className} rounded-md border`}>
-      <div className='flex flex-col gap-0.5 p-1.5'>
-        {sections.length === 0 && (
-          <p className='text-muted-foreground p-2 text-sm'>
-            No sub-sections found — the whole site will be crawled.
-          </p>
-        )}
-        {sections.map((section) => {
-          const checked = selectedPaths.includes(section.path)
-          return (
-            <TreeRow
-              key={section.path}
-              icon={
-                <Checkbox
-                  checked={checked}
-                  onCheckedChange={(c) => onToggle(section.path, c === true)}
-                />
-              }
-              title={section.title ?? section.path}
-              onTitleClick={() => onToggle(section.path, !checked)}
-              rowClassName='hover:bg-muted/50'
-              actions={
-                <Badge variant='secondary' className='shrink-0'>
-                  {countPages(section)}
-                </Badge>
-              }
-            />
-          )
-        })}
-      </div>
-    </ScrollArea>
+    <div className='rounded-xl border'>
+      {sections.length > 0 && (
+        <div className='flex items-center justify-between border-b px-3 py-2'>
+          <span className='text-muted-foreground text-sm'>
+            {allSelected ? 'Deselect all' : 'Select all'}
+          </span>
+          <Switch size='xs' checked={allSelected} onCheckedChange={(c) => toggleAll(c === true)} />
+        </div>
+      )}
+      <ScrollArea className={className} scrollbarClassName='w-1!'>
+        <div className='flex flex-col gap-0.5 pe-3'>
+          {sections.length === 0 && (
+            <p className='text-muted-foreground p-2 text-sm'>
+              No sub-sections found — the whole site will be crawled.
+            </p>
+          )}
+          {sections.map((section) => {
+            const checked = selectedPaths.includes(section.path)
+            return (
+              <TreeRow
+                key={section.path}
+                title={section.title ?? section.path}
+                onTitleClick={() => onToggle(section.path, !checked)}
+                rowClassName='hover:bg-muted/50'
+                secondary={`${countPages(section)} ${pluralize(countPages(section), 'page')}`}
+                actions={
+                  <Switch
+                    size='xs'
+                    checked={checked}
+                    onCheckedChange={(c) => onToggle(section.path, c === true)}
+                  />
+                }
+              />
+            )
+          })}
+        </div>
+      </ScrollArea>
+    </div>
   )
 }

--- a/apps/web/src/components/kb/ui/editor/crawl-website-wizard.tsx
+++ b/apps/web/src/components/kb/ui/editor/crawl-website-wizard.tsx
@@ -10,15 +10,13 @@ import { Label } from '@auxx/ui/components/label'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
 import { ToggleCard } from '@auxx/ui/components/toggle-card'
-import { Check, Globe } from 'lucide-react'
+import { Globe } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { api } from '~/trpc/react'
 import { CrawlSectionTree, countPages, type SitemapNode } from './crawl-section-picker'
 import { type ScheduleConfig, SyncFrequencyPicker } from './sync-frequency-picker'
 
 interface CrawlWebsiteWizardProps {
-  /** Optional KB to pre-link the new source into (when opened from a KB editor). */
-  knowledgeBaseId?: string
   open: boolean
   onOpenChange: (open: boolean) => void
 }
@@ -39,14 +37,10 @@ const STEP_TITLES: Record<Step, string> = {
  * Website crawler wizard: Connect → Pages → Target → Review. Discovers a sitemap via the
  * crawl provider, lets the user pick top-level sections, then creates a `website`
  * KnowledgeSource (its own hidden KB) and triggers a sync. Crawled pages materialize as
- * Locked managed articles in the source; the Target step optionally links the source into
- * existing knowledge bases.
+ * Locked managed articles in the source; once synced, individual articles are linked into
+ * real KBs from that KB's Add menu (per-article, post-sync).
  */
-export function CrawlWebsiteWizard({
-  knowledgeBaseId,
-  open,
-  onOpenChange,
-}: CrawlWebsiteWizardProps) {
+export function CrawlWebsiteWizard({ open, onOpenChange }: CrawlWebsiteWizardProps) {
   const [step, setStep] = useState<Step>('connect')
   const [url, setUrl] = useState('')
   const [name, setName] = useState('')
@@ -54,11 +48,9 @@ export function CrawlWebsiteWizard({
   const [selectedPaths, setSelectedPaths] = useState<string[]>([])
   const [excludeText, setExcludeText] = useState('')
   const [mainContentOnly, setMainContentOnly] = useState(true)
-  const [linkKbIds, setLinkKbIds] = useState<string[]>(knowledgeBaseId ? [knowledgeBaseId] : [])
   const [schedule, setSchedule] = useState<ScheduleConfig | null>(null)
 
   const utils = api.useUtils()
-  const knowledgeBases = api.kb.list.useQuery()
   const checkUrl = api.knowledgeSource.checkUrl.useMutation()
   const getSitemapTree = api.knowledgeSource.getSitemapTree.useMutation()
   const createSource = api.knowledgeSource.create.useMutation()
@@ -83,14 +75,8 @@ export function CrawlWebsiteWizard({
     setSelectedPaths([])
     setExcludeText('')
     setMainContentOnly(true)
-    setLinkKbIds(knowledgeBaseId ? [knowledgeBaseId] : [])
     setSchedule(null)
   }
-
-  const toggleLink = (kbId: string) =>
-    setLinkKbIds((prev) =>
-      prev.includes(kbId) ? prev.filter((id) => id !== kbId) : [...prev, kbId]
-    )
 
   const close = (next: boolean) => {
     if (!next) reset()
@@ -157,10 +143,8 @@ export function CrawlWebsiteWizard({
         },
         syncBehavior: schedule ? 'scheduled' : 'manual',
         scheduleConfig: schedule,
-        ...(linkKbIds.length > 0 ? { linkKnowledgeBaseIds: linkKbIds } : {}),
       })
       await syncNow.mutateAsync({ id: source.id })
-      for (const kbId of linkKbIds) void utils.kb.getArticles.invalidate({ knowledgeBaseId: kbId })
       void utils.knowledgeSource.list.invalidate()
       close(false)
     } catch (error) {
@@ -170,10 +154,6 @@ export function CrawlWebsiteWizard({
       })
     }
   }
-
-  const linkKbNames = (knowledgeBases.data ?? [])
-    .filter((kb) => linkKbIds.includes(kb.id))
-    .map((kb) => kb.name)
 
   const goBack = () => {
     const idx = STEP_ORDER.indexOf(step)
@@ -186,7 +166,7 @@ export function CrawlWebsiteWizard({
         <div className='flex flex-col'>
           <DialogNav
             title='Crawl a website'
-            description='Discover a site, pick the sections to ingest, and the crawler files each page as a locked, source-managed article in its own source — optionally linked into your knowledge bases.'
+            description='Discover a site, pick the sections to ingest, and the crawler files each page as a locked, source-managed article in its own source. Link articles into a knowledge base afterward from that KB.'
             onBack={step === 'connect' ? undefined : goBack}
             backDisabled={isSubmitting}
             crumbs={[{ label: STEP_TITLES[step], icon: <Globe /> }]}
@@ -213,7 +193,7 @@ export function CrawlWebsiteWizard({
             </DialogNavPage>
 
             <DialogNavPage value='pages' size='lg'>
-              <div className='flex flex-col gap-4 p-3'>
+              <div className='flex flex-col gap-4 p-3 pe-3'>
                 <div className='flex flex-col gap-1.5'>
                   <div className='flex items-center justify-between'>
                     <Label>Sections to crawl</Label>
@@ -263,36 +243,10 @@ export function CrawlWebsiteWizard({
                     placeholder='e.g. Docs site'
                   />
                 </div>
-                <div className='flex flex-col gap-1.5'>
-                  <Label>Link into knowledge bases (optional)</Label>
-                  <p className='text-muted-foreground text-xs'>
-                    The crawl becomes its own source. Pick any knowledge bases to surface it in —
-                    you can change this anytime in the source settings.
-                  </p>
-                  <div className='flex max-h-48 flex-col gap-0.5 overflow-auto rounded-md border p-1'>
-                    {(knowledgeBases.data ?? []).length === 0 ? (
-                      <p className='px-2 py-1.5 text-muted-foreground text-xs'>
-                        No knowledge bases yet.
-                      </p>
-                    ) : (
-                      (knowledgeBases.data ?? []).map((kb) => {
-                        const checked = linkKbIds.includes(kb.id)
-                        return (
-                          <button
-                            key={kb.id}
-                            type='button'
-                            onClick={() => toggleLink(kb.id)}
-                            className={`flex items-center justify-between rounded px-2 py-1.5 text-left text-sm hover:bg-muted ${
-                              checked ? 'bg-muted' : ''
-                            }`}>
-                            <span className='truncate'>{kb.name}</span>
-                            {checked && <Check className='size-4 text-info' />}
-                          </button>
-                        )
-                      })
-                    )}
-                  </div>
-                </div>
+                <p className='text-muted-foreground text-xs'>
+                  The crawl becomes its own source. Once it finishes, link individual articles into
+                  a knowledge base from that KB's <span className='font-medium'>Add</span> menu.
+                </p>
                 <SyncFrequencyPicker value={schedule} onChange={setSchedule} />
                 <ToggleCard
                   title='AI-only (catalog)'
@@ -313,12 +267,6 @@ export function CrawlWebsiteWizard({
                   <Row
                     label='Sections'
                     value={`${selectedPaths.length} selected · ~${selectedPageCount} pages`}
-                  />
-                  <Row
-                    label='Link into'
-                    value={
-                      linkKbNames.length > 0 ? linkKbNames.join(', ') : 'Not linked (source only)'
-                    }
                   />
                   <Row label='Sync' value={describeSchedule(schedule)} />
                   <Row label='Main content only' value={mainContentOnly ? 'Yes' : 'No'} />

--- a/apps/web/src/components/kb/ui/editor/create-knowledge-source-dialog.tsx
+++ b/apps/web/src/components/kb/ui/editor/create-knowledge-source-dialog.tsx
@@ -20,8 +20,6 @@ import { useState } from 'react'
 import { api } from '~/trpc/react'
 
 interface CreateKnowledgeSourceDialogProps {
-  /** Optional KB to pre-link the new source into (when opened from a KB editor). */
-  knowledgeBaseId?: string
   open: boolean
   onOpenChange: (open: boolean) => void
 }
@@ -53,12 +51,10 @@ function slugify(s: string): string {
 
 /**
  * Minimal manual-source form. Name + paste rows → create a standalone manual
- * KnowledgeSource (its own hidden KB), then trigger a sync. When opened from a KB
- * editor, the source is also linked into that KB. Manage links later in the source
- * workspace.
+ * KnowledgeSource (its own hidden KB), then trigger a sync. The source's articles are
+ * linked into real KBs afterward (per-article) from each KB's Add menu.
  */
 export function CreateKnowledgeSourceDialog({
-  knowledgeBaseId,
   open,
   onOpenChange,
 }: CreateKnowledgeSourceDialogProps) {
@@ -117,12 +113,8 @@ export function CreateKnowledgeSourceDialog({
         type: 'manual',
         surface: 'publishable',
         config: { items },
-        ...(knowledgeBaseId ? { linkKnowledgeBaseIds: [knowledgeBaseId] } : {}),
       })
       await syncNow.mutateAsync({ id: source.id })
-      // The sync runs in the background worker; nudge the sidebar of the linked KB to
-      // pick up the new articles once it lands.
-      if (knowledgeBaseId) void utils.kb.getArticles.invalidate({ knowledgeBaseId })
       void utils.knowledgeSource.list.invalidate()
       onOpenChange(false)
       reset()

--- a/apps/web/src/components/kb/ui/editor/kb-articles-header-actions.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-articles-header-actions.tsx
@@ -129,16 +129,8 @@ export function KBArticlesHeaderActions({ knowledgeBaseId }: KBArticlesHeaderAct
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <CreateKnowledgeSourceDialog
-        knowledgeBaseId={knowledgeBaseId}
-        open={isSourceDialogOpen}
-        onOpenChange={setIsSourceDialogOpen}
-      />
-      <CrawlWebsiteWizard
-        knowledgeBaseId={knowledgeBaseId}
-        open={isCrawlWizardOpen}
-        onOpenChange={setIsCrawlWizardOpen}
-      />
+      <CreateKnowledgeSourceDialog open={isSourceDialogOpen} onOpenChange={setIsSourceDialogOpen} />
+      <CrawlWebsiteWizard open={isCrawlWizardOpen} onOpenChange={setIsCrawlWizardOpen} />
       <input
         ref={importInputRef}
         type='file'

--- a/apps/web/src/components/kb/ui/sidebar/kb-articles-panel.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/kb-articles-panel.tsx
@@ -14,7 +14,16 @@ import { getFullSlugPath } from '@auxx/ui/components/kb/utils'
 import { cn } from '@auxx/ui/lib/utils'
 import { DndContext, DragOverlay } from '@dnd-kit/core'
 import { restrictToVerticalAxis, restrictToWindowEdges } from '@dnd-kit/modifiers'
-import { Archive, FileText, FolderClosed, Heading, Link2, Loader2, Plus } from 'lucide-react'
+import {
+  Archive,
+  Database,
+  FileText,
+  FolderClosed,
+  Heading,
+  Link2,
+  Loader2,
+  Plus,
+} from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useActiveArticle } from '../../hooks/use-active-article'
@@ -27,6 +36,7 @@ import { inferCreateParent } from '../../utils/infer-create-parent'
 import { ArticleSidebarItemPreview } from './article-sidebar-item'
 import { ArticleTreeSection } from './article-tree-section'
 import { KBTabStrip } from './kb-tab-strip'
+import { LinkArticlePicker } from './link-article-picker'
 
 interface KBArticlesPanelProps {
   knowledgeBaseId: string
@@ -59,6 +69,11 @@ export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
   const setPending = usePendingInsertStore((s) => s.setPending)
   const clearPending = usePendingInsertStore((s) => s.clearPending)
   const pending = usePendingInsertStore((s) => s.pending)
+
+  // The Add menu morphs in place: 'menu' shows the create/link actions, 'link' swaps the
+  // content to the cross-KB article picker (no separate dialog).
+  const [addMenuOpen, setAddMenuOpen] = useState(false)
+  const [addMenuMode, setAddMenuMode] = useState<'menu' | 'link'>('menu')
 
   const archivedKey = `kb-${knowledgeBaseId}-show-archived`
   const [showArchived, setShowArchived] = useState<boolean>(() => {
@@ -326,7 +341,12 @@ export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
 
       <div className='mt-2 px-2'>
         {tabSubtree.length > 0 && (
-          <DropdownMenu>
+          <DropdownMenu
+            open={addMenuOpen}
+            onOpenChange={(open) => {
+              setAddMenuOpen(open)
+              if (!open) setAddMenuMode('menu')
+            }}>
             <DropdownMenuTrigger asChild>
               <Button
                 className='w-full justify-start text-muted-foreground'
@@ -340,20 +360,42 @@ export function KBArticlesPanel({ knowledgeBaseId }: KBArticlesPanelProps) {
             </DropdownMenuTrigger>
             <DropdownMenuContent
               align='start'
-              className='w-48'
+              className={addMenuMode === 'link' ? 'w-72 p-0' : 'w-48'}
               onCloseAutoFocus={(e) => e.preventDefault()}>
-              <DropdownMenuItem onSelect={() => void handleCreateInTab(ArticleKind.page)}>
-                <FileText /> Page
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => void handleCreateInTab(ArticleKind.category)}>
-                <FolderClosed /> Category
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => void handleCreateInTab(ArticleKind.link)}>
-                <Link2 /> Link
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => void handleCreateInTab(ArticleKind.header)}>
-                <Heading /> Section header
-              </DropdownMenuItem>
+              {addMenuMode === 'menu' ? (
+                <>
+                  <DropdownMenuItem onSelect={() => void handleCreateInTab(ArticleKind.page)}>
+                    <FileText /> Page
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => void handleCreateInTab(ArticleKind.category)}>
+                    <FolderClosed /> Category
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => void handleCreateInTab(ArticleKind.link)}>
+                    <Link2 /> Link
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => void handleCreateInTab(ArticleKind.header)}>
+                    <Heading /> Section header
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={(e) => {
+                      // Keep the menu open and swap to the picker instead of closing.
+                      e.preventDefault()
+                      setAddMenuMode('link')
+                    }}>
+                    <Database /> Link an article
+                  </DropdownMenuItem>
+                </>
+              ) : (
+                // Stop keydown from reaching Radix's menu typeahead/roving focus so the
+                // embedded cmdk Command owns arrow/enter/typing.
+                <div onKeyDown={(e) => e.stopPropagation()}>
+                  <LinkArticlePicker
+                    knowledgeBaseId={knowledgeBaseId}
+                    targetParentArticleId={effectiveTabId}
+                    onClose={() => setAddMenuOpen(false)}
+                  />
+                </div>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/apps/web/src/components/kb/ui/sidebar/link-article-picker.tsx
+++ b/apps/web/src/components/kb/ui/sidebar/link-article-picker.tsx
@@ -1,0 +1,84 @@
+// apps/web/src/components/kb/ui/sidebar/link-article-picker.tsx
+'use client'
+
+import { toastError } from '@auxx/ui/components/toast'
+import { useMemo, useState } from 'react'
+import { api } from '~/trpc/react'
+import { useArticleList } from '../../hooks/use-article-list'
+import { ArticlePicker } from '../articles/article-picker'
+
+interface LinkArticlePickerProps {
+  knowledgeBaseId: string
+  /** Article the linked articles nest under (the active tab); null = KB root. */
+  targetParentArticleId: string | null
+  /** Dismiss the surface hosting this picker (dropdown/popover). */
+  onClose: () => void
+}
+
+/**
+ * The cross-KB article picker used to link `page` articles from any KB into this one.
+ * Surface-agnostic — embed it inside a dropdown or popover. The picker lists every KB you
+ * can pull from (other standard KBs + sources' hidden KBs), you drill in and pick articles,
+ * and each pick adds an `ArticlePlacement` under the active tab. Linking a source article
+ * keeps it managed (read-only); linking a plain article is a true multi-home (one `Article`,
+ * edited in either KB edits both). Articles already in this KB are filtered out.
+ */
+export function LinkArticlePicker({
+  knowledgeBaseId,
+  targetParentArticleId,
+  onClose,
+}: LinkArticlePickerProps) {
+  const utils = api.useUtils()
+  const kbs = api.kb.list.useQuery()
+  const sources = api.knowledgeSource.list.useQuery()
+
+  // KBs to pull from: standard KBs (minus this one) + each source's hidden KB
+  // (excluding ai-only sources, which surface no articles).
+  const knowledgeBasesOverride = useMemo(() => {
+    const standard = (kbs.data ?? [])
+      .filter((kb) => kb.id !== knowledgeBaseId)
+      .map((kb) => ({ id: kb.id, name: kb.name || 'Untitled' }))
+    const sourceKbs = (sources.data ?? [])
+      .filter((s) => s.surface !== 'ai-only')
+      .map((s) => ({ id: s.ownedKnowledgeBaseId, name: s.name }))
+    return [...standard, ...sourceKbs]
+  }, [kbs.data, sources.data, knowledgeBaseId])
+
+  // Articles already placed in this KB — hidden from the picker (the shared article id is
+  // the dedupe key). Tracks just-linked ids locally so they vanish before the refetch lands.
+  const currentArticles = useArticleList(knowledgeBaseId)
+  const [justLinked, setJustLinked] = useState<Set<string>>(new Set())
+  const forbiddenIds = useMemo(() => {
+    const set = new Set(justLinked)
+    for (const a of currentArticles) set.add(a.id)
+    return set
+  }, [currentArticles, justLinked])
+
+  const link = api.kb.linkArticles.useMutation({
+    onSuccess: () => {
+      void utils.kb.getArticles.invalidate({ knowledgeBaseId, includeUnpublished: true })
+      void utils.knowledgeSource.listLinks.invalidate()
+    },
+    onError: (e) => toastError({ title: 'Could not link article', description: e.message }),
+  })
+
+  const handlePick = (articleId: string) => {
+    setJustLinked((prev) => new Set(prev).add(articleId))
+    link.mutate({ knowledgeBaseId, articleIds: [articleId], targetParentArticleId })
+  }
+
+  return (
+    <ArticlePicker
+      knowledgeBasesOverride={knowledgeBasesOverride}
+      allowedKinds={['page']}
+      drillableKinds={['tab', 'category']}
+      forbiddenIds={forbiddenIds}
+      flattenSearch
+      autoFocusSearch
+      rootLabel='Link an article'
+      searchPlaceholder='Search knowledge bases…'
+      onPick={handlePick}
+      onClose={onClose}
+    />
+  )
+}

--- a/apps/web/src/components/kb/ui/sources/source-article-tree.tsx
+++ b/apps/web/src/components/kb/ui/sources/source-article-tree.tsx
@@ -1,0 +1,89 @@
+// apps/web/src/components/kb/ui/sources/source-article-tree.tsx
+'use client'
+
+import type { ArticleKind } from '@auxx/database/types'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { Book, FileText, FolderClosed, Heading, Link2, Loader2 } from 'lucide-react'
+import { parseAsString, useQueryState } from 'nuqs'
+import { useState } from 'react'
+import { useIsArticleListLoaded } from '../../hooks/use-article-list'
+import { useArticleTree } from '../../hooks/use-article-tree'
+import type { ArticleTreeNode } from '../../store/article-store'
+import type { KnowledgeSource } from './sources-provider'
+
+const KIND_ICON: Record<ArticleKind, typeof FileText> = {
+  page: FileText,
+  category: FolderClosed,
+  header: Heading,
+  tab: Book,
+  link: Link2,
+}
+
+/** Drop archived nodes recursively — the source view only browses live content. */
+function stripArchived(nodes: ArticleTreeNode[]): ArticleTreeNode[] {
+  return nodes
+    .filter((n) => n.status !== 'ARCHIVED')
+    .map((n) => ({ ...n, children: stripArchived(n.children) }))
+}
+
+/**
+ * Read-only article tree for the source workspace's **Articles** tab. Mirrors the
+ * KB sidebar tree's shape but without drag-and-drop, mutations, or routing —
+ * selecting a row writes the article id to the `?article` query param, which the
+ * right pane reads to render the (read-only, source-managed) editor.
+ */
+export function SourceArticleTree({ source }: { source: KnowledgeSource }) {
+  const kbId = source.ownedKnowledgeBaseId
+  const tree = useArticleTree(kbId)
+  const loaded = useIsArticleListLoaded(kbId)
+  const [selectedId, setSelectedId] = useQueryState('article', parseAsString)
+  const [openStates, setOpenStates] = useState<Record<string, boolean>>({})
+
+  const visible = stripArchived(tree)
+
+  if (!loaded) {
+    return (
+      <div className='flex flex-1 items-center justify-center py-8'>
+        <Loader2 className='size-6 animate-spin text-muted-foreground' />
+      </div>
+    )
+  }
+
+  if (visible.length === 0) {
+    return (
+      <p className='p-4 text-sm text-muted-foreground'>
+        No articles yet. Run a sync to ingest content.
+      </p>
+    )
+  }
+
+  const toggleOpen = (id: string) => setOpenStates((prev) => ({ ...prev, [id]: !prev[id] }))
+
+  const renderNode = (node: ArticleTreeNode, depth: number) => {
+    const hasChildren = node.children.length > 0
+    const isOpen = openStates[node.id] ?? false
+    const Icon = KIND_ICON[node.articleKind] ?? FileText
+    return (
+      <TreeRow
+        key={node.id}
+        depth={depth}
+        icon={<Icon className='size-4 text-muted-foreground' />}
+        title={node.title || 'Untitled'}
+        onTitleClick={() => void setSelectedId(node.id)}
+        expandable={hasChildren}
+        isOpen={isOpen}
+        onToggleOpen={() => toggleOpen(node.id)}
+        rowClassName={cn('hover:bg-muted/50', selectedId === node.id && 'bg-muted')}>
+        {hasChildren ? node.children.map((child) => renderNode(child, depth + 1)) : undefined}
+      </TreeRow>
+    )
+  }
+
+  return (
+    <ScrollArea className='flex min-h-0 flex-1 flex-col pt-3'>
+      <div className='flex flex-col gap-0.5 p-1'>{visible.map((node) => renderNode(node, 0))}</div>
+    </ScrollArea>
+  )
+}

--- a/apps/web/src/components/kb/ui/sources/source-article-view.tsx
+++ b/apps/web/src/components/kb/ui/sources/source-article-view.tsx
@@ -1,0 +1,37 @@
+// apps/web/src/components/kb/ui/sources/source-article-view.tsx
+'use client'
+
+import { FileText } from 'lucide-react'
+import { parseAsString, useQueryState } from 'nuqs'
+import { useArticleList } from '../../hooks/use-article-list'
+import { ArticleEditor } from '../editor/article-editor'
+import type { KnowledgeSource } from './sources-provider'
+
+/**
+ * Right pane of the source workspace. Reads the `?article` query param (set by the
+ * Articles tab tree) and renders the shared `ArticleEditor` for the selected
+ * article — source-managed articles render read-only there. With nothing
+ * selected it shows an empty-state prompt.
+ */
+export function SourceArticleView({ source }: { source: KnowledgeSource }) {
+  const [articleId] = useQueryState('article', parseAsString)
+  const articles = useArticleList(source.ownedKnowledgeBaseId)
+  const article = articleId ? articles.find((a) => a.id === articleId) : undefined
+
+  if (!article) {
+    return (
+      <div className='flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center'>
+        <FileText className='size-8 text-muted-foreground/60' />
+        <p className='text-sm text-muted-foreground'>
+          Select an article from the Articles tab to view it.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex min-h-0 flex-1 flex-col overflow-hidden'>
+      <ArticleEditor article={article} knowledgeBaseId={source.ownedKnowledgeBaseId} />
+    </div>
+  )
+}

--- a/apps/web/src/components/kb/ui/sources/source-settings-panel.tsx
+++ b/apps/web/src/components/kb/ui/sources/source-settings-panel.tsx
@@ -7,17 +7,10 @@ import { Button } from '@auxx/ui/components/button'
 import { LastUpdated } from '@auxx/ui/components/last-updated'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Section } from '@auxx/ui/components/section'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@auxx/ui/components/select'
 import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
-import { Cog, ScrollText, X } from 'lucide-react'
+import { Cog, FileText, ScrollText, X } from 'lucide-react'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
@@ -26,9 +19,10 @@ import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/inpu
 import { api } from '~/trpc/react'
 import { CrawlSectionTree, type SitemapNode } from '../editor/crawl-section-picker'
 import { type ScheduleConfig, SyncFrequencyPicker } from '../editor/sync-frequency-picker'
+import { SourceArticleTree } from './source-article-tree'
 import type { KnowledgeSource, SourceStatus } from './sources-provider'
 
-const PANEL_VALUES = ['general', 'runs'] as const
+const PANEL_VALUES = ['general', 'articles', 'runs'] as const
 
 const STATUS_PILL: Record<SourceStatus, { label: string; className: string }> = {
   live: { label: 'Live', className: 'bg-good-500/15 text-good-600' },
@@ -55,6 +49,7 @@ export function SourceSettingsPanel({ source }: { source: KnowledgeSource }) {
     'panel',
     parseAsStringLiteral(PANEL_VALUES).withDefault('general')
   )
+  const hasArticles = source.surface !== 'ai-only'
 
   return (
     <div className='flex flex-1 flex-col overflow-hidden'>
@@ -64,6 +59,12 @@ export function SourceSettingsPanel({ source }: { source: KnowledgeSource }) {
             <Cog />
             General
           </TabsTrigger>
+          {hasArticles && (
+            <TabsTrigger value='articles' variant='outline'>
+              <FileText />
+              Articles
+            </TabsTrigger>
+          )}
           <TabsTrigger value='runs' variant='outline'>
             <ScrollText />
             Runs
@@ -71,7 +72,13 @@ export function SourceSettingsPanel({ source }: { source: KnowledgeSource }) {
         </TabsList>
       </Tabs>
 
-      {panel === 'general' ? <GeneralPanel source={source} /> : <RunsPanel source={source} />}
+      {panel === 'articles' && hasArticles ? (
+        <SourceArticleTree source={source} />
+      ) : panel === 'runs' ? (
+        <RunsPanel source={source} />
+      ) : (
+        <GeneralPanel source={source} />
+      )}
     </div>
   )
 }
@@ -318,27 +325,21 @@ function GeneralPanel({ source }: { source: KnowledgeSource }) {
   )
 }
 
-/** Manage which user-facing KBs this source's content is linked into. */
+/**
+ * Read-only summary of which user-facing KBs this source is linked into, with a bulk
+ * "remove from KB" action. Linking itself is per-article and initiated from the target
+ * KB's Add menu (you pick individual articles there) — not from here.
+ */
 function LinkedKnowledgeBases({ source }: { source: KnowledgeSource }) {
   const utils = api.useUtils()
   const links = api.knowledgeSource.listLinks.useQuery({ id: source.id })
-  const kbList = api.kb.list.useQuery(undefined, { staleTime: 5 * 60 * 1000 })
 
-  const linkedIds = new Set((links.data ?? []).map((l) => l.id))
-  const available = (kbList.data ?? []).filter((kb) => !linkedIds.has(kb.id))
-
-  const invalidate = () => {
-    void utils.knowledgeSource.listLinks.invalidate({ id: source.id })
-  }
-  const link = api.knowledgeSource.linkToKnowledgeBases.useMutation({
-    onSuccess: invalidate,
-    onError: (e) => toastError({ title: 'Could not link', description: e.message }),
-  })
   const unlink = api.knowledgeSource.unlinkFromKnowledgeBase.useMutation({
-    onSuccess: invalidate,
+    onSuccess: () => {
+      void utils.knowledgeSource.listLinks.invalidate({ id: source.id })
+    },
     onError: (e) => toastError({ title: 'Could not unlink', description: e.message }),
   })
-  const busy = link.isPending || unlink.isPending
 
   return (
     <div className='flex flex-col gap-3'>
@@ -350,7 +351,7 @@ function LinkedKnowledgeBases({ source }: { source: KnowledgeSource }) {
               <button
                 type='button'
                 className='text-muted-foreground hover:text-foreground'
-                disabled={busy}
+                disabled={unlink.isPending}
                 onClick={() => unlink.mutate({ id: source.id, knowledgeBaseId: kb.id })}>
                 <X className='size-3' />
               </button>
@@ -360,24 +361,11 @@ function LinkedKnowledgeBases({ source }: { source: KnowledgeSource }) {
       ) : (
         <p className='text-sm text-muted-foreground'>Not linked into any knowledge base yet.</p>
       )}
-
-      {available.length > 0 && (
-        <Select
-          value=''
-          disabled={busy}
-          onValueChange={(kbId) => link.mutate({ id: source.id, knowledgeBaseIds: [kbId] })}>
-          <SelectTrigger className='w-full'>
-            <SelectValue placeholder='Link into a knowledge base…' />
-          </SelectTrigger>
-          <SelectContent>
-            {available.map((kb) => (
-              <SelectItem key={kb.id} value={kb.id}>
-                {kb.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      )}
+      <p className='text-xs text-muted-foreground'>
+        Link articles from a knowledge base's{' '}
+        <span className='font-medium'>Add → Link a source</span> menu. Removing a knowledge base
+        here unlinks all of this source's articles from it.
+      </p>
     </div>
   )
 }

--- a/apps/web/src/components/kb/ui/sources/source-workspace.tsx
+++ b/apps/web/src/components/kb/ui/sources/source-workspace.tsx
@@ -16,9 +16,16 @@ import { useMemo } from 'react'
 import { LoadingSpinner } from '~/components/global/loading-content'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
-import { SourceContentList } from './source-content-list'
+import { KnowledgeBaseProvider } from '../../providers/knowledge-base-provider'
+import type { ArticleMeta } from '../../store/article-store'
+import { ArticleEditorSurfaceProvider } from '../editor/article-editor-surface'
+import { KBPreviewHintProvider } from '../preview/preview-hint-context'
+import { SourceArticleView } from './source-article-view'
 import { SourceSettingsPanel } from './source-settings-panel'
 import type { SourceStatus } from './sources-provider'
+
+/** Keep article nav inside the source workspace (stable ref so the surface memo holds). */
+const buildSourceArticleHref = (a: ArticleMeta) => `?panel=articles&article=${a.id}`
 
 const STATUS_PILL: Record<SourceStatus, { label: string; className: string }> = {
   live: { label: 'Live', className: 'bg-good-500/15 text-good-600' },
@@ -116,9 +123,21 @@ export function SourceWorkspace({ sourceId }: { sourceId: string }) {
         </MainPageBreadcrumb>
       </MainPageHeader>
 
-      <MainPageContent leftPanels={leftPanels}>
-        {source ? <SourceContentList source={source} /> : <LoadingSpinner />}
-      </MainPageContent>
+      {source ? (
+        <KnowledgeBaseProvider knowledgeBaseId={source.ownedKnowledgeBaseId}>
+          <KBPreviewHintProvider>
+            <ArticleEditorSurfaceProvider buildHref={buildSourceArticleHref} hidePublishing>
+              <MainPageContent leftPanels={leftPanels}>
+                <SourceArticleView source={source} />
+              </MainPageContent>
+            </ArticleEditorSurfaceProvider>
+          </KBPreviewHintProvider>
+        </KnowledgeBaseProvider>
+      ) : (
+        <MainPageContent leftPanels={leftPanels}>
+          <LoadingSpinner />
+        </MainPageContent>
+      )}
     </MainPage>
   )
 }

--- a/apps/web/src/server/api/routers/kb.ts
+++ b/apps/web/src/server/api/routers/kb.ts
@@ -4,7 +4,7 @@ import { schema } from '@auxx/database'
 import { ArticleStatus } from '@auxx/database/enums'
 import { onCacheEvent } from '@auxx/lib/cache'
 import { getUserOrganizationId } from '@auxx/lib/email'
-import { articleToMarkdown, KBService } from '@auxx/lib/kb'
+import { articleToMarkdown, KBService, linkArticlesIntoKb } from '@auxx/lib/kb'
 import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
 import { TRPCError } from '@trpc/server'
 import { and, count, eq } from 'drizzle-orm'
@@ -225,6 +225,29 @@ export const knowledgeBaseRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       return await getKBService(ctx).getArticles(input.knowledgeBaseId, {
         includeUnpublished: input.includeUnpublished,
+      })
+    }),
+
+  // Link individually-chosen `page` articles from any KB into this KB, placed under
+  // `targetParentArticleId` (e.g. the active tab) or the KB root. Idempotent.
+  linkArticles: protectedProcedure
+    .input(
+      z.object({
+        knowledgeBaseId: z.string().min(1),
+        articleIds: z.array(z.string().min(1)).min(1),
+        targetParentArticleId: z.string().min(1).nullish(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const organizationId = getUserOrganizationId(ctx.session)
+      if (!organizationId) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'User organization context not found',
+        })
+      }
+      return linkArticlesIntoKb(ctx.db, organizationId, input.knowledgeBaseId, input.articleIds, {
+        targetParentArticleId: input.targetParentArticleId,
       })
     }),
 

--- a/apps/web/src/server/api/routers/knowledge-sources.ts
+++ b/apps/web/src/server/api/routers/knowledge-sources.ts
@@ -11,11 +11,11 @@ import {
   enqueueSourceSync,
   getCrawlProvider,
   getSource,
-  linkSourceToKb,
   listSourceLinks,
   listSources,
   pauseSource,
   resumeSource,
+  unlinkSourceArticleFromKb,
   unlinkSourceFromKb,
   updateSource,
 } from '@auxx/lib/knowledge-sources'
@@ -69,13 +69,9 @@ const scheduleFields = {
   scheduleConfig: scheduleConfigSchema.nullish(),
 }
 
-// Optional: link the new source's content into these user-facing KBs right after create.
-const linkKnowledgeBaseIds = z.array(z.string().min(1)).optional()
-
 const manualSourceSchema = z.object({
   name: z.string().min(1),
   type: z.literal('manual'),
-  linkKnowledgeBaseIds,
   surface: surfaceSchema,
   config: z.object({ items: z.array(manualItemSchema).default([]) }).default({ items: [] }),
   ...scheduleFields,
@@ -84,7 +80,6 @@ const manualSourceSchema = z.object({
 const websiteSourceSchema = z.object({
   name: z.string().min(1),
   type: z.literal('website'),
-  linkKnowledgeBaseIds,
   surface: surfaceSchema,
   config: z.object({
     url: z.string().url(),
@@ -128,7 +123,9 @@ export const knowledgeSourceRouter = createTRPCRouter({
       })
     }
     const organizationId = requireOrgId(ctx.session)
-    const source = await createSource(ctx.db, organizationId, {
+    // Linking is a post-sync, per-article action (from the KB side) — there are no
+    // articles to pick until the first sync completes, so create never pre-links.
+    return createSource(ctx.db, organizationId, {
       name: input.name,
       type: input.type,
       surface: input.surface,
@@ -137,11 +134,6 @@ export const knowledgeSourceRouter = createTRPCRouter({
       scheduleConfig: input.scheduleConfig,
       createdById: ctx.session.user.id,
     })
-    // Pre-link into chosen KBs (content materializes on the first sync's reconcile pass).
-    for (const kbId of input.linkKnowledgeBaseIds ?? []) {
-      await linkSourceToKb(ctx.db, organizationId, source.id, kbId)
-    }
-    return source
   }),
 
   update: protectedProcedure
@@ -176,16 +168,26 @@ export const knowledgeSourceRouter = createTRPCRouter({
       return listSourceLinks(ctx.db, requireOrgId(ctx.session), input.id)
     }),
 
-  linkToKnowledgeBases: protectedProcedure
-    .input(z.object({ id: z.string(), knowledgeBaseIds: z.array(z.string().min(1)).min(1) }))
+  // Remove one linked article's placement from a KB (source content untouched).
+  unlinkArticle: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        knowledgeBaseId: z.string().min(1),
+        articleId: z.string().min(1),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
-      const organizationId = requireOrgId(ctx.session)
-      for (const kbId of input.knowledgeBaseIds) {
-        await linkSourceToKb(ctx.db, organizationId, input.id, kbId)
-      }
-      return { success: true }
+      return unlinkSourceArticleFromKb(
+        ctx.db,
+        requireOrgId(ctx.session),
+        input.id,
+        input.articleId,
+        input.knowledgeBaseId
+      )
     }),
 
+  // Bulk-unlink: remove ALL of a source's articles from one KB.
   unlinkFromKnowledgeBase: protectedProcedure
     .input(z.object({ id: z.string(), knowledgeBaseId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {

--- a/apps/worker/src/dev/smoke-knowledge-sources.ts
+++ b/apps/worker/src/dev/smoke-knowledge-sources.ts
@@ -6,9 +6,10 @@
 //
 // Proves the source-owns-KB model: a source provisions its own hidden KB →
 // materialize there (root folder + home placements, linkedFromSourceId) → re-sync
-// diff (hash bump / skip) → link into a real KB (placements fan out, tree preserved)
-// → re-sync adds new items to the linked KB → unlink drops them → orphan archive →
-// detach survives re-sync → delete removes the source, its owned KB, and all content.
+// diff (hash bump / skip) → link INDIVIDUAL articles into a real KB (flat per-article
+// placements; categories never linked) → new items do NOT auto-join (per-article, no
+// fan-out) → unlink drops them → orphan archive → detach survives re-sync → delete
+// removes the source, its owned KB, and all content.
 //
 // Lives under the worker so it resolves @auxx/* via the worker's node_modules and
 // runs on the worker's ESM/tsx runtime (file-type is ESM-only — a plain CJS `tsx`
@@ -21,12 +22,11 @@
 // link the source into.
 
 import { closePools, database as db } from '@auxx/database'
-import { detachArticleFromSource } from '@auxx/lib/kb'
+import { detachArticleFromSource, linkArticlesIntoKb } from '@auxx/lib/kb'
 import {
   createSource,
   deleteSource,
   getSource,
-  linkSourceToKb,
   listSourceLinks,
   runSourceSync,
   unlinkSourceFromKb,
@@ -202,26 +202,39 @@ async function main() {
     check('A content hash changed', !!hashA2 && hashA2 !== hashA1, { hashA1, hashA2 })
     check('B content hash unchanged (skipped)', hashB2 === hashB1, { hashB1, hashB2 })
 
-    // ── 3. Link into the standard KB → placements materialize there ──────────
-    section('3. Link source into the standard KB → placements fan out, tree preserved')
-    await linkSourceToKb(db, orgId, sourceId, linkKbId)
+    // ── 3. Link individual articles into the standard KB (per-article) ───────
+    section('3. Link the page articles into the standard KB → flat per-article placements')
+    const pageIdsToLink = pages.map((a) => a.id)
+    await linkArticlesIntoKb(db, orgId, linkKbId, pageIdsToLink)
     arts = await articlesForSource(sourceId)
     placements = await placementsForArticles(arts.map((a) => a.id))
     const inLinkKb = placements.filter((p) => p.knowledgeBaseId === linkKbId)
-    check('all 3 articles linked into the standard KB', inLinkKb.length === arts.length, {
-      linked: inLinkKb.length,
-      total: arts.length,
-    })
+    check(
+      'only the page articles linked (root category excluded)',
+      inLinkKb.length === pageIdsToLink.length,
+      {
+        linked: inLinkKb.length,
+        pages: pageIdsToLink.length,
+      }
+    )
+    check('root category was NOT linked', !inLinkKb.some((p) => p.articleId === rootId))
     check(
       'linked placements carry linkedFromSourceId',
       inLinkKb.every((p) => p.linkedFromSourceId === sourceId)
     )
-    const linkRootPlacement = inLinkKb.find((p) => p.articleId === rootId)
-    const linkPagePlacements = inLinkKb.filter((p) => pages.some((a) => a.id === p.articleId))
     check(
-      'linked tree preserved (pages under root in the linked KB)',
-      !!linkRootPlacement && linkPagePlacements.every((p) => p.parentId === linkRootPlacement.id)
+      'linked pages sit at KB root (flat — no category mirrored)',
+      inLinkKb.every((p) => p.parentId === null)
     )
+    // Re-link is idempotent — no duplicate placements.
+    await linkArticlesIntoKb(db, orgId, linkKbId, pageIdsToLink)
+    const inLinkKbAgain = (await placementsForArticles(arts.map((a) => a.id))).filter(
+      (p) => p.knowledgeBaseId === linkKbId
+    )
+    check('re-linking is idempotent (no dupes)', inLinkKbAgain.length === inLinkKb.length, {
+      before: inLinkKb.length,
+      after: inLinkKbAgain.length,
+    })
     const links = await listSourceLinks(db, orgId, sourceId)
     check(
       'listSourceLinks reports the linked KB',
@@ -229,8 +242,8 @@ async function main() {
       links
     )
 
-    // ── 4. Add item C → re-sync → fan-out places C in the linked KB ──────────
-    section('4. Add item C → re-sync → C homes in owned KB and fans out to the linked KB')
+    // ── 4. Add item C → re-sync → C homes in owned KB but does NOT auto-join ──
+    section('4. Add item C → re-sync → C homes in owned KB; NOT auto-linked (per-article)')
     await updateSource(db, orgId, sourceId, {
       config: {
         items: [
@@ -250,8 +263,15 @@ async function main() {
       cPlacements.some((p) => p.knowledgeBaseId === ownedKbId)
     )
     check(
-      'C fanned out into the linked KB',
-      cPlacements.some((p) => p.knowledgeBaseId === linkKbId && p.linkedFromSourceId === sourceId)
+      'C did NOT auto-join the linked KB (no whole-source fan-out)',
+      !cPlacements.some((p) => p.knowledgeBaseId === linkKbId)
+    )
+    // Explicitly link C → now it appears in the linked KB.
+    if (cArticle) await linkArticlesIntoKb(db, orgId, linkKbId, [cArticle.id])
+    const cAfterLink = await placementsForArticles(cArticle ? [cArticle.id] : [])
+    check(
+      'C appears in the linked KB after an explicit per-article link',
+      cAfterLink.some((p) => p.knowledgeBaseId === linkKbId && p.linkedFromSourceId === sourceId)
     )
 
     // ── 5. Unlink from the standard KB → linked placements removed ───────────

--- a/packages/lib/src/datasets/services/document-service.ts
+++ b/packages/lib/src/datasets/services/document-service.ts
@@ -7,7 +7,7 @@ import type {
   DocumentType,
 } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
-import { and, asc, count, desc, eq, gte, ilike, inArray, lte, or } from 'drizzle-orm'
+import { and, asc, count, desc, eq, gte, ilike, inArray, lte, or, sql } from 'drizzle-orm'
 import { MediaAssetService } from '../../files/core/media-asset-service'
 import type {
   BatchProcessingRequest,
@@ -141,7 +141,7 @@ export class DocumentService {
       enabled?: boolean
       /** Pass partial settings to update, null to clear override, or undefined to leave unchanged */
       chunkSettings?: Partial<ChunkSettings> | null
-      /** Document metadata (replaces existing metadata) */
+      /** Document metadata — shallow-merged into existing metadata (top-level keys win) */
       metadata?: Record<string, unknown>
       /** Total number of chunks/segments */
       totalChunks?: number
@@ -177,7 +177,10 @@ export class DocumentService {
         updateData.chunkSettings = data.chunkSettings
       }
       if (data.metadata !== undefined) {
-        updateData.metadata = data.metadata
+        // Shallow-merge into existing metadata so processing-status writers
+        // (segmentCount, processingTime, error, …) don't clobber keys set
+        // elsewhere — notably the `kb` block that KB sync dedup relies on.
+        updateData.metadata = sql`COALESCE(${schema.Document.metadata}, '{}'::jsonb) || ${JSON.stringify(data.metadata)}::jsonb`
       }
       if (data.totalChunks !== undefined) {
         updateData.totalChunks = data.totalChunks

--- a/packages/lib/src/kb/articles/link-articles-into-kb.ts
+++ b/packages/lib/src/kb/articles/link-articles-into-kb.ts
@@ -1,0 +1,87 @@
+// @auxx/lib/kb/articles/link-articles-into-kb.ts
+// Link individually-chosen `page` articles from ANY KB into a target KnowledgeBase by
+// materializing ArticlePlacement rows (multi-home). The article's content stays canonical
+// (one Article row); each placement decides where it lives + its publish state per KB.
+// `linkedFromSourceId` mirrors the article's own `sourceId` so source-derived placements
+// stay distinguishable (and unlinkable) from hand-authored ones. Only `page` articles are
+// linkable — never categories/structural folders. See plans/kb/sources/link-articles-into-kb-PLAN.md.
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq, inArray } from 'drizzle-orm'
+import { BadRequestError } from '../../errors'
+import { addPlacement } from './add-placement'
+
+/**
+ * Resolve an article's placement id within a given KB (placement-id space, which
+ * `addPlacement` expects for `parentPlacementId`). Returns null when the article
+ * isn't placed in that KB.
+ */
+async function resolvePlacementId(
+  db: Database,
+  organizationId: string,
+  knowledgeBaseId: string,
+  articleId: string
+): Promise<string | null> {
+  const row = await db.query.ArticlePlacement.findFirst({
+    where: and(
+      eq(schema.ArticlePlacement.organizationId, organizationId),
+      eq(schema.ArticlePlacement.knowledgeBaseId, knowledgeBaseId),
+      eq(schema.ArticlePlacement.articleId, articleId)
+    ),
+    columns: { id: true },
+  })
+  return row?.id ?? null
+}
+
+/**
+ * Materialize placements for the chosen `articleIds` into `targetKbId`, each placed under
+ * `opts.targetParentArticleId` (e.g. the active tab) or the KB root. Articles may come from
+ * any KB (standard or a source's hidden KB). Idempotent — already-placed articles are no-ops.
+ * Rejects anything that isn't a `page` (categories/folders/tabs are not linkable).
+ */
+export async function linkArticlesIntoKb(
+  db: Database,
+  organizationId: string,
+  targetKbId: string,
+  articleIds: string[],
+  opts?: { targetParentArticleId?: string | null }
+): Promise<{ linked: number }> {
+  if (articleIds.length === 0) return { linked: 0 }
+
+  // Validate org ownership + kind in one read; carry each article's `sourceId` so the
+  // new placement records the same provenance the source-side unlink/summary keys off.
+  const articles = await db.query.Article.findMany({
+    where: and(
+      eq(schema.Article.organizationId, organizationId),
+      inArray(schema.Article.id, articleIds)
+    ),
+    columns: { id: true, articleKind: true, sourceId: true },
+  })
+  const byId = new Map(articles.map((a) => [a.id, a]))
+  for (const id of articleIds) {
+    const a = byId.get(id)
+    if (!a) throw new BadRequestError(`Article '${id}' not found`)
+    if (a.articleKind !== 'page') {
+      throw new BadRequestError('Only articles can be linked, not categories or folders')
+    }
+  }
+
+  // Resolve the attach point to placement-id space once (KB root if unresolved).
+  const parentPlacementId = opts?.targetParentArticleId
+    ? await resolvePlacementId(db, organizationId, targetKbId, opts.targetParentArticleId)
+    : null
+
+  const ctx = { db, organizationId }
+  let linked = 0
+  for (const articleId of articleIds) {
+    await addPlacement(ctx, {
+      articleId,
+      knowledgeBaseId: targetKbId,
+      parentPlacementId,
+      linkedFromSourceId: byId.get(articleId)?.sourceId ?? null,
+      isPublished: false,
+    })
+    linked++
+  }
+  return { linked }
+}

--- a/packages/lib/src/kb/index.ts
+++ b/packages/lib/src/kb/index.ts
@@ -17,6 +17,7 @@ export {
   getArticleBySlug,
   getArticleSlugPath,
 } from './articles/get-article'
+export { linkArticlesIntoKb } from './articles/link-articles-into-kb'
 export { getAllArticles, getArticles } from './articles/list-articles'
 export { moveArticle } from './articles/move-article'
 export { publishArticle, unpublishArticle } from './articles/publish-article'

--- a/packages/lib/src/kb/kb-sync-service.ts
+++ b/packages/lib/src/kb/kb-sync-service.ts
@@ -322,8 +322,16 @@ export class KBSyncService {
     const kbService = new KBService(this.db, this.organizationId)
     const datasetId = await kbService.ensureManagedDataset(kb, kb.createdById)
 
-    // Lookup an existing Document for this article in this dataset.
-    const existing = await this.findArticleDocument(datasetId, articleId)
+    const checksum = createHash('sha256').update(`${articleId}:${md}`, 'utf8').digest('hex')
+
+    // Lookup an existing Document for this article in this dataset. Fall back to
+    // the (datasetId, checksum) unique key: a row whose `kb` metadata block was
+    // stripped (e.g. by the processing pipeline) is invisible to the articleId
+    // lookup but still occupies the unique slot — adopt it instead of colliding
+    // on insert.
+    const existing =
+      (await this.findArticleDocument(datasetId, articleId)) ??
+      (await this.findArticleDocumentByChecksum(datasetId, checksum))
 
     if (existing) {
       const prevHash = (existing.metadata as any)?.kb?.contentHash as string | undefined
@@ -333,7 +341,6 @@ export class KBSyncService {
       }
     }
 
-    const checksum = createHash('sha256').update(`${articleId}:${md}`, 'utf8').digest('hex')
     const slugPath = (await kbService.getArticleSlugPath(articleId)) ?? homePlacementSlug
 
     const baseMetadata = {
@@ -391,6 +398,21 @@ export class KBSyncService {
           eq(schema.Document.datasetId, datasetId),
           eq(schema.Document.organizationId, this.organizationId),
           sql`${schema.Document.metadata}->'kb'->>'articleId' = ${articleId}`
+        )
+      )
+      .limit(1)
+    return row ?? null
+  }
+
+  private async findArticleDocumentByChecksum(datasetId: string, checksum: string) {
+    const [row] = await this.db
+      .select()
+      .from(schema.Document)
+      .where(
+        and(
+          eq(schema.Document.datasetId, datasetId),
+          eq(schema.Document.organizationId, this.organizationId),
+          eq(schema.Document.checksum, checksum)
         )
       )
       .limit(1)

--- a/packages/lib/src/knowledge-sources/index.ts
+++ b/packages/lib/src/knowledge-sources/index.ts
@@ -14,7 +14,11 @@ export type {
   SourceSink,
   SyncCtx,
 } from './sinks/types'
-export { linkSourceToKb, listSourceLinks, unlinkSourceFromKb } from './source-links'
+export {
+  listSourceLinks,
+  unlinkSourceArticleFromKb,
+  unlinkSourceFromKb,
+} from './source-links'
 export {
   reconcileSourceSchedulers,
   removeSourceScheduler,

--- a/packages/lib/src/knowledge-sources/run-source-sync.ts
+++ b/packages/lib/src/knowledge-sources/run-source-sync.ts
@@ -4,7 +4,7 @@
 
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, isNotNull, ne } from 'drizzle-orm'
+import { and, eq, ne } from 'drizzle-orm'
 import { connectorFor } from './connectors'
 import { sinkForSurface } from './sinks'
 import type { SyncCtx } from './sinks/types'
@@ -49,22 +49,7 @@ export async function runSourceSync(
     })
     if (!kb) throw new Error(`Owned KnowledgeBase ${source.ownedKnowledgeBaseId} not found`)
 
-    // KBs this source is already linked into — new/changed items fan out to each so a
-    // linked KB stays in sync without a re-link. Derived from existing linked placements.
-    const linkRows = await db
-      .selectDistinct({ knowledgeBaseId: schema.ArticlePlacement.knowledgeBaseId })
-      .from(schema.ArticlePlacement)
-      .where(
-        and(
-          eq(schema.ArticlePlacement.organizationId, organizationId),
-          eq(schema.ArticlePlacement.linkedFromSourceId, sourceId),
-          isNotNull(schema.ArticlePlacement.linkedFromSourceId),
-          ne(schema.ArticlePlacement.knowledgeBaseId, source.ownedKnowledgeBaseId)
-        )
-      )
-    const linkedKbIds = linkRows.map((r) => r.knowledgeBaseId)
-
-    const ctx: SyncCtx = { db, orgId: organizationId, source, kb, linkedKbIds }
+    const ctx: SyncCtx = { db, orgId: organizationId, source, kb }
     const connector = connectorFor(source.type)
     const sink = sinkForSurface(source)
 
@@ -91,9 +76,6 @@ export async function runSourceSync(
     for (const { externalId } of existing) {
       if (!seen.has(externalId)) await sink.archiveItem(ctx, externalId)
     }
-
-    // Propagate the freshly-synced tree into any KBs this source is linked into.
-    await sink.reconcileLinks?.(ctx)
 
     const itemCount = seen.size
     await db

--- a/packages/lib/src/knowledge-sources/sinks/article-sink.ts
+++ b/packages/lib/src/knowledge-sources/sinks/article-sink.ts
@@ -9,7 +9,6 @@ import { updateArticleDraft } from '../../kb/articles/update-article'
 import { enqueueKBSync } from '../../kb/kb-sync-queue'
 import { computeContentHash } from '../../kb/markdown/hash'
 import { mdToBlocks } from '../../kb/markdown/md-to-blocks'
-import { linkSourceToKb } from '../source-links'
 import {
   ensurePathFolders,
   ensureRootFolder,
@@ -88,13 +87,10 @@ export const articleSink: SourceSink = {
     })
   },
 
-  // After the item loop, backfill any KB this source is linked into with placements for
-  // new articles (idempotent, parent-first). Keeps linked KBs in sync on every re-sync.
-  async reconcileLinks(ctx) {
-    for (const kbId of ctx.linkedKbIds) {
-      await linkSourceToKb(ctx.db, ctx.orgId, ctx.source.id, kbId)
-    }
-  },
+  // Links are per-article now: a linked placement points at the same Article, so content
+  // edits flow through on re-sync without any fan-out, and archive/delete cascades clean up
+  // the placement. New source articles do NOT auto-join — they're linked manually per KB.
+  // (No reconcileLinks needed; the SourceSink interface leaves it optional.)
 
   async listExisting(ctx) {
     const arts = await listArticlesBySource(ctx)

--- a/packages/lib/src/knowledge-sources/sinks/types.ts
+++ b/packages/lib/src/knowledge-sources/sinks/types.ts
@@ -23,8 +23,6 @@ export interface SyncCtx {
   source: KnowledgeSourceRow
   /** The source's owned (hidden) KB — articles home + embed here. */
   kb: KnowledgeBaseRow
-  /** User-facing KBs this source is linked into — new/updated items fan out to these. */
-  linkedKbIds: string[]
 }
 
 export interface SourceSink {
@@ -32,6 +30,4 @@ export interface SourceSink {
   archiveItem(ctx: SyncCtx, externalId: string): Promise<void>
   /** Existing items for orphan reconciliation — content items only, no structural folders. */
   listExisting(ctx: SyncCtx): Promise<{ externalId: string; contentHash: string }[]>
-  /** Optional post-pass: propagate the synced tree into any linked user-facing KBs. */
-  reconcileLinks?(ctx: SyncCtx): Promise<void>
 }

--- a/packages/lib/src/knowledge-sources/source-links.ts
+++ b/packages/lib/src/knowledge-sources/source-links.ts
@@ -1,14 +1,14 @@
 // packages/lib/src/knowledge-sources/source-links.ts
 // Link a source's content into user-facing KnowledgeBases. A source homes (and embeds)
-// its articles once in its own hidden KB; "linking" materializes ArticlePlacement rows of
-// those articles into a target KB (linkedFromSourceId = source.id), preserving the tree.
-// Unlinking drops just those placements. See plans/kb/sources/source-owns-kb-REFACTOR.md.
+// its articles once in its own hidden KB; "linking" materializes ArticlePlacement rows for
+// individually chosen articles into a target KB (linkedFromSourceId = source.id), placed
+// under a chosen parent (e.g. the active tab). Only `page` articles are linkable — never
+// categories/structural folders. Unlinking drops just those placements.
+// See plans/kb/sources/source-owns-kb-REFACTOR.md.
 
 import { type Database, schema } from '@auxx/database'
 import { and, eq, isNotNull, ne } from 'drizzle-orm'
 import { NotFoundError } from '../errors'
-import { addPlacement } from '../kb/articles/add-placement'
-import { getArticles } from '../kb/articles/list-articles'
 
 async function loadSource(db: Database, organizationId: string, sourceId: string) {
   const source = await db.query.KnowledgeSource.findFirst({
@@ -22,50 +22,26 @@ async function loadSource(db: Database, organizationId: string, sourceId: string
   return source
 }
 
-/**
- * Materialize placements of every article in the source's owned KB into `targetKbId`,
- * preserving the tree (parents before children). Idempotent — re-linking is a no-op for
- * articles already placed there (so it doubles as the re-sync fan-out backfill).
- */
-export async function linkSourceToKb(
+/** Remove a single linked article's placement from one KB (source content untouched). */
+export async function unlinkSourceArticleFromKb(
   db: Database,
   organizationId: string,
   sourceId: string,
+  articleId: string,
   targetKbId: string
-): Promise<{ linked: number }> {
-  const source = await loadSource(db, organizationId, sourceId)
-  if (targetKbId === source.ownedKnowledgeBaseId) return { linked: 0 }
-
-  const ctx = { db, organizationId }
-  const items = await getArticles(ctx, source.ownedKnowledgeBaseId, { includeUnpublished: true })
-
-  // Place parent-first so each child's parentPlacementId resolves to the new placement.
-  const newPlacementByArticle = new Map<string, string>()
-  const remaining = [...items]
-  let linked = 0
-  let progress = true
-  while (remaining.length > 0 && progress) {
-    progress = false
-    for (let i = remaining.length - 1; i >= 0; i--) {
-      const item = remaining[i]!
-      if (item.parentId && !newPlacementByArticle.has(item.parentId)) continue
-      const placement = await addPlacement(ctx, {
-        articleId: item.id,
-        knowledgeBaseId: targetKbId,
-        parentPlacementId: item.parentId
-          ? (newPlacementByArticle.get(item.parentId) ?? null)
-          : null,
-        sortOrder: item.sortOrder,
-        linkedFromSourceId: sourceId,
-        isPublished: false,
-      })
-      newPlacementByArticle.set(item.id, placement.id)
-      remaining.splice(i, 1)
-      linked++
-      progress = true
-    }
-  }
-  return { linked }
+): Promise<{ success: boolean }> {
+  await loadSource(db, organizationId, sourceId)
+  await db
+    .delete(schema.ArticlePlacement)
+    .where(
+      and(
+        eq(schema.ArticlePlacement.organizationId, organizationId),
+        eq(schema.ArticlePlacement.linkedFromSourceId, sourceId),
+        eq(schema.ArticlePlacement.articleId, articleId),
+        eq(schema.ArticlePlacement.knowledgeBaseId, targetKbId)
+      )
+    )
+  return { success: true }
 }
 
 /** Remove a source's links from one KB (deletes those placements; cascades children). */

--- a/packages/lib/src/resources/registry/resources/article-fields.ts
+++ b/packages/lib/src/resources/registry/resources/article-fields.ts
@@ -265,7 +265,10 @@ export const ARTICLE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'article_kb',
     systemSortOrder: 'a4',
-    dbColumn: 'knowledgeBaseId',
+    // The article's canonical owner KB. Tree placement (and multi-KB membership)
+    // moved to the ArticlePlacement table, so there is no `knowledgeBaseId` column
+    // on Article — `homeKnowledgeBaseId` is the single owning KB this column shows.
+    dbColumn: 'homeKnowledgeBaseId',
     nullable: false,
     capabilities: {
       filterable: true,


### PR DESCRIPTION
## What

Replaces **whole-source** linking with **per-article** linking. One `ArticlePicker` lists every KB you can pull from (standard KBs + sources' hidden KBs); you drill in, pick `page` articles, and each becomes an `ArticlePlacement` under the active tab.

A link is just a placement (`linkedFromSourceId` mirrors the article's `sourceId`, or `null` for hand-authored) — **no new join table, no re-sync fan-out**. Content edits flow through the shared `Article` (linking a plain article is a true multi-home; source articles stay managed/read-only).

Supersedes the whole-source UX in `plans/kb/arch/knowledge-sources.md` §7–8; implements `plans/kb/sources/link-articles-into-kb-PLAN.md`.

## Backend
- **`linkArticlesIntoKb(db, org, targetKbId, articleIds, { targetParentArticleId })`** — validates org + `page` kind, resolves the attach point to placement-id space, idempotent `addPlacement` per article. Exported from `@auxx/lib/kb`.
- New **`kb.linkArticles`** router; dropped `knowledgeSource.linkArticles` + the old `linkSourceArticlesToKb` (source id is no longer an input). Source-side unlink/summary helpers (`listSourceLinks`, `unlinkSourceArticleFromKb`, `unlinkSourceFromKb`) kept — they still key off `linkedFromSourceId`.
- Smoke test (`smoke-knowledge-sources.ts`) updated to per-article semantics.

## Frontend
- **`ArticlePicker`** — added `knowledgeBasesOverride` for cross-KB mode; cross-KB browsing **fetches the drilled-into KB directly** (not the shared store) so a second KB's tree can't clobber `parentId` for multi-homed articles; loading row; `autoFocusSearch`; removed `articlesOverride`.
- **`LinkArticlePicker`** — surface-agnostic cross-KB picker (KB list = standard minus current + source KBs excluding `ai-only`; `forbiddenIds` = current KB's article ids). Embedded two ways:
  - **Sidebar Add menu** morphs in place (controlled `DropdownMenu` swaps content to the picker; keydown guard so cmdk owns nav).
  - **Container placeholder** ("Add to this tab / section header") opens it in a popover.
  - Replaces the old link dialog.
- **`container-article-placeholder`** — quick-create list rebuilt on `TreeRow` rows (create actions + "Link an article" popover + children) instead of cmdk, fixing the popover positioning/hover-close issues.

## Notes
- The KB article store stays article-id-keyed by design; cross-KB browsing is fenced out of it via direct fetch rather than a store redesign (see plan, constraint 2).
- Known trade-off: the TreeRow-based container list is click/Tab only (no arrow-key roving that cmdk gave).

## Test plan
- [ ] Sidebar **Add → Link an article**: menu morphs to picker; pick from another KB and a source KB; article appears under the active tab; stays open for multiple.
- [ ] Container placeholder **Link an article**: popover anchors to the row; linking works; closes cleanly.
- [ ] Already-present articles are filtered out (`forbiddenIds`).
- [ ] Move-picker (single-KB) still reflects optimistic moves.