### PR TITLE
feat(agents): chat-v9 procedures phase 4 — runtime stepper + control tools

### DIFF
--- a/apps/web/src/components/agents/procedures/ui/procedures-section-content.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedures-section-content.tsx
@@ -3,6 +3,7 @@
 
 import { EmptySection } from '@auxx/ui/components/section'
 import { toastError } from '@auxx/ui/components/toast'
+import { ListChecks } from 'lucide-react'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import type { AgentDetail } from '../../store/agent-store'
@@ -53,9 +54,13 @@ export function ProceduresSectionContent({ agent, onOpen }: ProceduresSectionCon
 
   if (rows.length === 0) {
     return (
-      <p className='px-3 py-6 text-center text-sm text-muted-foreground'>
-        No procedures yet. Add one to give this agent a step-by-step playbook.
-      </p>
+      <div className='px-3 py-2'>
+        <EmptySection
+          icon={<ListChecks className='size-5' />}
+          title='No procedures yet'
+          description='Add one to give this agent a step-by-step playbook for specific situations.'
+        />
+      </div>
     )
   }
 

--- a/packages/lib/src/agents/procedures/__tests__/classifier.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/classifier.test.ts
@@ -1,0 +1,96 @@
+// packages/lib/src/agents/procedures/__tests__/classifier.test.ts
+
+import type { Database } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { backstopClassify, classifyTextBranch, goalMetCheck } from '../classifier'
+import type { ClassifyDeps } from '../classify'
+import type { ProcedureStep } from '../types'
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }))
+vi.mock('../../../ai/orchestrator/llm-orchestrator', () => ({
+  LLMOrchestrator: class {
+    invoke = invokeMock
+  },
+}))
+
+const deps: ClassifyDeps = {
+  db: {} as Database,
+  organizationId: 'org-1',
+  userId: 'user-1',
+  model: 'claude-haiku-4-5',
+  provider: 'anthropic',
+}
+
+const step: Extract<ProcedureStep, { kind: 'instruction' }> = {
+  id: 's0',
+  kind: 'instruction',
+  doc: {
+    type: 'fragment',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Cancel the order.' }] }],
+  },
+  next: null,
+}
+
+const lastRequest = () => invokeMock.mock.calls.at(-1)?.[0]
+
+beforeEach(() => invokeMock.mockReset())
+
+describe('goalMetCheck', () => {
+  it('returns true/false from structured output and tags the call source', async () => {
+    invokeMock.mockResolvedValue({ structured_output: { met: true } })
+    expect(await goalMetCheck('Done, your order is cancelled.', step, deps)).toBe(true)
+    expect(lastRequest().context).toEqual({ source: 'procedure-advance-check' })
+
+    invokeMock.mockResolvedValue({ structured_output: { met: false } })
+    expect(await goalMetCheck('What is your order number?', step, deps)).toBe(false)
+  })
+
+  it('defaults to false when the model omits the field', async () => {
+    invokeMock.mockResolvedValue({ structured_output: {} })
+    expect(await goalMetCheck('…', step, deps)).toBe(false)
+  })
+})
+
+describe('backstopClassify', () => {
+  it('returns the on-procedure / multi-turn verdict', async () => {
+    invokeMock.mockResolvedValue({ structured_output: { onProcedure: false, multiTurn: true } })
+    expect(await backstopClassify('Sure, I can also help with returns…', step, deps)).toEqual({
+      onProcedure: false,
+      multiTurn: true,
+    })
+    expect(lastRequest().context).toEqual({ source: 'procedure-backstop' })
+  })
+
+  it('coerces missing fields to false', async () => {
+    invokeMock.mockResolvedValue({ structured_output: {} })
+    expect(await backstopClassify('…', step, deps)).toEqual({
+      onProcedure: false,
+      multiTurn: false,
+    })
+  })
+})
+
+describe('classifyTextBranch', () => {
+  const convo = [{ role: 'user' as const, content: 'I want to cancel now and re-order later' }]
+
+  it('returns the chosen in-range arm index', async () => {
+    invokeMock.mockResolvedValue({ structured_output: { arm: 1 } })
+    expect(await classifyTextBranch(convo, ['cancel only', 'cancel + re-order'], deps)).toBe(1)
+    expect(lastRequest().context).toEqual({ source: 'procedure-text-condition' })
+  })
+
+  it('clamps an out-of-range arm to null (else fallthrough)', async () => {
+    invokeMock.mockResolvedValue({ structured_output: { arm: 5 } })
+    expect(await classifyTextBranch(convo, ['a', 'b'], deps)).toBeNull()
+  })
+
+  it('returns null when the model picks none', async () => {
+    invokeMock.mockResolvedValue({ structured_output: { arm: null } })
+    expect(await classifyTextBranch(convo, ['a', 'b'], deps)).toBeNull()
+  })
+
+  it('short-circuits with no LLM call when there are no predicates', async () => {
+    expect(await classifyTextBranch(convo, [], deps)).toBeNull()
+    expect(invokeMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/agents/procedures/__tests__/context.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/context.test.ts
@@ -4,7 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Subject, ToolContext } from '../../../ai/agent-framework/tool-context'
 import { evaluateConditions } from '../../../conditions/evaluate'
 import type { Condition, ConditionGroup } from '../../../conditions/types'
-import { buildProcedureFieldResolver } from '../context'
+import { buildProcedureFieldResolver, buildProcedurePredicateResolver, scopedVar } from '../context'
+import type { ProcedureFrame } from '../types'
 
 // The v8 binding resolver is mocked: it returns whatever `resolveMap` holds for the
 // ref (joined for FieldPath), so the test controls "what the subject resolves to".
@@ -93,5 +94,95 @@ describe('buildProcedureFieldResolver', () => {
     ])
     expect(resolver(subject, 'status')).toBe('x')
     expect(innerCalls).toHaveLength(1) // deduped by simple key
+  })
+})
+
+const frame: ProcedureFrame = {
+  procedureId: 'p1',
+  procedureVersionId: 'v1',
+  cursor: 's0',
+  status: 'running',
+  history: [],
+  pushedBy: 'selection',
+}
+
+/** A ToolContext whose `context.read` serves `store` and whose `subject` is the empty subject. */
+function makeCtx(store: Record<string, unknown>, reads?: string[]): ToolContext {
+  return {
+    subject,
+    context: {
+      read: async (ref: string) => {
+        reads?.push(ref)
+        return store[ref]
+      },
+    },
+  } as unknown as ToolContext
+}
+
+describe('scopedVar', () => {
+  it('namespaces a local attribute under the procedure VERSION as a flat var key', () => {
+    expect(scopedVar(frame, 'cancel_result')).toBe('var:__la:v1:cancel_result')
+  })
+
+  it('a different procedureVersionId yields an isolated key (cross-procedure push)', () => {
+    const other: ProcedureFrame = { ...frame, procedureVersionId: 'v2' }
+    expect(scopedVar(other, 'cancel_result')).toBe('var:__la:v2:cancel_result')
+    expect(scopedVar(other, 'cancel_result')).not.toBe(scopedVar(frame, 'cancel_result'))
+  })
+})
+
+describe('buildProcedurePredicateResolver', () => {
+  it('reads a declared local attribute from the VERSION-scoped store key', async () => {
+    const ctxV = makeCtx({ 'var:__la:v1:cancel_result': 'done' })
+    const { resolver, prime } = buildProcedurePredicateResolver(ctxV, frame)
+    const groups = [group([cond('var:cancel_result', 'is', 'done')])]
+    await prime(groups)
+    // The evaluator strips `var:` → looks up the simple `cancel_result`.
+    expect(resolver(subject, 'cancel_result')).toBe('done')
+    expect(evaluateConditions(subject, groups, resolver)).toBe(true)
+  })
+
+  it('isolates locals by version — a v2 frame does not see a v1 write', async () => {
+    const ctxV = makeCtx({ 'var:__la:v1:cancel_result': 'done' })
+    const v2Frame: ProcedureFrame = { ...frame, procedureVersionId: 'v2' }
+    const { resolver, prime } = buildProcedurePredicateResolver(ctxV, v2Frame)
+    await prime([group([cond('var:cancel_result', 'is', 'done')])])
+    expect(resolver(subject, 'cancel_result')).toBeUndefined() // v2 key is empty
+  })
+
+  it('resolves CRM FieldReferences off the subject, same as selection', async () => {
+    resolveMap['contact:status'] = 'OPEN'
+    const { resolver, prime } = buildProcedurePredicateResolver(makeCtx({}), frame)
+    await prime([group([cond('contact:status', 'is', 'OPEN')])])
+    expect(resolver(subject, 'status')).toBe('OPEN')
+  })
+
+  it('mixes a local var and a CRM field in one group', async () => {
+    resolveMap['contact:status'] = 'OPEN'
+    const ctxV = makeCtx({ 'var:__la:v1:verified': true })
+    const { resolver, prime } = buildProcedurePredicateResolver(ctxV, frame)
+    const groups = [group([cond('contact:status', 'is', 'OPEN'), cond('var:verified', 'is', true)])]
+    await prime(groups)
+    expect(evaluateConditions(subject, groups, resolver)).toBe(true)
+  })
+
+  it('gate-by-absence: an unwritten local attribute is undefined, never throws', async () => {
+    const ctxV = makeCtx({}) // store empty
+    const { resolver, prime } = buildProcedurePredicateResolver(ctxV, frame)
+    const groups = [group([cond('var:cancel_result', 'is', 'done')])]
+    await prime(groups)
+    expect(resolver(subject, 'cancel_result')).toBeUndefined()
+    expect(evaluateConditions(subject, groups, resolver)).toBe(false)
+  })
+
+  it('prime is incremental + idempotent — each distinct field resolved once across calls', async () => {
+    const reads: string[] = []
+    const ctxV = makeCtx({ 'var:__la:v1:a': 1, 'var:__la:v1:b': 2 }, reads)
+    const { prime, resolver } = buildProcedurePredicateResolver(ctxV, frame)
+    await prime([group([cond('var:a', 'is', 1)])])
+    await prime([group([cond('var:a', 'is', 1), cond('var:b', 'is', 2)])]) // a repeated, b new
+    expect(reads).toEqual(['var:__la:v1:a', 'var:__la:v1:b']) // a read once, b once
+    expect(resolver(subject, 'a')).toBe(1)
+    expect(resolver(subject, 'b')).toBe(2)
   })
 })

--- a/packages/lib/src/agents/procedures/__tests__/control-tools.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/control-tools.test.ts
@@ -1,0 +1,73 @@
+// packages/lib/src/agents/procedures/__tests__/control-tools.test.ts
+
+import { describe, expect, it, vi } from 'vitest'
+import type { ToolContext } from '../../../ai/agent-framework/tool-context'
+import {
+  advanceProcedure,
+  awaitCustomer,
+  digress,
+  endProcedure,
+  handoffToHuman,
+  PROC_SIGNAL_KEY,
+  PROCEDURE_CONTROL_TOOLS,
+} from '../control-tools'
+
+function makeCtx() {
+  const write = vi.fn(async () => {})
+  return { ctx: { context: { write } } as unknown as ToolContext, write }
+}
+
+describe('control tools record their signal', () => {
+  it('advance_procedure writes {kind:advance}', async () => {
+    const { ctx, write } = makeCtx()
+    const r = await advanceProcedure.execute({}, ctx)
+    expect(write).toHaveBeenCalledWith(PROC_SIGNAL_KEY, { kind: 'advance' })
+    expect(r).toMatchObject({ success: true })
+  })
+
+  it('await_customer writes {kind:await}', async () => {
+    const { ctx, write } = makeCtx()
+    await awaitCustomer.execute({}, ctx)
+    expect(write).toHaveBeenCalledWith(PROC_SIGNAL_KEY, { kind: 'await' })
+  })
+
+  it('digress writes {kind:digress, reason} from the arg', async () => {
+    const { ctx, write } = makeCtx()
+    await digress.execute({ reason: 'wants a refund' }, ctx)
+    expect(write).toHaveBeenCalledWith(PROC_SIGNAL_KEY, {
+      kind: 'digress',
+      reason: 'wants a refund',
+    })
+  })
+
+  it('digress coerces a missing reason to empty string', async () => {
+    const { ctx, write } = makeCtx()
+    await digress.execute({}, ctx)
+    expect(write).toHaveBeenCalledWith(PROC_SIGNAL_KEY, { kind: 'digress', reason: '' })
+  })
+
+  it('handoff_to_human writes {kind:handoff}', async () => {
+    const { ctx, write } = makeCtx()
+    await handoffToHuman.execute({}, ctx)
+    expect(write).toHaveBeenCalledWith(PROC_SIGNAL_KEY, { kind: 'handoff' })
+  })
+
+  it('end_procedure writes {kind:end}', async () => {
+    const { ctx, write } = makeCtx()
+    await endProcedure.execute({}, ctx)
+    expect(write).toHaveBeenCalledWith(PROC_SIGNAL_KEY, { kind: 'end' })
+  })
+
+  it('exposes all five tools with unique names + required AgentToolDefinition fields', () => {
+    expect(PROCEDURE_CONTROL_TOOLS).toHaveLength(5)
+    const names = PROCEDURE_CONTROL_TOOLS.map((t) => t.name)
+    expect(new Set(names).size).toBe(5)
+    for (const t of PROCEDURE_CONTROL_TOOLS) {
+      expect(t.name).toBeTruthy()
+      expect(t.displayName).toBeTruthy()
+      expect(t.description).toBeTruthy()
+      expect(t.parameters).toBeTruthy()
+      expect(typeof t.execute).toBe('function')
+    }
+  })
+})

--- a/packages/lib/src/agents/procedures/__tests__/stepper.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/stepper.test.ts
@@ -1,0 +1,584 @@
+// packages/lib/src/agents/procedures/__tests__/stepper.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ToolContext } from '../../../ai/agent-framework/tool-context'
+import { PROC_SIGNAL_KEY } from '../control-tools'
+import { interpretSignal, type PrepareResult, prepareTurn, type StepperDeps } from '../stepper'
+import type { CompiledProcedure, ProcedureFrame, ProcedureStack, ProcedureStep } from '../types'
+
+// CRM-field resolution goes through the v8 binding resolver — mocked to read `resolveMap`.
+// The fixtures below use `var:*` predicates (served by `ctx.context.read`), so this is
+// only exercised by the one CRM test.
+const { resolveMap } = vi.hoisted(() => ({ resolveMap: {} as Record<string, unknown> }))
+vi.mock('../../bindings/resolve', () => ({
+  buildResolveVarSource: vi.fn(
+    () => async (source: { kind: string; ref: string | string[] }) =>
+      resolveMap[Array.isArray(source.ref) ? source.ref.join('|') : source.ref]
+  ),
+}))
+
+// ── fixture builders ───────────────────────────────────────────────────────
+
+const frag = (text = ''): unknown =>
+  text
+    ? { type: 'fragment', content: [{ type: 'paragraph', content: [{ type: 'text', text }] }] }
+    : { type: 'fragment', content: [] }
+
+const instruction = (id: string, next: string | null, text = ''): ProcedureStep => ({
+  id,
+  kind: 'instruction',
+  doc: frag(text),
+  next,
+})
+
+const structured = (
+  id: string,
+  cases: { thenStep: string | null; varName: string; value: unknown }[],
+  elseStep: string | null,
+  next: string | null
+): ProcedureStep => ({
+  id,
+  kind: 'condition',
+  mode: 'structured',
+  cases: cases.map((c) => ({
+    thenStep: c.thenStep,
+    group: {
+      id: `g-${c.varName}`,
+      logicalOperator: 'AND',
+      conditions: [
+        { id: `c-${c.varName}`, fieldId: `var:${c.varName}`, operator: 'is', value: c.value },
+      ],
+    },
+  })),
+  elseStep,
+  next,
+})
+
+const textCond = (
+  id: string,
+  cases: { thenStep: string | null; predicate: string }[],
+  elseStep: string | null,
+  next: string | null
+): ProcedureStep => ({
+  id,
+  kind: 'condition',
+  mode: 'text',
+  cases: cases.map((c) => ({ thenStep: c.thenStep, predicate: c.predicate })),
+  elseStep,
+  next,
+})
+
+const routing = (
+  id: string,
+  outcome: 'finished' | 'handoff' | 'switch' | 'call',
+  opts: { next?: string | null; subProcedureId?: string; switchToProcedureId?: string } = {}
+): ProcedureStep => ({
+  id,
+  kind: 'routing',
+  outcome,
+  next: opts.next ?? null,
+  ...(opts.subProcedureId ? { subProcedureId: opts.subProcedureId } : {}),
+  ...(opts.switchToProcedureId ? { switchToProcedureId: opts.switchToProcedureId } : {}),
+})
+
+const build = (
+  entryStepId: string,
+  steps: ProcedureStep[],
+  subProcedures: CompiledProcedure['subProcedures'] = {}
+): CompiledProcedure => ({
+  entryStepId,
+  steps: Object.fromEntries(steps.map((s) => [s.id, s])),
+  codeBlocks: {},
+  subProcedures,
+  localAttributes: [],
+})
+
+const frame = (
+  procedureVersionId: string,
+  cursor: string | null,
+  pushedBy: ProcedureFrame['pushedBy'] = 'selection',
+  procedureId = 'p1'
+): ProcedureFrame => ({
+  procedureId,
+  procedureVersionId,
+  cursor,
+  status: 'running',
+  history: [],
+  pushedBy,
+})
+
+const stackOf = (...frames: ProcedureFrame[]): ProcedureStack => ({ frames })
+
+// ── deps ─────────────────────────────────────────────────────────────────
+
+let varStore: Record<string, unknown>
+let reads: string[]
+
+function makeDeps(
+  versions: Record<string, CompiledProcedure>,
+  overrides: Partial<StepperDeps> = {}
+): StepperDeps {
+  return {
+    ctx: {
+      subject: { anchors: {}, identityVerified: false },
+      context: {
+        read: async (ref: string) => {
+          reads.push(ref)
+          return varStore[ref]
+        },
+        write: async (ref: string, value: unknown) => {
+          varStore[ref] = value
+        },
+      },
+    } as unknown as ToolContext,
+    readVersion: async (id) => (versions[id] ? { compiled: versions[id]! } : null),
+    loadActiveVersion: async () => null,
+    selectOther: async () => null,
+    pickTextBranch: async () => null,
+    checkGoalMet: async () => true,
+    classifyBackstop: async () => ({ onProcedure: true, multiTurn: false }),
+    ...overrides,
+  }
+}
+
+const asInject = (r: PrepareResult): Extract<PrepareResult, { kind: 'inject' }> => {
+  if (r.kind !== 'inject') throw new Error(`expected inject, got ${r.kind}`)
+  return r
+}
+
+beforeEach(() => {
+  varStore = {}
+  reads = []
+  for (const k of Object.keys(resolveMap)) delete resolveMap[k]
+})
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe('prepareTurn — deterministic advance', () => {
+  it('advances instruction → structured condition → instruction with NO classifier call', async () => {
+    varStore['var:__la:v1:a'] = 1
+    const compiled = build('i0', [
+      instruction('i0', 'cond'),
+      structured('cond', [{ thenStep: 'iThen', varName: 'a', value: 1 }], 'iElse', 'join'),
+      instruction('iThen', 'join'),
+      instruction('iElse', 'join'),
+      instruction('join', null),
+    ])
+    const pickTextBranch = vi.fn(async () => null)
+    const r = asInject(
+      await prepareTurn(stackOf(frame('v1', 'i0')), makeDeps({ v1: compiled }, { pickTextBranch }))
+    )
+    // i0 is the first instruction → stops there immediately.
+    expect(r.activeStep.id).toBe('i0')
+    expect(pickTextBranch).not.toHaveBeenCalled()
+  })
+
+  it('descends the structured TRUE branch from a var predicate', async () => {
+    varStore['var:__la:v1:a'] = 1
+    const compiled = build('cond', [
+      structured('cond', [{ thenStep: 'iThen', varName: 'a', value: 1 }], 'iElse', null),
+      instruction('iThen', null, 'then body'),
+      instruction('iElse', null, 'else body'),
+    ])
+    const r = asInject(await prepareTurn(stackOf(frame('v1', 'cond')), makeDeps({ v1: compiled })))
+    expect(r.activeStep.id).toBe('iThen')
+  })
+
+  it('falls to the ELSE branch when no case matches', async () => {
+    varStore['var:__la:v1:a'] = 999
+    const compiled = build('cond', [
+      structured('cond', [{ thenStep: 'iThen', varName: 'a', value: 1 }], 'iElse', null),
+      instruction('iThen', null),
+      instruction('iElse', null),
+    ])
+    const r = asInject(await prepareTurn(stackOf(frame('v1', 'cond')), makeDeps({ v1: compiled })))
+    expect(r.activeStep.id).toBe('iElse')
+  })
+
+  it('is idempotent — re-running from the resulting cursor yields the same step, no writes', async () => {
+    varStore['var:__la:v1:a'] = 1
+    const compiled = build('i0', [
+      instruction('i0', 'cond'),
+      structured('cond', [{ thenStep: 'iThen', varName: 'a', value: 1 }], null, null),
+      instruction('iThen', null),
+    ])
+    const stack = stackOf(frame('v1', 'i0'))
+    const first = asInject(await prepareTurn(stack, makeDeps({ v1: compiled })))
+    // advance again from where it stopped — instructions stop immediately, same result.
+    const second = asInject(await prepareTurn(first.stack, makeDeps({ v1: compiled })))
+    expect(second.activeStep.id).toBe(first.activeStep.id)
+    expect(second.stack.frames[0]!.cursor).toBe(first.stack.frames[0]!.cursor)
+  })
+
+  it('resumes correctly when the cursor starts INSIDE a nested condition (OQ#3)', async () => {
+    varStore['var:__la:v1:a'] = 1
+    varStore['var:__la:v1:b'] = 2
+    const compiled = build('outer', [
+      structured('outer', [{ thenStep: 'inner', varName: 'a', value: 1 }], 'iEnd', 'join'),
+      structured('inner', [{ thenStep: 'iThen', varName: 'b', value: 2 }], 'iElse', 'join'),
+      instruction('iThen', 'join'),
+      instruction('iElse', 'join'),
+      instruction('iEnd', 'join'),
+      instruction('join', null),
+    ])
+    // Resume directly at the inner condition (a parked mid-tree cursor).
+    const r = asInject(await prepareTurn(stackOf(frame('v1', 'inner')), makeDeps({ v1: compiled })))
+    expect(r.activeStep.id).toBe('iThen')
+  })
+
+  it('resolves a CRM FieldReference off the subject in a structured condition', async () => {
+    resolveMap['contact:status'] = 'OPEN'
+    const compiled: CompiledProcedure = {
+      entryStepId: 'cond',
+      steps: {
+        cond: {
+          id: 'cond',
+          kind: 'condition',
+          mode: 'structured',
+          cases: [
+            {
+              thenStep: 'iThen',
+              group: {
+                id: 'g',
+                logicalOperator: 'AND',
+                conditions: [{ id: 'c', fieldId: 'contact:status', operator: 'is', value: 'OPEN' }],
+              },
+            },
+          ],
+          elseStep: 'iElse',
+          next: null,
+        },
+        iThen: instruction('iThen', null),
+        iElse: instruction('iElse', null),
+      },
+      codeBlocks: {},
+      subProcedures: {},
+      localAttributes: [],
+    }
+    const r = asInject(await prepareTurn(stackOf(frame('v1', 'cond')), makeDeps({ v1: compiled })))
+    expect(r.activeStep.id).toBe('iThen')
+  })
+})
+
+describe('prepareTurn — text condition', () => {
+  it('spends ONE classify call and descends the chosen arm', async () => {
+    const compiled = build('cond', [
+      textCond(
+        'cond',
+        [
+          { thenStep: 'iA', predicate: 'customer wants to cancel' },
+          { thenStep: 'iB', predicate: 'customer wants a refund' },
+        ],
+        'iElse',
+        null
+      ),
+      instruction('iA', null),
+      instruction('iB', null),
+      instruction('iElse', null),
+    ])
+    const pickTextBranch = vi.fn(async () => 1)
+    const r = asInject(
+      await prepareTurn(
+        stackOf(frame('v1', 'cond')),
+        makeDeps({ v1: compiled }, { pickTextBranch })
+      )
+    )
+    expect(pickTextBranch).toHaveBeenCalledOnce()
+    expect(pickTextBranch).toHaveBeenCalledWith([
+      'customer wants to cancel',
+      'customer wants a refund',
+    ])
+    expect(r.activeStep.id).toBe('iB')
+  })
+
+  it('falls through to ELSE when the classifier returns null', async () => {
+    const compiled = build('cond', [
+      textCond('cond', [{ thenStep: 'iA', predicate: 'x' }], 'iElse', null),
+      instruction('iA', null),
+      instruction('iElse', null),
+    ])
+    const r = asInject(
+      await prepareTurn(
+        stackOf(frame('v1', 'cond')),
+        makeDeps({ v1: compiled }, { pickTextBranch: async () => null })
+      )
+    )
+    expect(r.activeStep.id).toBe('iElse')
+  })
+})
+
+describe('prepareTurn — routing & stack ops', () => {
+  it('finished routing pops frame 0 → free-form', async () => {
+    const compiled = build('end', [routing('end', 'finished')])
+    const r = await prepareTurn(stackOf(frame('v1', 'end')), makeDeps({ v1: compiled }))
+    expect(r.kind).toBe('free-form')
+    expect(r.stack.frames).toHaveLength(0)
+  })
+
+  it('handoff routing clears the stack → free-form', async () => {
+    const compiled = build('h', [routing('h', 'handoff')])
+    const r = await prepareTurn(
+      stackOf(frame('v1', 'a'), frame('v1', 'h')),
+      makeDeps({ v1: compiled })
+    )
+    expect(r.kind).toBe('free-form')
+    expect(r.stack.frames).toHaveLength(0)
+  })
+
+  it('switch replaces the top frame with the target procedure’s pinned active version', async () => {
+    const p1 = build('sw', [routing('sw', 'switch', { switchToProcedureId: 'p2' })])
+    const p2 = build('p2entry', [instruction('p2entry', null, 'p2 first')])
+    const loadActiveVersion = vi.fn(async () => ({ procedureVersionId: 'v2', compiled: p2 }))
+    const r = asInject(
+      await prepareTurn(
+        stackOf(frame('v1', 'sw')),
+        makeDeps({ v1: p1, v2: p2 }, { loadActiveVersion })
+      )
+    )
+    expect(loadActiveVersion).toHaveBeenCalledWith('p2')
+    expect(r.stack.frames).toHaveLength(1) // replaced, not pushed
+    expect(r.stack.frames[0]).toMatchObject({
+      procedureId: 'p2',
+      procedureVersionId: 'v2',
+      pushedBy: 'switch',
+    })
+    expect(r.activeStep.id).toBe('p2entry')
+  })
+
+  it('call pushes a same-version sub-procedure frame and parks the parent at routing.next', async () => {
+    const compiled = build(
+      'callStep',
+      [
+        routing('callStep', 'call', { subProcedureId: 'sub', next: 'afterCall' }),
+        instruction('afterCall', null),
+        instruction('subBody', null, 'sub body'),
+      ],
+      { sub: { id: 'sub', name: 'Sub', entryStepId: 'subBody' } }
+    )
+    const r = asInject(
+      await prepareTurn(stackOf(frame('v1', 'callStep')), makeDeps({ v1: compiled }))
+    )
+    expect(r.stack.frames).toHaveLength(2)
+    expect(r.stack.frames[0]!.cursor).toBe('afterCall') // parent parked at the return cursor
+    expect(r.stack.frames[1]).toMatchObject({
+      procedureVersionId: 'v1',
+      pushedBy: 'call',
+      cursor: 'subBody',
+    })
+    expect(r.activeStep.id).toBe('subBody')
+  })
+})
+
+describe('prepareTurn — pop & re-anchor', () => {
+  it('a digression pop re-injects the parent step WITH a breadcrumb', async () => {
+    const compiled = build('parentInstr', [
+      instruction('parentInstr', null, 'Your cancellation request is being processed.'),
+      routing('childEnd', 'finished'),
+    ])
+    const stack = stackOf(
+      frame('v1', 'parentInstr', 'selection'),
+      frame('v1', 'childEnd', 'digression')
+    )
+    const r = asInject(await prepareTurn(stack, makeDeps({ v1: compiled })))
+    expect(r.activeStep.id).toBe('parentInstr')
+    expect(r.stack.frames).toHaveLength(1)
+    expect(r.breadcrumb).toMatch(/^Back to /)
+  })
+
+  it('a call (sub-procedure) pop resumes the parent SILENTLY (no breadcrumb)', async () => {
+    const compiled = build('parentInstr', [
+      instruction('parentInstr', null, 'Parent step.'),
+      routing('childEnd', 'finished'),
+    ])
+    const stack = stackOf(frame('v1', 'parentInstr', 'selection'), frame('v1', 'childEnd', 'call'))
+    const r = asInject(await prepareTurn(stack, makeDeps({ v1: compiled })))
+    expect(r.activeStep.id).toBe('parentInstr')
+    expect(r.breadcrumb).toBeUndefined()
+  })
+})
+
+describe('prepareTurn — depth cap & pin integrity', () => {
+  it('a call AT the depth cap runs the sub-procedure inline (no push)', async () => {
+    const compiled = build(
+      'callStep',
+      [
+        routing('callStep', 'call', { subProcedureId: 'sub', next: 'afterCall' }),
+        instruction('afterCall', null),
+        instruction('subBody', null),
+      ],
+      { sub: { id: 'sub', name: 'Sub', entryStepId: 'subBody' } }
+    )
+    // Four frames = MAX_DEPTH; the top is at the call step.
+    const stack = stackOf(
+      frame('v1', 'afterCall'),
+      frame('v1', 'afterCall'),
+      frame('v1', 'afterCall'),
+      frame('v1', 'callStep')
+    )
+    const r = asInject(await prepareTurn(stack, makeDeps({ v1: compiled })))
+    expect(r.stack.frames).toHaveLength(4) // no push at the cap
+    expect(r.activeStep.id).toBe('subBody') // ran inline in the current frame
+  })
+
+  it('a hard-deleted pinned version (readVersion → null) discards the frame and recovers the parent', async () => {
+    const compiled = build('parentInstr', [instruction('parentInstr', null)])
+    // parent on v1 (loadable), child on v9 (deleted → null).
+    const stack = stackOf(frame('v1', 'parentInstr'), frame('v9', 'whatever', 'digression'))
+    const r = asInject(await prepareTurn(stack, makeDeps({ v1: compiled })))
+    expect(r.activeStep.id).toBe('parentInstr')
+    expect(r.stack.frames).toHaveLength(1)
+  })
+
+  it('frame 0 with a deleted pin → free-form', async () => {
+    const r = await prepareTurn(stackOf(frame('gone', 'x')), makeDeps({}))
+    expect(r.kind).toBe('free-form')
+    expect(r.stack.frames).toHaveLength(0)
+  })
+})
+
+describe('interpretSignal', () => {
+  const basic = () =>
+    build('i0', [instruction('i0', 'i1', 'Cancel the order.'), instruction('i1', null)])
+  const setSignal = (s: unknown) => {
+    varStore[PROC_SIGNAL_KEY] = s
+  }
+
+  it('advance + goal met → cursor moves to next, reinvoke; signal key is deleted', async () => {
+    setSignal({ kind: 'advance' })
+    const r = await interpretSignal(
+      stackOf(frame('v1', 'i0')),
+      'Cancelled.',
+      makeDeps({ v1: basic() })
+    )
+    expect(r).toMatchObject({ reinvoke: true, endTurn: false })
+    expect(r.stack.frames[0]!.cursor).toBe('i1')
+    expect(varStore[PROC_SIGNAL_KEY]).toBeUndefined()
+  })
+
+  it('advance + goal NOT met → stays on step, parks (await)', async () => {
+    setSignal({ kind: 'advance' })
+    const stack = stackOf(frame('v1', 'i0'))
+    const r = await interpretSignal(
+      stack,
+      'What is your order number?',
+      makeDeps({ v1: basic() }, { checkGoalMet: async () => false })
+    )
+    expect(r).toMatchObject({ reinvoke: false, endTurn: true })
+    expect(r.stack.frames[0]!.cursor).toBe('i0') // unchanged
+    expect(r.stack.frames[0]!.status).toBe('awaiting_customer')
+  })
+
+  it('await → parks', async () => {
+    setSignal({ kind: 'await' })
+    const r = await interpretSignal(stackOf(frame('v1', 'i0')), '…', makeDeps({ v1: basic() }))
+    expect(r).toMatchObject({ reinvoke: false, endTurn: true })
+    expect(r.stack.frames[0]!.status).toBe('awaiting_customer')
+  })
+
+  it('digress + match → push a digression frame, reinvoke (B opens this turn)', async () => {
+    setSignal({ kind: 'digress', reason: 'wants a refund' })
+    const selectOther = vi.fn(async () => ({
+      procedureId: 'p2',
+      procedureVersionId: 'v2',
+      compiled: basic(),
+    }))
+    const r = await interpretSignal(
+      stackOf(frame('v1', 'i0')),
+      '',
+      makeDeps({ v1: basic() }, { selectOther })
+    )
+    expect(selectOther).toHaveBeenCalledWith('p1')
+    expect(r).toMatchObject({ reinvoke: true, endTurn: false })
+    expect(r.stack.frames).toHaveLength(2)
+    expect(r.stack.frames[1]).toMatchObject({ procedureId: 'p2', pushedBy: 'digression' })
+  })
+
+  it('digress + no match → persona-only inline, parent parked', async () => {
+    setSignal({ kind: 'digress', reason: 'x' })
+    const r = await interpretSignal(
+      stackOf(frame('v1', 'i0')),
+      '',
+      makeDeps({ v1: basic() }, { selectOther: async () => null })
+    )
+    expect(r).toMatchObject({ inlineFallback: true, reinvoke: false })
+    expect(r.stack.frames).toHaveLength(1)
+  })
+
+  it('digress AT the depth cap → inline fallback, no selection call', async () => {
+    setSignal({ kind: 'digress', reason: 'x' })
+    const selectOther = vi.fn(async () => null)
+    const stack = stackOf(
+      frame('v1', 'i0'),
+      frame('v1', 'i0'),
+      frame('v1', 'i0'),
+      frame('v1', 'i0')
+    )
+    const r = await interpretSignal(stack, '', makeDeps({ v1: basic() }, { selectOther }))
+    expect(r.inlineFallback).toBe(true)
+    expect(selectOther).not.toHaveBeenCalled()
+  })
+
+  it('handoff → clears the stack', async () => {
+    setSignal({ kind: 'handoff' })
+    const r = await interpretSignal(
+      stackOf(frame('v1', 'i0')),
+      'Escalating.',
+      makeDeps({ v1: basic() })
+    )
+    expect(r).toMatchObject({ reinvoke: false, endTurn: true })
+    expect(r.stack.frames).toHaveLength(0)
+  })
+
+  it('end → pops one frame, reinvoke (parent resumes)', async () => {
+    setSignal({ kind: 'end' })
+    const stack = stackOf(frame('v1', 'i0'), frame('v1', 'i0', 'digression'))
+    const r = await interpretSignal(stack, 'All done.', makeDeps({ v1: basic() }))
+    expect(r).toMatchObject({ reinvoke: true, endTurn: false })
+    expect(r.stack.frames).toHaveLength(1)
+  })
+
+  it('silent + on-procedure → parks (no auto-advance off a guess)', async () => {
+    // no signal set → backstop fires; default classifyBackstop → onProcedure:true
+    const stack = stackOf(frame('v1', 'i0'))
+    const r = await interpretSignal(
+      stack,
+      'Continuing the cancellation…',
+      makeDeps({ v1: basic() })
+    )
+    expect(r).toMatchObject({ reinvoke: false, endTurn: true })
+    expect(r.stack.frames[0]!.cursor).toBe('i0')
+    expect(r.stack.frames[0]!.status).toBe('awaiting_customer')
+  })
+
+  it('silent + off-procedure + multiTurn → push for NEXT turn (no goto 1)', async () => {
+    const selectOther = vi.fn(async () => ({
+      procedureId: 'p2',
+      procedureVersionId: 'v2',
+      compiled: basic(),
+    }))
+    const r = await interpretSignal(
+      stackOf(frame('v1', 'i0')),
+      'Sure, about returns…',
+      makeDeps(
+        { v1: basic() },
+        { classifyBackstop: async () => ({ onProcedure: false, multiTurn: true }), selectOther }
+      )
+    )
+    expect(r).toMatchObject({ reinvoke: false, endTurn: true }) // reply already shipped
+    expect(r.stack.frames).toHaveLength(2)
+    expect(r.stack.frames[1]).toMatchObject({ pushedBy: 'digression' })
+  })
+
+  it('silent + off-procedure + NOT multiTurn → persona-only stands, no push', async () => {
+    const r = await interpretSignal(
+      stackOf(frame('v1', 'i0')),
+      'Quick aside.',
+      makeDeps(
+        { v1: basic() },
+        { classifyBackstop: async () => ({ onProcedure: false, multiTurn: false }) }
+      )
+    )
+    expect(r).toMatchObject({ reinvoke: false, endTurn: true })
+    expect(r.stack.frames).toHaveLength(1)
+  })
+})

--- a/packages/lib/src/agents/procedures/classifier.ts
+++ b/packages/lib/src/agents/procedures/classifier.ts
@@ -1,0 +1,181 @@
+// packages/lib/src/agents/procedures/classifier.ts
+
+import { LLMOrchestrator } from '../../ai/orchestrator/llm-orchestrator'
+import { docToText } from '../../tiptap'
+import type { ClassifyDeps, ConversationMessage } from './classify'
+import type { ProcedureStep } from './types'
+
+/**
+ * The cheap procedure classifiers — small structured-output calls that mirror the
+ * selection classifier (`classify.ts`) / `session-title.ts`. Three jobs, each a
+ * single Haiku-class call:
+ *
+ *  - {@link goalMetCheck} — the advance-check (#11): verify the ONE irreversible
+ *    signal before honoring it (`advance` moves the cursor past a step forever).
+ *  - {@link backstopClassify} — the silent-reply backstop (#2): when the model
+ *    replied with no control tool, decide whether it stayed on-procedure.
+ *  - {@link classifyTextBranch} — pick a `text`-mode condition arm (the one
+ *    condition path that costs a model call).
+ *
+ * All three reuse {@link ClassifyDeps} (db + org/user + the caller-resolved
+ * model/provider). Instrument every call from day one (STACK #11) — the wrong-await
+ * / missed-digress / compliance rates must be measured, not guessed.
+ *
+ * See plans/chat/v9/phase-3-stepper-and-stack.md §7.
+ */
+
+type ActiveStep = Extract<ProcedureStep, { kind: 'instruction' }>
+
+const BOOL_SCHEMA = (key: string) => ({
+  type: 'object' as const,
+  additionalProperties: false,
+  required: [key],
+  properties: { [key]: { type: 'boolean' } },
+})
+
+function renderConversation(conversation: ConversationMessage[]): string {
+  return conversation
+    .map((m) => `${m.role === 'user' ? 'Customer' : 'Agent'}: ${m.content}`)
+    .join('\n')
+}
+
+/**
+ * Advance-check — did the assistant's reply actually MEET the active step's goal?
+ * Strict: only `true` when the step's required outcome is unambiguously achieved.
+ * A `false` keeps the cursor on the step (the caller degrades `advance` → `await`).
+ */
+export async function goalMetCheck(
+  reply: string,
+  activeStep: ActiveStep,
+  deps: ClassifyDeps
+): Promise<boolean> {
+  const orchestrator = new LLMOrchestrator(undefined, deps.db)
+  const response = await orchestrator.invoke({
+    model: deps.model,
+    provider: deps.provider,
+    organizationId: deps.organizationId,
+    userId: deps.userId,
+    messages: [
+      {
+        role: 'system',
+        content:
+          "Decide whether the step goal was actually met by the assistant's reply. Respond only via the structured output. Be strict — set met=true only if the step's required outcome is unambiguously achieved.",
+      },
+      {
+        role: 'user',
+        content: `Step goal:\n${docToText(activeStep.doc)}\n\nAssistant reply:\n${reply}`,
+      },
+    ],
+    tools: [],
+    structuredOutput: { enabled: true, schema: BOOL_SCHEMA('met') },
+    parameters: { max_tokens: 20 },
+    context: { source: 'procedure-advance-check' },
+  })
+  return Boolean(response.structured_output?.met)
+}
+
+/** The backstop verdict on a silent reply (no control tool emitted). */
+export interface BackstopVerdict {
+  /** Did the reply continue THIS step, vs. answer something off-procedure? */
+  onProcedure: boolean
+  /** Off-procedure only: does the side request clearly need a multi-turn procedure? */
+  multiTurn: boolean
+}
+
+/**
+ * Silent-reply backstop — the model replied with text but emitted no control tool.
+ * Classify whether it stayed on the active step or drifted off-procedure (and if so,
+ * whether the drift is clearly multi-turn, gating a next-turn push — #8).
+ */
+export async function backstopClassify(
+  reply: string,
+  activeStep: ActiveStep,
+  deps: ClassifyDeps
+): Promise<BackstopVerdict> {
+  const orchestrator = new LLMOrchestrator(undefined, deps.db)
+  const response = await orchestrator.invoke({
+    model: deps.model,
+    provider: deps.provider,
+    organizationId: deps.organizationId,
+    userId: deps.userId,
+    messages: [
+      {
+        role: 'system',
+        content:
+          "Did the assistant's reply continue THIS procedure step, or answer something off-procedure? Respond only via the structured output. Set onProcedure=true if it advanced/continued the step. Set multiTurn=true only when an off-procedure request clearly needs its own multi-step handling.",
+      },
+      {
+        role: 'user',
+        content: `Current step:\n${docToText(activeStep.doc)}\n\nAssistant reply:\n${reply}`,
+      },
+    ],
+    tools: [],
+    structuredOutput: {
+      enabled: true,
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['onProcedure', 'multiTurn'],
+        properties: { onProcedure: { type: 'boolean' }, multiTurn: { type: 'boolean' } },
+      },
+    },
+    parameters: { max_tokens: 20 },
+    context: { source: 'procedure-backstop' },
+  })
+  return {
+    onProcedure: Boolean(response.structured_output?.onProcedure),
+    multiTurn: Boolean(response.structured_output?.multiTurn),
+  }
+}
+
+/**
+ * Pick a `text`-mode condition arm. Given the compiled NL `predicates` (arm order =
+ * precedence) and the conversation, return the matching arm index, or `null` for the
+ * else/fallthrough. This is the callback `prepareTurn` calls via `StepperDeps.pickTextBranch`;
+ * Phase 4 binds the turn's `conversation` into the closure.
+ */
+export async function classifyTextBranch(
+  conversation: ConversationMessage[],
+  predicates: string[],
+  deps: ClassifyDeps
+): Promise<number | null> {
+  if (predicates.length === 0) return null
+
+  const catalog = predicates.map((p, i) => `  ${i}: ${p}`).join('\n')
+  const orchestrator = new LLMOrchestrator(undefined, deps.db)
+  const response = await orchestrator.invoke({
+    model: deps.model,
+    provider: deps.provider,
+    organizationId: deps.organizationId,
+    userId: deps.userId,
+    messages: [
+      {
+        role: 'system',
+        content: [
+          'A procedure step branches on which of these conditions currently holds for the',
+          'customer. Evaluate them IN ORDER and pick the index of the FIRST that holds, or',
+          'null if none does. Respond only via the structured output.',
+          '',
+          'Conditions:',
+          catalog,
+        ].join('\n'),
+      },
+      { role: 'user', content: renderConversation(conversation) },
+    ],
+    tools: [],
+    structuredOutput: {
+      enabled: true,
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['arm'],
+        properties: { arm: { type: ['integer', 'null'] } },
+      },
+    },
+    parameters: { max_tokens: 20 },
+    context: { source: 'procedure-text-condition' },
+  })
+
+  const arm = response.structured_output?.arm
+  return typeof arm === 'number' && arm >= 0 && arm < predicates.length ? arm : null
+}

--- a/packages/lib/src/agents/procedures/context.ts
+++ b/packages/lib/src/agents/procedures/context.ts
@@ -5,6 +5,7 @@ import type { Subject, ToolContext } from '../../ai/agent-framework/tool-context
 import type { FieldResolver } from '../../conditions/evaluate'
 import type { ConditionGroup } from '../../conditions/types'
 import { buildResolveVarSource } from '../bindings/resolve'
+import type { ProcedureFrame } from './types'
 
 /**
  * The deterministic selection pre-filter (`select.ts`) gates candidate procedures
@@ -105,4 +106,95 @@ export async function buildProcedureFieldResolver(
   // The evaluator hands us the already-simplified field id (`extractFieldId`); the
   // `entity` arg is ignored — we read the pre-resolved map.
   return (_entity, fieldId) => values.get(fieldId)
+}
+
+// ── Phase 3: in-procedure `condition` predicates ───────────────────────────
+
+/** The `var:` prefix a declared local-attribute condition field carries (`use-procedure-condition-config.ts`). */
+const LOCAL_ATTR_PREFIX = 'var:'
+
+/**
+ * The Context-Variables store key a declared procedure-local attribute resolves
+ * to — namespaced by the **running procedure version**, NOT the frame. The same
+ * `procedureVersionId` is deliberate both ways (README / PROCEDURE-STACK #5):
+ *
+ *  - a LOCAL `call` frame carries the *same* `procedureVersionId` as its caller,
+ *    so a sub-procedure **shares** the parent's locals (how it returns a value);
+ *  - a CROSS-procedure push (`switch` / `digression`) carries a *different*
+ *    `procedureVersionId`, so it gets an **isolated** scope and can't clobber a
+ *    parent's `var:*`.
+ *
+ * Colons stay inside the store key's `root` (`parseContextRef` only splits a
+ * `var:` ref on `.` / `[`), so this is a single flat key. `name` is expected to
+ * be a plain identifier; a name containing `.`/`[` would nest (authoring contract).
+ */
+export function scopedVar(frame: ProcedureFrame, name: string): string {
+  return `var:__la:${frame.procedureVersionId}:${name}`
+}
+
+/**
+ * Build the synchronous {@link FieldResolver} an in-procedure `condition` step
+ * evaluates against. Unlike selection's resolver ({@link buildProcedureFieldResolver}),
+ * this one ALSO reads procedure-local `var:*` scratch — the procedure is running,
+ * so its declared `localAttributes` are readable (PROCEDURE-STACK #5). It reads:
+ *
+ *  - `var:<name>` — a declared local attribute, via `ctx.context.read` of the
+ *    version-scoped key ({@link scopedVar}); absent → `undefined` (gate-by-absence).
+ *  - any other `fieldId` — a CRM `FieldReference` resolved off `ctx.subject.anchors`
+ *    by the v8 resolver, exactly like selection.
+ *
+ * It deliberately does NOT resolve `tool:*` / `call:*` — those are latest-wins,
+ * turn-scoped captures, ambiguous when a tool runs more than once. Procedure logic
+ * reads named attributes only; a tool result reaches a condition solely by being
+ * written into a `localAttribute`.
+ *
+ * `evaluateConditions` is **synchronous** but reads (store + v8 resolver) are
+ * **async**, so the caller {@link prime}s every referenced field into an in-memory
+ * map first; the returned `resolver` is then a pure `Map.get` keyed by the
+ * evaluator's *simple* field id (`var:cancel_result` → `cancel_result`, byte-for-byte
+ * aligned with `evaluate.ts` `extractFieldId`). `prime` is incremental + idempotent
+ * (a field is resolved once), so the stepper can call it per `condition` step as it
+ * advances through several in one turn, accumulating into the shared map.
+ */
+export function buildProcedurePredicateResolver(
+  ctx: ToolContext,
+  frame: ProcedureFrame
+): { resolver: FieldResolver<unknown>; prime: (groups: ConditionGroup[]) => Promise<void> } {
+  const resolveVar = buildResolveVarSource(ctx)
+  const subject = ctx.subject
+  const values = new Map<string, unknown>()
+  const seen = new Set<string>()
+
+  const resolveOne = async (fieldId: string | string[]): Promise<unknown> => {
+    // Declared local attribute (`var:<name>`) — read the version-scoped store key.
+    if (typeof fieldId === 'string' && fieldId.startsWith(LOCAL_ATTR_PREFIX)) {
+      try {
+        return await ctx.context.read(scopedVar(frame, fieldId.slice(LOCAL_ATTR_PREFIX.length)))
+      } catch {
+        return undefined
+      }
+    }
+    // CRM FieldReference — resolve off subject anchors (v8), gate-by-absence. A bare
+    // legacy id (no entity root) or a missing subject yields `undefined`.
+    const ref = toVarRef(fieldId)
+    if (!ref || !subject) return undefined
+    try {
+      return await resolveVar({ kind: 'var', ref }, subject)
+    } catch {
+      // In-procedure predicates are best-effort — a misconfig gates by absence
+      // rather than throwing the turn.
+      return undefined
+    }
+  }
+
+  const prime = async (groups: ConditionGroup[]): Promise<void> => {
+    for (const fieldId of collectFieldRefs(groups)) {
+      const key = simpleKey(fieldId)
+      if (seen.has(key)) continue
+      seen.add(key)
+      values.set(key, await resolveOne(fieldId))
+    }
+  }
+
+  return { resolver: (_entity, fieldId) => values.get(fieldId), prime }
 }

--- a/packages/lib/src/agents/procedures/control-tools.ts
+++ b/packages/lib/src/agents/procedures/control-tools.ts
@@ -1,0 +1,108 @@
+// packages/lib/src/agents/procedures/control-tools.ts
+
+import type { AgentToolDefinition } from '../../ai/agent-framework/types'
+
+/**
+ * The control-tool surface — the small set of tools the model calls to signal
+ * procedure intent (the instruction step is the ONLY place semantic intent is
+ * judged). They don't mutate the stack (it lives in `domainState`, replaced each
+ * loop step); each tool **records its signal** into the always-present shared
+ * context store under {@link PROC_SIGNAL_KEY}, and the post-turn `interpretSignal`
+ * reads + clears it. The natural turn terminal is still "the model replies with no
+ * tool call" — a control tool is not a forced stop (there is no `tool_choice`
+ * forcing in the loop).
+ *
+ * These are ordinary {@link AgentToolDefinition}s; **Phase 4** mounts them on the
+ * agent only while a frame is active. See plans/chat/v9/phase-3-stepper-and-stack.md §1.
+ */
+
+/** Turn-local key the control tools write and `interpretSignal` reads then deletes. */
+export const PROC_SIGNAL_KEY = 'var:__proc_signal'
+
+/** The recorded model intent for the post-turn `interpretSignal`. */
+export type ProcedureSignal =
+  | { kind: 'advance' }
+  | { kind: 'await' }
+  | { kind: 'digress'; reason: string }
+  | { kind: 'handoff' }
+  | { kind: 'end' }
+
+const emptyParams = { type: 'object', properties: {}, additionalProperties: false } as const
+
+export const advanceProcedure: AgentToolDefinition = {
+  name: 'advance_procedure',
+  displayName: 'Advance procedure',
+  description:
+    'Call when THIS step of the procedure is complete and the conversation should move on to the next step.',
+  parameters: emptyParams,
+  execute: async (_args, ctx) => {
+    await ctx.context.write(PROC_SIGNAL_KEY, { kind: 'advance' })
+    return { success: true, output: { signal: 'advance' } }
+  },
+}
+
+export const awaitCustomer: AgentToolDefinition = {
+  name: 'await_customer',
+  displayName: 'Await customer',
+  description:
+    'Call when you need more information from the customer before this step can complete.',
+  parameters: emptyParams,
+  execute: async (_args, ctx) => {
+    await ctx.context.write(PROC_SIGNAL_KEY, { kind: 'await' })
+    return { success: true, output: { signal: 'await' } }
+  },
+}
+
+export const digress: AgentToolDefinition = {
+  name: 'digress',
+  displayName: 'Digress',
+  description:
+    'Call when the customer asked for something THIS procedure does not cover. Do NOT answer the side request yourself — signalling routes it.',
+  parameters: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['reason'],
+    properties: {
+      reason: { type: 'string', description: 'one line: what the customer asked for' },
+    },
+  },
+  execute: async (args, ctx) => {
+    const reason = typeof args.reason === 'string' ? args.reason : ''
+    await ctx.context.write(PROC_SIGNAL_KEY, { kind: 'digress', reason })
+    // Proactive digress: the model emits no customer text this turn — the routed
+    // procedure's first step produces the customer-facing opener same-turn.
+    return { success: true, output: { signal: 'digress', acknowledged: true } }
+  },
+}
+
+export const handoffToHuman: AgentToolDefinition = {
+  name: 'handoff_to_human',
+  displayName: 'Hand off to a human',
+  description: 'Call to escalate this conversation to a human agent and stop the procedure.',
+  parameters: emptyParams,
+  execute: async (_args, ctx) => {
+    await ctx.context.write(PROC_SIGNAL_KEY, { kind: 'handoff' })
+    return { success: true, output: { signal: 'handoff' } }
+  },
+}
+
+export const endProcedure: AgentToolDefinition = {
+  name: 'end_procedure',
+  displayName: 'End procedure',
+  description:
+    'Call when the whole procedure is finished and the conversation should return to where it was before.',
+  parameters: emptyParams,
+  execute: async (_args, ctx) => {
+    await ctx.context.write(PROC_SIGNAL_KEY, { kind: 'end' })
+    return { success: true, output: { signal: 'end' } }
+  },
+}
+
+/** All control tools, for Phase 4 to mount while a frame is active. */
+export const PROCEDURE_CONTROL_TOOLS: AgentToolDefinition[] = [
+  advanceProcedure,
+  awaitCustomer,
+  digress,
+  handoffToHuman,
+  endProcedure,
+]

--- a/packages/lib/src/agents/procedures/index.ts
+++ b/packages/lib/src/agents/procedures/index.ts
@@ -1,6 +1,12 @@
 // packages/lib/src/agents/procedures/index.ts
 
 export {
+  type BackstopVerdict,
+  backstopClassify,
+  classifyTextBranch,
+  goalMetCheck,
+} from './classifier'
+export {
   type ClassifierCandidate,
   type ClassifyDeps,
   type ConversationMessage,
@@ -8,7 +14,21 @@ export {
 } from './classify'
 export type { CompileError, CompileResult } from './compile'
 export { compileProcedure } from './compile'
-export { buildProcedureFieldResolver } from './context'
+export {
+  buildProcedureFieldResolver,
+  buildProcedurePredicateResolver,
+  scopedVar,
+} from './context'
+export {
+  advanceProcedure,
+  awaitCustomer,
+  digress,
+  endProcedure,
+  handoffToHuman,
+  PROC_SIGNAL_KEY,
+  PROCEDURE_CONTROL_TOOLS,
+  type ProcedureSignal,
+} from './control-tools'
 export {
   type CodeBlockMapEntry,
   type ConditionBlockAttrs,
@@ -50,6 +70,7 @@ export {
   updateDraftDoc,
   updateProcedure,
 } from './queries'
+export { buildReanchorBreadcrumb } from './re-anchor'
 export {
   type ResolvedCandidate,
   type SelectionResult,
@@ -67,6 +88,13 @@ export {
   replaceTop,
   top,
 } from './stack'
+export {
+  type InterpretResult,
+  interpretSignal,
+  type PrepareResult,
+  prepareTurn,
+  type StepperDeps,
+} from './stepper'
 export type {
   ArgBindingMap,
   CompiledProcedure,

--- a/packages/lib/src/agents/procedures/re-anchor.ts
+++ b/packages/lib/src/agents/procedures/re-anchor.ts
@@ -1,0 +1,40 @@
+// packages/lib/src/agents/procedures/re-anchor.ts
+
+import { docToText } from '../../tiptap'
+import type { ProcedureFrame, ProcedureStep } from './types'
+
+/**
+ * The one-line resume breadcrumb prepended to the active-step prompt section when
+ * a frame is resumed after a child frame popped. **Topic** comes from the PARENT
+ * step we're resuming (the first sentence of its `docToText`); **framing** comes
+ * from the POPPED frame's `pushedBy`:
+ *
+ *   - `'digression'` → a customer-visible detour → `"Back to {topic}"`.
+ *   - `'call'`       → an internal sub-procedure return the customer never saw →
+ *                      `''` (resume silently, no breadcrumb).
+ *
+ * `'switch'` never pops (it replaces); `'selection'` is frame 0 (no parent). So a
+ * non-digression pop yields `''` and the section renders no breadcrumb line.
+ *
+ * Pure — no DB/IO. See plans/chat/v9/phase-3-stepper-and-stack.md §5.
+ */
+export function buildReanchorBreadcrumb(
+  parentStep: ProcedureStep,
+  poppedFrame: ProcedureFrame
+): string {
+  if (poppedFrame.pushedBy !== 'digression') return ''
+  const topic = firstSentence(parentStep.kind === 'instruction' ? docToText(parentStep.doc) : '')
+  return topic ? `Back to ${lowerFirst(topic)}.` : 'Back to where we left off.'
+}
+
+/** The first sentence (up to the first `.!?` or newline) of a block of prose. */
+function firstSentence(text: string): string {
+  const trimmed = text.trim()
+  if (!trimmed) return ''
+  const match = trimmed.match(/^[^.!?\n]+/)
+  return (match ? match[0] : trimmed).trim()
+}
+
+function lowerFirst(value: string): string {
+  return value.length > 0 ? value[0]!.toLowerCase() + value.slice(1) : value
+}

--- a/packages/lib/src/agents/procedures/stepper.ts
+++ b/packages/lib/src/agents/procedures/stepper.ts
@@ -1,0 +1,402 @@
+// packages/lib/src/agents/procedures/stepper.ts
+
+import type { ToolContext } from '../../ai/agent-framework/tool-context'
+import { evaluateConditions } from '../../conditions/evaluate'
+import { buildProcedurePredicateResolver } from './context'
+import { PROC_SIGNAL_KEY, type ProcedureSignal } from './control-tools'
+import { buildReanchorBreadcrumb } from './re-anchor'
+import { atDepthCap, clear, pop, push, replaceTop, top } from './stack'
+import type {
+  CompiledProcedure,
+  ProcedureFrame,
+  ProcedureStack,
+  ProcedureStep,
+  StepId,
+} from './types'
+
+/** The only step kind the stepper stops on / classifies against. */
+type InstructionStep = Extract<ProcedureStep, { kind: 'instruction' }>
+
+/** The silent-reply backstop verdict (mirror of `classifier.ts` `BackstopVerdict`). */
+type BackstopVerdict = { onProcedure: boolean; multiTurn: boolean }
+
+/**
+ * The deterministic stepper — `prepareTurn` (this file) walks the top frame's
+ * cursor through every DETERMINISTIC step (conditions → branch, routing → stack
+ * op) until it reaches an `instruction` step to inject, or the stack empties
+ * (free-form). `interpretSignal` (the post-turn half) lands in a later step.
+ *
+ * **Invariant: `prepareTurn` is pure navigation — it executes NO tools or code.**
+ * An `instruction` step's inline `tool:`/`code:` references are hints the MODEL
+ * acts on inside the engine loop; the stepper only injects the step prose. This
+ * is load-bearing: `prepareTurn` re-runs from `frame.cursor` on every resume, so
+ * any side effect here would re-fire each turn. The only state it mutates is the
+ * cursor + the stack (pop/push/replace/clear from routing terminals).
+ *
+ * The module is what Phase 4 calls; it does not touch the turn processor.
+ * See plans/chat/v9/phase-3-stepper-and-stack.md §2.
+ */
+
+/** A loaded build keyed by procedureVersionId + the procedure it belongs to. */
+type LoadedVersion = { procedureVersionId: string; compiled: CompiledProcedure }
+
+export interface StepperDeps {
+  /** Carries db / subject / context / appAccounts for resolution. */
+  ctx: ToolContext
+  /**
+   * Load the PINNED version's compiled tree by id (the run reads the exact version
+   * it started on — STACK #10). `null` = the pin was hard-deleted (shouldn't happen;
+   * pinned versions are retention-protected) → the frame is discarded and recovery
+   * re-advances the parent. Phase 4 backs this with `getProcedureVersionById` +
+   * `readCompiled` (org-cache hit when the pin == the active version).
+   */
+  readVersion: (procedureVersionId: string) => Promise<{ compiled: CompiledProcedure } | null>
+  /**
+   * Resolve a standalone procedure's CURRENT active version (for a `switch`) and
+   * pin it into the new frame. `null` = no resolvable active version → discard +
+   * recover. Phase 4 backs this with the `agents` org-cache projection.
+   */
+  loadActiveVersion: (procedureId: string) => Promise<LoadedVersion | null>
+  /**
+   * Run Phase 1 selection over the agent's OTHER enabled procedures (digression).
+   * Used by `interpretSignal`; declared here so the deps object is shared.
+   */
+  selectOther: (excludeProcedureId: string) => Promise<{
+    procedureId: string
+    procedureVersionId: string
+    compiled: CompiledProcedure
+  } | null>
+  /**
+   * Pick a `text`-mode condition arm by classifying the conversation against the
+   * compiled predicate strings. Returns the matching case index, or `null` for the
+   * else/fallthrough. Backed by `classifier.ts` `classifyTextBranch`; Phase 4 binds
+   * the turn's conversation into this closure.
+   */
+  pickTextBranch: (predicates: string[]) => Promise<number | null>
+  /**
+   * Advance-check (#11) — verify the ONE irreversible signal before honoring it: did
+   * the reply actually MEET the active step's goal? Backed by `classifier.ts`
+   * `goalMetCheck`. Used by {@link interpretSignal} only.
+   */
+  checkGoalMet: (reply: string, activeStep: InstructionStep) => Promise<boolean>
+  /**
+   * Silent-reply backstop (#2) — when the model emitted no control tool, did the
+   * reply stay on the active step? Backed by `classifier.ts` `backstopClassify`.
+   */
+  classifyBackstop: (reply: string, activeStep: InstructionStep) => Promise<BackstopVerdict>
+}
+
+export type PrepareResult =
+  | {
+      kind: 'inject'
+      stack: ProcedureStack
+      activeStep: Extract<ProcedureStep, { kind: 'instruction' }>
+      /** Re-anchor line when this turn resumed a parent after a `digression` pop (§5). */
+      breadcrumb?: string
+    }
+  /** Stack emptied / handoff cleared → persona-only, no procedure section this turn (#9). */
+  | { kind: 'free-form'; stack: ProcedureStack }
+
+export interface InterpretResult {
+  stack: ProcedureStack
+  /** Re-run `prepareTurn` + the engine loop AGAIN this same turn (advance / digress goto 1 / end). */
+  reinvoke: boolean
+  /** Park: ship the reply and wait for the next customer message. */
+  endTurn: boolean
+  /** Re-run the loop WITHOUT a procedure section this turn (persona-only) and re-interpret (#9). */
+  inlineFallback?: boolean
+}
+
+/** Runaway guards — a valid compiled tree threads `next` acyclically, so these never trip. */
+const MAX_FRAME_TRANSITIONS = 1000
+const MAX_STEPS_PER_FRAME = 1000
+
+/**
+ * Advance the live stack to the next `instruction` step to inject, applying every
+ * deterministic transition (condition branch, routing pop/handoff/switch/call) and
+ * re-advancing the now-top frame after each stack op. Executes nothing.
+ */
+export async function prepareTurn(
+  stack: ProcedureStack,
+  deps: StepperDeps
+): Promise<PrepareResult> {
+  let working = stack
+  // The most recent `digression` frame popped THIS turn — its parent gets a
+  // re-anchor breadcrumb on the instruction we eventually inject (§5).
+  let poppedDigression: ProcedureFrame | null = null
+
+  for (let i = 0; i < MAX_FRAME_TRANSITIONS; i++) {
+    const frame = top(working)
+    if (!frame) return { kind: 'free-form', stack: working }
+
+    const version = await deps.readVersion(frame.procedureVersionId)
+    if (!version) {
+      // Hard-deleted pin → discard the frame, recover by re-advancing the parent.
+      working = pop(working).stack
+      continue
+    }
+
+    const action = await advanceFrame(frame, version.compiled, deps)
+
+    switch (action.type) {
+      case 'instruction': {
+        const breadcrumb = poppedDigression
+          ? buildReanchorBreadcrumb(action.step, poppedDigression) || undefined
+          : undefined
+        return { kind: 'inject', stack: working, activeStep: action.step, breadcrumb }
+      }
+
+      case 'pop': {
+        const { stack: next, popped } = pop(working)
+        working = next
+        if (popped?.pushedBy === 'digression') poppedDigression = popped
+        continue // re-advance the now-top (parent) at its parked cursor
+      }
+
+      case 'handoff':
+        // Routing handoff leaves the agent — clear the stack, fall to persona-only.
+        return { kind: 'free-form', stack: clear(working) }
+
+      case 'switch': {
+        const target = await deps.loadActiveVersion(action.toProcedureId)
+        if (!target) {
+          working = pop(working).stack // unresolvable target → discard + recover
+          continue
+        }
+        working = replaceTop(
+          working,
+          newFrame(
+            action.toProcedureId,
+            target.procedureVersionId,
+            target.compiled.entryStepId,
+            'switch'
+          )
+        )
+        continue
+      }
+
+      case 'call': {
+        const sub = version.compiled.subProcedures[action.subProcedureId]
+        if (!sub) continue // unknown sub (the compiler guards this) → resume at parked cursor
+        if (atDepthCap(working)) {
+          // Depth-cap relief: run the sub-procedure INLINE in the current frame (no
+          // push). The post-call continuation (`routing.next`, parked below) is lost
+          // at the cap — an accepted edge at MAX_DEPTH (acceptance: "runs inline").
+          frame.cursor = sub.entryStepId
+          continue
+        }
+        working = push(
+          working,
+          newFrame(frame.procedureId, frame.procedureVersionId, sub.entryStepId, 'call')
+        )
+        continue
+      }
+    }
+  }
+
+  // Runaway guard tripped (malformed tree) — fail safe to persona-only.
+  return { kind: 'free-form', stack: working }
+}
+
+/** What advancing one frame from its cursor resolved to. */
+type FrameAction =
+  | { type: 'instruction'; step: Extract<ProcedureStep, { kind: 'instruction' }> }
+  | { type: 'pop' } // frame finished (terminal `finished`, dangling, or chain end)
+  | { type: 'handoff' }
+  | { type: 'switch'; toProcedureId: string }
+  | { type: 'call'; subProcedureId: string }
+
+/**
+ * Walk one frame's cursor through deterministic steps until an `instruction` (stop)
+ * or a terminal. Mutates `frame.cursor` in place (the stack is rehydrated per turn
+ * and re-serialized after). For a `call`, parks `frame.cursor` at the routing step's
+ * `next` so the parent resumes there when the child pops.
+ */
+async function advanceFrame(
+  frame: ProcedureFrame,
+  compiled: CompiledProcedure,
+  deps: StepperDeps
+): Promise<FrameAction> {
+  const predicate = buildProcedurePredicateResolver(deps.ctx, frame)
+  const entity = deps.ctx.subject ?? {}
+  let cursor: StepId | null = frame.cursor
+
+  for (let i = 0; i < MAX_STEPS_PER_FRAME; i++) {
+    if (cursor === null) break
+    const step = compiled.steps[cursor]
+    if (!step) break // dangling ref → treat as finished
+
+    if (step.kind === 'instruction') {
+      frame.cursor = cursor
+      return { type: 'instruction', step }
+    }
+
+    if (step.kind === 'routing') {
+      switch (step.outcome) {
+        case 'finished':
+          return { type: 'pop' }
+        case 'handoff':
+          return { type: 'handoff' }
+        case 'switch':
+          return { type: 'switch', toProcedureId: step.switchToProcedureId ?? '' }
+        case 'call':
+          frame.cursor = step.next // park the parent's return cursor
+          return { type: 'call', subProcedureId: step.subProcedureId ?? '' }
+      }
+    }
+
+    // condition — pick the branch (no LLM for structured; one classify for text)
+    cursor = await pickConditionBranch(step, predicate, entity, deps)
+  }
+
+  frame.cursor = null
+  return { type: 'pop' } // chain ended without a terminal → frame finished
+}
+
+/**
+ * Resolve which step a `condition` descends to. `structured` evaluates each case's
+ * `group` in order (first true wins) against the in-procedure resolver — pure reads,
+ * idempotent. `text` asks the classifier which arm holds. Either falls through to
+ * `elseStep ?? next`.
+ */
+async function pickConditionBranch(
+  step: Extract<ProcedureStep, { kind: 'condition' }>,
+  predicate: ReturnType<typeof buildProcedurePredicateResolver>,
+  entity: unknown,
+  deps: StepperDeps
+): Promise<StepId | null> {
+  if (step.mode === 'structured') {
+    for (const branch of step.cases) {
+      if (!branch.group) continue
+      await predicate.prime([branch.group])
+      if (evaluateConditions(entity, [branch.group], predicate.resolver)) return branch.thenStep
+    }
+    return step.elseStep ?? step.next
+  }
+
+  const idx = await deps.pickTextBranch(step.cases.map((c) => c.predicate ?? ''))
+  if (idx !== null && idx >= 0 && idx < step.cases.length) return step.cases[idx]!.thenStep
+  return step.elseStep ?? step.next
+}
+
+/** A fresh running frame at `cursor`, pushed by `pushedBy`. */
+function newFrame(
+  procedureId: string,
+  procedureVersionId: string,
+  cursor: StepId | null,
+  pushedBy: ProcedureFrame['pushedBy']
+): ProcedureFrame {
+  return { procedureId, procedureVersionId, cursor, status: 'running', history: [], pushedBy }
+}
+
+/**
+ * Post-turn — read the recorded control signal, delete it, and mutate the stack
+ * (STACK per-turn algorithm steps 2–3). This is the second half Phase 4 calls after
+ * the engine loop; the `reply` is the model's customer-facing text this turn.
+ *
+ * The `reinvoke` vs `endTurn` split is the phase's subtlest point (STACK #8): a
+ * proactive `digress` produced NO customer text, so the routed procedure opens
+ * same-turn (`reinvoke`); the backstop off-procedure path already shipped a reply,
+ * so a push opens NEXT turn (`endTurn`, no goto 1). `advance` is the only signal we
+ * verify (#11) — it is the one irreversible cursor move; the rest self-correct.
+ *
+ * See plans/chat/v9/phase-3-stepper-and-stack.md §3.
+ */
+export async function interpretSignal(
+  stack: ProcedureStack,
+  reply: string,
+  deps: StepperDeps
+): Promise<InterpretResult> {
+  const signal = (await deps.ctx.context.read(PROC_SIGNAL_KEY)) as ProcedureSignal | undefined
+  // Turn-local key — `var:*` persists across turns, so delete it after reading.
+  await deps.ctx.context.write(PROC_SIGNAL_KEY, undefined)
+
+  const frame = top(stack)
+  if (!frame) return { stack, reinvoke: false, endTurn: true } // no active frame → nothing to do
+
+  const activeStep = await loadActiveInstruction(frame, deps)
+
+  switch (signal?.kind) {
+    case 'advance': {
+      // Verify the irreversible signal; on `met` advance the cursor (goto 1), else
+      // treat as `await` and stay on the step.
+      if (activeStep && (await deps.checkGoalMet(reply, activeStep))) {
+        frame.cursor = activeStep.next
+        return { stack, reinvoke: true, endTurn: false }
+      }
+      frame.status = 'awaiting_customer'
+      return { stack, reinvoke: false, endTurn: true }
+    }
+
+    case 'await':
+      frame.status = 'awaiting_customer'
+      return { stack, reinvoke: false, endTurn: true }
+
+    case 'digress': {
+      // Proactive: the model emitted no customer text; the routed procedure opens
+      // THIS turn (reinvoke). At the depth cap, refuse the push → persona-only inline.
+      if (atDepthCap(stack)) return { stack, reinvoke: false, endTurn: false, inlineFallback: true }
+      const pick = await deps.selectOther(frame.procedureId)
+      if (!pick) return { stack, reinvoke: false, endTurn: false, inlineFallback: true } // no match → one-off inline
+      const pushed = push(
+        stack,
+        newFrame(pick.procedureId, pick.procedureVersionId, pick.compiled.entryStepId, 'digression')
+      )
+      return { stack: pushed, reinvoke: true, endTurn: false }
+    }
+
+    case 'handoff':
+      return { stack: clear(stack), reinvoke: false, endTurn: true }
+
+    case 'end':
+      // Pop, resume parent at its parked cursor next prepareTurn. (A digression's
+      // re-anchor breadcrumb only attaches on the deterministic `finished` pop — an
+      // end-signal pop resumes correctly but without the "Back to…" line.)
+      return { stack: pop(stack).stack, reinvoke: true, endTurn: false }
+
+    default: {
+      // SILENT reply — no control tool. The backstop (#2).
+      if (!activeStep) {
+        frame.status = 'awaiting_customer'
+        return { stack, reinvoke: false, endTurn: true }
+      }
+      const verdict = await deps.classifyBackstop(reply, activeStep)
+      if (verdict.onProcedure) {
+        // Continued the step but forgot to signal → treat as await (self-corrects);
+        // never auto-advance off a guess.
+        frame.status = 'awaiting_customer'
+        return { stack, reinvoke: false, endTurn: true }
+      }
+      // Off-procedure — the reply already shipped under the parent's step prompt. The
+      // persona-only answer stands; push a frame ONLY if clearly multi-turn, opening
+      // NEXT turn (no goto 1).
+      if (verdict.multiTurn && !atDepthCap(stack)) {
+        const pick = await deps.selectOther(frame.procedureId)
+        if (pick) {
+          const pushed = push(
+            stack,
+            newFrame(
+              pick.procedureId,
+              pick.procedureVersionId,
+              pick.compiled.entryStepId,
+              'digression'
+            )
+          )
+          return { stack: pushed, reinvoke: false, endTurn: true }
+        }
+      }
+      return { stack, reinvoke: false, endTurn: true }
+    }
+  }
+}
+
+/** Load the active step at a frame's cursor, narrowed to an `instruction` (else `undefined`). */
+async function loadActiveInstruction(
+  frame: ProcedureFrame,
+  deps: StepperDeps
+): Promise<InstructionStep | undefined> {
+  if (frame.cursor === null) return undefined
+  const version = await deps.readVersion(frame.procedureVersionId)
+  const step = version?.compiled.steps[frame.cursor]
+  return step?.kind === 'instruction' ? step : undefined
+}

--- a/packages/lib/src/ai/kopilot/prompts/sections/__tests__/agent-procedure-step.test.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/__tests__/agent-procedure-step.test.ts
@@ -1,0 +1,57 @@
+// packages/lib/src/ai/kopilot/prompts/sections/__tests__/agent-procedure-step.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { agentProcedureStep } from '../agent-procedure-step'
+import type { ProcedureStepInput, PromptCtx } from '../types'
+
+const frag = (text: string): unknown => ({
+  type: 'fragment',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+})
+
+const ctxWith = (procedureStep?: ProcedureStepInput): PromptCtx =>
+  ({ procedureStep, instructionsReferences: undefined }) as unknown as PromptCtx
+
+describe('agentProcedureStep', () => {
+  it('is a turn-stability section (registered in tier 3 by Phase 4)', () => {
+    expect(agentProcedureStep.id).toBe('agent-procedure-step')
+    expect(agentProcedureStep.stability).toBe('turn')
+  })
+
+  it('returns null when no procedure step is active → persona-only (#9)', () => {
+    expect(agentProcedureStep.render(ctxWith(undefined))).toBeNull()
+  })
+
+  it('renders the active step text', () => {
+    const out = agentProcedureStep.render(
+      ctxWith({ activeStep: { doc: frag('Cancel the order.') }, depth: 1 })
+    )
+    expect(out).toBe('Current step: Cancel the order.')
+  })
+
+  it('prepends a re-anchor breadcrumb when present', () => {
+    const out = agentProcedureStep.render(
+      ctxWith({
+        activeStep: { doc: frag('Pick a plan.') },
+        depth: 1,
+        breadcrumb: 'Back to your cancellation.',
+      })
+    )
+    expect(out).toContain('Back to your cancellation.')
+    expect(out).toContain('Current step: Pick a plan.')
+  })
+
+  it('renders the thin side-request breadcrumb at depth > 1', () => {
+    const out = agentProcedureStep.render(
+      ctxWith({
+        activeStep: { doc: frag('Verify identity.') },
+        depth: 2,
+        topicLabel: 'a refund',
+        returnToLabel: 'your cancellation',
+      })
+    )
+    expect(out).toContain("You're handling a side request: a refund.")
+    expect(out).toContain("You'll return to: your cancellation.")
+    expect(out).toContain('Current step: Verify identity.')
+  })
+})

--- a/packages/lib/src/ai/kopilot/prompts/sections/agent-procedure-step.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/agent-procedure-step.ts
@@ -1,0 +1,42 @@
+// packages/lib/src/ai/kopilot/prompts/sections/agent-procedure-step.ts
+
+import { docToText } from '../../../../tiptap'
+import { ALL_MODES, type PromptSection } from './types'
+
+/**
+ * The active procedure step (v9 procedures, Phase 3). Injects ONLY the top frame's
+ * current step — never the whole stack, never the whole procedure (PROCEDURE-STACK
+ * "Prompt: top frame only"). `ctx.procedureStep` is populated by Phase 4 while a frame
+ * is active and left unset on free-form turns, so this section returns `null` for
+ * persona-only mode (#9) and the prompt is exactly today's persona-only prompt.
+ *
+ * `stability: 'turn'` — the cursor changes every turn → tier 3, never cached. **Phase 4
+ * registers it in tier 3** (near `context` / `active-refs`), NOT adjacent to
+ * `agentPersona` (tier 2), or `validateStabilityOrder` would throw. See
+ * plans/chat/v9/phase-3-stepper-and-stack.md §6.
+ */
+export const agentProcedureStep: PromptSection = {
+  id: 'agent-procedure-step',
+  modes: ALL_MODES,
+  stability: 'turn',
+  render: (ctx) => {
+    const proc = ctx.procedureStep
+    if (!proc) return null
+
+    const body = docToText(proc.activeStep.doc, {
+      references: ctx.instructionsReferences,
+      procedureMaps: proc.procedureMaps,
+    })
+
+    const lines: string[] = []
+    if (proc.depth > 1) {
+      // Thin stack breadcrumb — orient the model without dumping the whole stack.
+      if (proc.topicLabel) lines.push(`You're handling a side request: ${proc.topicLabel}.`)
+      if (proc.returnToLabel) lines.push(`You'll return to: ${proc.returnToLabel}.`)
+      if (lines.length > 0) lines.push('')
+    }
+    if (proc.breadcrumb) lines.push(proc.breadcrumb, '')
+    lines.push(`Current step: ${body}`)
+    return lines.join('\n').trim()
+  },
+}

--- a/packages/lib/src/ai/kopilot/prompts/sections/types.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/types.ts
@@ -27,6 +27,30 @@ export const AUTONOMOUS_ONLY: ReadonlySet<RunMode> = new Set(['autonomous'])
 export type Stability = 'static' | 'org' | 'turn'
 
 /**
+ * The top frame's active procedure step for the `agentProcedureStep` section (v9
+ * procedures, Phase 3). Phase 4 populates this from `prepareTurn`'s result while a
+ * frame is active; it is left unset on free-form / persona-only turns so the section
+ * drops out (PROCEDURE-STACK #9).
+ */
+export interface ProcedureStepInput {
+  /** The active `instruction` step to inject — its TipTap `doc` is rendered via `docToText`. */
+  readonly activeStep: { readonly doc: unknown }
+  /** The pinned version's doc-level maps so inline `subprocedure:`/`code:` badges render names. */
+  readonly procedureMaps?: {
+    subProcedures?: { id: string; name: string }[]
+    codeBlocks?: { id: string; name: string }[]
+  }
+  /** Stack depth — `> 1` renders the thin "side request" breadcrumb. */
+  readonly depth: number
+  /** Depth > 1: a short label for the side request being handled. */
+  readonly topicLabel?: string
+  /** Depth > 1: a short label for what the agent returns to. */
+  readonly returnToLabel?: string
+  /** Re-anchor line on a pop-resume turn (PROCEDURE-STACK §5). */
+  readonly breadcrumb?: string
+}
+
+/**
  * Read-only inputs each section can use. Built once per turn at the top of
  * `buildKopilotPrompt` and passed verbatim to every section. Pre-computed
  * fields (`toolNames`) avoid recomputing in each section.
@@ -46,6 +70,8 @@ export interface PromptCtx {
   readonly instructionsReferences?: (id: string) => string
   // Trigger inputs (Phase D)
   readonly triggerContext: TriggerContext | undefined
+  // Procedure stepper (Phase 3) — set by Phase 4 only while a frame is active.
+  readonly procedureStep?: ProcedureStepInput
 }
 
 export interface PromptSection {


### PR DESCRIPTION
## Summary

Phase 4 of chat-v9 procedures: the in-turn **runtime** that drives an agent through a published procedure. Builds on phase 1–3 (#745, #746, #747, #748).

- **stepper** (`stepper.ts`) — `prepareTurn` deterministically walks the top frame's cursor through condition/routing steps until it reaches the next `instruction` step to inject, or the stack empties (free-form). Pure navigation: it executes **no** tools or code. `interpretSignal` is the post-turn half that applies stack ops from the recorded control-tool signal.
- **control-tools** (`control-tools.ts`) — the small tool surface (`advance` / `await` / `digress` / `handoff` / `end`) the model calls to signal procedure intent. Each records its signal into a turn-local context key (`PROC_SIGNAL_KEY`); they don't mutate the stack directly. Mounted only while a frame is active.
- **classifier** (`classifier.ts`) — three cheap Haiku-class structured calls: `goalMetCheck` (advance-check before the irreversible cursor move), `backstopClassify` (silent-reply backstop), `classifyTextBranch` (text-mode condition arm selection).
- **re-anchor** (`re-anchor.ts`) — pure one-line resume breadcrumb when a child frame pops (`"Back to …"` for customer-visible digressions, silent for internal `call` returns).
- **context** (`context.ts`) — `buildProcedurePredicateResolver` + `scopedVar` for in-procedure `condition` predicates: reads version-scoped local attributes (`var:*`) plus CRM field refs, gate-by-absence, never throws.
- **prompts** — new `agentProcedureStep` section + `ProcedureStepInput` on `PromptCtx` (populated by phase 5 while a frame is active).
- **ui** — procedures empty state now uses `EmptySection` with an icon.

## Tests

62 passing across stepper (28), context (14), classifier (8), control-tools (7), and the prompt section (5).

\`\`\`
cd packages/lib && pnpm exec vitest run src/agents/procedures/__tests__/{stepper,classifier,control-tools,context}.test.ts src/ai/kopilot/prompts/sections/__tests__/agent-procedure-step.test.ts
\`\`\`