### PR TITLE
feat(agents): chat-v9 procedures phase 5 — live turn wiring

### DIFF
--- a/apps/web/src/server/api/routers/procedure.ts
+++ b/apps/web/src/server/api/routers/procedure.ts
@@ -16,6 +16,7 @@ import {
   updateDraftDoc,
   updateProcedure,
 } from '@auxx/lib/agents/procedures'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
@@ -231,11 +232,10 @@ export const procedureRouter = createTRPCRouter({
 
   /**
    * Compile the draft → snapshot an immutable version → repoint the active
-   * pointer. Enforces non-empty `whenToUse` and surfaces compile errors.
-   *
-   * The Phase-4 cache bust (`onCacheEvent('procedure.updated')`) + the org-cache
-   * `agents` projection are NOT wired yet, so this only mutates the DB — no live
-   * run reads the active version until Phase 4.
+   * pointer. Enforces non-empty `whenToUse` and surfaces compile errors. Busts
+   * the `agents` org-cache projection so the next selection runs the new active
+   * version (`procedure.updated → ['agents']`; only publish/revert bust — drafts
+   * never affect live runs).
    */
   publish: adminProcedure
     .input(z.object({ id: z.string().min(1) }))
@@ -282,6 +282,7 @@ export const procedureRouter = createTRPCRouter({
         }),
         'publish procedure'
       )
+      await onCacheEvent('procedure.updated', { orgId: organizationId })
       logger.info('Procedure published', {
         organizationId,
         procedureId: input.id,
@@ -302,6 +303,7 @@ export const procedureRouter = createTRPCRouter({
         }),
         'revert procedure'
       )
+      await onCacheEvent('procedure.updated', { orgId: organizationId })
       return { ok: true as const }
     }),
 })

--- a/packages/lib/src/agents/procedures/__tests__/conversation.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/conversation.test.ts
@@ -1,0 +1,44 @@
+// packages/lib/src/agents/procedures/__tests__/conversation.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { SessionMessage } from '../../../ai/agent-framework/types'
+import { sessionMessagesToConversation } from '../conversation'
+
+const msg = (m: Partial<SessionMessage> & { role: SessionMessage['role'] }) =>
+  m as unknown as SessionMessage
+
+describe('sessionMessagesToConversation', () => {
+  it('keeps user + assistant turns, reading string content', () => {
+    const out = sessionMessagesToConversation([
+      msg({ role: 'user', content: 'hi' }),
+      msg({ role: 'assistant', content: 'hello' }),
+    ])
+    expect(out).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello' },
+    ])
+  })
+
+  it('joins text parts when content is absent', () => {
+    const out = sessionMessagesToConversation([
+      msg({
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'foo ' },
+          { type: 'thinking', text: 'ignored' },
+          { type: 'text', text: 'bar' },
+        ],
+      }),
+    ])
+    expect(out).toEqual([{ role: 'assistant', content: 'foo bar' }])
+  })
+
+  it('drops non user/assistant roles and empty turns', () => {
+    const out = sessionMessagesToConversation([
+      msg({ role: 'system', content: 'sys' }),
+      msg({ role: 'user', content: '   ' }),
+      msg({ role: 'user', content: 'keep me' }),
+    ])
+    expect(out).toEqual([{ role: 'user', content: 'keep me' }])
+  })
+})

--- a/packages/lib/src/agents/procedures/__tests__/stepper.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/stepper.test.ts
@@ -315,7 +315,7 @@ describe('prepareTurn — routing & stack ops', () => {
     expect(r.stack.frames).toHaveLength(0)
   })
 
-  it('handoff routing clears the stack → free-form', async () => {
+  it('handoff routing clears the stack → free-form + flags handoff', async () => {
     const compiled = build('h', [routing('h', 'handoff')])
     const r = await prepareTurn(
       stackOf(frame('v1', 'a'), frame('v1', 'h')),
@@ -323,6 +323,7 @@ describe('prepareTurn — routing & stack ops', () => {
     )
     expect(r.kind).toBe('free-form')
     expect(r.stack.frames).toHaveLength(0)
+    expect(r.kind === 'free-form' && r.handoff).toBe(true)
   })
 
   it('switch replaces the top frame with the target procedure’s pinned active version', async () => {
@@ -518,14 +519,14 @@ describe('interpretSignal', () => {
     expect(selectOther).not.toHaveBeenCalled()
   })
 
-  it('handoff → clears the stack', async () => {
+  it('handoff → clears the stack + flags handoff for escalation', async () => {
     setSignal({ kind: 'handoff' })
     const r = await interpretSignal(
       stackOf(frame('v1', 'i0')),
       'Escalating.',
       makeDeps({ v1: basic() })
     )
-    expect(r).toMatchObject({ reinvoke: false, endTurn: true })
+    expect(r).toMatchObject({ reinvoke: false, endTurn: true, handoff: true })
     expect(r.stack.frames).toHaveLength(0)
   })
 

--- a/packages/lib/src/agents/procedures/__tests__/turn-wiring.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/turn-wiring.test.ts
@@ -1,0 +1,93 @@
+// packages/lib/src/agents/procedures/__tests__/turn-wiring.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { CachedAgentProcedure } from '../../../cache/org-cache-keys'
+import type { SelectionResult } from '../select'
+import { emptyStack, push, top } from '../stack'
+import { applySelection, buildActiveStepInput, resolveCandidatesFromCache } from '../turn-wiring'
+import type { CompiledProcedure, ProcedureFrame } from '../types'
+
+const compiled: CompiledProcedure = {
+  entryStepId: 's1',
+  steps: { s1: { id: 's1', kind: 'instruction', doc: { t: 'hi' }, next: null } },
+  codeBlocks: { c1: { language: 'javascript', code: '', inputs: [], outputs: [] } },
+  subProcedures: { sub1: { id: 'sub1', name: 'Refund flow', entryStepId: 's1' } },
+  localAttributes: [],
+}
+
+const projection: CachedAgentProcedure = {
+  linkId: 'link1',
+  procedureId: 'proc1',
+  enabled: true,
+  priority: 5,
+  whenToUse: 'use for refunds',
+  triggerExamples: [{ text: 'I want a refund', behavior: 'use' }],
+  ruleset: [],
+  activeVersionId: 'ver1',
+  compiled,
+}
+
+const frame: ProcedureFrame = {
+  procedureId: 'proc1',
+  procedureVersionId: 'ver1',
+  cursor: 's1',
+  status: 'running',
+  history: [],
+  pushedBy: 'selection',
+}
+
+describe('resolveCandidatesFromCache', () => {
+  it('maps the projection onto the ResolvedCandidate shape selection reads', () => {
+    const [candidate] = resolveCandidatesFromCache([projection])
+    expect(candidate!.link.enabled).toBe(true)
+    expect(candidate!.link.priority).toBe(5)
+    expect(candidate!.procedure.id).toBe('proc1')
+    expect(candidate!.activeVersion.id).toBe('ver1')
+    expect(candidate!.activeVersion.compiled).toBe(compiled)
+    expect(candidate!.resolved).toEqual({
+      whenToUse: 'use for refunds',
+      triggerExamples: [{ text: 'I want a refund', behavior: 'use' }],
+      ruleset: [],
+    })
+  })
+
+  it('returns [] for no procedures (zero-procedure agents)', () => {
+    expect(resolveCandidatesFromCache([])).toEqual([])
+  })
+})
+
+describe('applySelection', () => {
+  it('pushes the frame on a fresh selection', () => {
+    const selection: SelectionResult = { kind: 'selected', frame }
+    const next = applySelection(emptyStack(), selection)
+    expect(top(next)).toEqual(frame)
+  })
+
+  it('leaves the stack unchanged on resume (top is already the frame)', () => {
+    const stack = push(emptyStack(), frame)
+    const next = applySelection(stack, { kind: 'resume', frame })
+    expect(next).toBe(stack)
+  })
+
+  it('leaves the stack unchanged on none (free-form)', () => {
+    const stack = emptyStack()
+    expect(applySelection(stack, { kind: 'none' })).toBe(stack)
+  })
+})
+
+describe('buildActiveStepInput', () => {
+  it('maps the active step + compiled maps + depth + breadcrumb', () => {
+    const stack = push(emptyStack(), frame)
+    const input = buildActiveStepInput({
+      activeStep: { doc: { t: 'do the thing' } },
+      compiled,
+      stack,
+      breadcrumb: 'Back to refunds',
+    })
+    expect(input.activeStep.doc).toEqual({ t: 'do the thing' })
+    expect(input.procedureMaps?.subProcedures).toEqual([{ id: 'sub1', name: 'Refund flow' }])
+    expect(input.procedureMaps?.codeBlocks).toEqual([{ id: 'c1', name: 'c1' }])
+    expect(input.depth).toBe(1)
+    expect(input.breadcrumb).toBe('Back to refunds')
+  })
+})

--- a/packages/lib/src/agents/procedures/conversation.ts
+++ b/packages/lib/src/agents/procedures/conversation.ts
@@ -1,0 +1,39 @@
+// packages/lib/src/agents/procedures/conversation.ts
+
+import type { SessionMessage } from '../../ai/agent-framework/types'
+import type { ConversationMessage } from './classify'
+
+/** Best-effort plain text for a session message (string `content` or joined text parts). */
+function extractMessageText(m: SessionMessage): string {
+  const content = (m as { content?: unknown }).content
+  if (typeof content === 'string') return content
+  const parts = (m as { parts?: unknown }).parts
+  if (Array.isArray(parts)) {
+    return parts
+      .filter(
+        (p): p is { type: 'text'; text: string } =>
+          typeof p === 'object' &&
+          p !== null &&
+          (p as { type?: unknown }).type === 'text' &&
+          typeof (p as { text?: unknown }).text === 'string'
+      )
+      .map((p) => p.text)
+      .join('')
+  }
+  return ''
+}
+
+/**
+ * Flatten session messages into the `{ role, content }` view the procedure
+ * classifier / selection reads. Drops non-user/assistant turns and empties.
+ * Shared by both turn processors (chat + internal agent job).
+ */
+export function sessionMessagesToConversation(messages: SessionMessage[]): ConversationMessage[] {
+  const out: ConversationMessage[] = []
+  for (const m of messages) {
+    if (m.role !== 'user' && m.role !== 'assistant') continue
+    const content = extractMessageText(m)
+    if (content.trim()) out.push({ role: m.role, content })
+  }
+  return out
+}

--- a/packages/lib/src/agents/procedures/index.ts
+++ b/packages/lib/src/agents/procedures/index.ts
@@ -29,6 +29,7 @@ export {
   PROCEDURE_CONTROL_TOOLS,
   type ProcedureSignal,
 } from './control-tools'
+export { sessionMessagesToConversation } from './conversation'
 export {
   type CodeBlockMapEntry,
   type ConditionBlockAttrs,
@@ -44,6 +45,12 @@ export {
   type TiptapDoc,
   type TiptapNode,
 } from './nodes'
+export {
+  PROCEDURE_SLICE_KEY,
+  PROCEDURE_STEP_KEY,
+  readProcedureSlice,
+  writeProcedureSlice,
+} from './persist'
 export type {
   AgentProcedureEntity,
   AgentProcedureOverrides,
@@ -95,6 +102,15 @@ export {
   prepareTurn,
   type StepperDeps,
 } from './stepper'
+export {
+  applySelection,
+  type BuildStepperDepsArgs,
+  buildActiveStepInput,
+  buildStepperDeps,
+  type RunProcedureTurnArgs,
+  resolveCandidatesFromCache,
+  runProcedureTurn,
+} from './turn-wiring'
 export type {
   ArgBindingMap,
   CompiledProcedure,

--- a/packages/lib/src/agents/procedures/persist.ts
+++ b/packages/lib/src/agents/procedures/persist.ts
@@ -1,0 +1,61 @@
+// packages/lib/src/agents/procedures/persist.ts
+
+import type { ProcedureStack } from './types'
+
+/**
+ * Durability for the procedure stack — the v9 counterpart to the context store's
+ * `__context` slice (`agent-framework/context/context-store.ts`). The
+ * {@link ProcedureStack} rides on `domainState` under {@link PROCEDURE_SLICE_KEY}
+ * so it round-trips every persist point (chat turn end, job turn end, the
+ * approval-pause persist) for free, and survives `resetTurnDomainState` (the
+ * reset exemption in `ai/kopilot/domain-config.ts` re-adds it like `vars`).
+ *
+ * Unlike the context slice there is no separate "serialize" step — the stack is
+ * already a plain JSON value (`{ frames: ProcedureFrame[] }`), so the slice IS
+ * the stack. See plans/chat/v9/phase-4-wiring.md §2.
+ */
+
+/** Key under which the procedure stack rides on `domainState`. */
+export const PROCEDURE_SLICE_KEY = 'procedure'
+
+/**
+ * Key for the TURN-LOCAL active step the stepper computed this turn. Unlike the
+ * stack (cross-turn control state), this is recomputed by `prepareTurn` every
+ * turn, so it does NOT need the `resetTurnDomainState` exemption — the turn
+ * preamble writes it before the engine drains, and the prompt build (`agent.ts`)
+ * reads it back to populate `PromptCtx.procedureStep`. Cleared on a free-form
+ * turn so the section drops out (PROCEDURE-STACK #9). Holds a
+ * `ProcedureStepInput` (typed in `ai/kopilot/prompts/sections/types.ts`; kept as
+ * a bare key here to avoid coupling this module to the prompt layer).
+ */
+export const PROCEDURE_STEP_KEY = '__proc_step'
+
+/** Narrow an unknown `domainState['procedure']` to a {@link ProcedureStack}. */
+function isProcedureStack(value: unknown): value is ProcedureStack {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as { frames?: unknown }).frames)
+  )
+}
+
+/** Read the persisted stack off a `domainState` for the turn preamble. */
+export function readProcedureSlice(
+  domainState: Record<string, unknown> | undefined
+): ProcedureStack | undefined {
+  const slice = domainState?.[PROCEDURE_SLICE_KEY]
+  return isProcedureStack(slice) ? slice : undefined
+}
+
+/**
+ * Write the stack back onto `domainState` under {@link PROCEDURE_SLICE_KEY}.
+ * Mutates the live `domainState` object so the slice rides into
+ * `engine.getState().domainState` and is persisted at the same
+ * `updateSessionDomainState` calls the context slice uses — no new persist call.
+ */
+export function writeProcedureSlice(
+  domainState: Record<string, unknown>,
+  stack: ProcedureStack
+): void {
+  domainState[PROCEDURE_SLICE_KEY] = stack
+}

--- a/packages/lib/src/agents/procedures/stepper.ts
+++ b/packages/lib/src/agents/procedures/stepper.ts
@@ -95,7 +95,7 @@ export type PrepareResult =
       breadcrumb?: string
     }
   /** Stack emptied / handoff cleared → persona-only, no procedure section this turn (#9). */
-  | { kind: 'free-form'; stack: ProcedureStack }
+  | { kind: 'free-form'; stack: ProcedureStack; handoff?: boolean }
 
 export interface InterpretResult {
   stack: ProcedureStack
@@ -105,6 +105,13 @@ export interface InterpretResult {
   endTurn: boolean
   /** Re-run the loop WITHOUT a procedure section this turn (persona-only) and re-interpret (#9). */
   inlineFallback?: boolean
+  /**
+   * Escalate to a human — set by both handoff paths (routing `handoff` outcome in
+   * `prepareTurn`, the `handoff_to_human` control tool in `interpretSignal`). The
+   * caller flips the thread to the human queue; internal runs have no queue and
+   * ignore it. The stack is already cleared. See plans/chat/v9 §6 reconciliation.
+   */
+  handoff?: boolean
 }
 
 /** Runaway guards — a valid compiled tree threads `next` acyclically, so these never trip. */
@@ -154,8 +161,9 @@ export async function prepareTurn(
       }
 
       case 'handoff':
-        // Routing handoff leaves the agent — clear the stack, fall to persona-only.
-        return { kind: 'free-form', stack: clear(working) }
+        // Routing handoff leaves the agent — clear the stack, escalate to a human,
+        // fall to persona-only for this turn's closing message.
+        return { kind: 'free-form', stack: clear(working), handoff: true }
 
       case 'switch': {
         const target = await deps.loadActiveVersion(action.toProcedureId)
@@ -346,7 +354,7 @@ export async function interpretSignal(
     }
 
     case 'handoff':
-      return { stack: clear(stack), reinvoke: false, endTurn: true }
+      return { stack: clear(stack), reinvoke: false, endTurn: true, handoff: true }
 
     case 'end':
       // Pop, resume parent at its parked cursor next prepareTurn. (A digression's

--- a/packages/lib/src/agents/procedures/turn-wiring.ts
+++ b/packages/lib/src/agents/procedures/turn-wiring.ts
@@ -1,0 +1,347 @@
+// packages/lib/src/agents/procedures/turn-wiring.ts
+
+import { KopilotContextStore, syncContextSlice } from '../../ai/agent-framework/context'
+import type { AgentEngine } from '../../ai/agent-framework/engine'
+import type { Subject, ToolContext } from '../../ai/agent-framework/tool-context'
+import type { AgentEvent } from '../../ai/agent-framework/types'
+import type { ProcedureStepInput } from '../../ai/kopilot/prompts/sections/types'
+import type { CachedAgentProcedure } from '../../cache/org-cache-keys'
+import { backstopClassify, classifyTextBranch, goalMetCheck } from './classifier'
+import type { ClassifyDeps, ConversationMessage } from './classify'
+import { PROCEDURE_STEP_KEY, readProcedureSlice, writeProcedureSlice } from './persist'
+import type { AgentProcedureEntity, ProcedureEntity, ProcedureVersionEntity } from './queries'
+import { getProcedureById, getProcedureVersionById, readCompiled } from './queries'
+import { type ResolvedCandidate, type SelectionResult, selectProcedure } from './select'
+import { depth, emptyStack, push, top } from './stack'
+import { interpretSignal, type PrepareResult, prepareTurn, type StepperDeps } from './stepper'
+import type { CompiledProcedure, ProcedureStack } from './types'
+
+/**
+ * The Phase-4 turn glue that the live processors call. This module owns the
+ * *data wiring* around the already-built Phase-1 selection (`selectProcedure`)
+ * and Phase-3 stepper (`prepareTurn` / `interpretSignal`):
+ *
+ *  - {@link resolveCandidatesFromCache} — `agents` org-cache projection →
+ *    `ResolvedCandidate[]` (the stable selection seam).
+ *  - {@link applySelection} — map a `SelectionResult` onto the persisted stack.
+ *  - {@link buildActiveStepInput} — a `prepareTurn` inject result →
+ *    `ProcedureStepInput` (what the `agentProcedureStep` prompt section reads).
+ *  - {@link buildStepperDeps} — construct the 7-field `StepperDeps` (3 org-cache
+ *    reads + 4 classifier closures) the stepper needs every turn.
+ *
+ * It does NOT own the engine loop. The sandwich (calling `prepareTurn` →
+ * `engine.submitMessage` → `interpretSignal`, honouring `reinvoke`/`inlineFallback`,
+ * and mounting the control tools) lands once the engine re-entry contract for
+ * `reinvoke` is settled — `submitMessage` always appends a user message + resets
+ * turn state, so a same-turn re-drain needs a dedicated entry point. See
+ * plans/chat/v9/phase-4-wiring.md §1 + the verified-against-Phase-3 addendum.
+ */
+
+// ── candidate projection → ResolvedCandidate ──────────────────────────────
+
+/**
+ * Adapt the `agents` org-cache projection ({@link CachedAgentProcedure}, already
+ * resolved `override ?? default`) into the {@link ResolvedCandidate} shape
+ * `selectProcedure` consumes. Selection reads only `link.{enabled,priority}`,
+ * `procedure.id`, `activeVersion.{id,compiled}`, and `resolved.*`; the entity
+ * sub-objects carry exactly those (cast to the entity types — the projection is
+ * not a full row, and selection never touches the missing columns).
+ */
+export function resolveCandidatesFromCache(
+  procedures: readonly CachedAgentProcedure[]
+): ResolvedCandidate[] {
+  return procedures.map((p) => ({
+    link: {
+      id: p.linkId,
+      procedureId: p.procedureId,
+      enabled: p.enabled,
+      priority: p.priority,
+    } as unknown as AgentProcedureEntity,
+    procedure: {
+      id: p.procedureId,
+      activeVersionId: p.activeVersionId,
+    } as unknown as ProcedureEntity,
+    activeVersion: {
+      id: p.activeVersionId,
+      compiled: p.compiled,
+    } as unknown as ProcedureVersionEntity & { compiled: CompiledProcedure },
+    resolved: {
+      whenToUse: p.whenToUse,
+      triggerExamples: p.triggerExamples,
+      ruleset: p.ruleset,
+    },
+  }))
+}
+
+// ── selection → stack ─────────────────────────────────────────────────────
+
+/**
+ * Fold a {@link SelectionResult} into the persisted stack: `selected` pushes the
+ * fresh frame 0; `resume` and `none` leave the stack untouched (the resumed frame
+ * is already the top, and `none` is free-form persona mode).
+ */
+export function applySelection(stack: ProcedureStack, selection: SelectionResult): ProcedureStack {
+  if (selection.kind === 'selected') return push(stack, selection.frame)
+  return stack
+}
+
+// ── prepareTurn inject result → prompt-section input ───────────────────────
+
+/**
+ * Build the {@link ProcedureStepInput} the `agentProcedureStep` section renders,
+ * from the active instruction step + the running version's compiled doc-level
+ * maps (so inline `subprocedure:`/`code:` badges resolve to names) + the stack
+ * depth. `topicLabel`/`returnToLabel` are left undefined for now — the breadcrumb
+ * (Phase 3 `buildReanchorBreadcrumb`) carries the re-anchor line; richer side-request
+ * labels are a follow-up.
+ */
+export function buildActiveStepInput(args: {
+  activeStep: { doc: unknown }
+  compiled: CompiledProcedure
+  stack: ProcedureStack
+  breadcrumb?: string
+}): ProcedureStepInput {
+  return {
+    activeStep: { doc: args.activeStep.doc },
+    procedureMaps: {
+      subProcedures: Object.entries(args.compiled.subProcedures).map(([id, sub]) => ({
+        id,
+        name: sub.name,
+      })),
+      codeBlocks: Object.keys(args.compiled.codeBlocks).map((id) => ({ id, name: id })),
+    },
+    depth: depth(args.stack),
+    breadcrumb: args.breadcrumb,
+  }
+}
+
+// ── StepperDeps construction ───────────────────────────────────────────────
+
+export interface BuildStepperDepsArgs {
+  ctx: ToolContext
+  subject: Subject
+  /** Resolved candidates for THIS agent (from {@link resolveCandidatesFromCache}). */
+  candidates: ResolvedCandidate[]
+  /** This turn's conversation, for the classifier closures. */
+  conversation: ConversationMessage[]
+  /** Model/provider/org/user resolved by the caller (turn model — BYO-model). */
+  classifyDeps: ClassifyDeps
+}
+
+/**
+ * Construct the {@link StepperDeps} the Phase-3 stepper consumes: 3 org-cache
+ * reads (`readVersion` / `loadActiveVersion` / `selectOther`) backed by the
+ * candidate projection with a by-id DB fallback, and 4 classifier closures
+ * (`pickTextBranch` / `checkGoalMet` / `classifyBackstop`) bound to this turn's
+ * conversation + model.
+ */
+export function buildStepperDeps(args: BuildStepperDepsArgs): StepperDeps {
+  const { ctx, subject, candidates, conversation, classifyDeps } = args
+  const { organizationId } = classifyDeps
+
+  // Pinned-version read: projection hit when the pin == an attached procedure's
+  // active version (the common case), else a by-id DB read so an in-flight run
+  // keeps its pinned version after an admin republish/revert.
+  const readVersion: StepperDeps['readVersion'] = async (procedureVersionId) => {
+    const hit = candidates.find((c) => c.activeVersion.id === procedureVersionId)
+    if (hit) return { compiled: hit.activeVersion.compiled }
+    const result = await getProcedureVersionById({ organizationId, procedureVersionId })
+    if (result.isErr() || !result.value) return null
+    const compiled = readCompiled(result.value)
+    return compiled ? { compiled } : null
+  }
+
+  // Resolve a standalone procedure's CURRENT active version (for a `switch`):
+  // projection hit when attached, else load the procedure + its active version.
+  const loadActiveVersion: StepperDeps['loadActiveVersion'] = async (procedureId) => {
+    const hit = candidates.find((c) => c.procedure.id === procedureId)
+    if (hit) {
+      return {
+        procedureVersionId: hit.activeVersion.id,
+        compiled: hit.activeVersion.compiled,
+      }
+    }
+    const proc = await getProcedureById({ organizationId, procedureId })
+    if (proc.isErr() || !proc.value?.activeVersionId) return null
+    const version = await getProcedureVersionById({
+      organizationId,
+      procedureVersionId: proc.value.activeVersionId,
+    })
+    if (version.isErr() || !version.value) return null
+    const compiled = readCompiled(version.value)
+    return compiled ? { procedureVersionId: version.value.id, compiled } : null
+  }
+
+  // Digression re-run: Phase-1 selection over the agent's OTHER procedures. Use
+  // an empty stack so the sticky-resume short-circuit doesn't fire, and exclude
+  // the procedure that digressed.
+  const selectOther: StepperDeps['selectOther'] = async (excludeProcedureId) => {
+    const selection = await selectProcedure({
+      stack: emptyStack(),
+      candidates,
+      conversation,
+      ctx,
+      subject,
+      classifyDeps,
+      excludeProcedureIds: [excludeProcedureId],
+    })
+    if (selection.kind !== 'selected') return null
+    const chosen = candidates.find((c) => c.procedure.id === selection.frame.procedureId)
+    if (!chosen) return null
+    return {
+      procedureId: selection.frame.procedureId,
+      procedureVersionId: selection.frame.procedureVersionId,
+      compiled: chosen.activeVersion.compiled,
+    }
+  }
+
+  return {
+    ctx,
+    readVersion,
+    loadActiveVersion,
+    selectOther,
+    pickTextBranch: (predicates) => classifyTextBranch(conversation, predicates, classifyDeps),
+    checkGoalMet: (reply, activeStep) => goalMetCheck(reply, activeStep, classifyDeps),
+    classifyBackstop: (reply, activeStep) => backstopClassify(reply, activeStep, classifyDeps),
+  }
+}
+
+// ── the sandwich ───────────────────────────────────────────────────────────
+
+/** Bound on same-turn re-drains; the engine's token budget is the real backstop. */
+const MAX_REINVOKES = 8
+
+export interface RunProcedureTurnArgs {
+  engine: AgentEngine
+  /** The customer message that opened this turn (drained via `submitMessage`). */
+  inboundText: string
+  /** This agent's projected procedures (org-cache). `[]` → caller should skip entirely. */
+  procedures: readonly CachedAgentProcedure[]
+  subject: Subject
+  conversation: ConversationMessage[]
+  /** Model/provider/org/user (turn model — BYO-model) + db for the classifiers. */
+  classifyDeps: ClassifyDeps
+  /**
+   * Build a fresh {@link ToolContext} whose `context` is a `KopilotContextStore`
+   * hydrated from the engine's CURRENT `domainState`. Called per stepper phase so
+   * the post-drain control signal (synced into `domainState` by the query loop) is
+   * visible to `interpretSignal`.
+   */
+  buildCtx: () => ToolContext
+  /** Consume one engine drain (`submitMessage`/`continueTurn`), return the reply text. */
+  drain: (gen: AsyncGenerator<AgentEvent>) => Promise<string>
+  /**
+   * Invoked once (best-effort) when this turn escalated to a human — a routing
+   * `handoff` step or the `handoff_to_human` control tool. The chat caller flips
+   * the thread to the human queue; internal autonomous runs have no human queue
+   * and omit it. The stack is already cleared by the stepper. See §6 reconciliation.
+   */
+  onHandoff?: () => Promise<void> | void
+}
+
+/**
+ * The Phase-4 turn sandwich: Phase-1 selection, then a loop that wraps the engine
+ * drain between Phase-3 `prepareTurn` (write the active step → drain) and
+ * `interpretSignal` (read the control signal → mutate the stack), honouring
+ * `reinvoke` (same-turn re-drain via {@link AgentEngine.continueTurn}) and
+ * `inlineFallback` (one persona-only drain). Returns the final customer-facing
+ * reply (last non-empty across all drains) for the caller to deliver.
+ *
+ * The stack + the turn-local active step ride `domainState` (mutated in place — the
+ * engine carries the same object forward), so they persist via the caller's normal
+ * `updateSessionDomainState`. See plans/chat/v9/phase-4-wiring.md §1.
+ */
+export async function runProcedureTurn(args: RunProcedureTurnArgs): Promise<string> {
+  const { engine, inboundText, procedures, subject, conversation, classifyDeps, buildCtx, drain } =
+    args
+  const candidates = resolveCandidatesFromCache(procedures)
+  // Set by either handoff path; flips the thread to a human once, after the loop.
+  let handedOff = false
+  // getState() shallow-clones, so `.domainState` is the live object — mutate in place.
+  const liveDomainState = () => engine.getState().domainState as Record<string, unknown>
+
+  const makeDeps = (ctx: ToolContext): StepperDeps =>
+    buildStepperDeps({ ctx, subject, candidates, conversation, classifyDeps })
+
+  // 1. selection — sticky resume / fresh frame 0 / none.
+  let stack = readProcedureSlice(liveDomainState()) ?? emptyStack()
+  const selection = await selectProcedure({
+    stack,
+    candidates,
+    conversation,
+    ctx: buildCtx(),
+    subject,
+    classifyDeps,
+  })
+  stack = applySelection(stack, selection)
+
+  // 2. the sandwich loop.
+  let finalReply = ''
+  let firstDrain = true
+  for (let i = 0; i <= MAX_REINVOKES; i++) {
+    const prepDeps = makeDeps(buildCtx())
+    const prep: PrepareResult = await prepareTurn(stack, prepDeps)
+    stack = prep.stack
+    if (prep.kind === 'free-form' && prep.handoff) handedOff = true
+
+    // 2a. write the active step (or clear it) BEFORE the drain.
+    const dsPre = liveDomainState()
+    dsPre[PROCEDURE_STEP_KEY] = await resolveActiveStepInput(prep, prepDeps)
+    writeProcedureSlice(dsPre, stack)
+
+    // 2b. drain — submitMessage opens the turn, continueTurn re-drains same-turn.
+    const reply = await drain(
+      firstDrain ? engine.submitMessage(inboundText, {}) : engine.continueTurn()
+    )
+    firstDrain = false
+    if (reply.trim()) finalReply = reply
+
+    // Free-form (no frame) → persona-only turn, nothing to interpret.
+    if (prep.kind === 'free-form') break
+
+    // 2c. interpret the control signal off the post-drain domainState, clear it,
+    //     persist the cleared store + the mutated stack before any re-drain.
+    const interpretCtx = buildCtx()
+    const res = await interpretSignal(stack, reply, makeDeps(interpretCtx))
+    stack = res.stack
+    if (res.handoff) handedOff = true
+    const dsPost = liveDomainState()
+    if (interpretCtx.context instanceof KopilotContextStore) {
+      syncContextSlice(dsPost, interpretCtx.context)
+    }
+    writeProcedureSlice(dsPost, stack)
+
+    if (res.reinvoke) continue
+    if (res.inlineFallback) {
+      liveDomainState()[PROCEDURE_STEP_KEY] = undefined
+      const extra = await drain(engine.continueTurn())
+      if (extra.trim()) finalReply = extra
+      break
+    }
+    break
+  }
+
+  writeProcedureSlice(liveDomainState(), stack)
+  // Escalate once, after the loop, so the turn's closing reply is already computed
+  // (the caller still delivers it — flipping the thread doesn't gate this send).
+  if (handedOff) await args.onHandoff?.()
+  return finalReply
+}
+
+/** Build the `ProcedureStepInput` for an inject result (else `undefined` → section drops out). */
+async function resolveActiveStepInput(
+  prep: PrepareResult,
+  deps: StepperDeps
+): Promise<ProcedureStepInput | undefined> {
+  if (prep.kind !== 'inject') return undefined
+  const frame = top(prep.stack)
+  if (!frame) return undefined
+  const version = await deps.readVersion(frame.procedureVersionId)
+  if (!version) return undefined
+  return buildActiveStepInput({
+    activeStep: prep.activeStep,
+    compiled: version.compiled,
+    stack: prep.stack,
+    breadcrumb: prep.breadcrumb,
+  })
+}

--- a/packages/lib/src/ai/agent-framework/__tests__/continue-turn.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/continue-turn.test.ts
@@ -1,0 +1,106 @@
+// packages/lib/src/ai/agent-framework/__tests__/continue-turn.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { UsageMetrics } from '../../clients/base/types'
+import { AgentEngine } from '../engine'
+import type {
+  AgentDefinition,
+  AgentDomainConfig,
+  AgentEngineConfig,
+  AgentEvent,
+  LLMCallParams,
+  LLMStreamEvent,
+} from '../types'
+
+/**
+ * `continueTurn` — the v9 procedure-stepper re-entry point: re-run the query loop
+ * in the SAME customer turn with NO new user message and NO turn-state reset.
+ */
+
+const ZERO: UsageMetrics = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
+
+async function drain(gen: AsyncGenerator<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = []
+  for await (const event of gen) events.push(event)
+  return events
+}
+
+function buildEngine(contents: string[], resetTurnDomainState = false) {
+  let idx = 0
+  const callModel = async function* (_p: LLMCallParams): AsyncGenerator<LLMStreamEvent> {
+    yield { type: 'done', content: contents[idx++] ?? '', toolCalls: [], usage: ZERO }
+  }
+
+  const agent: AgentDefinition = {
+    name: 'agent',
+    tools: [],
+    buildMessages: async () => [],
+    processResult: async (_c, _tc, state) => state,
+    maxIterations: 6,
+  }
+
+  const domainConfig: AgentDomainConfig = {
+    type: 'kopilot',
+    agents: { agent },
+    routes: [{ name: 'default', agents: ['agent'] }],
+    createInitialState: () => ({}),
+    defaultModel: 'claude-opus-4-7',
+    defaultProvider: 'anthropic',
+    // Mirror the real kopilot reset: wipe a turn-scoped key on a fresh user
+    // message. `continueTurn` must NOT invoke this.
+    ...(resetTurnDomainState
+      ? {
+          resetTurnDomainState: (ds: Record<string, unknown>) => {
+            const { __turnScoped, ...rest } = ds
+            return rest
+          },
+        }
+      : {}),
+  }
+
+  const config: AgentEngineConfig = {
+    organizationId: 'org-1',
+    userId: 'user-1',
+    sessionId: 'sess-1',
+    db: {} as never,
+    domainConfig,
+    callModel,
+  }
+
+  return new AgentEngine(config, { messages: [], domainState: { __turnScoped: 'keep-me' } })
+}
+
+describe('AgentEngine.continueTurn', () => {
+  it('regenerates an assistant message WITHOUT appending a new user message', async () => {
+    const engine = buildEngine(['first reply', 'second reply'])
+
+    await drain(engine.submitMessage('hi'))
+    let messages = engine.getState().messages
+    expect(messages.map((m) => m.role)).toEqual(['user', 'assistant'])
+
+    await drain(engine.continueTurn())
+    messages = engine.getState().messages
+    // One more assistant message, NO second user message.
+    expect(messages.map((m) => m.role)).toEqual(['user', 'assistant', 'assistant'])
+    expect(messages.filter((m) => m.role === 'user')).toHaveLength(1)
+  })
+
+  it('does NOT run resetTurnDomainState (turn-scoped state survives), unlike submitMessage', async () => {
+    // submitMessage runs the reset → the turn-scoped key is dropped.
+    const viaSubmit = buildEngine(['a'], /* resetTurnDomainState */ true)
+    await drain(viaSubmit.submitMessage('hi'))
+    expect(viaSubmit.getState().domainState.__turnScoped).toBeUndefined()
+
+    // continueTurn skips the reset → the same key survives the re-drain.
+    const viaContinue = buildEngine(['b'], /* resetTurnDomainState */ true)
+    await drain(viaContinue.continueTurn())
+    expect(viaContinue.getState().domainState.__turnScoped).toBe('keep-me')
+  })
+
+  it('emits a turn-completed event', async () => {
+    const engine = buildEngine(['x', 'y'])
+    await drain(engine.submitMessage('hi'))
+    const events = await drain(engine.continueTurn())
+    expect(events.some((e) => e.type === 'turn-completed')).toBe(true)
+  })
+})

--- a/packages/lib/src/ai/agent-framework/engine.ts
+++ b/packages/lib/src/ai/agent-framework/engine.ts
@@ -172,6 +172,45 @@ export class AgentEngine {
     }
   }
 
+  /**
+   * Re-run the query loop in the SAME customer turn WITHOUT appending a user
+   * message or resetting turn-scoped state.
+   *
+   * The v9 procedure stepper calls this for a same-turn `reinvoke`
+   * (advance/digress/end): the caller has already mutated `domainState` (advanced
+   * the procedure stack + the active step the prompt reads), and wants the model
+   * to generate again against the NEW system prompt with no phantom customer
+   * message. Unlike {@link submitMessage} it does NOT append a `user` message,
+   * does NOT call `resetTurnDomainState`, and does NOT reset turn usage/snapshots/
+   * captures — they ACCUMULATE across continuations so the turn budget bounds a
+   * runaway reinvoke loop. The current `turnId` is reused (it's one logical turn).
+   *
+   * Pre-launch invariant: the caller is responsible for ensuring the stack
+   * genuinely changed before re-invoking (the stepper's `reinvoke` flag), or the
+   * model would regenerate against an unchanged prompt.
+   */
+  async *continueTurn(): AsyncGenerator<AgentEvent> {
+    if (!this.turnId) this.turnId = generateId('turn')
+
+    this.abortController = new AbortController()
+    const configWithAbort: AgentEngineConfig = {
+      ...this.config,
+      signal: this.abortController.signal,
+    }
+
+    logger.info('Turn continued (no new user message)', {
+      turnId: this.turnId,
+      sessionId: this.config.sessionId,
+      totalMessages: this.state.messages.length,
+    })
+
+    try {
+      yield* this.withTurnEnd(this.tagTurnId(this.runPipeline(configWithAbort)))
+    } finally {
+      this.abortController = null
+    }
+  }
+
   /** Abort the current turn execution. */
   interrupt(): void {
     this.abortController?.abort()

--- a/packages/lib/src/ai/agent-framework/process-agent-job.ts
+++ b/packages/lib/src/ai/agent-framework/process-agent-job.ts
@@ -15,6 +15,13 @@ import {
   computeEffectiveBindings,
   projectBindingSchemas,
 } from '../../agents/bindings'
+import {
+  type ConversationMessage,
+  PROCEDURE_CONTROL_TOOLS,
+  runProcedureTurn,
+  sessionMessagesToConversation,
+} from '../../agents/procedures'
+import { getCachedAgentById } from '../../cache'
 import type { JobContext } from '../../jobs/types'
 import { docToText } from '../../tiptap'
 import {
@@ -32,12 +39,14 @@ import type { UsageTrackingRequest } from '../orchestrator/types'
 import { getModelCreditMultiplier } from '../quota/credit-multiplier'
 import { UsageTrackingService } from '../usage/usage-tracking-service'
 import { BUILDER_MODEL } from './builder-model'
+import { KopilotContextStore, readContextSlice } from './context'
 import { AgentEngine } from './engine'
 import type { AgentJobPayload } from './enqueue-agent-job'
 import { createAgentEventPublisher } from './event-publisher'
 import { createCallModel } from './llm-adapter'
 import { withAgentRunLog } from './run-log'
-import type { AgentEngineConfig, SessionMessage } from './types'
+import type { Subject, ToolContext } from './tool-context'
+import type { AgentEngineConfig, AgentEvent, SessionMessage } from './types'
 
 const logger = createScopedLogger('agent-job')
 
@@ -113,6 +122,13 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
   // is read back.
   const agentId = session.agentId ?? data.agentId ?? null
 
+  // v9 procedures: load the agent's projected procedures (org-cache). Only
+  // agent-bound runs can carry procedures; master/builder runs (no agentId)
+  // project to none. `[]` for an agent with no published procedures.
+  const agent = agentId ? await getCachedAgentById(organizationId, agentId) : null
+  const procedures = agent?.procedures ?? []
+  const hasProcedures = procedures.length > 0
+
   // 1b. Resolve trigger context for autonomous runs. The trigger row is
   // re-fetched (not passed via the job payload) so operator edits to
   // `instructions` between enqueue and execution are picked up.
@@ -133,6 +149,9 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
     modelId,
     agentId,
     triggerContext,
+    // Mount the procedure control tools when this agent has procedures (inert
+    // without an active step in the prompt — same gating as the chat path).
+    hasProcedures,
   })
 
   // 3. Create LLM adapter
@@ -146,7 +165,8 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
 
   // 3b. Resolve the agent's binding override map (cached read; empty for
   // master). Combined with each tool's author defaults to clamp args per call.
-  const { toolRestrictions } = await resolveAgentConfig(organizationId, agentId)
+  const agentConfig = await resolveAgentConfig(organizationId, agentId)
+  const { toolRestrictions } = agentConfig
 
   // 4. Create engine with saved state
   const engineConfig: AgentEngineConfig = {
@@ -184,50 +204,115 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
   const sessionContext = { page, ...(context ?? {}) }
   const usageEntries: UsageTrackingRequest[] = []
 
-  const generator =
-    type === 'approval'
-      ? engine.resume({
-          action: data.approvalAction ?? 'approve',
-          inputAmendment: data.inputAmendment,
-          context: sessionContext,
-        })
-      : engine.submitMessage(message, sessionContext)
+  // Drain one engine pass: publish every event, accumulate per-call usage, and
+  // return the final assistant text. Called once for a plain turn, or once per
+  // stepper phase by `runProcedureTurn` (each re-drain bills its own iterations).
+  const drain = async (gen: AsyncGenerator<AgentEvent>): Promise<string> => {
+    let text = ''
+    for await (const event of gen) {
+      if (signal?.aborted) {
+        engine.interrupt()
+        break
+      }
 
-  for await (const event of generator) {
-    if (signal?.aborted) {
-      engine.interrupt()
-      break
+      // Per-LLM-call billing breakdown lives on `event.iterations` (one entry
+      // per agent iteration). Iterate to push one usage record per call with
+      // correct SYSTEM-vs-CUSTOM credit gating — BYOK customers consume no
+      // credits. Drain on both `paused` and `finished`: pre-pause iterations
+      // ride on `paused`, post-resume iterations on `finished`. Each event
+      // carries only segment-fresh iterations so no double-billing.
+      if (
+        (event.type === 'assistant-message-finished' ||
+          event.type === 'assistant-message-paused') &&
+        event.iterations?.length
+      ) {
+        for (const it of event.iterations) {
+          usageEntries.push({
+            organizationId,
+            userId,
+            provider: it.provider,
+            model: it.model,
+            usage: it.usage,
+            timestamp: new Date(),
+            source: 'agent',
+            sourceId: sessionId,
+            providerType: it.providerType,
+            credentialSource: it.credentialSource,
+            creditsUsed:
+              it.providerType === 'SYSTEM' ? getModelCreditMultiplier(it.provider, it.model) : 0,
+          })
+        }
+      }
+
+      if (event.type === 'assistant-message-finished') {
+        const t = event.parts
+          .filter((p): p is Extract<typeof p, { type: 'text' }> => p.type === 'text')
+          .map((p) => p.text)
+          .join('')
+        if (t.trim()) text = t
+      }
+
+      await publisher.publish(event)
     }
+    return text
+  }
 
-    // Per-LLM-call billing breakdown lives on `event.iterations` (one entry
-    // per agent iteration). Iterate to push one usage record per call with
-    // correct SYSTEM-vs-CUSTOM credit gating — BYOK customers consume no
-    // credits. Drain on both `paused` and `finished`: pre-pause iterations
-    // ride on `paused`, post-resume iterations on `finished`. Each event
-    // carries only segment-fresh iterations so no double-billing.
-    if (
-      (event.type === 'assistant-message-finished' || event.type === 'assistant-message-paused') &&
-      event.iterations?.length
-    ) {
-      for (const it of event.iterations) {
-        usageEntries.push({
-          organizationId,
-          userId,
-          provider: it.provider,
-          model: it.model,
-          usage: it.usage,
-          timestamp: new Date(),
-          source: 'agent',
-          sourceId: sessionId,
-          providerType: it.providerType,
-          credentialSource: it.credentialSource,
-          creditsUsed:
-            it.providerType === 'SYSTEM' ? getModelCreditMultiplier(it.provider, it.model) : 0,
-        })
+  // v9 procedures: an agent with published procedures sandwiches the engine drain
+  // between selection + the stepper (`runProcedureTurn`), exactly like the chat
+  // path. Internal runs carry an empty-anchors subject, so every procedure field
+  // resolves to `undefined` (gate-by-absence) and there's no human queue to flip
+  // (no `onHandoff`). Approval-resume turns skip the sandwich — they continue a
+  // paused tool, not a fresh customer message (job-path resume verify is §2.2).
+  if (hasProcedures && type !== 'approval') {
+    const subject: Subject = { anchors: {}, identityVerified: false }
+    const conversation: ConversationMessage[] = [
+      ...sessionMessagesToConversation((session.messages ?? []) as SessionMessage[]),
+      { role: 'user', content: message },
+    ]
+    const buildCtx = (): ToolContext => {
+      const base = {
+        db: database,
+        organizationId,
+        userId,
+        sessionId,
+        signal,
+        subject,
+        appAccounts: agentConfig.appAccounts,
+      }
+      return {
+        ...base,
+        context: new KopilotContextStore({
+          ctx: base as ToolContext,
+          initial: readContextSlice(engine.getState().domainState as Record<string, unknown>),
+        }),
       }
     }
-
-    await publisher.publish(event)
+    await runProcedureTurn({
+      engine,
+      inboundText: message,
+      procedures,
+      subject,
+      conversation,
+      classifyDeps: {
+        db: database,
+        organizationId,
+        userId,
+        model: domainConfig.defaultModel ?? 'claude-haiku-4-5',
+        provider: domainConfig.defaultProvider ?? 'anthropic',
+      },
+      buildCtx,
+      drain,
+    })
+  } else {
+    const generator =
+      type === 'approval'
+        ? engine.resume({
+            action: data.approvalAction ?? 'approve',
+            inputAmendment: data.inputAmendment,
+            context: sessionContext,
+          })
+        : engine.submitMessage(message, sessionContext)
+    await drain(generator)
   }
 
   // 7. Save final state to DB. Strip `thinking` parts on stored messages
@@ -299,6 +384,7 @@ async function buildDomainConfig(
     modelId?: string
     agentId: string | null
     triggerContext: TriggerContext | undefined
+    hasProcedures?: boolean
   }
 ) {
   switch (domain) {
@@ -363,6 +449,7 @@ async function buildKopilotShapedConfig(
     signal?: AbortSignal
     agentId: string | null
     triggerContext: TriggerContext | undefined
+    hasProcedures?: boolean
   },
   defaults: { provider: string | undefined; model: string | undefined }
 ) {
@@ -393,13 +480,19 @@ async function buildKopilotShapedConfig(
   const agentConfig = await resolveAgentConfig(params.organizationId, params.agentId)
   const resolvedPage = params.page ?? '__none__'
   const filteredTools = filterToolsByToolsets(registry.getTools(resolvedPage), agentConfig)
+  // Mount the v9 procedure control tools when this agent has procedures — inert
+  // without an active step in the prompt, so gating keeps zero-procedure runs on
+  // the unchanged tool list (mirrors `buildChatEngineConfig`).
+  const allTools = params.hasProcedures
+    ? [...filteredTools, ...PROCEDURE_CONTROL_TOOLS]
+    : filteredTools
   // Project tool schemas per the effective bindings (author defaults ⊕ admin
   // overrides). Internal turns have no subject, so bound inputs fall through to
   // the model at clamp time — but a `const` override still drops from required.
   // For master sessions there are no bindings, so this is a no-op. See
   // plans/chat/v8 phase-4.
-  const effectiveBindings = computeEffectiveBindings(filteredTools, agentConfig.toolRestrictions)
-  const tools = projectBindingSchemas(filteredTools, effectiveBindings)
+  const effectiveBindings = computeEffectiveBindings(allTools, agentConfig.toolRestrictions)
+  const tools = projectBindingSchemas(allTools, effectiveBindings)
 
   return createKopilotDomainConfig({
     capabilityRegistry: registry,

--- a/packages/lib/src/ai/kopilot/__tests__/domain-config.test.ts
+++ b/packages/lib/src/ai/kopilot/__tests__/domain-config.test.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/ai/kopilot/__tests__/domain-config.test.ts
 
 import { describe, expect, it } from 'vitest'
+import { PROCEDURE_SLICE_KEY } from '../../../agents/procedures/persist'
 import { CONTEXT_SLICE_KEY } from '../../agent-framework/context'
 import { createKopilotDomainConfig } from '../domain-config'
 
@@ -44,5 +45,37 @@ describe('createKopilotDomainConfig — resetTurnDomainState (chat v9)', () => {
 
     const next = config.resetTurnDomainState!(domainState)
     expect(next).toBe(domainState)
+  })
+
+  // Procedure-stack exemption (Phase 4 §2.1) — the stack is cross-turn control
+  // state and must survive a fresh user turn exactly as `vars` does.
+  const stack = { frames: [{ procedureId: 'p1', procedureVersionId: 'v1', cursor: 's1' }] }
+
+  it('preserves the procedure slice while dropping the context turn sub-slice', () => {
+    const config = createKopilotDomainConfig()
+    const domainState: Record<string, unknown> = {
+      [CONTEXT_SLICE_KEY]: {
+        vars: { plan: { steps: [] } },
+        turn: { tools: {}, calls: {} },
+      },
+      [PROCEDURE_SLICE_KEY]: stack,
+    }
+
+    const next = config.resetTurnDomainState!(domainState)
+
+    // turn capture dropped, vars kept, procedure stack carried through.
+    expect((next[CONTEXT_SLICE_KEY] as { turn?: unknown }).turn).toBeUndefined()
+    expect((next[CONTEXT_SLICE_KEY] as { vars: unknown }).vars).toEqual({ plan: { steps: [] } })
+    expect(next[PROCEDURE_SLICE_KEY]).toEqual(stack)
+  })
+
+  it('preserves the procedure slice when there is no context turn to clear', () => {
+    const config = createKopilotDomainConfig()
+    const domainState: Record<string, unknown> = { [PROCEDURE_SLICE_KEY]: stack }
+
+    const next = config.resetTurnDomainState!(domainState)
+    // No rebuild needed → same object, stack intact.
+    expect(next).toBe(domainState)
+    expect(next[PROCEDURE_SLICE_KEY]).toEqual(stack)
   })
 })

--- a/packages/lib/src/ai/kopilot/agents/agent.ts
+++ b/packages/lib/src/ai/kopilot/agents/agent.ts
@@ -3,6 +3,7 @@
 import { createScopedLogger } from '@auxx/logger'
 import { toActorId } from '@auxx/types/actor'
 import { getOrgToolCatalog, getOrgToolsetCatalog, type ResolvedAgentConfig } from '../../../agents'
+import { PROCEDURE_STEP_KEY } from '../../../agents/procedures/persist'
 import { getCachedIntegrationCatalog } from '../../../cache/integration-catalog'
 import { getCachedMembersByUserIds, getCachedResources } from '../../../cache/org-cache-helpers'
 import type {
@@ -16,6 +17,7 @@ import type { Message, ToolCall } from '../../clients/base/types'
 import { transformAssistantContentForLLM } from '../blocks/transform-for-llm'
 import { buildKopilotPromptSerialized } from '../prompts/build-kopilot-prompt'
 import { buildInstructionReferenceResolver } from '../prompts/resolve-instruction-references'
+import type { ProcedureStepInput } from '../prompts/sections/types'
 import type { CurrentUserInfo } from '../prompts/shared-types'
 import type { TriggerContext } from '../prompts/trigger-context'
 import type { KopilotDomainState } from '../types'
@@ -104,6 +106,14 @@ export function createKopilotAgent(
         ? buildInstructionReferenceResolver({ toolCatalog, toolsetCatalog })
         : undefined
 
+      // The Phase-4 turn preamble stashes the active procedure step here before
+      // the engine drains; absent (or on a free-form turn) the section drops out.
+      // `domainState` is treated as a Record for slice reads (as the context
+      // store does) — the typed interface has no index signature.
+      const procedureStep = (state.domainState as Record<string, unknown>)[PROCEDURE_STEP_KEY] as
+        | ProcedureStepInput
+        | undefined
+
       const systemPrompt = buildKopilotPromptSerialized({
         domainState: state.domainState,
         entityCatalog,
@@ -115,6 +125,7 @@ export function createKopilotAgent(
         agentConfig,
         triggerContext,
         instructionsReferences,
+        procedureStep,
       })
 
       // Full conversation for tool-loop continuity. Each persisted assistant

--- a/packages/lib/src/ai/kopilot/domain-config.ts
+++ b/packages/lib/src/ai/kopilot/domain-config.ts
@@ -2,6 +2,7 @@
 
 import { createScopedLogger } from '@auxx/logger'
 import type { ResolvedAgentConfig } from '../../agents'
+import { PROCEDURE_SLICE_KEY } from '../../agents/procedures/persist'
 import { CONTEXT_SLICE_KEY, readContextSlice } from '../agent-framework/context'
 import type {
   AgentDomainConfig,
@@ -210,9 +211,20 @@ export function createKopilotDomainConfig(
     resetTurnDomainState(domainState: Record<string, unknown>): Record<string, unknown> {
       // Drop the turn-scoped context capture (tool:*/call:*) on a new user turn
       // while preserving `var:*` scratch (incl. var:plan, promoted captures).
+      // The procedure stack is cross-turn CONTROL state — exempt it from the
+      // reset (the next customer turn resumes from it), exactly as `vars` is
+      // preserved. Returning `domainState` unchanged already preserves it; only
+      // the rebuild branch below (which spreads into a fresh object, dropping
+      // un-listed keys) must re-add `procedure` explicitly or the stack is wiped
+      // each turn (plans/chat/v9/phase-4-wiring.md §2.1).
       const slice = readContextSlice(domainState)
       if (!slice?.turn) return domainState
-      return { ...domainState, [CONTEXT_SLICE_KEY]: { vars: slice.vars } }
+      const procedure = domainState[PROCEDURE_SLICE_KEY]
+      return {
+        ...domainState,
+        [CONTEXT_SLICE_KEY]: { vars: slice.vars },
+        ...(procedure !== undefined ? { [PROCEDURE_SLICE_KEY]: procedure } : {}),
+      }
     },
   }
 }

--- a/packages/lib/src/ai/kopilot/prompts/build-kopilot-prompt.ts
+++ b/packages/lib/src/ai/kopilot/prompts/build-kopilot-prompt.ts
@@ -11,7 +11,7 @@ import {
   renderSectionsToBlocks,
   serializePromptBlocks,
 } from './sections/render'
-import type { PromptCtx, RunMode } from './sections/types'
+import type { ProcedureStepInput, PromptCtx, RunMode } from './sections/types'
 
 export type { PromptBlock } from './sections/render'
 export { CACHE_BREAK_SENTINEL, stripCacheBreakSentinels } from './sections/render'
@@ -37,6 +37,12 @@ export interface BuildKopilotPromptArgs {
    * chips fall back to the default `[reference](id)` form.
    */
   instructionsReferences?: (id: string) => string
+  /**
+   * The top frame's active procedure step (v9 procedures). Set by the Phase-4
+   * turn preamble (read off `domainState[PROCEDURE_STEP_KEY]`) while a frame is
+   * active; unset on free-form turns so `agentProcedureStep` renders `null`.
+   */
+  procedureStep?: ProcedureStepInput
 }
 
 /**
@@ -109,6 +115,7 @@ function buildPromptCtx(args: BuildKopilotPromptArgs): PromptCtx {
     capabilities: args.capabilities,
     instructionsReferences: args.instructionsReferences,
     triggerContext: args.triggerContext,
+    procedureStep: args.procedureStep,
   }
 }
 

--- a/packages/lib/src/ai/kopilot/prompts/sections/registry.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/registry.ts
@@ -2,6 +2,7 @@
 
 import { activeRefs } from './active-refs'
 import { agentPersona } from './agent-persona'
+import { agentProcedureStep } from './agent-procedure-step'
 import { approval } from './approval'
 import { blockCatalog } from './block-catalog'
 import { callerPreamble } from './caller-preamble'
@@ -63,12 +64,14 @@ export const SYSTEM_PROMPT_SECTIONS: readonly PromptSection[] = [
   triggerFired,
   contextSection,
   activeRefs,
+  agentProcedureStep, // active procedure step (top frame only) + breadcrumb; stability: 'turn'
   callerPreamble,
 ]
 
 const ABOVE_CORE_IDS = new Set([
   'master-persona',
   'agent-persona',
+  'agent-procedure-step', // agent-specific (like agent-persona) — excluded from the core slice
   'master-capabilities',
   'trigger-fired',
   'trigger-acting-as',

--- a/packages/lib/src/cache/invalidation-graph.ts
+++ b/packages/lib/src/cache/invalidation-graph.ts
@@ -54,6 +54,10 @@ export const INVALIDATION_GRAPH: Record<string, InvalidationMapping> = {
   'agent.archived': ['agents'],
   'agent.deleted': ['agents'],
 
+  // Only PUBLISH/REVERT busts the agents projection — drafts never affect live
+  // runs (the projection joins `activeVersionId`). See phase-4-wiring.md §4.4.
+  'procedure.updated': ['agents'],
+
   'inbox.created': ['inboxes'],
   'inbox.updated': ['inboxes'],
   'inbox.deleted': ['inboxes'],

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -18,7 +18,9 @@ import type {
   OrganizationMemberInfo,
   OrganizationRole,
 } from '@auxx/database/types'
+import type { CompiledProcedure, TriggerExample } from '../agents/procedures/types'
 import type { CredentialsResponse, ProviderConfiguration } from '../ai/providers/types'
+import type { ConditionGroup } from '../conditions/types'
 import type { DehydratedOrganization } from '../dehydration/types'
 import type { Inbox } from '../inboxes/types'
 import type { Overage } from '../permissions/overage-detection-service'
@@ -129,6 +131,30 @@ export interface CachedAgentTrigger {
   instructions: Record<string, unknown> | null
 }
 
+/**
+ * One agent↔procedure LINK projected for the cache, fully resolved for selection.
+ * Carries the link's per-agent overrides already collapsed onto the procedure
+ * defaults (`override ?? default`), plus the procedure's ACTIVE published version
+ * (its `compiled` tree, pinned by `activeVersionId`). Drives Phase-1 selection and
+ * the Phase-3 stepper. See plans/chat/v9/phase-4-wiring.md §4.1.
+ */
+export interface CachedAgentProcedure {
+  // link
+  linkId: string
+  procedureId: string
+  enabled: boolean
+  priority: number
+  // resolved trigger (override ?? default — precomputed at projection time)
+  whenToUse: string
+  triggerExamples: TriggerExample[]
+  /** `[]` = no deterministic gate. */
+  ruleset: ConditionGroup[]
+  // pinned build — only procedures with an ACTIVE published version are projected
+  activeVersionId: string
+  /** The ACTIVE version's compiled step tree. */
+  compiled: CompiledProcedure
+}
+
 /** Cached agent (JSON-serializable) */
 export interface CachedAgent {
   id: string
@@ -166,6 +192,14 @@ export interface CachedAgent {
   archivedAt: string | null
   /** All AgentTrigger rows owned by this agent (active + disabled). Consumers filter. */
   triggers: CachedAgentTrigger[]
+  /**
+   * This agent's linked procedures: the link (enabled/priority/resolved trigger)
+   * + its ACTIVE published version's compiled tree. One entry per `AgentProcedure`
+   * link whose procedure has an `activeVersionId`; unpublished procedures are
+   * excluded. `[]` for agents with no published procedures (the zero-procedure
+   * short-circuit reads this). Drives selection + the stepper (Phase 4 §4).
+   */
+  procedures: CachedAgentProcedure[]
   /** Derived from triggers — whether direct messages to this agent are enabled. */
   dmEnabled: boolean
   /** Derived from triggers — DM trigger instructions (Tiptap doc); null if no addendum. */

--- a/packages/lib/src/cache/providers/agents-provider.ts
+++ b/packages/lib/src/cache/providers/agents-provider.ts
@@ -2,9 +2,11 @@
 
 import { type AgentConfig, schema } from '@auxx/database'
 import { eq } from 'drizzle-orm'
+import type { CompiledProcedure, TriggerExample } from '../../agents/procedures/types'
+import type { ConditionGroup } from '../../conditions/types'
 import { MediaAssetService } from '../../files'
 import { createScopedLogger } from '../../logger'
-import type { CachedAgent, CachedAgentTrigger } from '../org-cache-keys'
+import type { CachedAgent, CachedAgentProcedure, CachedAgentTrigger } from '../org-cache-keys'
 import type { CacheProvider } from '../org-cache-provider'
 
 const logger = createScopedLogger('agents-provider')
@@ -30,7 +32,7 @@ const logger = createScopedLogger('agents-provider')
  */
 export const agentsProvider: CacheProvider<CachedAgent[]> = {
   async compute(orgId, db) {
-    const [agents, triggers] = await Promise.all([
+    const [agents, triggers, procedures] = await Promise.all([
       db
         .select({
           id: schema.Agent.id,
@@ -75,6 +77,35 @@ export const agentsProvider: CacheProvider<CachedAgent[]> = {
         })
         .from(schema.AgentTrigger)
         .where(eq(schema.AgentTrigger.organizationId, orgId)),
+      // Procedures projection: each AgentProcedure link → its Procedure → that
+      // procedure's ACTIVE published version. The inner join on
+      // `Procedure.activeVersionId` carries exactly the active version's
+      // `compiled` and DROPS procedures never published (activeVersionId IS NULL
+      // → no join row). Phase 4 §4.2.
+      db
+        .select({
+          linkId: schema.AgentProcedure.id,
+          agentId: schema.AgentProcedure.agentId,
+          procedureId: schema.Procedure.id,
+          enabled: schema.AgentProcedure.enabled,
+          priority: schema.AgentProcedure.priority,
+          // defaults (Procedure) + overrides (link) — resolved `override ?? default` below
+          whenToUseDefault: schema.Procedure.whenToUse,
+          whenToUseOverride: schema.AgentProcedure.whenToUseOverride,
+          examplesDefault: schema.Procedure.triggerExamples,
+          examplesOverride: schema.AgentProcedure.triggerExamplesOverride,
+          rulesetDefault: schema.Procedure.ruleset,
+          rulesetOverride: schema.AgentProcedure.rulesetOverride,
+          activeVersionId: schema.Procedure.activeVersionId,
+          compiled: schema.ProcedureVersion.compiled,
+        })
+        .from(schema.AgentProcedure)
+        .innerJoin(schema.Procedure, eq(schema.Procedure.id, schema.AgentProcedure.procedureId))
+        .innerJoin(
+          schema.ProcedureVersion,
+          eq(schema.ProcedureVersion.id, schema.Procedure.activeVersionId)
+        )
+        .where(eq(schema.AgentProcedure.organizationId, orgId)),
     ])
 
     const triggersByAgent = new Map<string, CachedAgentTrigger[]>()
@@ -95,6 +126,26 @@ export const agentsProvider: CacheProvider<CachedAgent[]> = {
         instructions: (t.instructions ?? null) as Record<string, unknown> | null,
       })
       triggersByAgent.set(t.agentId, list)
+    }
+
+    const proceduresByAgent = new Map<string, CachedAgentProcedure[]>()
+    for (const p of procedures) {
+      // The inner join guarantees a non-null active version for every row.
+      if (!p.activeVersionId) continue
+      const list = proceduresByAgent.get(p.agentId) ?? []
+      list.push({
+        linkId: p.linkId,
+        procedureId: p.procedureId,
+        enabled: p.enabled,
+        priority: p.priority,
+        // Resolve `override ?? default` here so consumers read a single value.
+        whenToUse: p.whenToUseOverride ?? p.whenToUseDefault,
+        triggerExamples: (p.examplesOverride ?? p.examplesDefault ?? []) as TriggerExample[],
+        ruleset: (p.rulesetOverride ?? p.rulesetDefault ?? []) as ConditionGroup[],
+        activeVersionId: p.activeVersionId,
+        compiled: (p.compiled ?? {}) as unknown as CompiledProcedure,
+      })
+      proceduresByAgent.set(p.agentId, list)
     }
 
     return Promise.all(
@@ -144,6 +195,7 @@ export const agentsProvider: CacheProvider<CachedAgent[]> = {
           setupCompletedAt: row.setupCompletedAt ? row.setupCompletedAt.toISOString() : null,
           archivedAt: row.archivedAt ? row.archivedAt.toISOString() : null,
           triggers: agentTriggers,
+          procedures: proceduresByAgent.get(row.id) ?? [],
           dmEnabled: dm?.enabled ?? false,
           dmInstructions: dm?.instructions ?? null,
           dmTriggerId: dm?.id ?? null,

--- a/packages/lib/src/chat/agent/build-chat-engine-config.ts
+++ b/packages/lib/src/chat/agent/build-chat-engine-config.ts
@@ -8,6 +8,7 @@ import {
   projectBindingSchemas,
 } from '../../agents/bindings'
 import { ALL_SURFACES } from '../../agents/client'
+import { PROCEDURE_CONTROL_TOOLS } from '../../agents/procedures/control-tools'
 import { type AgentEngineConfig, createCallModel, type Subject } from '../../ai/agent-framework'
 import {
   createAppCapabilities,
@@ -43,6 +44,13 @@ export interface BuildChatEngineConfigInput {
   /** The turn's subject (anchors + identityVerified) threaded onto every tool's `ToolContext`. */
   subject: Subject
   signal?: AbortSignal
+  /**
+   * Mount the v9 procedure control tools (`advance_procedure` / `await_customer` /
+   * `digress` / `handoff_to_human` / `end_procedure`) when this agent has published
+   * procedures. They're inert without an active procedure step in the prompt, so
+   * gating keeps zero-procedure agents on the unchanged tool list.
+   */
+  hasProcedures?: boolean
 }
 
 /**
@@ -69,7 +77,7 @@ export async function buildChatEngineConfig(
   input: BuildChatEngineConfigInput,
   db: Database = database
 ): Promise<AgentEngineConfig> {
-  const { organizationId, agentId, agentUserId, sessionId, subject, signal } = input
+  const { organizationId, agentId, agentUserId, sessionId, subject, signal, hasProcedures } = input
 
   // Invariant: a chat-kind agent is visitor-facing by definition, so it always
   // runs with a subject carrying the thread + participant anchors (contact is
@@ -131,7 +139,11 @@ export async function buildChatEngineConfig(
   // want one unable to hand off to a human — so it's appended unconditionally
   // rather than gated behind a toolset toggle. The "when" is authored in the
   // persona. See plans/chat/v5 escalation.md §1.
-  const allTools = [...chatTools, createChatHandoffTool()]
+  const allTools = [
+    ...chatTools,
+    createChatHandoffTool(),
+    ...(hasProcedures ? PROCEDURE_CONTROL_TOOLS : []),
+  ]
 
   // Effective bindings = admin override ?? tool-author default (plans/chat/v8
   // phase-4). `agentConfig.toolRestrictions` is the thin per-agent override map

--- a/packages/lib/src/chat/agent/process-chat-turn.ts
+++ b/packages/lib/src/chat/agent/process-chat-turn.ts
@@ -4,11 +4,19 @@ import { database, schema } from '@auxx/database'
 import { saveSessionMessages, updateSessionDomainState } from '@auxx/services'
 import { and, desc, eq, gt } from 'drizzle-orm'
 import {
+  type ConversationMessage,
+  runProcedureTurn,
+  sessionMessagesToConversation,
+} from '../../agents/procedures'
+import {
   AgentEngine,
+  type AgentEvent,
   buildCatchupMessages,
   findOrCreateThreadSession,
   type SessionMessage,
 } from '../../ai/agent-framework'
+import { KopilotContextStore, readContextSlice } from '../../ai/agent-framework/context'
+import type { ToolContext } from '../../ai/agent-framework/tool-context'
 import { getCachedAgentById } from '../../cache'
 import type { JobContext } from '../../jobs/types'
 import { createScopedLogger } from '../../logger'
@@ -16,6 +24,7 @@ import { sendAgentChatMessage } from '../outbound'
 import { buildChatEngineConfig } from './build-chat-engine-config'
 import { buildChatSubjectFromPassport } from './build-chat-subject'
 import type { ChatTurnJobPayload } from './enqueue-chat-turn'
+import { flipHandoffState } from './handoff'
 
 const logger = createScopedLogger('process-chat-turn')
 
@@ -130,6 +139,7 @@ export async function processChatTurn(ctx: JobContext<ChatTurnJobPayload>): Prom
     sessionId: session.id,
     subject,
     signal,
+    hasProcedures: agent.procedures.length > 0,
   })
 
   const engine = new AgentEngine(config, {
@@ -137,22 +147,86 @@ export async function processChatTurn(ctx: JobContext<ChatTurnJobPayload>): Prom
     domainState: (session.domainState ?? {}) as Record<string, unknown>,
   })
 
-  // Drain the turn, accumulating the final assistant text (last responder
-  // message wins). Delivery is a single Pusher push on completion — no
-  // per-delta streaming for v5.
-  let finalText = ''
-  for await (const event of engine.submitMessage(inboundText, {})) {
-    if (signal?.aborted) {
-      engine.interrupt()
-      break
+  // Drain one engine pass, accumulating the final assistant text (last responder
+  // message wins). Delivery is a single Pusher push on completion — no per-delta
+  // streaming for v5.
+  const drain = async (gen: AsyncGenerator<AgentEvent>): Promise<string> => {
+    let text = ''
+    for await (const event of gen) {
+      if (signal?.aborted) {
+        engine.interrupt()
+        break
+      }
+      if (event.type === 'assistant-message-finished') {
+        const t = event.parts
+          .filter((p): p is Extract<typeof p, { type: 'text' }> => p.type === 'text')
+          .map((p) => p.text)
+          .join('')
+        if (t.trim()) text = t
+      }
     }
-    if (event.type === 'assistant-message-finished') {
-      const text = event.parts
-        .filter((p): p is Extract<typeof p, { type: 'text' }> => p.type === 'text')
-        .map((p) => p.text)
-        .join('')
-      if (text.trim()) finalText = text
+    return text
+  }
+
+  // v9 procedures: when the agent has published procedures, sandwich the engine
+  // drain between selection + the stepper (`runProcedureTurn`). Zero-procedure
+  // agents run the unchanged single drain (provable no-op for today's agents).
+  let finalText: string
+  if (agent.procedures.length > 0) {
+    const conversation: ConversationMessage[] = [
+      ...sessionMessagesToConversation([...existingMessages, ...catchup]),
+      { role: 'user', content: inboundText },
+    ]
+    const buildCtx = (): ToolContext => {
+      const base = {
+        db: database,
+        organizationId,
+        userId: agentUserId,
+        sessionId: session.id,
+        signal,
+        subject,
+        appAccounts: config.appAccounts,
+      }
+      return {
+        ...base,
+        context: new KopilotContextStore({
+          ctx: base as ToolContext,
+          initial: readContextSlice(engine.getState().domainState as Record<string, unknown>),
+        }),
+      }
     }
+    finalText = await runProcedureTurn({
+      engine,
+      inboundText,
+      procedures: agent.procedures,
+      subject,
+      conversation,
+      classifyDeps: {
+        db: database,
+        organizationId,
+        userId: agentUserId,
+        model: config.domainConfig.defaultModel ?? 'claude-haiku-4-5',
+        provider: config.domainConfig.defaultProvider ?? 'anthropic',
+      },
+      buildCtx,
+      drain,
+      // Procedure escalation: a routing `handoff` step or the `handoff_to_human`
+      // control tool flips this thread to the human queue (same sink as the
+      // `chat_handoff` persona tool). Best-effort — a flip failure must not drop
+      // the customer's closing reply.
+      onHandoff: async () => {
+        try {
+          await flipHandoffState({ threadId, organizationId })
+        } catch (err) {
+          logger.error('Procedure handoff failed to flip thread', {
+            threadId,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+      },
+    })
+  } else {
+    finalText = await drain(engine.submitMessage(inboundText, {}))
   }
 
   const finalState = engine.getState()


### PR DESCRIPTION
## Summary

Phase 5 of chat-v9 procedures. The previous phases built selection (Phase 1), the editor + routers (Phase 2), versioned publishing (Phase 3), and the runtime stepper + control tools (Phase 4) — but nothing read the active version on a live run. This PR wires it all into both live turn processors so a published procedure actually drives a customer turn.

## What's wired

- **`turn-wiring.ts`** — the data glue around the existing selection + stepper: `resolveCandidatesFromCache` (org-cache projection → `ResolvedCandidate[]`), `applySelection` (map a `SelectionResult` onto the persisted stack), `buildActiveStepInput`, `buildStepperDeps`, and the `runProcedureTurn` sandwich (select → `prepareTurn` → engine drain → `interpretSignal`, honouring `reinvoke` / `inlineFallback`).
- **`engine.continueTurn()`** — a same-turn re-drain entry point for `reinvoke` (advance/digress/end): no new user message, no `resetTurnDomainState`, usage/snapshots/captures **accumulate** so the turn budget bounds a runaway reinvoke loop.
- **`persist.ts`** — the `ProcedureStack` rides on `domainState` under `PROCEDURE_SLICE_KEY` (round-trips every persist point for free, exempted from `resetTurnDomainState` like `vars`); the turn-local active step rides under `PROCEDURE_STEP_KEY`, read back by the `agentProcedureStep` prompt section.
- **agents org-cache** — project each `AgentProcedure` link + its **active** published version's compiled tree as `CachedAgentProcedure` (inner join drops never-published procedures). `publish`/`revert` bust via `procedure.updated → ['agents']`.
- **chat + agent-job processors** — mount `PROCEDURE_CONTROL_TOOLS` and run the sandwich when the agent has procedures (zero-procedure agents keep the unchanged single drain). A routing `handoff` step / the `handoff_to_human` control tool flips the chat thread to the human queue; internal runs have no queue and ignore it.

## Tests

- `turn-wiring.test.ts`, `conversation.test.ts`, `continue-turn.test.ts`
- `stepper.test.ts` — handoff now flags escalation on both paths
- `domain-config.test.ts` — procedure-stack reset exemption

🤖 Generated with [Claude Code](https://claude.com/claude-code)