### PR TITLE
feat(ai): utility model tier for low-stakes internal LLM calls

### DIFF
--- a/packages/lib/src/agents/procedures/classify.ts
+++ b/packages/lib/src/agents/procedures/classify.ts
@@ -25,9 +25,11 @@ export interface ClassifyDeps {
   organizationId: string
   userId: string
   /**
-   * Resolved BY THE CALLER (Phase 4) from the agent's pinned model
-   * ([[feedback_kopilot_byo_model]] — one model per turn, no per-agent tiering),
-   * falling back to a cheap default (`claude-haiku-4-5`) for this low-stakes routing.
+   * The cheap UTILITY tier, resolved by the caller via `resolveUtilityModel`
+   * (`ai/providers/utility-model.ts`): a same-provider sibling of the agent's
+   * primary model for this low-stakes routing. Does NOT violate
+   * [[feedback_kopilot_byo_model]] — the customer-facing reply still runs on the
+   * primary; only internal classification drops a tier.
    */
   model: string
   provider: string

--- a/packages/lib/src/ai/agent-framework/process-agent-job.ts
+++ b/packages/lib/src/ai/agent-framework/process-agent-job.ts
@@ -297,8 +297,10 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
         db: database,
         organizationId,
         userId,
-        model: domainConfig.defaultModel ?? 'claude-haiku-4-5',
-        provider: domainConfig.defaultProvider ?? 'anthropic',
+        // Low-stakes routing/classification runs on the cheap utility tier, not
+        // the customer-facing reply model. See `ai/providers/utility-model.ts`.
+        model: domainConfig.utilityModel ?? domainConfig.defaultModel ?? 'claude-haiku-4-5',
+        provider: domainConfig.utilityProvider ?? domainConfig.defaultProvider ?? 'anthropic',
       },
       buildCtx,
       drain,

--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -611,6 +611,16 @@ export interface AgentDomainConfig<TDomainState = Record<string, unknown>> {
   /** Default provider for agents that don't override */
   defaultProvider: string
   /**
+   * Cheap same-provider sibling of {@link defaultModel}, auto-derived via
+   * `resolveUtilityModel`, for low-stakes internal LLM tasks (procedure
+   * selection/routing, goal-met checks) — never the customer-facing reply.
+   * Optional: producers that don't set it leave callers to fall back to the
+   * primary. See `ai/providers/utility-model.ts`.
+   */
+  utilityModel?: string
+  /** Provider for {@link utilityModel} (same family as {@link defaultProvider}). */
+  utilityProvider?: string
+  /**
    * Optional hook called after every successful tool result. Lets a domain mine
    * snapshot data (e.g. `turnSnapshots`) out of tool outputs without the
    * framework knowing the tool's shape. Must return a fresh state object.

--- a/packages/lib/src/ai/kopilot/domain-config.ts
+++ b/packages/lib/src/ai/kopilot/domain-config.ts
@@ -12,6 +12,7 @@ import type {
   PostProcessResult,
   TurnSnapshots,
 } from '../agent-framework/types'
+import { resolveUtilityModel } from '../providers/utility-model'
 import { createKopilotAgent } from './agents/agent'
 import { extractLinkSnapshots } from './blocks/extract-link-snapshots'
 import { injectSnapshotsIntoFinal } from './blocks/inject-snapshots'
@@ -80,6 +81,11 @@ export function createKopilotDomainConfig(
     triggerContext,
   } = options
 
+  // Cheap same-provider sibling for low-stakes internal LLM tasks (procedure
+  // selection/routing, goal-met checks). Returns the primary unchanged when it's
+  // already tier-1. See `ai/providers/utility-model.ts`.
+  const utility = resolveUtilityModel({ provider: defaultProvider, model: defaultModel })
+
   // Resolve tools: if the caller passed `tools`, use them verbatim (pre-filtered
   // path). Otherwise fall back to the registry's page-scoped tools so the
   // master-session default is byte-equivalent to today.
@@ -121,6 +127,8 @@ export function createKopilotDomainConfig(
     type: 'kopilot',
     defaultModel,
     defaultProvider,
+    utilityModel: utility.model,
+    utilityProvider: utility.provider,
     // supervisorAgent intentionally omitted — solo-agent domain
     agents: {
       agent,

--- a/packages/lib/src/ai/providers/__tests__/utility-model.test.ts
+++ b/packages/lib/src/ai/providers/__tests__/utility-model.test.ts
@@ -1,0 +1,43 @@
+// packages/lib/src/ai/providers/__tests__/utility-model.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { ProviderRegistry } from '../provider-registry'
+import { ModelType } from '../types'
+import { resolveUtilityModel } from '../utility-model'
+
+describe('resolveUtilityModel', () => {
+  it('downgrades a tier-5 primary (Opus) to a cheap same-provider sibling', () => {
+    const util = resolveUtilityModel({ provider: 'anthropic', model: 'claude-opus-4-6' })
+    expect(util.provider).toBe('anthropic') // never crosses providers
+    expect(util.model).not.toBe('claude-opus-4-6')
+    const caps = ProviderRegistry.getModelCapabilities(util.model)
+    expect(caps?.creditMultiplier ?? 1).toBe(1) // tier-1
+    expect(caps?.modelType).toBe(ModelType.LLM)
+    expect(caps?.supports.structured).toBe(true) // classifiers require it
+    expect(caps?.deprecated).toBeFalsy()
+    expect(caps?.retired).toBeFalsy()
+  })
+
+  it('downgrades a tier-3 primary (Sonnet) to a cheap same-provider sibling', () => {
+    const util = resolveUtilityModel({ provider: 'anthropic', model: 'claude-sonnet-4-6' })
+    expect(util.provider).toBe('anthropic')
+    expect(ProviderRegistry.getModelCapabilities(util.model)?.creditMultiplier ?? 1).toBe(1)
+  })
+
+  it('leaves an already-cheap (tier-1) primary unchanged — nothing cheaper to pick', () => {
+    const primary = { provider: 'anthropic', model: 'claude-haiku-4-5-20251001' }
+    expect(resolveUtilityModel(primary)).toEqual(primary)
+  })
+
+  it('leaves an unknown/custom model unchanged (best-effort, never throws)', () => {
+    const primary = { provider: 'anthropic', model: 'some-self-hosted-llama' }
+    expect(resolveUtilityModel(primary)).toEqual(primary)
+  })
+
+  it('never crosses provider families', () => {
+    // Whatever the OpenAI primary, the utility pick stays an OpenAI model so the
+    // org's existing credentials still apply.
+    const util = resolveUtilityModel({ provider: 'openai', model: 'gpt-5.4-pro' })
+    expect(util.provider).toBe('openai')
+  })
+})

--- a/packages/lib/src/ai/providers/utility-model.ts
+++ b/packages/lib/src/ai/providers/utility-model.ts
@@ -1,0 +1,57 @@
+// packages/lib/src/ai/providers/utility-model.ts
+
+import { ProviderRegistry } from './provider-registry'
+import { type ModelCapabilities, ModelType } from './types'
+
+export interface ResolvedModel {
+  provider: string
+  model: string
+}
+
+/**
+ * Derive the **utility model** — a cheap, same-provider sibling of the primary
+ * model, used for low-stakes internal LLM tasks (procedure selection/routing,
+ * goal-met & backstop checks, text-branch picking) where the agent's full
+ * BYO-model tier is wasted. Customer-facing replies always keep running on the
+ * primary; only internal plumbing drops to this tier.
+ *
+ * Fully auto-derived from the model registry — no config, no DB, no UI:
+ *  - Already-cheap (tier-1) or unknown/custom primary → returned unchanged
+ *    (nothing cheaper worth switching to).
+ *  - Otherwise the newest tier-1 LLM **in the same provider family** that
+ *    supports structured output (every internal caller relies on it). Staying in
+ *    the primary's provider means the org already holds working credentials, so
+ *    this can never hit a missing-creds wall the way a cross-provider pick would.
+ *  - No suitable cheap sibling in the family → falls back to the primary.
+ *
+ * `creditMultiplier` is the tier proxy (1 = cheap/Haiku/mini/nano, 3 = Sonnet/
+ * GPT-class, 5 = Opus); it defaults to 1 when unset (matches the registry).
+ */
+export function resolveUtilityModel(primary: ResolvedModel): ResolvedModel {
+  const caps = ProviderRegistry.getModelCapabilities(primary.model)
+  if (!caps || (caps.creditMultiplier ?? 1) === 1) return primary
+
+  const candidates = ProviderRegistry.getAllModelsForProvider(primary.provider)
+    .map((id) => ({ id, caps: ProviderRegistry.getModelCapabilities(id) }))
+    .filter((c): c is { id: string; caps: ModelCapabilities } => c.caps !== null)
+    .filter(
+      ({ caps: c }) =>
+        c.modelType === ModelType.LLM &&
+        !c.deprecated &&
+        !c.retired &&
+        c.supports.structured &&
+        (c.creditMultiplier ?? 1) === 1
+    )
+  if (candidates.length === 0) return primary
+
+  // Newest first (releaseDate), then widest context, then stable by id — so the
+  // pick auto-tracks the catalog (a newer Haiku/mini wins on its own) and is
+  // deterministic across runs.
+  candidates.sort(
+    (a, b) =>
+      (b.caps.releaseDate ?? '').localeCompare(a.caps.releaseDate ?? '') ||
+      b.caps.contextLength - a.caps.contextLength ||
+      a.id.localeCompare(b.id)
+  )
+  return { provider: primary.provider, model: candidates[0].id }
+}

--- a/packages/lib/src/chat/agent/process-chat-turn.ts
+++ b/packages/lib/src/chat/agent/process-chat-turn.ts
@@ -205,8 +205,14 @@ export async function processChatTurn(ctx: JobContext<ChatTurnJobPayload>): Prom
         db: database,
         organizationId,
         userId: agentUserId,
-        model: config.domainConfig.defaultModel ?? 'claude-haiku-4-5',
-        provider: config.domainConfig.defaultProvider ?? 'anthropic',
+        // Low-stakes routing/classification runs on the cheap utility tier, not
+        // the customer-facing reply model. See `ai/providers/utility-model.ts`.
+        model:
+          config.domainConfig.utilityModel ??
+          config.domainConfig.defaultModel ??
+          'claude-haiku-4-5',
+        provider:
+          config.domainConfig.utilityProvider ?? config.domainConfig.defaultProvider ?? 'anthropic',
       },
       buildCtx,
       drain,


### PR DESCRIPTION
## What

Adds a **utility model tier** — a cheap, same-provider sibling of the agent's primary model, used only for low-stakes internal LLM calls (procedure selection/routing, goal-met, backstop, text-branch classifiers).

## Why

The procedure classifiers ran on the agent's full BYO-model — often Opus/Sonnet — which is wasteful for low-stakes routing (a selection turn could fire 4+ Opus calls before the actual reply). The `ClassifyDeps` doc comment claimed a cheap default was passed, but in practice the agent's turn model was always used. This closes that gap.

## How

- **`ai/providers/utility-model.ts`** (new) — `resolveUtilityModel({provider, model})`: registry-driven. A tier-3/5 primary (`creditMultiplier` 3 or 5) maps to the **newest tier-1 LLM in the same provider family** that supports structured output; an already-cheap or unknown/custom primary is returned unchanged. Staying same-provider guarantees the org's existing credentials still apply (no cross-provider creds wall).
- **`AgentDomainConfig`** — optional `utilityModel`/`utilityProvider`.
- **`createKopilotDomainConfig`** — computes it once (the seam both chat + job paths funnel through).
- **Procedure `classifyDeps`** (`process-chat-turn.ts`, `process-agent-job.ts`) now read the utility tier.
- Fixed the misleading `classify.ts` comment.

Customer-facing replies still run on the primary, so BYO-model holds — only internal classification drops a tier.

## Design notes

- **Newest-first ranking** (by `releaseDate`) means the pick auto-tracks the catalog — a future Haiku/mini wins on its own, no hardcoded model id to maintain.
- **No config / no UI / no DB** — fully auto-derived, per the ask. The resolver is the single seam if an org-level override is ever wanted.
- Left `session-title.ts` untouched: it's already on the cheapest tier (Haiku), so there's no cost win, and the primary model isn't resolved at its early kickoff point.

## Concrete result

| Primary | Tier | Utility pick |
|---|---|---|
| `claude-opus-4-6` | 5 | `claude-haiku-4-5-20251001` |
| `claude-sonnet-4-6` | 3 | `claude-haiku-4-5-20251001` |
| `claude-haiku-4-5-20251001` | 1 | unchanged |
| `gpt-5.4-pro` | 5 | newest tier-1 OpenAI model |
| custom/self-hosted | — | unchanged |

## Test

`ai/providers/__tests__/utility-model.test.ts` — 5 tests (downgrade tier-5/3, leave tier-1/unknown, never cross provider). Existing domain-config tests still green. `lint:changed` clean.