### PR TITLE
feat(agents): chat-v9 procedures phase 6 — deterministic code steps

### DIFF
--- a/apps/web/src/components/agents/procedures/ui/code-bindings-editor.tsx
+++ b/apps/web/src/components/agents/procedures/ui/code-bindings-editor.tsx
@@ -1,0 +1,178 @@
+// apps/web/src/components/agents/procedures/ui/code-bindings-editor.tsx
+'use client'
+
+import type { CodeInput, CodeOutput, LocalAttribute } from '@auxx/lib/agents/procedures/client'
+import { Button } from '@auxx/ui/components/button'
+import { Checkbox } from '@auxx/ui/components/checkbox'
+import { Input } from '@auxx/ui/components/input'
+import { Label } from '@auxx/ui/components/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+import { Plus, X } from 'lucide-react'
+import { useState } from 'react'
+
+/**
+ * The input/output binding surface for a code block (v9 procedures, Phase 5 §5). Lives
+ * above the {@link CodeBlockEditor} in the `code:` drill-in panel; edits the doc-level
+ * `codeBlocks` map entry's `inputs`/`outputs` (the compiler lifts them onto the emitted
+ * `code` step). Bindings are per-block — a block invoked once (the common case) reads as
+ * its single invocation's contract.
+ *
+ *  - **Inputs** — `{ name, ref }` rows passed to `main(codeInput)`. `ref` is a free-text
+ *    field (a local `var:<name>` or a CRM `FieldReference` like `contact:email`); the
+ *    declared local attributes are offered as a datalist. The compiler rejects an
+ *    unresolvable ref at publish (`BAD_INPUT_REF`).
+ *  - **Outputs** — `{ name, surfaceToModel }` rows. `name` is picked from the declared
+ *    local attributes (a `result[name]` write to `var:<name>`); `surfaceToModel` decides
+ *    whether the value feeds the model's prose or stays branch-only.
+ *
+ * Holds the rows in LOCAL state (seeded once on mount; the panel remounts keyed per
+ * block) so editing stays responsive without re-rendering the parent `ProcedureEditor`.
+ * `onChange` propagates into the editor's `codeRef` (the save source), mirroring
+ * {@link CodeBlockEditor}.
+ */
+export function CodeBindingsEditor({
+  initialInputs,
+  initialOutputs,
+  localAttributes,
+  onChange,
+}: {
+  initialInputs: CodeInput[]
+  initialOutputs: CodeOutput[]
+  localAttributes: LocalAttribute[]
+  onChange: (next: { inputs: CodeInput[]; outputs: CodeOutput[] }) => void
+}) {
+  const [inputs, setInputsState] = useState<CodeInput[]>(initialInputs)
+  const [outputs, setOutputsState] = useState<CodeOutput[]>(initialOutputs)
+  const setInputs = (next: CodeInput[]) => {
+    setInputsState(next)
+    onChange({ inputs: next, outputs })
+  }
+  const setOutputs = (next: CodeOutput[]) => {
+    setOutputsState(next)
+    onChange({ inputs, outputs: next })
+  }
+
+  const datalistId = 'code-input-ref-suggestions'
+
+  return (
+    <div className='flex flex-col gap-4 px-1 pb-3'>
+      {/* Inputs */}
+      <div className='flex flex-col gap-2'>
+        <div className='flex items-center justify-between'>
+          <Label className='text-xs text-muted-foreground'>Inputs → main(codeInput)</Label>
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={() => setInputs([...inputs, { name: '', ref: '' }])}>
+            <Plus />
+            Add input
+          </Button>
+        </div>
+        <datalist id={datalistId}>
+          {localAttributes.map((a) => (
+            <option key={a.name} value={`var:${a.name}`} />
+          ))}
+        </datalist>
+        {inputs.length === 0 && (
+          <p className='text-xs text-muted-foreground'>
+            No inputs — the block receives an empty object.
+          </p>
+        )}
+        {inputs.map((input, i) => (
+          <div key={i} className='flex items-center gap-2'>
+            <Input
+              value={input.name}
+              placeholder='name'
+              className='h-8 flex-1 text-xs'
+              onChange={(e) =>
+                setInputs(inputs.map((r, j) => (j === i ? { ...r, name: e.target.value } : r)))
+              }
+            />
+            <Input
+              value={input.ref}
+              placeholder='var:cartTotal or contact:email'
+              list={datalistId}
+              className='h-8 flex-[2] font-mono text-xs'
+              onChange={(e) =>
+                setInputs(inputs.map((r, j) => (j === i ? { ...r, ref: e.target.value } : r)))
+              }
+            />
+            <Button
+              variant='ghost'
+              size='icon'
+              aria-label='Remove input'
+              onClick={() => setInputs(inputs.filter((_, j) => j !== i))}>
+              <X />
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      {/* Outputs */}
+      <div className='flex flex-col gap-2'>
+        <div className='flex items-center justify-between'>
+          <Label className='text-xs text-muted-foreground'>Outputs → var:*</Label>
+          <Button
+            variant='ghost'
+            size='sm'
+            disabled={localAttributes.length === 0}
+            onClick={() => setOutputs([...outputs, { name: '', surfaceToModel: false }])}>
+            <Plus />
+            Add output
+          </Button>
+        </div>
+        {localAttributes.length === 0 && (
+          <p className='text-xs text-muted-foreground'>
+            Declare a local attribute (the `@` → Create attribute tab) to capture an output.
+          </p>
+        )}
+        {outputs.map((output, i) => (
+          <div key={i} className='flex items-center gap-2'>
+            <Select
+              value={output.name || undefined}
+              onValueChange={(name) =>
+                setOutputs(outputs.map((r, j) => (j === i ? { ...r, name } : r)))
+              }>
+              <SelectTrigger className='h-8 flex-1 text-xs'>
+                <SelectValue placeholder='attribute' />
+              </SelectTrigger>
+              <SelectContent>
+                {localAttributes.map((a) => (
+                  <SelectItem key={a.name} value={a.name}>
+                    {a.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <label className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+              <Checkbox
+                checked={output.surfaceToModel}
+                onCheckedChange={(checked) =>
+                  setOutputs(
+                    outputs.map((r, j) =>
+                      j === i ? { ...r, surfaceToModel: checked === true } : r
+                    )
+                  )
+                }
+              />
+              Show to model
+            </label>
+            <Button
+              variant='ghost'
+              size='icon'
+              aria-label='Remove output'
+              onClick={() => setOutputs(outputs.filter((_, j) => j !== i))}>
+              <X />
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
@@ -1,7 +1,12 @@
 // apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
 'use client'
 
-import { type LocalAttribute, parseStepBadgeId } from '@auxx/lib/agents/procedures/client'
+import {
+  type CodeInput,
+  type CodeOutput,
+  type LocalAttribute,
+  parseStepBadgeId,
+} from '@auxx/lib/agents/procedures/client'
 import { Dialog, DialogContent, DialogTitle } from '@auxx/ui/components/dialog'
 import { NavStack, NavStackPanel, NavStackPanels } from '@auxx/ui/components/nav-stack'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
@@ -24,6 +29,7 @@ import type { ReferencePickerHandle } from '~/components/pickers/reference-picke
 import type { AutosaveState } from '../../ui/shared/autosave-indicator'
 import { useProcedure } from '../hooks/use-procedure'
 import { useProcedureMutations } from '../hooks/use-procedure-mutations'
+import { CodeBindingsEditor } from './code-bindings-editor'
 import { CodeBlockEditor } from './code-block-editor'
 import { ProcedureEditorProvider } from './procedure-editor-context'
 import { ProcedureTriggerHeader } from './procedure-trigger-header'
@@ -56,6 +62,10 @@ interface CodeBlockEntry {
   name: string
   language: 'javascript'
   code: string
+  /** Per-block input bindings → `main(codeInput)` (compiled onto the `code` step). */
+  inputs?: CodeInput[]
+  /** Per-block output bindings → `var:*` (compiled onto the `code` step). */
+  outputs?: CodeOutput[]
 }
 
 interface DraftDoc {
@@ -196,6 +206,16 @@ export function ProcedureEditor({ procedureId, onAutosaveChange }: ProcedureEdit
   const handleCodeChange = useCallback(
     (id: string, code: string) => {
       codeRef.current = codeRef.current.map((c) => (c.id === id ? { ...c, code } : c))
+      commit()
+    },
+    [commit]
+  )
+
+  // Input/output bindings ride the code-block map entry (the compiler lifts them onto
+  // the emitted `code` step). Written to `codeRef`, the save source — same as the body.
+  const handleCodeBindingsChange = useCallback(
+    (id: string, bindings: { inputs: CodeInput[]; outputs: CodeOutput[] }) => {
+      codeRef.current = codeRef.current.map((c) => (c.id === id ? { ...c, ...bindings } : c))
       commit()
     },
     [commit]
@@ -383,17 +403,26 @@ export function ProcedureEditor({ procedureId, onAutosaveChange }: ProcedureEdit
               />
             </NavStackPanel>
           ))}
-          {codeBlocks.map((c) => (
-            <NavStackPanel
-              key={c.id}
-              value={`code:${c.id}`}
-              className='bg-transparent dark:bg-transparent shadow-none'>
-              <CodeBlockEditor
-                code={codeRef.current.find((r) => r.id === c.id)?.code ?? c.code}
-                onChange={(code) => handleCodeChange(c.id, code)}
-              />
-            </NavStackPanel>
-          ))}
+          {codeBlocks.map((c) => {
+            const entry = codeRef.current.find((r) => r.id === c.id)
+            return (
+              <NavStackPanel
+                key={c.id}
+                value={`code:${c.id}`}
+                className='bg-transparent dark:bg-transparent shadow-none'>
+                <CodeBindingsEditor
+                  initialInputs={entry?.inputs ?? []}
+                  initialOutputs={entry?.outputs ?? []}
+                  localAttributes={localAttributes}
+                  onChange={(bindings) => handleCodeBindingsChange(c.id, bindings)}
+                />
+                <CodeBlockEditor
+                  code={entry?.code ?? c.code}
+                  onChange={(code) => handleCodeChange(c.id, code)}
+                />
+              </NavStackPanel>
+            )
+          })}
         </NavStackPanels>
       </NavStack>
     ),
@@ -401,9 +430,11 @@ export function ProcedureEditor({ procedureId, onAutosaveChange }: ProcedureEdit
       drillStack,
       subProcedures,
       codeBlocks,
+      localAttributes,
       handleMainChange,
       makeSubChange,
       handleCodeChange,
+      handleCodeBindingsChange,
       handleEditorReady,
     ]
   )

--- a/apps/web/src/components/agents/procedures/ui/procedure-trigger-header.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-trigger-header.tsx
@@ -5,7 +5,7 @@ import type { LocalAttribute, TriggerExample } from '@auxx/lib/agents/procedures
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { AutosizeTextarea } from '@auxx/ui/components/autosize-textarea'
 import { Section } from '@auxx/ui/components/section'
-import { Filter, Info, Tags } from 'lucide-react'
+import { Clock, Filter, Tags } from 'lucide-react'
 import { memo, useMemo, useRef, useState } from 'react'
 import { ConditionContainer, ConditionProvider } from '~/components/conditions'
 import CollapseWrap from '~/components/workflow/ui/collapse-wrap'
@@ -84,7 +84,14 @@ export const ProcedureTriggerHeader = memo(function ProcedureTriggerHeader({
 
   return (
     <>
-      <div className='pe-4 border-b'>
+      <Section
+        title='When to run'
+        icon={<Clock className='size-4' />}
+        collapsible={false}
+        isRequired
+        className='[&>[data-slot=section]]:pb-0 [&_[data-slot=section-content]]:-ms-2 [&_[data-slot=section-content]]:-mt-2'
+        description='Describe when this procedure should run…'
+        initialOpen={true}>
         <CollapseWrap
           minHeight={60}
           isCollapsed={isDescCollapsed}
@@ -108,7 +115,7 @@ export const ProcedureTriggerHeader = memo(function ProcedureTriggerHeader({
         {whenToUseEmpty && (
           <span className='ps-2 mt-0.5 text-xs text-amber-600'>Required to publish.</span>
         )}
-      </div>
+      </Section>
 
       <Section
         title='Trigger examples'

--- a/packages/lib/src/agents/procedures/__tests__/compile.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/compile.test.ts
@@ -51,11 +51,20 @@ const sub = (id: string, name: string, content: TiptapNode[]): SubProcedureMapEn
   content,
 })
 
-const code = (id: string, name: string): CodeBlockMapEntry => ({
+const code = (
+  id: string,
+  name: string,
+  bindings?: {
+    inputs?: { name: string; ref: string }[]
+    outputs?: { name: string; surfaceToModel: boolean }[]
+  }
+): CodeBlockMapEntry => ({
   id,
   name,
   language: 'javascript',
   code: 'return 1',
+  ...(bindings?.inputs ? { inputs: bindings.inputs } : {}),
+  ...(bindings?.outputs ? { outputs: bindings.outputs } : {}),
 })
 
 type Condition = Extract<ProcedureStep, { kind: 'condition' }>
@@ -77,7 +86,7 @@ describe('compileProcedure', () => {
     expect(instructions).toHaveLength(1)
   })
 
-  it('keeps inline tool/code reference badges inside the instruction doc (no split)', () => {
+  it('keeps an inline tool badge in prose but splits a code badge into its own step', () => {
     const { compiled, errors } = compileProcedure(
       doc(
         [
@@ -95,9 +104,12 @@ describe('compileProcedure', () => {
       )
     )
     expect(errors).toBeUndefined()
-    // a single instruction — neither tool nor code split the chain.
+    // tool stays inline (one instruction), code splits out into a deterministic code step.
     const instructions = Object.values(compiled.steps).filter((s) => s.kind === 'instruction')
     expect(instructions).toHaveLength(1)
+    const codeSteps = Object.values(compiled.steps).filter((s) => s.kind === 'code')
+    expect(codeSteps).toHaveLength(1)
+    expect((codeSteps[0] as Extract<ProcedureStep, { kind: 'code' }>).codeBlockId).toBe('c1')
   })
 
   it('splits the prose chain on an own-step route badge (terminal)', () => {
@@ -276,9 +288,54 @@ describe('compileProcedure', () => {
     expect(errors?.some((e) => e.code === 'UNCALLED_SUBPROCEDURE')).toBe(true)
   })
 
-  it('errors on an inline code badge with no matching code block', () => {
+  it('errors on a code step with no matching code block', () => {
     const { errors } = compileProcedure(doc([badge('code:ghost')]))
     expect(errors?.some((e) => e.code === 'UNKNOWN_CODE_BLOCK')).toBe(true)
+  })
+
+  it('compiles a code badge to a code step threading next with bindings from the code-block entry', () => {
+    const { compiled, errors } = compileProcedure(
+      doc([badge('code:c1'), prose('after')], {
+        codeBlocks: [
+          code('c1', 'Compute', {
+            inputs: [{ name: 'total', ref: 'var:cartTotal' }],
+            outputs: [{ name: 'tier', surfaceToModel: true }],
+          }),
+        ],
+        localAttributes: [
+          { name: 'cartTotal', dataType: 'NUMBER' },
+          { name: 'tier', dataType: 'TEXT' },
+        ],
+      })
+    )
+    expect(errors).toBeUndefined()
+    const step = compiled.steps[compiled.entryStepId] as Extract<ProcedureStep, { kind: 'code' }>
+    expect(step.kind).toBe('code')
+    expect(step.codeBlockId).toBe('c1')
+    expect(step.inputs).toEqual([{ name: 'total', ref: 'var:cartTotal' }])
+    expect(step.outputs).toEqual([{ name: 'tier', surfaceToModel: true }])
+    // deterministic — threads to the following instruction.
+    expect(compiled.steps[step.next!]!.kind).toBe('instruction')
+  })
+
+  it('errors on a code output that is not a declared local attribute', () => {
+    const { errors } = compileProcedure(
+      doc([badge('code:c1')], {
+        codeBlocks: [
+          code('c1', 'Compute', { outputs: [{ name: 'ghostAttr', surfaceToModel: false }] }),
+        ],
+      })
+    )
+    expect(errors?.some((e) => e.code === 'UNKNOWN_OUTPUT_ATTRIBUTE')).toBe(true)
+  })
+
+  it('errors on a code input with an unresolvable (bare) ref', () => {
+    const { errors } = compileProcedure(
+      doc([badge('code:c1')], {
+        codeBlocks: [code('c1', 'Compute', { inputs: [{ name: 'x', ref: 'bareToken' }] })],
+      })
+    )
+    expect(errors?.some((e) => e.code === 'BAD_INPUT_REF')).toBe(true)
   })
 
   it('errors on a structured arm with no conditions', () => {

--- a/packages/lib/src/agents/procedures/__tests__/context.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/context.test.ts
@@ -175,14 +175,32 @@ describe('buildProcedurePredicateResolver', () => {
     expect(evaluateConditions(subject, groups, resolver)).toBe(false)
   })
 
-  it('prime is incremental + idempotent — each distinct field resolved once across calls', async () => {
+  it('re-reads local var:* LIVE on every prime (no memo) — for compute→branch', async () => {
     const reads: string[] = []
-    const ctxV = makeCtx({ 'var:__la:v1:a': 1, 'var:__la:v1:b': 2 }, reads)
+    const store: Record<string, unknown> = { 'var:__la:v1:a': 1, 'var:__la:v1:b': 2 }
+    const ctxV = makeCtx(store, reads)
     const { prime, resolver } = buildProcedurePredicateResolver(ctxV, frame)
     await prime([group([cond('var:a', 'is', 1)])])
-    await prime([group([cond('var:a', 'is', 1), cond('var:b', 'is', 2)])]) // a repeated, b new
-    expect(reads).toEqual(['var:__la:v1:a', 'var:__la:v1:b']) // a read once, b once
-    expect(resolver(subject, 'a')).toBe(1)
+    // A code step mutates the var between primes — the next prime MUST see the new value.
+    store['var:__la:v1:a'] = 99
+    await prime([group([cond('var:a', 'is', 99), cond('var:b', 'is', 2)])])
+    // `a` is re-read each prime (live), `b` once — locals are never memoized.
+    expect(reads).toEqual(['var:__la:v1:a', 'var:__la:v1:a', 'var:__la:v1:b'])
+    expect(resolver(subject, 'a')).toBe(99) // fresh value, not the stale 1
     expect(resolver(subject, 'b')).toBe(2)
+  })
+
+  it('memoizes CRM fields — a repeated FieldReference resolves once across primes', async () => {
+    resolveMap['contact:status'] = 'OPEN'
+    const resolveSpy = vi.fn(
+      async (source: { ref: string | string[] }) => resolveMap[String(source.ref)]
+    )
+    const mod = await import('../../bindings/resolve')
+    vi.mocked(mod.buildResolveVarSource).mockReturnValue(resolveSpy as never)
+    const { prime, resolver } = buildProcedurePredicateResolver(makeCtx({}), frame)
+    await prime([group([cond('contact:status', 'is', 'OPEN')])])
+    await prime([group([cond('contact:status', 'is', 'OPEN')])]) // repeated — must NOT re-resolve
+    expect(resolveSpy).toHaveBeenCalledTimes(1)
+    expect(resolver(subject, 'status')).toBe('OPEN')
   })
 })

--- a/packages/lib/src/agents/procedures/__tests__/stepper.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/stepper.test.ts
@@ -137,9 +137,32 @@ function makeDeps(
     pickTextBranch: async () => null,
     checkGoalMet: async () => true,
     classifyBackstop: async () => ({ onProcedure: true, multiTurn: false }),
+    runCode: async () => ({ ok: true, result: {} }),
     ...overrides,
   }
 }
+
+/** A `code` step fixture — runs `codeBlockId`, binds `inputs`, writes `outputs`, threads `next`. */
+const codeStep = (
+  id: string,
+  codeBlockId: string,
+  next: string | null,
+  inputs: { name: string; ref: string }[] = [],
+  outputs: { name: string; surfaceToModel: boolean }[] = []
+): ProcedureStep => ({ id, kind: 'code', codeBlockId, inputs, outputs, next })
+
+/** Build a compiled procedure that carries code blocks (the default `build` has none). */
+const buildWithCode = (
+  entryStepId: string,
+  steps: ProcedureStep[],
+  codeBlocks: CompiledProcedure['codeBlocks']
+): CompiledProcedure => ({
+  entryStepId,
+  steps: Object.fromEntries(steps.map((s) => [s.id, s])),
+  codeBlocks,
+  subProcedures: {},
+  localAttributes: [],
+})
 
 const asInject = (r: PrepareResult): Extract<PrepareResult, { kind: 'inject' }> => {
   if (r.kind !== 'inject') throw new Error(`expected inject, got ${r.kind}`)
@@ -434,6 +457,131 @@ describe('prepareTurn — depth cap & pin integrity', () => {
     const r = await prepareTurn(stackOf(frame('gone', 'x')), makeDeps({}))
     expect(r.kind).toBe('free-form')
     expect(r.stack.frames).toHaveLength(0)
+  })
+})
+
+describe('prepareTurn — code steps (deterministic execution)', () => {
+  it('runs the block ONCE, writes its outputs to scoped vars, and lands on the next instruction', async () => {
+    const compiled = buildWithCode(
+      'code',
+      [
+        codeStep('code', 'c1', 'after', [], [{ name: 'tier', surfaceToModel: true }]),
+        instruction('after', null),
+      ],
+      { c1: { language: 'javascript', code: 'noop' } }
+    )
+    const runCode = vi.fn(async () => ({ ok: true as const, result: { tier: 'gold' } }))
+    const r = asInject(
+      await prepareTurn(stackOf(frame('v1', 'code')), makeDeps({ v1: compiled }, { runCode }))
+    )
+    expect(runCode).toHaveBeenCalledTimes(1)
+    expect(r.activeStep.id).toBe('after')
+    expect(varStore['var:__la:v1:tier']).toBe('gold')
+    // surfaceToModel output is carried on the inject result (D4).
+    expect(r.codeOutputs).toEqual([{ name: 'tier', value: 'gold' }])
+  })
+
+  it('compute→branch: a code output feeds a downstream structured condition LIVE', async () => {
+    const compiled = buildWithCode(
+      'code',
+      [
+        codeStep('code', 'c1', 'cond', [], [{ name: 'tier', surfaceToModel: false }]),
+        structured(
+          'cond',
+          [{ thenStep: 'goldArm', varName: 'tier', value: 'gold' }],
+          'elseArm',
+          null
+        ),
+        instruction('goldArm', null),
+        instruction('elseArm', null),
+      ],
+      { c1: { language: 'javascript', code: 'noop' } }
+    )
+    const runCode = vi.fn(async () => ({ ok: true as const, result: { tier: 'gold' } }))
+    const r = asInject(
+      await prepareTurn(stackOf(frame('v1', 'code')), makeDeps({ v1: compiled }, { runCode }))
+    )
+    expect(r.activeStep.id).toBe('goldArm') // the freshly-computed var routed the branch
+  })
+
+  it('feeds resolved inputs to the block; an absent local var gates to undefined', async () => {
+    varStore['var:__la:v1:known'] = 42
+    const compiled = buildWithCode(
+      'code',
+      [
+        codeStep('code', 'c1', 'after', [
+          { name: 'a', ref: 'var:known' },
+          { name: 'b', ref: 'var:missing' },
+        ]),
+        instruction('after', null),
+      ],
+      { c1: { language: 'javascript', code: 'noop' } }
+    )
+    const runCode = vi.fn(async () => ({ ok: true as const, result: {} }))
+    await prepareTurn(stackOf(frame('v1', 'code')), makeDeps({ v1: compiled }, { runCode }))
+    expect(runCode).toHaveBeenCalledWith({ code: 'noop' }, { a: 42, b: undefined })
+  })
+
+  it('failure (D5/D6): clears the output var, takes the else-arm, carries an error note', async () => {
+    // Seed a stale prior-success value — a loop re-run that fails must NOT branch on it.
+    varStore['var:__la:v1:tier'] = 'gold'
+    const compiled = buildWithCode(
+      'code',
+      [
+        codeStep('code', 'c1', 'cond', [], [{ name: 'tier', surfaceToModel: false }]),
+        structured(
+          'cond',
+          [{ thenStep: 'goldArm', varName: 'tier', value: 'gold' }],
+          'elseArm',
+          null
+        ),
+        instruction('goldArm', null),
+        instruction('elseArm', null),
+      ],
+      { c1: { language: 'javascript', code: 'noop' } }
+    )
+    const runCode = vi.fn(async () => ({ ok: false as const, error: 'boom' }))
+    const r = asInject(
+      await prepareTurn(stackOf(frame('v1', 'code')), makeDeps({ v1: compiled }, { runCode }))
+    )
+    expect(varStore['var:__la:v1:tier']).toBeUndefined() // cleared, not left stale
+    expect(r.activeStep.id).toBe('elseArm') // gate-by-absence → else
+    expect(r.codeErrors).toEqual([{ codeBlockId: 'c1', error: 'boom' }])
+  })
+
+  it('does NOT re-fire on resume — the cursor rests on the instruction after the code step', async () => {
+    const compiled = buildWithCode(
+      'code',
+      [
+        codeStep('code', 'c1', 'after', [], [{ name: 'tier', surfaceToModel: false }]),
+        instruction('after', null),
+      ],
+      { c1: { language: 'javascript', code: 'noop' } }
+    )
+    const runCode = vi.fn(async () => ({ ok: true as const, result: { tier: 'gold' } }))
+    const deps = makeDeps({ v1: compiled }, { runCode })
+    const first = asInject(await prepareTurn(stackOf(frame('v1', 'code')), deps))
+    // Resume from the landed cursor (what the caller persists) — the code is behind it.
+    const second = asInject(await prepareTurn(first.stack, deps))
+    expect(second.activeStep.id).toBe('after')
+    expect(runCode).toHaveBeenCalledTimes(1) // not re-run on resume
+  })
+
+  it('a false surfaceToModel output is written but not surfaced to the model', async () => {
+    const compiled = buildWithCode(
+      'code',
+      [
+        codeStep('code', 'c1', 'after', [], [{ name: 'tier', surfaceToModel: false }]),
+        instruction('after', null),
+      ],
+      { c1: { language: 'javascript', code: 'noop' } }
+    )
+    const runCode = vi.fn(async () => ({ ok: true as const, result: { tier: 'gold' } }))
+    const r = asInject(
+      await prepareTurn(stackOf(frame('v1', 'code')), makeDeps({ v1: compiled }, { runCode }))
+    )
+    expect(varStore['var:__la:v1:tier']).toBe('gold') // still written (branch-readable)
+    expect(r.codeOutputs).toBeUndefined() // but not surfaced
   })
 })
 

--- a/packages/lib/src/agents/procedures/__tests__/turn-wiring.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/turn-wiring.test.ts
@@ -10,7 +10,7 @@ import type { CompiledProcedure, ProcedureFrame } from '../types'
 const compiled: CompiledProcedure = {
   entryStepId: 's1',
   steps: { s1: { id: 's1', kind: 'instruction', doc: { t: 'hi' }, next: null } },
-  codeBlocks: { c1: { language: 'javascript', code: '', inputs: [], outputs: [] } },
+  codeBlocks: { c1: { language: 'javascript', code: '' } },
   subProcedures: { sub1: { id: 'sub1', name: 'Refund flow', entryStepId: 's1' } },
   localAttributes: [],
 }

--- a/packages/lib/src/agents/procedures/client.ts
+++ b/packages/lib/src/agents/procedures/client.ts
@@ -26,6 +26,8 @@ export {
 } from './nodes'
 export type {
   ArgBindingMap,
+  CodeInput,
+  CodeOutput,
   CompiledProcedure,
   LocalAttribute,
   ProcedureFrame,

--- a/packages/lib/src/agents/procedures/compile.ts
+++ b/packages/lib/src/agents/procedures/compile.ts
@@ -3,11 +3,12 @@
 import { createHash } from 'node:crypto'
 import { generateId } from '@auxx/utils'
 import type { ConditionGroup } from '../../conditions/types'
-import { collectReferenceIds, docToText } from '../../tiptap'
+import { docToText } from '../../tiptap'
 import {
   isOwnStepBadge,
   type ParsedStepBadge,
   PROCEDURE_NODE_TYPES,
+  parseCodeBindings,
   parseStepBadgeId,
   type TiptapDoc,
   type TiptapNode,
@@ -43,6 +44,8 @@ export interface CompileError {
     | 'UNKNOWN_SUBPROCEDURE'
     | 'UNCALLED_SUBPROCEDURE'
     | 'UNKNOWN_CODE_BLOCK'
+    | 'UNKNOWN_OUTPUT_ATTRIBUTE'
+    | 'BAD_INPUT_REF'
     | 'EMPTY_CONDITION_GROUP'
     | 'EMPTY_PREDICATE'
     | 'DANGLING_REF'
@@ -126,8 +129,29 @@ export function compileProcedure(doc: TiptapDoc): CompileResult {
     return out
   }
 
-  /** Compile one `subprocedure:`/`route:` own-step badge, linking to `continuation`. */
+  // Per-block input/output bindings, lifted from the doc-level `codeBlocks` map onto each
+  // emitted `code` step (the compiled block holds source only; bindings live on the step).
+  const codeBindingsById = new Map(
+    (doc.codeBlocks ?? []).filter((cb) => cb?.id).map((cb) => [cb.id, parseCodeBindings(cb)])
+  )
+
+  /** Compile one `subprocedure:`/`route:`/`code:` own-step badge, linking to `continuation`. */
   const compileBadge = (badge: ParsedStepBadge, continuation: StepId | null): StepId => {
+    if (badge.kind === 'code') {
+      // A deterministic code step — its bindings come from the doc-level code-block entry.
+      const { inputs, outputs } = codeBindingsById.get(badge.codeBlockId) ?? {
+        inputs: [],
+        outputs: [],
+      }
+      return emit({
+        id: generateId(),
+        kind: 'code',
+        codeBlockId: badge.codeBlockId,
+        inputs,
+        outputs,
+        next: continuation,
+      })
+    }
     if (badge.kind === 'subprocedure') {
       // a call returns to `continuation` after the sub-procedure finishes.
       return emit({
@@ -151,7 +175,7 @@ export function compileProcedure(doc: TiptapDoc): CompileResult {
       }
       return emit({ id: generateId(), kind: 'routing', outcome: badge.outcome, next: null })
     }
-    // `code:` badges are inline ops, never own-steps — unreachable, but keep the chain intact.
+    // All badge kinds are handled above — keep the chain intact for an unknown future kind.
     return emitTrivial(continuation)
   }
 
@@ -244,12 +268,7 @@ export function compileProcedure(doc: TiptapDoc): CompileResult {
   // ── code blocks (doc-level map → compiled.codeBlocks, referenced by `code:` badges) ──
   for (const cb of doc.codeBlocks ?? []) {
     if (!cb?.id) continue
-    codeBlocks[cb.id] = {
-      language: cb.language ?? 'javascript',
-      code: cb.code ?? '',
-      inputs: [],
-      outputs: [],
-    }
+    codeBlocks[cb.id] = { language: cb.language ?? 'javascript', code: cb.code ?? '' }
   }
 
   // ── sub-procedures (doc-level map → shared `steps`, reached only via a `call`) ──
@@ -272,6 +291,16 @@ export function compileProcedure(doc: TiptapDoc): CompileResult {
   return { compiled, contentHash, ...(errors.length > 0 ? { errors } : {}) }
 }
 
+/**
+ * A code-input `ref` resolves iff it's a local `var:<name>` or a CRM `FieldReference`
+ * rootable at a subject anchor (carries a `:` segment) — the exact shapes
+ * `readProcedureRef` branches on. A bare token has no source and gates by absence at
+ * run time, so we reject it at publish.
+ */
+function isResolvableRef(ref: string): boolean {
+  return ref.startsWith('var:') || ref.includes(':')
+}
+
 /** Render a `conditionCase`'s `conditionPredicate` child to a plain NL test string. */
 function predicateText(caseNode: TiptapNode): string {
   const pred = (caseNode.content ?? []).find(
@@ -283,11 +312,12 @@ function predicateText(caseNode: TiptapNode): string {
 // ── validation ────────────────────────────────────────────────────────────
 
 function validate(compiled: CompiledProcedure): CompileError[] {
-  const { steps, codeBlocks, subProcedures } = compiled
+  const { steps, codeBlocks, subProcedures, localAttributes } = compiled
   const errors: CompileError[] = []
 
   const subProcIds = new Set(Object.keys(subProcedures))
   const calledSubProcs = new Set<SubProcedureId>()
+  const attrNames = new Set(localAttributes.map((a) => a.name))
 
   const exists = (ref: StepId | null): boolean => ref === null || ref in steps
 
@@ -357,14 +387,30 @@ function validate(compiled: CompiledProcedure): CompileError[] {
       }
     }
 
-    // inline `code:<id>` badges in an instruction's `doc` must resolve to a code block.
-    if (step.kind === 'instruction') {
-      for (const id of collectReferenceIds(step.doc)) {
-        const badge = parseStepBadgeId(id)
-        if (badge?.kind === 'code' && !(badge.codeBlockId in codeBlocks)) {
+    // a `code` step must reference a known block, write only declared attributes, and
+    // bind inputs to a resolvable ref (local `var:<name>` or a rootable CRM FieldReference).
+    if (step.kind === 'code') {
+      if (!(step.codeBlockId in codeBlocks)) {
+        errors.push({
+          code: 'UNKNOWN_CODE_BLOCK',
+          message: `Code step references unknown code block "${step.codeBlockId}".`,
+          stepId: step.id,
+        })
+      }
+      for (const output of step.outputs) {
+        if (!attrNames.has(output.name)) {
           errors.push({
-            code: 'UNKNOWN_CODE_BLOCK',
-            message: `Instruction references unknown code block "${badge.codeBlockId}".`,
+            code: 'UNKNOWN_OUTPUT_ATTRIBUTE',
+            message: `Code output "${output.name}" is not a declared local attribute.`,
+            stepId: step.id,
+          })
+        }
+      }
+      for (const input of step.inputs) {
+        if (!isResolvableRef(input.ref)) {
+          errors.push({
+            code: 'BAD_INPUT_REF',
+            message: `Code input "${input.name}" has an unresolvable ref "${input.ref}".`,
             stepId: step.id,
           })
         }

--- a/packages/lib/src/agents/procedures/context.ts
+++ b/packages/lib/src/agents/procedures/context.ts
@@ -133,6 +133,57 @@ export function scopedVar(frame: ProcedureFrame, name: string): string {
 }
 
 /**
+ * Resolve ONE procedure ref off the running frame + the turn's subject — the single
+ * resolution path BOTH in-procedure conditions and `code`-step inputs go through, so
+ * the two never diverge:
+ *
+ *  - `var:<name>` — a declared local attribute, read LIVE from the version-scoped store
+ *    key ({@link scopedVar}). Live (no caching) because a `code` step writes one and a
+ *    downstream condition reads it within the SAME frame walk (compute→branch).
+ *  - any other ref — a CRM `FieldReference` resolved off `ctx.subject.anchors` by the v8
+ *    resolver, exactly like selection.
+ *
+ * Gate-by-absence: an unknown/absent ref (a local var not yet written, a CRM field on an
+ * internal run, a bare un-rootable id, or a missing subject) resolves to `undefined` and
+ * never throws.
+ */
+export async function readProcedureRef(
+  ctx: ToolContext,
+  frame: ProcedureFrame,
+  ref: string | string[]
+): Promise<unknown> {
+  if (typeof ref === 'string' && ref.startsWith(LOCAL_ATTR_PREFIX)) {
+    try {
+      return await ctx.context.read(scopedVar(frame, ref.slice(LOCAL_ATTR_PREFIX.length)))
+    } catch {
+      return undefined
+    }
+  }
+  const varRef = toVarRef(ref)
+  if (!varRef || !ctx.subject) return undefined
+  try {
+    return await buildResolveVarSource(ctx)({ kind: 'var', ref: varRef }, ctx.subject)
+  } catch {
+    // Best-effort — a resolver misconfig gates by absence rather than throwing the turn.
+    return undefined
+  }
+}
+
+/**
+ * The symmetric writer — the FIRST thing in v9 to write a scoped local `var:*`. A
+ * `code` step writes its outputs through this; it is also the seam a later
+ * tool-result→`var:*` binding writes through. Pairs with {@link readProcedureRef}.
+ */
+export function writeProcedureVar(
+  ctx: ToolContext,
+  frame: ProcedureFrame,
+  name: string,
+  value: unknown
+): Promise<void> {
+  return ctx.context.write(scopedVar(frame, name), value)
+}
+
+/**
  * Build the synchronous {@link FieldResolver} an in-procedure `condition` step
  * evaluates against. Unlike selection's resolver ({@link buildProcedureFieldResolver}),
  * this one ALSO reads procedure-local `var:*` scratch — the procedure is running,
@@ -160,39 +211,22 @@ export function buildProcedurePredicateResolver(
   ctx: ToolContext,
   frame: ProcedureFrame
 ): { resolver: FieldResolver<unknown>; prime: (groups: ConditionGroup[]) => Promise<void> } {
-  const resolveVar = buildResolveVarSource(ctx)
-  const subject = ctx.subject
   const values = new Map<string, unknown>()
   const seen = new Set<string>()
-
-  const resolveOne = async (fieldId: string | string[]): Promise<unknown> => {
-    // Declared local attribute (`var:<name>`) — read the version-scoped store key.
-    if (typeof fieldId === 'string' && fieldId.startsWith(LOCAL_ATTR_PREFIX)) {
-      try {
-        return await ctx.context.read(scopedVar(frame, fieldId.slice(LOCAL_ATTR_PREFIX.length)))
-      } catch {
-        return undefined
-      }
-    }
-    // CRM FieldReference — resolve off subject anchors (v8), gate-by-absence. A bare
-    // legacy id (no entity root) or a missing subject yields `undefined`.
-    const ref = toVarRef(fieldId)
-    if (!ref || !subject) return undefined
-    try {
-      return await resolveVar({ kind: 'var', ref }, subject)
-    } catch {
-      // In-procedure predicates are best-effort — a misconfig gates by absence
-      // rather than throwing the turn.
-      return undefined
-    }
-  }
 
   const prime = async (groups: ConditionGroup[]): Promise<void> => {
     for (const fieldId of collectFieldRefs(groups)) {
       const key = simpleKey(fieldId)
-      if (seen.has(key)) continue
-      seen.add(key)
-      values.set(key, await resolveOne(fieldId))
+      // CRM fields memo on `seen` (the expensive `batchGetValues`). Local `var:*` are
+      // DELIBERATELY NOT memoed: a `code` step mutates one mid-walk and a downstream
+      // condition must re-read the fresh value — caching it would serve the pre-write
+      // stale value. The store read is cheap, so re-resolving every prime costs nothing.
+      const isLocal = typeof fieldId === 'string' && fieldId.startsWith(LOCAL_ATTR_PREFIX)
+      if (!isLocal) {
+        if (seen.has(key)) continue
+        seen.add(key)
+      }
+      values.set(key, await readProcedureRef(ctx, frame, fieldId))
     }
   }
 

--- a/packages/lib/src/agents/procedures/index.ts
+++ b/packages/lib/src/agents/procedures/index.ts
@@ -17,7 +17,9 @@ export { compileProcedure } from './compile'
 export {
   buildProcedureFieldResolver,
   buildProcedurePredicateResolver,
+  readProcedureRef,
   scopedVar,
+  writeProcedureVar,
 } from './context'
 export {
   advanceProcedure,
@@ -39,6 +41,7 @@ export {
   type ParsedStepBadge,
   PROCEDURE_NODE_TYPES,
   type ProcedureNodeType,
+  parseCodeBindings,
   parseStepBadgeId,
   STEP_BADGE_PREFIXES,
   type SubProcedureMapEntry,
@@ -96,6 +99,8 @@ export {
   top,
 } from './stack'
 export {
+  type CodeErrorNote,
+  type CodeOutputValue,
   type InterpretResult,
   interpretSignal,
   type PrepareResult,
@@ -113,6 +118,8 @@ export {
 } from './turn-wiring'
 export type {
   ArgBindingMap,
+  CodeInput,
+  CodeOutput,
   CompiledProcedure,
   LocalAttribute,
   ProcedureFrame,

--- a/packages/lib/src/agents/procedures/nodes.ts
+++ b/packages/lib/src/agents/procedures/nodes.ts
@@ -3,7 +3,7 @@
 import type { FieldType } from '@auxx/database/types'
 import type { ConditionGroup } from '../../conditions/types'
 import type { FieldOptions } from '../../custom-fields/field-options'
-import type { LocalAttribute, SubProcedureId } from './types'
+import type { CodeInput, CodeOutput, LocalAttribute, SubProcedureId } from './types'
 
 /**
  * The TipTap node JSON contract the v2 compiler consumes. The v2 editor
@@ -37,12 +37,19 @@ export interface SubProcedureMapEntry {
   content: TiptapNode[]
 }
 
-/** A doc-level code block — a named JavaScript snippet referenced by inline `code:<id>` badges. */
+/**
+ * A doc-level code block — a named JavaScript snippet referenced by inline `code:<id>`
+ * badges. Beyond the source, it carries the per-block input/output bindings the §5 UI
+ * authors: which refs feed `main(codeInput)` and which result keys land in `var:*`. The
+ * compiler lifts these onto the emitted `code` step ({@link parseCodeBindings}).
+ */
 export interface CodeBlockMapEntry {
   id: string
   name: string
   language: 'javascript'
   code: string
+  inputs?: CodeInput[]
+  outputs?: CodeOutput[]
 }
 
 /**
@@ -118,9 +125,41 @@ export function parseStepBadgeId(id: string): ParsedStepBadge | null {
   return null
 }
 
-/** Whether an inline badge is an **own-step** badge (splits the prose chain) vs. an inline op. */
+/**
+ * Whether an inline badge is an **own-step** badge (splits the prose chain) vs. an inline op.
+ * `code:` is an own step (D2) — it compiles to a deterministic `code` step the stepper walks
+ * through, NOT an inline hint left in an instruction's prose.
+ */
 export function isOwnStepBadge(id: string): boolean {
-  return id.startsWith(STEP_BADGE_PREFIXES.subProcedure) || id.startsWith(STEP_BADGE_PREFIXES.route)
+  return (
+    id.startsWith(STEP_BADGE_PREFIXES.subProcedure) ||
+    id.startsWith(STEP_BADGE_PREFIXES.route) ||
+    id.startsWith(STEP_BADGE_PREFIXES.code)
+  )
+}
+
+/**
+ * Parse the input/output bindings carried on a doc-level `codeBlocks` map entry (authored
+ * by the §5 binding UI). Tolerant: a malformed or absent entry is dropped, so a
+ * half-authored block compiles to a code step with the bindings it does have (the compiler
+ * then `validate`s the survivors). PURE.
+ */
+export function parseCodeBindings(entry: { inputs?: unknown; outputs?: unknown } | undefined): {
+  inputs: CodeInput[]
+  outputs: CodeOutput[]
+} {
+  const inputs: CodeInput[] = []
+  for (const raw of Array.isArray(entry?.inputs) ? entry.inputs : []) {
+    const name = typeof (raw as CodeInput)?.name === 'string' ? (raw as CodeInput).name : ''
+    const ref = typeof (raw as CodeInput)?.ref === 'string' ? (raw as CodeInput).ref : ''
+    if (name && ref) inputs.push({ name, ref })
+  }
+  const outputs: CodeOutput[] = []
+  for (const raw of Array.isArray(entry?.outputs) ? entry.outputs : []) {
+    const name = typeof (raw as CodeOutput)?.name === 'string' ? (raw as CodeOutput).name : ''
+    if (name) outputs.push({ name, surfaceToModel: (raw as CodeOutput)?.surfaceToModel === true })
+  }
+  return { inputs, outputs }
 }
 
 // ── per-node attr shapes (documentation of the contract) ─────────────────

--- a/packages/lib/src/agents/procedures/stepper.ts
+++ b/packages/lib/src/agents/procedures/stepper.ts
@@ -2,7 +2,7 @@
 
 import type { ToolContext } from '../../ai/agent-framework/tool-context'
 import { evaluateConditions } from '../../conditions/evaluate'
-import { buildProcedurePredicateResolver } from './context'
+import { buildProcedurePredicateResolver, readProcedureRef, writeProcedureVar } from './context'
 import { PROC_SIGNAL_KEY, type ProcedureSignal } from './control-tools'
 import { buildReanchorBreadcrumb } from './re-anchor'
 import { atDepthCap, clear, pop, push, replaceTop, top } from './stack'
@@ -26,12 +26,17 @@ type BackstopVerdict = { onProcedure: boolean; multiTurn: boolean }
  * op) until it reaches an `instruction` step to inject, or the stack empties
  * (free-form). `interpretSignal` (the post-turn half) lands in a later step.
  *
- * **Invariant: `prepareTurn` is pure navigation — it executes NO tools or code.**
- * An `instruction` step's inline `tool:`/`code:` references are hints the MODEL
- * acts on inside the engine loop; the stepper only injects the step prose. This
- * is load-bearing: `prepareTurn` re-runs from `frame.cursor` on every resume, so
- * any side effect here would re-fire each turn. The only state it mutates is the
- * cursor + the stack (pop/push/replace/clear from routing terminals).
+ * **Invariant: `prepareTurn` is pure navigation EXCEPT for `code` steps.** An
+ * `instruction` step's inline `tool:` references are hints the MODEL acts on inside the
+ * engine loop. A `code` step is the ONE deterministic side effect the stepper performs
+ * (D1): it runs the block (a real Lambda call) and writes its outputs to `var:*`. This
+ * is safe against the resume re-fire hazard because the stepper walks *through* a code
+ * step (advances to `next`, never rests on it), so the cursor always rests on the next
+ * `instruction`; on resume `prepareTurn` re-enters there, behind the code, and it does
+ * NOT re-fire (plan §"Why deterministic"). A genuine graph loop back through the block
+ * re-runs it (desired); a crash after the run but before cursor-persist gives
+ * at-least-once on retry (same as the workflow code node). Aside from code outputs, the
+ * only state it mutates is the cursor + the stack (pop/push/replace/clear from routing).
  *
  * The module is what Phase 4 calls; it does not touch the turn processor.
  * See plans/chat/v9/phase-3-stepper-and-stack.md §2.
@@ -84,7 +89,22 @@ export interface StepperDeps {
    * reply stay on the active step? Backed by `classifier.ts` `backstopClassify`.
    */
   classifyBackstop: (reply: string, activeStep: InstructionStep) => Promise<BackstopVerdict>
+  /**
+   * Run a `code` step's block in the sandbox and return its result (D1). Injected so
+   * the stepper stays free of `@auxx/services` — Phase 4 binds the `invokeLambdaExecutor`
+   * adapter (`turn-wiring.ts`). A throw / timeout / runtime error resolves to
+   * `{ ok: false, error }` (never rejects), so the stepper applies D5/D6 gate-by-absence.
+   */
+  runCode: (
+    block: { code: string },
+    codeInput: Record<string, unknown>
+  ) => Promise<{ ok: true; result: Record<string, unknown> } | { ok: false; error: string }>
 }
+
+/** A surfaced (`surfaceToModel`) code output the walk produced on its way to the landed step (D4). */
+export type CodeOutputValue = { name: string; value: unknown }
+/** A failed code step's note, surfaced to the model so it can cope honestly (D5). */
+export type CodeErrorNote = { codeBlockId: string; error: string }
 
 export type PrepareResult =
   | {
@@ -93,6 +113,10 @@ export type PrepareResult =
       activeStep: Extract<ProcedureStep, { kind: 'instruction' }>
       /** Re-anchor line when this turn resumed a parent after a `digression` pop (§5). */
       breadcrumb?: string
+      /** `surfaceToModel` outputs computed by `code` steps walked this turn (D4). */
+      codeOutputs?: CodeOutputValue[]
+      /** Failure notes from `code` steps that threw/timed out this turn (D5). */
+      codeErrors?: CodeErrorNote[]
     }
   /** Stack emptied / handoff cleared → persona-only, no procedure section this turn (#9). */
   | { kind: 'free-form'; stack: ProcedureStack; handoff?: boolean }
@@ -131,6 +155,9 @@ export async function prepareTurn(
   // The most recent `digression` frame popped THIS turn — its parent gets a
   // re-anchor breadcrumb on the instruction we eventually inject (§5).
   let poppedDigression: ProcedureFrame | null = null
+  // Accumulates code effects across EVERY frame walked this turn (a code step may sit in
+  // a sub-procedure frame, its branch land in the parent) — surfaced on the inject result.
+  const codeAcc: CodeAccumulator = { outputs: [], errors: [] }
 
   for (let i = 0; i < MAX_FRAME_TRANSITIONS; i++) {
     const frame = top(working)
@@ -143,14 +170,21 @@ export async function prepareTurn(
       continue
     }
 
-    const action = await advanceFrame(frame, version.compiled, deps)
+    const action = await advanceFrame(frame, version.compiled, deps, codeAcc)
 
     switch (action.type) {
       case 'instruction': {
         const breadcrumb = poppedDigression
           ? buildReanchorBreadcrumb(action.step, poppedDigression) || undefined
           : undefined
-        return { kind: 'inject', stack: working, activeStep: action.step, breadcrumb }
+        return {
+          kind: 'inject',
+          stack: working,
+          activeStep: action.step,
+          breadcrumb,
+          ...(codeAcc.outputs.length > 0 ? { codeOutputs: codeAcc.outputs } : {}),
+          ...(codeAcc.errors.length > 0 ? { codeErrors: codeAcc.errors } : {}),
+        }
       }
 
       case 'pop': {
@@ -214,16 +248,21 @@ type FrameAction =
   | { type: 'switch'; toProcedureId: string }
   | { type: 'call'; subProcedureId: string }
 
+/** Code effects collected as the stepper walks through `code` steps this turn. */
+type CodeAccumulator = { outputs: CodeOutputValue[]; errors: CodeErrorNote[] }
+
 /**
  * Walk one frame's cursor through deterministic steps until an `instruction` (stop)
  * or a terminal. Mutates `frame.cursor` in place (the stack is rehydrated per turn
  * and re-serialized after). For a `call`, parks `frame.cursor` at the routing step's
- * `next` so the parent resumes there when the child pops.
+ * `next` so the parent resumes there when the child pops. A `code` step is RUN here
+ * (the one side effect) and its results pushed into `codeAcc`.
  */
 async function advanceFrame(
   frame: ProcedureFrame,
   compiled: CompiledProcedure,
-  deps: StepperDeps
+  deps: StepperDeps,
+  codeAcc: CodeAccumulator
 ): Promise<FrameAction> {
   const predicate = buildProcedurePredicateResolver(deps.ctx, frame)
   const entity = deps.ctx.subject ?? {}
@@ -237,6 +276,12 @@ async function advanceFrame(
     if (step.kind === 'instruction') {
       frame.cursor = cursor
       return { type: 'instruction', step }
+    }
+
+    if (step.kind === 'code') {
+      await runCodeStep(step, compiled, frame, deps, codeAcc)
+      cursor = step.next // deterministic — always advance, never rest on the code step
+      continue
     }
 
     if (step.kind === 'routing') {
@@ -285,6 +330,58 @@ async function pickConditionBranch(
   const idx = await deps.pickTextBranch(step.cases.map((c) => c.predicate ?? ''))
   if (idx !== null && idx >= 0 && idx < step.cases.length) return step.cases[idx]!.thenStep
   return step.elseStep ?? step.next
+}
+
+/**
+ * Run a `code` step: resolve its inputs through the shared {@link readProcedureRef}
+ * (so a local `var:*` written by an earlier code step is visible, and a CRM field on an
+ * internal run gates to `undefined`), invoke the sandbox, then apply D5/D6:
+ *
+ *  - **ok** → write each declared output to its scoped `var:*`; collect the
+ *    `surfaceToModel` ones (skipping `undefined`, so we never claim a value was computed
+ *    that wasn't).
+ *  - **err** → CLEAR each declared output (`var:* = undefined`) and collect an error
+ *    note. Clearing is load-bearing: `var:*` persists across turns, so on a loop re-run
+ *    a stale prior-success value would otherwise survive and a downstream condition would
+ *    branch on it instead of taking its else-arm. Clearing makes gate-by-absence (D6)
+ *    actually hold on re-run, not just on first execution.
+ */
+async function runCodeStep(
+  step: Extract<ProcedureStep, { kind: 'code' }>,
+  compiled: CompiledProcedure,
+  frame: ProcedureFrame,
+  deps: StepperDeps,
+  codeAcc: CodeAccumulator
+): Promise<void> {
+  const block = compiled.codeBlocks[step.codeBlockId]
+  const clearOutputs = async (error: string) => {
+    for (const output of step.outputs)
+      await writeProcedureVar(deps.ctx, frame, output.name, undefined)
+    codeAcc.errors.push({ codeBlockId: step.codeBlockId, error })
+  }
+
+  if (!block) {
+    await clearOutputs(`code block "${step.codeBlockId}" not found`)
+    return
+  }
+
+  const codeInput: Record<string, unknown> = {}
+  for (const input of step.inputs) {
+    codeInput[input.name] = await readProcedureRef(deps.ctx, frame, input.ref)
+  }
+
+  const outcome = await deps.runCode({ code: block.code }, codeInput)
+  if (!outcome.ok) {
+    await clearOutputs(outcome.error)
+    return
+  }
+
+  for (const output of step.outputs) {
+    const value = outcome.result[output.name]
+    await writeProcedureVar(deps.ctx, frame, output.name, value)
+    if (output.surfaceToModel && value !== undefined)
+      codeAcc.outputs.push({ name: output.name, value })
+  }
 }
 
 /** A fresh running frame at `cursor`, pushed by `pushedBy`. */

--- a/packages/lib/src/agents/procedures/turn-wiring.ts
+++ b/packages/lib/src/agents/procedures/turn-wiring.ts
@@ -100,6 +100,8 @@ export function buildActiveStepInput(args: {
   compiled: CompiledProcedure
   stack: ProcedureStack
   breadcrumb?: string
+  codeOutputs?: { name: string; value: unknown }[]
+  codeErrors?: { codeBlockId: string; error: string }[]
 }): ProcedureStepInput {
   return {
     activeStep: { doc: args.activeStep.doc },
@@ -112,6 +114,8 @@ export function buildActiveStepInput(args: {
     },
     depth: depth(args.stack),
     breadcrumb: args.breadcrumb,
+    codeOutputs: args.codeOutputs,
+    codeErrors: args.codeErrors,
   }
 }
 
@@ -203,6 +207,43 @@ export function buildStepperDeps(args: BuildStepperDepsArgs): StepperDeps {
     pickTextBranch: (predicates) => classifyTextBranch(conversation, predicates, classifyDeps),
     checkGoalMet: (reply, activeStep) => goalMetCheck(reply, activeStep, classifyDeps),
     classifyBackstop: (reply, activeStep) => backstopClassify(reply, activeStep, classifyDeps),
+    runCode,
+  }
+}
+
+/**
+ * The {@link StepperDeps.runCode} adapter over `invokeLambdaExecutor` — the same JS
+ * sandbox the workflow code node uses (`workflow-engine/nodes/action-nodes/code.ts`).
+ * Dynamically imported to keep `@auxx/services` off the import graph until a code step
+ * actually runs. Unwraps the neverthrow `Result` + the structured runtime/validation
+ * errors into the stepper's `{ ok, error }` contract; NEVER throws (a thrown adapter
+ * would surface as an unhandled turn failure instead of D5 gate-by-absence).
+ */
+const runCode: StepperDeps['runCode'] = async (block, codeInput) => {
+  try {
+    const { invokeLambdaExecutor } = await import('@auxx/services/lambda-execution')
+    const result = await invokeLambdaExecutor({
+      caller: 'procedure-stepper',
+      payload: {
+        type: 'code',
+        code: block.code,
+        codeLanguage: 'javascript',
+        codeInput,
+        inputsConfig: [],
+        variables: {},
+        timeout: 30000,
+      },
+    })
+    if (result.isErr()) return { ok: false, error: result.error.message }
+    const meta = result.value.metadata
+    if (meta?.runtime_error) return { ok: false, error: meta.runtime_error.message }
+    if (meta?.validation_error) return { ok: false, error: meta.validation_error.message }
+    const execResult = result.value.execution_result
+    const out =
+      execResult && typeof execResult === 'object' ? (execResult as Record<string, unknown>) : {}
+    return { ok: true, result: out }
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) }
   }
 }
 
@@ -343,5 +384,7 @@ async function resolveActiveStepInput(
     compiled: version.compiled,
     stack: prep.stack,
     breadcrumb: prep.breadcrumb,
+    codeOutputs: prep.codeOutputs,
+    codeErrors: prep.codeErrors,
   })
 }

--- a/packages/lib/src/agents/procedures/types.ts
+++ b/packages/lib/src/agents/procedures/types.ts
@@ -30,14 +30,37 @@ export type ArgBindingMap = Record<
 >
 
 /**
- * The compiled runtime step. The v2 union is `instruction | condition | routing`
- * (decision D4): **tool calls and code execution are inline ops** carried inside
- * an `instruction` step's `doc` (reference badges the Phase-3 stepper executes in
- * place; a tool result binds to a local attribute), NOT their own steps. Only
- * sub-procedure calls and routing/terminals are own steps.
+ * One resolved input passed to a code block's `main(codeInput)`. `ref` is the SAME
+ * string shape {@link readProcedureRef} branches on: a local `var:<name>` (read from
+ * the version-scoped local store) or a CRM `FieldReference` (resolved off the subject).
+ */
+export type CodeInput = { name: string; ref: string }
+
+/**
+ * One declared output of a code block. `name` MUST be a declared {@link LocalAttribute}
+ * — `result[name]` writes to `var:<name>`. `surfaceToModel` (D4) decides whether the
+ * value is fed into the model's prose context or stays branch-only.
+ */
+export type CodeOutput = { name: string; surfaceToModel: boolean }
+
+/**
+ * The compiled runtime step. The v9 union is `instruction | condition | routing | code`.
+ * **Tool calls stay inline ops** carried inside an `instruction` step's `doc` (the model
+ * acts on them inside the engine loop; a tool result binds to a local attribute). **Code
+ * is its OWN deterministic step** (D2): the stepper walks *through* it — runs the block,
+ * writes its outputs to `var:*`, advances to `next`, never rests on it — so on resume the
+ * cursor is past the code and it does not re-fire (plan §"Why deterministic").
  */
 export type ProcedureStep =
   | { id: StepId; kind: 'instruction'; doc: unknown /* TiptapFragment */; next: StepId | null }
+  | {
+      id: StepId
+      kind: 'code'
+      codeBlockId: string // → compiled.codeBlocks[id]
+      inputs: CodeInput[] // resolved at run time, passed as main(codeInput)
+      outputs: CodeOutput[] // result[name] → scopedVar(frame, name)
+      next: StepId | null // deterministic — always advances, never stops
+    }
   | {
       id: StepId
       kind: 'condition'
@@ -104,10 +127,8 @@ export interface CompiledProcedure {
   entryStepId: StepId
   /** Shared by the main body AND every sub-procedure — one flat map. */
   steps: Record<StepId, ProcedureStep>
-  codeBlocks: Record<
-    string,
-    { language: 'javascript'; code: string; inputs: unknown[]; outputs: unknown[] }
-  >
+  /** Doc-level code sources; per-invocation input/output bindings live on the `code` step. */
+  codeBlocks: Record<string, { language: 'javascript'; code: string }>
   /** Named local sub-procedures; each `entryStepId` ∈ `steps`. */
   subProcedures: Record<SubProcedureId, SubProcedure>
   /**

--- a/packages/lib/src/ai/kopilot/prompts/sections/__tests__/agent-procedure-step.test.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/__tests__/agent-procedure-step.test.ts
@@ -54,4 +54,33 @@ describe('agentProcedureStep', () => {
     expect(out).toContain("You'll return to: your cancellation.")
     expect(out).toContain('Current step: Verify identity.')
   })
+
+  it('surfaces code outputs as labeled context (D4)', () => {
+    const out = agentProcedureStep.render(
+      ctxWith({
+        activeStep: { doc: frag('Offer the discount.') },
+        depth: 1,
+        codeOutputs: [
+          { name: 'discountTier', value: 'gold' },
+          { name: 'pct', value: 20 },
+        ],
+      })
+    )
+    expect(out).toContain('Computed: `discountTier` = `gold`')
+    expect(out).toContain('Computed: `pct` = `20`')
+    expect(out).toContain('Current step: Offer the discount.')
+  })
+
+  it('renders a caution note for a failed code step (D5)', () => {
+    const out = agentProcedureStep.render(
+      ctxWith({
+        activeStep: { doc: frag('Confirm eligibility.') },
+        depth: 1,
+        codeErrors: [{ codeBlockId: 'c1', error: 'timeout' }],
+      })
+    )
+    expect(out).toContain('⚠️')
+    expect(out).toContain('offer to escalate')
+    expect(out).toContain('Current step: Confirm eligibility.')
+  })
 })

--- a/packages/lib/src/ai/kopilot/prompts/sections/agent-procedure-step.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/agent-procedure-step.ts
@@ -36,7 +36,33 @@ export const agentProcedureStep: PromptSection = {
       if (lines.length > 0) lines.push('')
     }
     if (proc.breadcrumb) lines.push(proc.breadcrumb, '')
+
+    // Computed values (D4) — let the model speak the transformed result.
+    for (const out of proc.codeOutputs ?? []) {
+      lines.push(`Computed: \`${out.name}\` = \`${formatValue(out.value)}\``)
+    }
+    // Failure notes (D5) — the compute couldn't run; cope honestly, don't invent a value.
+    for (const _err of proc.codeErrors ?? []) {
+      lines.push(
+        '⚠️ A computation for this step failed — explain you couldn’t verify it and offer to escalate rather than guessing.'
+      )
+    }
+    if ((proc.codeOutputs?.length ?? 0) > 0 || (proc.codeErrors?.length ?? 0) > 0) lines.push('')
+
     lines.push(`Current step: ${body}`)
     return lines.join('\n').trim()
   },
+}
+
+/** Render a code output value compactly for the prompt — primitives verbatim, objects as JSON. */
+function formatValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
 }

--- a/packages/lib/src/ai/kopilot/prompts/sections/types.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/types.ts
@@ -48,6 +48,10 @@ export interface ProcedureStepInput {
   readonly returnToLabel?: string
   /** Re-anchor line on a pop-resume turn (PROCEDURE-STACK §5). */
   readonly breadcrumb?: string
+  /** `surfaceToModel` outputs computed by `code` steps walked this turn (v9 Phase 5, D4). */
+  readonly codeOutputs?: { name: string; value: unknown }[]
+  /** Failure notes from `code` steps that threw/timed out this turn (v9 Phase 5, D5). */
+  readonly codeErrors?: { codeBlockId: string; error: string }[]
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 6 of chat-v9 procedures. Promotes `code:` badges from inline instruction hints to their own **deterministic runtime step**. The stepper walks *through* a code step — resolves inputs, runs the block in the workflow JS sandbox, writes outputs to version-scoped `var:*`, and advances to `next` — so on resume the cursor rests past the code and it never re-fires.

## What changed

- **types** — add `CodeInput`/`CodeOutput`; add `code` to the `ProcedureStep` union. Code sources stay doc-level (`compiled.codeBlocks`), per-invocation bindings ride the step.
- **nodes** — `parseCodeBindings` lifts per-block input/output bindings off the doc-level map; `code` is now an own-step badge.
- **compile** — emit `code` steps from badges; `validate` rejects unknown block, undeclared output attribute, and unresolvable input refs (`UNKNOWN_OUTPUT_ATTRIBUTE` / `BAD_INPUT_REF`).
- **context** — shared `readProcedureRef`/`writeProcedureVar`: one resolution path for both in-procedure conditions and code-step inputs, so they never diverge. Local `var:*` are read live (deliberately not memoed) so a compute→branch within one frame walk sees fresh values.
- **stepper** — run code steps (the one deterministic side effect), surface `surfaceToModel` outputs + failure notes; clear outputs on error so gate-by-absence (D6) holds on a loop re-run.
- **turn-wiring** — `runCode` adapter over `@auxx/services/lambda-execution` (dynamic import to keep services off the import graph), never throws.
- **prompt section** — render computed values (D4) and honest failure notes (D5) to the model.
- **web** — new code-bindings editor UI; "When to run" trigger header polish.

## Test plan

- `pnpm --filter @auxx/lib test src/agents/procedures` — **128 passed** (new coverage in compile / context / stepper / agent-procedure-step).