### PR TITLE
feat(agents): chat-v9 procedures phase 2 — editor UI + routers

### DIFF
--- a/apps/web/src/components/agents/constant.ts
+++ b/apps/web/src/components/agents/constant.ts
@@ -4,5 +4,12 @@
 export const DEFAULT_AGENT_TAB = 'prompt'
 
 /** Tab keys used by the agent detail page. */
-export const AGENT_TABS = ['prompt', 'tools', 'restrictions', 'knowledge', 'triggers'] as const
+export const AGENT_TABS = [
+  'prompt',
+  'procedures',
+  'tools',
+  'restrictions',
+  'knowledge',
+  'triggers',
+] as const
 export type AgentTab = (typeof AGENT_TABS)[number]

--- a/apps/web/src/components/agents/procedures/hooks/use-procedure-autosave.ts
+++ b/apps/web/src/components/agents/procedures/hooks/use-procedure-autosave.ts
@@ -1,0 +1,82 @@
+// apps/web/src/components/agents/procedures/hooks/use-procedure-autosave.ts
+'use client'
+
+import type { TriggerExample } from '@auxx/lib/agents/procedures/client'
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { api } from '~/trpc/react'
+import type { AutosaveState } from '../../ui/shared/autosave-indicator'
+
+interface ProcedureUpdatePatch {
+  name?: string
+  whenToUse?: string
+  triggerExamples?: TriggerExample[]
+  ruleset?: ConditionGroup[]
+  /** The TipTap DRAFT doc — NEVER the published compiled/version. */
+  doc?: Record<string, unknown>
+}
+
+interface UseProcedureAutosaveOptions {
+  onStateChange?: (state: AutosaveState) => void
+}
+
+/**
+ * Debounced patch wrapper around `api.procedure.update`, draft-only by
+ * construction (the patch never carries `compiled`/`version` — publishing is the
+ * separate explicit mutation). Clone of `use-agent-autosave.ts`; coalesces
+ * consecutive patches within `debounceMs` and fires one mutation per flush.
+ */
+export function useProcedureAutosave(
+  procedureId: string,
+  { onStateChange }: UseProcedureAutosaveOptions = {}
+): {
+  state: AutosaveState
+  patch: (input: ProcedureUpdatePatch, opts?: { debounceMs?: number }) => void
+  flush: () => Promise<void>
+} {
+  const updateProcedure = api.procedure.update.useMutation()
+  const [state, setState] = useState<AutosaveState>({ kind: 'idle' })
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const queuedPatchRef = useRef<ProcedureUpdatePatch | null>(null)
+  const onStateChangeRef = useRef(onStateChange)
+  onStateChangeRef.current = onStateChange
+
+  const setStateAndNotify = useCallback((next: AutosaveState) => {
+    setState(next)
+    onStateChangeRef.current?.(next)
+  }, [])
+
+  const flush = useCallback(async () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = null
+    const patch = queuedPatchRef.current
+    queuedPatchRef.current = null
+    if (!patch) return
+    setStateAndNotify({ kind: 'saving' })
+    try {
+      await updateProcedure.mutateAsync({ id: procedureId, ...patch })
+      setStateAndNotify({ kind: 'saved', at: Date.now() })
+    } catch (err) {
+      setStateAndNotify({ kind: 'idle' })
+      toastError({ title: 'Save failed', description: (err as Error).message })
+    }
+  }, [procedureId, updateProcedure, setStateAndNotify])
+
+  const patch = useCallback(
+    (input: ProcedureUpdatePatch, opts?: { debounceMs?: number }) => {
+      queuedPatchRef.current = { ...queuedPatchRef.current, ...input }
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => void flush(), opts?.debounceMs ?? 600)
+    },
+    [flush]
+  )
+
+  useEffect(() => {
+    return () => {
+      if (queuedPatchRef.current) void flush()
+    }
+  }, [flush])
+
+  return { state, patch, flush }
+}

--- a/apps/web/src/components/agents/procedures/hooks/use-procedure-condition-config.ts
+++ b/apps/web/src/components/agents/procedures/hooks/use-procedure-condition-config.ts
@@ -1,0 +1,96 @@
+// apps/web/src/components/agents/procedures/hooks/use-procedure-condition-config.ts
+'use client'
+
+import type { LocalAttribute } from '@auxx/lib/agents/procedures/client'
+import type { Operator } from '@auxx/lib/conditions/client'
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { BaseType } from '@auxx/lib/workflow-engine/client'
+import { useCallback, useMemo } from 'react'
+import type { ConditionSystemConfig, FieldDefinition } from '~/components/conditions'
+import { useResourceFields } from '~/components/resources/hooks/use-resource-fields'
+
+/** CRM entity slugs whose fields back the STRUCTURED condition mode. */
+const CONTACT_SLUG = 'contact'
+const THREAD_SLUG = 'thread'
+
+/** ResourceField[] → FieldDefinition[] for the ConditionProvider (records-searchbar pattern). */
+function toConditionFields(fields: ResourceField[]): FieldDefinition[] {
+  return fields
+    .filter((f) => f.capabilities?.filterable && !f.capabilities?.hidden)
+    .map((f) => ({
+      id: f.id,
+      label: f.label,
+      type: f.type,
+      fieldType: f.fieldType,
+      options: f.options,
+      operators: f.operators as Operator[] | undefined,
+    }))
+}
+
+/** Declared local attribute → a `var:*` FieldDefinition (the "Temporary" group). */
+function localToField(attr: LocalAttribute): FieldDefinition {
+  return {
+    id: `var:${attr.name}`,
+    label: attr.name,
+    type: BaseType.STRING,
+    fieldType: attr.dataType,
+    options: attr.options,
+  }
+}
+
+/**
+ * Builds the `ConditionSystemConfig` + field resolvers for the STRUCTURED
+ * predicate mode — the trigger ruleset (multi-group: `singleGroup=false`) and
+ * each `conditionCase` arm (single group: `singleGroup=true`). Fields are the CRM
+ * contact/thread resource fields plus the procedure's declared `localAttributes`
+ * (the `var:*` "Temporary" group).
+ *
+ * NOTE: reconstruction of the original (untracked) hook — CRM resolution follows
+ * the records-searchbar `toConditionFields` pattern; the contact/thread slugs may
+ * need tuning to your entity-definition slugs.
+ */
+export function useProcedureConditionConfig(
+  localAttributes: LocalAttribute[],
+  singleGroup: boolean
+) {
+  const contact = useResourceFields(CONTACT_SLUG)
+  const thread = useResourceFields(THREAD_SLUG)
+
+  const fields = useMemo<FieldDefinition[]>(
+    () => [
+      ...toConditionFields(contact.filterableFields),
+      ...toConditionFields(thread.filterableFields),
+      ...localAttributes.map(localToField),
+    ],
+    [contact.filterableFields, thread.filterableFields, localAttributes]
+  )
+
+  const getAvailableFields = useCallback(() => fields, [fields])
+
+  const getFieldDefinition = useCallback(
+    (fieldId: string | string[]) => {
+      const id = Array.isArray(fieldId) ? fieldId[0] : fieldId
+      return fields.find((f) => f.id === id)
+    },
+    [fields]
+  )
+
+  const config = useMemo<ConditionSystemConfig>(
+    () => ({
+      mode: 'resource',
+      fields,
+      showLogicalOperators: true,
+      showGrouping: !singleGroup,
+      allowGroupNaming: false,
+      allowGroupCollapse: !singleGroup,
+      allowGroupReordering: false,
+      showGroupSubtext: false,
+      allowVarEditor: false,
+      allowConstantToggle: false,
+      display: 'inline',
+    }),
+    [fields, singleGroup]
+  )
+
+  return { config, getAvailableFields, getFieldDefinition }
+}

--- a/apps/web/src/components/agents/procedures/nodes/condition-block-node-view.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/condition-block-node-view.tsx
@@ -1,0 +1,45 @@
+// apps/web/src/components/agents/procedures/nodes/condition-block-node-view.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import type { NodeViewProps } from '@tiptap/react'
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import { Plus } from 'lucide-react'
+import { appendChild, newConditionCase, newConditionElse, nodePos } from './condition-helpers'
+
+/**
+ * `conditionBlock` view — an IF / ELSE-IF / ELSE construct rendered inline-expanded
+ * (plan §4, the screenshot). Renders its arm children via {@link NodeViewContent}
+ * and a footer to append another ELSE-IF arm or (once) the ELSE arm. Arm order is
+ * the IF/ELSE-IF precedence the compiler reads.
+ */
+export function ConditionBlockNodeView({ node, editor, getPos }: NodeViewProps) {
+  const hasElse = node.lastChild?.type.name === 'conditionElse'
+
+  const addCase = () => {
+    const pos = nodePos(getPos)
+    if (pos != null) appendChild(editor, pos, newConditionCase())
+  }
+  const addElse = () => {
+    const pos = nodePos(getPos)
+    if (pos != null) appendChild(editor, pos, newConditionElse())
+  }
+
+  return (
+    <NodeViewWrapper as='div' className='my-2'>
+      <NodeViewContent />
+      <div className='mt-1 flex items-center gap-2 pl-8' contentEditable={false}>
+        <Button variant='ghost' size='xs' onClick={addCase}>
+          <Plus />
+          Else if
+        </Button>
+        {!hasElse && (
+          <Button variant='ghost' size='xs' onClick={addElse}>
+            <Plus />
+            Else
+          </Button>
+        )}
+      </div>
+    </NodeViewWrapper>
+  )
+}

--- a/apps/web/src/components/agents/procedures/nodes/condition-block-node.ts
+++ b/apps/web/src/components/agents/procedures/nodes/condition-block-node.ts
@@ -1,0 +1,44 @@
+// apps/web/src/components/agents/procedures/nodes/condition-block-node.ts
+
+import { mergeAttributes, Node } from '@tiptap/core'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+import { ConditionBlockNodeView } from './condition-block-node-view'
+
+/**
+ * `conditionBlock` — a v9 procedure IF / ELSE-IF / ELSE construct. Container
+ * whose children are a fixed set of arm nodes; the compiler reads the arm order
+ * (first `conditionCase` → IF, subsequent → ELSE IF, `conditionElse` → ELSE) and
+ * each case's single `ConditionGroup`. Mirrors `tabs-node.ts` (a container with a
+ * fixed child type). The two child node NAMES are listed explicitly in `content`
+ * because PM resolves bare tokens to node names before groups.
+ *
+ * See plans/chat/v9/phase-2-authoring.md §1.1 and phase-0 §3.
+ */
+export const ConditionBlock = Node.create({
+  name: 'conditionBlock',
+  group: 'procedureBlock',
+  content: '(conditionCase | conditionElse)+',
+  defining: true,
+
+  addAttributes() {
+    return {
+      id: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-id'),
+        renderHTML: (attrs) => (attrs.id ? { 'data-id': attrs.id } : {}),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-condition-block]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-condition-block': '' }, HTMLAttributes), 0]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ConditionBlockNodeView)
+  },
+})

--- a/apps/web/src/components/agents/procedures/nodes/condition-case-node-view.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/condition-case-node-view.tsx
@@ -1,0 +1,121 @@
+// apps/web/src/components/agents/procedures/nodes/condition-case-node-view.tsx
+'use client'
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { cn } from '@auxx/ui/lib/utils'
+import { generateId } from '@auxx/utils'
+import type { NodeViewProps } from '@tiptap/react'
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import { GitBranch, X } from 'lucide-react'
+import { ConditionContainer, ConditionProvider } from '~/components/conditions'
+import { useProcedureConditionConfig } from '../hooks/use-procedure-condition-config'
+import { useProcedureEditorContext } from '../ui/procedure-editor-context'
+import { nodePos } from './condition-helpers'
+
+/**
+ * `conditionCase` view — one IF / ELSE-IF arm. The gutter badge + keyword reflect
+ * the arm's POSITION (first = IF, later = ELSE IF). The predicate is dual-mode
+ * (plan §4): a `Text`/`Rules` toggle flips `mode`. In `text` mode the leading
+ * `conditionPredicate` child (rendered inside {@link NodeViewContent}) is the
+ * writer; in `structured` mode the {@link ConditionProvider} builder binds to the
+ * `group` attr (and the predicate child hides itself). The body is the arm's
+ * `block+` content, rendered after the predicate in the same content hole.
+ */
+export function ConditionCaseNodeView({ node, editor, getPos, updateAttributes }: NodeViewProps) {
+  const ctx = useProcedureEditorContext()
+  const mode = (node.attrs.mode as string) ?? 'text'
+  const { config, getAvailableFields, getFieldDefinition } = useProcedureConditionConfig(
+    ctx?.localAttributes ?? [],
+    true
+  )
+
+  const ordinal = (() => {
+    const pos = nodePos(getPos)
+    if (pos == null) return 0
+    try {
+      return editor.state.doc.resolve(pos).index()
+    } catch {
+      return 0
+    }
+  })()
+
+  const group: ConditionGroup =
+    (node.attrs.group as ConditionGroup | null) ??
+    ({ id: generateId(), conditions: [], logicalOperator: 'AND' } as ConditionGroup)
+
+  const onGroupsChange = (groups: ConditionGroup[]) => {
+    updateAttributes({ group: groups[0] ?? group })
+  }
+
+  const removeArm = () => {
+    const pos = nodePos(getPos)
+    if (pos == null) return
+    editor
+      .chain()
+      .focus()
+      .deleteRange({ from: pos, to: pos + node.nodeSize })
+      .run()
+  }
+
+  return (
+    <NodeViewWrapper as='div' className='my-1.5'>
+      <div className='flex items-center gap-2' contentEditable={false}>
+        <span className='flex size-6 shrink-0 items-center justify-center rounded-md bg-primary-100 text-primary-700'>
+          <GitBranch className='size-3.5' />
+        </span>
+        <span className='text-xs font-semibold uppercase tracking-wide text-foreground'>
+          {ordinal === 0 ? 'If' : 'Else if'}
+        </span>
+        <div className='ml-auto flex items-center gap-1'>
+          <ModeToggle mode={mode} onChange={(next) => updateAttributes({ mode: next })} />
+          <button
+            type='button'
+            onClick={removeArm}
+            aria-label='Remove branch'
+            className='rounded p-0.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'>
+            <X className='size-3.5' />
+          </button>
+        </div>
+      </div>
+
+      <div className='pl-8'>
+        {mode === 'structured' && (
+          <div className='my-1.5' contentEditable={false}>
+            <ConditionProvider
+              conditions={group.conditions}
+              groups={[group]}
+              config={config}
+              onConditionsChange={() => {}}
+              onGroupsChange={onGroupsChange}
+              getAvailableFields={getAvailableFields}
+              getFieldDefinition={getFieldDefinition}>
+              <ConditionContainer showAddButton emptyStateText='Add a condition' />
+            </ConditionProvider>
+          </div>
+        )}
+        <NodeViewContent />
+      </div>
+    </NodeViewWrapper>
+  )
+}
+
+function ModeToggle({ mode, onChange }: { mode: string; onChange: (mode: string) => void }) {
+  return (
+    <div
+      className='flex items-center rounded-md border border-border p-0.5 text-[11px]'
+      contentEditable={false}>
+      {(['text', 'structured'] as const).map((m) => (
+        <button
+          key={m}
+          type='button'
+          onClick={() => onChange(m)}
+          className={cn(
+            'rounded px-1.5 py-0.5 font-medium',
+            mode === m ? 'bg-primary-100 text-primary-700' : 'text-muted-foreground'
+          )}>
+          {m === 'text' ? 'Text' : 'Rules'}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/procedures/nodes/condition-case-node.ts
+++ b/apps/web/src/components/agents/procedures/nodes/condition-case-node.ts
@@ -1,0 +1,74 @@
+// apps/web/src/components/agents/procedures/nodes/condition-case-node.ts
+
+import { mergeAttributes, Node } from '@tiptap/core'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+import { selectAncestorContent } from '~/components/editor/keymap-helpers'
+import { ConditionCaseNodeView } from './condition-case-node-view'
+
+/**
+ * `conditionCase` — one IF / ELSE-IF arm of a {@link ConditionBlock}. The
+ * predicate is **dual-mode** (plan §4 / decision #9):
+ *
+ * - `mode: 'text'` (default) — a leading `conditionPredicate` prose node holds a
+ *   natural-language predicate (`@` inserts attribute badges); the model reads it.
+ * - `mode: 'structured'` — the `group: ConditionGroup` attr holds the structured
+ *   builder state (`evaluateConditions()`-compatible), serialized as JSON on
+ *   `data-group` like `block-node.ts`'s `cards` attr.
+ *
+ * Content is `conditionPredicate block+` (the predicate writer + the arm body).
+ * `isolating` so Cmd-A scopes to this arm (mirror `panel-node.ts`). Arm order =
+ * IF/ELSE-IF precedence; there is no `kind` attr.
+ */
+export const ConditionCase = Node.create({
+  name: 'conditionCase',
+  content: 'conditionPredicate block+',
+  defining: true,
+  isolating: true,
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-a': ({ editor }) =>
+        selectAncestorContent(editor, (n) => n.type.name === 'conditionCase'),
+    }
+  },
+
+  addAttributes() {
+    return {
+      id: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-id'),
+        renderHTML: (attrs) => (attrs.id ? { 'data-id': attrs.id } : {}),
+      },
+      mode: {
+        default: 'text',
+        parseHTML: (el) => el.getAttribute('data-mode') ?? 'text',
+        renderHTML: (attrs) => ({ 'data-mode': attrs.mode ?? 'text' }),
+      },
+      group: {
+        default: null,
+        parseHTML: (el) => {
+          const raw = el.getAttribute('data-group')
+          if (!raw) return null
+          try {
+            return JSON.parse(raw)
+          } catch {
+            return null
+          }
+        },
+        renderHTML: (attrs) => (attrs.group ? { 'data-group': JSON.stringify(attrs.group) } : {}),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-condition-case]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-condition-case': '' }, HTMLAttributes), 0]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ConditionCaseNodeView)
+  },
+})

--- a/apps/web/src/components/agents/procedures/nodes/condition-else-node-view.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/condition-else-node-view.tsx
@@ -1,0 +1,41 @@
+// apps/web/src/components/agents/procedures/nodes/condition-else-node-view.tsx
+'use client'
+
+import type { NodeViewProps } from '@tiptap/react'
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import { CornerDownRight, X } from 'lucide-react'
+import { nodePos } from './condition-helpers'
+
+/** `conditionElse` view — the ELSE fallthrough arm (no predicate), `block+` body. */
+export function ConditionElseNodeView({ node, editor, getPos }: NodeViewProps) {
+  const removeArm = () => {
+    const pos = nodePos(getPos)
+    if (pos == null) return
+    editor
+      .chain()
+      .focus()
+      .deleteRange({ from: pos, to: pos + node.nodeSize })
+      .run()
+  }
+
+  return (
+    <NodeViewWrapper as='div' className='my-1.5'>
+      <div className='flex items-center gap-2' contentEditable={false}>
+        <span className='flex size-6 shrink-0 items-center justify-center rounded-md bg-primary-100 text-primary-700'>
+          <CornerDownRight className='size-3.5' />
+        </span>
+        <span className='text-xs font-semibold uppercase tracking-wide text-foreground'>Else</span>
+        <button
+          type='button'
+          onClick={removeArm}
+          aria-label='Remove else branch'
+          className='ml-auto rounded p-0.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'>
+          <X className='size-3.5' />
+        </button>
+      </div>
+      <div className='pl-8'>
+        <NodeViewContent />
+      </div>
+    </NodeViewWrapper>
+  )
+}

--- a/apps/web/src/components/agents/procedures/nodes/condition-else-node.ts
+++ b/apps/web/src/components/agents/procedures/nodes/condition-else-node.ts
@@ -1,0 +1,47 @@
+// apps/web/src/components/agents/procedures/nodes/condition-else-node.ts
+
+import { mergeAttributes, Node } from '@tiptap/core'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+import { selectAncestorContent } from '~/components/editor/keymap-helpers'
+import { ConditionElseNodeView } from './condition-else-node-view'
+
+/**
+ * `conditionElse` — the ELSE fallthrough arm of a {@link ConditionBlock}. No
+ * predicate; `block+` body, isolating (mirror `panel-node.ts`). At most one per
+ * block (enforced author-side; the compiler reads the last `conditionElse`).
+ */
+export const ConditionElse = Node.create({
+  name: 'conditionElse',
+  content: 'block+',
+  defining: true,
+  isolating: true,
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-a': ({ editor }) =>
+        selectAncestorContent(editor, (n) => n.type.name === 'conditionElse'),
+    }
+  },
+
+  addAttributes() {
+    return {
+      id: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-id'),
+        renderHTML: (attrs) => (attrs.id ? { 'data-id': attrs.id } : {}),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-condition-else]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-condition-else': '' }, HTMLAttributes), 0]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ConditionElseNodeView)
+  },
+})

--- a/apps/web/src/components/agents/procedures/nodes/condition-helpers.ts
+++ b/apps/web/src/components/agents/procedures/nodes/condition-helpers.ts
@@ -1,0 +1,56 @@
+// apps/web/src/components/agents/procedures/nodes/condition-helpers.ts
+
+import { generateId } from '@auxx/utils'
+import type { Editor } from '@tiptap/core'
+import type { NodeViewProps } from '@tiptap/react'
+
+/** An empty text `block` — the shared body child the arm containers require. */
+export function emptyBlock() {
+  return { type: 'block', attrs: { blockType: 'text' }, content: [] }
+}
+
+/** Resolve the document position of the node this NodeView renders, or null. */
+export function nodePos(getPos: NodeViewProps['getPos']): number | null {
+  if (typeof getPos !== 'function') return null
+  const pos = getPos()
+  return typeof pos === 'number' ? pos : null
+}
+
+/** Append a child node at the end of the container node at `containerPos`. */
+export function appendChild(
+  editor: Editor,
+  containerPos: number,
+  child: Record<string, unknown>
+): void {
+  const node = editor.state.doc.nodeAt(containerPos)
+  if (!node) return
+  const insertAt = containerPos + node.nodeSize - 1
+  editor.chain().focus().insertContentAt(insertAt, child).run()
+}
+
+/** A fresh `conditionCase` arm: empty text predicate (text mode) + one empty body block. */
+export function newConditionCase() {
+  return {
+    type: 'conditionCase',
+    attrs: {
+      id: generateId(),
+      mode: 'text',
+      group: { id: generateId(), conditions: [], logicalOperator: 'AND' },
+    },
+    content: [{ type: 'conditionPredicate', content: [] }, emptyBlock()],
+  }
+}
+
+/** A fresh `conditionElse` arm with one empty body block. */
+export function newConditionElse() {
+  return { type: 'conditionElse', attrs: { id: generateId() }, content: [emptyBlock()] }
+}
+
+/** A fresh `conditionBlock` with a single IF arm — what the `@` Condition picker inserts. */
+export function newConditionBlock() {
+  return {
+    type: 'conditionBlock',
+    attrs: { id: generateId() },
+    content: [newConditionCase()],
+  }
+}

--- a/apps/web/src/components/agents/procedures/nodes/condition-predicate-node-view.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/condition-predicate-node-view.tsx
@@ -1,0 +1,50 @@
+// apps/web/src/components/agents/procedures/nodes/condition-predicate-node-view.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import type { NodeViewProps } from '@tiptap/react'
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import { useMemo } from 'react'
+import { nodePos } from './condition-helpers'
+
+/**
+ * `conditionPredicate` view — the natural-language predicate writer. Renders as a
+ * bordered box with a placeholder hint; its `inline*` content holds the prose +
+ * attribute badges (`@`). Hidden when the parent {@link ConditionCase} is in
+ * `structured` mode (the builder takes over there) — detected by walking the PM
+ * parent for its `mode` attr (same technique as panel-node-view.tsx).
+ */
+export function ConditionPredicateNodeView({ node, editor, getPos }: NodeViewProps) {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `node` re-resolves parent mode on each doc change
+  const parentMode = useMemo(() => {
+    const pos = nodePos(getPos)
+    if (pos == null) return 'text'
+    try {
+      return (editor.state.doc.resolve(pos).parent.attrs.mode as string) ?? 'text'
+    } catch {
+      return 'text'
+    }
+  }, [editor, getPos, node])
+
+  const isEmpty = node.content.size === 0
+  const hidden = parentMode === 'structured'
+
+  return (
+    <NodeViewWrapper
+      as='div'
+      className={cn(
+        'relative my-1.5 rounded-lg border border-border bg-background px-3 py-2 text-sm',
+        hidden && 'hidden'
+      )}>
+      <NodeViewContent className='min-h-5 outline-none' />
+      {isEmpty && (
+        <span
+          className='pointer-events-none absolute left-3 top-2 select-none text-muted-foreground/60'
+          contentEditable={false}
+          aria-hidden='true'>
+          Write a condition in natural language, type “@” to insert attribute.
+        </span>
+      )}
+    </NodeViewWrapper>
+  )
+}

--- a/apps/web/src/components/agents/procedures/nodes/condition-predicate-node.ts
+++ b/apps/web/src/components/agents/procedures/nodes/condition-predicate-node.ts
@@ -1,0 +1,32 @@
+// apps/web/src/components/agents/procedures/nodes/condition-predicate-node.ts
+
+import { mergeAttributes, Node } from '@tiptap/core'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+import { ConditionPredicateNodeView } from './condition-predicate-node-view'
+
+/**
+ * `conditionPredicate` — the natural-language predicate writer for a
+ * {@link ConditionCase} in `text` mode (plan §4). `inline*` content so it holds
+ * text + inline reference badges (`@` inserts attribute badges). One per arm, the
+ * leading child of `conditionCase`. In `structured` mode it stays empty and the
+ * arm's `group` attr is the source of truth instead.
+ */
+export const ConditionPredicate = Node.create({
+  name: 'conditionPredicate',
+  content: 'inline*',
+  defining: true,
+  isolating: true,
+  marks: '',
+
+  parseHTML() {
+    return [{ tag: 'div[data-condition-predicate]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-condition-predicate': '' }, HTMLAttributes), 0]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ConditionPredicateNodeView)
+  },
+})

--- a/apps/web/src/components/agents/procedures/nodes/procedure-step-badge.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/procedure-step-badge.tsx
@@ -1,0 +1,141 @@
+// apps/web/src/components/agents/procedures/nodes/procedure-step-badge.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { ArrowRight, Code2, CornerDownRight, Hand, Settings2, Square, Workflow } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { api } from '~/trpc/react'
+import { useProcedureEditorContext } from '../ui/procedure-editor-context'
+
+const PILL =
+  'inline-flex items-center gap-1 align-baseline rounded-md px-1.5 py-0 text-sm bg-primary-100 text-primary-700 ring-1 ring-primary-200 transition-all'
+
+/**
+ * Inline step badges for the v9 procedure editor — one badge system, the kind
+ * keyed off the id-prefix (plan §2):
+ *
+ * - `route:finished` / `route:handoff` / `route:switch:<procId>` — terminal pills,
+ * - `subprocedure:<id>` — "run sub-procedure" pill + cog → drill into its body,
+ * - `code:<id>` — code pill + cog → drill into the code editor.
+ *
+ * Names + the cog's drill target come from {@link useProcedureEditorContext}
+ * (the doc-level `subProcedures` / `codeBlocks` maps); `switch` resolves the
+ * target procedure name from the org list.
+ */
+export function ProcedureStepBadge({ id, selected }: { id: string; selected: boolean }) {
+  if (id.startsWith('subprocedure:')) {
+    return <SubProcedureBadge subId={id.slice('subprocedure:'.length)} selected={selected} />
+  }
+  if (id.startsWith('code:')) {
+    return <CodeBadge codeId={id.slice('code:'.length)} selected={selected} />
+  }
+  if (id.startsWith('route:')) {
+    return <RouteBadge payload={id.slice('route:'.length)} selected={selected} />
+  }
+  return <span className={cn(PILL, selected && 'ring-primary-400')}>{id}</span>
+}
+
+/** Detects whether a given prefixed id is a procedure step badge (vs. a plain reference). */
+export function isProcedureStepId(id: string): boolean {
+  return id.startsWith('subprocedure:') || id.startsWith('code:') || id.startsWith('route:')
+}
+
+function Pill({
+  icon,
+  selected,
+  onCog,
+  children,
+}: {
+  icon: ReactNode
+  selected: boolean
+  onCog?: () => void
+  children: ReactNode
+}) {
+  return (
+    <span className={cn(PILL, selected && 'ring-primary-400')}>
+      <span className='shrink-0 opacity-70'>{icon}</span>
+      <span className='truncate'>{children}</span>
+      {onCog && (
+        <button
+          type='button'
+          tabIndex={-1}
+          aria-label='Edit'
+          contentEditable={false}
+          onMouseDown={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+          }}
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            onCog()
+          }}
+          className='ml-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm opacity-60 hover:bg-primary-200 hover:opacity-100'>
+          <Settings2 className='size-3' />
+        </button>
+      )}
+    </span>
+  )
+}
+
+function SubProcedureBadge({ subId, selected }: { subId: string; selected: boolean }) {
+  const ctx = useProcedureEditorContext()
+  const name = ctx?.subProcedures.find((s) => s.id === subId)?.name ?? 'Sub-procedure'
+  return (
+    <Pill
+      icon={<Workflow className='size-3.5' />}
+      selected={selected}
+      onCog={ctx ? () => ctx.drillInto(`sub:${subId}`) : undefined}>
+      {name}
+      <ArrowRight className='ml-0.5 inline size-3 opacity-60' />
+    </Pill>
+  )
+}
+
+function CodeBadge({ codeId, selected }: { codeId: string; selected: boolean }) {
+  const ctx = useProcedureEditorContext()
+  const name = ctx?.codeBlocks.find((c) => c.id === codeId)?.name ?? 'Code'
+  return (
+    <Pill
+      icon={<Code2 className='size-3.5' />}
+      selected={selected}
+      onCog={ctx ? () => ctx.drillInto(`code:${codeId}`) : undefined}>
+      {name}
+    </Pill>
+  )
+}
+
+function RouteBadge({ payload, selected }: { payload: string; selected: boolean }) {
+  if (payload === 'finished') {
+    return (
+      <Pill icon={<Square className='size-3.5' />} selected={selected}>
+        End procedure
+      </Pill>
+    )
+  }
+  if (payload === 'handoff') {
+    return (
+      <Pill icon={<Hand className='size-3.5' />} selected={selected}>
+        Hand off to human
+      </Pill>
+    )
+  }
+  if (payload.startsWith('switch:')) {
+    return <SwitchBadge procId={payload.slice('switch:'.length)} selected={selected} />
+  }
+  return (
+    <Pill icon={<CornerDownRight className='size-3.5' />} selected={selected}>
+      {payload}
+    </Pill>
+  )
+}
+
+function SwitchBadge({ procId, selected }: { procId: string; selected: boolean }) {
+  const list = api.procedure.list.useQuery()
+  const name = list.data?.find((p) => p.id === procId)?.name ?? 'Procedure'
+  return (
+    <Pill icon={<CornerDownRight className='size-3.5' />} selected={selected}>
+      Switch to {name}
+    </Pill>
+  )
+}

--- a/apps/web/src/components/agents/procedures/ui/code-block-editor.tsx
+++ b/apps/web/src/components/agents/procedures/ui/code-block-editor.tsx
@@ -1,0 +1,30 @@
+// apps/web/src/components/agents/procedures/ui/code-block-editor.tsx
+'use client'
+
+import { Textarea } from '@auxx/ui/components/textarea'
+
+interface CodeBlockEditorProps {
+  code: string
+  onChange: (code: string) => void
+}
+
+/**
+ * The drilled body for a `code:<id>` badge — a plain monospace editor over the
+ * code-block's JavaScript. Reached by the badge cog (NavStack push); the body
+ * lives in the doc-level `codeBlocks` map, never inline in the prose (plan §6).
+ * The full inputs/outputs binding UI is a follow-up; today the script reads /
+ * writes declared attributes by name.
+ */
+export function CodeBlockEditor({ code, onChange }: CodeBlockEditorProps) {
+  return (
+    <div className='w-full py-3'>
+      <Textarea
+        value={code}
+        spellCheck={false}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder='// JavaScript — read/write declared attributes by name'
+        className='min-h-64 w-full resize-none border-0 font-mono text-xs focus-visible:ring-0'
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/procedures/ui/procedure-detail-bar.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-detail-bar.tsx
@@ -1,0 +1,68 @@
+// apps/web/src/components/agents/procedures/ui/procedure-detail-bar.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { useNavStack } from '@auxx/ui/components/nav-stack'
+import { toastError } from '@auxx/ui/components/toast'
+import { ChevronLeft } from 'lucide-react'
+import { useCallback } from 'react'
+import { api } from '~/trpc/react'
+import { AutosaveIndicator, type AutosaveState } from '../../ui/shared/autosave-indicator'
+
+interface ProcedureDetailBarProps {
+  procedureId: string
+  /** Lifted from the editor — shows live Saving…/Saved next to Publish. */
+  autosave: AutosaveState
+}
+
+/**
+ * The procedure-detail nav bar: the shared-bar content for the pushed `procedure`
+ * NavStack level. Same height as the agent tab strip (`h-9`) so the shared
+ * `<NavStackBar>` frame doesn't jump as the two cross-fade. Carries Back, the
+ * procedure name, autosave status, and Publish — version history lands here next.
+ *
+ * Rendered by `<NavStackBar>` (which sits OUTSIDE `NavStackPanels`' `overflow-hidden`),
+ * so the page-level sticky bar pins to the outer `ScrollArea` while the panels slide.
+ */
+export function ProcedureDetailBar({ procedureId, autosave }: ProcedureDetailBarProps) {
+  const { pop } = useNavStack()
+  const utils = api.useUtils()
+  const query = api.procedure.getById.useQuery({ id: procedureId })
+  const publish = api.procedure.publish.useMutation()
+
+  const data = query.data
+  const name = data?.name ?? 'Procedure'
+  const whenToUseEmpty = (data?.whenToUse ?? '').trim() === ''
+
+  const handlePublish = useCallback(async () => {
+    try {
+      await publish.mutateAsync({ id: procedureId })
+      await utils.procedure.getById.invalidate({ id: procedureId })
+      await utils.procedure.listVersions.invalidate({ id: procedureId })
+    } catch (err) {
+      toastError({ title: 'Publish failed', description: (err as Error).message })
+    }
+  }, [publish, procedureId, utils])
+
+  return (
+    <div className='flex h-9 items-center gap-2 px-2'>
+      <Button variant='ghost' size='sm' onClick={() => pop()}>
+        <ChevronLeft />
+        Back
+      </Button>
+      <span className='truncate text-sm font-medium'>{name}</span>
+      <div className='ml-auto flex items-center gap-2'>
+        <AutosaveIndicator state={autosave} />
+        {/* TODO: version-history dropdown (procedure.listVersions + revert) lands here. */}
+        <Button
+          size='sm'
+          loading={publish.isPending}
+          loadingText='Publishing…'
+          disabled={whenToUseEmpty}
+          onClick={handlePublish}>
+          Publish
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/procedures/ui/procedure-editor-context.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-editor-context.tsx
@@ -1,0 +1,70 @@
+// apps/web/src/components/agents/procedures/ui/procedure-editor-context.tsx
+'use client'
+
+import type { LocalAttribute } from '@auxx/lib/agents/procedures/client'
+import { createContext, type ReactNode, useContext } from 'react'
+
+/** Lightweight identity for a drilled body — what the inline badge needs to render. */
+export interface SubProcedureMeta {
+  id: string
+  name: string
+}
+
+export interface CodeBlockMeta {
+  id: string
+  name: string
+  language: 'javascript'
+}
+
+/**
+ * Editor-level shared state the procedure node views + inline step badges read.
+ * Node views render in their own React roots but DO see app-level context that
+ * wraps `<EditorContent>` (only sibling/parent NODE-VIEW context is unreachable —
+ * see panel-node-view.tsx). So the procedure editor wraps its canvas in this
+ * provider and the badges / condition views consume:
+ *
+ * - `localAttributes` — declared scratch (the "Temporary" attribute group),
+ * - the `subProcedures` / `codeBlocks` maps (drilled bodies, by id) — badges
+ *   resolve their display name + the cog's drill target from here,
+ * - `drillInto` — push a level onto the editor's NavStack (the cog action),
+ *
+ * rather than threading props through TipTap. Returns `null` outside an editor.
+ */
+export interface ProcedureEditorContextValue {
+  procedureId: string
+  /** Declared procedure-local scratch (the doc's `localAttributes`). */
+  localAttributes: LocalAttribute[]
+  /** Append a new declared local attribute (the "Create attribute" affordance). */
+  addLocalAttribute: (attr: LocalAttribute) => void
+  /** Sub-procedure bodies declared in this doc (drilled via the `subprocedure:` badge cog). */
+  subProcedures: SubProcedureMeta[]
+  /** Code-block bodies declared in this doc (drilled via the `code:` badge cog). */
+  codeBlocks: CodeBlockMeta[]
+  /** Push a drill level onto the editor NavStack — e.g. `sub:<id>` or `code:<id>`. */
+  drillInto: (level: string) => void
+  /** Create a sub-procedure body (picker "new") → returns its id for the badge. */
+  createSubProcedure: (name: string) => string
+  /** Create a code-block body (picker "new") → returns its id for the badge. */
+  createCodeBlock: (name: string) => string
+  /** Insert a block node into the active canvas (the `@` Condition path; not a badge). */
+  insertBlock: (node: Record<string, unknown>) => void
+  /** Remove the open `@`-picker chip without inserting a badge. */
+  closePicker: () => void
+}
+
+const ProcedureEditorContext = createContext<ProcedureEditorContextValue | null>(null)
+
+export function ProcedureEditorProvider({
+  value,
+  children,
+}: {
+  value: ProcedureEditorContextValue
+  children: ReactNode
+}) {
+  return <ProcedureEditorContext.Provider value={value}>{children}</ProcedureEditorContext.Provider>
+}
+
+/** Read editor-level procedure state from inside a node view (returns null outside an editor). */
+export function useProcedureEditorContext(): ProcedureEditorContextValue | null {
+  return useContext(ProcedureEditorContext)
+}

--- a/apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
@@ -1,0 +1,420 @@
+// apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
+'use client'
+
+import type { LocalAttribute, TriggerExample } from '@auxx/lib/agents/procedures/client'
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { Dialog, DialogContent, DialogTitle } from '@auxx/ui/components/dialog'
+import { NavStack, NavStackPanel, NavStackPanels } from '@auxx/ui/components/nav-stack'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import Section, { EmptySection } from '@auxx/ui/components/section'
+import { VisuallyHidden } from '@auxx/ui/components/visually-hidden'
+import { cn } from '@auxx/ui/lib/utils'
+import { generateId } from '@auxx/utils'
+import type { JSONContent } from '@tiptap/core'
+import type { Editor } from '@tiptap/react'
+import { ListChecks } from 'lucide-react'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { DEFAULT_TABS } from '~/components/editor/inline-picker'
+import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
+import {
+  PromptCharacterCount,
+  PromptEditorContent,
+  PromptEditorHeader,
+} from '~/components/editor/prompt-editor'
+import type { ReferencePickerHandle } from '~/components/pickers/reference-picker/reference-picker-content'
+import CollapseWrap from '~/components/workflow/ui/collapse-wrap'
+import { api } from '~/trpc/react'
+import type { AutosaveState } from '../../ui/shared/autosave-indicator'
+import { useProcedureAutosave } from '../hooks/use-procedure-autosave'
+import { CodeBlockEditor } from './code-block-editor'
+import { ProcedureEditorProvider } from './procedure-editor-context'
+import { ProcedureTriggerHeader } from './procedure-trigger-header'
+
+const COLLAPSED_MIN_HEIGHT = 120
+
+// Procedures opt into the admin tabs (Tools, Resources, Fields) exactly like the
+// persona editor, PLUS the procedure step tabs (Routing, Code, Sub-procedure,
+// Condition) — the `@` picker is the only insertion surface (plan §5).
+const PROCEDURE_REFERENCE_TABS: ReferenceTab[] = [
+  ...DEFAULT_TABS,
+  'tools',
+  'resources',
+  'fields',
+  'routing',
+  'code',
+  'subprocedure',
+  'condition',
+]
+
+interface SubProcedureEntry {
+  id: string
+  name: string
+  content: JSONContent[]
+}
+
+interface CodeBlockEntry {
+  id: string
+  name: string
+  language: 'javascript'
+  code: string
+}
+
+interface DraftDoc {
+  content?: JSONContent[]
+  localAttributes?: LocalAttribute[]
+  subProcedures?: SubProcedureEntry[]
+  codeBlocks?: CodeBlockEntry[]
+}
+
+interface ProcedureEditorProps {
+  procedureId: string
+  /** Lifted autosave state — used by the page-header indicator. */
+  onAutosaveChange?: (state: AutosaveState) => void
+}
+
+function readContent(content: unknown): JSONContent[] {
+  return Array.isArray(content) ? (content as JSONContent[]) : []
+}
+
+/**
+ * The procedure authoring canvas. Visual structure is the **persona editor**
+ * (`persona-editor.tsx`) verbatim — focus-gradient border, header with copy +
+ * expand actions, `CollapseWrap`, the expand-to-dialog two-editor pattern — with
+ * the procedure step nodes enabled and `@` as the only insertion surface.
+ *
+ * Drill-in: sub-procedure / code-block bodies live OUTSIDE the prose tree in the
+ * doc-level `subProcedures` / `codeBlocks` maps (plan §6). The inline badge cog
+ * pushes a level onto an editor-local `NavStack`; the canvas swaps to that body
+ * and the header retitles + grows a back button. Each level autosaves into its own
+ * map slot; the whole draft flushes as one `patch({ doc })`.
+ */
+export function ProcedureEditor({ procedureId, onAutosaveChange }: ProcedureEditorProps) {
+  const referencePickerRef = useRef<ReferencePickerHandle | null>(null)
+  const { patch } = useProcedureAutosave(procedureId, { onStateChange: onAutosaveChange })
+  const query = api.procedure.getById.useQuery({ id: procedureId })
+  const data = query.data
+
+  const [isExpanded, setExpanded] = useState(false)
+  const [isFocused, setFocused] = useState(false)
+  const [isCollapsed, setCollapsed] = useState(true)
+  const [isCopied, setIsCopied] = useState(false)
+  const [activeEditor, setActiveEditor] = useState<Editor | null>(null)
+  const [drillStack, setDrillStack] = useState<string[]>(['root'])
+
+  // Render state — what the canvas + badges read.
+  const [localAttributes, setLocalAttributes] = useState<LocalAttribute[]>([])
+  const [subProcedures, setSubProcedures] = useState<SubProcedureEntry[]>([])
+  const [codeBlocks, setCodeBlocks] = useState<CodeBlockEntry[]>([])
+
+  // Save-source refs — read by `commit` so debounced flushes never see stale
+  // closures. Kept in lockstep with the state setters below.
+  const mainContentRef = useRef<JSONContent[]>([])
+  const localAttrRef = useRef<LocalAttribute[]>([])
+  const subRef = useRef<SubProcedureEntry[]>([])
+  const codeRef = useRef<CodeBlockEntry[]>([])
+  const loadedRef = useRef<string | null>(null)
+
+  // Seed every slice once per loaded procedure (async query → can't be a ref
+  // initializer; seeding in render guarantees the canvas mounts with content).
+  if (data && loadedRef.current !== procedureId) {
+    loadedRef.current = procedureId
+    const doc = (data.draftDoc ?? null) as DraftDoc | null
+    mainContentRef.current = readContent(doc?.content)
+    localAttrRef.current = doc?.localAttributes ?? []
+    subRef.current = (doc?.subProcedures ?? []).map((s) => ({
+      ...s,
+      content: readContent(s.content),
+    }))
+    codeRef.current = doc?.codeBlocks ?? []
+    setLocalAttributes(localAttrRef.current)
+    setSubProcedures(subRef.current)
+    setCodeBlocks(codeRef.current)
+  }
+
+  const commit = useCallback(() => {
+    patch(
+      {
+        doc: {
+          type: 'doc',
+          content: mainContentRef.current,
+          localAttributes: localAttrRef.current,
+          subProcedures: subRef.current,
+          codeBlocks: codeRef.current,
+        },
+      },
+      { debounceMs: 1500 }
+    )
+  }, [patch])
+
+  const handleMainChange = useCallback(
+    ({ json }: { json: JSONContent; html: string }) => {
+      mainContentRef.current = readContent(json.content)
+      commit()
+    },
+    [commit]
+  )
+
+  const makeSubChange = useCallback(
+    (id: string) =>
+      ({ json }: { json: JSONContent; html: string }) => {
+        const next = subRef.current.map((s) =>
+          s.id === id ? { ...s, content: readContent(json.content) } : s
+        )
+        subRef.current = next
+        setSubProcedures(next)
+        commit()
+      },
+    [commit]
+  )
+
+  const handleCodeChange = useCallback(
+    (id: string, code: string) => {
+      const next = codeRef.current.map((c) => (c.id === id ? { ...c, code } : c))
+      codeRef.current = next
+      setCodeBlocks(next)
+      commit()
+    },
+    [commit]
+  )
+
+  const addLocalAttribute = useCallback(
+    (attr: LocalAttribute) => {
+      if (localAttrRef.current.some((a) => a.name === attr.name)) return
+      const next = [...localAttrRef.current, attr]
+      localAttrRef.current = next
+      setLocalAttributes(next)
+      commit()
+    },
+    [commit]
+  )
+
+  const createSubProcedure = useCallback(
+    (name: string) => {
+      const id = generateId()
+      const entry: SubProcedureEntry = { id, name: name.trim() || 'Untitled', content: [] }
+      const next = [...subRef.current, entry]
+      subRef.current = next
+      setSubProcedures(next)
+      commit()
+      return id
+    },
+    [commit]
+  )
+
+  const createCodeBlock = useCallback(
+    (name: string) => {
+      const id = generateId()
+      const entry: CodeBlockEntry = {
+        id,
+        name: name.trim() || 'Code',
+        language: 'javascript',
+        code: '',
+      }
+      const next = [...codeRef.current, entry]
+      codeRef.current = next
+      setCodeBlocks(next)
+      commit()
+      return id
+    },
+    [commit]
+  )
+
+  const insertBlock = useCallback(
+    (node: Record<string, unknown>) => {
+      if (!activeEditor) return
+      // Two commands, not a chain: a chained `closeReferencePicker` returning
+      // false (no open chip) would abort the `insertContent`.
+      activeEditor.commands.closeReferencePicker({ keepText: false })
+      activeEditor.commands.insertContent(node)
+      activeEditor.commands.focus()
+    },
+    [activeEditor]
+  )
+
+  const closePicker = useCallback(() => {
+    activeEditor?.commands.closeReferencePicker({ keepText: false })
+  }, [activeEditor])
+
+  const drillInto = useCallback((level: string) => {
+    setDrillStack((prev) => (prev.includes(level) ? prev : [...prev, level]))
+  }, [])
+
+  const popDrill = useCallback(() => {
+    setDrillStack((prev) => (prev.length > 1 ? prev.slice(0, -1) : prev))
+  }, [])
+
+  const handleCopy = useCallback(() => {
+    if (!activeEditor) return
+    const text = activeEditor.getText()
+    if (navigator.clipboard) navigator.clipboard.writeText(text)
+    setIsCopied(true)
+    setTimeout(() => setIsCopied(false), 2000)
+  }, [activeEditor])
+
+  const handleUserActivity = useCallback(() => setCollapsed(false), [])
+
+  // NavStack keeps the exiting panel mounted during the slide, so the old
+  // editor's unmount cleanup (`onEditorReady(null)`) can land AFTER the new one
+  // registered. Keep the newest live editor: ignore a null when the current one
+  // is still alive (a real swap always re-registers a non-null editor first).
+  const handleEditorReady = useCallback((editor: Editor | null) => {
+    setActiveEditor((prev) => {
+      if (editor) return editor
+      return prev?.isDestroyed === false ? prev : null
+    })
+  }, [])
+
+  const countSlot = useMemo(() => <PromptCharacterCount editor={activeEditor} />, [activeEditor])
+
+  // Title + back reflect the drill stack: root = "Procedure", deeper = the body's name.
+  const top = drillStack[drillStack.length - 1] ?? 'root'
+  const title = useMemo(() => {
+    if (top === 'root') return 'Procedure'
+    const [kind, id] = top.split(/:(.+)/)
+    if (kind === 'sub') return subProcedures.find((s) => s.id === id)?.name ?? 'Sub-procedure'
+    if (kind === 'code') return codeBlocks.find((c) => c.id === id)?.name ?? 'Code'
+    return 'Procedure'
+  }, [top, subProcedures, codeBlocks])
+
+  const ctxValue = useMemo(
+    () => ({
+      procedureId,
+      localAttributes,
+      addLocalAttribute,
+      subProcedures: subProcedures.map((s) => ({ id: s.id, name: s.name })),
+      codeBlocks: codeBlocks.map((c) => ({ id: c.id, name: c.name, language: c.language })),
+      drillInto,
+      createSubProcedure,
+      createCodeBlock,
+      insertBlock,
+      closePicker,
+    }),
+    [
+      procedureId,
+      localAttributes,
+      addLocalAttribute,
+      subProcedures,
+      codeBlocks,
+      drillInto,
+      createSubProcedure,
+      createCodeBlock,
+      insertBlock,
+      closePicker,
+    ]
+  )
+
+  const header = (
+    <PromptEditorHeader
+      title={title}
+      onBack={drillStack.length > 1 ? popDrill : undefined}
+      countSlot={countSlot}
+      isExpanded={isExpanded}
+      setExpanded={setExpanded}
+      isCopied={isCopied}
+      onCopy={handleCopy}
+    />
+  )
+
+  // The drilled canvas for the current stack top. Sub-procedure → a fresh
+  // PromptEditorContent on its slice; code → the code editor. NavStackPanels only
+  // mounts the top panel (+ the one beneath during a transition), so editor
+  // instances stay ~1-2 at a time despite the dynamic declaration.
+  const canvas = (
+    <NavStack stack={drillStack} onStackChange={setDrillStack} className='w-full'>
+      <NavStackPanels>
+        <NavStackPanel value='root'>
+          <PromptEditorContent
+            initialContent={mainContentRef.current}
+            onChange={handleMainChange}
+            onEditorReady={handleEditorReady}
+            onFocusChange={setFocused}
+            onUserActivity={handleUserActivity}
+            referencePickerRef={referencePickerRef}
+            referenceTabs={PROCEDURE_REFERENCE_TABS}
+            enableProcedureNodes
+          />
+        </NavStackPanel>
+        {subProcedures.map((s) => (
+          <NavStackPanel key={s.id} value={`sub:${s.id}`}>
+            <PromptEditorContent
+              initialContent={s.content}
+              onChange={makeSubChange(s.id)}
+              onEditorReady={handleEditorReady}
+              onFocusChange={setFocused}
+              onUserActivity={handleUserActivity}
+              referencePickerRef={referencePickerRef}
+              referenceTabs={PROCEDURE_REFERENCE_TABS}
+              enableProcedureNodes
+            />
+          </NavStackPanel>
+        ))}
+        {codeBlocks.map((c) => (
+          <NavStackPanel key={c.id} value={`code:${c.id}`}>
+            <CodeBlockEditor code={c.code} onChange={(code) => handleCodeChange(c.id, code)} />
+          </NavStackPanel>
+        ))}
+      </NavStackPanels>
+    </NavStack>
+  )
+
+  if (query.isLoading || !data) return <EmptySection loading className='mx-3 my-3' />
+
+  return (
+    <ProcedureEditorProvider value={ctxValue}>
+      <ProcedureTriggerHeader
+        whenToUse={data.whenToUse}
+        triggerExamples={(data.triggerExamples ?? []) as TriggerExample[]}
+        ruleset={(data.ruleset ?? []) as ConditionGroup[]}
+        localAttributes={localAttributes}
+        onPatch={patch}
+      />
+      <Section
+        title='When to use'
+        icon={<ListChecks className='size-4' />}
+        description='Describe the situation that should select this procedure.'
+        initialOpen
+        collapsible={false}>
+        <div
+          className={cn(
+            isFocused && !isExpanded
+              ? 'bg-gradient-to-r from-[#0ba5ec] to-[#155aef]'
+              : 'bg-transparent',
+            '!rounded-[9px] p-0.5'
+          )}>
+          <div
+            className={cn(isFocused ? 'bg-background' : 'bg-primary-200/30', 'rounded-lg border')}>
+            {header}
+            {!isExpanded && (
+              <CollapseWrap
+                minHeight={COLLAPSED_MIN_HEIGHT}
+                isCollapsed={isCollapsed}
+                onCollapsedChange={setCollapsed}
+                className='px-3'
+                gradientClassName='from-primary-200/30 dark:from-primary-200/30'>
+                <div className='relative flex w-full bg-red-500'>{canvas}</div>
+              </CollapseWrap>
+            )}
+          </div>
+        </div>
+      </Section>
+
+      <Dialog open={isExpanded} onOpenChange={setExpanded}>
+        <DialogContent size='3xl' innerClassName='h-[80vh] flex flex-col p-0' showClose={false}>
+          <VisuallyHidden>
+            <DialogTitle>{title}</DialogTitle>
+          </VisuallyHidden>
+          <div className='shrink-0 border-b'>{header}</div>
+          <div className='flex-1 min-h-0 overflow-hidden'>
+            <ScrollArea
+              className='relative h-full min-h-0 px-3 flex-1 flex'
+              fadeClassName=''
+              allowScrollChaining
+              scrollbarClassName='w-1 mr-0.5 data-[hovering]:opacity-0 hover:!opacity-100'>
+              {isExpanded && canvas}
+            </ScrollArea>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </ProcedureEditorProvider>
+  )
+}

--- a/apps/web/src/components/agents/procedures/ui/procedure-picker-lists.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-picker-lists.tsx
@@ -1,0 +1,189 @@
+// apps/web/src/components/agents/procedures/ui/procedure-picker-lists.tsx
+'use client'
+
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandPlaceholder,
+} from '@auxx/ui/components/command'
+import { Code2, CornerDownRight, GitBranch, Hand, Plus, Square, Workflow } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { api } from '~/trpc/react'
+import { newConditionBlock } from '../nodes/condition-helpers'
+import { useProcedureEditorContext } from './procedure-editor-context'
+
+/**
+ * The `@`-picker lists for the v9 procedure step tabs (plan §5). Every insertion
+ * goes through `@`: these render inside `ReferencePickerContent` for the
+ * `routing` / `code` / `subprocedure` / `condition` tabs and act on the
+ * {@link useProcedureEditorContext} (create / drill / insert). Terminal picks call
+ * `onSelect(id)` → an inline reference badge; `condition` inserts a block node.
+ */
+
+interface PickerListProps {
+  /** Search query forwarded from the picker chip. */
+  query: string
+  /** Insert an inline badge with this id (→ `confirmReferencePicker`). */
+  onSelect: (id: string) => void
+}
+
+function Row({
+  icon,
+  label,
+  value,
+  onSelect,
+}: {
+  icon: ReactNode
+  label: string
+  value: string
+  onSelect: () => void
+}) {
+  return (
+    <CommandItem value={value} onSelect={onSelect} className='flex items-center gap-2'>
+      <span className='text-muted-foreground'>{icon}</span>
+      <span className='truncate text-sm'>{label}</span>
+    </CommandItem>
+  )
+}
+
+function matches(label: string, query: string) {
+  return !query.trim() || label.toLowerCase().includes(query.trim().toLowerCase())
+}
+
+/** Routing tab — End / Hand off / Switch to another procedure (terminal badges). */
+export function RoutingPickerList({ query, onSelect }: PickerListProps) {
+  const list = api.procedure.list.useQuery()
+  const switchTargets = (list.data ?? []).filter((p) => matches(`Switch to ${p.name}`, query))
+
+  return (
+    <Command shouldFilter={false} className='rounded-lg'>
+      <CommandList>
+        <CommandGroup aria-label='Routing'>
+          {matches('End procedure', query) && (
+            <Row
+              icon={<Square className='size-4' />}
+              label='End procedure'
+              value='route:finished'
+              onSelect={() => onSelect('route:finished')}
+            />
+          )}
+          {matches('Hand off to human', query) && (
+            <Row
+              icon={<Hand className='size-4' />}
+              label='Hand off to human'
+              value='route:handoff'
+              onSelect={() => onSelect('route:handoff')}
+            />
+          )}
+          {switchTargets.map((p) => (
+            <Row
+              key={p.id}
+              icon={<CornerDownRight className='size-4' />}
+              label={`Switch to ${p.name}`}
+              value={`route:switch:${p.id}`}
+              onSelect={() => onSelect(`route:switch:${p.id}`)}
+            />
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}
+
+/** Sub-procedure tab — pick an existing one, or create from the typed query. */
+export function SubProcedurePickerList({ query, onSelect }: PickerListProps) {
+  const ctx = useProcedureEditorContext()
+  const existing = (ctx?.subProcedures ?? []).filter((s) => matches(s.name, query))
+
+  const create = () => {
+    if (!ctx) return
+    const id = ctx.createSubProcedure(query)
+    onSelect(`subprocedure:${id}`)
+    ctx.drillInto(`sub:${id}`)
+  }
+
+  return (
+    <Command shouldFilter={false} className='rounded-lg'>
+      <CommandList>
+        <CommandGroup aria-label='Sub-procedures'>
+          {existing.map((s) => (
+            <Row
+              key={s.id}
+              icon={<Workflow className='size-4' />}
+              label={s.name}
+              value={`subprocedure:${s.id}`}
+              onSelect={() => onSelect(`subprocedure:${s.id}`)}
+            />
+          ))}
+          <Row
+            icon={<Plus className='size-4' />}
+            label={query.trim() ? `Create sub-procedure “${query.trim()}”` : 'Create sub-procedure'}
+            value='__create-subprocedure'
+            onSelect={create}
+          />
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}
+
+/** Code tab — pick an existing code block, or create from the typed query. */
+export function CodePickerList({ query, onSelect }: PickerListProps) {
+  const ctx = useProcedureEditorContext()
+  const existing = (ctx?.codeBlocks ?? []).filter((c) => matches(c.name, query))
+
+  const create = () => {
+    if (!ctx) return
+    const id = ctx.createCodeBlock(query)
+    onSelect(`code:${id}`)
+    ctx.drillInto(`code:${id}`)
+  }
+
+  return (
+    <Command shouldFilter={false} className='rounded-lg'>
+      <CommandList>
+        <CommandGroup aria-label='Code'>
+          {existing.map((c) => (
+            <Row
+              key={c.id}
+              icon={<Code2 className='size-4' />}
+              label={c.name}
+              value={`code:${c.id}`}
+              onSelect={() => onSelect(`code:${c.id}`)}
+            />
+          ))}
+          <Row
+            icon={<Plus className='size-4' />}
+            label={query.trim() ? `Create code block “${query.trim()}”` : 'Create code block'}
+            value='__create-code'
+            onSelect={create}
+          />
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}
+
+/** Condition tab — inserts an IF/ELSE block (not a badge). */
+export function ConditionPickerList() {
+  const ctx = useProcedureEditorContext()
+  return (
+    <Command shouldFilter={false} className='rounded-lg'>
+      <CommandList>
+        {!ctx && <CommandPlaceholder>Unavailable</CommandPlaceholder>}
+        {ctx && (
+          <CommandGroup aria-label='Condition'>
+            <Row
+              icon={<GitBranch className='size-4' />}
+              label='Insert condition (IF / ELSE)'
+              value='__insert-condition'
+              onSelect={() => ctx.insertBlock(newConditionBlock())}
+            />
+          </CommandGroup>
+        )}
+      </CommandList>
+    </Command>
+  )
+}

--- a/apps/web/src/components/agents/procedures/ui/procedure-row.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-row.tsx
@@ -1,0 +1,61 @@
+// apps/web/src/components/agents/procedures/ui/procedure-row.tsx
+'use client'
+
+import { Switch } from '@auxx/ui/components/switch'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { ChevronRight, FileText, Trash2 } from 'lucide-react'
+import { Tooltip } from '~/components/global/tooltip'
+import type { RouterOutputs } from '~/trpc/react'
+
+type ProcedureLink = RouterOutputs['agentProcedure']['list'][number]
+
+interface ProcedureRowProps {
+  row: ProcedureLink
+  onOpen: () => void
+  onToggle: (enabled: boolean) => void
+  onDelete: () => void
+}
+
+/**
+ * One attached-procedure row. Clicking the title drills into the editor; the
+ * enable switch + delete live in `actions` (TreeRow stops their propagation) and
+ * a static chevron signals the drill-in.
+ */
+export function ProcedureRow({ row, onOpen, onToggle, onDelete }: ProcedureRowProps) {
+  const summary = row.whenToUse?.trim() || 'No description yet'
+  return (
+    <TreeRow
+      icon={<FileText className='size-4 text-muted-foreground' />}
+      title={row.name}
+      secondary={
+        <span className='truncate text-xs text-muted-foreground'>
+          {summary}
+          {row.hasUnpublishedChanges ? ' · unpublished' : ''}
+          {!row.isPublished ? ' · draft' : ''}
+        </span>
+      }
+      onTitleClick={onOpen}
+      actions={
+        <>
+          <Tooltip side='left' content='Delete procedure' allowInteraction>
+            <button
+              type='button'
+              onClick={onDelete}
+              aria-label='Delete procedure'
+              className='p-1 rounded-md hover:bg-destructive/10 opacity-0 group-hover/tree-row:opacity-100'>
+              <Trash2 className='size-4 text-muted-foreground hover:text-destructive' />
+            </button>
+          </Tooltip>
+          <Switch size='xs' className='ml-1' checked={row.enabled} onCheckedChange={onToggle} />
+          <button
+            type='button'
+            onClick={onOpen}
+            aria-label='Open procedure'
+            className='ml-1 p-1 rounded-md hover:bg-primary/5'>
+            <ChevronRight className='size-4 text-muted-foreground' />
+          </button>
+        </>
+      }
+    />
+  )
+}

--- a/apps/web/src/components/agents/procedures/ui/procedure-trigger-header.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-trigger-header.tsx
@@ -1,0 +1,104 @@
+// apps/web/src/components/agents/procedures/ui/procedure-trigger-header.tsx
+'use client'
+
+import type { LocalAttribute, TriggerExample } from '@auxx/lib/agents/procedures/client'
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { Section } from '@auxx/ui/components/section'
+import { Textarea } from '@auxx/ui/components/textarea'
+import { Filter, Info, Tags } from 'lucide-react'
+import { useMemo } from 'react'
+import { ConditionContainer, ConditionProvider } from '~/components/conditions'
+import { useProcedureConditionConfig } from '../hooks/use-procedure-condition-config'
+import { TriggerExamplesEditor } from './trigger-examples-editor'
+
+interface ProcedureTriggerHeaderProps {
+  whenToUse: string
+  triggerExamples: TriggerExample[]
+  ruleset: ConditionGroup[]
+  localAttributes: LocalAttribute[]
+  onPatch: (patch: {
+    whenToUse?: string
+    triggerExamples?: TriggerExample[]
+    ruleset?: ConditionGroup[]
+  }) => void
+}
+
+/**
+ * The selection-trigger defaults above the procedure canvas, rendered as the
+ * same full-bleed `<Section>` stack as the agent-detail tabs: a `whenToUse`
+ * description, the use/avoid examples, and the structured ruleset (the SAME
+ * conditions builder as the `conditionCase` arms, but multi-group). All three
+ * write through the same debounced autosave patch.
+ */
+export function ProcedureTriggerHeader({
+  whenToUse,
+  triggerExamples,
+  ruleset,
+  localAttributes,
+  onPatch,
+}: ProcedureTriggerHeaderProps) {
+  const { config, getAvailableFields, getFieldDefinition } = useProcedureConditionConfig(
+    localAttributes,
+    false
+  )
+
+  const groups = useMemo(() => (ruleset.length > 0 ? ruleset : []), [ruleset])
+  const allConditions = useMemo(() => groups.flatMap((g) => g.conditions ?? []), [groups])
+  const whenToUseEmpty = whenToUse.trim() === ''
+
+  return (
+    <>
+      <Section
+        title='When to use'
+        icon={<Info className='size-4' />}
+        description='Describe the situation that should select this procedure.'
+        isRequired={whenToUseEmpty}
+        initialOpen
+        collapsible={false}>
+        <Textarea
+          value={whenToUse}
+          onChange={(e) => onPatch({ whenToUse: e.target.value })}
+          placeholder='Describe when this procedure should run…'
+          className='min-h-16 text-sm'
+        />
+        {whenToUseEmpty && (
+          <span className='mt-1.5 text-xs text-amber-600'>Required to publish.</span>
+        )}
+      </Section>
+
+      <Section
+        title='Trigger examples'
+        icon={<Tags className='size-4' />}
+        description='Use / avoid examples that sharpen selection. Aim for 10 or more.'
+        initialOpen
+        collapsible={false}>
+        <TriggerExamplesEditor
+          value={triggerExamples}
+          onChange={(triggerExamples) => onPatch({ triggerExamples })}
+        />
+      </Section>
+
+      <Section
+        title='Rules'
+        icon={<Filter className='size-4' />}
+        description='Structured conditions that must hold for this procedure to run.'
+        initialOpen
+        collapsible={false}>
+        <ConditionProvider
+          conditions={allConditions}
+          groups={groups}
+          config={config}
+          onConditionsChange={() => {}}
+          onGroupsChange={(ruleset) => onPatch({ ruleset })}
+          getAvailableFields={getAvailableFields}
+          getFieldDefinition={getFieldDefinition}>
+          <ConditionContainer
+            showGrouping
+            showAddButton
+            emptyStateText='No rules — selection relies on the description + examples.'
+          />
+        </ConditionProvider>
+      </Section>
+    </>
+  )
+}

--- a/apps/web/src/components/agents/procedures/ui/procedures-section-content.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedures-section-content.tsx
@@ -1,0 +1,76 @@
+// apps/web/src/components/agents/procedures/ui/procedures-section-content.tsx
+'use client'
+
+import { EmptySection } from '@auxx/ui/components/section'
+import { toastError } from '@auxx/ui/components/toast'
+import { useConfirm } from '~/hooks/use-confirm'
+import { api } from '~/trpc/react'
+import type { AgentDetail } from '../../store/agent-store'
+import { ProcedureRow } from './procedure-row'
+
+interface ProceduresSectionContentProps {
+  agent: AgentDetail
+  /** Drill into a procedure — sets the page-level `procedure` nuqs param (NavStack push). */
+  onOpen: (procedureId: string) => void
+}
+
+/**
+ * The agent-detail Procedures list — a flat list of `TreeRow`s (mirroring Tools /
+ * Bindings). The "Add procedure" button lives in `<Section actions>` (owned by the
+ * agent-detail tab wrapper); clicking a row pushes the detail panel via the
+ * page-level `NavStack`. Shows for chat AND internal agents.
+ */
+export function ProceduresSectionContent({ agent, onOpen }: ProceduresSectionContentProps) {
+  const [confirm, ConfirmDialog] = useConfirm()
+  const utils = api.useUtils()
+
+  const procedures = api.agentProcedure.list.useQuery({ agentId: agent.id })
+  const invalidate = () => utils.agentProcedure.list.invalidate({ agentId: agent.id })
+
+  const updateLink = api.agentProcedure.update.useMutation({
+    onSuccess: invalidate,
+    onError: (err) => toastError({ title: 'Failed to update procedure', description: err.message }),
+  })
+  const detach = api.agentProcedure.detach.useMutation({
+    onSuccess: invalidate,
+    onError: (err) => toastError({ title: 'Failed to remove procedure', description: err.message }),
+  })
+
+  const rows = procedures.data ?? []
+
+  const handleDelete = async (linkId: string, name: string) => {
+    const confirmed = await confirm({
+      title: 'Delete procedure?',
+      description: `"${name}" will be removed from this agent. This cannot be undone.`,
+      confirmText: 'Remove',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) detach.mutate({ id: linkId })
+  }
+
+  if (procedures.isLoading) return <EmptySection loading className='mx-3' />
+
+  if (rows.length === 0) {
+    return (
+      <p className='px-3 py-6 text-center text-sm text-muted-foreground'>
+        No procedures yet. Add one to give this agent a step-by-step playbook.
+      </p>
+    )
+  }
+
+  return (
+    <div className='flex flex-col pe-4'>
+      {rows.map((row) => (
+        <ProcedureRow
+          key={row.linkId}
+          row={row}
+          onOpen={() => onOpen(row.procedureId)}
+          onToggle={(enabled) => updateLink.mutate({ id: row.linkId, enabled })}
+          onDelete={() => void handleDelete(row.linkId, row.name)}
+        />
+      ))}
+      <ConfirmDialog />
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/procedures/ui/trigger-examples-editor.tsx
+++ b/apps/web/src/components/agents/procedures/ui/trigger-examples-editor.tsx
@@ -1,0 +1,113 @@
+// apps/web/src/components/agents/procedures/ui/trigger-examples-editor.tsx
+'use client'
+
+import type { TriggerExample } from '@auxx/lib/agents/procedures/client'
+import { Input } from '@auxx/ui/components/input'
+import { X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+interface TriggerExamplesEditorProps {
+  value: TriggerExample[]
+  onChange: (next: TriggerExample[]) => void
+}
+
+/**
+ * Two tag lists — "Use when" / "Avoid when" — backing the Phase-0
+ * `TriggerExample[]` shape. The `avoid` half is load-bearing for selection, so
+ * both lists are equally prominent. Mirrors Lyra's "add at least 10" nudge.
+ */
+export function TriggerExamplesEditor({ value, onChange }: TriggerExamplesEditorProps) {
+  const useList = useMemo(
+    () => value.filter((e) => e.behavior === 'use').map((e) => e.text),
+    [value]
+  )
+  const avoidList = useMemo(
+    () => value.filter((e) => e.behavior === 'avoid').map((e) => e.text),
+    [value]
+  )
+
+  const emit = (next: { use: string[]; avoid: string[] }) => {
+    onChange([
+      ...next.use.map((text) => ({ text, behavior: 'use' as const })),
+      ...next.avoid.map((text) => ({ text, behavior: 'avoid' as const })),
+    ])
+  }
+
+  return (
+    <div className='space-y-3'>
+      <TagList
+        label='Use when'
+        items={useList}
+        onAdd={(text) => emit({ use: [...useList, text], avoid: avoidList })}
+        onRemove={(i) => emit({ use: useList.filter((_, idx) => idx !== i), avoid: avoidList })}
+      />
+      <TagList
+        label='Avoid when'
+        items={avoidList}
+        onAdd={(text) => emit({ use: useList, avoid: [...avoidList, text] })}
+        onRemove={(i) => emit({ use: useList, avoid: avoidList.filter((_, idx) => idx !== i) })}
+      />
+      {value.length < 10 && (
+        <p className='text-xs text-muted-foreground'>
+          Add at least 10 examples to sharpen selection.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function TagList({
+  label,
+  items,
+  onAdd,
+  onRemove,
+}: {
+  label: string
+  items: string[]
+  onAdd: (text: string) => void
+  onRemove: (index: number) => void
+}) {
+  const [draft, setDraft] = useState('')
+
+  const commit = () => {
+    const text = draft.trim()
+    if (!text) return
+    onAdd(text)
+    setDraft('')
+  }
+
+  return (
+    <div className='space-y-1.5'>
+      <span className='text-xs font-medium text-muted-foreground'>{label}</span>
+      <div className='flex flex-wrap gap-1.5'>
+        {items.map((text, i) => (
+          <span
+            key={`${text}-${i}`}
+            className='inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs'>
+            {text}
+            <button
+              type='button'
+              onClick={() => onRemove(i)}
+              aria-label={`Remove ${text}`}
+              className='text-muted-foreground hover:text-destructive'>
+              <X className='size-3' />
+            </button>
+          </span>
+        ))}
+      </div>
+      <Input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            commit()
+          }
+        }}
+        onBlur={commit}
+        placeholder={`Add a "${label.toLowerCase()}" example…`}
+        className='h-7 text-xs'
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
@@ -8,13 +8,29 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
+import { NavStack, NavStackBar, NavStackPanel, NavStackPanels } from '@auxx/ui/components/nav-stack'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Section } from '@auxx/ui/components/section'
 import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
-import { BookOpen, Clock, FileText, Plug, Plus, ShieldCheck, Wrench, Zap } from 'lucide-react'
+import { toastError } from '@auxx/ui/components/toast'
+import {
+  BookOpen,
+  Clock,
+  FileText,
+  ListChecks,
+  Plug,
+  Plus,
+  ShieldCheck,
+  Wrench,
+  Zap,
+} from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { api } from '~/trpc/react'
 import { AGENT_TABS, type AgentTab, DEFAULT_AGENT_TAB } from '../../constant'
+import { ProcedureDetailBar } from '../../procedures/ui/procedure-detail-bar'
+import { ProcedureEditor } from '../../procedures/ui/procedure-editor'
+import { ProceduresSectionContent } from '../../procedures/ui/procedures-section-content'
 import type { AgentDetail } from '../../store/agent-store'
 import type { AutosaveState } from '../shared/autosave-indicator'
 import { AgentHero } from './agent-hero'
@@ -31,6 +47,7 @@ const SECTION_ICONS: Record<AgentTab, React.ComponentType<{ className?: string }
   tools: Wrench,
   restrictions: ShieldCheck,
   knowledge: BookOpen,
+  procedures: ListChecks,
   triggers: Zap,
 }
 
@@ -39,6 +56,7 @@ const SECTION_LABELS: Record<AgentTab, string> = {
   tools: 'Tools',
   restrictions: 'Bindings',
   knowledge: 'Knowledge',
+  procedures: 'Procedures',
   triggers: 'Triggers',
 }
 
@@ -58,13 +76,19 @@ interface AgentDetailTabsProps {
  */
 export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProps) {
   const [tab, setTab] = useQueryState('tab', { defaultValue: DEFAULT_AGENT_TAB })
+  // The pushed procedure detail. Set ⇒ NavStack shows ['root','procedure']; cleared ⇒ ['root'].
+  const [selectedProcedureId, setSelectedProcedureId] = useQueryState('procedure')
   const [addingKind, setAddingKind] = useState<'scheduled' | 'event' | 'app' | null>(null)
+  // Lifted from the pushed ProcedureEditor so the detail bar (rendered by
+  // <NavStackBar>, a separate subtree) can show live Saving…/Saved next to Publish.
+  const [procedureAutosave, setProcedureAutosave] = useState<AutosaveState>({ kind: 'idle' })
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const sectionRefs = useRef<Record<AgentTab, HTMLDivElement | null>>({
     prompt: null,
     tools: null,
     restrictions: null,
     knowledge: null,
+    procedures: null,
     triggers: null,
   })
   const isProgrammaticScrollRef = useRef(false)
@@ -95,10 +119,12 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
 
   const handleTabChange = useCallback(
     (value: string) => {
+      // Selecting any tab while in the detail pops back to root, then scrolls.
+      void setSelectedProcedureId(null)
       setTab(value)
       scrollToSection(value)
     },
-    [setTab, scrollToSection]
+    [setTab, setSelectedProcedureId, scrollToSection]
   )
 
   // Scroll-spy: as the user scrolls, switch the active tab to whichever
@@ -150,100 +176,188 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
         noFade>
         <AgentHero agent={agent} />
 
-        <div className='sticky top-0 z-10'>
-          <div className='bg-background border-b'>
-            <Tabs value={tab} onValueChange={handleTabChange}>
-              <TabsList className='w-full justify-start rounded-none bg-primary-150 px-2'>
-                {tabs.map((value) => {
-                  const Icon = SECTION_ICONS[value]
-                  return (
-                    <TabsTrigger key={value} value={value} variant='outline'>
-                      <Icon />
-                      {SECTION_LABELS[value]}
-                    </TabsTrigger>
-                  )
-                })}
-              </TabsList>
-            </Tabs>
+        {/* Shared-bar layout: the sticky bar (NavStackBar) lives OUTSIDE NavStackPanels
+            so it pins to this ScrollArea, while the panels slide cleanly under it
+            (NavStackPanels is overflow-hidden — a sticky bar inside a panel would
+            scroll away). The bar's content cross-fades root↔procedure; the section
+            column / editor below it does the horizontal push/pop. The hero stays
+            above + scrolls away in both levels. Stack ⇄ the `procedure` nuqs param. */}
+        <NavStack
+          stack={selectedProcedureId ? ['root', 'procedure'] : ['root']}
+          onStackChange={(next) => {
+            if (next.length === 1) void setSelectedProcedureId(null)
+          }}>
+          {/* The shared bar surface lives on the persistent <NavStackBar> frame, so
+              the bg stays constant root↔procedure and only the foreground content
+              cross-fades over it (no see-through to the page during the fade). Both
+              bars' own content is therefore transparent. */}
+          <div className='sticky top-0 z-10'>
+            <NavStackBar className='border-b bg-primary-150' />
+            <div className='pointer-events-none h-3 bg-gradient-to-b from-neutral-100 to-transparent dark:from-background' />
           </div>
-          <div className='pointer-events-none h-3 bg-gradient-to-b from-background to-transparent' />
-        </div>
-
-        <div ref={assignRef('prompt')}>
-          <Section
-            title='Prompt'
-            icon={<FileText className='size-4' />}
-            initialOpen
-            collapsible={false}>
-            <PersonaEditor agent={agent} onAutosaveChange={onAutosaveChange} />
-          </Section>
-        </div>
-
-        <div ref={assignRef('tools')}>
-          <ToolsSection agent={agent} onAutosaveChange={onAutosaveChange} />
-        </div>
-
-        <div ref={assignRef('restrictions')}>
-          <BindingsSection agent={agent} />
-        </div>
-
-        <div ref={assignRef('knowledge')}>
-          <Section
-            title='Knowledge'
-            icon={<BookOpen className='size-4' />}
-            className='[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
-            initialOpen
-            collapsible={false}>
-            <KnowledgeSectionContent agent={agent} onAutosaveChange={onAutosaveChange} />
-          </Section>
-        </div>
-
-        {agent.kind !== 'chat' ? (
-          <div ref={assignRef('triggers')}>
-            <Section
-              title='Triggers'
-              icon={<Zap className='size-4' />}
-              className='[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
-              initialOpen
-              description='Autonomous triggers fire this agent on a schedule, on a record event, or on an app event.'
-              collapsible={false}
-              actions={
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant='ghost' size='xs'>
-                      <Plus />
-                      Add trigger
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align='end'>
-                    <DropdownMenuItem onClick={() => setAddingKind('scheduled')}>
-                      <Clock />
-                      Scheduled
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => setAddingKind('event')}>
-                      <Zap />
-                      Event
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => setAddingKind('app')}>
-                      <Plug />
-                      App
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+          <NavStackPanels>
+            <NavStackPanel
+              value='root'
+              className='min-h-dvh bg-neutral-100 dark:bg-background'
+              bar={
+                <Tabs value={tab} onValueChange={handleTabChange}>
+                  <TabsList className='w-full justify-start rounded-none bg-transparent px-2'>
+                    {tabs.map((value) => {
+                      const Icon = SECTION_ICONS[value]
+                      return (
+                        <TabsTrigger key={value} value={value} variant='outline'>
+                          <Icon />
+                          {SECTION_LABELS[value]}
+                        </TabsTrigger>
+                      )
+                    })}
+                  </TabsList>
+                </Tabs>
               }>
-              <TriggersSectionContent
-                agent={agent}
-                addingKind={addingKind}
-                onAddingKindChange={setAddingKind}
-              />
-            </Section>
-          </div>
-        ) : null}
+              <div ref={assignRef('prompt')}>
+                <Section
+                  title='Prompt'
+                  icon={<FileText className='size-4' />}
+                  initialOpen
+                  collapsible={false}>
+                  <PersonaEditor agent={agent} onAutosaveChange={onAutosaveChange} />
+                </Section>
+              </div>
 
-        {/* Spacer so the last section can scroll up to the activation line. */}
-        <div className='h-[40vh]' />
+              <div ref={assignRef('procedures')}>
+                <ProceduresSection agent={agent} onSelect={setSelectedProcedureId} />
+              </div>
+
+              <div ref={assignRef('tools')}>
+                <ToolsSection agent={agent} onAutosaveChange={onAutosaveChange} />
+              </div>
+
+              <div ref={assignRef('restrictions')}>
+                <BindingsSection agent={agent} />
+              </div>
+
+              <div ref={assignRef('knowledge')}>
+                <Section
+                  title='Knowledge'
+                  icon={<BookOpen className='size-4' />}
+                  className='[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
+                  initialOpen
+                  collapsible={false}>
+                  <KnowledgeSectionContent agent={agent} onAutosaveChange={onAutosaveChange} />
+                </Section>
+              </div>
+
+              {agent.kind !== 'chat' ? (
+                <div ref={assignRef('triggers')}>
+                  <Section
+                    title='Triggers'
+                    icon={<Zap className='size-4' />}
+                    className='[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
+                    initialOpen
+                    description='Autonomous triggers fire this agent on a schedule, on a record event, or on an app event.'
+                    collapsible={false}
+                    actions={
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant='ghost' size='xs'>
+                            <Plus />
+                            Add trigger
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align='end'>
+                          <DropdownMenuItem onClick={() => setAddingKind('scheduled')}>
+                            <Clock />
+                            Scheduled
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => setAddingKind('event')}>
+                            <Zap />
+                            Event
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => setAddingKind('app')}>
+                            <Plug />
+                            App
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    }>
+                    <TriggersSectionContent
+                      agent={agent}
+                      addingKind={addingKind}
+                      onAddingKindChange={setAddingKind}
+                    />
+                  </Section>
+                </div>
+              ) : null}
+
+              {/* Spacer so the last section can scroll up to the activation line. */}
+              <div className='h-[40vh]' />
+            </NavStackPanel>
+
+            <NavStackPanel
+              value='procedure'
+              className='min-h-dvh bg-neutral-100 dark:bg-background'
+              bar={
+                selectedProcedureId ? (
+                  <ProcedureDetailBar
+                    procedureId={selectedProcedureId}
+                    autosave={procedureAutosave}
+                  />
+                ) : null
+              }>
+              {selectedProcedureId ? (
+                <ProcedureEditor
+                  procedureId={selectedProcedureId}
+                  onAutosaveChange={setProcedureAutosave}
+                />
+              ) : null}
+            </NavStackPanel>
+          </NavStackPanels>
+        </NavStack>
       </ScrollArea>
     </div>
+  )
+}
+
+/**
+ * Procedures tab wrapper. Owns the "Add procedure" action (in `<Section actions>`)
+ * which creates + attaches a fresh procedure and drills into it. The list itself
+ * renders inside; both chat and internal agents get this section.
+ */
+function ProceduresSection({
+  agent,
+  onSelect,
+}: {
+  agent: AgentDetail
+  onSelect: (procedureId: string) => void
+}) {
+  const utils = api.useUtils()
+  const createAndAttach = api.agentProcedure.createAndAttach.useMutation({
+    onSuccess: ({ procedureId }) => {
+      void utils.agentProcedure.list.invalidate({ agentId: agent.id })
+      onSelect(procedureId)
+    },
+    onError: (err) => toastError({ title: 'Failed to add procedure', description: err.message }),
+  })
+  return (
+    <Section
+      title='Procedures'
+      icon={<ListChecks className='size-4' />}
+      className='[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
+      initialOpen
+      description='Step-by-step playbooks the agent follows for specific situations.'
+      collapsible={false}
+      actions={
+        <Button
+          variant='ghost'
+          size='xs'
+          loading={createAndAttach.isPending}
+          onClick={() => createAndAttach.mutate({ agentId: agent.id, name: 'New procedure' })}>
+          <Plus />
+          Add procedure
+        </Button>
+      }>
+      <ProceduresSectionContent agent={agent} onOpen={onSelect} />
+    </Section>
   )
 }
 

--- a/apps/web/src/components/editor/inline-picker/nodes/reference-picker-node.tsx
+++ b/apps/web/src/components/editor/inline-picker/nodes/reference-picker-node.tsx
@@ -38,6 +38,11 @@ export type ReferenceTab =
   | 'tools'
   | 'resources'
   | 'fields'
+  // v9 procedure step tabs — opt-in, only the procedure editor passes these.
+  | 'routing'
+  | 'code'
+  | 'subprocedure'
+  | 'condition'
 
 /**
  * Default tab set rendered by `@`-pickers. Opt-in tabs (currently just
@@ -56,6 +61,10 @@ export const TAB_LABEL: Record<ReferenceTab, string> = {
   tools: 'Tools',
   resources: 'Resources',
   fields: 'Fields',
+  routing: 'Routing',
+  code: 'Code',
+  subprocedure: 'Sub-procedure',
+  condition: 'Condition',
 }
 
 /** Resolve digit (1–9) → tab from the configured tab list. */

--- a/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
+++ b/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
@@ -61,6 +61,8 @@ interface PromptEditorContentProps {
    * (e.g. the workflow `{`-variable picker). Defaults to `[]`.
    */
   inlineExtensions?: Extension[]
+  /** Mount the v9 procedure control-flow nodes. Forwarded to `useRichTextEditor`. */
+  enableProcedureNodes?: boolean
 }
 
 interface LinkPopoverState {
@@ -93,6 +95,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
   editable = true,
   placeholderText,
   inlineExtensions,
+  enableProcedureNodes,
 }: PromptEditorContentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [linkPopover, setLinkPopover] = useState<LinkPopoverState | null>(null)
@@ -119,6 +122,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
     editable,
     placeholderText,
     inlineExtensions,
+    enableProcedureNodes,
   })
 
   const activePicker = useActivePicker(editor)

--- a/apps/web/src/components/editor/prompt-editor/prompt-editor-header.tsx
+++ b/apps/web/src/components/editor/prompt-editor/prompt-editor-header.tsx
@@ -2,12 +2,18 @@
 'use client'
 
 import { cn } from '@auxx/ui/lib/utils'
-import { Clipboard, ClipboardCheck, Maximize2, Minimize2 } from 'lucide-react'
+import { ChevronLeft, Clipboard, ClipboardCheck, Maximize2, Minimize2 } from 'lucide-react'
 import React from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 
 interface PromptEditorHeaderProps {
   title: string
+  /**
+   * When set, a back `ActionButton` renders before the title (used by the
+   * procedure editor's drill-in NavStack to pop a level). Omit for the flat
+   * persona / workflow headers.
+   */
+  onBack?: () => void
   /**
    * Character-count slot — rendered as-is between the title and the
    * action buttons. Passed in by the parent (typically `PromptCharacterCount`)
@@ -45,6 +51,7 @@ ActionButton.displayName = 'ActionButton'
 
 export const PromptEditorHeader = React.memo(function PromptEditorHeader({
   title,
+  onBack,
   countSlot,
   isExpanded,
   setExpanded,
@@ -60,7 +67,14 @@ export const PromptEditorHeader = React.memo(function PromptEditorHeader({
         isExpanded && 'h-10',
         headerClassName
       )}>
-      <div className='flex gap-2'>
+      <div className='flex items-center gap-1'>
+        {onBack && (
+          <Tooltip content='Back'>
+            <ActionButton onClick={onBack} aria-label='Back' className='-ml-1.5'>
+              <ChevronLeft className='size-4' />
+            </ActionButton>
+          </Tooltip>
+        )}
         <div
           className={cn(
             'text-xs font-semibold uppercase leading-4 text-primary-500',

--- a/apps/web/src/components/editor/rich-text/render-reference-badge.tsx
+++ b/apps/web/src/components/editor/rich-text/render-reference-badge.tsx
@@ -5,6 +5,10 @@
 import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import type { ActorId } from '@auxx/types/actor'
 import { cn } from '@auxx/ui/lib/utils'
+import {
+  isProcedureStepId,
+  ProcedureStepBadge,
+} from '~/components/agents/procedures/nodes/procedure-step-badge'
 import { ToolBadge } from '~/components/pickers/tool-picker/tool-badge'
 import { ToolsetBadge } from '~/components/pickers/toolset-picker/toolset-badge'
 import { ActorBadge } from '~/components/resources/ui/actor-badge'
@@ -21,6 +25,11 @@ const referenceBadgeRing = 'transition-all inline-flex'
  * editor, agent persona editor).
  */
 export function renderReferenceBadge({ id, selected }: { id: string; selected: boolean }) {
+  // v9 procedure step badges (`route:`/`code:`/`subprocedure:`) — only present in
+  // the procedure editor; resolve names + drill via ProcedureEditorContext.
+  if (isProcedureStepId(id)) {
+    return <ProcedureStepBadge id={id} selected={selected} />
+  }
   const ring = cn(referenceBadgeRing, selected && 'ring-2 ring-primary ring-offset-1')
   if (id.startsWith('user:') || id.startsWith('group:') || id.startsWith('agent:')) {
     return <ActorBadge actorId={id as ActorId} className={ring} />

--- a/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
+++ b/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
@@ -15,6 +15,10 @@ import { Decoration, DecorationSet } from '@tiptap/pm/view'
 import { useEditor, useEditorState } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { ConditionBlock } from '~/components/agents/procedures/nodes/condition-block-node'
+import { ConditionCase } from '~/components/agents/procedures/nodes/condition-case-node'
+import { ConditionElse } from '~/components/agents/procedures/nodes/condition-else-node'
+import { ConditionPredicate } from '~/components/agents/procedures/nodes/condition-predicate-node'
 import { Table, TableCell, TableHeader, TableRow } from '../extensions/table'
 import {
   createPlaceholderNode,
@@ -33,14 +37,20 @@ import { Panel } from '../kb-article/panel-node'
 import { Tabs } from '../kb-article/tabs-node'
 import { buildReferencePickerExtensions } from './reference-picker-extensions'
 
-const Doc = Node.create({
-  name: 'doc',
-  topNode: true,
-  // PM resolves a bare `block` token to the NODE named `block` (which we have),
-  // not the group. So we have to list `table` explicitly even though it's in
-  // `group: 'block'` — node-name resolution takes precedence over group.
-  content: '(block | containerBlock | table)+',
-})
+// The `doc` content union. `procedureBlock` is only a valid token when at least
+// one node declares `group: 'procedureBlock'` (PM rejects an empty group), so the
+// alternative is added ONLY when the procedure nodes are mounted (§1.2). PM
+// resolves a bare `block` token to the NODE named `block`, not the group, so
+// `table` is listed explicitly even though it's in `group: 'block'`.
+function createDoc(enableProcedureNodes: boolean) {
+  return Node.create({
+    name: 'doc',
+    topNode: true,
+    content: enableProcedureNodes
+      ? '(block | containerBlock | procedureBlock | table)+'
+      : '(block | containerBlock | table)+',
+  })
+}
 
 const FocusClasses = Extension.create({
   name: 'focus-classes',
@@ -112,6 +122,15 @@ export interface UseRichTextEditorOptions {
    * the reference-picker extensions. Defaults to `[]`.
    */
   inlineExtensions?: Extension[]
+  /**
+   * Mount the v9 procedure control-flow nodes (conditionBlock / conditionCase /
+   * conditionElse / conditionPredicate) and extend the `doc` content union with
+   * the `procedureBlock` group. The step "nodes" (tool / code / routing /
+   * sub-procedure) are inline reference badges, not block nodes. Defaults to `false`
+   * — only the procedure editor opts in; KB / persona / mail schemas are
+   * untouched (no procedure node types in their autosave payloads).
+   */
+  enableProcedureNodes?: boolean
 }
 
 /**
@@ -134,6 +153,7 @@ export function useRichTextEditor({
   editable = true,
   placeholderText,
   inlineExtensions,
+  enableProcedureNodes = false,
 }: UseRichTextEditorOptions) {
   const normalizedInitialContent = useMemo<JSONContent>(() => {
     const migrated = migrateLegacyContent(initialContent)
@@ -175,7 +195,7 @@ export function useRichTextEditor({
       immediatelyRender: false,
       editable,
       extensions: [
-        Doc,
+        createDoc(enableProcedureNodes),
         StarterKit.configure({
           document: false,
           heading: false,
@@ -213,6 +233,9 @@ export function useRichTextEditor({
         // via the Placeholder extension's CSS pseudo-element (which would
         // overlap the line gutter). See block-node-view.tsx `showPlaceholder`.
         ...(slashCommand ? [slashCommand.slashCommandExtension] : []),
+        ...(enableProcedureNodes
+          ? [ConditionBlock, ConditionCase, ConditionElse, ConditionPredicate]
+          : []),
         ...referencePickerExtensions,
         ...(inlineExtensions ?? []),
         placeholderNodeExtension,

--- a/apps/web/src/components/pickers/reference-picker/reference-picker-content.tsx
+++ b/apps/web/src/components/pickers/reference-picker/reference-picker-content.tsx
@@ -6,6 +6,12 @@ import type { RecordId } from '@auxx/lib/resources/client'
 import { cn } from '@auxx/ui/lib/utils'
 import { useEffect, useImperativeHandle, useMemo, useRef } from 'react'
 import {
+  CodePickerList,
+  ConditionPickerList,
+  RoutingPickerList,
+  SubProcedurePickerList,
+} from '~/components/agents/procedures/ui/procedure-picker-lists'
+import {
   DEFAULT_TABS,
   type ReferenceTab,
   TAB_LABEL,
@@ -224,6 +230,20 @@ export function ReferencePickerContent({
             onSelectSingle={(id) => onSelect(id as unknown as RecordId)}
           />
         )}
+        {/* v9 procedure step tabs — insertion via the same `@` picker (plan §5). */}
+        {tab === 'routing' && (
+          <RoutingPickerList query={query} onSelect={(id) => onSelect(id as unknown as RecordId)} />
+        )}
+        {tab === 'subprocedure' && (
+          <SubProcedurePickerList
+            query={query}
+            onSelect={(id) => onSelect(id as unknown as RecordId)}
+          />
+        )}
+        {tab === 'code' && (
+          <CodePickerList query={query} onSelect={(id) => onSelect(id as unknown as RecordId)} />
+        )}
+        {tab === 'condition' && <ConditionPickerList />}
       </div>
     </div>
   )

--- a/apps/web/src/server/api/root.ts
+++ b/apps/web/src/server/api/root.ts
@@ -3,6 +3,7 @@ import { createCallerFactory, createTRPCRouter } from '~/server/api/trpc'
 import { actorRouter } from './routers/actor'
 import { adminRouter } from './routers/admin'
 import { agentRouter } from './routers/agent'
+import { agentProcedureRouter } from './routers/agent-procedure'
 import { agentScopeRouter } from './routers/agent-scope'
 import { agentToolsetRouter } from './routers/agent-toolset'
 import { agentTriggerRouter } from './routers/agent-trigger'
@@ -54,6 +55,7 @@ import { notificationRouter } from './routers/notification'
 import { orderRouter } from './routers/order'
 import { organizationRouter } from './routers/organization'
 import { participantRouter } from './routers/participant'
+import { procedureRouter } from './routers/procedure'
 import { productRouter } from './routers/product'
 import { promptTemplateRouter } from './routers/promptTemplate'
 import { quickActionRouter } from './routers/quick-actions'
@@ -91,6 +93,7 @@ export const appRouter = createTRPCRouter({
   actor: actorRouter,
   admin: adminRouter,
   agent: agentRouter,
+  agentProcedure: agentProcedureRouter,
   agentScope: agentScopeRouter,
   agentToolset: agentToolsetRouter,
   agentTrigger: agentTriggerRouter,
@@ -142,6 +145,7 @@ export const appRouter = createTRPCRouter({
   order: orderRouter,
   organization: organizationRouter,
   participant: participantRouter,
+  procedure: procedureRouter,
   product: productRouter,
   promptTemplate: promptTemplateRouter,
   quickAction: quickActionRouter,

--- a/apps/web/src/server/api/routers/agent-procedure.ts
+++ b/apps/web/src/server/api/routers/agent-procedure.ts
@@ -1,0 +1,135 @@
+// apps/web/src/server/api/routers/agent-procedure.ts
+
+import { agentExistsInOrg } from '@auxx/lib/agents'
+import {
+  attachProcedure,
+  createProcedure,
+  detachProcedure,
+  listAgentProcedures,
+  listProcedures,
+  updateAgentProcedure,
+} from '@auxx/lib/agents/procedures'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { adminProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
+
+/** Unwrap a neverthrow Result, mapping an error to a TRPCError. */
+function unwrap<T>(
+  result: { isErr(): boolean; value?: T; error?: { message?: string } | Error },
+  message: string
+): T {
+  if (result.isErr()) {
+    const detail =
+      (result.error as { message?: string } | undefined)?.message ?? String(result.error)
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: `${message}: ${detail}` })
+  }
+  return result.value as T
+}
+
+async function ensureAgentInOrg(organizationId: string, agentId: string): Promise<void> {
+  if (!(await agentExistsInOrg(organizationId, agentId))) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Agent not found' })
+  }
+}
+
+/**
+ * Agent ↔ procedure links (the M:N `AgentProcedure` table) — attach/detach + the
+ * per-agent `enabled`/`priority` + optional trigger overrides. The procedure
+ * library itself (the standalone `Procedure` + its draft/versions) lives on the
+ * `procedure` router; this one only manages the links rendered on the agent detail.
+ */
+export const agentProcedureRouter = createTRPCRouter({
+  // The agent's attached procedures, joined with each procedure's summary.
+  list: protectedProcedure
+    .input(z.object({ agentId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      await ensureAgentInOrg(organizationId, input.agentId)
+      const links = unwrap(
+        await listAgentProcedures({ agentId: input.agentId }),
+        'list agent procedures'
+      )
+      const procedures = unwrap(await listProcedures({ organizationId }), 'list procedures')
+      const byId = new Map(procedures.map((p) => [p.id, p]))
+      return links
+        .map((link) => {
+          const proc = byId.get(link.procedureId)
+          if (!proc) return null
+          return {
+            linkId: link.id,
+            procedureId: proc.id,
+            name: proc.name,
+            whenToUse: link.whenToUseOverride ?? proc.whenToUse,
+            enabled: link.enabled,
+            priority: link.priority,
+            hasUnpublishedChanges: proc.hasUnpublishedChanges,
+            isPublished: proc.activeVersionId != null,
+          }
+        })
+        .filter((row): row is NonNullable<typeof row> => row != null)
+    }),
+
+  // "Add procedure": create a new standalone procedure and attach it to the agent.
+  createAndAttach: adminProcedure
+    .input(z.object({ agentId: z.string().min(1), name: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      await ensureAgentInOrg(organizationId, input.agentId)
+      const procedure = unwrap(
+        await createProcedure({ organizationId, name: input.name }),
+        'create procedure'
+      )
+      const link = unwrap(
+        await attachProcedure({
+          organizationId,
+          agentId: input.agentId,
+          procedureId: procedure.id,
+        }),
+        'attach procedure'
+      )
+      return { linkId: link.id, procedureId: procedure.id }
+    }),
+
+  // Attach an EXISTING procedure to the agent.
+  attach: adminProcedure
+    .input(z.object({ agentId: z.string().min(1), procedureId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      await ensureAgentInOrg(organizationId, input.agentId)
+      const link = unwrap(
+        await attachProcedure({
+          organizationId,
+          agentId: input.agentId,
+          procedureId: input.procedureId,
+        }),
+        'attach procedure'
+      )
+      return { linkId: link.id }
+    }),
+
+  update: adminProcedure
+    .input(
+      z.object({
+        id: z.string().min(1),
+        enabled: z.boolean().optional(),
+        priority: z.number().int().optional(),
+        whenToUseOverride: z.string().nullable().optional(),
+        triggerExamplesOverride: z.array(z.unknown()).nullable().optional(),
+        rulesetOverride: z.array(z.unknown()).nullable().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const { id, ...patch } = input
+      unwrap(await updateAgentProcedure({ organizationId, id, patch }), 'update agent procedure')
+      return { ok: true as const }
+    }),
+
+  detach: adminProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      unwrap(await detachProcedure({ organizationId, id: input.id }), 'detach procedure')
+      return { ok: true as const }
+    }),
+})

--- a/apps/web/src/server/api/routers/procedure.ts
+++ b/apps/web/src/server/api/routers/procedure.ts
@@ -1,0 +1,252 @@
+// apps/web/src/server/api/routers/procedure.ts
+
+import {
+  compileProcedure,
+  createProcedure,
+  deleteProcedure,
+  getProcedureById,
+  getProcedureVersionById,
+  listProcedures,
+  listProcedureVersions,
+  publishProcedure,
+  revertProcedure,
+  type TiptapDoc,
+  updateDraftDoc,
+  updateProcedure,
+} from '@auxx/lib/agents/procedures'
+import { createScopedLogger } from '@auxx/logger'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { adminProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
+
+const logger = createScopedLogger('procedure-router')
+
+/** Unwrap a neverthrow Result, mapping an error to a TRPCError. */
+function unwrap<T>(
+  result: { isErr(): boolean; value?: T; error?: { message?: string } | Error },
+  message: string
+): T {
+  if (result.isErr()) {
+    const detail =
+      (result.error as { message?: string } | undefined)?.message ?? String(result.error)
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: `${message}: ${detail}` })
+  }
+  return result.value as T
+}
+
+const triggerExampleSchema = z.object({
+  text: z.string(),
+  behavior: z.enum(['use', 'avoid']),
+})
+
+/**
+ * Org-level standalone procedures (v9). The editor autosaves the DRAFT version's
+ * `doc` + the procedure's trigger DEFAULTS here; `publish` snapshots an immutable
+ * version and repoints the active pointer; `revert` repoints to an older version.
+ *
+ * Note: the org-cache `agents` projection + the `procedure.updated` cache bust are
+ * Phase 4 (the live selection/stepper path). Until then publish/revert change only
+ * the DB; nothing consumes the active version yet.
+ */
+export const procedureRouter = createTRPCRouter({
+  // Org-wide list — drives the routing-step `switch` picker + the library view.
+  list: protectedProcedure.query(async ({ ctx }) => {
+    const { organizationId } = ctx.session
+    const rows = unwrap(await listProcedures({ organizationId }), 'list procedures')
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      whenToUse: row.whenToUse,
+      hasUnpublishedChanges: row.hasUnpublishedChanges,
+      activeVersionId: row.activeVersionId,
+      updatedAt: row.updatedAt.toISOString(),
+    }))
+  }),
+
+  // Full procedure + its draft doc — the editor's load.
+  getById: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const procedure = unwrap(
+        await getProcedureById({ organizationId, procedureId: input.id }),
+        'get procedure'
+      )
+      if (!procedure) throw new TRPCError({ code: 'NOT_FOUND', message: 'Procedure not found' })
+      const draft = procedure.draftVersionId
+        ? unwrap(
+            await getProcedureVersionById({
+              organizationId,
+              procedureVersionId: procedure.draftVersionId,
+            }),
+            'get draft version'
+          )
+        : null
+      return {
+        id: procedure.id,
+        name: procedure.name,
+        whenToUse: procedure.whenToUse,
+        triggerExamples: procedure.triggerExamples,
+        ruleset: procedure.ruleset,
+        activeVersionId: procedure.activeVersionId,
+        hasUnpublishedChanges: procedure.hasUnpublishedChanges,
+        draftDoc: (draft?.doc ?? null) as Record<string, unknown> | null,
+      }
+    }),
+
+  create: adminProcedure
+    .input(z.object({ name: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const row = unwrap(
+        await createProcedure({ organizationId, name: input.name }),
+        'create procedure'
+      )
+      return { id: row.id }
+    }),
+
+  // DRAFT autosave target — patches the draft `doc` and/or trigger defaults.
+  // Never touches the published `compiled`/`version` (STACK #10).
+  update: adminProcedure
+    .input(
+      z.object({
+        id: z.string().min(1),
+        name: z.string().optional(),
+        whenToUse: z.string().optional(),
+        triggerExamples: z.array(triggerExampleSchema).optional(),
+        ruleset: z.array(z.unknown()).optional(),
+        doc: z.record(z.string(), z.unknown()).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const { id, doc, ...meta } = input
+      if (
+        meta.name !== undefined ||
+        meta.whenToUse !== undefined ||
+        meta.triggerExamples !== undefined ||
+        meta.ruleset !== undefined
+      ) {
+        unwrap(
+          await updateProcedure({
+            organizationId,
+            procedureId: id,
+            patch: {
+              name: meta.name,
+              whenToUse: meta.whenToUse,
+              triggerExamples: meta.triggerExamples,
+              ruleset: meta.ruleset,
+            },
+          }),
+          'update procedure'
+        )
+      }
+      if (doc !== undefined) {
+        unwrap(
+          await updateDraftDoc({ organizationId, procedureId: id, doc: doc as TiptapDoc }),
+          'update draft doc'
+        )
+      }
+      return { ok: true as const }
+    }),
+
+  delete: adminProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      unwrap(await deleteProcedure({ organizationId, procedureId: input.id }), 'delete procedure')
+      return { ok: true as const }
+    }),
+
+  // Published version history (newest first) for the revert UI.
+  listVersions: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .query(async ({ input }) => {
+      const rows = unwrap(
+        await listProcedureVersions({ procedureId: input.id }),
+        'list procedure versions'
+      )
+      return rows.map((row) => ({
+        id: row.id,
+        versionNumber: row.versionNumber,
+        label: row.label,
+        createdAt: row.createdAt.toISOString(),
+      }))
+    }),
+
+  /**
+   * Compile the draft → snapshot an immutable version → repoint the active
+   * pointer. Enforces non-empty `whenToUse` and surfaces compile errors.
+   *
+   * The Phase-4 cache bust (`onCacheEvent('procedure.updated')`) + the org-cache
+   * `agents` projection are NOT wired yet, so this only mutates the DB — no live
+   * run reads the active version until Phase 4.
+   */
+  publish: adminProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const procedure = unwrap(
+        await getProcedureById({ organizationId, procedureId: input.id }),
+        'get procedure'
+      )
+      if (!procedure) throw new TRPCError({ code: 'NOT_FOUND', message: 'Procedure not found' })
+      if (procedure.whenToUse.trim() === '') {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Set "when to use" before publishing.',
+        })
+      }
+      if (!procedure.draftVersionId) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Procedure has no draft to publish.' })
+      }
+      const draft = unwrap(
+        await getProcedureVersionById({
+          organizationId,
+          procedureVersionId: procedure.draftVersionId,
+        }),
+        'get draft version'
+      )
+      if (!draft) throw new TRPCError({ code: 'NOT_FOUND', message: 'Draft version not found' })
+
+      const { compiled, errors } = compileProcedure(draft.doc as TiptapDoc)
+      if (errors && errors.length > 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Procedure has errors: ${errors[0]!.message}`,
+        })
+      }
+
+      const version = unwrap(
+        await publishProcedure({
+          organizationId,
+          procedureId: input.id,
+          doc: draft.doc as TiptapDoc,
+          compiled,
+          editorId: ctx.session.userId,
+        }),
+        'publish procedure'
+      )
+      logger.info('Procedure published', {
+        organizationId,
+        procedureId: input.id,
+        versionNumber: version.versionNumber,
+      })
+      return { versionNumber: version.versionNumber, procedureVersionId: version.id }
+    }),
+
+  revert: adminProcedure
+    .input(z.object({ id: z.string().min(1), toVersionId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      unwrap(
+        await revertProcedure({
+          organizationId,
+          procedureId: input.id,
+          toVersionId: input.toVersionId,
+        }),
+        'revert procedure'
+      )
+      return { ok: true as const }
+    }),
+})

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -46,6 +46,18 @@
       "import": "./dist/agents/client.mjs",
       "default": "./src/agents/client.ts"
     },
+    "./agents/procedures": {
+      "types": "./src/agents/procedures/index.ts",
+      "source": "./src/agents/procedures/index.ts",
+      "import": "./dist/agents/procedures/index.mjs",
+      "default": "./src/agents/procedures/index.ts"
+    },
+    "./agents/procedures/client": {
+      "types": "./src/agents/procedures/client.ts",
+      "source": "./src/agents/procedures/client.ts",
+      "import": "./dist/agents/procedures/client.mjs",
+      "default": "./src/agents/procedures/client.ts"
+    },
     "./ai": {
       "types": "./src/ai/index.ts",
       "source": "./src/ai/index.ts",

--- a/packages/lib/src/agents/procedures/client.ts
+++ b/packages/lib/src/agents/procedures/client.ts
@@ -1,0 +1,35 @@
+// packages/lib/src/agents/procedures/client.ts
+
+/**
+ * Client-safe surface of the procedures module — pure types + the node-type
+ * const only. The barrel (`index.ts`) re-exports `queries.ts`, which pulls in
+ * `@auxx/database`; client code (the Phase-2 editor / node views) must import
+ * from HERE, not the barrel (CLAUDE.md client-import rule). `./types` and
+ * `./nodes` carry only type-level deps (`FieldType`/`ConditionGroup`/`FieldOptions`
+ * are erased), so this entry stays free of server-only code.
+ */
+
+export {
+  type CodeStepAttrs,
+  type ConditionCaseAttrs,
+  type LocalAttributeNodeAttrs,
+  PROCEDURE_NODE_TYPES,
+  type ProcedureNodeType,
+  type RoutingStepAttrs,
+  type SubProcedureNodeAttrs,
+  type TiptapDoc,
+  type TiptapNode,
+  type ToolStepAttrs,
+} from './nodes'
+export type {
+  ArgBindingMap,
+  CompiledProcedure,
+  LocalAttribute,
+  ProcedureFrame,
+  ProcedureStack,
+  ProcedureStep,
+  StepId,
+  SubProcedure,
+  SubProcedureId,
+  TriggerExample,
+} from './types'

--- a/packages/lib/src/tiptap/doc-to-text.ts
+++ b/packages/lib/src/tiptap/doc-to-text.ts
@@ -53,12 +53,64 @@ const BLOCK_CONTAINER_TYPES = new Set([
   // KB block schema — `Doc -> block -> inline`. Each `block` is a block-
   // level container that should join its siblings with newlines.
   'block',
+  // v9 procedure condition arms — `conditionBlock -> (conditionCase | conditionElse) -> block+`.
+  // The arm bodies are block-level; join their children with newlines like any block container.
+  'conditionCase',
+  'conditionElse',
+  // A named local sub-procedure body is block-level prose too.
+  'subProcedure',
 ])
 
 // Inline containers whose children are inline (text + chips) — join with ''.
 const INLINE_CONTAINER_TYPES = new Set(['paragraph', 'heading', 'codeBlock', 'horizontalRule'])
 
-function walkNode(node: TiptapNode, options: DocToTextOptions): string {
+/** Indent every line of `text` by two spaces (for nested condition-arm bodies). */
+function indent(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => (line.length > 0 ? `  ${line}` : line))
+    .join('\n')
+}
+
+/**
+ * Render a single {@link ConditionGroup} to a compact human predicate
+ * (`field op value`, joined by the group's AND/OR). Tolerant of malformed
+ * input — returns `''` rather than throwing, matching the file contract.
+ * Execution NEVER reads this text; it's only for the overview / instruction
+ * framing (the branch is taken deterministically from the compiled groups).
+ */
+function summarizeGroup(group: unknown): string {
+  if (!group || typeof group !== 'object') return ''
+  const conditions = (group as { conditions?: unknown }).conditions
+  if (!Array.isArray(conditions) || conditions.length === 0) return ''
+  const parts: string[] = []
+  for (let i = 0; i < conditions.length; i++) {
+    const c = conditions[i] as Record<string, unknown> | null
+    if (!c || typeof c !== 'object') continue
+    const field = Array.isArray(c.fieldId)
+      ? c.fieldId.join('.')
+      : typeof c.fieldId === 'string'
+        ? c.fieldId
+        : ''
+    if (!field) continue
+    const op = typeof c.operator === 'string' ? c.operator : ''
+    const value =
+      c.value === undefined || c.value === null || c.value === ''
+        ? ''
+        : Array.isArray(c.value)
+          ? c.value.join(', ')
+          : String(c.value)
+    const clause = [field, op, value].filter((s) => s.length > 0).join(' ')
+    if (i > 0) {
+      const joiner = c.logicalOperator === 'OR' ? 'OR' : 'AND'
+      parts.push(joiner)
+    }
+    parts.push(clause)
+  }
+  return parts.join(' ')
+}
+
+function walkNode(node: TiptapNode, options: DocToTextOptions, caseIdx?: number): string {
   if (typeof node.text === 'string') return node.text
   if (node.type === 'mention' || node.type === 'mentionRecord' || node.type === 'mentionAgent') {
     const label = (node.attrs?.label as string | undefined) ?? ''
@@ -75,6 +127,49 @@ function walkNode(node: TiptapNode, options: DocToTextOptions): string {
     if (!variableId) return ''
     return options.variables ? options.variables(variableId) : `{{${variableId}}}`
   }
+
+  // ── v9 procedure control-flow nodes ──────────────────────────────────────
+  // The IF / ELSE IF keyword comes from each `conditionCase`'s POSITION in the
+  // block (there is no `kind` attr) — the block handler threads the running index.
+  if (node.type === 'conditionBlock') {
+    let idx = 0
+    return (node.content ?? [])
+      .map((arm) =>
+        arm.type === 'conditionCase' ? walkNode(arm, options, idx++) : walkNode(arm, options)
+      )
+      .filter((s) => s.length > 0)
+      .join('\n')
+  }
+  if (node.type === 'conditionCase') {
+    const kw = (caseIdx ?? 0) === 0 ? 'IF' : 'ELSE IF'
+    const pred = summarizeGroup(node.attrs?.group)
+    const body = (node.content ?? [])
+      .map((c) => walkNode(c, options))
+      .filter((s) => s.length > 0)
+      .join('\n')
+    return `${kw} ${pred}:\n${indent(body)}`
+  }
+  if (node.type === 'conditionElse') {
+    const body = (node.content ?? [])
+      .map((c) => walkNode(c, options))
+      .filter((s) => s.length > 0)
+      .join('\n')
+    return `ELSE:\n${indent(body)}`
+  }
+  // Step leaves — one-line markers for the read-only overview.
+  if (node.type === 'routingStep') {
+    const outcome = node.attrs?.outcome
+    if (outcome === 'handoff') return '[handoff]'
+    if (outcome === 'switch') return '[switch procedure]'
+    if (outcome === 'call') return '[run sub-procedure]'
+    return '[end]'
+  }
+  if (node.type === 'codeStep') return '[run code]'
+  if (node.type === 'toolStep') {
+    const toolName = typeof node.attrs?.toolName === 'string' ? node.attrs.toolName : ''
+    return toolName ? `[call ${toolName}]` : '[call tool]'
+  }
+
   if (Array.isArray(node.content)) {
     const parts = node.content.map((child) => walkNode(child, options)).filter((s) => s.length > 0)
     if (!node.type || BLOCK_CONTAINER_TYPES.has(node.type)) return parts.join('\n')

--- a/packages/ui/src/components/nav-stack.tsx
+++ b/packages/ui/src/components/nav-stack.tsx
@@ -14,8 +14,9 @@ import {
   useState,
 } from 'react'
 
-/** App-wide spring, shared with `dialog-nav`. */
-const SPRING = { type: 'spring', stiffness: 300, damping: 30 } as const
+/** App-wide spring. `damping: 38` is past critical (~35 at this stiffness) so the
+ * panel settles cleanly with no end-bounce/overshoot, while staying snappy. */
+const SPRING = { type: 'spring', stiffness: 300, damping: 38 } as const
 
 /** Parallax depth: the back screen travels this far while the front travels 100%. Tune on device. */
 const PARALLAX = '-30%'
@@ -208,6 +209,10 @@ export interface NavStackPanelsProps {
  * during a transition, the panel beneath it (the parallax target). Does not
  * manage its own scroll or height — the active panel's content defines the
  * height; place inside a parent `ScrollArea`.
+ *
+ * Note: this clips both axes, so a `position: sticky` bar must NOT live inside a
+ * panel — it would stick to this (unscrollable) box and scroll away. Put the bar
+ * outside, in a sticky `<NavStackBar>`, so it pins to the outer `ScrollArea`.
  */
 export function NavStackPanels({ className }: NavStackPanelsProps) {
   const { top, direction } = useNavStack()
@@ -215,6 +220,16 @@ export function NavStackPanels({ className }: NavStackPanelsProps) {
   const reduce = useReducedMotion()
   const active = panels.find((p) => p.value === top)
   const variants = reduce ? fadeVariants : slideVariants
+
+  // Stack panels by their declaration order (= depth): the deeper panel always
+  // sits above the shallower one, so the FRONT screen occludes the BACK during
+  // BOTH push and pop. Without this, the in-flow (entering) panel and the
+  // popLayout-absolute (leaving) panel have no defined order and bleed through
+  // each other. `relative` is required for z-index to apply to the in-flow panel.
+  const activeIndex = Math.max(
+    0,
+    panels.findIndex((p) => p.value === top)
+  )
 
   return (
     <div className={cn('relative overflow-hidden', className)}>
@@ -227,7 +242,11 @@ export function NavStackPanels({ className }: NavStackPanelsProps) {
           animate='center'
           exit='exit'
           transition={reduce ? { duration: 0.15 } : SPRING}
-          className={cn('w-full shadow-[-8px_0_24px_rgba(0,0,0,0.08)]', active?.className)}>
+          style={{ zIndex: activeIndex }}
+          className={cn(
+            'relative w-full bg-background shadow-[-8px_0_24px_rgba(0,0,0,0.08)]',
+            active?.className
+          )}>
           {active?.children}
         </motion.div>
       </AnimatePresence>


### PR DESCRIPTION
## Summary

Phase 2 of chat-v9 procedures (follows #745 selection / #743 schema). Adds the **procedure editor UI** and the tRPC routers that back it.

- **`procedure` router** — org-level standalone procedures: list, get, autosave draft `doc` + trigger defaults, `publish` (snapshot immutable version + repoint active), `revert`, compile.
- **`agentProcedure` router** — the M:N agent↔procedure links: attach/detach + per-agent `enabled`/`priority` + trigger overrides.
- **Editor UI** (`components/agents/procedures/`) — tiptap node views for routing / condition (case/else/predicate) / tool / code steps, autosave hook, trigger-examples editor, picker lists, detail bar, and the **Procedures** tab on agent detail.
- **Client export** — `@auxx/lib/agents/procedures` + `/client` subpaths (client-safe types-only surface, per the client-import rule).
- Supporting tweaks to the rich-text / reference-picker editor and `doc-to-text`.

## Notes

Publish/revert currently change only the DB — the org-cache `agents` projection + live selection/stepper consumption land in Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)