### PR TITLE
feat(editor): allowedBlocks allowlist + app-connection expiry detection

### DIFF
--- a/apps/lambda/src/runtime-helpers/server-sdk.ts
+++ b/apps/lambda/src/runtime-helpers/server-sdk.ts
@@ -26,6 +26,30 @@ import type { RuntimeContext } from '../types.ts'
 import { parseError } from '../utils.ts'
 
 /**
+ * Minimal local mirror of `@auxx/sdk`'s `ConnectionExpiredError`.
+ *
+ * `@auxx/sdk/server` is types-only at build time — the whole module is
+ * externalized to the `AUXX_SERVER_SDK` global, so a `new ConnectionExpiredError()`
+ * in app code compiles to `AUXX_SERVER_SDK.ConnectionExpiredError`. The class
+ * therefore has to be a real member of the injected global, not just a type.
+ *
+ * Mirrors `packages/sdk/src/shared/errors.ts`. The executors detect this across
+ * the sandbox / module boundary by `error.name === 'ConnectionExpiredError'`
+ * and `error.code === 'CONNECTION_EXPIRED'` (see `parseError` in `../utils.ts`),
+ * not `instanceof` — so the class extends `Error` directly.
+ */
+class ConnectionExpiredError extends Error {
+  readonly code: string
+  readonly scope: 'user' | 'organization'
+  constructor(scope: 'user' | 'organization' = 'organization') {
+    super(`${scope} connection expired or revoked. Please reconnect your account.`)
+    this.name = 'ConnectionExpiredError'
+    this.code = 'CONNECTION_EXPIRED'
+    this.scope = scope
+  }
+}
+
+/**
  * Connection interface (matches @auxx/sdk/server/connections)
  *
  * Represents an external service connection (OAuth2 or secret-based).
@@ -187,6 +211,9 @@ export interface ServerSDK {
   findContactByPhone: (input: {
     phone: string
   }) => Promise<{ recordId: string; displayName: string | null } | null>
+  // Error classes re-exported from `@auxx/sdk/server`. App code constructs these
+  // via the externalized global, so they must be real constructors here.
+  ConnectionExpiredError: typeof ConnectionExpiredError
 }
 
 /**
@@ -911,5 +938,13 @@ export function createServerSDK(context: RuntimeContext): ServerSDK {
       }
       return data.entity ?? null
     },
+
+    /**
+     * Error class re-exported from `@auxx/sdk/server`. Exposed on the global so
+     * `new ConnectionExpiredError(scope)` in app code resolves to a real
+     * constructor — the platform catches it (by name/code) and prompts the user
+     * to reconnect instead of surfacing a raw execution error.
+     */
+    ConnectionExpiredError,
   }
 }

--- a/apps/web/src/components/agents/hooks/use-agent-autosave.ts
+++ b/apps/web/src/components/agents/hooks/use-agent-autosave.ts
@@ -86,11 +86,17 @@ export function useAgentAutosave(
   )
 
   // Flush any pending patch on unmount so a fast tab-away doesn't drop edits.
+  // `flush` is rebuilt every render (it closes over `updateAgent`), so this
+  // effect must NOT depend on it — otherwise the cleanup runs on every render
+  // and immediately flushes any queued patch, defeating the debounce. Read the
+  // latest `flush` via a ref and run the cleanup on real unmount only.
+  const flushRef = useRef(flush)
+  flushRef.current = flush
   useEffect(() => {
     return () => {
-      if (queuedPatchRef.current) void flush()
+      if (queuedPatchRef.current) void flushRef.current()
     }
-  }, [flush])
+  }, [])
 
   return { state, patch, flush }
 }

--- a/apps/web/src/components/agents/hooks/use-agent-mutations.ts
+++ b/apps/web/src/components/agents/hooks/use-agent-mutations.ts
@@ -190,7 +190,16 @@ export function useAgentMutations(): UseAgentMutationsResult {
         return false
       }
     },
-    [updateMutation, utils.agent.list, utils.agent.getById, utils.agentToolset.listTools]
+    // Depend on the stable `mutateAsync`, not the whole `updateMutation` object
+    // (React Query returns a new object every render). Keeping `updateAgent`
+    // stable stops the autosave `patch`/`flush` callbacks — and the persona
+    // editor's `onChange` memo — from being rebuilt on every render.
+    [
+      updateMutation.mutateAsync,
+      utils.agent.list,
+      utils.agent.getById,
+      utils.agentToolset.listTools,
+    ]
   )
 
   const archiveAgent = useCallback<UseAgentMutationsResult['archiveAgent']>(

--- a/apps/web/src/components/agents/procedures/ui/procedure-drill-panel.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-drill-panel.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import type { FieldType } from '@auxx/database/types'
+import { PROCEDURE_BLOCKS } from '~/components/editor/blocks/allowed-blocks'
 import { PromptEditorContent } from '~/components/editor/prompt-editor'
 import CodeEditor, {
   type CodeEditorOutput,
@@ -9,7 +10,7 @@ import CodeEditor, {
 } from '~/components/workflow/ui/code-editor'
 import { CodeOutputsEditor } from './code-outputs-editor'
 import { useProcedureDraft } from './procedure-draft-provider'
-import { PROCEDURE_REFERENCE_TABS } from './procedure-editor'
+import { PROCEDURE_PLACEHOLDER, PROCEDURE_REFERENCE_TABS } from './procedure-editor'
 
 /**
  * The full-height drilled body (v9 Phase 6) — the `drill` panel on the outer
@@ -53,7 +54,9 @@ export function ProcedureDrillPanel() {
           onFocusChange={() => {}}
           referencePickerRef={referencePickerRef}
           referenceTabs={PROCEDURE_REFERENCE_TABS}
-          enableProcedureNodes
+          allowedBlocks={PROCEDURE_BLOCKS}
+          slash={false}
+          placeholderText={PROCEDURE_PLACEHOLDER}
         />
       </div>
     )

--- a/apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
@@ -8,6 +8,7 @@ import { VisuallyHidden } from '@auxx/ui/components/visually-hidden'
 import { cn } from '@auxx/ui/lib/utils'
 import { ListChecks } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
+import { PROCEDURE_BLOCKS } from '~/components/editor/blocks/allowed-blocks'
 import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
 import {
   PromptCharacterCount,
@@ -33,6 +34,10 @@ export const PROCEDURE_REFERENCE_TABS: ReferenceTab[] = [
   'condition',
   'attribute',
 ]
+
+// Empty-block hint. Slash is dropped in procedures (`@` is the only insertion
+// surface), so the default "Press '/' for commands" placeholder would be wrong.
+export const PROCEDURE_PLACEHOLDER = 'Write a step, or type @ to add a tool, condition, or field…'
 
 /**
  * The procedure authoring canvas — slimmed to the ROOT prose surface (v9 Phase 6).
@@ -104,7 +109,9 @@ function ProcedureEditorBody({ draft }: { draft: ProcedureDraftContextValue }) {
       onFocusChange={setFocused}
       referencePickerRef={referencePickerRef}
       referenceTabs={PROCEDURE_REFERENCE_TABS}
-      enableProcedureNodes
+      allowedBlocks={PROCEDURE_BLOCKS}
+      slash={false}
+      placeholderText={PROCEDURE_PLACEHOLDER}
     />
   )
 

--- a/apps/web/src/components/agents/ui/detail/prompt/persona-editor.tsx
+++ b/apps/web/src/components/agents/ui/detail/prompt/persona-editor.tsx
@@ -8,6 +8,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import type { JSONContent } from '@tiptap/core'
 import type { Editor } from '@tiptap/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { PERSONA_BLOCKS } from '~/components/editor/blocks/allowed-blocks'
 import { DEFAULT_TABS } from '~/components/editor/inline-picker'
 import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
 import {
@@ -164,6 +165,7 @@ export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
                   onUserActivity={handleUserActivity}
                   referencePickerRef={referencePickerRef}
                   referenceTabs={PERSONA_REFERENCE_TABS}
+                  allowedBlocks={PERSONA_BLOCKS}
                 />
               </div>
             </CollapseWrap>
@@ -192,6 +194,7 @@ export function PersonaEditor({ agent, onAutosaveChange }: PersonaEditorProps) {
                   onUserActivity={handleUserActivity}
                   referencePickerRef={referencePickerRef}
                   referenceTabs={PERSONA_REFERENCE_TABS}
+                  allowedBlocks={PERSONA_BLOCKS}
                 />
               )}
             </ScrollArea>

--- a/apps/web/src/components/editor/blocks/allowed-blocks.ts
+++ b/apps/web/src/components/editor/blocks/allowed-blocks.ts
@@ -1,0 +1,151 @@
+// apps/web/src/components/editor/blocks/allowed-blocks.ts
+
+import type { JSONContent } from '@tiptap/core'
+import type { BlockType } from '../kb-article/block-node'
+
+/**
+ * The single source of truth for "which block kinds an editor instance
+ * exposes". A flat, context-free union covering every block the schema can
+ * hold, in two physical shapes:
+ *
+ * - **`block`-node attr variants** (`BlockType`: text / heading / lists / quote
+ *   / image / divider / codeBlock / callout / embed / cards) — one `block`
+ *   node carrying a `blockType` attribute. The `block` node is always mounted;
+ *   these are gated at the entry points that *set* the attribute.
+ * - **Separate node types** (`table`, `panel`, `tabs`, `accordion`,
+ *   `conditionBlock`) — distinct ProseMirror nodes. These are gated at the
+ *   schema level: not in the list → not mounted → unreachable from paste,
+ *   drag, or programmatic insert.
+ *
+ * Surfaces state the set they want **positively**, by spreading presets. There
+ * is no include/exclude profile — `allowedBlocks={KB_BLOCKS}` etc.
+ *
+ * Nesting constraints (e.g. no table-in-table) are NOT expressed here — they
+ * live in each node's own `content:` expression, where ProseMirror enforces
+ * them. This list is deliberately flat: "which kinds exist at all", top-level.
+ */
+export type EditorBlock =
+  | BlockType // text | heading | bulletListItem | … | callout | embed | cards
+  | 'table'
+  | 'panel'
+  | 'tabs'
+  | 'accordion'
+  | 'conditionBlock'
+
+/** Kinds that are distinct PM nodes (not `block`-node `blockType` attrs). */
+const SEPARATE_NODE_KINDS = new Set<EditorBlock>([
+  'table',
+  'panel',
+  'tabs',
+  'accordion',
+  'conditionBlock',
+])
+
+/** True when `kind` is a `block`-node `blockType` attribute variant. */
+function isBlockAttrKind(kind: EditorBlock): boolean {
+  return !SEPARATE_NODE_KINDS.has(kind)
+}
+
+// --- Presets --------------------------------------------------------------
+
+/** Prose-only set — text + headings + lists + quote + divider + code. */
+export const PLAIN_PROSE: EditorBlock[] = [
+  'text',
+  'heading',
+  'bulletListItem',
+  'numberedListItem',
+  'todoListItem',
+  'quote',
+  'divider',
+  'codeBlock',
+]
+
+/** Full KB article set — prose plus rich/structural blocks. */
+export const KB_BLOCKS: EditorBlock[] = [
+  ...PLAIN_PROSE,
+  'callout',
+  'image',
+  'embed',
+  'cards',
+  'table',
+  'panel',
+  'tabs',
+  'accordion',
+]
+
+/** Persona prompt editor — prose only (matches its slash affordances). */
+export const PERSONA_BLOCKS: EditorBlock[] = PLAIN_PROSE
+
+/**
+ * Procedure canvas — only `text` lines plus the `conditionBlock` IF/ELSE
+ * construct. Step "nodes" (tool / code / routing / sub-procedure) and the
+ * `condition` reference tag are inline `@` badges, governed separately by
+ * `referenceTabs`, not by this block list.
+ */
+export const PROCEDURE_BLOCKS: EditorBlock[] = ['text', 'conditionBlock']
+
+/**
+ * Default when a surface doesn't restrict — the full KB set (the historical
+ * behavior before `allowedBlocks` existed). `conditionBlock` is opt-in only.
+ */
+export const DEFAULT_BLOCKS: EditorBlock[] = KB_BLOCKS
+
+// --- Helpers --------------------------------------------------------------
+
+const has = (allowed: EditorBlock[], kind: EditorBlock) => allowed.includes(kind)
+
+/** A container node (Tabs/Accordion → `containerBlock` group) is in the set. */
+export function allowsContainers(allowed: EditorBlock[]): boolean {
+  return has(allowed, 'tabs') || has(allowed, 'accordion') || has(allowed, 'panel')
+}
+export const allowsTable = (allowed: EditorBlock[]) => has(allowed, 'table')
+export const allowsConditions = (allowed: EditorBlock[]) => has(allowed, 'conditionBlock')
+
+/**
+ * Build the top-level `doc` content expression from the allowed set. `block`
+ * is always present (it carries `text` + every attr variant). `table` is a
+ * `group: 'block'` node but PM resolves the bare `block` token to the NODE
+ * named `block`, so it must be listed explicitly. `containerBlock` /
+ * `procedureBlock` are groups, valid only when ≥1 member node is mounted.
+ */
+export function docContentExpr(allowed: EditorBlock[]): string {
+  const tokens = ['block']
+  if (allowsContainers(allowed)) tokens.push('containerBlock')
+  if (allowsTable(allowed)) tokens.push('table')
+  if (allowsConditions(allowed)) tokens.push('procedureBlock')
+  return `(${tokens.join(' | ')})+`
+}
+
+/**
+ * Coerce a list of pasted block-JSON nodes to fit the allowed set:
+ * - `block` nodes whose `blockType` ∉ allowed → reset to plain `text`
+ *   (stripping `level`/`checked`/variant attrs), content preserved.
+ * - separate-node types (`table`/`tabs`/`accordion`) ∉ allowed → dropped
+ *   (they aren't in the restricted schema; PM would reject them anyway).
+ * Used by the markdown-paste path so paste follows the same list.
+ */
+export function coerceBlocks(nodes: JSONContent[], allowed: EditorBlock[]): JSONContent[] {
+  const allow = new Set(allowed)
+  const out: JSONContent[] = []
+  for (const node of nodes) {
+    if (!node || typeof node !== 'object' || typeof node.type !== 'string') continue
+    const type = node.type as EditorBlock | 'block'
+    if (type === 'block') {
+      const bt = (node.attrs?.blockType as EditorBlock | undefined) ?? 'text'
+      if (isBlockAttrKind(bt) && !allow.has(bt)) {
+        out.push({
+          ...node,
+          attrs: { ...node.attrs, blockType: 'text', level: null, checked: false },
+        })
+      } else {
+        out.push(node)
+      }
+    } else if (SEPARATE_NODE_KINDS.has(type as EditorBlock)) {
+      if (allow.has(type as EditorBlock)) out.push(node)
+      // else drop — not in the restricted schema
+    } else {
+      out.push(node) // unknown / inline content — leave untouched
+    }
+  }
+  return out
+}

--- a/apps/web/src/components/editor/bubble-menu/sections/turn-into.tsx
+++ b/apps/web/src/components/editor/bubble-menu/sections/turn-into.tsx
@@ -10,7 +10,7 @@ import {
 import { EntityIcon } from '@auxx/ui/components/icons'
 import type { Editor } from '@tiptap/react'
 import { useEditorState } from '@tiptap/react'
-import { ChevronDown } from 'lucide-react'
+import { DEFAULT_BLOCKS, type EditorBlock } from '../../blocks/allowed-blocks'
 import { BubbleSection } from '../bubble-menu'
 import { useBubbleSubPopover } from '../bubble-menu-context'
 import { BubbleToggleButton } from '../ui/bubble-toggle-button'
@@ -88,6 +88,8 @@ const TURN_INTO_OPTIONS: TurnIntoOption[] = [
 
 interface TurnIntoSectionProps {
   editor: Editor
+  /** Block kinds this editor allows. Options producing other kinds are hidden. */
+  allowedBlocks?: EditorBlock[]
 }
 
 interface SelectionBlocks {
@@ -130,7 +132,7 @@ function labelForBlockType(blockType: string, editor: Editor, pos?: number): str
   return opt?.label ?? blockType
 }
 
-export function TurnIntoSection({ editor }: TurnIntoSectionProps) {
+export function TurnIntoSection({ editor, allowedBlocks = DEFAULT_BLOCKS }: TurnIntoSectionProps) {
   const onOpenChange = useBubbleSubPopover()
   const selection = useEditorState({
     editor,
@@ -141,9 +143,14 @@ export function TurnIntoSection({ editor }: TurnIntoSectionProps) {
       a.positions.every((p, i) => p === b.positions[i]),
   })
 
+  // Only show options for kinds this surface allows.
+  const allow = new Set(allowedBlocks)
+  const options = TURN_INTO_OPTIONS.filter((o) => allow.has(o.blockType as EditorBlock))
+
   // Hide entirely if the selection has no convertible blocks (e.g. only
-  // crossed table cells, or no shared type to derive a label from).
-  if (selection.positions.length === 0) return null
+  // crossed table cells), or there's nothing meaningful to turn into (≤1
+  // allowed option, e.g. a procedure surface that only permits `text`).
+  if (selection.positions.length === 0 || options.length <= 1) return null
 
   const apply = (option: TurnIntoOption) => {
     const chain = editor.chain().focus()
@@ -173,7 +180,7 @@ export function TurnIntoSection({ editor }: TurnIntoSectionProps) {
           </BubbleToggleButton>
         </DropdownMenuTrigger>
         <DropdownMenuContent align='start' className='max-h-72 w-48 overflow-y-auto'>
-          {TURN_INTO_OPTIONS.map((opt) => (
+          {options.map((opt) => (
             <DropdownMenuItem
               key={opt.id}
               onSelect={() => apply(opt)}

--- a/apps/web/src/components/editor/kb-article/markdown-input-rules.ts
+++ b/apps/web/src/components/editor/kb-article/markdown-input-rules.ts
@@ -2,12 +2,18 @@
 
 import { Extension, InputRule } from '@tiptap/core'
 import type { Node as PMNode, ResolvedPos } from '@tiptap/pm/model'
+import { DEFAULT_BLOCKS, type EditorBlock } from '../blocks/allowed-blocks'
 import type { BlockType } from './block-node'
 
 interface BlockSpec {
   blockType: BlockType
   level?: number | null
   checked?: boolean
+}
+
+export interface MarkdownInputRulesOptions {
+  /** Block kinds this editor allows. Rules that produce a disallowed kind are skipped. */
+  allowed: EditorBlock[]
 }
 
 /**
@@ -18,23 +24,40 @@ interface BlockSpec {
  * Rules only apply when the block is currently a plain `text` block — we
  * don't auto-convert headings into lists mid-stream. To revert, the user
  * can hit Backspace immediately after typing (Tiptap default).
+ *
+ * A rule is only registered when its target kind is in `options.allowed`, so
+ * a restricted surface (e.g. procedures, `allowed: ['text', 'conditionBlock']`)
+ * gets no block-producing shortcuts at all.
  */
-export const MarkdownInputRules = Extension.create({
+export const MarkdownInputRules = Extension.create<MarkdownInputRulesOptions>({
   name: 'markdown-input-rules',
 
+  addOptions() {
+    return { allowed: DEFAULT_BLOCKS }
+  },
+
   addInputRules() {
-    return [
-      headingRule(/^#\s$/, 1),
-      headingRule(/^##\s$/, 2),
-      headingRule(/^###\s$/, 3),
-      blockRule(/^[-*]\s$/, { blockType: 'bulletListItem', level: 1 }),
-      blockRule(/^1\.\s$/, { blockType: 'numberedListItem', level: 1 }),
-      blockRule(/^\[\s?\]\s$/, { blockType: 'todoListItem', checked: false, level: 1 }),
-      blockRule(/^\[x\]\s$/i, { blockType: 'todoListItem', checked: true, level: 1 }),
-      blockRule(/^>\s$/, { blockType: 'quote' }),
-      blockRule(/^```$/, { blockType: 'codeBlock' }),
-      dividerRule(),
-    ]
+    const allow = new Set(this.options.allowed)
+    const rules: InputRule[] = []
+    if (allow.has('heading')) {
+      rules.push(headingRule(/^#\s$/, 1), headingRule(/^##\s$/, 2), headingRule(/^###\s$/, 3))
+    }
+    if (allow.has('bulletListItem')) {
+      rules.push(blockRule(/^[-*]\s$/, { blockType: 'bulletListItem', level: 1 }))
+    }
+    if (allow.has('numberedListItem')) {
+      rules.push(blockRule(/^1\.\s$/, { blockType: 'numberedListItem', level: 1 }))
+    }
+    if (allow.has('todoListItem')) {
+      rules.push(
+        blockRule(/^\[\s?\]\s$/, { blockType: 'todoListItem', checked: false, level: 1 }),
+        blockRule(/^\[x\]\s$/i, { blockType: 'todoListItem', checked: true, level: 1 })
+      )
+    }
+    if (allow.has('quote')) rules.push(blockRule(/^>\s$/, { blockType: 'quote' }))
+    if (allow.has('codeBlock')) rules.push(blockRule(/^```$/, { blockType: 'codeBlock' }))
+    if (allow.has('divider')) rules.push(dividerRule())
+    return rules
   },
 })
 

--- a/apps/web/src/components/editor/kb-article/markdown-paste.ts
+++ b/apps/web/src/components/editor/kb-article/markdown-paste.ts
@@ -1,7 +1,8 @@
 // apps/web/src/components/editor/kb-article/markdown-paste.ts
 
-import { type Editor, Extension } from '@tiptap/core'
+import { type Editor, Extension, type JSONContent } from '@tiptap/core'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { coerceBlocks, DEFAULT_BLOCKS, type EditorBlock } from '../blocks/allowed-blocks'
 
 // Blocks whose shape forbids "lift out and insert N new blocks" semantics.
 // Pasting markdown inside one of these falls through to PM's plain-text
@@ -42,16 +43,31 @@ function looksLikeMarkdown(text: string): boolean {
   return MARKDOWN_HEURISTIC.some((re) => re.test(text))
 }
 
+export interface MarkdownPasteOptions {
+  /**
+   * Block kinds this editor allows. Parsed markdown is run through
+   * `coerceBlocks` against this set, so a disallowed heading/list collapses to
+   * `text` and a disallowed table/container is dropped — paste follows the
+   * same allowlist as every other entry point.
+   */
+  allowed: EditorBlock[]
+}
+
 /**
  * Intercepts plain-text clipboard payloads that look like markdown and
  * replaces them with parsed BlockJSON. The converter is loaded via
  * dynamic import on first use so it stays out of the cold editor bundle.
  */
-export const MarkdownPaste = Extension.create({
+export const MarkdownPaste = Extension.create<MarkdownPasteOptions>({
   name: 'markdown-paste',
+
+  addOptions() {
+    return { allowed: DEFAULT_BLOCKS }
+  },
 
   addProseMirrorPlugins() {
     const editor = this.editor
+    const allowed = this.options.allowed
     return [
       new Plugin({
         key: new PluginKey('markdown-paste'),
@@ -91,7 +107,7 @@ export const MarkdownPaste = Extension.create({
             if (!looksLikeMarkdown(text)) return false
 
             event.preventDefault()
-            void importAndInsert(editor, text)
+            void importAndInsert(editor, text, allowed)
             return true
           },
         },
@@ -100,18 +116,26 @@ export const MarkdownPaste = Extension.create({
   },
 })
 
-async function importAndInsert(editor: Editor, text: string): Promise<void> {
-  let parsed: unknown[] | null = null
+async function importAndInsert(
+  editor: Editor,
+  text: string,
+  allowed: EditorBlock[]
+): Promise<void> {
+  let parsed: JSONContent[] | null = null
   try {
     const { mdToBlocks } = await import('@auxx/lib/kb/markdown')
-    parsed = mdToBlocks(text)
+    parsed = mdToBlocks(text) as JSONContent[]
   } catch (error) {
     console.error('Markdown parse failed; falling back to plain text paste', error)
     insertPlainText(editor, text)
     return
   }
 
-  if (!parsed || parsed.length === 0) {
+  // Coerce the parsed blocks to fit the surface's allowed set — disallowed
+  // headings/lists collapse to text, disallowed tables/containers drop out.
+  const blocks = coerceBlocks(parsed, allowed)
+
+  if (blocks.length === 0) {
     insertPlainText(editor, text)
     return
   }
@@ -120,7 +144,7 @@ async function importAndInsert(editor: Editor, text: string): Promise<void> {
     editor
       .chain()
       .focus()
-      .insertContent(parsed as never[])
+      .insertContent(blocks as never[])
       .run()
   } catch (error) {
     console.error('Markdown insert failed; falling back to plain text paste', error)

--- a/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
+++ b/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
@@ -13,6 +13,7 @@ import type { Editor } from '@tiptap/react'
 import { EditorContent } from '@tiptap/react'
 import { Link as LinkIcon } from 'lucide-react'
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { DEFAULT_BLOCKS, type EditorBlock } from '~/components/editor/blocks/allowed-blocks'
 import {
   EditorBubbleMenu,
   InlineMarksSection,
@@ -62,8 +63,17 @@ interface PromptEditorContentProps {
    * (e.g. the workflow `{`-variable picker). Defaults to `[]`.
    */
   inlineExtensions?: Extension[]
-  /** Mount the v9 procedure control-flow nodes. Forwarded to `useRichTextEditor`. */
-  enableProcedureNodes?: boolean
+  /**
+   * The block kinds this editor exposes. Forwarded to `useRichTextEditor` and
+   * used to filter the slash menu + "Turn into" options. Defaults to the full
+   * KB set. Spread a preset (`PERSONA_BLOCKS`, `PROCEDURE_BLOCKS`, …).
+   */
+  allowedBlocks?: EditorBlock[]
+  /**
+   * Mount the slash (`/`) command menu. Defaults to `true`. Set `false` on
+   * surfaces where `@` is the only insertion affordance (procedures).
+   */
+  slash?: boolean
 }
 
 interface LinkPopoverState {
@@ -96,11 +106,14 @@ export const PromptEditorContent = memo(function PromptEditorContent({
   editable = true,
   placeholderText,
   inlineExtensions,
-  enableProcedureNodes,
+  allowedBlocks = DEFAULT_BLOCKS,
+  slash = true,
 }: PromptEditorContentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [linkPopover, setLinkPopover] = useState<LinkPopoverState | null>(null)
 
+  // `useSlashCommand` is a hook — always called — but only wired into the
+  // editor / mounted as a popover when `slash` is on.
   const slashCommand = useSlashCommand()
 
   const onPickerEnter = useCallback(
@@ -115,7 +128,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
   const { editor } = useRichTextEditor({
     initialContent,
     onChange,
-    slashCommand,
+    slashCommand: slash ? slashCommand : undefined,
     enableReferencePicker: true,
     onPickerEnter,
     onPickerArrowVertical,
@@ -123,7 +136,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
     editable,
     placeholderText,
     inlineExtensions,
-    enableProcedureNodes,
+    allowedBlocks,
   })
 
   const activePicker = useActivePicker(editor)
@@ -224,20 +237,25 @@ export const PromptEditorContent = memo(function PromptEditorContent({
       <EditorBubbleMenu
         editor={editor}
         renderBlockSection={({ editor }) => <KBBlockSection editor={editor} />}
-        renderTurnInto={({ editor }) => <TurnIntoSection editor={editor} />}
+        renderTurnInto={({ editor }) => (
+          <TurnIntoSection editor={editor} allowedBlocks={allowedBlocks} />
+        )}
         renderInlineMarks={({ editor }) => <InlineMarksSection editor={editor} />}
         renderLink={({ editor }) => <LinkButton editor={editor} onRequest={handleLinkRequest} />}
       />
-      <InlinePickerPopover
-        state={slashCommand.suggestionState}
-        onClose={slashCommand.closePicker}
-        width={288}>
-        <BasicSlashCommandPicker
-          query={slashCommand.suggestionState.query}
-          onExecute={slashCommand.executeCommand}
+      {slash && (
+        <InlinePickerPopover
+          state={slashCommand.suggestionState}
           onClose={slashCommand.closePicker}
-        />
-      </InlinePickerPopover>
+          width={288}>
+          <BasicSlashCommandPicker
+            query={slashCommand.suggestionState.query}
+            onExecute={slashCommand.executeCommand}
+            onClose={slashCommand.closePicker}
+            allowedBlocks={allowedBlocks}
+          />
+        </InlinePickerPopover>
+      )}
       <InlinePickerPopover
         state={{
           isOpen: !!activePicker,

--- a/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
+++ b/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
@@ -19,6 +19,14 @@ import { ConditionBlock } from '~/components/agents/procedures/nodes/condition-b
 import { ConditionCase } from '~/components/agents/procedures/nodes/condition-case-node'
 import { ConditionElse } from '~/components/agents/procedures/nodes/condition-else-node'
 import { ConditionPredicate } from '~/components/agents/procedures/nodes/condition-predicate-node'
+import {
+  allowsConditions,
+  allowsContainers,
+  allowsTable,
+  DEFAULT_BLOCKS,
+  docContentExpr,
+  type EditorBlock,
+} from '../blocks/allowed-blocks'
 import { Table, TableCell, TableHeader, TableRow } from '../extensions/table'
 import {
   createPlaceholderNode,
@@ -37,18 +45,15 @@ import { Panel } from '../kb-article/panel-node'
 import { Tabs } from '../kb-article/tabs-node'
 import { buildReferencePickerExtensions } from './reference-picker-extensions'
 
-// The `doc` content union. `procedureBlock` is only a valid token when at least
-// one node declares `group: 'procedureBlock'` (PM rejects an empty group), so the
-// alternative is added ONLY when the procedure nodes are mounted (§1.2). PM
-// resolves a bare `block` token to the NODE named `block`, not the group, so
-// `table` is listed explicitly even though it's in `group: 'block'`.
-function createDoc(enableProcedureNodes: boolean) {
+// The `doc` content union is derived from the surface's allowed block set (see
+// `docContentExpr`). A group token (`containerBlock` / `procedureBlock`) is only
+// valid when ≥1 member node is mounted, so each is included only when the
+// corresponding nodes are allowed below.
+function createDoc(allowedBlocks: EditorBlock[]) {
   return Node.create({
     name: 'doc',
     topNode: true,
-    content: enableProcedureNodes
-      ? '(block | containerBlock | procedureBlock | table)+'
-      : '(block | containerBlock | table)+',
+    content: docContentExpr(allowedBlocks),
   })
 }
 
@@ -129,14 +134,14 @@ export interface UseRichTextEditorOptions {
    */
   inlineExtensions?: Extension[]
   /**
-   * Mount the v9 procedure control-flow nodes (conditionBlock / conditionCase /
-   * conditionElse / conditionPredicate) and extend the `doc` content union with
-   * the `procedureBlock` group. The step "nodes" (tool / code / routing /
-   * sub-procedure) are inline reference badges, not block nodes. Defaults to `false`
-   * — only the procedure editor opts in; KB / persona / mail schemas are
-   * untouched (no procedure node types in their autosave payloads).
+   * The block kinds this editor exposes — the single source of truth for the
+   * schema (which separate nodes mount), markdown rules/paste, and the bubble
+   * "Turn into" menu. Defaults to {@link DEFAULT_BLOCKS} (the full KB set).
+   * Spread a preset: `KB_BLOCKS`, `PERSONA_BLOCKS`, `PROCEDURE_BLOCKS`.
+   * `conditionBlock` in the set mounts the v9 procedure control-flow nodes
+   * (replacing the old `enableProcedureNodes` flag).
    */
-  enableProcedureNodes?: boolean
+  allowedBlocks?: EditorBlock[]
 }
 
 /**
@@ -144,9 +149,11 @@ export interface UseRichTextEditorOptions {
  * - `useKBArticleEditor` (thin shim — adds KB-specific picker / link popover)
  * - `PersonaEditor` (agent persona prompt, no slash menu)
  *
- * Mounts the full block set (StarterKit + Block / Panel / Tabs / Accordion /
- * Table), the markdown input/paste rules, the focus decoration plugin, and —
- * by default — the inline reference picker. Slash command is opt-in.
+ * Mounts StarterKit + the `block` node, the markdown input/paste rules, the
+ * focus decoration plugin, and — by default — the inline reference picker.
+ * The separate structural nodes (Panel / Tabs / Accordion / Table / procedure
+ * condition nodes) mount only when their kind is in `allowedBlocks`. Slash
+ * command is opt-in.
  */
 export function useRichTextEditor({
   initialContent,
@@ -159,7 +166,7 @@ export function useRichTextEditor({
   editable = true,
   placeholderText,
   inlineExtensions,
-  enableProcedureNodes = false,
+  allowedBlocks = DEFAULT_BLOCKS,
 }: UseRichTextEditorOptions) {
   const normalizedInitialContent = useMemo<JSONContent>(() => {
     const migrated = migrateLegacyContent(initialContent)
@@ -201,7 +208,7 @@ export function useRichTextEditor({
       immediatelyRender: false,
       editable,
       extensions: [
-        createDoc(enableProcedureNodes),
+        createDoc(allowedBlocks),
         StarterKit.configure({
           document: false,
           heading: false,
@@ -216,18 +223,18 @@ export function useRichTextEditor({
           // Marks stay enabled (bold, italic, strike, code).
         }),
         placeholderText ? Block.configure({ placeholderText }) : Block,
-        Panel,
-        Tabs,
-        Accordion,
-        MarkdownInputRules,
-        MarkdownPaste,
+        // Container nodes (Panel/Tabs/Accordion) and Table are separate PM
+        // nodes — mounting them is the enforcement. Not in `allowedBlocks` →
+        // not in the schema → unreachable from paste / drag / programmatic.
+        // Panel is the child of Tabs/Accordion, so it rides along whenever any
+        // container is allowed.
+        ...(allowsContainers(allowedBlocks) ? [Panel, Tabs, Accordion] : []),
+        MarkdownInputRules.configure({ allowed: allowedBlocks }),
+        MarkdownPaste.configure({ allowed: allowedBlocks }),
         // Column resizing is disabled — the React NodeView (TableNodeView)
         // owns the table chrome and column resize is a follow-up. Reorder +
         // add/remove are handled via table-helpers.ts.
-        Table,
-        TableRow,
-        TableHeader,
-        TableCell,
+        ...(allowsTable(allowedBlocks) ? [Table, TableRow, TableHeader, TableCell] : []),
         Underline,
         TextStyle,
         Color,
@@ -239,7 +246,7 @@ export function useRichTextEditor({
         // via the Placeholder extension's CSS pseudo-element (which would
         // overlap the line gutter). See block-node-view.tsx `showPlaceholder`.
         ...(slashCommand ? [slashCommand.slashCommandExtension] : []),
-        ...(enableProcedureNodes
+        ...(allowsConditions(allowedBlocks)
           ? [ConditionBlock, ConditionCase, ConditionElse, ConditionPredicate]
           : []),
         ...referencePickerExtensions,

--- a/apps/web/src/components/editor/slash-commands/basic-slash-command-picker.tsx
+++ b/apps/web/src/components/editor/slash-commands/basic-slash-command-picker.tsx
@@ -3,7 +3,13 @@
 
 import type { Editor } from '@tiptap/react'
 import { useEffect, useMemo, useState } from 'react'
-import { BASIC_BLOCK_COMMANDS, type BlockCommandDef, runBlockCommand } from './block-commands'
+import { DEFAULT_BLOCKS, type EditorBlock } from '../blocks/allowed-blocks'
+import {
+  BASIC_BLOCK_COMMANDS,
+  type BlockCommandDef,
+  filterBlockCommands,
+  runBlockCommand,
+} from './block-commands'
 import {
   type SlashCommandItem,
   SlashCommandPicker,
@@ -16,6 +22,8 @@ interface BasicSlashCommandPickerProps {
   query: string
   onExecute: (command: (editor: Editor, range: Range) => void) => void
   onClose: () => void
+  /** Block kinds to show. Defaults to the full set. */
+  allowedBlocks?: EditorBlock[]
 }
 
 /**
@@ -27,6 +35,7 @@ export function BasicSlashCommandPicker({
   query,
   onExecute,
   onClose,
+  allowedBlocks = DEFAULT_BLOCKS,
 }: BasicSlashCommandPickerProps) {
   const [searchQuery, setSearchQuery] = useState(query)
 
@@ -41,11 +50,11 @@ export function BasicSlashCommandPicker({
       {
         id: 'blocks',
         heading: 'Blocks',
-        items: BASIC_BLOCK_COMMANDS,
+        items: filterBlockCommands(BASIC_BLOCK_COMMANDS, allowedBlocks),
         onSelect: (item) => onExecute(runBlockCommand(item as BlockCommandDef)),
       },
     ],
-    [onExecute]
+    [onExecute, allowedBlocks]
   )
 
   return (

--- a/apps/web/src/components/editor/slash-commands/block-commands.ts
+++ b/apps/web/src/components/editor/slash-commands/block-commands.ts
@@ -1,6 +1,7 @@
 // apps/web/src/components/editor/slash-commands/block-commands.ts
 
 import type { Editor } from '@tiptap/react'
+import type { EditorBlock } from '../blocks/allowed-blocks'
 import type { SlashCommandItem } from './slash-command-picker'
 
 export type SlashRange = { from: number; to: number }
@@ -27,6 +28,29 @@ export interface BlockCommandDef extends SlashCommandItem {
   /** Free-form action — used when the insert is more than an attr swap
    *  (divider, image, table, etc.). */
   custom?: (editor: Editor, range: SlashRange) => void
+  /**
+   * The block kind this command produces, used for `allowedBlocks` filtering.
+   * For `spec`-based commands it defaults to `spec.blockType`; set it
+   * explicitly on `custom` commands (divider, table, tabs, …).
+   */
+  kind?: EditorBlock
+}
+
+/** The block kind a command produces (for allowlist filtering). */
+export function blockCommandKind(def: BlockCommandDef): EditorBlock | undefined {
+  return def.kind ?? (def.spec?.blockType as EditorBlock | undefined)
+}
+
+/** Drop commands whose produced kind isn't in `allowed`. Untagged commands pass. */
+export function filterBlockCommands(
+  defs: BlockCommandDef[],
+  allowed: EditorBlock[]
+): BlockCommandDef[] {
+  const allow = new Set(allowed)
+  return defs.filter((def) => {
+    const kind = blockCommandKind(def)
+    return kind ? allow.has(kind) : true
+  })
 }
 
 /** Basic block set shared by every slash-menu surface. */
@@ -109,6 +133,7 @@ export const BASIC_BLOCK_COMMANDS: BlockCommandDef[] = [
     description: 'Visual separator',
     keywords: ['hr', 'horizontal', 'rule', 'line'],
     iconId: 'minus',
+    kind: 'divider',
     custom: (editor, range) => {
       editor
         .chain()

--- a/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
@@ -1,6 +1,9 @@
 // packages/lib/src/ai/kopilot/capabilities/apps/index.ts
 
-import { resolveAppConnectionForRuntime } from '@auxx/services/app-connections'
+import {
+  markAppConnectionExpired,
+  resolveAppConnectionForRuntime,
+} from '@auxx/services/app-connections'
 import {
   invokeLambdaExecutor,
   invokeLambdaExecutorStreaming,
@@ -170,6 +173,10 @@ export async function createAppCapabilities(deps: {
 
         return {
           ok: true as const,
+          // The credential the tool will actually run against — used to mark the
+          // connection expired if the provider later rejects its token.
+          resolvedConnectionId:
+            resolved.organizationConnection?.id ?? resolved.userConnection?.id ?? null,
           payload: {
             type: 'tool' as const,
             serverBundleSha,
@@ -259,9 +266,15 @@ export async function createAppCapabilities(deps: {
                 // Result below — we don't push them through the queue.
               },
             })
-              .then((res) => {
+              .then(async (res) => {
                 let final: AgentToolResult
                 if (res.isErr()) {
+                  if (prep.resolvedConnectionId && res.error.code === 'CONNECTION_REQUIRED') {
+                    await markAppConnectionExpired({
+                      credentialId: prep.resolvedConnectionId,
+                      organizationId,
+                    })
+                  }
                   final = {
                     success: false,
                     output: null,
@@ -320,6 +333,12 @@ export async function createAppCapabilities(deps: {
 
             if (lambdaResult.isErr()) {
               const lambdaError = lambdaResult.error
+              if (prep.resolvedConnectionId && lambdaError.code === 'CONNECTION_REQUIRED') {
+                await markAppConnectionExpired({
+                  credentialId: prep.resolvedConnectionId,
+                  organizationId,
+                })
+              }
               return {
                 success: false,
                 output: null,

--- a/packages/services/src/app-connections/index.ts
+++ b/packages/services/src/app-connections/index.ts
@@ -8,6 +8,10 @@ export { getAppConnectionDefinition } from './get-app-connection-definition'
 // Export interpolation utilities
 export { extractPlaceholders, interpolateConnectionFields } from './interpolate-connection'
 export { listAppConnections } from './list-app-connections'
+export {
+  CONNECTION_CIRCUIT_OPEN_THRESHOLD,
+  markAppConnectionExpired,
+} from './mark-app-connection-expired'
 export { renameAppConnection } from './rename-app-connection'
 export { resolveAppConnectionForRuntime } from './resolve-app-connection-for-runtime'
 export { saveAppConnection } from './save-app-connection'

--- a/packages/services/src/app-connections/list-app-connections.ts
+++ b/packages/services/src/app-connections/list-app-connections.ts
@@ -5,6 +5,7 @@ import { database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { ok, type Result } from 'neverthrow'
 import { fromDatabase } from '../shared/utils'
+import { CONNECTION_CIRCUIT_OPEN_THRESHOLD } from './mark-app-connection-expired'
 import type { AppConnection, DecryptedConnectionData } from './types'
 
 const logger = createScopedLogger('list-app-connections')
@@ -102,6 +103,14 @@ export async function listAppConnections(organizationId: string, userId?: string
     // Determine status by checking expiration
     let status: 'connected' | 'not_connected' | 'expired' = 'connected'
     let expiresAt: Date | undefined
+
+    // Circuit-breaker: a connection whose refresh circuit is open — or that was
+    // marked failed at tool-execution time via `markAppConnectionExpired` — is
+    // surfaced as expired even when the token itself carries no expiry (e.g.
+    // Shopify offline tokens, which never expire but can be revoked).
+    if (cred.consecutiveRefreshFailures >= CONNECTION_CIRCUIT_OPEN_THRESHOLD) {
+      status = 'expired'
+    }
 
     // Check if OAuth2 token is expired
     try {

--- a/packages/services/src/app-connections/mark-app-connection-expired.ts
+++ b/packages/services/src/app-connections/mark-app-connection-expired.ts
@@ -1,0 +1,57 @@
+// packages/services/src/app-connections/mark-app-connection-expired.ts
+
+import { database, schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import { ok } from 'neverthrow'
+import { fromDatabase } from '../shared/utils'
+import { logger } from './utils'
+
+/**
+ * Number of consecutive failures at which the refresh circuit breaker is
+ * considered "open" — mirrors `OAuth2WorkflowService` (a permanent failure
+ * jumps straight to this value). A connection at or above this count is
+ * surfaced as `expired` by {@link listAppConnections}.
+ */
+export const CONNECTION_CIRCUIT_OPEN_THRESHOLD = 5
+
+/**
+ * Mark an app connection as expired/broken.
+ *
+ * Reuses the existing circuit-breaker fields written by the OAuth2 token
+ * refresh path (`consecutiveRefreshFailures` / `lastRefreshFailureAt`) so a
+ * connection that fails at tool-execution time (e.g. the provider rejected the
+ * token with a 401/403) surfaces in the UI exactly like a refresh failure does.
+ *
+ * Idempotent: re-marking an already-open connection just refreshes the
+ * timestamp. Does not throw — returns a neverthrow Result.
+ */
+export async function markAppConnectionExpired(params: {
+  credentialId: string
+  organizationId: string
+}) {
+  const { credentialId, organizationId } = params
+
+  const result = await fromDatabase(
+    database
+      .update(schema.WorkflowCredentials)
+      .set({
+        consecutiveRefreshFailures: CONNECTION_CIRCUIT_OPEN_THRESHOLD,
+        lastRefreshFailureAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(schema.WorkflowCredentials.id, credentialId),
+          eq(schema.WorkflowCredentials.organizationId, organizationId)
+        )
+      ),
+    'mark-app-connection-expired'
+  )
+
+  if (result.isErr()) {
+    return result
+  }
+
+  logger.info('Marked app connection expired', { credentialId })
+  return ok(undefined)
+}

--- a/scripts/check-shopify-app-connection.ts
+++ b/scripts/check-shopify-app-connection.ts
@@ -1,0 +1,112 @@
+// scripts/check-shopify-app-connection.ts
+//
+// Verify a Shopify *app-connection* (WorkflowCredentials, type 'app-connection')
+// by decrypting its stored token and making a live Shopify Admin API call.
+// Answers "is this token actually dead?" independently of the kopilot path.
+//
+// Usage:
+//   npx dotenv -- npx tsx scripts/check-shopify-app-connection.ts [organizationId] [appId]
+// Defaults: DemoOrg + the Shopify appId.
+
+import { CredentialService } from '@auxx/credentials'
+import { database, schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+
+const DEFAULT_ORG = 'abgwpa1l81reht2zmwrcihfu' // DemoOrg
+const DEFAULT_SHOPIFY_APP_ID = 'ni0jjtpn6sreobwrue44r8re'
+const API_VERSION = '2024-10'
+
+const organizationId = process.argv[2] ?? DEFAULT_ORG
+const appId = process.argv[3] ?? DEFAULT_SHOPIFY_APP_ID
+
+function resolveShopDomain(metadata: Record<string, unknown> | undefined): string {
+  const vars = metadata?.connectionVariables as Record<string, string> | undefined
+  const shop = vars?.shop
+  if (!shop) return ''
+  return shop.includes('.') ? shop : `${shop}.myshopify.com`
+}
+
+async function main() {
+  console.log({ organizationId, appId })
+
+  const cred = await database.query.WorkflowCredentials.findFirst({
+    where: and(
+      eq(schema.WorkflowCredentials.organizationId, organizationId),
+      eq(schema.WorkflowCredentials.appId, appId),
+      eq(schema.WorkflowCredentials.type, 'app-connection')
+    ),
+  })
+
+  if (!cred) {
+    console.error('No app-connection credential found for that org + appId')
+    process.exit(1)
+  }
+
+  console.log('\n--- credential row ---')
+  console.log({
+    id: cred.id,
+    name: cred.name,
+    label: cred.label,
+    expiresAt: cred.expiresAt,
+    consecutiveRefreshFailures: cred.consecutiveRefreshFailures,
+    lastRefreshFailureAt: cred.lastRefreshFailureAt,
+    createdAt: cred.createdAt,
+  })
+
+  const decrypted = CredentialService.decrypt(cred.encryptedData) as {
+    accessToken?: string
+    secret?: string
+    metadata?: Record<string, unknown>
+    expiresAt?: string
+  }
+
+  const token = decrypted.accessToken ?? decrypted.secret
+  const shopDomain = resolveShopDomain(decrypted.metadata)
+
+  console.log('\n--- decrypted (sanitized) ---')
+  console.log({
+    shopDomain,
+    hasToken: Boolean(token),
+    tokenPrefix: token ? `${token.slice(0, 8)}…` : null,
+    tokenLength: token?.length ?? 0,
+    decryptedExpiresAt: decrypted.expiresAt ?? null,
+    metadataKeys: Object.keys(decrypted.metadata ?? {}),
+  })
+
+  if (!token || !shopDomain) {
+    console.error('\nMissing token or shop domain — cannot test live.')
+    process.exit(1)
+  }
+
+  // Live probe: /shop.json is the cheapest authenticated read.
+  const url = `https://${shopDomain}/admin/api/${API_VERSION}/shop.json`
+  console.log('\n--- live probe ---')
+  console.log('GET', url)
+
+  const res = await fetch(url, {
+    headers: { 'X-Shopify-Access-Token': token, 'Content-Type': 'application/json' },
+  })
+
+  const bodyText = await res.text()
+  console.log('status:', res.status, res.statusText)
+  if (res.ok) {
+    const shop = JSON.parse(bodyText)?.shop
+    console.log('✅ token VALID — shop:', {
+      name: shop?.name,
+      domain: shop?.domain,
+      plan: shop?.plan_name,
+    })
+  } else {
+    console.log(`❌ token REJECTED (${res.status}) — body:`, bodyText.slice(0, 500))
+    if (res.status === 401 || res.status === 403) {
+      console.log('→ This is the revoked/expired case the app maps to ConnectionExpiredError.')
+    }
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error('\nthrew:', e instanceof Error ? e.message : e)
+    process.exit(1)
+  })


### PR DESCRIPTION
## Summary

Two related-but-independent changes bundled per request.

### Editor — `allowedBlocks` allowlist
- New `apps/web/src/components/editor/blocks/allowed-blocks.ts` is the single source of truth for which block kinds an editor surface exposes. Presets: `PLAIN_PROSE`, `KB_BLOCKS`, `PERSONA_BLOCKS`, `PROCEDURE_BLOCKS`, `DEFAULT_BLOCKS`.
- Replaces the boolean `enableProcedureNodes` flag with `allowedBlocks`, threaded through `useRichTextEditor` → `PromptEditorContent`. The allowlist now drives:
  - the `doc` schema (which PM nodes mount — Panel/Tabs/Accordion/Table/condition nodes),
  - markdown input rules (block-producing shortcuts only registered when allowed),
  - markdown paste (`coerceBlocks` collapses disallowed headings/lists to text, drops disallowed tables/containers),
  - the slash command menu (`filterBlockCommands`),
  - the bubble **Turn into** menu.
- Persona editor → `PERSONA_BLOCKS` (prose only). Procedure editor/drill → `PROCEDURE_BLOCKS` with slash disabled and an `@`-oriented placeholder.

### Agent autosave stability fix
- Unmount flush reads `flush` via a ref so the cleanup no longer fires on every render (was defeating the debounce).
- `updateAgent` stays referentially stable by depending on `mutateAsync` instead of the whole React Query mutation object.

### App connections — expiry detection
- `markAppConnectionExpired` reuses the OAuth2 circuit-breaker fields (`consecutiveRefreshFailures` / `lastRefreshFailureAt`) so a token rejected at tool-execution time surfaces as expired.
- `listAppConnections` reports `expired` once the refresh circuit is open — covers non-expiring tokens (e.g. Shopify offline tokens) that get revoked.
- Kopilot app capabilities mark the resolved connection expired on `CONNECTION_REQUIRED` errors from the executor.
- Lambda server SDK exposes a real `ConnectionExpiredError` constructor on the injected global so app code can construct it across the externalized module boundary.
- `scripts/check-shopify-app-connection.ts` live-probes a stored token against the Shopify Admin API.

## Test plan
- [ ] KB editor retains full block set; persona editor shows prose-only slash/turn-into; procedure editor has no slash and `@`-only insertion.
- [ ] Pasting markdown with tables/headings into a restricted surface coerces correctly.
- [ ] Fast tab-away still flushes a pending agent autosave patch without flushing on every render.
- [ ] A revoked Shopify connection surfaces as `expired` in the connections list after a failed tool run.