### PR TITLE
feat: shopify/stripe billing coexistence + sdk provider-call errors

### DIFF
--- a/apps/lambda/src/index.ts
+++ b/apps/lambda/src/index.ts
@@ -251,7 +251,7 @@ export async function handler(
     }
   } catch (error: unknown) {
     const duration = Date.now() - startTime
-    const { message, code, stack, scope } = parseError(error)
+    const { message, code, stack, scope, details } = parseError(error)
 
     console.error('[Lambda] Execution failed:', {
       error: message,
@@ -279,6 +279,7 @@ export async function handler(
           message,
           code,
           scope,
+          details,
           stack: Deno.env.get('NODE_ENV') === 'development' ? stack : undefined,
         },
         metadata: {

--- a/apps/lambda/src/runtime-helpers/server-sdk.ts
+++ b/apps/lambda/src/runtime-helpers/server-sdk.ts
@@ -50,6 +50,81 @@ class ConnectionExpiredError extends Error {
 }
 
 /**
+ * Local mirrors of the provider-call errors in `@auxx/sdk`'s shared errors.
+ * Same rationale as {@link ConnectionExpiredError}: `@auxx/sdk/server` is
+ * externalized to `AUXX_SERVER_SDK`, so `new RateLimitError()` in app code
+ * compiles to `AUXX_SERVER_SDK.RateLimitError` and the class must be a real
+ * member of the injected global. Detection is by `name`/`code`, so these only
+ * need matching `name` + `code` + the structured fields the platform forwards.
+ * Mirrors `packages/sdk/src/shared/errors.ts`.
+ */
+class InsufficientPermissionsError extends Error {
+  readonly code = 'INSUFFICIENT_PERMISSIONS'
+  readonly scope: 'user' | 'organization'
+  readonly requiredScopes?: string[]
+  constructor(scope: 'user' | 'organization' = 'organization', requiredScopes?: string[]) {
+    super(
+      `The connected account lacks the required permission${
+        requiredScopes?.length ? ` (${requiredScopes.join(', ')})` : ''
+      }. An admin may need to re-authorize the app with additional scopes.`
+    )
+    this.name = 'InsufficientPermissionsError'
+    this.scope = scope
+    this.requiredScopes = requiredScopes
+  }
+}
+
+class RateLimitError extends Error {
+  readonly code = 'RATE_LIMIT'
+  readonly retryAfterSeconds?: number
+  constructor(retryAfterSeconds?: number) {
+    super(
+      `Rate limited by the provider${retryAfterSeconds ? `; retry in ~${retryAfterSeconds}s` : ''}.`
+    )
+    this.name = 'RateLimitError'
+    this.retryAfterSeconds = retryAfterSeconds
+  }
+}
+
+class UpstreamServiceError extends Error {
+  readonly code = 'UPSTREAM_ERROR'
+  readonly statusCode?: number
+  constructor(message = 'The provider is temporarily unavailable.', statusCode?: number) {
+    super(message)
+    this.name = 'UpstreamServiceError'
+    this.statusCode = statusCode
+  }
+}
+
+class InvalidInputError extends Error {
+  readonly code = 'INVALID_INPUT'
+  readonly fields?: Array<{ field: string; message: string }>
+  constructor(message: string, fields?: Array<{ field: string; message: string }>) {
+    super(message)
+    this.name = 'InvalidInputError'
+    this.fields = fields
+  }
+}
+
+class NotFoundError extends Error {
+  readonly code = 'RESOURCE_NOT_FOUND'
+  readonly resource?: string
+  constructor(message = 'The requested resource was not found.', resource?: string) {
+    super(message)
+    this.name = 'NotFoundError'
+    this.resource = resource
+  }
+}
+
+class ConflictError extends Error {
+  readonly code = 'CONFLICT'
+  constructor(message = 'The request conflicts with the current state of the resource.') {
+    super(message)
+    this.name = 'ConflictError'
+  }
+}
+
+/**
  * Connection interface (matches @auxx/sdk/server/connections)
  *
  * Represents an external service connection (OAuth2 or secret-based).
@@ -214,6 +289,12 @@ export interface ServerSDK {
   // Error classes re-exported from `@auxx/sdk/server`. App code constructs these
   // via the externalized global, so they must be real constructors here.
   ConnectionExpiredError: typeof ConnectionExpiredError
+  InsufficientPermissionsError: typeof InsufficientPermissionsError
+  RateLimitError: typeof RateLimitError
+  UpstreamServiceError: typeof UpstreamServiceError
+  InvalidInputError: typeof InvalidInputError
+  NotFoundError: typeof NotFoundError
+  ConflictError: typeof ConflictError
 }
 
 /**
@@ -946,5 +1027,11 @@ export function createServerSDK(context: RuntimeContext): ServerSDK {
      * to reconnect instead of surfacing a raw execution error.
      */
     ConnectionExpiredError,
+    InsufficientPermissionsError,
+    RateLimitError,
+    UpstreamServiceError,
+    InvalidInputError,
+    NotFoundError,
+    ConflictError,
   }
 }

--- a/apps/lambda/src/utils.ts
+++ b/apps/lambda/src/utils.ts
@@ -12,6 +12,7 @@ export function parseError(error: unknown): {
   code: string
   stack: string | undefined
   scope?: string
+  details?: Record<string, unknown>
 } {
   // Extract message
   const message = error instanceof Error ? error.message : String(error)
@@ -39,5 +40,18 @@ export function parseError(error: unknown): {
     scope = (error as Error & { scope: string }).scope
   }
 
-  return { message, code, stack, scope }
+  // Forward the structured fields the typed `@auxx/sdk` errors carry so they
+  // survive the sandbox boundary (e.g. RateLimitError.retryAfterSeconds,
+  // InsufficientPermissionsError.requiredScopes, InvalidInputError.fields).
+  let details: Record<string, unknown> | undefined
+  if (error instanceof Error) {
+    const extra: Record<string, unknown> = {}
+    for (const key of ['retryAfterSeconds', 'requiredScopes', 'fields', 'resource', 'statusCode']) {
+      const value = (error as unknown as Record<string, unknown>)[key]
+      if (value !== undefined) extra[key] = value
+    }
+    if (Object.keys(extra).length > 0) details = extra
+  }
+
+  return { message, code, stack, scope, details }
 }

--- a/apps/web/src/app/(auth)/shopify/claim/_components/claim-flow.tsx
+++ b/apps/web/src/app/(auth)/shopify/claim/_components/claim-flow.tsx
@@ -12,23 +12,30 @@ import { api } from '~/trpc/react'
 
 interface ClaimFlowProps {
   shop: string
-  orgs: { id: string; name: string | null; handle: string | null }[]
+  orgs: { id: string; name: string | null; handle: string | null; stripeBilled: boolean }[]
   defaultOrganizationId: string | null
   claimToken: string
 }
 
 /**
- * Workspace picker for an App-Store-initiated install. Under Shopify App Pricing the
- * plan picker lives on Shopify's hosted page, so this flow only chooses which Auxx
- * workspace the shop attaches to (a shop can belong to more than one). Clicking
- * "Continue to plan selection" finalizes the install and browser-redirects to Shopify's
- * pricing page; the merchant picks + approves there and returns to
- * `/billing/subscription/activated`.
+ * Workspace picker for an App-Store-initiated install. This flow only chooses which Auxx
+ * workspace the shop attaches to (a shop can belong to more than one) — the outcome depends
+ * on the selected workspace's billing:
+ * - Workspace with no/dead billing (new App Store merchant): finalize redirects to Shopify's
+ *   hosted plan picker; the merchant approves there and returns to
+ *   `/billing/subscription/activated`.
+ * - Workspace already on live Stripe billing: per the §4.5 operating model, connecting
+ *   Shopify keeps Stripe untouched — no plan picker. Finalize just attaches the data
+ *   integration and drops them on the Shopify app page.
  */
 export function ClaimFlow({ shop, orgs, defaultOrganizationId, claimToken }: ClaimFlowProps) {
   const [selectedOrgId, setSelectedOrgId] = useState<string | null>(
     defaultOrganizationId ?? orgs[0]?.id ?? null
   )
+
+  // When the picked workspace already bills through Stripe, this install just connects the
+  // shop (no plan selection) — drives the copy below.
+  const keepsBilling = orgs.find((o) => o.id === selectedOrgId)?.stripeBilled ?? false
 
   const finalize = api.shopify.finalizeAppStoreInstall.useMutation({
     onSuccess: ({ redirectUrl }) => {
@@ -64,7 +71,9 @@ export function ClaimFlow({ shop, orgs, defaultOrganizationId, claimToken }: Cla
                 Connect <span className='font-mono text-base'>{shop}</span> to Auxx
               </CardTitle>
               <CardDescription>
-                Choose the workspace for this shop. You'll pick a plan on Shopify next.
+                {keepsBilling
+                  ? 'Choose the workspace for this shop. Your current billing stays unchanged.'
+                  : "Choose the workspace for this shop. You'll pick a plan on Shopify next."}
               </CardDescription>
             </CardHeader>
             <CardContent className='flex flex-col gap-6'>
@@ -122,7 +131,7 @@ export function ClaimFlow({ shop, orgs, defaultOrganizationId, claimToken }: Cla
                 disabled={finalizeDisabled}
                 loading={finalize.isPending}
                 loadingText='Connecting…'>
-                Continue to plan selection
+                {keepsBilling ? 'Connect shop' : 'Continue to plan selection'}
               </Button>
             </CardContent>
           </Card>

--- a/apps/web/src/app/(auth)/shopify/claim/page.tsx
+++ b/apps/web/src/app/(auth)/shopify/claim/page.tsx
@@ -98,24 +98,43 @@ export default async function ShopifyClaimPage({ searchParams }: PageProps) {
   const defaultOrgId =
     (session.user as { defaultOrganizationId?: string | null }).defaultOrganizationId ?? null
 
+  // Per-org profile + billing for every workspace the user is in (all cached — one Redis
+  // lookup each). `stripeBilled` drives the claim copy: an org already on live Stripe
+  // billing keeps it (no plan picker), so the flow says "connect" not "pick a plan".
+  // `isLiveShopifyLink` short-circuits the picker when the shop is already attached.
+  const orgInfos = await Promise.all(
+    activeMemberships.map(async (m) => {
+      const [profile, sub] = await Promise.all([
+        getOrgCache().get(m.organizationId, 'orgProfile'),
+        getOrgCache().get(m.organizationId, 'subscription'),
+      ])
+      const stripeBilled =
+        sub?.billingProvider === 'stripe' &&
+        sub.status !== 'incomplete' &&
+        sub.status !== 'canceled' &&
+        sub.status !== 'incomplete_expired'
+      const isLiveShopifyLink =
+        sub?.billingProvider === 'shopify' &&
+        sub.shopifyShopDomain === claim.shop &&
+        sub.status !== 'canceled' &&
+        sub.status !== 'incomplete'
+      return {
+        id: profile.id,
+        name: profile.name,
+        handle: profile.handle,
+        stripeBilled,
+        isLiveShopifyLink,
+      }
+    })
+  )
+
   // Short-circuit the picker when this shop is already linked to a single *live*
   // workspace. Shopify's "Open app" re-runs the install → OAuth → claim round-trip on
   // every open, so an already-billed merchant lands here repeatedly; drop them straight
   // into that workspace instead of re-picking it. `incomplete`/`canceled` rows are
   // excluded — those still belong in the picker → finalizeAppStoreInstall flow (resume
   // plan selection / fresh link). A shop attached to >1 live org stays ambiguous → picker.
-  const liveLinkedOrgIds: string[] = []
-  for (const m of activeMemberships) {
-    const sub = await getOrgCache().get(m.organizationId, 'subscription')
-    const isLiveLink =
-      sub?.billingProvider === 'shopify' &&
-      sub.shopifyShopDomain === claim.shop &&
-      sub.status !== 'canceled' &&
-      sub.status !== 'incomplete'
-    if (isLiveLink) {
-      liveLinkedOrgIds.push(m.organizationId)
-    }
-  }
+  const liveLinkedOrgIds = orgInfos.filter((o) => o.isLiveShopifyLink).map((o) => o.id)
 
   if (liveLinkedOrgIds.length === 1) {
     const targetOrgId = liveLinkedOrgIds[0]
@@ -128,13 +147,13 @@ export default async function ShopifyClaimPage({ searchParams }: PageProps) {
   }
 
   // A Shopify store can be attached to more than one Auxx org, so show the picker with
-  // every workspace the user is in (per-org profile is cached).
-  const orgs = await Promise.all(
-    activeMemberships.map(async (m) => {
-      const profile = await getOrgCache().get(m.organizationId, 'orgProfile')
-      return { id: profile.id, name: profile.name, handle: profile.handle }
-    })
-  )
+  // every workspace the user is in (profile + billing already resolved above).
+  const orgs = orgInfos.map((o) => ({
+    id: o.id,
+    name: o.name,
+    handle: o.handle,
+    stripeBilled: o.stripeBilled,
+  }))
 
   return (
     <ClaimFlow

--- a/apps/web/src/app/(protected)/app/settings/apps/installed/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/installed/page.tsx
@@ -3,6 +3,7 @@ import { Input } from '@auxx/ui/components/input'
 // apps/web/src/app/(protected)/app/settings/apps/installed/page.tsx
 import { Code } from 'lucide-react'
 import { useState } from 'react'
+import { dedupeInstallationsByApp } from '~/components/apps/dedupe-installations'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { AppListCard } from '~/components/apps/ui/app-list-card'
 import SettingsPage from '~/components/global/settings-page'
@@ -18,7 +19,8 @@ export default function AppsInstalledListPage() {
   })
   const { data: results } = api.apps.list.useQuery({})
 
-  const installed = installedResult?.installations ?? []
+  // Collapse dev+production installs of the same app to one entry (see helper).
+  const installed = dedupeInstallationsByApp(installedResult?.installations ?? [])
   const apps = results?.apps ?? []
 
   // Search state

--- a/apps/web/src/app/(protected)/app/settings/apps/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/page.tsx
@@ -17,6 +17,7 @@ import {
 import Link from 'next/link'
 // ~/app/(protected)/app/settings/integrations/_components/integration-list.tsx
 import { useLayoutEffect, useRef, useState } from 'react'
+import { dedupeInstallationsByApp } from '~/components/apps/dedupe-installations'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { AppListCard } from '~/components/apps/ui/app-list-card'
 import SettingsPage from '~/components/global/settings-page'
@@ -48,7 +49,8 @@ export default function IntegrationList() {
   const { data: installedResult } = api.apps.listInstalled.useQuery({
     // type filter is optional - omitting it returns all installations (both dev and production)
   })
-  const installed = installedResult?.installations ?? []
+  // Collapse dev+production installs of the same app to one entry (see helper).
+  const installed = dedupeInstallationsByApp(installedResult?.installations ?? [])
   const apps = results?.apps ?? []
 
   // Search state

--- a/apps/web/src/components/agents/procedures/nodes/condition-block-node-view.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/condition-block-node-view.tsx
@@ -26,7 +26,7 @@ export function ConditionBlockNodeView({ node, editor, getPos }: NodeViewProps) 
   }
 
   return (
-    <NodeViewWrapper as='div' className='my-2'>
+    <NodeViewWrapper as='div' className='my-2' data-condition-block=''>
       <NodeViewContent />
       <div className='mt-1 flex items-center gap-2 pl-8' contentEditable={false}>
         <Button variant='ghost' size='xs' onClick={addCase}>

--- a/apps/web/src/components/agents/procedures/nodes/condition-case-node-view.module.css
+++ b/apps/web/src/components/agents/procedures/nodes/condition-case-node-view.module.css
@@ -1,0 +1,77 @@
+/* apps/web/src/components/agents/procedures/nodes/condition-case-node-view.module.css */
+
+/* The arm's editable content hole holds the predicate (first child) followed by
+   the instruction `block`s. Tiptap renders the hole as `.armContent` wrapping an
+   internal content-holder div; `display: contents` on BOTH removes their boxes
+   so the predicate and the step blocks become flex items of the arm row (the
+   NodeViewWrapper) — letting the predicate sit inline on the keyword line while
+   the steps drop to their own lines below. No schema change. */
+.armContent,
+.armContent > div {
+  display: contents;
+}
+
+/* Predicate — fills line 1 between the keyword and the toggle. */
+.armContent :global(.node-conditionPredicate) {
+  flex: 1 1 0%;
+  min-width: 0;
+}
+
+/* Steps — `order` pushes them past the line-1 chrome (toggle / ✕); `flex-basis`
+   forces each onto its own full-width line; the left padding lines their gutter
+   up with the start of the "If" keyword (label 1.5rem + icon 1.5rem + 2 gaps). */
+.armContent :global(.node-block) {
+  order: 1;
+  flex-basis: 100%;
+  width: 100%;
+  padding-left: 4rem;
+}
+
+/* First-arm label doubles as the drag handle for the whole condition block.
+   Mirrors the block gutter: shows the "6.1" number at rest, swaps to a 6-dot
+   grab grid on hover. */
+.armDragHandle {
+  position: relative;
+  cursor: grab;
+  transition: color 0.15s;
+}
+
+.armDragHandle:active {
+  cursor: grabbing;
+}
+
+.armDragHandle::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 5px;
+  --dot-size: 2px;
+  --dot-gap: 4px;
+  width: var(--dot-size);
+  height: var(--dot-size);
+  border-radius: 50%;
+  background-color: var(--color-muted-foreground);
+  box-shadow:
+    0 var(--dot-gap) 0 var(--color-muted-foreground),
+    0 calc(var(--dot-gap) * -1) 0 var(--color-muted-foreground),
+    calc(var(--dot-gap) * -1) 0 0 var(--color-muted-foreground),
+    calc(var(--dot-gap) * -1) var(--dot-gap) 0 var(--color-muted-foreground),
+    calc(var(--dot-gap) * -1) calc(var(--dot-gap) * -1) 0 var(--color-muted-foreground);
+  transform: translateY(-50%);
+  opacity: 0;
+  transition: opacity 0.15s;
+  pointer-events: none;
+}
+
+@media (hover: hover) {
+  .armDragHandle:hover {
+    color: transparent;
+  }
+  .armDragHandle:hover::before {
+    opacity: 0.7;
+  }
+}
+
+:global(body.is-block-dragging) .armDragHandle::before {
+  opacity: 0 !important;
+}

--- a/apps/web/src/components/agents/procedures/nodes/condition-case-node-view.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/condition-case-node-view.tsx
@@ -5,12 +5,18 @@ import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { cn } from '@auxx/ui/lib/utils'
 import { generateId } from '@auxx/utils'
 import type { NodeViewProps } from '@tiptap/react'
-import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import { NodeViewContent, NodeViewWrapper, useEditorState } from '@tiptap/react'
 import { GitBranch, X } from 'lucide-react'
 import { ConditionContainer, ConditionProvider } from '~/components/conditions'
+import {
+  computeOutlinePath,
+  procedureLineNumberFormatter,
+  procedureNumberPolicy,
+} from '~/components/editor/rich-text/outline-numbering'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useProcedureConditionConfig } from '../hooks/use-procedure-condition-config'
 import { useProcedureEditorContext } from '../ui/procedure-draft-provider'
+import styles from './condition-case-node-view.module.css'
 import { applyBlockMode, findParentBlock, nodePos, switchLosesData } from './condition-helpers'
 
 /**
@@ -56,15 +62,38 @@ export function ConditionCaseNodeView({ node, editor, getPos, updateAttributes }
     applyBlockMode(editor, parent.pos, next)
   }
 
-  const ordinal = (() => {
-    const pos = nodePos(getPos)
-    if (pos == null) return 0
-    try {
-      return editor.state.doc.resolve(pos).index()
-    } catch {
-      return 0
-    }
-  })()
+  // Arm position + hierarchical label, read through `useEditorState` so they
+  // re-render when the doc shifts around this arm (e.g. another arm or a
+  // top-level step removed) — a node view isn't re-rendered for position-only
+  // changes, which would otherwise leave "If"/"Else if" and the number stale.
+  const isFirstArm = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      const pos = nodePos(getPos)
+      if (pos == null) return false
+      try {
+        return editor.state.doc.resolve(pos).index() === 0
+      } catch {
+        return false
+      }
+    },
+  })
+
+  // `{blockNum}.{armNum}` (e.g. "6.1"). Display-only (plan §3.1, drag variant
+  // D1): the whole conditionBlock moves, not the arm.
+  const armLabel = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      const pos = nodePos(getPos)
+      if (pos == null) return null
+      const path = computeOutlinePath(editor.state.doc, pos, procedureNumberPolicy)
+      return procedureLineNumberFormatter({
+        path,
+        nodeName: node.type.name,
+        depth: path.length - 1,
+      })
+    },
+  })
 
   const group: ConditionGroup =
     (node.attrs.group as ConditionGroup | null) ??
@@ -102,43 +131,66 @@ export function ConditionCaseNodeView({ node, editor, getPos, updateAttributes }
       .run()
   }
 
+  // The arm is a single flex-wrap row. The chrome (label, icon, keyword,
+  // toggle) and the editable content hole share it: `display: contents` on the
+  // hole lifts its children (predicate, then steps) into this flex row, so the
+  // predicate box lands inline on line 1 next to the keyword while each step is
+  // forced to its own line below (`basis-full` + `pl-8`, see the CSS module).
   return (
-    <NodeViewWrapper as='div' className='my-1.5'>
-      <div className='flex items-center gap-2' contentEditable={false}>
-        <span className='flex size-6 shrink-0 items-center justify-center rounded-md bg-primary-100 text-primary-700'>
-          <GitBranch className='size-3.5' />
-        </span>
-        <span className='text-xs font-semibold uppercase tracking-wide text-foreground'>
-          {ordinal === 0 ? 'If' : 'Else if'}
-        </span>
-        <div className='ml-auto flex items-center gap-1'>
-          <ModeToggle mode={mode} onChange={changeMode} />
-          <button
-            type='button'
-            onClick={removeArm}
-            aria-label='Remove branch'
-            className='rounded p-0.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'>
-            <X className='size-3.5' />
-          </button>
-        </div>
-      </div>
-
-      <div className='pl-8'>
-        {mode === 'structured' && (
-          <div className='my-1.5' contentEditable={false}>
-            <ConditionProvider
-              conditions={group.conditions}
-              groups={[group]}
-              config={config}
-              onConditionsChange={() => {}}
-              onGroupsChange={onGroupsChange}
-              getAvailableFields={getAvailableFields}
-              getFieldDefinition={getFieldDefinition}>
-              <ConditionContainer showAddButton emptyStateText='Add a condition' />
-            </ConditionProvider>
-          </div>
+    <NodeViewWrapper as='div' className='my-1.5 flex flex-wrap items-start gap-x-2 gap-y-1'>
+      {/* First arm only: this label is the drag handle for the WHOLE condition
+          block (the plugin resolves `data-block-drag-handle="condition"` up to
+          the conditionBlock). Else-if / else labels stay plain — arms can't be
+          reordered or moved on their own. */}
+      <span
+        className={cn(
+          'min-w-6 shrink-0 pt-0.5 text-right text-xs tabular-nums text-muted-foreground',
+          isFirstArm && styles.armDragHandle
         )}
-        <NodeViewContent />
+        contentEditable={false}
+        draggable={isFirstArm}
+        data-block-drag-handle={isFirstArm ? 'condition' : undefined}>
+        {armLabel}
+      </span>
+      <span
+        className='flex size-6 shrink-0 items-center justify-center rounded-md bg-primary-100 text-primary-700'
+        contentEditable={false}>
+        <GitBranch className='size-3.5' />
+      </span>
+      <span
+        className='pt-0.5 text-xs font-semibold uppercase tracking-wide text-foreground'
+        contentEditable={false}>
+        {isFirstArm ? 'If' : 'Else if'}
+      </span>
+
+      {mode === 'structured' && (
+        <div className='min-w-0 flex-1' contentEditable={false}>
+          <ConditionProvider
+            conditions={group.conditions}
+            groups={[group]}
+            config={config}
+            onConditionsChange={() => {}}
+            onGroupsChange={onGroupsChange}
+            getAvailableFields={getAvailableFields}
+            getFieldDefinition={getFieldDefinition}>
+            <ConditionContainer showAddButton emptyStateText='Add a condition' />
+          </ConditionProvider>
+        </div>
+      )}
+
+      {/* `display: contents` — predicate + steps become flex items of this row.
+          The predicate (first child) is flex-1 on line 1; steps drop below. */}
+      <NodeViewContent className={styles.armContent} />
+
+      <div className='ml-auto flex shrink-0 items-center gap-1' contentEditable={false}>
+        <ModeToggle mode={mode} onChange={changeMode} />
+        <button
+          type='button'
+          onClick={removeArm}
+          aria-label='Remove branch'
+          className='rounded p-0.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'>
+          <X className='size-3.5' />
+        </button>
       </div>
       <ConfirmDialog />
     </NodeViewWrapper>

--- a/apps/web/src/components/agents/procedures/nodes/condition-else-node-view.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/condition-else-node-view.tsx
@@ -2,12 +2,34 @@
 'use client'
 
 import type { NodeViewProps } from '@tiptap/react'
-import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import { NodeViewContent, NodeViewWrapper, useEditorState } from '@tiptap/react'
 import { CornerDownRight, X } from 'lucide-react'
+import {
+  computeOutlinePath,
+  procedureLineNumberFormatter,
+  procedureNumberPolicy,
+} from '~/components/editor/rich-text/outline-numbering'
 import { nodePos } from './condition-helpers'
 
 /** `conditionElse` view — the ELSE fallthrough arm (no predicate), `block+` body. */
 export function ConditionElseNodeView({ node, editor, getPos }: NodeViewProps) {
+  // `{blockNum}.{armNum}` (e.g. "6.3"). Display-only. Read via `useEditorState`
+  // so it re-renders on position-only doc shifts (the node view isn't otherwise
+  // re-rendered for those, which would leave the number stale).
+  const armLabel = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      const pos = nodePos(getPos)
+      if (pos == null) return null
+      const path = computeOutlinePath(editor.state.doc, pos, procedureNumberPolicy)
+      return procedureLineNumberFormatter({
+        path,
+        nodeName: node.type.name,
+        depth: path.length - 1,
+      })
+    },
+  })
+
   const removeArm = () => {
     const pos = nodePos(getPos)
     if (pos == null) return
@@ -21,6 +43,9 @@ export function ConditionElseNodeView({ node, editor, getPos }: NodeViewProps) {
   return (
     <NodeViewWrapper as='div' className='my-1.5'>
       <div className='flex items-center gap-2' contentEditable={false}>
+        <span className='min-w-6 shrink-0 text-right text-xs tabular-nums text-muted-foreground'>
+          {armLabel}
+        </span>
         <span className='flex size-6 shrink-0 items-center justify-center rounded-md bg-primary-100 text-primary-700'>
           <CornerDownRight className='size-3.5' />
         </span>

--- a/apps/web/src/components/agents/procedures/nodes/condition-predicate-node-view.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/condition-predicate-node-view.tsx
@@ -20,13 +20,13 @@ export function ConditionPredicateNodeView({ node }: NodeViewProps) {
     <NodeViewWrapper
       as='div'
       className={cn(
-        'relative my-1.5 rounded-lg border border-border bg-background px-3 py-2 text-sm',
+        'relative rounded-lg border border-border bg-background px-3 py-1 text-sm',
         hidden && 'hidden'
       )}>
       <NodeViewContent className='min-h-5 outline-none' />
       {isEmpty && (
         <span
-          className='pointer-events-none absolute left-3 top-2 select-none text-muted-foreground/60'
+          className='pointer-events-none absolute left-3 top-1 select-none text-muted-foreground/60'
           contentEditable={false}
           aria-hidden='true'>
           Write a condition in natural language, type “@” to insert attribute.

--- a/apps/web/src/components/agents/procedures/nodes/procedure-step-badge.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/procedure-step-badge.tsx
@@ -80,7 +80,7 @@ function Pill({
 
 function SubProcedureBadge({ subId, selected }: { subId: string; selected: boolean }) {
   const ctx = useProcedureEditorContext()
-  const name = ctx?.subProcedures.find((s) => s.id === subId)?.name ?? 'Sub-procedure'
+  const name = ctx?.subProcedures.find((s) => s.id === subId)?.name?.trim() || 'Sub-procedure'
   return (
     <Pill
       icon={<Workflow className='size-3.5' />}
@@ -94,7 +94,7 @@ function SubProcedureBadge({ subId, selected }: { subId: string; selected: boole
 
 function CodeBadge({ codeId, selected }: { codeId: string; selected: boolean }) {
   const ctx = useProcedureEditorContext()
-  const name = ctx?.codeBlocks.find((c) => c.id === codeId)?.name ?? 'Code'
+  const name = ctx?.codeBlocks.find((c) => c.id === codeId)?.name?.trim() || 'Code'
   return (
     <Pill
       icon={<Code2 className='size-3.5' />}

--- a/apps/web/src/components/agents/procedures/ui/procedure-detail-bar.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-detail-bar.tsx
@@ -4,11 +4,12 @@
 import { AutosizeInput, type AutosizeInputRef } from '@auxx/ui/components/autosize-input'
 import { Button } from '@auxx/ui/components/button'
 import { useNavStack } from '@auxx/ui/components/nav-stack'
-import { ChevronLeft } from 'lucide-react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { AutosaveIndicator, type AutosaveState } from '../../ui/shared/autosave-indicator'
 import { useProcedure } from '../hooks/use-procedure'
 import { useProcedureMutations } from '../hooks/use-procedure-mutations'
+import { useProcedureDraft } from './procedure-draft-provider'
 import { ProcedurePublishCluster } from './procedure-publish-cluster'
 
 interface ProcedureDetailBarProps {
@@ -21,10 +22,15 @@ interface ProcedureDetailBarProps {
 
 /**
  * The procedure-detail nav bar: the shared-bar content for the pushed `procedure`
- * NavStack level. Same height as the agent tab strip (`h-9`) so the shared
- * `<NavStackBar>` frame doesn't jump as the two cross-fade. Carries Back, the
- * editable procedure name, autosave status, and the publish cluster (status pill +
- * publish/changes/discard + `⌄`: version history / delete).
+ * AND `drill` NavStack levels (same instance). Same height as the agent tab strip
+ * (`h-9`) so the shared `<NavStackBar>` frame doesn't jump as the levels cross-fade.
+ * Carries Back, the editable name, autosave status, and the publish cluster (status
+ * pill + publish/changes/discard + `⌄`: version history / delete).
+ *
+ * Context-aware title: at the `procedure` level the input renames the procedure; when
+ * drilled into a `sub:`/`code:` body it renames THAT block (via the lifted draft owner)
+ * and shows the procedure name as a back-crumb. One header for the whole stack — no
+ * second name field inside the panel.
  *
  * Rendered by `<NavStackBar>` (which sits OUTSIDE `NavStackPanels`' `overflow-hidden`),
  * so the page-level sticky bar pins to the outer `ScrollArea` while the panels slide.
@@ -35,13 +41,27 @@ export function ProcedureDetailBar({ procedureId, autosave, onReload }: Procedur
   // the same overlay the rename writes to.
   const { meta } = useProcedure(procedureId)
   const { patchMeta } = useProcedureMutations()
+  const draft = useProcedureDraft()
 
-  const name = meta?.name ?? 'Procedure'
+  // Which entity the bar is titling: the drilled block when drilled, else the procedure.
+  const drill = draft?.drill ?? null
+  const subId = drill?.startsWith('sub:') ? drill.slice('sub:'.length) : null
+  const codeId = drill?.startsWith('code:') ? drill.slice('code:'.length) : null
+  const isDrilled = Boolean(subId || codeId)
 
-  // Local draft so typing stays smooth; the optimistic store update lands via
-  // `patchMeta`. Re-seed from `name` when it changes externally (procedure switch
-  // or background refetch) but never while the field is focused — that would
-  // clobber an in-progress edit. The bar is reused across procedures (not keyed).
+  const procedureName = meta?.name ?? 'Procedure'
+  const blockName = subId
+    ? draft?.subProcedures.find((s) => s.id === subId)?.name
+    : codeId
+      ? draft?.codeBlocks.find((c) => c.id === codeId)?.name
+      : undefined
+  const name = isDrilled ? (blockName ?? '') : procedureName
+  const placeholder = subId ? 'Sub-procedure name' : codeId ? 'Code block name' : 'Procedure name'
+
+  // Local draft so typing stays smooth; the optimistic update lands via the right
+  // writer. Re-seed from `name` when it changes externally (procedure switch, drill
+  // change, or background refetch) but never while focused — that would clobber an
+  // in-progress edit. The bar is reused across levels (not keyed).
   const inputRef = useRef<AutosizeInputRef>(null)
   const [editValue, setEditValue] = useState(name)
   const [focused, setFocused] = useState(false)
@@ -56,7 +76,9 @@ export function ProcedureDetailBar({ procedureId, autosave, onReload }: Procedur
       setEditValue(name)
       return
     }
-    patchMeta(procedureId, { name: trimmed })
+    if (subId && draft) draft.renameSubProcedure(subId, trimmed)
+    else if (codeId && draft) draft.renameCodeBlock(codeId, trimmed)
+    else patchMeta(procedureId, { name: trimmed })
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -76,6 +98,17 @@ export function ProcedureDetailBar({ procedureId, autosave, onReload }: Procedur
       <Button variant='ghost' size='icon-xs' className='rounded-md' onClick={() => pop()}>
         <ChevronLeft />
       </Button>
+      {isDrilled && (
+        <>
+          <button
+            type='button'
+            onClick={() => pop()}
+            className='shrink-0 truncate max-w-[140px] text-sm text-muted-foreground hover:text-foreground'>
+            {procedureName}
+          </button>
+          <ChevronRight className='size-3.5 shrink-0 text-muted-foreground' />
+        </>
+      )}
       <AutosizeInput
         ref={inputRef}
         value={editValue}
@@ -86,7 +119,7 @@ export function ProcedureDetailBar({ procedureId, autosave, onReload }: Procedur
           commitName()
         }}
         onKeyDown={handleKeyDown}
-        placeholder='Procedure name'
+        placeholder={placeholder}
         inputClassName='text-sm font-medium text-foreground bg-transparent outline-none truncate placeholder:text-muted-foreground'
         minWidth={40}
         maxWidth={240}

--- a/apps/web/src/components/agents/procedures/ui/procedure-draft-provider.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-draft-provider.tsx
@@ -112,6 +112,8 @@ export interface ProcedureDraftContextValue {
   addLocalAttribute: (attr: LocalAttribute) => void
   createSubProcedure: (name: string) => string
   createCodeBlock: (name: string) => string
+  renameSubProcedure: (id: string, name: string) => void
+  renameCodeBlock: (id: string, name: string) => void
 
   // ── the `@` picker / shared-editor seam ──
   activeEditor: Editor | null
@@ -344,6 +346,29 @@ export function ProcedureDraftProvider({
     [commit]
   )
 
+  // Rename a drilled body. Writes the ref (save source) AND the render state, so the
+  // drill header AND the inline badge (which resolves its label from `subProcedures` /
+  // `codeBlocks`) both reflect the new name live.
+  const renameSubProcedure = useCallback(
+    (id: string, name: string) => {
+      const next = subRef.current.map((s) => (s.id === id ? { ...s, name } : s))
+      subRef.current = next
+      setSubProcedures(next)
+      commit()
+    },
+    [commit]
+  )
+
+  const renameCodeBlock = useCallback(
+    (id: string, name: string) => {
+      const next = codeRef.current.map((c) => (c.id === id ? { ...c, name } : c))
+      codeRef.current = next
+      setCodeBlocks(next)
+      commit()
+    },
+    [commit]
+  )
+
   const insertBlock = useCallback(
     (node: Record<string, unknown>) => {
       if (!activeEditor) return
@@ -411,6 +436,8 @@ export function ProcedureDraftProvider({
             addLocalAttribute,
             createSubProcedure,
             createCodeBlock,
+            renameSubProcedure,
+            renameCodeBlock,
             activeEditor,
             handleEditorReady,
             referencePickerRef,
@@ -437,6 +464,8 @@ export function ProcedureDraftProvider({
       addLocalAttribute,
       createSubProcedure,
       createCodeBlock,
+      renameSubProcedure,
+      renameCodeBlock,
       activeEditor,
       handleEditorReady,
       insertBlock,

--- a/apps/web/src/components/agents/procedures/ui/procedure-drill-panel.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-drill-panel.tsx
@@ -2,26 +2,28 @@
 'use client'
 
 import type { FieldType } from '@auxx/database/types'
-import { PROCEDURE_BLOCKS } from '~/components/editor/blocks/allowed-blocks'
-import { PromptEditorContent } from '~/components/editor/prompt-editor'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import CodeEditor, {
   type CodeEditorOutput,
   CodeLanguage,
 } from '~/components/workflow/ui/code-editor'
 import { CodeOutputsEditor } from './code-outputs-editor'
 import { useProcedureDraft } from './procedure-draft-provider'
-import { PROCEDURE_PLACEHOLDER, PROCEDURE_REFERENCE_TABS } from './procedure-editor'
+import { ProseEditorCard } from './prose-editor-card'
 
 /**
  * The full-height drilled body (v9 Phase 6) — the `drill` panel on the outer
- * `agent-detail-tabs` NavStack. ONE bar above it (the shared `ProcedureDetailBar`), so
- * no inner header. Reads the `drill` param + the live entry from the lifted draft owner:
+ * `agent-detail-tabs` NavStack. The shared `ProcedureDetailBar` sits above it; each body
+ * carries its OWN editor wrapper + header (titled with the block name) so the drilled view
+ * reads as a first-class editor, not a bare canvas. Reads the `drill` param + the live
+ * entry from the lifted draft owner:
  *
- *  - `sub:<id>` → a bare full-height prose editor on that sub-procedure's slice (no
- *    header; the detail bar is the only chrome). `@` picker + procedure nodes on.
- *  - `code:<id>` → the {@link CodeOutputsEditor} (declared outputs) above a full-height
- *    Monaco editor over the block's JavaScript. AI codegen is seeded from the declared
- *    local attributes (offered as outputs); a tip documents the ambient `inputs` bag.
+ *  - `sub:<id>` → the shared {@link ProseEditorCard} (focus-gradient border + header with
+ *    copy / char-count / expand) filling the panel height. `@` picker + procedure nodes on.
+ *  - `code:<id>` → the {@link CodeOutputsEditor} (declared outputs) above the `CodeEditor`
+ *    in its OWN wrapper (gradient border + header with format / copy / expand). AI codegen
+ *    is seeded from the declared local attributes (offered as outputs); a tip documents the
+ *    ambient `inputs` bag.
  */
 export function ProcedureDrillPanel() {
   // Null during the procedure→root pop where this panel is still mounted by
@@ -37,6 +39,9 @@ export function ProcedureDrillPanel() {
     handleCodeChange,
     handleCodeOutputsChange,
     localAttributes,
+    subProcedures,
+    codeBlocks,
+    activeEditor,
     handleEditorReady,
     referencePickerRef,
   } = draft
@@ -45,18 +50,17 @@ export function ProcedureDrillPanel() {
 
   if (drill.startsWith('sub:')) {
     const id = drill.slice('sub:'.length)
+    const name = subProcedures.find((s) => s.id === id)?.name ?? 'Sub-procedure'
     return (
-      <div className='flex flex-1 flex-col min-h-0 px-3 py-2'>
-        <PromptEditorContent
+      <div className='flex flex-1 flex-col min-h-0 p-3'>
+        <ProseEditorCard
+          fill
+          title={name}
           initialContent={getSubContent(id)}
           onChange={makeSubChange(id)}
+          activeEditor={activeEditor}
           onEditorReady={handleEditorReady}
-          onFocusChange={() => {}}
           referencePickerRef={referencePickerRef}
-          referenceTabs={PROCEDURE_REFERENCE_TABS}
-          allowedBlocks={PROCEDURE_BLOCKS}
-          slash={false}
-          placeholderText={PROCEDURE_PLACEHOLDER}
         />
       </div>
     )
@@ -65,24 +69,22 @@ export function ProcedureDrillPanel() {
   if (drill.startsWith('code:')) {
     const id = drill.slice('code:'.length)
     const entry = getCodeEntry(id)
+    const name = codeBlocks.find((c) => c.id === id)?.name ?? 'Code'
     // AI codegen — offer the declared attributes as the block's outputs.
     const codeOutputs: CodeEditorOutput[] = localAttributes.map((a) => ({
       name: a.name,
       type: dataTypeToJs(a.dataType),
     }))
     return (
-      <div className='flex flex-1 flex-col min-h-0'>
-        <div className='shrink-0 px-3 pt-2'>
+      <ScrollArea className='h-full' scrollbarClassName='w-1.5 z-20' noFade>
+        <div className='flex flex-col gap-2 p-3'>
           <CodeOutputsEditor
             initialOutputs={entry?.outputs ?? []}
             localAttributes={localAttributes}
             onChange={(outputs) => handleCodeOutputsChange(id, outputs)}
           />
-        </div>
-        <div className='flex flex-1 flex-col min-h-0'>
           <CodeEditor
-            noWrapper
-            isExpand
+            title={name}
             language={CodeLanguage.javascript}
             value={entry?.code ?? ''}
             onChange={(code) => handleCodeChange(id, code)}
@@ -105,7 +107,7 @@ export function ProcedureDrillPanel() {
             }
           />
         </div>
-      </div>
+      </ScrollArea>
     )
   }
 

--- a/apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
@@ -1,43 +1,12 @@
 // apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
 'use client'
 
-import { Dialog, DialogContent, DialogTitle } from '@auxx/ui/components/dialog'
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import Section, { EmptySection } from '@auxx/ui/components/section'
-import { VisuallyHidden } from '@auxx/ui/components/visually-hidden'
-import { cn } from '@auxx/ui/lib/utils'
 import { ListChecks } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
-import { PROCEDURE_BLOCKS } from '~/components/editor/blocks/allowed-blocks'
-import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
-import {
-  PromptCharacterCount,
-  PromptEditorContent,
-  PromptEditorHeader,
-} from '~/components/editor/prompt-editor'
+import { useCallback } from 'react'
 import { type ProcedureDraftContextValue, useProcedureDraft } from './procedure-draft-provider'
 import { ProcedureTriggerHeader } from './procedure-trigger-header'
-
-// Procedures opt into the admin tabs (Tools, Resources, Fields) exactly like the
-// persona editor, PLUS the procedure step tabs (Routing, Code, Sub-procedure,
-// Condition, Attribute) — the `@` picker is the only insertion surface (plan §5).
-// The CRM/inbox tabs from DEFAULT_TABS (people, records, messages) are dropped —
-// they're meaningless inside a procedure; only `articles` carries over.
-export const PROCEDURE_REFERENCE_TABS: ReferenceTab[] = [
-  'articles',
-  'tools',
-  'resources',
-  'fields',
-  'routing',
-  'code',
-  'subprocedure',
-  'condition',
-  'attribute',
-]
-
-// Empty-block hint. Slash is dropped in procedures (`@` is the only insertion
-// surface), so the default "Press '/' for commands" placeholder would be wrong.
-export const PROCEDURE_PLACEHOLDER = 'Write a step, or type @ to add a tool, condition, or field…'
+import { ProseEditorCard } from './prose-editor-card'
 
 /**
  * The procedure authoring canvas — slimmed to the ROOT prose surface (v9 Phase 6).
@@ -73,48 +42,6 @@ function ProcedureEditorBody({ draft }: { draft: ProcedureDraftContextValue }) {
     patchMeta,
   } = draft
 
-  const [isExpanded, setExpanded] = useState(false)
-  const [isFocused, setFocused] = useState(false)
-  const [isCopied, setIsCopied] = useState(false)
-
-  const handleCopy = useCallback(() => {
-    if (!activeEditor) return
-    const text = activeEditor.getText()
-    if (navigator.clipboard) navigator.clipboard.writeText(text)
-    setIsCopied(true)
-    setTimeout(() => setIsCopied(false), 2000)
-  }, [activeEditor])
-
-  const countSlot = useMemo(() => <PromptCharacterCount editor={activeEditor} />, [activeEditor])
-
-  const header = (
-    <PromptEditorHeader
-      title='Procedure'
-      countSlot={countSlot}
-      isExpanded={isExpanded}
-      setExpanded={setExpanded}
-      isCopied={isCopied}
-      onCopy={handleCopy}
-    />
-  )
-
-  // The root prose surface. Rendered inline OR in the expand dialog (one instance at a
-  // time — same as the persona editor). `initialContent` reads the owner's live main
-  // body, so a remount on expand re-seeds the latest content, not a stale snapshot.
-  const prose = (
-    <PromptEditorContent
-      initialContent={mainContent}
-      onChange={handleMainChange}
-      onEditorReady={handleEditorReady}
-      onFocusChange={setFocused}
-      referencePickerRef={referencePickerRef}
-      referenceTabs={PROCEDURE_REFERENCE_TABS}
-      allowedBlocks={PROCEDURE_BLOCKS}
-      slash={false}
-      placeholderText={PROCEDURE_PLACEHOLDER}
-    />
-  )
-
   const handlePatch = useCallback((p: Parameters<typeof patchMeta>[0]) => patchMeta(p), [patchMeta])
 
   if (isLoading || !meta) return <EmptySection loading className='mx-3 my-3' />
@@ -135,42 +62,15 @@ function ProcedureEditorBody({ draft }: { draft: ProcedureDraftContextValue }) {
         description='Describe the situation that should select this procedure.'
         initialOpen
         collapsible={false}>
-        <div
-          className={cn(
-            isFocused && !isExpanded
-              ? 'bg-gradient-to-r from-[#0ba5ec] to-[#155aef]'
-              : 'bg-transparent',
-            '!rounded-[9px] p-0.5 me-1'
-          )}>
-          <div
-            className={cn(isFocused ? 'bg-background' : 'bg-primary-200/30', 'rounded-lg border')}>
-            {header}
-            {!isExpanded && (
-              <div className='px-3'>
-                <div className='relative flex w-full min-h-[300px]'>{prose}</div>
-              </div>
-            )}
-          </div>
-        </div>
+        <ProseEditorCard
+          title='Procedure'
+          initialContent={mainContent}
+          onChange={handleMainChange}
+          activeEditor={activeEditor}
+          onEditorReady={handleEditorReady}
+          referencePickerRef={referencePickerRef}
+        />
       </Section>
-
-      <Dialog open={isExpanded} onOpenChange={setExpanded}>
-        <DialogContent size='3xl' innerClassName='h-[80vh] flex flex-col p-0' showClose={false}>
-          <VisuallyHidden>
-            <DialogTitle>Procedure</DialogTitle>
-          </VisuallyHidden>
-          <div className='shrink-0 border-b'>{header}</div>
-          <div className='flex-1 min-h-0 overflow-hidden'>
-            <ScrollArea
-              className='relative h-full min-h-0 px-3 flex-1 flex'
-              fadeClassName=''
-              allowScrollChaining
-              scrollbarClassName='w-1 mr-0.5 data-[hovering]:opacity-0 hover:!opacity-100'>
-              {isExpanded && prose}
-            </ScrollArea>
-          </div>
-        </DialogContent>
-      </Dialog>
     </>
   )
 }

--- a/apps/web/src/components/agents/procedures/ui/prose-editor-card.tsx
+++ b/apps/web/src/components/agents/procedures/ui/prose-editor-card.tsx
@@ -1,0 +1,168 @@
+// apps/web/src/components/agents/procedures/ui/prose-editor-card.tsx
+'use client'
+
+import { Dialog, DialogContent, DialogTitle } from '@auxx/ui/components/dialog'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { VisuallyHidden } from '@auxx/ui/components/visually-hidden'
+import { cn } from '@auxx/ui/lib/utils'
+import type { JSONContent } from '@tiptap/core'
+import type { Editor } from '@tiptap/react'
+import { type RefObject, useCallback, useMemo, useState } from 'react'
+import { PROCEDURE_BLOCKS } from '~/components/editor/blocks/allowed-blocks'
+import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
+import {
+  PromptCharacterCount,
+  PromptEditorContent,
+  PromptEditorHeader,
+} from '~/components/editor/prompt-editor'
+import type { ReferencePickerHandle } from '~/components/pickers/reference-picker/reference-picker-content'
+
+// Procedures opt into the admin tabs (Tools, Resources, Fields) exactly like the
+// persona editor, PLUS the procedure step tabs (Routing, Code, Sub-procedure,
+// Condition, Attribute) — the `@` picker is the only insertion surface (plan §5).
+// The CRM/inbox tabs from DEFAULT_TABS (people, records, messages) are dropped —
+// they're meaningless inside a procedure; only `articles` carries over.
+export const PROCEDURE_REFERENCE_TABS: ReferenceTab[] = [
+  'articles',
+  'tools',
+  'resources',
+  'fields',
+  'routing',
+  'code',
+  'subprocedure',
+  'condition',
+  'attribute',
+]
+
+// Empty-block hint. Slash is dropped in procedures (`@` is the only insertion
+// surface), so the default "Press '/' for commands" placeholder would be wrong.
+export const PROCEDURE_PLACEHOLDER = 'Write a step, or type @ to add a tool, condition, or field…'
+
+interface ProseEditorCardProps {
+  /** Header label — 'Procedure' at the root, the sub-procedure name when drilled. */
+  title: string
+  /** Initial body content (read once at mount; the owner's refs own it thereafter). */
+  initialContent: JSONContent[]
+  onChange: (e: { json: JSONContent }) => void
+  /** The draft owner's live editor — feeds char count + copy. */
+  activeEditor: Editor | null
+  onEditorReady: (editor: Editor | null) => void
+  referencePickerRef: RefObject<ReferencePickerHandle | null>
+  /**
+   * Fill the parent's height (the drilled sub-procedure panel, which has no outer
+   * ScrollArea) vs. the root's fixed min-height prose that the panel ScrollArea bounds.
+   */
+  fill?: boolean
+}
+
+/**
+ * The procedure prose surface + its chrome (focus-gradient border, {@link PromptEditorHeader}
+ * with char-count / copy / expand-to-dialog). Shared by the root {@link ProcedureEditor} and
+ * the drilled sub-procedure body so both carry the same wrapper — the only difference is
+ * `fill` (the drill fills its panel height; the root uses a min-height inside the panel scroll).
+ */
+export function ProseEditorCard({
+  title,
+  initialContent,
+  onChange,
+  activeEditor,
+  onEditorReady,
+  referencePickerRef,
+  fill = false,
+}: ProseEditorCardProps) {
+  const [isExpanded, setExpanded] = useState(false)
+  const [isFocused, setFocused] = useState(false)
+  const [isCopied, setIsCopied] = useState(false)
+
+  const handleCopy = useCallback(() => {
+    if (!activeEditor) return
+    const text = activeEditor.getText()
+    if (navigator.clipboard) navigator.clipboard.writeText(text)
+    setIsCopied(true)
+    setTimeout(() => setIsCopied(false), 2000)
+  }, [activeEditor])
+
+  const countSlot = useMemo(() => <PromptCharacterCount editor={activeEditor} />, [activeEditor])
+
+  const header = (
+    <PromptEditorHeader
+      title={title}
+      countSlot={countSlot}
+      isExpanded={isExpanded}
+      setExpanded={setExpanded}
+      isCopied={isCopied}
+      onCopy={handleCopy}
+    />
+  )
+
+  // One prose instance; rendered inline OR in the expand dialog (the `!isExpanded` /
+  // `isExpanded` branches are mutually exclusive, so only one mounts at a time).
+  const prose = (
+    <PromptEditorContent
+      initialContent={initialContent}
+      onChange={onChange}
+      onEditorReady={onEditorReady}
+      onFocusChange={setFocused}
+      referencePickerRef={referencePickerRef}
+      referenceTabs={PROCEDURE_REFERENCE_TABS}
+      allowedBlocks={PROCEDURE_BLOCKS}
+      slash={false}
+      placeholderText={PROCEDURE_PLACEHOLDER}
+      alwaysShowLineNumbers
+    />
+  )
+
+  return (
+    <>
+      <div
+        className={cn(
+          isFocused && !isExpanded
+            ? 'bg-gradient-to-r from-[#0ba5ec] to-[#155aef]'
+            : 'bg-transparent',
+          '!rounded-[9px] p-0.5',
+          fill ? 'flex flex-1 flex-col min-h-0' : 'me-1'
+        )}>
+        <div
+          className={cn(
+            isFocused ? 'bg-background' : 'bg-primary-200/30',
+            'rounded-lg border',
+            fill && 'flex flex-1 flex-col min-h-0'
+          )}>
+          {header}
+          {!isExpanded &&
+            (fill ? (
+              <ScrollArea
+                className='relative h-full min-h-0 px-3 flex-1 flex'
+                fadeClassName=''
+                allowScrollChaining
+                scrollbarClassName='w-1 mr-0.5 data-[hovering]:opacity-0 hover:!opacity-100'>
+                {prose}
+              </ScrollArea>
+            ) : (
+              <div className='px-3'>
+                <div className='relative flex w-full min-h-[300px]'>{prose}</div>
+              </div>
+            ))}
+        </div>
+      </div>
+
+      <Dialog open={isExpanded} onOpenChange={setExpanded}>
+        <DialogContent size='3xl' innerClassName='h-[80vh] flex flex-col p-0' showClose={false}>
+          <VisuallyHidden>
+            <DialogTitle>{title}</DialogTitle>
+          </VisuallyHidden>
+          <div className='shrink-0 border-b'>{header}</div>
+          <div className='flex-1 min-h-0 overflow-hidden'>
+            <ScrollArea
+              className='relative h-full min-h-0 px-3 flex-1 flex'
+              fadeClassName=''
+              allowScrollChaining
+              scrollbarClassName='w-1 mr-0.5 data-[hovering]:opacity-0 hover:!opacity-100'>
+              {isExpanded && prose}
+            </ScrollArea>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/apps/web/src/components/apps/dedupe-installations.ts
+++ b/apps/web/src/components/apps/dedupe-installations.ts
@@ -1,0 +1,24 @@
+// apps/web/src/components/apps/dedupe-installations.ts
+
+/**
+ * Collapse an installed-apps list to one entry per app.
+ *
+ * An organization can legitimately hold both a `development` and a `production`
+ * installation of the same app (`installApp` dedupes per installationType, not per app),
+ * so `apps.listInstalled` returns a row per installation. The apps UI renders one card
+ * per app, so without this the same app appears twice (and collides on its React key).
+ *
+ * Keeps the production installation when both exist, otherwise the first seen.
+ */
+export function dedupeInstallationsByApp<
+  T extends { app: { id: string }; installationType: string },
+>(installations: T[]): T[] {
+  const byApp = new Map<string, T>()
+  for (const installation of installations) {
+    const existing = byApp.get(installation.app.id)
+    if (!existing || installation.installationType === 'production') {
+      byApp.set(installation.app.id, installation)
+    }
+  }
+  return [...byApp.values()]
+}

--- a/apps/web/src/components/editor/kb-article/block-drag-plugin.ts
+++ b/apps/web/src/components/editor/kb-article/block-drag-plugin.ts
@@ -20,24 +20,53 @@ interface DraggingState {
   slice: Slice
 }
 
-function getBlockEl(target: EventTarget | null): HTMLElement | null {
+interface DragHandle {
+  el: HTMLElement
+  /**
+   * `'condition'` resolves to the enclosing `conditionBlock` directly (the arm
+   * label is the handle for the whole construct). `'block'` uses the generic
+   * outermost-draggable walk below.
+   */
+  kind: 'block' | 'condition'
+}
+
+function getDragHandle(target: EventTarget | null): DragHandle | null {
   if (!(target instanceof HTMLElement)) return null
-  const gutter = target.closest<HTMLElement>('[data-block-drag-handle]')
-  if (!gutter) return null
+  const handle = target.closest<HTMLElement>('[data-block-drag-handle]')
+  if (!handle) return null
+  const attr = handle.getAttribute('data-block-drag-handle')
   // Article-level drag handles live on `[data-block]`. In-container
   // (panel) drag handles use a different attribute and are handled by
   // their own dnd-kit instance — bail out so we don't grab the panel
   // through this plugin.
-  if (gutter.getAttribute('data-block-drag-handle') === 'panel') return null
+  if (attr === 'panel') return null
+  // Procedure condition arms: the arm label drags the whole `conditionBlock`.
+  // Resolved separately from the generic walk so the per-step gutters INSIDE
+  // an arm still drag the individual step, not the whole construct.
+  if (attr === 'condition') {
+    const el = handle.closest<HTMLElement>('[data-condition-block]')
+    return el ? { el, kind: 'condition' } : null
+  }
   // Match either a flat block or a container element. Containers render
   // their own outer wrapper with `data-tabs` / `data-accordion` / `data-table`.
-  return gutter.closest<HTMLElement>('[data-block], [data-tabs], [data-accordion], [data-table]')
+  const el = handle.closest<HTMLElement>(
+    '[data-block], [data-tabs], [data-accordion], [data-table]'
+  )
+  return el ? { el, kind: 'block' } : null
 }
 
-function blockPos(view: EditorView, blockEl: HTMLElement): number | null {
-  const pos = view.posAtDOM(blockEl, 0)
+function resolveDragPos(view: EditorView, handle: DragHandle): number | null {
+  const pos = view.posAtDOM(handle.el, 0)
   if (pos == null || pos < 0) return null
   const $pos = view.state.doc.resolve(pos)
+  // Condition handle: target the enclosing `conditionBlock` exactly (not the
+  // outermost draggable), so the move grabs the whole if/else construct.
+  if (handle.kind === 'condition') {
+    for (let depth = $pos.depth; depth >= 0; depth--) {
+      if ($pos.node(depth).type.name === 'conditionBlock') return $pos.before(depth)
+    }
+    return null
+  }
   // Walk up to the OUTERMOST draggable so clicking the gutter next to a
   // tabs/accordion container grabs the whole container, not the active
   // panel's first paragraph.
@@ -64,13 +93,14 @@ export function blockDragPlugin() {
 
       const onDragStart = (event: DragEvent) => {
         console.log(`${tag} dragstart on view.dom`, event.target)
-        const blockEl = getBlockEl(event.target)
-        if (!blockEl || !event.dataTransfer) {
-          console.log(`${tag} dragstart bailed: no blockEl or dataTransfer`)
+        const handle = getDragHandle(event.target)
+        if (!handle || !event.dataTransfer) {
+          console.log(`${tag} dragstart bailed: no handle or dataTransfer`)
           return
         }
+        const blockEl = handle.el
 
-        const pos = blockPos(editorView, blockEl)
+        const pos = resolveDragPos(editorView, handle)
         if (pos == null) {
           console.log(`${tag} dragstart bailed: no pos`)
           return

--- a/apps/web/src/components/editor/kb-article/block-node-view.module.css
+++ b/apps/web/src/components/editor/kb-article/block-node-view.module.css
@@ -8,6 +8,9 @@
    Gutter / left rail:
      --editor-gutter-min-width      (24px)
      --editor-gutter-margin-right   (0.75rem)
+   Per-block vertical rhythm (text blocks; headings keep their own margins):
+     --editor-block-margin-top      (0)
+     --editor-block-margin-bottom   (0)
    Body text:
      --editor-text-font-size        (0.875rem)
      --editor-text-line-height      (24px)
@@ -53,6 +56,11 @@
   flex-direction: row;
   overflow: visible;
   max-width: 100%;
+  /* Vertical rhythm — defaults to 0 (no gap). The heading variants below set
+     their own margins and override these. Procedures opt into a little spacing
+     via the `.procedureBlockSpacing` root class. */
+  margin-top: var(--editor-block-margin-top, 0);
+  margin-bottom: var(--editor-block-margin-bottom, 0);
 }
 
 /* ============================================
@@ -132,11 +140,29 @@
   text-align: right;
   color: var(--color-muted-foreground);
   line-height: 24px;
-  opacity: 0;
+  /* Resting opacity is a custom property so the always-show class can flip it
+     without a second `opacity` declaration — the hover / focus / drag rules
+     below set `opacity` directly at higher specificity and always win. */
+  opacity: var(--ln-rest-opacity, 0);
   transition: opacity 0.15s, color 0.15s;
   position: relative;
   pointer-events: none;
   user-select: none;
+}
+
+/* `alwaysShowLineNumbers` (a class on the `.ProseMirror` root, set by
+   useRichTextEditor) raises only the resting opacity — the gutter-hover →
+   drag-dot swap is untouched. Used by the procedure editor. */
+:global(.alwaysShowLineNumbers) {
+  --ln-rest-opacity: 0.5;
+}
+
+/* Procedure surface — give each step a little breathing room. A class on the
+   `.ProseMirror` root (set by useRichTextEditor) so it reaches blocks in both
+   the inline card and the portaled expand dialog. */
+:global(.procedureBlockSpacing) {
+  --editor-block-margin-top: 0.25rem;
+  --editor-block-margin-bottom: 0.25rem;
 }
 
 @media (hover: hover) {

--- a/apps/web/src/components/editor/kb-article/block-node-view.tsx
+++ b/apps/web/src/components/editor/kb-article/block-node-view.tsx
@@ -18,10 +18,15 @@ import type {
 import { CalloutIcon } from '@auxx/ui/components/kb/article'
 import { parseEmbedUrl } from '@auxx/ui/components/kb/utils'
 import type { NodeViewProps } from '@tiptap/react'
-import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import { NodeViewContent, NodeViewWrapper, useEditorState } from '@tiptap/react'
 import { Check, ChevronDown } from 'lucide-react'
 import type React from 'react'
 import { useState } from 'react'
+import {
+  computeOutlinePath,
+  defaultNumberPolicy,
+  flatLineNumberFormatter,
+} from '../rich-text/outline-numbering'
 import type { BlockOptions } from './block-node'
 import styles from './block-node-view.module.css'
 import { CardsBlockView } from './cards-block-view'
@@ -201,25 +206,41 @@ export function BlockNodeView({
     }
   }
 
-  let lineNumber: number | null = null
+  // Gutter label. The path math is factored into `computeOutlinePath`; the
+  // per-surface formatter (flat by default, hierarchical for procedures) turns
+  // it into the displayed string. See `outline-numbering.ts`.
+  //
+  // Read through `useEditorState` so the label re-renders whenever it changes —
+  // including position-only shifts (a block inserted / removed / reordered
+  // elsewhere) that don't touch THIS node and so wouldn't otherwise re-render
+  // its node view, leaving the number stale.
+  const blockOptions = extension.options as BlockOptions
+  const lineLabel = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      const p = typeof getPos === 'function' ? getPos() : null
+      if (typeof p !== 'number') return null
+      const policy = blockOptions.numberPolicy ?? defaultNumberPolicy
+      const formatter = blockOptions.lineNumberFormatter ?? flatLineNumberFormatter
+      const path = computeOutlinePath(editor.state.doc, p, policy)
+      return formatter({ path, nodeName: node.type.name, blockType, depth: path.length - 1 })
+    },
+  })
+
   let numberedIndex = 1
-  if (typeof pos === 'number') {
+  if (typeof pos === 'number' && blockType === 'numberedListItem') {
     const doc = editor.state.doc
     const myIndex = doc.resolve(pos).index(0)
-    lineNumber = myIndex + 1
-
-    if (blockType === 'numberedListItem') {
-      const myLevel = level ?? 1
-      let count = 1
-      for (let i = myIndex - 1; i >= 0; i--) {
-        const sibling = doc.child(i)
-        if (sibling.type.name !== 'block') break
-        if (sibling.attrs.blockType !== 'numberedListItem') break
-        if ((sibling.attrs.level ?? 1) !== myLevel) break
-        count++
-      }
-      numberedIndex = count
+    const myLevel = level ?? 1
+    let count = 1
+    for (let i = myIndex - 1; i >= 0; i--) {
+      const sibling = doc.child(i)
+      if (sibling.type.name !== 'block') break
+      if (sibling.attrs.blockType !== 'numberedListItem') break
+      if ((sibling.attrs.level ?? 1) !== myLevel) break
+      count++
     }
+    numberedIndex = count
   }
 
   const isFocused =
@@ -326,7 +347,7 @@ export function BlockNodeView({
           draggable={true}
           data-block-drag-handle='true'
           onClick={selectThisBlock}>
-          <div className={`${styles.lineNumber} text-xs tabular-nums`}>{lineNumber ?? ''}</div>
+          <div className={`${styles.lineNumber} text-xs tabular-nums`}>{lineLabel ?? ''}</div>
         </div>
 
         <div

--- a/apps/web/src/components/editor/kb-article/block-node.ts
+++ b/apps/web/src/components/editor/kb-article/block-node.ts
@@ -4,6 +4,7 @@ import { type Editor, mergeAttributes, Node } from '@tiptap/core'
 import type { ResolvedPos } from '@tiptap/pm/model'
 import { ReactNodeViewRenderer } from '@tiptap/react'
 import { selectAncestorContent } from '../keymap-helpers'
+import type { LineNumberFormatter, NumberPolicy } from '../rich-text/outline-numbering'
 import { blockDragPlugin } from './block-drag-plugin'
 import { blockIdPlugin } from './block-id-plugin'
 import { BlockNodeView } from './block-node-view'
@@ -53,6 +54,14 @@ const escapeBlockDownward = (editor: Editor, depth: number): boolean => {
 
 export interface BlockOptions {
   placeholderText: string
+  /**
+   * Per-surface gutter label policy. Defaults (undefined) to the flat
+   * top-level number — KB / persona / triggers stay byte-for-byte unchanged.
+   * Procedures inject the hierarchical formatter + policy via
+   * `useRichTextEditor` when condition nodes are mounted.
+   */
+  lineNumberFormatter?: LineNumberFormatter
+  numberPolicy?: NumberPolicy
 }
 
 export const Block = Node.create<BlockOptions>({

--- a/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
+++ b/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
@@ -74,6 +74,11 @@ interface PromptEditorContentProps {
    * surfaces where `@` is the only insertion affordance (procedures).
    */
   slash?: boolean
+  /**
+   * Show the gutter line numbers at rest instead of only on hover/focus.
+   * Defaults to `false`. Forwarded to `useRichTextEditor`.
+   */
+  alwaysShowLineNumbers?: boolean
 }
 
 interface LinkPopoverState {
@@ -108,6 +113,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
   inlineExtensions,
   allowedBlocks = DEFAULT_BLOCKS,
   slash = true,
+  alwaysShowLineNumbers = false,
 }: PromptEditorContentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [linkPopover, setLinkPopover] = useState<LinkPopoverState | null>(null)
@@ -137,6 +143,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
     placeholderText,
     inlineExtensions,
     allowedBlocks,
+    alwaysShowLineNumbers,
   })
 
   const activePicker = useActivePicker(editor)

--- a/apps/web/src/components/editor/rich-text/outline-numbering.ts
+++ b/apps/web/src/components/editor/rich-text/outline-numbering.ts
@@ -1,0 +1,102 @@
+// apps/web/src/components/editor/rich-text/outline-numbering.ts
+
+import type { Node as PMNode } from '@tiptap/pm/model'
+
+/**
+ * Engine output → formatter input. The engine computes the outline `path`; the
+ * formatter is the per-surface rendering policy that turns it into a gutter
+ * string (or `null` for "draw no number").
+ */
+export interface LineNumberContext {
+  /**
+   * 0-based outline path; `[]` = not numbered. e.g. `[5, 0]` → renders `6.1`
+   * (arm), `[5, 0, 1]` → inner instruction `2`. The formatter adds `+1` on
+   * every element, so the engine emits 0-based indices.
+   */
+  path: number[]
+  /** PM node type: 'block' | 'conditionBlock' | 'conditionCase' | 'conditionElse'. */
+  nodeName: string
+  /** For a `block`: its blockType ('text' | 'heading' | …). */
+  blockType?: string
+  /** 0 = top level. */
+  depth: number
+}
+
+export type LineNumberFormatter = (ctx: LineNumberContext) => string | null
+
+/**
+ * Engine-side counting policy. Scheme C (the chosen procedure scheme) only needs
+ * to know which sibling nodes are *skipped* — i.e. the `conditionPredicate`, which
+ * is condition text, not a numbered instruction. There are no transparent
+ * containers and nested conditions are a permanent non-goal, so every structural
+ * level is a numbered level and the path is at most 3 deep.
+ */
+export interface NumberPolicy {
+  /** Skipped sibling — not counted toward indices, never numbered. */
+  isSkipped: (node: PMNode) => boolean
+}
+
+/** KB / persona / triggers — nothing is skipped (flat top-level numbering). */
+export const defaultNumberPolicy: NumberPolicy = {
+  isSkipped: () => false,
+}
+
+/** Procedures — the leading `conditionPredicate` of each arm doesn't count. */
+export const procedureNumberPolicy: NumberPolicy = {
+  isSkipped: (node) => node.type.name === 'conditionPredicate',
+}
+
+/**
+ * Walk from the doc root down to the node at `pos`, returning the 0-based,
+ * skip-adjusted index at each depth. Returns `[]` when `pos` can't be resolved.
+ *
+ * e.g. an instruction inside the first arm of the 6th top-level node →
+ * `[5, 0, 0]` (top-level index 5 = the condition block, arm 0, instruction 0).
+ */
+export function computeOutlinePath(doc: PMNode, pos: number, policy: NumberPolicy): number[] {
+  let $pos: ReturnType<PMNode['resolve']>
+  try {
+    $pos = doc.resolve(pos)
+  } catch {
+    return []
+  }
+  const path: number[] = []
+  for (let depth = 0; depth <= $pos.depth; depth++) {
+    const parent = $pos.node(depth)
+    const rawIndex = $pos.index(depth)
+    let adjusted = 0
+    for (let i = 0; i < rawIndex; i++) {
+      if (!policy.isSkipped(parent.child(i))) adjusted++
+    }
+    path.push(adjusted)
+  }
+  return path
+}
+
+/** Today's behavior — the flat, top-level number (e.g. `7`). */
+export const flatLineNumberFormatter: LineNumberFormatter = ({ path }) =>
+  path.length ? String((path[0] ?? 0) + 1) : null
+
+/**
+ * Procedures — Scheme C (plan §3 DECIDED box). The `conditionBlock` draws no
+ * number of its own; each arm shows `{blockNum}.{armNum}` (`6.1`); instruction
+ * blocks inside an arm restart at a plain `1, 2, 3`; the top-level sequence
+ * resumes after the block. The path is at most `[block, arm, instruction]`.
+ */
+export const procedureLineNumberFormatter: LineNumberFormatter = ({ nodeName, path }) => {
+  switch (nodeName) {
+    case 'conditionBlock': // the construct draws no number of its own
+    case 'conditionPredicate': // condition text, never numbered
+      return null
+    case 'conditionCase': // arm = {blockNum}.{armNum} → "6.1"
+    case 'conditionElse': {
+      const armIdx = path[path.length - 1] ?? 0
+      const ownerIdx = path[path.length - 2] ?? 0 // the conditionBlock's top-level index
+      return `${ownerIdx + 1}.${armIdx + 1}`
+    }
+    case 'block': // top-level → "6"; nested in an arm → plain restart "1"
+      return path.length ? String((path[path.length - 1] ?? 0) + 1) : null
+    default:
+      return null
+  }
+}

--- a/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
+++ b/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
@@ -43,6 +43,7 @@ import { MarkdownPaste } from '../kb-article/markdown-paste'
 import { migrateLegacyContent } from '../kb-article/migrate-legacy-content'
 import { Panel } from '../kb-article/panel-node'
 import { Tabs } from '../kb-article/tabs-node'
+import { procedureLineNumberFormatter, procedureNumberPolicy } from './outline-numbering'
 import { buildReferencePickerExtensions } from './reference-picker-extensions'
 
 // The `doc` content union is derived from the surface's allowed block set (see
@@ -142,6 +143,14 @@ export interface UseRichTextEditorOptions {
    * (replacing the old `enableProcedureNodes` flag).
    */
   allowedBlocks?: EditorBlock[]
+  /**
+   * When `true`, the gutter line numbers are visible at rest instead of fading
+   * in only on hover/focus. Adds a class to the `.ProseMirror` root that flips
+   * the resting opacity custom property; every existing hover / focus / drag
+   * rule keeps working on top. Defaults to `false` (today's behavior). Opt-in
+   * the same way as a procedure block set — used by the procedure editor.
+   */
+  alwaysShowLineNumbers?: boolean
 }
 
 /**
@@ -167,6 +176,7 @@ export function useRichTextEditor({
   placeholderText,
   inlineExtensions,
   allowedBlocks = DEFAULT_BLOCKS,
+  alwaysShowLineNumbers = false,
 }: UseRichTextEditorOptions) {
   const normalizedInitialContent = useMemo<JSONContent>(() => {
     const migrated = migrateLegacyContent(initialContent)
@@ -203,10 +213,21 @@ export function useRichTextEditor({
   const slashCommandRef = useRef(slashCommand)
   slashCommandRef.current = slashCommand
 
+  // Presentation classes on the `.ProseMirror` root — each flips a CSS custom
+  // property consumed by the block renderer. Set on the root (not a wrapper) so
+  // they reach blocks in both the inline card and the portaled expand dialog.
+  const rootClass = [
+    alwaysShowLineNumbers && 'alwaysShowLineNumbers', // resting line-number opacity
+    allowsConditions(allowedBlocks) && 'procedureBlockSpacing', // per-step vertical rhythm
+  ]
+    .filter(Boolean)
+    .join(' ')
+
   const editor = useEditor(
     {
       immediatelyRender: false,
       editable,
+      ...(rootClass ? { editorProps: { attributes: { class: rootClass } } } : {}),
       extensions: [
         createDoc(allowedBlocks),
         StarterKit.configure({
@@ -222,7 +243,18 @@ export function useRichTextEditor({
           history: undefined,
           // Marks stay enabled (bold, italic, strike, code).
         }),
-        placeholderText ? Block.configure({ placeholderText }) : Block,
+        // Hierarchical gutter numbering rides on the same `conditionBlock`
+        // opt-in as the procedure nodes; every other surface keeps the default
+        // flat formatter (set in BlockOptions). placeholderText merges in too.
+        Block.configure({
+          ...(placeholderText ? { placeholderText } : {}),
+          ...(allowsConditions(allowedBlocks)
+            ? {
+                lineNumberFormatter: procedureLineNumberFormatter,
+                numberPolicy: procedureNumberPolicy,
+              }
+            : {}),
+        }),
         // Container nodes (Panel/Tabs/Accordion) and Table are separate PM
         // nodes — mounting them is the enforcement. Not in `allowedBlocks` →
         // not in the schema → unreachable from paste / drag / programmatic.

--- a/apps/web/src/server/api/routers/shopify.ts
+++ b/apps/web/src/server/api/routers/shopify.ts
@@ -2,7 +2,7 @@ import { getProvider, type ShopifyBillingProvider, stripeClient } from '@auxx/bi
 import { WEBAPP_URL } from '@auxx/config/server'
 import { database as db, schema } from '@auxx/database'
 import { getOrgCache, isOrgMember, onCacheEvent, resolveAppSlug } from '@auxx/lib/cache'
-import { BadRequestError, ConflictError } from '@auxx/lib/errors'
+import { ConflictError } from '@auxx/lib/errors'
 import { getQueue, Queues } from '@auxx/lib/jobs/queues'
 import { OrganizationService } from '@auxx/lib/organizations'
 import { disableWebhooks, isShopifyConnected, SyncManager } from '@auxx/lib/shopify'
@@ -423,11 +423,16 @@ export const shopifyRouter = createTRPCRouter({
    * Reads the claim token from the `shopify_claim_token` cookie (or the cross-device
    * `claimToken` input), validates the user is a member of `organizationId`, lazily
    * creates the AppInstallation, writes the WorkflowCredentials + ShopifyIntegration
-   * rows, reconciles any pre-existing PlanSubscription row (the shopify-claim signupSource
-   * skips the Stripe trial seed, so the hot path is no-op; the fallback path covers an
-   * existing Auxx user signing in to claim), upserts the Shopify PlanSubscription row
-   * (status `incomplete`, `planId` null until the merchant picks, `shopifyShopDomain` set
-   * for the Admin API read), and returns `{ redirectUrl }`.
+   * rows, then reconciles any pre-existing PlanSubscription row:
+   * - **No row** (the shopify-claim signupSource skips the Stripe trial seed — the hot path
+   *   for a fresh App Store merchant): upsert the Shopify row + return the hosted plan-picker
+   *   URL.
+   * - **Live Stripe row** (existing Auxx customer installing via the App Store): keep Stripe
+   *   billing untouched, skip the plan picker, return `{ redirectUrl: '/app' }`. Per the §4.5
+   *   operating model, connecting Shopify never changes an existing billing relationship.
+   * - **Dead Stripe row** (incomplete/canceled): drop it and fall through to the Shopify upsert.
+   * The upserted Shopify row is `status: 'incomplete'`, `planId` null until the merchant picks,
+   * `shopifyShopDomain` set for the Admin API read.
    */
   finalizeAppStoreInstall: protectedProcedure
     .input(
@@ -567,6 +572,12 @@ export const shopifyRouter = createTRPCRouter({
           metadata: {
             scope: claim.scope,
             shopDomain: claim.shop,
+            // The hourly token refresh interpolates {shop} in the ConnectionDefinition's
+            // access-token URL from `connectionVariables` (oauth2-workflow.service.ts).
+            // Without this the App-Store-saved credential refreshes against a literal
+            // `https://{shop}.myshopify.com/...` URL and the connection dies an hour after
+            // install — store the subdomain exactly as the in-app OAuth callback does.
+            connectionVariables: { shop: claim.shop.replace(/\.myshopify\.com$/, '') },
           },
         },
         existingConn ? { connectionId: existingConn.id } : undefined
@@ -622,20 +633,33 @@ export const shopifyRouter = createTRPCRouter({
       })
 
       if (existing?.billingProvider === 'stripe') {
-        const reusable =
-          existing.status === 'trialing' ||
-          existing.status === 'incomplete' ||
-          existing.status === 'canceled' ||
-          existing.status === 'incomplete_expired'
-        if (!reusable) {
-          throw new BadRequestError(
-            'This organization has an active paid Stripe subscription. Cancel it before switching to Shopify billing.'
-          )
+        // Operating model (plans/billing/00-multi-provider-billing-overview.md §4.5): an
+        // existing Stripe-billed org that connects Shopify keeps its Stripe billing. We
+        // honor that on the App Store install path too — rather than forcing a provider
+        // switch (or dead-ending on an active sub), attach the Shopify data integration
+        // (credentials + ShopifyIntegration already saved above) and leave billing
+        // untouched: no Shopify PlanSubscription row, no hosted plan picker.
+        const stripeIsLive =
+          existing.status !== 'incomplete' &&
+          existing.status !== 'canceled' &&
+          existing.status !== 'incomplete_expired'
+        if (stripeIsLive) {
+          // Activate the picked workspace first so the apps page opens it rather than the
+          // user's current default org, then drop them on the Shopify app's connections
+          // page — the data integration is now connected and billing is unchanged.
+          if (ctx.session.user.defaultOrganizationId !== organizationId) {
+            await setUserDefaultOrganization(db, userId, organizationId)
+          }
+          return {
+            redirectUrl: '/app/settings/apps/installed/shopify/connections',
+            shop: claim.shop,
+          }
         }
-        // Cancel the auto-created Stripe trial (or whatever Stripe sub is sitting here)
-        // and delete the local row. Calling Stripe directly — not via
-        // resolveBillingProvider — because we're explicitly reconciling that row; the
-        // resolver picks the provider based on the current row, which is exactly the
+        // Dead Stripe row (incomplete / canceled / incomplete_expired) — no working
+        // billing. Cancel any lingering Stripe sub and drop the row so the Shopify upsert
+        // below can establish billing through the App Store path. Calling Stripe directly —
+        // not via resolveBillingProvider — because we're explicitly reconciling that row;
+        // the resolver picks the provider based on the current row, which is exactly the
         // value we're about to change. Done this way once at this site only.
         if (existing.stripeSubscriptionId) {
           try {

--- a/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
@@ -4,6 +4,7 @@ import {
   markAppConnectionExpired,
   resolveAppConnectionForRuntime,
 } from '@auxx/services/app-connections'
+import type { ConsoleLog } from '@auxx/services/apps'
 import {
   invokeLambdaExecutor,
   invokeLambdaExecutorStreaming,
@@ -90,9 +91,41 @@ export async function createAppCapabilities(deps: {
     if (!installation.currentDeployment) continue
 
     const serverBundleSha = installation.currentDeployment.serverBundleSha
+    const appDeploymentId = installation.currentDeployment.id
     const appId = installation.app.id
     const appSlug = installation.app.slug
     const installationId = installation.installationId
+
+    // Persist a tool invocation's captured console logs to AppEventLog so they
+    // surface in the dev-portal logs viewer (/apps/<slug>/logs). The agent tool
+    // path doesn't route through apps/api like server-functions / workflow
+    // blocks do, so it must write directly — mirrors quick-action-executor.
+    // Never let logging failure (or empty logs) affect the tool result.
+    const persistAppLogs = async (toolId: string, consoleLogs: unknown, durationMs?: number) => {
+      if (!Array.isArray(consoleLogs) || consoleLogs.length === 0) return
+      try {
+        const { logAppExecution } = await import('@auxx/services/apps')
+        await logAppExecution({
+          appId,
+          organizationId,
+          appDeploymentId,
+          userId: userId ?? '',
+          installationId,
+          consoleLogs: consoleLogs as ConsoleLog[],
+          durationMs,
+          execution: {
+            type: 'tool',
+            toolId,
+            invocationKind: 'agent',
+            sessionId,
+            agentId: agentId ?? null,
+            triggerId: triggerId ?? null,
+          },
+        })
+      } catch {
+        // Logging is best-effort; swallow so it never breaks tool execution.
+      }
+    }
 
     // Per plans/kopilot/apps/agent-credentials.md §3.5 — registration is
     // gated on the bound credId from the agent's (or master's)
@@ -281,7 +314,31 @@ export async function createAppCapabilities(deps: {
                     error: `${res.error.code}: ${res.error.message}`,
                   }
                 } else {
-                  final = { success: true, output: res.value.finalResult }
+                  // The streaming `event: result` frame carries the full
+                  // ExecutionResult (`{ result, metadata: { consoleLogs } }`), not
+                  // the bare tool output — unwrap it so the LLM sees `result`, and
+                  // persist the captured console logs.
+                  const execResult = res.value.finalResult as
+                    | {
+                        result?: unknown
+                        metadata?: {
+                          consoleLogs?: ConsoleLog[]
+                          console_logs?: ConsoleLog[]
+                          duration?: number
+                        }
+                      }
+                    | undefined
+                  const isWrapped =
+                    !!execResult && typeof execResult === 'object' && 'result' in execResult
+                  await persistAppLogs(
+                    toolId,
+                    execResult?.metadata?.consoleLogs ?? execResult?.metadata?.console_logs,
+                    execResult?.metadata?.duration
+                  )
+                  final = {
+                    success: true,
+                    output: isWrapped ? execResult.result : res.value.finalResult,
+                  }
                 }
                 queue.push({ kind: 'done', result: final })
                 wake()
@@ -333,6 +390,9 @@ export async function createAppCapabilities(deps: {
 
             if (lambdaResult.isErr()) {
               const lambdaError = lambdaResult.error
+              // Persist any console output captured before the failure (e.g. the
+              // ServerSDK / provider error logs) so failed calls show in the viewer.
+              await persistAppLogs(toolId, lambdaError.consoleLogs)
               if (prep.resolvedConnectionId && lambdaError.code === 'CONNECTION_REQUIRED') {
                 await markAppConnectionExpired({
                   credentialId: prep.resolvedConnectionId,
@@ -346,6 +406,11 @@ export async function createAppCapabilities(deps: {
               }
             }
             const value = lambdaResult.value
+            await persistAppLogs(
+              toolId,
+              value.metadata?.consoleLogs ?? value.metadata?.console_logs,
+              value.metadata?.duration
+            )
             // Runtime errors thrown via BlockRuntimeError surface here.
             if (value.metadata?.runtime_error) {
               return {

--- a/packages/sdk/src/server/connections.ts
+++ b/packages/sdk/src/server/connections.ts
@@ -33,6 +33,28 @@ export interface Connection {
 }
 
 /**
+ * Optional value an app's `connection-added` event handler may return to name
+ * the connection. The platform dedupes this against existing connections in the
+ * same scope (appending " (2)", " (3)", …) and falls back to the app name when
+ * no label is returned.
+ *
+ * @example
+ * // src/events/connection-added.event.ts
+ * export default async function connectionAdded(
+ *   { connection }: { connection: Connection },
+ * ): Promise<ConnectionAddedResult> {
+ *   const me = await fetch('https://api.example.com/me', {
+ *     headers: { Authorization: `Bearer ${connection.value}` },
+ *   }).then((r) => r.json())
+ *   return { label: me.email }
+ * }
+ */
+export interface ConnectionAddedResult {
+  /** Human-readable label for this connection (email, shop domain, workspace name). */
+  label?: string
+}
+
+/**
  * Error thrown when connection is not found.
  * Platform catches this and prompts user to authenticate.
  */

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -7,7 +7,15 @@
  * All implementations are provided by the Auxx platform at runtime.
  */
 
-export { ConnectionExpiredError } from '../shared/errors.js'
+export {
+  ConflictError,
+  ConnectionExpiredError,
+  InsufficientPermissionsError,
+  InvalidInputError,
+  NotFoundError,
+  RateLimitError,
+  UpstreamServiceError,
+} from '../shared/errors.js'
 export * from './auth.js'
 export * from './connections.js'
 export * from './database.js'

--- a/packages/sdk/src/shared/errors.ts
+++ b/packages/sdk/src/shared/errors.ts
@@ -124,6 +124,120 @@ export class ConnectionExpiredError extends AuxxError {
 }
 
 // ============================================================
+// Provider call errors (thrown by app tools/blocks when an
+// external API call fails). Detection across the Lambda sandbox /
+// module boundary uses `error.name` / `error.code`, NOT `instanceof`.
+//
+// NOTE: some names (NotFoundError, ConflictError, RateLimitError)
+// collide with `@auxx/lib/errors` — those are the platform/tRPC
+// classes in a DIFFERENT package. These are the app-facing
+// `@auxx/sdk` contract; import them from `@auxx/sdk/server`.
+// ============================================================
+
+/**
+ * Throw when the provider rejects the request because the connected account
+ * lacks the required permission/scope (typically HTTP 403).
+ *
+ * Distinct from {@link ConnectionExpiredError}: the token is VALID, it just
+ * can't perform this action. The platform does NOT mark the connection
+ * expired — an admin re-authorizes the app with the missing scopes.
+ */
+export class InsufficientPermissionsError extends AuxxError {
+  readonly scope: 'user' | 'organization'
+  readonly requiredScopes?: string[]
+
+  constructor(scope: 'user' | 'organization' = 'organization', requiredScopes?: string[]) {
+    super(
+      `The connected account lacks the required permission${
+        requiredScopes?.length ? ` (${requiredScopes.join(', ')})` : ''
+      }. An admin may need to re-authorize the app with additional scopes.`,
+      'INSUFFICIENT_PERMISSIONS'
+    )
+    this.name = 'InsufficientPermissionsError'
+    this.scope = scope
+    this.requiredScopes = requiredScopes
+  }
+}
+
+/**
+ * Throw when the provider rate-limits the request (HTTP 429). Transient — the
+ * platform surfaces `retryAfterSeconds` to the caller and does NOT mark the
+ * connection expired. Not auto-retried: write operations may be non-idempotent,
+ * so the caller decides whether to retry.
+ */
+export class RateLimitError extends AuxxError {
+  readonly retryAfterSeconds?: number
+
+  constructor(retryAfterSeconds?: number) {
+    super(
+      `Rate limited by the provider${retryAfterSeconds ? `; retry in ~${retryAfterSeconds}s` : ''}.`,
+      'RATE_LIMIT'
+    )
+    this.name = 'RateLimitError'
+    this.retryAfterSeconds = retryAfterSeconds
+  }
+}
+
+/**
+ * Throw when the provider returns a server-side failure (HTTP 5xx) or the
+ * request never completed (network/transport error, connection refused).
+ * Transient and retryable; the connection is NOT marked expired.
+ */
+export class UpstreamServiceError extends AuxxError {
+  readonly statusCode?: number
+
+  constructor(message = 'The provider is temporarily unavailable.', statusCode?: number) {
+    super(message, 'UPSTREAM_ERROR')
+    this.name = 'UpstreamServiceError'
+    this.statusCode = statusCode
+  }
+}
+
+/**
+ * Throw when the provider rejects the request as invalid (HTTP 400/422) — bad
+ * arguments supplied by the caller. The message is surfaced to the agent so it
+ * can correct its input and retry. Nothing is marked expired.
+ *
+ * For workflow-block field-level validation use {@link BlockValidationError}.
+ */
+export class InvalidInputError extends AuxxError {
+  readonly fields?: Array<{ field: string; message: string }>
+
+  constructor(message: string, fields?: Array<{ field: string; message: string }>) {
+    super(message, 'INVALID_INPUT')
+    this.name = 'InvalidInputError'
+    this.fields = fields
+  }
+}
+
+/**
+ * Throw when the requested resource does not exist (HTTP 404). Distinct from
+ * {@link ConnectionNotFoundError} (that's the connection itself) — this lets the
+ * agent report "not found" cleanly instead of surfacing a tool failure.
+ */
+export class NotFoundError extends AuxxError {
+  readonly resource?: string
+
+  constructor(message = 'The requested resource was not found.', resource?: string) {
+    super(message, 'RESOURCE_NOT_FOUND')
+    this.name = 'NotFoundError'
+    this.resource = resource
+  }
+}
+
+/**
+ * Throw when the request conflicts with the resource's current state (HTTP 409)
+ * — e.g. an order already refunded, a duplicate create. Signals the caller it is
+ * a state conflict, not something to blindly retry.
+ */
+export class ConflictError extends AuxxError {
+  constructor(message = 'The request conflicts with the current state of the resource.') {
+    super(message, 'CONFLICT')
+    this.name = 'ConflictError'
+  }
+}
+
+// ============================================================
 // Workflow block execution errors (thrown inside execute())
 // ============================================================
 

--- a/packages/sdk/src/shared/index.ts
+++ b/packages/sdk/src/shared/index.ts
@@ -8,13 +8,19 @@ export {
   AuxxUnexpectedTransportError,
   BlockRuntimeError,
   BlockValidationError,
+  ConflictError,
   ConnectionExpiredError,
   ExtensionInitError,
   ExtensionLoadError,
+  InsufficientPermissionsError,
+  InvalidInputError,
   MessageError,
+  NotFoundError,
+  RateLimitError,
   RenderError,
   ServerFunctionError,
   SurfaceError,
+  UpstreamServiceError,
 } from './errors.js'
 // Export fetchable state utilities
 export {

--- a/packages/sdk/template/src/events/connection-added.event.ts
+++ b/packages/sdk/template/src/events/connection-added.event.ts
@@ -1,8 +1,12 @@
 // src/events/connection-added.event.ts
 import { createWebhookHandler, updateWebhookHandler } from '@auxx/sdk/server'
-import type { Connection } from '@auxx/sdk/server'
+import type { Connection, ConnectionAddedResult } from '@auxx/sdk/server'
 
-export default async function connectionAdded({ connection }: { connection: Connection }) {
+export default async function connectionAdded({
+  connection,
+}: {
+  connection: Connection
+}): Promise<ConnectionAddedResult> {
   // You can create multiple webhook handlers for the same file
   const webhookHandler = await createWebhookHandler({
     fileName: 'example',
@@ -31,4 +35,15 @@ export default async function connectionAdded({ connection }: { connection: Conn
   await updateWebhookHandler(webhookHandler.id, {
     externalWebhookId: 'someId', //body.webhookId,
   })
+
+  // Optionally name this connection so it's recognizable in the connections
+  // list (otherwise it falls back to the app name, e.g. "Acme (2)"). Use
+  // whatever identifies the account — the authenticated email, a workspace
+  // name, a shop domain, etc. Returning nothing keeps the default label.
+  // const profile = await fetch('https://api.acmeinc.com/me', {
+  //   headers: { Authorization: `Bearer ${connection.value}` },
+  // }).then((r) => r.json())
+  // return { label: profile.email }
+
+  return {}
 }

--- a/packages/services/src/app-connections/save-app-connection.ts
+++ b/packages/services/src/app-connections/save-app-connection.ts
@@ -8,6 +8,7 @@ import { triggerAppEvent } from '../app-events'
 import { resolveActiveInstallationId } from '../app-installations/resolve-active-installation'
 import { getInstallationCatalog, provisionAppFields } from '../custom-fields/app-field-provisioning'
 import { fromDatabase } from '../shared/utils'
+import { renameAppConnection } from './rename-app-connection'
 import { logger, safeSerializeMetadata } from './utils'
 
 /**
@@ -181,10 +182,12 @@ export async function saveAppConnection(
   // Create new connection with auto-generated label
   logger.info('Creating new app connection')
 
-  // Generate auto-increment label
+  // Generate the initial label. Defaults to the app name, deduped within this
+  // connection's own visibility scope (see dedupeLabel). An app's
+  // connection-added handler may replace it with something meaningful below.
   const label =
     options?.label ||
-    (await generateConnectionLabel(appName, organizationId, appId, appInstallationId))
+    (await dedupeLabel(appName, { organizationId, appId, appInstallationId, userId }))
 
   // Parse expiresAt for database field (duplicate from encrypted data for querying)
   const expiresAt = connectionData.expiresAt ? new Date(connectionData.expiresAt) : null
@@ -280,36 +283,85 @@ export async function saveAppConnection(
     })
   } else {
     logger.info('Triggered connection-added event', { credentialId: created.id })
+
+    // An app's connection-added handler may return `{ label }` to name the
+    // connection meaningfully — the shop domain, the authenticated email, the
+    // workspace name. An explicit caller-provided label (options.label) wins.
+    // Best-effort: a missing/failed handler or rename leaves the autoincrement
+    // label intact and never fails the connection save.
+    if (!options?.label) {
+      const handlerResult = eventResult.value.result
+      const handlerLabel =
+        handlerResult && typeof handlerResult === 'object' && 'label' in handlerResult
+          ? String((handlerResult as { label?: unknown }).label ?? '').trim()
+          : ''
+
+      if (handlerLabel) {
+        const deduped = await dedupeLabel(
+          handlerLabel,
+          { organizationId, appId, appInstallationId, userId },
+          created.id
+        )
+        const renamed = await renameAppConnection(created.id, deduped, organizationId)
+        if (renamed.isErr()) {
+          logger.error('Failed to apply handler connection label', {
+            credentialId: created.id,
+            error: renamed.error,
+          })
+        }
+      }
+    }
   }
 
   return ok(created.id)
 }
 
 /**
- * Generate an auto-incrementing connection label.
- * First connection: "AppName", second: "AppName (2)", etc.
+ * Make a desired connection label unique within its visibility scope by
+ * appending the lowest free `(n)` suffix: "Gmail", "Gmail (2)", "Gmail (3)".
+ *
+ * Scope is matched to how the connections UI renders rows — Personal rows are
+ * filtered to a single user, Workspace rows are org-wide — so dedup counts only
+ * rows the same viewer would see:
+ *  - `userId === null`  → workspace scope (other org-wide rows)
+ *  - `userId === <id>`  → that user's personal rows
+ *
+ * `excludeId` skips a just-inserted row when re-deriving its own label.
  */
-async function generateConnectionLabel(
-  appName: string,
-  organizationId: string,
-  appId: string,
-  appInstallationId: string
+async function dedupeLabel(
+  desired: string,
+  scope: {
+    organizationId: string
+    appId: string
+    appInstallationId: string
+    userId: string | null
+  },
+  excludeId?: string
 ): Promise<string> {
   const existingResult = await fromDatabase(
     database.query.WorkflowCredentials.findMany({
-      where: (creds, { eq, and, isNull }) =>
+      where: (creds, { eq, and, isNull, ne }) =>
         and(
-          eq(creds.organizationId, organizationId),
-          eq(creds.appId, appId),
-          eq(creds.appInstallationId, appInstallationId),
+          eq(creds.organizationId, scope.organizationId),
+          eq(creds.appId, scope.appId),
+          eq(creds.appInstallationId, scope.appInstallationId),
           eq(creds.type, 'app-connection'),
-          isNull(creds.userId)
+          scope.userId === null ? isNull(creds.userId) : eq(creds.userId, scope.userId),
+          excludeId ? ne(creds.id, excludeId) : undefined
         ),
-      columns: { id: true },
+      columns: { label: true },
     }),
-    'count-existing-connections'
+    'dedupe-connection-label'
   )
 
-  const count = existingResult.isOk() ? existingResult.value.length : 0
-  return count === 0 ? appName : `${appName} (${count + 1})`
+  const taken = new Set(
+    (existingResult.isOk() ? existingResult.value : [])
+      .map((row) => row.label)
+      .filter((l): l is string => !!l)
+  )
+
+  if (!taken.has(desired)) return desired
+  let n = 2
+  while (taken.has(`${desired} (${n})`)) n++
+  return `${desired} (${n})`
 }

--- a/packages/services/src/app-events/index.ts
+++ b/packages/services/src/app-events/index.ts
@@ -112,7 +112,7 @@ export async function triggerAppEvent(params: {
   if (!serverBundle) {
     // No server bundle - app doesn't have event handlers
     logger.info('No server bundle for app, skipping event', { appInstallationId })
-    return ok(undefined)
+    return ok({ result: undefined })
   }
 
   // Build context and invoke Lambda via shared helper
@@ -151,5 +151,7 @@ export async function triggerAppEvent(params: {
   }
 
   logger.info('Event execution completed', { appInstallationId, eventType })
-  return ok(undefined)
+  // Surface the handler's return value so callers (e.g. saveAppConnection
+  // reading a `connection-added` { label }) can act on it.
+  return ok({ result: lambdaResult.value.execution_result })
 }

--- a/packages/services/src/lambda-execution/invoke-lambda-executor-streaming.ts
+++ b/packages/services/src/lambda-execution/invoke-lambda-executor-streaming.ts
@@ -19,6 +19,7 @@ import { INTERNAL_LAMBDA_URL } from '@auxx/config/server'
 import { signInboundRequest } from '@auxx/credentials/lambda-auth'
 import type { Result } from 'neverthrow'
 import { err, ok } from 'neverthrow'
+import { KNOWN_ERROR_STATUS } from './invoke-lambda-executor'
 
 export interface StreamEvent {
   event: string
@@ -169,7 +170,7 @@ export async function invokeLambdaExecutorStreaming(params: {
       return err({
         code: isConnectionError ? 'CONNECTION_REQUIRED' : code,
         message,
-        statusCode: isConnectionError ? 403 : 500,
+        statusCode: isConnectionError ? 403 : (KNOWN_ERROR_STATUS[code] ?? 500),
       })
     }
 

--- a/packages/services/src/lambda-execution/invoke-lambda-executor.ts
+++ b/packages/services/src/lambda-execution/invoke-lambda-executor.ts
@@ -6,6 +6,21 @@ import type { Result } from 'neverthrow'
 import { err, ok } from 'neverthrow'
 
 /**
+ * Stable HTTP status for the typed `@auxx/sdk` provider-call error codes. The
+ * lambda transport always returns 500 on a thrown error, so we re-derive a
+ * meaningful status from the error code. Connection errors are handled
+ * separately (mapped to CONNECTION_REQUIRED / 403) and are intentionally absent.
+ */
+export const KNOWN_ERROR_STATUS: Record<string, number> = {
+  INSUFFICIENT_PERMISSIONS: 403,
+  RATE_LIMIT: 429,
+  UPSTREAM_ERROR: 502,
+  INVALID_INPUT: 400,
+  RESOURCE_NOT_FOUND: 404,
+  CONFLICT: 409,
+}
+
+/**
  * Console log entry from Lambda execution
  */
 export interface ConsoleLog {
@@ -119,12 +134,17 @@ export async function invokeLambdaExecutor(params: {
         })
       }
 
-      // Other errors
+      // Other errors. Known typed `@auxx/sdk` errors get a stable HTTP status so
+      // downstream consumers (kopilot bridge, workflow engine, UI) can branch on
+      // the code without inspecting the (always-500) lambda transport status.
+      // Only the connection errors above trigger `markAppConnectionExpired` — a
+      // 403/429/4xx/5xx from the provider must NOT brick a healthy connection.
+      const errorCode = errorData.error?.code || 'EXECUTION_ERROR'
       return err({
-        code: errorData.error?.code || 'EXECUTION_ERROR',
+        code: errorCode,
         message: errorData.error?.message || 'Lambda execution failed',
         details: errorData.error?.details,
-        statusCode: lambdaResponse.status,
+        statusCode: KNOWN_ERROR_STATUS[errorCode] ?? lambdaResponse.status,
         consoleLogs: errorConsoleLogs,
       })
     }


### PR DESCRIPTION
## Summary

- **App Store install respects existing billing** — an org already on live Stripe billing keeps it when connecting Shopify (operating model §4.5): finalize skips the hosted plan picker, attaches the data integration, and lands the merchant on the Shopify connections page. Orgs with no/dead billing still get the Shopify plan picker.
- **Claim page resolves billing once** — per-org profile + subscription are looked up together (cached); the claim copy and CTA adapt to whether the picked workspace keeps its billing (`Connect shop`) or picks a plan (`Continue to plan selection`).
- **Token-refresh fix** — the App-Store-saved credential now persists `connectionVariables.shop` so the hourly refresh interpolates `{shop}` instead of dying an hour after install against a literal URL.
- **SDK provider-call errors** — added structured error classes (`InsufficientPermissions`, `RateLimit`, `UpstreamService`, `InvalidInput`, `NotFound`, `Conflict`) to `@auxx/sdk` shared errors and mirrored them in the externalized lambda runtime SDK so app code can construct them via `AUXX_SERVER_SDK`. `connection-added` handlers may now name a connection; the platform dedupes it.
- **Editor refinements** — procedures condition-case node view, prose editor card, drill panel, draft provider; KB-article block drag plugin + outline numbering.

## Test plan

- [ ] App Store install into a Stripe-billed org connects Shopify without a plan picker and lands on the connections page
- [ ] App Store install into a new/dead-billing org redirects to the Shopify hosted plan picker
- [ ] Saved Shopify connection survives the hourly token refresh
- [ ] Procedures + KB-article editors render and behave as before