### PR TITLE
feat(agents): chat-v9 procedures phase 1 — selection

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -40,12 +40,6 @@
       "import": "./dist/agents/bindings/client.mjs",
       "default": "./src/agents/bindings/client.ts"
     },
-    "./agents/procedures": {
-      "types": "./src/agents/procedures/index.ts",
-      "source": "./src/agents/procedures/index.ts",
-      "import": "./dist/agents/procedures/index.mjs",
-      "default": "./src/agents/procedures/index.ts"
-    },
     "./agents/client": {
       "types": "./src/agents/client.ts",
       "source": "./src/agents/client.ts",

--- a/packages/lib/src/agents/procedures/__tests__/classify.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/classify.test.ts
@@ -1,0 +1,96 @@
+// packages/lib/src/agents/procedures/__tests__/classify.test.ts
+
+import type { Database } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { type ClassifierCandidate, type ClassifyDeps, classifyProcedure } from '../classify'
+
+// Mock the orchestrator: capture the request and return a controllable structured output.
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }))
+vi.mock('../../../ai/orchestrator/llm-orchestrator', () => ({
+  LLMOrchestrator: class {
+    invoke = invokeMock
+  },
+}))
+
+const deps: ClassifyDeps = {
+  db: {} as Database,
+  organizationId: 'org-1',
+  userId: 'user-1',
+  model: 'claude-haiku-4-5',
+  provider: 'anthropic',
+}
+const conversation = [{ role: 'user' as const, content: 'I want to cancel my subscription' }]
+const candidates: ClassifierCandidate[] = [
+  { id: 'p-cancel', whenToUse: 'Customer wants to cancel', triggerExamples: [] },
+  { id: 'p-refund', whenToUse: 'Customer wants a refund', triggerExamples: [] },
+]
+
+beforeEach(() => invokeMock.mockReset())
+
+describe('classifyProcedure', () => {
+  it('returns the chosen id from structured output', async () => {
+    invokeMock.mockResolvedValue({ structured_output: { procedureId: 'p-cancel' } })
+    expect(await classifyProcedure(conversation, candidates, deps)).toEqual({ id: 'p-cancel' })
+  })
+
+  it('is O(1): exactly one invoke regardless of candidate count', async () => {
+    invokeMock.mockResolvedValue({ structured_output: { procedureId: 'p-refund' } })
+    const many = Array.from({ length: 8 }, (_, i) => ({
+      id: `p-${i}`,
+      whenToUse: `case ${i}`,
+      triggerExamples: [],
+    }))
+    await classifyProcedure(conversation, many, deps)
+    expect(invokeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null when the model picks null', async () => {
+    invokeMock.mockResolvedValue({ structured_output: { procedureId: null } })
+    expect(await classifyProcedure(conversation, candidates, deps)).toEqual({ id: null })
+  })
+
+  it('belt-and-suspenders: rejects an id outside the candidate set', async () => {
+    invokeMock.mockResolvedValue({ structured_output: { procedureId: 'p-not-a-candidate' } })
+    expect(await classifyProcedure(conversation, candidates, deps)).toEqual({ id: null })
+  })
+
+  it('constrains the structured-output enum to the candidate ids ∪ null', async () => {
+    invokeMock.mockResolvedValue({ structured_output: { procedureId: 'p-cancel' } })
+    await classifyProcedure(conversation, candidates, deps)
+    const req = invokeMock.mock.calls[0][0]
+    expect(req.structuredOutput.enabled).toBe(true)
+    expect(req.structuredOutput.schema.properties.procedureId.enum).toEqual([
+      'p-cancel',
+      'p-refund',
+      null,
+    ])
+  })
+
+  it('splits triggerExamples into Use/Avoid blocks in the system prompt', async () => {
+    invokeMock.mockResolvedValue({ structured_output: { procedureId: null } })
+    await classifyProcedure(
+      conversation,
+      [
+        {
+          id: 'p-cancel',
+          whenToUse: 'Customer wants to cancel',
+          triggerExamples: [
+            { text: 'please cancel my plan', behavior: 'use' },
+            { text: 'I want to upgrade', behavior: 'avoid' },
+          ],
+        },
+      ],
+      deps
+    )
+    const sys = invokeMock.mock.calls[0][0].messages[0].content
+    expect(sys).toContain('Use when:')
+    expect(sys).toContain('please cancel my plan')
+    expect(sys).toContain('Avoid when:')
+    expect(sys).toContain('I want to upgrade')
+  })
+
+  it('returns null without an LLM call when there are no candidates', async () => {
+    expect(await classifyProcedure(conversation, [], deps)).toEqual({ id: null })
+    expect(invokeMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/agents/procedures/__tests__/context.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/context.test.ts
@@ -1,0 +1,97 @@
+// packages/lib/src/agents/procedures/__tests__/context.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Subject, ToolContext } from '../../../ai/agent-framework/tool-context'
+import { evaluateConditions } from '../../../conditions/evaluate'
+import type { Condition, ConditionGroup } from '../../../conditions/types'
+import { buildProcedureFieldResolver } from '../context'
+
+// The v8 binding resolver is mocked: it returns whatever `resolveMap` holds for the
+// ref (joined for FieldPath), so the test controls "what the subject resolves to".
+const { resolveMap } = vi.hoisted(() => ({ resolveMap: {} as Record<string, unknown> }))
+vi.mock('../../bindings/resolve', () => ({
+  buildResolveVarSource: vi.fn(
+    () => async (source: { kind: string; ref: string | string[] }) =>
+      resolveMap[Array.isArray(source.ref) ? source.ref.join('|') : source.ref]
+  ),
+}))
+
+const ctx = {} as ToolContext
+const subject: Subject = { anchors: {}, identityVerified: false }
+
+const cond = (
+  fieldId: Condition['fieldId'],
+  operator: Condition['operator'],
+  value: unknown
+): Condition => ({
+  id: `c-${String(fieldId)}`,
+  fieldId,
+  operator,
+  value,
+})
+const group = (conditions: Condition[]): ConditionGroup => ({
+  id: 'g',
+  conditions,
+  logicalOperator: 'AND',
+})
+
+beforeEach(() => {
+  for (const k of Object.keys(resolveMap)) delete resolveMap[k]
+})
+
+describe('buildProcedureFieldResolver', () => {
+  it('keys the map by the SIMPLE field id the evaluator looks up (ResourceFieldId)', async () => {
+    resolveMap['contact:status'] = 'OPEN'
+    const resolver = await buildProcedureFieldResolver(ctx, subject, [
+      group([cond('contact:status', 'is', 'OPEN')]),
+    ])
+    // The evaluator strips `contact:` and looks up the simple `status`.
+    expect(resolver(subject, 'status')).toBe('OPEN')
+    // The full ResourceFieldId is NOT a key (that mis-keying is the silent-corruption risk).
+    expect(resolver(subject, 'contact:status')).toBeUndefined()
+  })
+
+  it('end-to-end: a matching ruleset evaluates true through evaluateConditions', async () => {
+    resolveMap['contact:status'] = 'OPEN'
+    const groups = [group([cond('contact:status', 'is', 'OPEN')])]
+    const resolver = await buildProcedureFieldResolver(ctx, subject, groups)
+    expect(evaluateConditions(subject, groups, resolver)).toBe(true)
+  })
+
+  it('uses the LAST segment of a FieldPath as the simple key', async () => {
+    resolveMap['contact:company|company:name'] = 'Acme'
+    const resolver = await buildProcedureFieldResolver(ctx, subject, [
+      group([cond(['contact:company', 'company:name'] as Condition['fieldId'], 'is', 'Acme')]),
+    ])
+    expect(resolver(subject, 'name')).toBe('Acme')
+  })
+
+  it('gate-by-absence: an unresolved anchor yields undefined (empty subject)', async () => {
+    // resolveMap has no entry for contact:status → resolver returns undefined.
+    const groups = [group([cond('contact:status', 'is', 'OPEN')])]
+    const resolver = await buildProcedureFieldResolver(ctx, subject, groups)
+    expect(resolver(subject, 'status')).toBeUndefined()
+    expect(evaluateConditions(subject, groups, resolver)).toBe(false)
+  })
+
+  it('a bare legacy field id (no entity root) resolves to undefined, never throws', async () => {
+    const resolver = await buildProcedureFieldResolver(ctx, subject, [
+      group([cond('status', 'is', 'OPEN')]),
+    ])
+    expect(resolver(subject, 'status')).toBeUndefined()
+  })
+
+  it('resolves each distinct field exactly once even when referenced repeatedly', async () => {
+    const { buildResolveVarSource } = await import('../../bindings/resolve')
+    const innerCalls: unknown[] = []
+    vi.mocked(buildResolveVarSource).mockReturnValueOnce(async (source) => {
+      if (source.kind === 'var') innerCalls.push(source.ref)
+      return 'x'
+    })
+    const resolver = await buildProcedureFieldResolver(ctx, subject, [
+      group([cond('contact:status', 'is', 'a'), cond('contact:status', 'is not', 'b')]),
+    ])
+    expect(resolver(subject, 'status')).toBe('x')
+    expect(innerCalls).toHaveLength(1) // deduped by simple key
+  })
+})

--- a/packages/lib/src/agents/procedures/__tests__/select.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/select.test.ts
@@ -1,0 +1,246 @@
+// packages/lib/src/agents/procedures/__tests__/select.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Subject, ToolContext } from '../../../ai/agent-framework/tool-context'
+import type { Condition, ConditionGroup } from '../../../conditions/types'
+import { type ResolvedCandidate, type SelectProcedureArgs, selectProcedure } from '../select'
+import type { CompiledProcedure, ProcedureFrame, ProcedureStack } from '../types'
+
+// `buildProcedureFieldResolver` is mocked to a sync lookup over a controllable map,
+// so the REAL `evaluateConditions` runs against values we pin per test.
+const { resolved, classifyMock, buildResolverMock } = vi.hoisted(() => ({
+  resolved: {} as Record<string, unknown>,
+  classifyMock: vi.fn(),
+  buildResolverMock: vi.fn(),
+}))
+vi.mock('../classify', () => ({ classifyProcedure: classifyMock }))
+vi.mock('../context', () => ({ buildProcedureFieldResolver: buildResolverMock }))
+
+const compiled = (entryStepId = 's0'): CompiledProcedure => ({
+  entryStepId,
+  steps: { [entryStepId]: { id: entryStepId, kind: 'instruction', doc: {}, next: null } },
+  codeBlocks: {},
+  subProcedures: {},
+  localAttributes: [],
+})
+
+const candidate = (over: Partial<ResolvedCandidate> & { id?: string } = {}): ResolvedCandidate => {
+  const id = over.id ?? 'p1'
+  return {
+    link: { enabled: true, priority: 0, ...(over.link ?? {}) } as ResolvedCandidate['link'],
+    procedure: {
+      id,
+      activeVersionId: 'v1',
+      ...(over.procedure ?? {}),
+    } as ResolvedCandidate['procedure'],
+    activeVersion: {
+      id: 'v1',
+      compiled: compiled(),
+      ...(over.activeVersion ?? {}),
+    } as ResolvedCandidate['activeVersion'],
+    resolved: {
+      whenToUse: 'help with X',
+      triggerExamples: [],
+      ruleset: [],
+      ...(over.resolved ?? {}),
+    },
+  }
+}
+
+const group = (conditions: Condition[]): ConditionGroup => ({
+  id: 'g',
+  conditions,
+  logicalOperator: 'AND',
+})
+const cond = (fieldId: string, value: unknown): Condition => ({
+  id: 'c',
+  fieldId,
+  operator: 'is',
+  value,
+})
+
+const ctx = { db: {} } as ToolContext
+const subject: Subject = { anchors: {}, identityVerified: false }
+const baseArgs = (over: Partial<SelectProcedureArgs>): SelectProcedureArgs => ({
+  stack: { frames: [] },
+  candidates: [],
+  conversation: [{ role: 'user', content: 'hi' }],
+  ctx,
+  subject,
+  classifyDeps: { organizationId: 'org', userId: 'u', model: 'm', provider: 'anthropic' },
+  ...over,
+})
+
+const runningFrame: ProcedureFrame = {
+  procedureId: 'p-old',
+  procedureVersionId: 'v-old',
+  cursor: 's2',
+  status: 'running',
+  history: [],
+  pushedBy: 'selection',
+}
+
+beforeEach(() => {
+  for (const k of Object.keys(resolved)) delete resolved[k]
+  classifyMock.mockReset()
+  buildResolverMock.mockReset()
+  buildResolverMock.mockResolvedValue((_e: unknown, fieldId: string) => resolved[fieldId])
+})
+
+describe('selectProcedure', () => {
+  it('STICKY: a running top frame resumes without a classifier call', async () => {
+    const stack: ProcedureStack = { frames: [runningFrame] }
+    const result = await selectProcedure(baseArgs({ stack, candidates: [candidate()] }))
+    expect(result).toEqual({ kind: 'resume', frame: runningFrame })
+    expect(classifyMock).not.toHaveBeenCalled()
+    expect(buildResolverMock).not.toHaveBeenCalled()
+  })
+
+  it('a FINISHED top frame does NOT short-circuit (proceeds to classify)', async () => {
+    classifyMock.mockResolvedValue({ id: 'p1' })
+    const stack: ProcedureStack = { frames: [{ ...runningFrame, status: 'finished' }] }
+    const result = await selectProcedure(baseArgs({ stack, candidates: [candidate()] }))
+    expect(result.kind).toBe('selected')
+    expect(classifyMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('ZERO candidates: returns none with no LLM call (no regression)', async () => {
+    const result = await selectProcedure(baseArgs({ candidates: [] }))
+    expect(result).toEqual({ kind: 'none' })
+    expect(classifyMock).not.toHaveBeenCalled()
+    expect(buildResolverMock).not.toHaveBeenCalled()
+  })
+
+  it('drops disabled / empty-whenToUse candidates before classify', async () => {
+    const result = await selectProcedure(
+      baseArgs({
+        candidates: [
+          candidate({
+            id: 'disabled',
+            link: { enabled: false, priority: 0 } as ResolvedCandidate['link'],
+          }),
+          candidate({
+            id: 'blank',
+            resolved: { whenToUse: '   ', triggerExamples: [], ruleset: [] },
+          }),
+        ],
+      })
+    )
+    expect(result).toEqual({ kind: 'none' })
+    expect(classifyMock).not.toHaveBeenCalled()
+  })
+
+  it('RULESET pre-filter: a non-matching ruleset is dropped; an empty ruleset survives', async () => {
+    classifyMock.mockResolvedValue({ id: 'always' })
+    resolved.status = 'CLOSED' // so the contact:status=OPEN gate fails
+    const result = await selectProcedure(
+      baseArgs({
+        candidates: [
+          candidate({
+            id: 'open-only',
+            resolved: {
+              whenToUse: 'a',
+              triggerExamples: [],
+              ruleset: [group([cond('contact:status', 'OPEN')])],
+            },
+          }),
+          candidate({
+            id: 'always',
+            resolved: { whenToUse: 'b', triggerExamples: [], ruleset: [] },
+          }),
+        ],
+      })
+    )
+    // only the empty-ruleset candidate reaches the classifier
+    const survivors = classifyMock.mock.calls[0]![1] as { id: string }[]
+    expect(survivors.map((s) => s.id)).toEqual(['always'])
+    expect(result.kind).toBe('selected')
+  })
+
+  it('GATE-BY-ABSENCE: empty subject drops a ruleset requiring a present field', async () => {
+    const result = await selectProcedure(
+      baseArgs({
+        candidates: [
+          candidate({
+            id: 'needs-contact',
+            resolved: {
+              whenToUse: 'a',
+              triggerExamples: [],
+              ruleset: [group([cond('contact:status', 'OPEN')])],
+            },
+          }),
+        ],
+      })
+    )
+    expect(result).toEqual({ kind: 'none' })
+    expect(classifyMock).not.toHaveBeenCalled()
+  })
+
+  it('excludeProcedureIds filters before filter/classify (Phase 3 digression reuse)', async () => {
+    const result = await selectProcedure(
+      baseArgs({ candidates: [candidate({ id: 'p1' })], excludeProcedureIds: ['p1'] })
+    )
+    expect(result).toEqual({ kind: 'none' })
+    expect(classifyMock).not.toHaveBeenCalled()
+  })
+
+  it('FRAME 0: pins the active version and entry step', async () => {
+    classifyMock.mockResolvedValue({ id: 'p1' })
+    const c = candidate({
+      id: 'p1',
+      procedure: { id: 'p1', activeVersionId: 'v9' } as ResolvedCandidate['procedure'],
+      activeVersion: {
+        id: 'v9',
+        compiled: compiled('entry'),
+      } as ResolvedCandidate['activeVersion'],
+    })
+    const result = await selectProcedure(baseArgs({ candidates: [c] }))
+    expect(result).toEqual({
+      kind: 'selected',
+      frame: {
+        procedureId: 'p1',
+        procedureVersionId: 'v9',
+        cursor: 'entry',
+        status: 'running',
+        history: [],
+        pushedBy: 'selection',
+      },
+    })
+  })
+
+  it('whole-procedure-as-text: a single-step build selects cleanly', async () => {
+    classifyMock.mockResolvedValue({ id: 'p1' })
+    const c = candidate({
+      activeVersion: { id: 'v1', compiled: compiled('only') } as ResolvedCandidate['activeVersion'],
+    })
+    const result = await selectProcedure(baseArgs({ candidates: [c] }))
+    expect(result.kind).toBe('selected')
+    if (result.kind === 'selected') expect(result.frame.cursor).toBe('only')
+  })
+
+  it('classifier null → none', async () => {
+    classifyMock.mockResolvedValue({ id: null })
+    const result = await selectProcedure(baseArgs({ candidates: [candidate()] }))
+    expect(result).toEqual({ kind: 'none' })
+  })
+
+  it('sorts survivors by link.priority desc before the classifier', async () => {
+    classifyMock.mockResolvedValue({ id: 'low' })
+    await selectProcedure(
+      baseArgs({
+        candidates: [
+          candidate({
+            id: 'low',
+            link: { enabled: true, priority: 1 } as ResolvedCandidate['link'],
+          }),
+          candidate({
+            id: 'high',
+            link: { enabled: true, priority: 9 } as ResolvedCandidate['link'],
+          }),
+        ],
+      })
+    )
+    const survivors = classifyMock.mock.calls[0]![1] as { id: string }[]
+    expect(survivors.map((s) => s.id)).toEqual(['high', 'low'])
+  })
+})

--- a/packages/lib/src/agents/procedures/classify.ts
+++ b/packages/lib/src/agents/procedures/classify.ts
@@ -1,0 +1,121 @@
+// packages/lib/src/agents/procedures/classify.ts
+
+import type { Database } from '@auxx/database'
+import { LLMOrchestrator } from '../../ai/orchestrator/llm-orchestrator'
+import type { TriggerExample } from './types'
+
+/**
+ * The selection classifier — ONE constrained, multi-way LLM call that, given the
+ * conversation plus the survivors' `{ id, whenToUse, triggerExamples }`, returns the
+ * single best procedure id or `null`. **O(1) in #procedures** (one call, not one per
+ * candidate). The model cannot invent an id: the structured-output schema constrains
+ * `procedureId` to the candidate id set ∪ `null`, and a belt-and-suspenders filter
+ * rejects anything outside it. Mirrors `ai/kopilot/session-title.ts`'s minimal-deps
+ * `LLMOrchestrator` invocation, with `structuredOutput` enabled.
+ */
+
+export interface ClassifierCandidate {
+  id: string
+  whenToUse: string
+  triggerExamples: TriggerExample[]
+}
+
+export interface ClassifyDeps {
+  db: Database
+  organizationId: string
+  userId: string
+  /**
+   * Resolved BY THE CALLER (Phase 4) from the agent's pinned model
+   * ([[feedback_kopilot_byo_model]] — one model per turn, no per-agent tiering),
+   * falling back to a cheap default (`claude-haiku-4-5`) for this low-stakes routing.
+   */
+  model: string
+  provider: string
+}
+
+export type ConversationMessage = { role: 'user' | 'assistant'; content: string }
+
+/**
+ * Build the few-shot system prompt: a compact catalog of each candidate's `id`,
+ * `whenToUse` prose, and its `triggerExamples` split into "Use when" / "Avoid when"
+ * lists. The `avoid` shots are the primary lever against over-triggering on an
+ * adjacent intent.
+ */
+function buildSystemPrompt(candidates: ClassifierCandidate[]): string {
+  const catalog = candidates
+    .map((c) => {
+      const use = c.triggerExamples
+        .filter((e) => e.behavior === 'use')
+        .map((e) => `    - ${e.text}`)
+      const avoid = c.triggerExamples
+        .filter((e) => e.behavior === 'avoid')
+        .map((e) => `    - ${e.text}`)
+      const lines = [`- id: ${c.id}`, `  When to use: ${c.whenToUse}`]
+      if (use.length > 0) lines.push('  Use when:', ...use)
+      if (avoid.length > 0) lines.push('  Avoid when:', ...avoid)
+      return lines.join('\n')
+    })
+    .join('\n')
+
+  return [
+    'You route a customer conversation to at most one support procedure.',
+    'Below is the catalog of available procedures. Each has a "When to use" description',
+    'and may list example messages it should be used for ("Use when") or explicitly',
+    'NOT used for ("Avoid when").',
+    '',
+    'Procedures:',
+    catalog,
+    '',
+    'Pick the single best-matching procedure id for the latest customer intent, or',
+    'null if none clearly applies. Prefer null over a weak match — a wrong match is',
+    'worse than free-form. Respond only via the structured output.',
+  ].join('\n')
+}
+
+function renderConversation(conversation: ConversationMessage[]): string {
+  return conversation
+    .map((m) => `${m.role === 'user' ? 'Customer' : 'Agent'}: ${m.content}`)
+    .join('\n')
+}
+
+/** ONE constrained multi-way call. Returns the chosen procedure id or null. */
+export async function classifyProcedure(
+  conversation: ConversationMessage[],
+  candidates: ClassifierCandidate[],
+  deps: ClassifyDeps
+): Promise<{ id: string | null }> {
+  if (candidates.length === 0) return { id: null } // never reached via select.ts; defensive
+
+  const orchestrator = new LLMOrchestrator(undefined, deps.db)
+  const response = await orchestrator.invoke({
+    model: deps.model,
+    provider: deps.provider,
+    organizationId: deps.organizationId,
+    userId: deps.userId,
+    messages: [
+      { role: 'system', content: buildSystemPrompt(candidates) },
+      { role: 'user', content: renderConversation(conversation) },
+    ],
+    tools: [],
+    structuredOutput: {
+      enabled: true,
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['procedureId'],
+        properties: {
+          procedureId: {
+            type: ['string', 'null'],
+            enum: [...candidates.map((c) => c.id), null],
+          },
+        },
+      },
+    },
+    parameters: { max_tokens: 60 },
+    context: { source: 'procedure-classify' },
+  })
+
+  const picked = response.structured_output?.procedureId ?? null
+  // Belt-and-suspenders: reject any id not in the candidate set.
+  return { id: candidates.some((c) => c.id === picked) ? picked : null }
+}

--- a/packages/lib/src/agents/procedures/context.ts
+++ b/packages/lib/src/agents/procedures/context.ts
@@ -1,0 +1,108 @@
+// packages/lib/src/agents/procedures/context.ts
+
+import type { VarRef } from '@auxx/types/field'
+import type { Subject, ToolContext } from '../../ai/agent-framework/tool-context'
+import type { FieldResolver } from '../../conditions/evaluate'
+import type { ConditionGroup } from '../../conditions/types'
+import { buildResolveVarSource } from '../bindings/resolve'
+
+/**
+ * The deterministic selection pre-filter (`select.ts`) gates candidate procedures
+ * with `evaluateConditions(entity, ruleset, resolver)` — a **synchronous** evaluator
+ * (`conditions/evaluate.ts`, shared with client-side view filters). The procedure
+ * rulesets reference fields off the turn's `Subject` anchors, resolved by the v8
+ * binding resolver `buildResolveVarSource(ctx)` — which is **async**
+ * (`batchGetValues`). We bridge the two by **pre-resolving** every field a candidate
+ * ruleset references into an in-memory sync map, once per turn, before evaluating.
+ *
+ * Procedure-local `var:*` are deliberately NOT available here: the procedure hasn't
+ * run yet, so the only readable axis at selection is the subject (PROCEDURE-STACK #5).
+ */
+
+/**
+ * Extract the **simple** field id the synchronous evaluator looks up — it strips the
+ * `entityDef:` prefix and, for a relationship path, uses the LAST segment's simple
+ * name. This MUST stay byte-for-byte aligned with `evaluate.ts`'s `extractFieldId` /
+ * `extractSimpleField`, or the pre-resolved map is keyed differently than the
+ * evaluator reads it and every lookup silently returns `undefined`.
+ */
+function simpleKey(fieldId: string | string[]): string {
+  if (Array.isArray(fieldId)) return stripEntityDef(fieldId[fieldId.length - 1] ?? '')
+  return stripEntityDef(fieldId)
+}
+
+function stripEntityDef(fieldId: string): string {
+  const colon = fieldId.indexOf(':')
+  return colon === -1 ? fieldId : fieldId.slice(colon + 1)
+}
+
+/**
+ * Build a `VarRef` from a condition `fieldId`. A `ResourceFieldId[]` is a `FieldPath`;
+ * a scoped `entityDef:field` string is a `ResourceFieldId`. A bare legacy field id
+ * (no `:`, no entity root) cannot be rooted at a subject anchor, so it has no var
+ * source — we return `null` and the field resolves to `undefined` (gate-by-absence).
+ */
+function toVarRef(fieldId: string | string[]): VarRef | null {
+  if (Array.isArray(fieldId)) return fieldId.length > 0 ? (fieldId as VarRef) : null
+  return fieldId.includes(':') ? (fieldId as VarRef) : null
+}
+
+/**
+ * Collect every distinct condition `fieldId` referenced across a set of rulesets, so
+ * each is resolved exactly once. Mirrors the evaluator's reach: top-level groups,
+ * each group's `conditions` (the evaluator does not recurse `subConditions`).
+ */
+function collectFieldRefs(groups: ConditionGroup[]): (string | string[])[] {
+  const out: (string | string[])[] = []
+  for (const group of groups) {
+    for (const condition of group.conditions) {
+      out.push(condition.fieldId)
+    }
+  }
+  return out
+}
+
+/**
+ * Build the synchronous `FieldResolver` selection conditions evaluate against, by
+ * PRE-RESOLVING each referenced field off `subject.anchors` via the v8 resolver into
+ * a map keyed by the evaluator's *simple* field id.
+ *
+ * Gate-by-absence: an absent anchor (anonymous participant, no `contact`) yields
+ * `undefined` from the v8 resolver, so the predicate sees a missing value — exactly
+ * the property `evaluateConditions` relies on (`empty` / `is not` behave correctly on
+ * `undefined`). Internal runs pass an empty-anchors `Subject`, so every field is
+ * `undefined` and a ruleset requiring a present field simply doesn't match.
+ *
+ * @param allGroups union of every candidate ruleset — resolve the field set once.
+ */
+export async function buildProcedureFieldResolver(
+  ctx: ToolContext,
+  subject: Subject,
+  allGroups: ConditionGroup[]
+): Promise<FieldResolver<Subject>> {
+  const resolveVar = buildResolveVarSource(ctx)
+  const values = new Map<string, unknown>()
+  const seen = new Set<string>()
+
+  for (const fieldId of collectFieldRefs(allGroups)) {
+    const key = simpleKey(fieldId)
+    if (seen.has(key)) continue
+    seen.add(key)
+    const ref = toVarRef(fieldId)
+    if (!ref) {
+      values.set(key, undefined)
+      continue
+    }
+    try {
+      values.set(key, await resolveVar({ kind: 'var', ref }, subject))
+    } catch {
+      // Selection is best-effort routing — a resolver misconfig gates by absence
+      // rather than throwing the whole turn.
+      values.set(key, undefined)
+    }
+  }
+
+  // The evaluator hands us the already-simplified field id (`extractFieldId`); the
+  // `entity` arg is ignored — we read the pre-resolved map.
+  return (_entity, fieldId) => values.get(fieldId)
+}

--- a/packages/lib/src/agents/procedures/index.ts
+++ b/packages/lib/src/agents/procedures/index.ts
@@ -1,7 +1,14 @@
 // packages/lib/src/agents/procedures/index.ts
 
+export {
+  type ClassifierCandidate,
+  type ClassifyDeps,
+  type ConversationMessage,
+  classifyProcedure,
+} from './classify'
 export type { CompileError, CompileResult } from './compile'
 export { compileProcedure } from './compile'
+export { buildProcedureFieldResolver } from './context'
 export {
   type CodeStepAttrs,
   type ConditionCaseAttrs,
@@ -38,6 +45,12 @@ export {
   updateDraftDoc,
   updateProcedure,
 } from './queries'
+export {
+  type ResolvedCandidate,
+  type SelectionResult,
+  type SelectProcedureArgs,
+  selectProcedure,
+} from './select'
 export {
   atDepthCap,
   clear,

--- a/packages/lib/src/agents/procedures/select.ts
+++ b/packages/lib/src/agents/procedures/select.ts
@@ -1,0 +1,110 @@
+// packages/lib/src/agents/procedures/select.ts
+
+import type { Subject, ToolContext } from '../../ai/agent-framework/tool-context'
+import { evaluateConditions } from '../../conditions/evaluate'
+import type { ConditionGroup } from '../../conditions/types'
+import { type ClassifyDeps, type ConversationMessage, classifyProcedure } from './classify'
+import { buildProcedureFieldResolver } from './context'
+import type { AgentProcedureEntity, ProcedureEntity, ProcedureVersionEntity } from './queries'
+import { top } from './stack'
+import type { CompiledProcedure, ProcedureFrame, ProcedureStack, TriggerExample } from './types'
+
+/**
+ * Selection — the layer that decides *which* procedure (if any) runs this turn and
+ * hands back **frame 0** of the `ProcedureStack`. Composition: sticky resume →
+ * zero-procedure short-circuit → deterministic ruleset pre-filter → ONE classifier
+ * call → frame 0. This is the function Phase 4 calls between engine construction and
+ * `submitMessage`, and the SAME function Phase 3 re-runs for digression (over the
+ * other procedures via `excludeProcedureIds`).
+ *
+ * No runtime path is touched here — the turn-processor wiring is Phase 4.
+ */
+
+export type SelectionResult =
+  | { kind: 'resume'; frame: ProcedureFrame } // sticky — top frame still running
+  | { kind: 'selected'; frame: ProcedureFrame } // a fresh frame 0
+  | { kind: 'none' } // free-form persona mode (today's behavior)
+
+/**
+ * One agent↔procedure LINK resolved for selection. Phase 4 builds these from the
+ * `agents` org-cache projection; Phase 1 can read them via the Phase 0 `queries.ts`
+ * (`listAgentProcedures` + `getProcedureById` + `getProcedureVersionById`) as a
+ * stand-in — `ResolvedCandidate[]` is the stable seam, so the swap is one line in the
+ * caller. `resolved` is `override ?? default` for each trigger field.
+ */
+export interface ResolvedCandidate {
+  link: AgentProcedureEntity // enabled, priority, *Override fields
+  procedure: ProcedureEntity // defaults (whenToUse/triggerExamples/ruleset) + activeVersionId
+  activeVersion: ProcedureVersionEntity & { compiled: CompiledProcedure } // the pinned build
+  resolved: {
+    whenToUse: string
+    triggerExamples: TriggerExample[]
+    ruleset: ConditionGroup[]
+  }
+}
+
+export interface SelectProcedureArgs {
+  stack: ProcedureStack
+  candidates: ResolvedCandidate[]
+  conversation: ConversationMessage[]
+  ctx: ToolContext
+  subject: Subject // turn's anchors (empty-anchors for internal runs)
+  classifyDeps: Omit<ClassifyDeps, 'db'> // model/provider/org/user resolved by caller
+  /** Phase 3 digression: exclude procedures already on the live stack. Defaults to []. */
+  excludeProcedureIds?: string[]
+}
+
+export async function selectProcedure(args: SelectProcedureArgs): Promise<SelectionResult> {
+  const { stack, candidates, conversation, ctx, subject, excludeProcedureIds = [] } = args
+
+  // 0. STICKY: an active, unfinished top frame resumes — selection does NOT run, no
+  //    classifier call. (Phase 3 digression bypasses this with an exclude-set.)
+  const t = top(stack)
+  if (t && t.status !== 'finished') return { kind: 'resume', frame: t }
+
+  // 1. Zero-procedure short-circuit — NO LLM call, no regression for today's agents.
+  const usable = candidates.filter(
+    (c) =>
+      c.link.enabled &&
+      c.resolved.whenToUse.trim() !== '' && // empty whenToUse = nothing for the classifier to reason about
+      !excludeProcedureIds.includes(c.procedure.id)
+  )
+  if (usable.length === 0) return { kind: 'none' }
+
+  // 2. DETERMINISTIC ruleset pre-filter (cheap, before any LLM) over the RESOLVED
+  //    ruleset. `[]` groups match all (`evaluateConditions` empty = true).
+  const allGroups = usable.flatMap((c) => c.resolved.ruleset)
+  const resolver = await buildProcedureFieldResolver(ctx, subject, allGroups)
+  const survivors = usable
+    .filter((c) => evaluateConditions(subject, c.resolved.ruleset, resolver))
+    .sort((a, b) => b.link.priority - a.link.priority)
+  if (survivors.length === 0) return { kind: 'none' }
+
+  // 3. ONE classifier call among survivors (few-shot use/avoid) over the RESOLVED
+  //    whenToUse/examples.
+  const { id } = await classifyProcedure(
+    conversation,
+    survivors.map((c) => ({
+      id: c.procedure.id,
+      whenToUse: c.resolved.whenToUse,
+      triggerExamples: c.resolved.triggerExamples,
+    })),
+    { ...args.classifyDeps, db: ctx.db }
+  )
+  if (!id) return { kind: 'none' }
+
+  // 4. Build FRAME 0 — PIN the active version (the run reads this exact version
+  //    throughout). A one-step compiled build is a valid frame 0 (whole-procedure-as-
+  //    text fallback) — selection makes no multi-step assumption.
+  const chosen = survivors.find((c) => c.procedure.id === id)
+  if (!chosen) return { kind: 'none' }
+  const frame: ProcedureFrame = {
+    procedureId: chosen.procedure.id,
+    procedureVersionId: chosen.activeVersion.id,
+    cursor: chosen.activeVersion.compiled.entryStepId,
+    status: 'running',
+    history: [],
+    pushedBy: 'selection',
+  }
+  return { kind: 'selected', frame }
+}


### PR DESCRIPTION
## Chat v9 Procedures — Phase 1: Selection

Builds the **selection layer**: three server-side `@auxx/lib/agents/procedures` modules that decide *which* procedure (if any) runs a turn and hand back **frame 0** of the `ProcedureStack`. Consumes the Phase 0 contract (PR #743). **No runtime path is touched** — the turn-processor wiring is Phase 4.

### What's here
- **`context.ts`** — `buildProcedureFieldResolver`. Bridges the **sync** `evaluateConditions` to the **async** v8 binding resolver (`buildResolveVarSource`) by pre-resolving each ruleset-referenced field off `subject.anchors` into a sync `FieldResolver`, keyed by the evaluator's *simple* field id (`entityDef:` stripped, last segment of a `FieldPath`). Gate-by-absence on missing anchors; bare legacy ids / resolver throws degrade to `undefined` and never throw the turn.
- **`classify.ts`** — `classifyProcedure`. **ONE** constrained `LLMOrchestrator.invoke` with `structuredOutput`, `procedureId` enum-constrained to the candidate ids ∪ `null` plus a belt-and-suspenders post-filter. **O(1) in #procedures.** Few-shot system prompt splits `triggerExamples` into Use/Avoid. Caller supplies `model`/`provider` (default `claude-haiku-4-5`; no per-agent tiering).
- **`select.ts`** — `selectProcedure`: sticky resume (top frame still running → no classifier call) → zero/disabled/empty-`whenToUse` short-circuit → priority-sorted ruleset pre-filter → one classifier call → pinned **frame 0** (`procedureVersionId = activeVersion.id`, `cursor = compiled.entryStepId`, `pushedBy:'selection'`). `excludeProcedureIds` makes it the same function Phase 3 re-runs for digression. `ResolvedCandidate[]` is the stable seam Phase 4 fills from the org-cache.

### Tests
24 new across `context`/`classify`/`select` (**45 green** in the module). Cover the simple-field-id key alignment (the one silent-corruption risk), O(1) call count, sticky-no-call, gate-by-absence, exclude-set, frame-0 pinning, and the single-step (whole-procedure-as-text) build.

```
cd packages/lib && npx vitest run src/agents/procedures/__tests__
```

### Notes
- `packages/lib/package.json` drops the `@auxx/lib/agents/procedures` export — it's **auto-managed** by `scripts/generate-exports.ts`, which only emits subpaths an external consumer imports. Nothing outside lib imports it yet, so it's pruned; it returns automatically when Phase 4 wires `selectProcedure` into the turn processor. `pnpm -F @auxx/lib check:exports` is green.
- `pnpm lint` clean; no `tsc` (project rule).