### PR TITLE
feat(procedures): building blocks popover + oauth2 reconnect var reuse

### DIFF
--- a/apps/api/public/app-runtime/index.html
+++ b/apps/api/public/app-runtime/index.html
@@ -73,7 +73,7 @@
 
     <!-- Platform Runtime Bundle (same for ALL extensions) -->
     <!-- Hash is replaced during build: platform.{HASH}.js -->
-    <script src="/api/v1/app-runtime/platform.396ef911.js"></script>
+    <script src="/api/v1/app-runtime/platform.a151919c.js"></script>
 
     <!-- Extension bundle will be loaded dynamically by platform runtime -->
   </body>

--- a/apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
@@ -6,7 +6,10 @@ import { database as db } from '@auxx/database'
 import { resolveAppSlug } from '@auxx/lib/cache'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
-import { interpolateConnectionFields } from '@auxx/services/app-connections'
+import {
+  interpolateConnectionFields,
+  resolveAppConnectionForRuntime,
+} from '@auxx/services/app-connections'
 import crypto from 'crypto'
 
 const OAUTH_REDIRECT_BASE = process.env.NGROK_URL || WEBAPP_URL
@@ -133,11 +136,30 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       codeVerifier = crypto.randomBytes(96).toString('base64url')
     }
 
+    // On reconnect, reuse the variables saved with the existing connection (e.g. the
+    // Shopify shop) so the user isn't asked for them again. Explicit query params still win.
+    let storedVariables: Record<string, string> = {}
+    if (connectionId) {
+      const resolved = await resolveAppConnectionForRuntime({
+        appId,
+        organizationId,
+        userId: session.user.id,
+        connectionId,
+      })
+      if (resolved.isOk()) {
+        const conn = resolved.value.userConnection ?? resolved.value.organizationConnection
+        const vars = conn?.metadata?.connectionVariables
+        if (vars && typeof vars === 'object') {
+          storedVariables = vars as Record<string, string>
+        }
+      }
+    }
+
     // Extract connection variables from query params (allowlisted by definitions)
     const connectionVariables: Record<string, string> = {}
     const connectionVarDefs = features.connectionVariables ?? []
     for (const varDef of connectionVarDefs) {
-      const value = searchParams.get(`var_${varDef.key}`)
+      const value = searchParams.get(`var_${varDef.key}`) ?? storedVariables[varDef.key]
       if (!value && varDef.required !== false) {
         return NextResponse.json(
           { error: `Missing required variable: ${varDef.label}` },

--- a/apps/web/src/components/agents/procedures/nodes/condition-block-node-view.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/condition-block-node-view.tsx
@@ -5,7 +5,13 @@ import { Button } from '@auxx/ui/components/button'
 import type { NodeViewProps } from '@tiptap/react'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import { Plus } from 'lucide-react'
-import { appendChild, newConditionCase, newConditionElse, nodePos } from './condition-helpers'
+import {
+  appendChild,
+  insertConditionCase,
+  newConditionCase,
+  newConditionElse,
+  nodePos,
+} from './condition-helpers'
 
 /**
  * `conditionBlock` view — an IF / ELSE-IF / ELSE construct rendered inline-expanded
@@ -18,7 +24,7 @@ export function ConditionBlockNodeView({ node, editor, getPos }: NodeViewProps) 
 
   const addCase = () => {
     const pos = nodePos(getPos)
-    if (pos != null) appendChild(editor, pos, newConditionCase())
+    if (pos != null) insertConditionCase(editor, pos, newConditionCase())
   }
   const addElse = () => {
     const pos = nodePos(getPos)

--- a/apps/web/src/components/agents/procedures/nodes/condition-block-node.ts
+++ b/apps/web/src/components/agents/procedures/nodes/condition-block-node.ts
@@ -12,12 +12,17 @@ import { ConditionBlockNodeView } from './condition-block-node-view'
  * fixed child type). The two child node NAMES are listed explicitly in `content`
  * because PM resolves bare tokens to node names before groups.
  *
+ * The grammar `conditionCase+ conditionElse?` enforces the construct structurally:
+ * at least one IF/ELSE-IF arm, and AT MOST ONE ELSE that must come LAST. PM rejects
+ * a second else or an else-before-case at the schema level (the footer's `!hasElse`
+ * guard is the matching soft UI gate).
+ *
  * See plans/chat/v9/phase-2-authoring.md §1.1 and phase-0 §3.
  */
 export const ConditionBlock = Node.create({
   name: 'conditionBlock',
   group: 'procedureBlock',
-  content: '(conditionCase | conditionElse)+',
+  content: 'conditionCase+ conditionElse?',
   defining: true,
 
   addAttributes() {

--- a/apps/web/src/components/agents/procedures/nodes/condition-else-node-view.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/condition-else-node-view.tsx
@@ -58,7 +58,7 @@ export function ConditionElseNodeView({ node, editor, getPos }: NodeViewProps) {
           <X className='size-3.5' />
         </button>
       </div>
-      <div className='pl-8'>
+      <div className='pl-16'>
         <NodeViewContent />
       </div>
     </NodeViewWrapper>

--- a/apps/web/src/components/agents/procedures/nodes/condition-helpers.ts
+++ b/apps/web/src/components/agents/procedures/nodes/condition-helpers.ts
@@ -29,6 +29,27 @@ export function appendChild(
   editor.chain().focus().insertContentAt(insertAt, child).run()
 }
 
+/**
+ * Insert a new IF/ELSE-IF arm into the `conditionBlock` at `containerPos`, keeping
+ * arm precedence intact: if the block ends in an ELSE fallthrough, the case lands
+ * just BEFORE it (a trailing else must stay last — it's the compiler's catch-all);
+ * otherwise it appends at the end.
+ */
+export function insertConditionCase(
+  editor: Editor,
+  containerPos: number,
+  child: Record<string, unknown>
+): void {
+  const node = editor.state.doc.nodeAt(containerPos)
+  if (!node) return
+  const lastChild = node.lastChild
+  const insertAt =
+    lastChild?.type.name === 'conditionElse'
+      ? containerPos + node.nodeSize - 1 - lastChild.nodeSize
+      : containerPos + node.nodeSize - 1
+  editor.chain().focus().insertContentAt(insertAt, child).run()
+}
+
 /** A fresh `conditionCase` arm: empty text predicate (text mode) + one empty body block. */
 export function newConditionCase() {
   return {

--- a/apps/web/src/components/agents/procedures/ui/procedure-blocks-popover.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-blocks-popover.tsx
@@ -1,0 +1,104 @@
+// apps/web/src/components/agents/procedures/ui/procedure-blocks-popover.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  Command,
+  CommandGroup,
+  CommandGroupLabel,
+  CommandIconItem,
+  CommandList,
+  CommandPlaceholder,
+  CommandSeparator,
+} from '@auxx/ui/components/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { Blocks, Code2, Plus, Workflow } from 'lucide-react'
+import { useState } from 'react'
+import { useProcedureDraft } from './procedure-draft-provider'
+
+/**
+ * The "Building blocks" Section action — a popover listing every sub-procedure and
+ * code block that belongs to the open procedure, each in its own labelled group,
+ * plus a create group. Selecting any row (existing or create) drills into that body
+ * on the outer NavStack via `openDrill('sub:<id>' | 'code:<id>')`.
+ */
+export function ProcedureBlocksPopover() {
+  const draft = useProcedureDraft()
+  const [open, setOpen] = useState(false)
+  if (!draft) return null
+
+  const { subProcedures, codeBlocks, createSubProcedure, createCodeBlock, openDrill } = draft
+
+  // Close the popover, then navigate to the drilled body.
+  const go = (key: string) => {
+    openDrill(key)
+    setOpen(false)
+  }
+
+  const isEmpty = subProcedures.length === 0 && codeBlocks.length === 0
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant='ghost' size='xs'>
+          <Blocks />
+          Building blocks
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align='end' className='w-72 p-0'>
+        <Command shouldFilter={false} className='rounded-lg'>
+          <CommandList>
+            {isEmpty && <CommandPlaceholder>No building blocks yet</CommandPlaceholder>}
+
+            {subProcedures.length > 0 && (
+              <CommandGroup aria-label='Sub-procedures'>
+                <CommandGroupLabel>Sub-procedures</CommandGroupLabel>
+                {subProcedures.map((s) => (
+                  <CommandIconItem
+                    key={s.id}
+                    icon={<Workflow className='size-4' />}
+                    label={s.name}
+                    value={`sub:${s.id}`}
+                    onSelect={() => go(`sub:${s.id}`)}
+                  />
+                ))}
+              </CommandGroup>
+            )}
+
+            {codeBlocks.length > 0 && (
+              <CommandGroup aria-label='Code blocks'>
+                <CommandGroupLabel>Code blocks</CommandGroupLabel>
+                {codeBlocks.map((c) => (
+                  <CommandIconItem
+                    key={c.id}
+                    icon={<Code2 className='size-4' />}
+                    label={c.name}
+                    value={`code:${c.id}`}
+                    onSelect={() => go(`code:${c.id}`)}
+                  />
+                ))}
+              </CommandGroup>
+            )}
+
+            <CommandSeparator />
+
+            <CommandGroup aria-label='Create'>
+              <CommandIconItem
+                icon={<Plus className='size-4' />}
+                label='Create sub-procedure'
+                value='__create-subprocedure'
+                onSelect={() => go(`sub:${createSubProcedure('')}`)}
+              />
+              <CommandIconItem
+                icon={<Plus className='size-4' />}
+                label='Create code block'
+                value='__create-code'
+                onSelect={() => go(`code:${createCodeBlock('')}`)}
+              />
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/agents/procedures/ui/procedure-draft-provider.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-draft-provider.tsx
@@ -2,7 +2,6 @@
 'use client'
 
 import type { CodeOutput, LocalAttribute, TriggerExample } from '@auxx/lib/agents/procedures/client'
-import { parseStepBadgeId } from '@auxx/lib/agents/procedures/client'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { generateId } from '@auxx/utils'
 import type { JSONContent } from '@tiptap/core'
@@ -155,22 +154,6 @@ function readContent(content: unknown): JSONContent[] {
   return Array.isArray(content) ? (content as JSONContent[]) : []
 }
 
-/** Collect the sub-procedure / code ids referenced by inline step badges in a prose tree. */
-function collectStepRefs(nodes: JSONContent[]): { subs: Set<string>; codes: Set<string> } {
-  const subs = new Set<string>()
-  const codes = new Set<string>()
-  const walk = (node: JSONContent) => {
-    if (node.type === 'reference' && typeof node.attrs?.id === 'string') {
-      const badge = parseStepBadgeId(node.attrs.id)
-      if (badge?.kind === 'subprocedure') subs.add(badge.subProcedureId)
-      else if (badge?.kind === 'code') codes.add(badge.codeBlockId)
-    }
-    if (Array.isArray(node.content)) for (const child of node.content) walk(child)
-  }
-  for (const node of nodes) walk(node)
-  return { subs, codes }
-}
-
 interface ProcedureDraftProviderProps {
   /** Null on the `root` panel — context is null, but this component stays mounted. */
   procedureId: string | null
@@ -215,10 +198,6 @@ export function ProcedureDraftProvider({
   const subRef = useRef<SubProcedureEntry[]>([])
   const codeRef = useRef<CodeBlockEntry[]>([])
   const loadedRef = useRef<string | null>(null)
-  // The open drill id, mirrored in a ref so `flush` (debounced) reads the live value
-  // for the orphan-sweep pin without re-creating the callback on every drill change.
-  const drillRef = useRef<string | null>(drill)
-  drillRef.current = drill
 
   // Seed every slice once per loaded procedure (async query → can't be a ref
   // initializer; seeding in render guarantees the canvas mounts with content). Keyed by
@@ -239,26 +218,18 @@ export function ProcedureDraftProvider({
     setCodeBlocks(codeRef.current)
   }
 
-  // Build + persist the draft from the live refs. The whole-tree orphan sweep runs
-  // HERE (inside the debounced flush), once per idle save. The currently-open drill id
-  // is PINNED through the sweep even if its badge was just deleted from prose, so
-  // editing it never yanks the panel out; it drops on the next flush after the drill
-  // closes (when `drillRef` is null).
+  // Build + persist the draft from the live refs. EVERY building block is kept —
+  // sub-procedures and code blocks are first-class parts of the procedure (authored
+  // via the Building blocks popover), so they persist even when no badge references
+  // them. Deleting the last badge no longer deletes the block. (No orphan sweep.)
   const flush = useCallback(() => {
     if (!procedureId) return
-    const content = mainContentRef.current
-    const subs = subRef.current
-    const codes = codeRef.current
-    const referenced = collectStepRefs([...content, ...subs.flatMap((s) => s.content)])
-    const open = drillRef.current
-    const pinnedSub = open?.startsWith('sub:') ? open.slice('sub:'.length) : null
-    const pinnedCode = open?.startsWith('code:') ? open.slice('code:'.length) : null
     saveDoc(procedureId, {
       type: 'doc',
-      content,
+      content: mainContentRef.current,
       localAttributes: localAttrRef.current,
-      subProcedures: subs.filter((s) => referenced.subs.has(s.id) || s.id === pinnedSub),
-      codeBlocks: codes.filter((c) => referenced.codes.has(c.id) || c.id === pinnedCode),
+      subProcedures: subRef.current,
+      codeBlocks: codeRef.current,
     })
   }, [saveDoc, procedureId])
 
@@ -396,11 +367,7 @@ export function ProcedureDraftProvider({
   }, [])
 
   const openDrill = useCallback((key: string) => void setDrill(key), [setDrill])
-  const closeDrill = useCallback(() => {
-    void setDrill(null)
-    // Flush soon so the orphan sweep (now un-pinned) drops a body whose badge is gone.
-    commit()
-  }, [setDrill, commit])
+  const closeDrill = useCallback(() => void setDrill(null), [setDrill])
 
   const patchMeta = useCallback(
     (fields: MetaPatch) => {

--- a/apps/web/src/components/agents/procedures/ui/procedure-drill-panel.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-drill-panel.tsx
@@ -2,7 +2,6 @@
 'use client'
 
 import type { FieldType } from '@auxx/database/types'
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import CodeEditor, {
   type CodeEditorOutput,
   CodeLanguage,
@@ -76,38 +75,39 @@ export function ProcedureDrillPanel() {
       type: dataTypeToJs(a.dataType),
     }))
     return (
-      <ScrollArea className='h-full' scrollbarClassName='w-1.5 z-20' noFade>
-        <div className='flex flex-col gap-2 p-3'>
+      <div className='flex flex-1 flex-col gap-2 min-h-0 p-3'>
+        <div className='shrink-0'>
           <CodeOutputsEditor
             initialOutputs={entry?.outputs ?? []}
             localAttributes={localAttributes}
             onChange={(outputs) => handleCodeOutputsChange(id, outputs)}
           />
-          <CodeEditor
-            title={name}
-            language={CodeLanguage.javascript}
-            value={entry?.code ?? ''}
-            onChange={(code) => handleCodeChange(id, code)}
-            enableWorkflowCompletions={false}
-            placeholder='// function main(inputs) { … return { <attr>: value } }'
-            codeInputs={[
-              {
-                name: 'inputs',
-                description:
-                  'inputs.vars.<attr> (declared attributes), inputs.subject.<anchor>.<field> (record fields)',
-              },
-            ]}
-            codeOutputs={codeOutputs}
-            tip={
-              <p className='text-xs text-muted-foreground'>
-                <code>main(inputs)</code> receives <code>inputs.vars.&lt;attr&gt;</code> and{' '}
-                <code>inputs.subject.&lt;anchor&gt;.&lt;field&gt;</code>; return{' '}
-                <code>{'{ <attr>: value }'}</code> to write declared outputs.
-              </p>
-            }
-          />
         </div>
-      </ScrollArea>
+        <CodeEditor
+          fill
+          title={name}
+          language={CodeLanguage.javascript}
+          value={entry?.code ?? ''}
+          onChange={(code) => handleCodeChange(id, code)}
+          enableWorkflowCompletions={false}
+          placeholder='// function main(inputs) { … return { <attr>: value } }'
+          codeInputs={[
+            {
+              name: 'inputs',
+              description:
+                'inputs.vars.<attr> (declared attributes), inputs.subject.<anchor>.<field> (record fields)',
+            },
+          ]}
+          codeOutputs={codeOutputs}
+          tip={
+            <p className='text-xs text-muted-foreground'>
+              <code>main(inputs)</code> receives <code>inputs.vars.&lt;attr&gt;</code> and{' '}
+              <code>inputs.subject.&lt;anchor&gt;.&lt;field&gt;</code>; return{' '}
+              <code>{'{ <attr>: value }'}</code> to write declared outputs.
+            </p>
+          }
+        />
+      </div>
     )
   }
 

--- a/apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-editor.tsx
@@ -4,6 +4,7 @@
 import Section, { EmptySection } from '@auxx/ui/components/section'
 import { ListChecks } from 'lucide-react'
 import { useCallback } from 'react'
+import { ProcedureBlocksPopover } from './procedure-blocks-popover'
 import { type ProcedureDraftContextValue, useProcedureDraft } from './procedure-draft-provider'
 import { ProcedureTriggerHeader } from './procedure-trigger-header'
 import { ProseEditorCard } from './prose-editor-card'
@@ -60,6 +61,7 @@ function ProcedureEditorBody({ draft }: { draft: ProcedureDraftContextValue }) {
         title='Procedure'
         icon={<ListChecks className='size-4' />}
         description='Describe the situation that should select this procedure.'
+        actions={<ProcedureBlocksPopover />}
         initialOpen
         collapsible={false}>
         <ProseEditorCard

--- a/apps/web/src/components/agents/procedures/ui/procedure-picker-lists.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-picker-lists.tsx
@@ -5,7 +5,7 @@ import type { FieldType } from '@auxx/database/types'
 import {
   Command,
   CommandGroup,
-  CommandItem,
+  CommandIconItem,
   CommandList,
   CommandPlaceholder,
 } from '@auxx/ui/components/command'
@@ -34,6 +34,8 @@ import { useProcedureEditorContext } from './procedure-draft-provider'
  * `routing` / `code` / `subprocedure` / `condition` tabs and act on the
  * {@link useProcedureEditorContext} (create / drill / insert). Terminal picks call
  * `onSelect(id)` → an inline reference badge; `condition` inserts a block node.
+ *
+ * Rows are the shared {@link CommandIconItem} (icon + truncating label).
  */
 
 interface PickerListProps {
@@ -41,25 +43,6 @@ interface PickerListProps {
   query: string
   /** Insert an inline badge with this id (→ `confirmReferencePicker`). */
   onSelect: (id: string) => void
-}
-
-function Row({
-  icon,
-  label,
-  value,
-  onSelect,
-}: {
-  icon: ReactNode
-  label: string
-  value: string
-  onSelect: () => void
-}) {
-  return (
-    <CommandItem value={value} onSelect={onSelect} className='flex items-center gap-2'>
-      <span className='text-muted-foreground'>{icon}</span>
-      <span className='truncate text-sm'>{label}</span>
-    </CommandItem>
-  )
 }
 
 function matches(label: string, query: string) {
@@ -76,7 +59,7 @@ export function RoutingPickerList({ query, onSelect }: PickerListProps) {
       <CommandList>
         <CommandGroup aria-label='Routing'>
           {matches('End procedure', query) && (
-            <Row
+            <CommandIconItem
               icon={<Square className='size-4' />}
               label='End procedure'
               value='route:finished'
@@ -84,7 +67,7 @@ export function RoutingPickerList({ query, onSelect }: PickerListProps) {
             />
           )}
           {matches('Hand off to human', query) && (
-            <Row
+            <CommandIconItem
               icon={<Hand className='size-4' />}
               label='Hand off to human'
               value='route:handoff'
@@ -92,7 +75,7 @@ export function RoutingPickerList({ query, onSelect }: PickerListProps) {
             />
           )}
           {switchTargets.map((p) => (
-            <Row
+            <CommandIconItem
               key={p.id}
               icon={<CornerDownRight className='size-4' />}
               label={`Switch to ${p.name}`}
@@ -123,7 +106,7 @@ export function SubProcedurePickerList({ query, onSelect }: PickerListProps) {
       <CommandList>
         <CommandGroup aria-label='Sub-procedures'>
           {existing.map((s) => (
-            <Row
+            <CommandIconItem
               key={s.id}
               icon={<Workflow className='size-4' />}
               label={s.name}
@@ -131,7 +114,7 @@ export function SubProcedurePickerList({ query, onSelect }: PickerListProps) {
               onSelect={() => onSelect(`subprocedure:${s.id}`)}
             />
           ))}
-          <Row
+          <CommandIconItem
             icon={<Plus className='size-4' />}
             label={query.trim() ? `Create sub-procedure “${query.trim()}”` : 'Create sub-procedure'}
             value='__create-subprocedure'
@@ -160,7 +143,7 @@ export function CodePickerList({ query, onSelect }: PickerListProps) {
       <CommandList>
         <CommandGroup aria-label='Code'>
           {existing.map((c) => (
-            <Row
+            <CommandIconItem
               key={c.id}
               icon={<Code2 className='size-4' />}
               label={c.name}
@@ -168,7 +151,7 @@ export function CodePickerList({ query, onSelect }: PickerListProps) {
               onSelect={() => onSelect(`code:${c.id}`)}
             />
           ))}
-          <Row
+          <CommandIconItem
             icon={<Plus className='size-4' />}
             label={query.trim() ? `Create code block “${query.trim()}”` : 'Create code block'}
             value='__create-code'
@@ -217,7 +200,7 @@ export function AttributePickerList({ query }: { query: string }) {
         {ctx && name && !taken && (
           <CommandGroup aria-label='Create attribute'>
             {ATTRIBUTE_TYPES.map((t) => (
-              <Row
+              <CommandIconItem
                 key={t.dataType}
                 icon={t.icon}
                 label={`Create “${name}” as ${t.label}`}
@@ -230,7 +213,7 @@ export function AttributePickerList({ query }: { query: string }) {
         {ctx && existing.length > 0 && (
           <CommandGroup aria-label='Attributes'>
             {existing.map((a) => (
-              <Row
+              <CommandIconItem
                 key={a.name}
                 icon={<Variable className='size-4' />}
                 label={a.name}
@@ -254,7 +237,7 @@ export function ConditionPickerList() {
         {!ctx && <CommandPlaceholder>Unavailable</CommandPlaceholder>}
         {ctx && (
           <CommandGroup aria-label='Condition'>
-            <Row
+            <CommandIconItem
               icon={<GitBranch className='size-4' />}
               label='Insert condition (IF / ELSE)'
               value='__insert-condition'

--- a/apps/web/src/components/apps/hooks/use-connect-flow.tsx
+++ b/apps/web/src/components/apps/hooks/use-connect-flow.tsx
@@ -224,7 +224,9 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
       if (def.connectionType === 'oauth2-code') {
         const vars: ConnectionVariable[] =
           (def.oauth2Features as OAuth2Features | null)?.connectionVariables ?? []
-        if (vars.length > 0) {
+        // Reconnect reuses the stored variables (e.g. the Shopify shop) server-side,
+        // so only prompt for them on a fresh connect.
+        if (vars.length > 0 && !next.connectionId) {
           setVariableOpen(true)
         } else {
           kickOauth(next)

--- a/apps/web/src/components/apps/ui/app-connections.tsx
+++ b/apps/web/src/components/apps/ui/app-connections.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
-import { MoreHorizontal, Pencil, Plus, Unplug, User, Users } from 'lucide-react'
+import { MoreHorizontal, Pencil, Plus, RefreshCw, Unplug, User, Users } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
 import { useUser } from '~/hooks/use-user'
@@ -225,6 +225,7 @@ function ConnectionSection({
                               onClick={() =>
                                 flow.start({ target, scope, returnTo, connectionId: conn.id })
                               }>
+                              <RefreshCw />
                               Reconnect
                             </DropdownMenuItem>
                           )}

--- a/apps/web/src/components/workflow/ui/code-editor/code-editor-content.tsx
+++ b/apps/web/src/components/workflow/ui/code-editor/code-editor-content.tsx
@@ -68,6 +68,7 @@ const CodeEditorContent: React.FC = () => {
     height,
     minHeight,
     isExpanded,
+    fill,
     isFocused,
     setIsFocused,
     editorRef,
@@ -219,8 +220,9 @@ const CodeEditorContent: React.FC = () => {
     <WorkflowCompletionsBridge contextRef={workflowContextRef} />
   ) : null
 
-  // When expanded, use full height layout without resize wrapper
-  if (isExpanded) {
+  // When expanded OR fill, use the full-height layout (no resize wrapper) — the
+  // editor fills its bounded parent instead of growing with content.
+  if (isExpanded || fill) {
     return (
       <>
         {bridgeElement}

--- a/apps/web/src/components/workflow/ui/code-editor/code-editor-context.tsx
+++ b/apps/web/src/components/workflow/ui/code-editor/code-editor-context.tsx
@@ -32,6 +32,7 @@ interface CodeEditorContextType {
   headerRight?: React.ReactNode
   tip?: React.ReactNode
   noWrapper?: boolean
+  fill?: boolean
 
   // UI State
   isExpanded: boolean
@@ -98,6 +99,7 @@ export const CodeEditorProvider = ({
   headerRight,
   tip,
   noWrapper = false,
+  fill = false,
   className,
   gradientBorder = true,
   isExpand = false,
@@ -189,6 +191,7 @@ export const CodeEditorProvider = ({
       headerRight,
       tip,
       noWrapper,
+      fill,
 
       // UI State
       isExpanded: isExpand || isExpanded,
@@ -239,6 +242,7 @@ export const CodeEditorProvider = ({
       headerRight,
       tip,
       noWrapper,
+      fill,
       isExpand,
       isExpanded,
       setIsExpanded,

--- a/apps/web/src/components/workflow/ui/code-editor/code-editor-wrapper.tsx
+++ b/apps/web/src/components/workflow/ui/code-editor/code-editor-wrapper.tsx
@@ -22,6 +22,7 @@ const CodeEditorWrapper: React.FC = () => {
     isFocused,
     gradientBorder,
     noWrapper,
+    fill,
     nodeId,
     enableWorkflowCompletions,
     language,
@@ -48,13 +49,17 @@ const CodeEditorWrapper: React.FC = () => {
           isFocused
             ? gradientBorder && 'bg-gradient-to-r from-[#0ba5ec] to-[#155aef]'
             : 'bg-transparent',
-          '!rounded-[9px] p-0.5 w-full'
+          '!rounded-[9px] p-0.5 w-full',
+          // Fill mode: stretch through the bounded parent so the content's
+          // full-height flex layout has a height to resolve against.
+          fill && 'flex min-h-0 flex-1 flex-col'
         )}>
         <div
           className={cn(
             isFocused ? 'bg-background' : 'bg-primary-100',
             'rounded-lg border',
-            shouldAllowOverflow ? 'overflow-visible' : 'overflow-hidden'
+            shouldAllowOverflow ? 'overflow-visible' : 'overflow-hidden',
+            fill && 'flex min-h-0 flex-1 flex-col'
           )}>
           <CodeEditorHeader />
           {!isExpanded && <CodeEditorContent />}

--- a/apps/web/src/components/workflow/ui/code-editor/constants.ts
+++ b/apps/web/src/components/workflow/ui/code-editor/constants.ts
@@ -6,6 +6,13 @@ export const DEFAULT_MIN_HEIGHT = 100
 export const DEFAULT_EDITOR_OPTIONS = {
   readOnly: false,
   domReadOnly: true,
+  // Use the legacy hidden <textarea> input path instead of the EditContext API
+  // (Monaco's default since 0.52). With EditContext on, the focused editable
+  // element is a <div class="native-edit-context"> — NOT a textarea/contentEditable
+  // — so @tanstack/react-hotkeys' input detection (isInputElement) misses it and
+  // global single-key shortcuts ('c' compose, etc.) fire while typing in the editor.
+  // The textarea path is correctly detected and suppresses those hotkeys.
+  editContext: false,
   quickSuggestions: false,
   minimap: { enabled: false },
   lineNumbersMinChars: 1,

--- a/apps/web/src/components/workflow/ui/code-editor/types.ts
+++ b/apps/web/src/components/workflow/ui/code-editor/types.ts
@@ -56,6 +56,13 @@ export interface CodeEditorProps {
   className?: string
   noWrapper?: boolean
   isExpand?: boolean
+  /**
+   * Fill the parent's height instead of growing with content. Renders the
+   * full-height flex layout (no resize handle) for embedding in a flex column
+   * that bounds the height — e.g. the procedure code drill panel. Default is
+   * the content-sized, user-resizable inline box.
+   */
+  fill?: boolean
   tip?: React.ReactNode
   gradientBorder?: boolean
 

--- a/packages/lib/src/agents/procedures/__tests__/compile.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/compile.test.ts
@@ -279,11 +279,15 @@ describe('compileProcedure', () => {
     expect(errors?.some((e) => e.code === 'UNKNOWN_SUBPROCEDURE')).toBe(true)
   })
 
-  it('errors on a declared sub-procedure that is never called', () => {
-    const { errors } = compileProcedure(
+  it('warns (does NOT block publish) on a declared sub-procedure that is never called', () => {
+    const { errors, warnings, compiled } = compileProcedure(
       doc([prose('body')], { subProcedures: [sub('orphan', 'Orphan', [prose('x')])] })
     )
-    expect(errors?.some((e) => e.code === 'UNCALLED_SUBPROCEDURE')).toBe(true)
+    // Unreferenced building blocks are kept on purpose — a warning, not an error.
+    expect(errors?.some((e) => e.code === 'UNCALLED_SUBPROCEDURE')).toBeFalsy()
+    expect(warnings?.some((w) => w.code === 'UNCALLED_SUBPROCEDURE')).toBe(true)
+    // …and the sub-procedure is still compiled into the published output.
+    expect(compiled.subProcedures.orphan).toBeDefined()
   })
 
   it('errors on a code step with no matching code block', () => {

--- a/packages/lib/src/agents/procedures/compile.ts
+++ b/packages/lib/src/agents/procedures/compile.ts
@@ -42,7 +42,6 @@ export interface CompileError {
     | 'MISSING_SWITCH_TARGET'
     | 'MISSING_CALL_TARGET'
     | 'UNKNOWN_SUBPROCEDURE'
-    | 'UNCALLED_SUBPROCEDURE'
     | 'UNKNOWN_CODE_BLOCK'
     | 'UNKNOWN_OUTPUT_ATTRIBUTE'
     | 'EMPTY_CONDITION_GROUP'
@@ -54,10 +53,23 @@ export interface CompileError {
   subProcedureId?: SubProcedureId
 }
 
+/**
+ * Non-blocking compile signals — surfaced for authoring lint, but they do NOT
+ * block publish. `UNCALLED_SUBPROCEDURE` is intentionally a warning: a procedure's
+ * sub-procedures / code blocks are first-class building blocks that persist even
+ * when no badge references them (authored via the Building blocks popover).
+ */
+export interface CompileWarning {
+  code: 'UNCALLED_SUBPROCEDURE'
+  message: string
+  subProcedureId?: SubProcedureId
+}
+
 export interface CompileResult {
   compiled: CompiledProcedure
   contentHash: string
   errors?: CompileError[]
+  warnings?: CompileWarning[]
 }
 
 export function compileProcedure(doc: TiptapDoc): CompileResult {
@@ -284,8 +296,13 @@ export function compileProcedure(doc: TiptapDoc): CompileResult {
     localAttributes: doc.localAttributes ?? [],
   }
 
-  const errors = validate(compiled)
-  return { compiled, contentHash, ...(errors.length > 0 ? { errors } : {}) }
+  const { errors, warnings } = validate(compiled)
+  return {
+    compiled,
+    contentHash,
+    ...(errors.length > 0 ? { errors } : {}),
+    ...(warnings.length > 0 ? { warnings } : {}),
+  }
 }
 
 /** Render a `conditionCase`'s `conditionPredicate` child to a plain NL test string. */
@@ -298,9 +315,13 @@ function predicateText(caseNode: TiptapNode): string {
 
 // ── validation ────────────────────────────────────────────────────────────
 
-function validate(compiled: CompiledProcedure): CompileError[] {
+function validate(compiled: CompiledProcedure): {
+  errors: CompileError[]
+  warnings: CompileWarning[]
+} {
   const { steps, codeBlocks, subProcedures, localAttributes } = compiled
   const errors: CompileError[] = []
+  const warnings: CompileWarning[] = []
 
   const subProcIds = new Set(Object.keys(subProcedures))
   const calledSubProcs = new Set<SubProcedureId>()
@@ -396,10 +417,11 @@ function validate(compiled: CompiledProcedure): CompileError[] {
     }
   }
 
-  // a declared sub-procedure that is never called (the run-time 422, surfaced at compile)
+  // A declared sub-procedure that is never called. NON-BLOCKING (warning, not
+  // error): unreferenced building blocks are kept on purpose — see CompileWarning.
   for (const id of subProcIds) {
     if (!calledSubProcs.has(id)) {
-      errors.push({
+      warnings.push({
         code: 'UNCALLED_SUBPROCEDURE',
         message: `Sub-procedure "${id}" is declared but never called.`,
         subProcedureId: id,
@@ -410,7 +432,7 @@ function validate(compiled: CompiledProcedure): CompileError[] {
   // cycle detection over the call graph (a sub-procedure that call's itself transitively)
   errors.push(...detectCallCycles(compiled))
 
-  return errors
+  return { errors, warnings }
 }
 
 /** Steps reachable from `entry` following `next` / condition branches (NOT crossing `call`). */

--- a/packages/lib/src/agents/procedures/index.ts
+++ b/packages/lib/src/agents/procedures/index.ts
@@ -12,7 +12,7 @@ export {
   type ConversationMessage,
   classifyProcedure,
 } from './classify'
-export type { CompileError, CompileResult } from './compile'
+export type { CompileError, CompileResult, CompileWarning } from './compile'
 export { compileProcedure } from './compile'
 export {
   buildCodeInputs,

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -505,6 +505,36 @@ function CommandItem({ className, ...props }: React.ComponentProps<typeof Comman
   )
 }
 
+/**
+ * A {@link CommandItem} with a leading muted icon and a single truncating label —
+ * the common "icon + text" row used across pickers (procedure step pickers, the
+ * building-blocks popover). `value` feeds cmdk selection/filtering; `onSelect`
+ * fires on click / Enter.
+ */
+function CommandIconItem({
+  icon,
+  label,
+  value,
+  onSelect,
+  className,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string
+  onSelect: () => void
+  className?: string
+}) {
+  return (
+    <CommandItem
+      value={value}
+      onSelect={onSelect}
+      className={cn('flex items-center gap-2', className)}>
+      <span className='text-muted-foreground'>{icon}</span>
+      <span className='truncate text-sm'>{label}</span>
+    </CommandItem>
+  )
+}
+
 function CommandShortcut({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) {
   return (
     <span
@@ -902,6 +932,7 @@ export {
   CommandGroup,
   CommandGroupLabel,
   CommandItem,
+  CommandIconItem,
   CommandShortcut,
   CommandSeparator,
   CommandDescription,


### PR DESCRIPTION
## Summary

- **Procedures — Building blocks popover.** New "Building blocks" Section action opens a popover listing every sub-procedure and code block of the open procedure (grouped + labelled), plus create rows; selecting any row drills into that body. Building blocks are now **first-class** — they persist even when no inline badge references them (orphan sweep removed). Deleting the last badge no longer deletes the block.
- **Compile: `UNCALLED_SUBPROCEDURE` is now a non-blocking warning** (new `CompileWarning` type) instead of a publish-blocking error. Unreferenced sub-procedures still compile into the published output.
- **Condition block grammar** tightened to `conditionCase+ conditionElse?` (at most one ELSE, must come last). New IF/ELSE-IF arms insert *before* a trailing ELSE to keep arm precedence intact.
- **Code editor `fill` mode** — full-height flex layout (no resize handle) for embedding in a bounded flex column, used by the procedure code drill panel. Also disables Monaco's EditContext API so `@tanstack/react-hotkeys` input detection works and global single-key shortcuts don't fire while typing in the editor.
- **OAuth2 reconnect** reuses the connection variables stored with the existing connection (e.g. the Shopify shop) so the user isn't re-prompted; explicit query params still win. Reconnect menu item gets a refresh icon.
- **Shared `CommandIconItem`** (icon + truncating label row) extracted into `@auxx/ui`, replacing the local `Row` in the procedure pickers.

## Test plan

- `pnpm test` — `packages/lib/src/agents/procedures/__tests__/compile.test.ts` updated to assert the uncalled-subprocedure case now warns (not errors) and the block still compiles.
- Manual: open a procedure → Building blocks popover lists/creates sub-procedures & code blocks; reconnect an OAuth2 app (e.g. Shopify) without re-entering the shop; condition block keeps ELSE last; code drill panel fills height and single-key hotkeys don't fire while typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)