### PR TITLE
fix(kb): diff view follows app light/dark, not KB mode

### DIFF
--- a/apps/web/src/components/kb/ui/editor/article-diff-view.tsx
+++ b/apps/web/src/components/kb/ui/editor/article-diff-view.tsx
@@ -7,6 +7,7 @@ import type { ArticleNodeJSON, DiffDecorations, DocJSON } from '@auxx/ui/compone
 import { KBArticleNode, kbArticleContainerClass } from '@auxx/ui/components/kb/article'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { cn } from '@auxx/ui/lib/utils'
+import { useTheme } from 'next-themes'
 import { useMemo } from 'react'
 import type { ArticleMeta } from '../../store/article-store'
 import { buildDiffRender } from './article-diff-tree'
@@ -26,6 +27,8 @@ interface ArticleDiffViewProps {
    * KB theme to render the blocks under, so callouts/tables/code/links match
    * the published article (their colors come from `--kb-*` tokens injected by
    * `KBThemeProvider`). Map a store KnowledgeBase with `mapKBForPreview`.
+   * Light/dark follows the app — not the KB's own mode — since the diff lives
+   * in the editor pane.
    */
   kbTheme: KBThemeProviderProps['kb']
   /** Clears the `?diff=` param and returns to the editor. */
@@ -61,8 +64,15 @@ export function ArticleDiffView({
   const { added, removed, modified, moved } = diff.stats
   const hasChanges = added + removed + modified + moved > 0
 
+  // The diff renders in the editor pane, so its light/dark should track the app
+  // (not the KB's stored mode). Pin the provider mode to the app's resolved
+  // theme and disable cookie sync so the KB's own mode preference can't override
+  // it. KB *colors* still come from `kbTheme`.
+  const { resolvedTheme } = useTheme()
+  const appMode = resolvedTheme === 'dark' ? 'dark' : 'light'
+
   return (
-    <KBThemeProvider kb={kbTheme}>
+    <KBThemeProvider kb={kbTheme} mode={appMode} syncModeFromCookie={false}>
       <ArticleEditorHeader
         article={article}
         knowledgeBaseId={knowledgeBaseId}

--- a/packages/ui/src/components/kb/theme/kb-theme-provider.tsx
+++ b/packages/ui/src/components/kb/theme/kb-theme-provider.tsx
@@ -7,10 +7,23 @@ export interface KBThemeProviderProps {
   kb: KBThemeInput & { defaultMode?: string | null }
   /** Override the mode (admin preview uses this). */
   mode?: KBMode
+  /**
+   * Whether to sync `data-kb-mode` from the `kb-mode-{id}` cookie before paint.
+   * On for the public site (lets the KB's own mode toggle stick). Surfaces that
+   * pin the mode to an external source — e.g. the editor diff view, which
+   * follows the app's light/dark — pass `false` so the cookie can't override the
+   * forced `mode`.
+   */
+  syncModeFromCookie?: boolean
   children: ReactNode
 }
 
-export function KBThemeProvider({ kb, mode, children }: KBThemeProviderProps) {
+export function KBThemeProvider({
+  kb,
+  mode,
+  syncModeFromCookie = true,
+  children,
+}: KBThemeProviderProps) {
   const css = buildKBCss(kb)
   const initialMode = mode ?? normalizeMode(kb.defaultMode)
   const theme = sanitizeTheme(kb.theme)
@@ -24,7 +37,7 @@ export function KBThemeProvider({ kb, mode, children }: KBThemeProviderProps) {
       className='flex min-h-0 flex-1 flex-col'
       style={{ background: 'var(--kb-page-bg)' }}>
       <style dangerouslySetInnerHTML={{ __html: css }} />
-      <NoFlashModeScript kbId={kb.id} />
+      {syncModeFromCookie && <NoFlashModeScript kbId={kb.id} />}
       {children}
     </div>
   )


### PR DESCRIPTION
## Problem

In the article editor, the diff view (`ArticleDiffView` / `ArticleDiffPane`) wrapped its blocks in `KBThemeProvider` using the KB's own `defaultMode`/`kb-mode-{id}` cookie. The `--kb-*` color tokens (and `dark:` utilities) are keyed off `data-kb-mode`, so the diff rendered in the **KB's** light/dark — which can clash with the surrounding app chrome when the two differ.

## Fix

Keep the KB's colors, but make the diff's light/dark follow the **app's** mode:

- **`kb-theme-provider.tsx`** — add a `syncModeFromCookie` prop (default `true`, preserving public-site behavior). When `false`, the `NoFlashModeScript` cookie sync is skipped so an externally forced `mode` can't be overridden.
- **`article-diff-view.tsx`** — read the app's mode via next-themes `useTheme().resolvedTheme` and pass `mode={appMode}` + `syncModeFromCookie={false}`.

Pinning `data-kb-mode` to the app mode drives both the `--kb-*` tokens and `dark:` utilities consistently, and stays reactive — toggling the app theme flips the diff with it. KB brand/callout colors still come from the KB theme.

## Notes

Only the *mode selection* follows the app; each KB still uses its own `light`/`dark` palettes.