### PR TITLE
feat(kopilot): inline full output schemas on tools, slim digests

### DIFF
--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -234,22 +234,28 @@ export interface AgentToolDefinition {
    */
   idempotent?: boolean
   /**
-   * Optional Zod schema for the tool's success `output`. Reserved for future
-   * runtime validation + inference; today the snapshot walker uses structural
-   * probes instead. Optional so migration is incremental.
+   * Zod schema for the **full** shape of the tool's success `output` — the same
+   * value persisted on `ToolCallPart.output` and replayed to the model. This is
+   * the single source of truth for the output's shape.
+   *
+   * **Declarative, not enforced:** the engine does NOT parse/throw against this at
+   * execute time (output stays `unknown` on the wire). It exists so consumers can
+   * (a) type/enumerate an addressable `tool:<name>.<path>` ref for the prompt's
+   * available-context section, (b) let v8 bind a later tool's input to an earlier
+   * tool's output, and (c) declare a connector referenceable before it is called
+   * (lazy fetch-on-read). See plans/chat/v9/OUTPUT-SCHEMAS.md.
+   *
+   * The small UI render projection is `buildDigest` — a *projection of this
+   * schema*, not a competing one. Optional so migration is incremental.
    */
   outputSchema?: z.ZodType
   /**
-   * Schema describing the display projection of the tool's output. Persisted
-   * alongside the tool message; status pills and approval/result cards render
-   * from this. When omitted, falls through to a generic pill rendering name +
-   * args summary.
-   */
-  outputDigestSchema?: z.ZodType
-  /**
-   * Build the digest from the raw output. Called once at tool-completion time;
-   * the result is stored on the tool message and re-emitted on session reload.
-   * MUST be deterministic and pure.
+   * Build the small display projection of the tool's output. Called once at
+   * tool-completion time; the result is persisted on `ToolCallPart.digest` and
+   * re-emitted on session reload — status pills and approval/result cards render
+   * from it. A projection of `outputSchema` (the single source of truth); trusted
+   * as-is (not re-validated). When omitted, the UI falls through to a generic
+   * pill rendering name + args summary. MUST be deterministic and pure.
    */
   buildDigest?: (output: unknown) => unknown
   /**

--- a/packages/lib/src/ai/agent-framework/utils.ts
+++ b/packages/lib/src/ai/agent-framework/utils.ts
@@ -32,9 +32,10 @@ export interface ToolExecResult {
 
 /**
  * Compute the display digest for a tool result. Best-effort — `buildDigest`
- * errors and `outputDigestSchema` validation failures are logged and dropped so
- * a misshapen digest never fails the turn. Returns `undefined` when the tool
- * has no `buildDigest` or the output cannot be projected.
+ * errors are logged and dropped so a misshapen digest never fails the turn.
+ * Returns `undefined` when the tool has no `buildDigest` or the output cannot
+ * be projected. `buildDigest` is the projection of `outputSchema` (the single
+ * source of truth); it is trusted as-is and not re-validated.
  */
 export function buildToolDigest(
   tool: AgentToolDefinition | undefined,
@@ -42,9 +43,8 @@ export function buildToolDigest(
   logger?: { warn: (msg: string, meta?: Record<string, unknown>) => void }
 ): unknown {
   if (!tool?.buildDigest) return undefined
-  let digest: unknown
   try {
-    digest = tool.buildDigest(output)
+    return tool.buildDigest(output)
   } catch (err) {
     logger?.warn('buildDigest threw', {
       tool: tool.name,
@@ -52,18 +52,6 @@ export function buildToolDigest(
     })
     return undefined
   }
-  if (tool.outputDigestSchema) {
-    const parsed = tool.outputDigestSchema.safeParse(digest)
-    if (!parsed.success) {
-      logger?.warn('digest failed outputDigestSchema validation', {
-        tool: tool.name,
-        issues: parsed.error.issues.slice(0, 3),
-      })
-      return undefined
-    }
-    return parsed.data
-  }
-  return digest
 }
 
 /**

--- a/packages/lib/src/ai/kopilot/capabilities/actors/tools/list-groups.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/actors/tools/list-groups.ts
@@ -1,9 +1,24 @@
 // packages/lib/src/ai/kopilot/capabilities/actors/tools/list-groups.ts
 
+import { z } from 'zod'
 import { ActorService } from '../../../../../actors/actor-service'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { ListGroupsDigest, takeSample } from '../../../digests'
+import { takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `list_groups` — matched groups with a count. */
+const ListGroupsOutput = z.object({
+  groups: z.array(
+    z.object({
+      actorId: z.string(),
+      name: z.string(),
+      description: z.string().nullable(),
+      memberCount: z.number(),
+      visibility: z.enum(['public', 'private']),
+    })
+  ),
+  count: z.number(),
+})
 
 export function createListGroupsTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -11,7 +26,7 @@ export function createListGroupsTool(getDeps: GetToolDeps): AgentToolDefinition 
     displayName: 'List groups',
     toolsetSlug: 'auxx:actors',
     idempotent: true,
-    outputDigestSchema: ListGroupsDigest,
+    outputSchema: ListGroupsOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         groups?: Array<{ name?: string | null }>

--- a/packages/lib/src/ai/kopilot/capabilities/actors/tools/list-members.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/actors/tools/list-members.ts
@@ -1,9 +1,24 @@
 // packages/lib/src/ai/kopilot/capabilities/actors/tools/list-members.ts
 
+import { z } from 'zod'
 import { ActorService } from '../../../../../actors/actor-service'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { ListMembersDigest, takeSample } from '../../../digests'
+import { takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `list_members` — matched workspace members with a count. */
+const ListMembersOutput = z.object({
+  members: z.array(
+    z.object({
+      actorId: z.string(),
+      name: z.string(),
+      email: z.string(),
+      role: z.enum(['OWNER', 'ADMIN', 'USER']),
+      avatarUrl: z.string().nullable(),
+    })
+  ),
+  count: z.number(),
+})
 
 export function createListMembersTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -11,7 +26,7 @@ export function createListMembersTool(getDeps: GetToolDeps): AgentToolDefinition
     displayName: 'List members',
     toolsetSlug: 'auxx:actors',
     idempotent: true,
-    outputDigestSchema: ListMembersDigest,
+    outputSchema: ListMembersOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         members?: Array<{ name?: string | null }>

--- a/packages/lib/src/ai/kopilot/capabilities/entities/format-enriched-fields.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/format-enriched-fields.ts
@@ -1,7 +1,18 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/format-enriched-fields.ts
 
 import type { FieldType } from '@auxx/database/types'
+import { z } from 'zod'
 import type { EnrichedField } from './enrich-entity-fields'
+
+/** Zod shape of {@link FormattedField} — the addressable per-field cell shape. */
+export const FormattedFieldSchema = z.object({
+  text: z.string(),
+  type: z.string().optional(),
+  actorId: z.string().optional(),
+  tags: z.array(z.object({ label: z.string(), color: z.string().optional() })).optional(),
+  recordId: z.string().optional(),
+  recordIds: z.array(z.string()).optional(),
+})
 
 /** Maps FieldType → cell type hint for the auxx:table block */
 const FIELD_TYPE_TO_CELL_TYPE: Partial<Record<FieldType, string>> = {

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
@@ -1,12 +1,21 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
 
+import { z } from 'zod'
 import { findCachedResource } from '../../../../../cache/org-cache-helpers'
 import { FieldValueService } from '../../../../../field-values/field-value-service'
 import { getDefinitionId } from '../../../../../resources/resource-id'
 import { getKnownDefIds, normalizeRecordIdArrayArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { BulkUpdateEntityDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `bulk_update_entity` — record counts and updated field labels. */
+const BulkUpdateEntityOutput = z.object({
+  total: z.number(),
+  approved: z.number(),
+  updated: z.number(),
+  updatedFields: z.array(z.string()),
+})
+
 import {
   formatUnknownFieldsError,
   resolveFieldLabels,
@@ -19,7 +28,7 @@ export function createBulkUpdateEntityTool(getDeps: GetToolDeps): AgentToolDefin
     name: 'bulk_update_entity',
     displayName: 'Bulk update records',
     toolsetSlug: 'auxx:entities:write',
-    outputDigestSchema: BulkUpdateEntityDigest,
+    outputSchema: BulkUpdateEntityOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { updated?: number; updatedFields?: string[] }
       return {

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-entity.ts
@@ -1,12 +1,18 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/create-entity.ts
 
+import { z } from 'zod'
 import { findCachedResource, getCachedResources } from '../../../../../cache/org-cache-helpers'
 import { UnprocessableEntityError } from '../../../../../errors'
 import { UnifiedCrudHandler } from '../../../../../resources/crud'
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { CreateEntityDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `create_entity` — the new record's id. */
+const CreateEntityOutput = z.object({
+  recordId: z.string(),
+})
+
 import { formatUnknownFieldsError, validateFieldKeys } from './field-label-helpers'
 import { formatActorResolutionError, resolveActorValues } from './resolve-actor-values'
 
@@ -15,7 +21,7 @@ export function createCreateEntityTool(getDeps: GetToolDeps): AgentToolDefinitio
     name: 'create_entity',
     displayName: 'Create record',
     toolsetSlug: 'auxx:entities:write',
-    outputDigestSchema: CreateEntityDigest,
+    outputSchema: CreateEntityOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { recordId?: string }
       const recordId = String(out.recordId ?? '')

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-note.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/create-note.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/create-note.ts
 
+import { z } from 'zod'
 import { CommentService } from '../../../../../comments'
 import type { RecordId } from '../../../../../resources/resource-id'
 import { textToDoc } from '../../../../../tiptap'
@@ -9,15 +10,21 @@ import {
   parseStringArg,
 } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { CreateNoteDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `create_note` — the created comment id and a content preview. */
+const CreateNoteOutput = z.object({
+  commentId: z.string(),
+  recordId: z.string(),
+  contentPreview: z.string(),
+})
 
 export function createCreateNoteTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'create_note',
     displayName: 'Add note',
     toolsetSlug: 'auxx:comments:write',
-    outputDigestSchema: CreateNoteDigest,
+    outputSchema: CreateNoteOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { commentId?: string; recordId?: string }
       return {

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-entity-history.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-entity-history.ts
@@ -2,6 +2,7 @@
 
 import { schema } from '@auxx/database'
 import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, ne, or } from 'drizzle-orm'
+import { z } from 'zod'
 import { getCachedMembersByUserIds } from '../../../../../cache/org-cache-helpers'
 import type {
   TimelineFieldChangeSnapshot,
@@ -9,8 +10,87 @@ import type {
 } from '../../../../../timeline/field-change-snapshot'
 import { docToText } from '../../../../../tiptap'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { GetEntityHistoryDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `get_entity_history` — a token-bounded recent-activity digest. */
+const GetEntityHistoryOutput = z.object({
+  entity: z.object({
+    id: z.string(),
+    entityDefinitionId: z.string(),
+    primaryDisplay: z.string().nullable(),
+    secondaryDisplay: z.string().nullable(),
+    createdAt: z.string(),
+    lastActivityAt: z.string().nullable(),
+  }),
+  threads: z.array(
+    z.object({
+      id: z.string(),
+      subject: z.string(),
+      lastMessageAt: z.string().nullable(),
+      messageCount: z.number(),
+      lastMessageSnippet: z.string().nullable(),
+      role: z.enum(['primary', 'secondary']),
+    })
+  ),
+  recentComments: z.array(
+    z.object({
+      id: z.string(),
+      content: z.string(),
+      by: z.string().nullable(),
+      byUserId: z.string().nullable(),
+      at: z.string(),
+      parentId: z.string().nullable(),
+    })
+  ),
+  recentTimelineEvents: z.array(
+    z.object({
+      type: z.string(),
+      at: z.string(),
+      by: z.string().nullable(),
+      byUserId: z.string().nullable(),
+      payloadSummary: z.string(),
+    })
+  ),
+  openTasks: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      deadline: z.string().nullable(),
+      assignees: z.array(z.string()),
+    })
+  ),
+  recentFieldChanges: z.array(
+    z.object({
+      fieldSystemAttribute: z.string(),
+      oldDisplay: z.string().nullable(),
+      newDisplay: z.string().nullable(),
+      at: z.string(),
+      by: z.string().nullable(),
+      byUserId: z.string().nullable(),
+    })
+  ),
+  relatedEntities: z.array(
+    z.object({
+      id: z.string(),
+      entityDefinitionId: z.string(),
+      primaryDisplay: z.string().nullable(),
+      relationship: z.literal('shares-thread'),
+    })
+  ),
+  meetings: z.array(
+    z.object({
+      id: z.string(),
+      callRecordingId: z.string(),
+      title: z.string().nullable(),
+      at: z.string().nullable(),
+      durationMin: z.number().nullable(),
+      participantNames: z.array(z.string()),
+      transcriptAvailable: z.boolean(),
+      transcriptId: z.string().nullable(),
+    })
+  ),
+  truncated: z.boolean(),
+})
 
 const FIELD_UPDATE_EVENT_TYPES = [
   'contact:field:updated',
@@ -84,7 +164,7 @@ export function createGetEntityHistoryTool(getDeps: GetToolDeps): AgentToolDefin
     displayName: 'Get record history',
     toolsetSlug: 'auxx:entities:search',
     idempotent: true,
-    outputDigestSchema: GetEntityHistoryDigest,
+    outputSchema: GetEntityHistoryOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         entity?: { id?: string }

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-entity.ts
@@ -3,16 +3,27 @@
 import { schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
 import { RecordPickerService } from '../../../../../resources/picker'
 import { parseRecordId } from '../../../../../resources/resource-id'
 import { getKnownDefIds, normalizeRecordIdArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { GetEntityDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 import { enrichEntitiesWithFieldValues } from '../enrich-entity-fields'
-import { formatEnrichedFields } from '../format-enriched-fields'
+import { FormattedFieldSchema, formatEnrichedFields } from '../format-enriched-fields'
 
 const logger = createScopedLogger('kopilot-get-entity')
+
+/** Full success output of `get_entity` — one enriched record. */
+const GetEntityOutput = z.object({
+  recordId: z.string(),
+  displayName: z.string(),
+  secondaryInfo: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+  fields: z.record(z.string(), FormattedFieldSchema),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
 
 export function createGetEntityTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -20,7 +31,7 @@ export function createGetEntityTool(getDeps: GetToolDeps): AgentToolDefinition {
     displayName: 'Get record',
     toolsetSlug: 'auxx:entities:search',
     idempotent: true,
-    outputDigestSchema: GetEntityDigest,
+    outputSchema: GetEntityOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         recordId?: string

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-transcript.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/get-transcript.ts
@@ -2,13 +2,36 @@
 
 import { schema } from '@auxx/database'
 import { and, asc, eq } from 'drizzle-orm'
+import { z } from 'zod'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { GetTranscriptDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 
 const DEFAULT_MAX_TOKENS = 4000
 /** Rough char→token ratio for safe truncation. */
 const CHARS_PER_TOKEN = 4
+
+/**
+ * Full success output of `get_transcript`. Two shapes by granularity:
+ * `full_text` returns `fullText` + `totalWords`; `utterances` returns the
+ * `utterances` array. `fullText`/`totalWords` and `utterances` are mutually
+ * exclusive per call.
+ */
+const GetTranscriptOutput = z.object({
+  transcriptId: z.string(),
+  truncated: z.boolean(),
+  fullText: z.string().optional(),
+  totalWords: z.number().optional(),
+  utterances: z
+    .array(
+      z.object({
+        speakerName: z.string().nullable(),
+        text: z.string(),
+        startMs: z.number(),
+        endMs: z.number(),
+      })
+    )
+    .optional(),
+})
 
 export function createGetTranscriptTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -16,7 +39,7 @@ export function createGetTranscriptTool(getDeps: GetToolDeps): AgentToolDefiniti
     displayName: 'Get transcript',
     toolsetSlug: 'auxx:entities:search',
     idempotent: true,
-    outputDigestSchema: GetTranscriptDigest,
+    outputSchema: GetTranscriptOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { transcriptId?: string }
       return {

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entities.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entities.ts
@@ -1,9 +1,25 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entities.ts
 
+import { z } from 'zod'
 import { getCachedResources } from '../../../../../cache/org-cache-helpers'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { ListEntitiesDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `list_entities` — discovered entity TYPES (not records). */
+const ListEntitiesOutput = z.object({
+  entities: z.array(
+    z.object({
+      id: z.string(),
+      apiSlug: z.string(),
+      label: z.string(),
+      plural: z.string(),
+      entityType: z.string().nullable(),
+      icon: z.string(),
+      color: z.string(),
+    })
+  ),
+  count: z.number(),
+})
 
 export function createListEntitiesTool(_getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -14,7 +30,7 @@ export function createListEntitiesTool(_getDeps: GetToolDeps): AgentToolDefiniti
     // Schema only — entity TYPES, no record data — so safe for an external
     // caller. See plans/chat/v6/chat-tool-availability.md.
     externalSafe: true,
-    outputDigestSchema: ListEntitiesDigest,
+    outputSchema: ListEntitiesOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { entities?: Array<{ apiSlug?: string; label?: string }> }
       return {

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
@@ -1,10 +1,37 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
 
+import { z } from 'zod'
 import { findCachedResource, getCachedResources } from '../../../../../cache/org-cache-helpers'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { ListEntityFieldsDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 import { buildListEntityFieldsOutput } from './list-entity-fields-output'
+
+/** Full success output of `list_entity_fields` — field definitions + create-time summaries. */
+const ListEntityFieldsOutput = z.object({
+  entityDefinitionId: z.string(),
+  requiredOnCreate: z.array(z.string()),
+  autoFilled: z.array(z.string()),
+  fields: z.array(
+    z.object({
+      id: z.string(),
+      label: z.string(),
+      fieldType: z.string().optional(),
+      required: z.literal(true).optional(),
+      unique: z.literal(true).optional(),
+      readOnly: z.literal(true).optional(),
+      createOnly: z.literal(true).optional(),
+      options: z.array(z.object({ value: z.string(), label: z.string() })).optional(),
+      moreOptions: z.literal(true).optional(),
+      totalOptions: z.number().optional(),
+      relationship: z
+        .object({
+          targetEntityDefinitionId: z.string().nullable(),
+          relationshipType: z.string(),
+        })
+        .optional(),
+    })
+  ),
+})
 
 export function createListEntityFieldsTool(_getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -15,7 +42,7 @@ export function createListEntityFieldsTool(_getDeps: GetToolDeps): AgentToolDefi
     // Schema only — field definitions, no record data — so safe for an external
     // caller. See plans/chat/v6/chat-tool-availability.md.
     externalSafe: true,
-    outputDigestSchema: ListEntityFieldsDigest,
+    outputSchema: ListEntityFieldsOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { entityDefinitionId?: string; fields?: unknown[] }
       return {

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-field-changes.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-field-changes.ts
@@ -2,6 +2,7 @@
 
 import { schema } from '@auxx/database'
 import { and, desc, eq, gte, inArray } from 'drizzle-orm'
+import { z } from 'zod'
 import { getCachedMembersByUserIds } from '../../../../../cache/org-cache-helpers'
 import type {
   TimelineFieldChangeSnapshot,
@@ -9,10 +10,27 @@ import type {
 } from '../../../../../timeline/field-change-snapshot'
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { ListFieldChangesDigest, takeSample } from '../../../digests'
+import { takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 
 const MAX_LIMIT = 50
+
+/** Full success output of `list_field_changes` — recent custom-field changes from timeline. */
+const ListFieldChangesOutput = z.object({
+  changes: z.array(
+    z.object({
+      fieldSystemAttribute: z.string(),
+      oldDisplay: z.string().nullable(),
+      newDisplay: z.string().nullable(),
+      at: z.string(),
+      by: z.object({
+        actorType: z.string().nullable(),
+        userId: z.string().nullable(),
+        name: z.string().nullable(),
+      }),
+    })
+  ),
+})
 
 /** Field-update event types across system + custom entities. */
 const FIELD_UPDATE_EVENT_TYPES = [
@@ -75,7 +93,7 @@ export function createListFieldChangesTool(getDeps: GetToolDeps): AgentToolDefin
     name: 'list_field_changes',
     displayName: 'List field changes',
     toolsetSlug: 'auxx:entities:search',
-    outputDigestSchema: ListFieldChangesDigest,
+    outputSchema: ListFieldChangesOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         changes?: Array<{

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-notes.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-notes.ts
@@ -1,16 +1,43 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/list-notes.ts
 
+import { z } from 'zod'
 import { getCachedMembersByUserIds } from '../../../../../cache/org-cache-helpers'
 import { CommentService } from '../../../../../comments'
 import type { RecordId } from '../../../../../resources/resource-id'
 import { docToText } from '../../../../../tiptap'
 import { getKnownDefIds, normalizeRecordIdArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { ListNotesDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 
 const MAX_LIMIT = 50
 const MAX_CONTENT_LENGTH = 600
+
+/** Recursive note shape — top-level notes carry nested `replies` or a `replyCount`. */
+const NoteDigestSchema: z.ZodType<{
+  id: string
+  content: string
+  by: { userId: string; name: string | null }
+  at: string
+  parentId: string | null
+  isPinned: boolean
+  replyCount?: number
+  replies?: unknown[]
+}> = z.object({
+  id: z.string(),
+  content: z.string(),
+  by: z.object({ userId: z.string(), name: z.string().nullable() }),
+  at: z.string(),
+  parentId: z.string().nullable(),
+  isPinned: z.boolean(),
+  replyCount: z.number().optional(),
+  replies: z.array(z.lazy(() => NoteDigestSchema)).optional(),
+})
+
+/** Full success output of `list_notes` — top-level notes (most-recent first) + pagination flag. */
+const ListNotesOutput = z.object({
+  notes: z.array(NoteDigestSchema),
+  hasMore: z.boolean(),
+})
 
 interface NoteDigest {
   id: string
@@ -34,7 +61,7 @@ export function createListNotesTool(getDeps: GetToolDeps): AgentToolDefinition {
     displayName: 'List notes',
     toolsetSlug: 'auxx:comments:read',
     idempotent: true,
-    outputDigestSchema: ListNotesDigest,
+    outputSchema: ListNotesOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { notes?: unknown[] }
       return { count: Array.isArray(out.notes) ? out.notes.length : 0 }

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-transcripts-for-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-transcripts-for-entity.ts
@@ -2,12 +2,32 @@
 
 import { schema } from '@auxx/database'
 import { and, desc, eq, gte, inArray, isNotNull, or } from 'drizzle-orm'
+import { z } from 'zod'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { ListTranscriptsForEntityDigest, takeSample } from '../../../digests'
+import { takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 
 const MAX_LIMIT = 25
 const SNIPPET_LENGTH = 100
+
+/** Full success output of `list_transcripts_for_entity` — transcript metadata (no text). */
+const ListTranscriptsForEntityOutput = z.object({
+  transcripts: z.array(
+    z.object({
+      transcriptId: z.string(),
+      callRecordingId: z.string(),
+      meetingId: z.string(),
+      meetingTitle: z.string().nullable(),
+      at: z.string().nullable(),
+      durationMin: z.number().nullable(),
+      participantNames: z.array(z.string()),
+      speakerCount: z.number(),
+      wordCount: z.number(),
+      status: z.string(),
+      snippet: z.string(),
+    })
+  ),
+})
 
 export function createListTranscriptsForEntityTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -15,7 +35,7 @@ export function createListTranscriptsForEntityTool(getDeps: GetToolDeps): AgentT
     displayName: 'List transcripts',
     toolsetSlug: 'auxx:entities:search',
     idempotent: true,
-    outputDigestSchema: ListTranscriptsForEntityDigest,
+    outputSchema: ListTranscriptsForEntityOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { transcripts?: Array<{ transcriptId?: string }> }
       const transcripts = Array.isArray(out.transcripts) ? out.transcripts : []

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/query-records.ts
@@ -2,6 +2,7 @@
 
 import type { ResourceFieldId } from '@auxx/types/field'
 import { toResourceFieldId } from '@auxx/types/field'
+import { z } from 'zod'
 import { findCachedResource, getCachedResources } from '../../../../../cache/org-cache-helpers'
 import type { Condition, ConditionGroup } from '../../../../../conditions'
 import {
@@ -20,7 +21,7 @@ import { getFieldOptions } from '../../../../../resources/registry/option-helper
 import type { Resource } from '../../../../../resources/registry/types'
 import { toRecordId } from '../../../../../resources/resource-id'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { QueryRecordsDigest, takeSample } from '../../../digests'
+import { takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 
 interface SimplifiedFilter {
@@ -28,6 +29,46 @@ interface SimplifiedFilter {
   operator: string
   value?: unknown
 }
+
+/** Dropped-filter warning surfaced to the LLM (mirrors `QueryWarning`). */
+const QueryWarningSchema = z.object({
+  kind: z.string(),
+  field: z.string().optional(),
+  operator: z.string().optional(),
+  fieldType: z.string().optional(),
+  value: z.unknown().optional(),
+  validValues: z.array(z.string()).optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  hint: z.string(),
+})
+
+/**
+ * Full success output of `query_records`. Two shapes:
+ * countOnly mode returns `{ entityType, total_matching, warnings? }`;
+ * full mode adds `items`, `returned_count`, and `hasMore`. Each item carries
+ * `recordId`/`displayName` plus dynamic label-keyed field values from the
+ * matched record (and an unknown-record fallback that only has recordId +
+ * displayName).
+ */
+const QueryRecordsOutput = z.object({
+  entityType: z.string(),
+  total_matching: z.number(),
+  returned_count: z.number().optional(),
+  hasMore: z.boolean().optional(),
+  warnings: z.array(QueryWarningSchema).optional(),
+  items: z
+    .array(
+      z
+        .object({
+          recordId: z.string(),
+          displayName: z.string(),
+          secondaryInfo: z.string().nullable().optional(),
+        })
+        .catchall(z.unknown())
+    )
+    .optional(),
+})
 
 type QueryWarning =
   | { kind: 'unknown_field'; field: string; hint: string }
@@ -56,7 +97,7 @@ export function createQueryRecordsTool(getDeps: GetToolDeps): AgentToolDefinitio
     displayName: 'Filter records',
     toolsetSlug: 'auxx:entities:search',
     idempotent: true,
-    outputDigestSchema: QueryRecordsDigest,
+    outputSchema: QueryRecordsOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         items?: Array<Record<string, unknown>>

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
@@ -1,17 +1,40 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
 
 import type { RecordId } from '@auxx/types/resource'
+import { z } from 'zod'
 import { findCachedResource, getCachedResources } from '../../../../../cache/org-cache-helpers'
 import { RecordPickerService } from '../../../../../resources/picker'
 import { parseRecordId } from '../../../../../resources/resource-id'
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { SearchEntitiesDigest, takeSample } from '../../../digests'
+import { takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 import { enrichEntitiesWithFieldValues } from '../enrich-entity-fields'
-import { formatEnrichedFields } from '../format-enriched-fields'
+import { FormattedFieldSchema, formatEnrichedFields } from '../format-enriched-fields'
 
 const MAX_RESULTS = 25
+
+/**
+ * Full success output of `search_entities`. Each item always has
+ * recordId/displayName/entityType/secondaryInfo; when the result set is small
+ * (≤5) items are auto-enriched with `fields` plus `createdAt`/`updatedAt`.
+ * Empty results additionally carry a `suggestion` string.
+ */
+const SearchEntitiesOutput = z.object({
+  items: z.array(
+    z.object({
+      recordId: z.string(),
+      displayName: z.string(),
+      entityType: z.string().nullable(),
+      secondaryInfo: z.string().nullable(),
+      fields: z.record(z.string(), FormattedFieldSchema).optional(),
+      createdAt: z.date().optional(),
+      updatedAt: z.date().optional(),
+    })
+  ),
+  count: z.number(),
+  suggestion: z.string().optional(),
+})
 
 export function createSearchEntitiesTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -19,7 +42,7 @@ export function createSearchEntitiesTool(getDeps: GetToolDeps): AgentToolDefinit
     displayName: 'Search records',
     toolsetSlug: 'auxx:entities:search',
     idempotent: true,
-    outputDigestSchema: SearchEntitiesDigest,
+    outputSchema: SearchEntitiesOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         items?: Array<Record<string, unknown>>

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/update-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/update-entity.ts
@@ -1,12 +1,19 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/update-entity.ts
 
+import { z } from 'zod'
 import { findCachedResource } from '../../../../../cache/org-cache-helpers'
 import { UnifiedCrudHandler } from '../../../../../resources/crud'
 import { getDefinitionId } from '../../../../../resources/resource-id'
 import { getKnownDefIds, normalizeRecordIdArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { UpdateEntityDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `update_entity` — the updated record and human-readable field labels. */
+const UpdateEntityOutput = z.object({
+  recordId: z.string(),
+  updatedFields: z.array(z.string()),
+})
+
 import {
   formatUnknownFieldsError,
   resolveFieldLabels,
@@ -19,7 +26,7 @@ export function createUpdateEntityTool(getDeps: GetToolDeps): AgentToolDefinitio
     name: 'update_entity',
     displayName: 'Update record',
     toolsetSlug: 'auxx:entities:write',
-    outputDigestSchema: UpdateEntityDigest,
+    outputSchema: UpdateEntityOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { recordId?: string; updatedFields?: string[] }
       return {

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-docs.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-docs.ts
@@ -1,10 +1,33 @@
 // packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-docs.ts
 
 import { DOCS_URL } from '@auxx/config/urls'
+import { z } from 'zod'
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { ArticleSearchDigest, takeSample } from '../../../digests'
+import { takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/**
+ * Full success output of `search_docs`. NOTE the two-shape `articles`: the
+ * empty-result branch returns `articles: []` (array), while the populated
+ * branch returns the articles joined into a single delimited string.
+ */
+const SearchDocsOutput = z.object({
+  count: z.number(),
+  articles: z.union([z.string(), z.array(z.unknown())]),
+  message: z.string().optional(),
+  query: z.string().optional(),
+  docs: z
+    .array(
+      z.object({
+        slug: z.string(),
+        title: z.string(),
+        url: z.string(),
+        description: z.string().optional(),
+      })
+    )
+    .optional(),
+})
 
 interface SortedResult {
   id: string
@@ -28,7 +51,7 @@ export function createSearchDocsTool(_getDeps: GetToolDeps): AgentToolDefinition
     displayName: 'Search docs',
     toolsetSlug: 'auxx:docs',
     idempotent: true,
-    outputDigestSchema: ArticleSearchDigest,
+    outputSchema: SearchDocsOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { articles?: string; count?: number }
       const titles =

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
@@ -2,11 +2,51 @@
 
 import { schema } from '@auxx/database'
 import { and, eq, inArray, isNotNull } from 'drizzle-orm'
+import { z } from 'zod'
 import { SearchService } from '../../../../../datasets/services/search.service'
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { ArticleSearchDigest, takeSample } from '../../../digests'
+import { takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/**
+ * Full success output of `search_knowledge`. Empty-result branches return just
+ * `{ results: [], count: 0, message }`; the populated branch adds `total` and
+ * `docs`, and either branch may carry `warnings` when one search lane failed.
+ */
+const SearchKnowledgeOutput = z.object({
+  results: z.array(
+    z.object({
+      id: z.string(),
+      source: z.enum(['kb', 'rag']),
+      content: z.string(),
+      score: z.number(),
+      documentTitle: z.string(),
+      datasetName: z.string(),
+      datasetId: z.string(),
+      articleId: z.string().optional(),
+      articleSlug: z.string().optional(),
+      articleSlugPath: z.string().optional(),
+      kbId: z.string().optional(),
+      kbSlug: z.string().optional(),
+      docSlug: z.string().optional(),
+      searchType: z.string(),
+    })
+  ),
+  count: z.number(),
+  total: z.number().optional(),
+  message: z.string().optional(),
+  docs: z
+    .array(
+      z.object({
+        slug: z.string(),
+        title: z.string(),
+        description: z.string(),
+      })
+    )
+    .optional(),
+  warnings: z.array(z.string()).optional(),
+})
 
 const MAX_RESULTS = 10
 const DEFAULT_RESULTS = 5
@@ -31,7 +71,7 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
     // surfaces (default); `externalSafe` drops the chat/email warning. See
     // plans/chat/v6/chat-tool-availability.md.
     externalSafe: true,
-    outputDigestSchema: ArticleSearchDigest,
+    outputSchema: SearchKnowledgeOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         results?: Array<Record<string, unknown>>

--- a/packages/lib/src/ai/kopilot/capabilities/kopilot/tools/plan-create.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kopilot/tools/plan-create.ts
@@ -1,8 +1,25 @@
 // packages/lib/src/ai/kopilot/capabilities/kopilot/tools/plan-create.ts
 
 import { generateId } from '@auxx/utils/generateId'
+import { z } from 'zod'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
+
+/** Success output of `plan_create` — the canonical plan with timestamped steps. */
+const PlanCreateOutput = z.object({
+  plan: z.object({
+    steps: z.array(
+      z.object({
+        id: z.string(),
+        label: z.string(),
+        status: z.literal('pending'),
+        detail: z.string().optional(),
+      })
+    ),
+    createdAt: z.number(),
+    updatedAt: z.number(),
+  }),
+})
 
 /** Hard upper bound on plan size — beyond this, the agent should split tasks. */
 const MAX_STEPS = 30
@@ -20,6 +37,7 @@ export function createPlanCreateTool(_getDeps: GetToolDeps): AgentToolDefinition
   return {
     name: 'plan_create',
     displayName: 'Create plan',
+    outputSchema: PlanCreateOutput,
     description:
       "Create or replace the active plan for this session. Call when the user asks for a multi-step task (review N tickets, process a list, multi-stage research). Each step is a short imperative title; statuses start as 'pending'. Returns the canonical plan you should mirror in the auxx:plan-steps fence.",
     usageNotes:

--- a/packages/lib/src/ai/kopilot/capabilities/kopilot/tools/plan-update-step.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kopilot/tools/plan-update-step.ts
@@ -1,8 +1,22 @@
 // packages/lib/src/ai/kopilot/capabilities/kopilot/tools/plan-update-step.ts
 
+import { z } from 'zod'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { PlanStepStatus } from '../../../types'
 import type { GetToolDeps } from '../../types'
+
+/**
+ * Raw success output of `plan_update_step` — the `_planPatch` sentinel the
+ * kopilot domain's `transformToolResult` hook expands into `{ plan }` before
+ * the LLM sees it. This schema describes what the tool itself emits.
+ */
+const PlanUpdateStepOutput = z.object({
+  _planPatch: z.object({
+    stepId: z.string(),
+    status: z.enum(['pending', 'running', 'completed', 'failed']),
+    detail: z.string().optional(),
+  }),
+})
 
 /** Statuses accepted by `plan_update_step` — must match `PlanStepStatus`. */
 const VALID_STATUSES: PlanStepStatus[] = ['pending', 'running', 'completed', 'failed']
@@ -20,6 +34,7 @@ export function createPlanUpdateStepTool(_getDeps: GetToolDeps): AgentToolDefini
   return {
     name: 'plan_update_step',
     displayName: 'Update plan step',
+    outputSchema: PlanUpdateStepOutput,
     description:
       'Update the status (and optional one-line detail) of a single plan step. Use to mark a step running before you start it, completed when done, or failed if it hit a blocker. Returns the full updated plan.',
     parameters: {

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/find-threads.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/find-threads.ts
@@ -2,14 +2,40 @@
 
 import { parseRecordId } from '@auxx/types/resource'
 import { generateId } from '@auxx/utils'
+import { z } from 'zod'
 import type { Condition, ConditionGroup } from '../../../../../conditions'
 import { TagService } from '../../../../../tags'
 import { ThreadQueryService } from '../../../../../threads'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { FindThreadsDigest, takeSample } from '../../../digests'
+import { takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 
 const MAX_RESULTS = 25
+
+/** Full success output of `find_threads` — matching thread summaries with resolved tags. */
+const FindThreadsOutput = z.object({
+  threads: z.array(
+    z.object({
+      id: z.string(),
+      subject: z.string(),
+      status: z.string(),
+      assigneeId: z.string().nullable(),
+      lastMessageAt: z.string(),
+      messageCount: z.number(),
+      isUnread: z.boolean(),
+      tagIds: z.array(z.string()),
+      tags: z.array(
+        z.object({
+          id: z.string(),
+          name: z.string(),
+          color: z.string(),
+          emoji: z.string().nullable(),
+        })
+      ),
+    })
+  ),
+  count: z.number(),
+})
 
 /**
  * Build ConditionGroups from flat search args.
@@ -88,7 +114,7 @@ export function createFindThreadsTool(getDeps: GetToolDeps): AgentToolDefinition
     displayName: 'Find threads',
     toolsetSlug: 'auxx:mail:threads',
     idempotent: true,
-    outputDigestSchema: FindThreadsDigest,
+    outputSchema: FindThreadsOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { threads?: Array<Record<string, unknown>>; count?: number }
       const threads = Array.isArray(out.threads) ? out.threads : []

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/get-thread-detail.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/get-thread-detail.ts
@@ -1,13 +1,49 @@
 // packages/lib/src/ai/kopilot/capabilities/mail/tools/get-thread-detail.ts
 
 import { parseRecordId } from '@auxx/types/resource'
+import { z } from 'zod'
 import { MessageQueryService } from '../../../../../messages'
 import { TagService } from '../../../../../tags'
 import { ThreadQueryService } from '../../../../../threads'
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { GetThreadDetailDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `get_thread_detail` — thread metadata plus recent messages. */
+const GetThreadDetailOutput = z.object({
+  thread: z.object({
+    id: z.string(),
+    subject: z.string(),
+    status: z.string(),
+    assigneeId: z.string().nullable(),
+    lastMessageAt: z.string(),
+    messageCount: z.number(),
+    isUnread: z.boolean(),
+    tagIds: z.array(z.string()),
+    tags: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        color: z.string(),
+        emoji: z.string().nullable(),
+      })
+    ),
+    integrationId: z.string(),
+  }),
+  messages: z.array(
+    z.object({
+      id: z.string(),
+      subject: z.string().nullable(),
+      snippet: z.string().nullable(),
+      textPlain: z.string(),
+      isInbound: z.boolean(),
+      hasAttachments: z.boolean(),
+      sentAt: z.string().nullable(),
+      participants: z.array(z.string()),
+    })
+  ),
+  totalMessages: z.number(),
+})
 
 const MAX_MESSAGES = 20
 const MAX_BODY_LENGTH = 500
@@ -23,7 +59,7 @@ export function createGetThreadDetailTool(getDeps: GetToolDeps): AgentToolDefini
     displayName: 'Read thread',
     toolsetSlug: 'auxx:mail:threads',
     idempotent: true,
-    outputDigestSchema: GetThreadDetailDigest,
+    outputSchema: GetThreadDetailOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         thread?: { id?: string; subject?: string | null; lastMessageAt?: string | null }

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/list-drafts.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/list-drafts.ts
@@ -1,14 +1,21 @@
 // packages/lib/src/ai/kopilot/capabilities/mail/tools/list-drafts.ts
 
 import { generateId } from '@auxx/utils'
+import { z } from 'zod'
 import type { Condition, ConditionGroup } from '../../../../../conditions'
 import { DraftService } from '../../../../../drafts'
 import { ThreadQueryService } from '../../../../../threads'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { type DraftDigestSnapshot, ListDraftsDigest, takeSample } from '../../../digests'
+import { DraftDigestSnapshot, takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 
 const MAX_RESULTS = 25
+
+/** Full success output of `list_drafts` — the user's unsent drafts (reply + standalone). */
+const ListDraftsOutput = z.object({
+  drafts: z.array(DraftDigestSnapshot),
+  count: z.number(),
+})
 
 /**
  * Build ConditionGroups for the DRAFTS context. Always anchored on
@@ -58,7 +65,7 @@ export function createListDraftsTool(getDeps: GetToolDeps): AgentToolDefinition 
     displayName: 'List drafts',
     toolsetSlug: 'auxx:mail:drafts',
     idempotent: true,
-    outputDigestSchema: ListDraftsDigest,
+    outputSchema: ListDraftsOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { drafts?: DraftDigestSnapshot[]; count?: number }
       const drafts = Array.isArray(out.drafts) ? out.drafts : []

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/list-tags.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/list-tags.ts
@@ -1,9 +1,25 @@
 // packages/lib/src/ai/kopilot/capabilities/mail/tools/list-tags.ts
 
+import { z } from 'zod'
 import { TagService } from '../../../../../tags'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { ListTagsDigest, takeSample } from '../../../digests'
+import { takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `list_tags` — the workspace's tags with hierarchy. */
+const ListTagsOutput = z.object({
+  tags: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      color: z.string(),
+      emoji: z.string().nullable(),
+      isSystemTag: z.boolean(),
+      parentId: z.string().nullable(),
+    })
+  ),
+  count: z.number(),
+})
 
 const DEFAULT_LIMIT = 50
 const MAX_LIMIT = 200
@@ -14,7 +30,7 @@ export function createListTagsTool(getDeps: GetToolDeps): AgentToolDefinition {
     displayName: 'List tags',
     toolsetSlug: 'auxx:mail:threads',
     idempotent: true,
-    outputDigestSchema: ListTagsDigest,
+    outputSchema: ListTagsOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         tags?: Array<{ name?: string | null }>

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/reply-to-thread.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/reply-to-thread.ts
@@ -7,7 +7,6 @@ import { MessageQueryService, MessageSenderService } from '../../../../../messag
 import { ParticipantService } from '../../../../../participants'
 import { ThreadQueryService } from '../../../../../threads'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { EmailWriteDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 import { type ResolvedRecipient, resolveRecipients } from '../recipient-resolver'
 import { stripSignOff } from './strip-sign-off'
@@ -22,6 +21,31 @@ interface ReplyArgs {
   bcc?: string[]
   attachments?: string[]
 }
+
+/**
+ * Full success output of `reply_to_thread`. Two shapes share one object: the
+ * draft branch sets `draftId` + `status: 'draft_saved'`; the send branch sets
+ * `messageId` + the provider `sendStatus`.
+ */
+const ReplyToThreadOutput = z.object({
+  draftId: z.string().optional(),
+  messageId: z.string().optional(),
+  threadId: z.string(),
+  subject: z.string().optional(),
+  body: z.string(),
+  mode: z.enum(['draft', 'send']),
+  resolvedRecipients: z.array(
+    z.object({
+      recordId: z.string().optional(),
+      participantId: z.string().optional(),
+      identifier: z.string(),
+      identifierType: z.string(),
+      role: z.enum(['to', 'cc', 'bcc']),
+      displayName: z.string().optional(),
+    })
+  ),
+  status: z.string(),
+})
 
 const ReplyAmendmentSchema = z.object({
   mode: z.enum(['draft', 'send']),
@@ -38,7 +62,7 @@ export function createReplyToThreadTool(getDeps: GetToolDeps): AgentToolDefiniti
     toolsetSlug: 'auxx:mail:compose',
     requiresApproval: true,
     inputAmendmentSchema: ReplyAmendmentSchema,
-    outputDigestSchema: EmailWriteDigest,
+    outputSchema: ReplyToThreadOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         threadId?: string

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/start-new-conversation.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/start-new-conversation.ts
@@ -5,7 +5,6 @@ import { getCachedIntegrationCatalog } from '../../../../../cache/integration-ca
 import { DraftService } from '../../../../../drafts'
 import { MessageSenderService } from '../../../../../messages'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { EmailWriteDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
 import { resolveRecipients } from '../recipient-resolver'
 import { stripSignOff } from './strip-sign-off'
@@ -21,6 +20,31 @@ interface StartArgs {
   mode?: 'draft' | 'send'
   attachments?: string[]
 }
+
+/**
+ * Full success output of `start_new_conversation`. Two shapes share one object:
+ * the draft branch sets `draftId` + `status: 'draft_saved'`; the send branch
+ * sets `messageId` + `threadId` + the provider `sendStatus`.
+ */
+const StartNewConversationOutput = z.object({
+  draftId: z.string().optional(),
+  messageId: z.string().optional(),
+  threadId: z.string().optional(),
+  subject: z.string().optional(),
+  body: z.string(),
+  mode: z.enum(['draft', 'send']),
+  resolvedRecipients: z.array(
+    z.object({
+      recordId: z.string().optional(),
+      participantId: z.string().optional(),
+      identifier: z.string(),
+      identifierType: z.string(),
+      role: z.enum(['to', 'cc', 'bcc']),
+      displayName: z.string().optional(),
+    })
+  ),
+  status: z.string(),
+})
 
 const StartAmendmentSchema = z.object({
   mode: z.enum(['draft', 'send']),
@@ -38,7 +62,7 @@ export function createStartNewConversationTool(getDeps: GetToolDeps): AgentToolD
     toolsetSlug: 'auxx:mail:compose',
     requiresApproval: true,
     inputAmendmentSchema: StartAmendmentSchema,
-    outputDigestSchema: EmailWriteDigest,
+    outputSchema: StartNewConversationOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         threadId?: string

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/update-thread.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/update-thread.ts
@@ -1,19 +1,31 @@
 // packages/lib/src/ai/kopilot/capabilities/mail/tools/update-thread.ts
 
 import { toRecordId } from '@auxx/types/resource'
+import { z } from 'zod'
 import { requireCachedEntityDefId } from '../../../../../cache'
 import { ThreadMutationService } from '../../../../../threads'
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { UpdateThreadDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `update_thread` — the applied status/assignee/tag changes. */
+const UpdateThreadOutput = z.object({
+  threadId: z.string(),
+  updated: z.boolean(),
+  changes: z.object({
+    status: z.string().optional(),
+    assigneeId: z.string().optional(),
+    addedTags: z.array(z.string()).optional(),
+    removedTags: z.array(z.string()).optional(),
+  }),
+})
 
 export function createUpdateThreadTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'update_thread',
     displayName: 'Update thread',
     toolsetSlug: 'auxx:mail:threads',
-    outputDigestSchema: UpdateThreadDigest,
+    outputSchema: UpdateThreadOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as { threadId?: string; changes?: Record<string, unknown> }
       const changes: string[] = []

--- a/packages/lib/src/ai/kopilot/capabilities/tasks/tools/create-task.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/tasks/tools/create-task.ts
@@ -2,6 +2,7 @@
 
 import { toActorId } from '@auxx/types/actor'
 import type { AbsoluteDate, RelativeDate } from '@auxx/types/task'
+import { z } from 'zod'
 import { createTaskService } from '../../../../../tasks/task-service'
 import {
   getKnownDefIds,
@@ -11,8 +12,16 @@ import {
   parseStringArg,
 } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { CreateTaskDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `create_task` — the created task summary. */
+const CreateTaskOutput = z.object({
+  taskId: z.string(),
+  title: z.string(),
+  deadline: z.string().nullable(),
+  priority: z.enum(['low', 'medium', 'high']).nullable(),
+  assignees: z.array(z.string()),
+})
 
 export function createCreateTaskTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -22,7 +31,7 @@ export function createCreateTaskTool(getDeps: GetToolDeps): AgentToolDefinition 
     description:
       'Create a new task. Resolving names: try list_members first for the assignee — assignees are workspace members (teammates), not contacts. If the name does not match any member, fall back to search_entities — the person is likely a contact (or the subject is a company/record). Pass the matched recordId to linkedRecordIds and leave assigneeIds empty so the task is assigned to the caller. Use search_entities for any other referenced records (products, orders, etc.). Supports natural language deadlines like "next Friday", "in 3 days", "end of week".',
     requiresApproval: true,
-    outputDigestSchema: CreateTaskDigest,
+    outputSchema: CreateTaskOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         taskId?: string

--- a/packages/lib/src/ai/kopilot/capabilities/tasks/tools/list-tasks.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/tasks/tools/list-tasks.ts
@@ -1,9 +1,27 @@
 // packages/lib/src/ai/kopilot/capabilities/tasks/tools/list-tasks.ts
 
+import { z } from 'zod'
 import { createTaskService } from '../../../../../tasks/task-service'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
-import { ListTasksDigest, takeSample } from '../../../digests'
+import { takeSample } from '../../../digests'
 import type { GetToolDeps } from '../../types'
+
+/** Full success output of `list_tasks` — matched tasks with a count. */
+const ListTasksOutput = z.object({
+  tasks: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      deadline: z.string().nullable(),
+      priority: z.string().nullable(),
+      completedAt: z.string().nullable(),
+      assignees: z.array(z.string()),
+      referenceCount: z.number(),
+    })
+  ),
+  count: z.number(),
+  hasMore: z.boolean(),
+})
 
 export function createListTasksTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -11,7 +29,7 @@ export function createListTasksTool(getDeps: GetToolDeps): AgentToolDefinition {
     displayName: 'List tasks',
     toolsetSlug: 'auxx:tasks:read',
     idempotent: true,
-    outputDigestSchema: ListTasksDigest,
+    outputSchema: ListTasksOutput,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         tasks?: Array<{

--- a/packages/lib/src/ai/kopilot/capabilities/workflow/assign-variable.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow/assign-variable.ts
@@ -1,8 +1,15 @@
 // packages/lib/src/ai/kopilot/capabilities/workflow/assign-variable.ts
 
+import { z } from 'zod'
 import type { AgentToolDefinition } from '../../../agent-framework/types'
 import type { GetToolDeps } from '../types'
 import { WORKFLOW_NATIVE_TOOLSET_SLUG } from './index'
+
+/** Success output of `assign_variable` — the assigned name and its arbitrary value. */
+const AssignVariableOutput = z.object({
+  name: z.string(),
+  value: z.unknown(),
+})
 
 /**
  * Native workflow tool — set a variable on the active workflow run's context
@@ -36,6 +43,7 @@ export function assignVariableTool(_deps: GetToolDeps): AgentToolDefinition {
       additionalProperties: false,
     },
     idempotent: false,
+    outputSchema: AssignVariableOutput,
     toolsetSlug: WORKFLOW_NATIVE_TOOLSET_SLUG,
     buildDigest: (output) => {
       const out = (output ?? {}) as { name?: string }

--- a/packages/lib/src/ai/kopilot/digests.ts
+++ b/packages/lib/src/ai/kopilot/digests.ts
@@ -3,50 +3,19 @@
 import { z } from 'zod'
 
 /**
- * Shared digest schemas for kopilot tools. A digest is the small, typed
- * projection of a tool's output that the frontend uses to render status pills
- * and approval/result cards. See the implementation plan §B for the rationale.
- *
- * Conventions:
- *  - `count` always reflects the full result count, not the sample length.
- *  - `sample` is capped at 3 items so digests stay small in storage.
- *  - Snapshot shapes (thread, entity, task) match `TurnSnapshots` so the
- *    frontend can reuse the same renderers for both.
+ * Shared helpers for kopilot tool digests. A digest is the small projection of a
+ * tool's output (built by each tool's `buildDigest`) that the frontend renders as
+ * status pills and approval/result cards. The full output shape is each tool's
+ * `outputSchema` (the single source of truth); this module holds only the bits
+ * shared across tools.
  */
 
 const DIGEST_SAMPLE_MAX = 3
 
-export const ThreadDigestSnapshot = z.object({
-  threadId: z.string(),
-  subject: z.string().nullable(),
-  sender: z.string().optional(),
-  lastMessageAt: z.string().nullable().optional(),
-  isUnread: z.boolean().optional(),
-})
-export type ThreadDigestSnapshot = z.infer<typeof ThreadDigestSnapshot>
-
-export const EntityDigestSnapshot = z.object({
-  recordId: z.string(),
-  entityDefinitionId: z.string(),
-  displayName: z.string(),
-  secondary: z.string().optional(),
-})
-export type EntityDigestSnapshot = z.infer<typeof EntityDigestSnapshot>
-
-export const TaskDigestSnapshot = z.object({
-  taskId: z.string(),
-  title: z.string(),
-  deadline: z.string().nullable().optional(),
-  completedAt: z.string().nullable().optional(),
-})
-export type TaskDigestSnapshot = z.infer<typeof TaskDigestSnapshot>
-
-export const FindThreadsDigest = z.object({
-  count: z.number(),
-  sample: z.array(ThreadDigestSnapshot).max(DIGEST_SAMPLE_MAX),
-})
-export type FindThreadsDigest = z.infer<typeof FindThreadsDigest>
-
+/**
+ * Shared draft shape — `list_drafts` uses it for both its `outputSchema` items
+ * and its digest sample.
+ */
 export const DraftDigestSnapshot = z.object({
   id: z.string(),
   kind: z.enum(['reply', 'standalone']),
@@ -59,172 +28,9 @@ export const DraftDigestSnapshot = z.object({
 })
 export type DraftDigestSnapshot = z.infer<typeof DraftDigestSnapshot>
 
-export const ListDraftsDigest = z.object({
-  count: z.number(),
-  sample: z.array(DraftDigestSnapshot).max(DIGEST_SAMPLE_MAX),
-})
-export type ListDraftsDigest = z.infer<typeof ListDraftsDigest>
-
-export const GetThreadDetailDigest = z.object({
-  threadId: z.string(),
-  subject: z.string().nullable(),
-  messageCount: z.number(),
-  lastMessageAt: z.string().nullable().optional(),
-})
-export type GetThreadDetailDigest = z.infer<typeof GetThreadDetailDigest>
-
-export const SearchEntitiesDigest = z.object({
-  count: z.number(),
-  sample: z.array(EntityDigestSnapshot).max(DIGEST_SAMPLE_MAX),
-})
-export type SearchEntitiesDigest = z.infer<typeof SearchEntitiesDigest>
-
-export const QueryRecordsDigest = SearchEntitiesDigest
-export type QueryRecordsDigest = z.infer<typeof QueryRecordsDigest>
-
-export const GetEntityDigest = z.object({
-  recordId: z.string(),
-  entityDefinitionId: z.string().optional(),
-  displayName: z.string(),
-  secondary: z.string().optional(),
-})
-export type GetEntityDigest = z.infer<typeof GetEntityDigest>
-
-export const GetEntityHistoryDigest = z.object({
-  entityId: z.string(),
-  threadCount: z.number(),
-  commentCount: z.number(),
-  taskCount: z.number(),
-})
-export type GetEntityHistoryDigest = z.infer<typeof GetEntityHistoryDigest>
-
-export const ListEntitiesDigest = z.object({
-  entityTypes: z.array(z.string()),
-})
-export type ListEntitiesDigest = z.infer<typeof ListEntitiesDigest>
-
-export const ListEntityFieldsDigest = z.object({
-  entityType: z.string(),
-  fieldCount: z.number(),
-})
-export type ListEntityFieldsDigest = z.infer<typeof ListEntityFieldsDigest>
-
-export const ListTasksDigest = z.object({
-  count: z.number(),
-  sample: z.array(TaskDigestSnapshot).max(DIGEST_SAMPLE_MAX),
-})
-export type ListTasksDigest = z.infer<typeof ListTasksDigest>
-
-export const ListMembersDigest = z.object({
-  count: z.number(),
-  names: z.array(z.string()).max(DIGEST_SAMPLE_MAX),
-})
-export type ListMembersDigest = z.infer<typeof ListMembersDigest>
-
-export const ListGroupsDigest = ListMembersDigest
-export type ListGroupsDigest = z.infer<typeof ListGroupsDigest>
-
-export const ListTagsDigest = z.object({
-  count: z.number(),
-  names: z.array(z.string()).max(DIGEST_SAMPLE_MAX),
-})
-export type ListTagsDigest = z.infer<typeof ListTagsDigest>
-
-export const ListFieldChangesDigest = z.object({
-  count: z.number(),
-  sample: z
-    .array(
-      z.object({
-        fieldKey: z.string(),
-        oldValue: z.unknown().optional(),
-        newValue: z.unknown().optional(),
-      })
-    )
-    .max(DIGEST_SAMPLE_MAX),
-})
-export type ListFieldChangesDigest = z.infer<typeof ListFieldChangesDigest>
-
-export const ArticleSearchDigest = z.object({
-  articleCount: z.number(),
-  titles: z.array(z.string()).max(DIGEST_SAMPLE_MAX),
-})
-export type ArticleSearchDigest = z.infer<typeof ArticleSearchDigest>
-
-export const GetTranscriptDigest = z.object({
-  recordingId: z.string(),
-  durationMin: z.number().optional(),
-})
-export type GetTranscriptDigest = z.infer<typeof GetTranscriptDigest>
-
-export const ListTranscriptsForEntityDigest = z.object({
-  count: z.number(),
-  ids: z.array(z.string()).max(DIGEST_SAMPLE_MAX),
-})
-export type ListTranscriptsForEntityDigest = z.infer<typeof ListTranscriptsForEntityDigest>
-
-export const EmailWriteDigest = z.object({
-  threadId: z.string().optional(),
-  draftId: z.string().optional(),
-  messageId: z.string().optional(),
-  mode: z.enum(['draft', 'send']),
-  status: z.string().optional(),
-  recipients: z.array(z.string()).optional(),
-  subject: z.string().nullable().optional(),
-  body: z.string().optional(),
-})
-export type EmailWriteDigest = z.infer<typeof EmailWriteDigest>
-
-export const UpdateThreadDigest = z.object({
-  threadId: z.string(),
-  subject: z.string().nullable().optional(),
-  changes: z.array(z.string()),
-})
-export type UpdateThreadDigest = z.infer<typeof UpdateThreadDigest>
-
-export const UpdateEntityDigest = z.object({
-  recordId: z.string(),
-  displayName: z.string().optional(),
-  updatedFields: z.array(z.string()),
-})
-export type UpdateEntityDigest = z.infer<typeof UpdateEntityDigest>
-
-export const BulkUpdateEntityDigest = z.object({
-  recordCount: z.number(),
-  updatedFields: z.array(z.string()),
-  sample: z.array(EntityDigestSnapshot).max(DIGEST_SAMPLE_MAX),
-})
-export type BulkUpdateEntityDigest = z.infer<typeof BulkUpdateEntityDigest>
-
-export const CreateEntityDigest = z.object({
-  recordId: z.string(),
-  displayName: z.string(),
-  entityDefinitionId: z.string().optional(),
-})
-export type CreateEntityDigest = z.infer<typeof CreateEntityDigest>
-
-export const CreateTaskDigest = z.object({
-  taskId: z.string(),
-  title: z.string(),
-  deadline: z.string().nullable().optional(),
-  assignees: z.array(z.string()).optional(),
-})
-export type CreateTaskDigest = z.infer<typeof CreateTaskDigest>
-
-export const CreateNoteDigest = z.object({
-  entityId: z.string().optional(),
-  noteId: z.string(),
-})
-export type CreateNoteDigest = z.infer<typeof CreateNoteDigest>
-
-export const ListNotesDigest = z.object({
-  count: z.number(),
-})
-export type ListNotesDigest = z.infer<typeof ListNotesDigest>
-
 /**
- * Helper for tools whose output is a `{ count, ... }` shape and that don't
- * benefit from per-tool snapshots — keeps the pill renderable without a
- * bespoke `buildDigest`.
+ * Cap a list to its first `n` items (default 3) for a digest sample, so digests
+ * stay small in storage. Tolerates a non-array / undefined input.
  */
 export function takeSample<T>(items: readonly T[] | undefined, n = DIGEST_SAMPLE_MAX): T[] {
   if (!items || !Array.isArray(items)) return []


### PR DESCRIPTION
## Summary

Migrates kopilot tools from the old `outputDigestSchema` to a full `outputSchema` declared inline on each tool. The full schema becomes the **single source of truth** for the tool's success output — the same value persisted on `ToolCallPart.output` and replayed to the model.

- Each kopilot tool now declares its full output shape inline (e.g. `GetEntityHistoryOutput`, `PlanCreateOutput`).
- `buildDigest` is reframed as a *projection* of `outputSchema` (the small UI render shape for status pills / approval+result cards), not a competing schema.
- `agent-framework/types.ts`: replaces `outputDigestSchema` with the declarative `outputSchema` contract (not enforced at execute time; powers addressable `tool:<name>.<path>` refs, v8 input bindings, and connector lazy-fetch).
- `digests.ts`: drops all per-tool digest schemas, keeping only shared bits (`DraftDigestSnapshot`, `takeSample`).

## Notes

Declarative, not enforced — the engine does not parse/throw against `outputSchema` at execute time; output stays `unknown` on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)