### PR TITLE
feat(procedures): building-block delete + multi-root condition fields

### DIFF
--- a/apps/web/src/components/agents/procedures/hooks/use-delete-building-block.ts
+++ b/apps/web/src/components/agents/procedures/hooks/use-delete-building-block.ts
@@ -1,0 +1,67 @@
+// apps/web/src/components/agents/procedures/hooks/use-delete-building-block.ts
+'use client'
+
+import { toastError } from '@auxx/ui/components/toast'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useProcedureDraft } from '../ui/procedure-draft-provider'
+import { countReferences } from '../ui/reference-usage'
+
+export type BuildingBlockKind = 'code' | 'sub'
+
+/**
+ * Shared delete flow for procedure building blocks (code blocks + sub-procedures),
+ * used by both the Building blocks popover and the drill-header `⋯` menu so both surfaces
+ * behave identically: refuse while the block is still referenced in the prose (naming
+ * where), otherwise confirm (destructive) and delete via the draft owner.
+ *
+ * Render the returned `ConfirmDialog` once in the consumer — OUTSIDE any element that
+ * unmounts on the action (e.g. a closing Popover), so the dialog survives the close.
+ */
+export function useDeleteBuildingBlock() {
+  const draft = useProcedureDraft()
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  const requestDelete = async (kind: BuildingBlockKind, id: string, name: string) => {
+    if (!draft) return
+    const label = name.trim() || (kind === 'code' ? 'Code' : 'Sub-procedure')
+    const refId = kind === 'code' ? `code:${id}` : `subprocedure:${id}`
+
+    const usage = countReferences(refId, {
+      mainContent: draft.getMainContent(),
+      subProcedures: draft.subProcedures.map((s) => ({
+        id: s.id,
+        name: s.name,
+        content: draft.getSubContent(s.id),
+      })),
+      excludeSubId: kind === 'sub' ? id : undefined,
+    })
+
+    if (usage.count > 0) {
+      toastError({
+        title: `Can’t delete “${label}”`,
+        description: `Still referenced in ${formatLocations(usage.locations)}. Remove those references first.`,
+      })
+      return
+    }
+
+    const ok = await confirm({
+      title: `Delete “${label}”?`,
+      description: 'This permanently removes it from the procedure and can’t be undone.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!ok) return
+
+    if (kind === 'code') draft.deleteCodeBlock(id)
+    else draft.deleteSubProcedure(id)
+  }
+
+  return { requestDelete, ConfirmDialog }
+}
+
+/** Join locations into a readable phrase: "A", "A and B", "A, B and C". */
+function formatLocations(locations: string[]): string {
+  if (locations.length <= 1) return locations[0] ?? 'the procedure'
+  return `${locations.slice(0, -1).join(', ')} and ${locations[locations.length - 1]}`
+}

--- a/apps/web/src/components/agents/procedures/hooks/use-procedure-condition-config.ts
+++ b/apps/web/src/components/agents/procedures/hooks/use-procedure-condition-config.ts
@@ -6,7 +6,12 @@ import type { Operator } from '@auxx/lib/conditions/client'
 import type { ResourceField } from '@auxx/lib/resources/client'
 import { BaseType } from '@auxx/lib/workflow-engine/client'
 import { useCallback, useMemo } from 'react'
-import type { ConditionSystemConfig, FieldDefinition } from '~/components/conditions'
+import type {
+  ConditionRootEntity,
+  ConditionSystemConfig,
+  FieldDefinition,
+} from '~/components/conditions'
+import { useResourceProperty } from '~/components/resources'
 import { useResourceFields } from '~/components/resources/hooks/use-resource-fields'
 
 // CRM entity keys whose fields back the STRUCTURED condition mode. These are the
@@ -16,12 +21,21 @@ import { useResourceFields } from '~/components/resources/hooks/use-resource-fie
 const CONTACT_SLUG = 'contact'
 const THREAD_SLUG = 'thread'
 
-/** ResourceField[] → FieldDefinition[] for the ConditionProvider (records-searchbar pattern). */
+/**
+ * ResourceField[] → FieldDefinition[] for the ConditionProvider.
+ *
+ * `id` is the entity-scoped `resourceFieldId` (`contact:email`), NOT the bare field
+ * key (`email`): bare keys collide across entities (contact + thread both expose
+ * `email`/`name`), and at runtime the selection resolver
+ * (`agents/procedures/context.ts` `toVarRef`) needs the `entityDef:` prefix to root
+ * the ref at a subject anchor — a bare key resolves to `undefined` and the rule never
+ * matches.
+ */
 function toConditionFields(fields: ResourceField[]): FieldDefinition[] {
   return fields
     .filter((f) => f.capabilities?.filterable && !f.capabilities?.hidden)
     .map((f) => ({
-      id: f.id,
+      id: f.resourceFieldId,
       label: f.label,
       type: f.type,
       fieldType: f.fieldType,
@@ -56,6 +70,8 @@ export function useProcedureConditionConfig(
 ) {
   const contact = useResourceFields(CONTACT_SLUG)
   const thread = useResourceFields(THREAD_SLUG)
+  const contactMeta = useResourceProperty(CONTACT_SLUG, ['entityDefinitionId', 'label'])
+  const threadMeta = useResourceProperty(THREAD_SLUG, ['entityDefinitionId', 'label'])
 
   const fields = useMemo<FieldDefinition[]>(
     () => [
@@ -65,6 +81,20 @@ export function useProcedureConditionConfig(
     ],
     [contact.filterableFields, thread.filterableFields, localAttributes]
   )
+
+  // The drill-down roots: Contact + Thread (whichever resolve from the store). The
+  // multi-root `ProcedureFieldSelector` lists these, then drills into each entity's
+  // fields — instead of one flat concatenated list with duplicate labels.
+  const rootEntities = useMemo<ConditionRootEntity[]>(() => {
+    const out: ConditionRootEntity[] = []
+    if (contactMeta?.entityDefinitionId) {
+      out.push({ entityDefinitionId: contactMeta.entityDefinitionId, label: contactMeta.label })
+    }
+    if (threadMeta?.entityDefinitionId) {
+      out.push({ entityDefinitionId: threadMeta.entityDefinitionId, label: threadMeta.label })
+    }
+    return out
+  }, [contactMeta, threadMeta])
 
   const getAvailableFields = useCallback(() => fields, [fields])
 
@@ -80,6 +110,7 @@ export function useProcedureConditionConfig(
     () => ({
       mode: 'resource',
       fields,
+      rootEntities,
       showLogicalOperators: true,
       showGrouping: !singleGroup,
       allowGroupNaming: false,
@@ -90,7 +121,7 @@ export function useProcedureConditionConfig(
       allowConstantToggle: false,
       display: 'inline',
     }),
-    [fields, singleGroup]
+    [fields, rootEntities, singleGroup]
   )
 
   return { config, getAvailableFields, getFieldDefinition }

--- a/apps/web/src/components/agents/procedures/nodes/condition-predicate-node-view.tsx
+++ b/apps/web/src/components/agents/procedures/nodes/condition-predicate-node-view.tsx
@@ -20,7 +20,7 @@ export function ConditionPredicateNodeView({ node }: NodeViewProps) {
     <NodeViewWrapper
       as='div'
       className={cn(
-        'relative rounded-lg border border-border bg-background px-3 py-1 text-sm',
+        'relative rounded-lg border border-border border-dashed bg-background/40 px-3 py-1 text-sm',
         hidden && 'hidden'
       )}>
       <NodeViewContent className='min-h-5 outline-none' />

--- a/apps/web/src/components/agents/procedures/ui/procedure-blocks-popover.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-blocks-popover.tsx
@@ -7,14 +7,17 @@ import {
   CommandGroup,
   CommandGroupLabel,
   CommandIconItem,
+  CommandItem,
   CommandList,
   CommandPlaceholder,
   CommandSeparator,
 } from '@auxx/ui/components/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
-import { Blocks, Code2, Plus, Workflow } from 'lucide-react'
-import { useState } from 'react'
+import { Blocks, Code2, Plus, Trash2, Workflow } from 'lucide-react'
+import { type ReactNode, useState } from 'react'
+import { type BuildingBlockKind, useDeleteBuildingBlock } from '../hooks/use-delete-building-block'
 import { useProcedureDraft } from './procedure-draft-provider'
+import { countReferences } from './reference-usage'
 
 /**
  * The "Building blocks" Section action — a popover listing every sub-procedure and
@@ -25,9 +28,24 @@ import { useProcedureDraft } from './procedure-draft-provider'
 export function ProcedureBlocksPopover() {
   const draft = useProcedureDraft()
   const [open, setOpen] = useState(false)
+  const { requestDelete, ConfirmDialog } = useDeleteBuildingBlock()
   if (!draft) return null
 
   const { subProcedures, codeBlocks, createSubProcedure, createCodeBlock, openDrill } = draft
+
+  // Live reference universe for the counters — main prose + every sub-procedure body.
+  const mainContent = draft.getMainContent()
+  const subsWithContent = subProcedures.map((s) => ({
+    id: s.id,
+    name: s.name,
+    content: draft.getSubContent(s.id),
+  }))
+  const refCount = (kind: BuildingBlockKind, id: string) =>
+    countReferences(kind === 'code' ? `code:${id}` : `subprocedure:${id}`, {
+      mainContent,
+      subProcedures: subsWithContent,
+      excludeSubId: kind === 'sub' ? id : undefined,
+    }).count
 
   // Close the popover, then navigate to the drilled body.
   const go = (key: string) => {
@@ -35,70 +53,132 @@ export function ProcedureBlocksPopover() {
     setOpen(false)
   }
 
+  // Delete without selecting the row — close the popover first so its outside-focus
+  // close doesn't fight the confirm dialog (which is rendered outside the popover).
+  const remove = (kind: BuildingBlockKind, id: string, name: string) => {
+    setOpen(false)
+    void requestDelete(kind, id, name)
+  }
+
   const isEmpty = subProcedures.length === 0 && codeBlocks.length === 0
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button variant='ghost' size='xs'>
-          <Blocks />
-          Building blocks
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align='end' className='w-72 p-0'>
-        <Command shouldFilter={false} className='rounded-lg'>
-          <CommandList>
-            {isEmpty && <CommandPlaceholder>No building blocks yet</CommandPlaceholder>}
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button variant='ghost' size='xs'>
+            <Blocks />
+            Building blocks
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align='end' className='w-72 p-0'>
+          <Command shouldFilter={false} className='rounded-lg'>
+            <CommandList>
+              {isEmpty && <CommandPlaceholder>No building blocks yet</CommandPlaceholder>}
 
-            {subProcedures.length > 0 && (
-              <CommandGroup aria-label='Sub-procedures'>
-                <CommandGroupLabel>Sub-procedures</CommandGroupLabel>
-                {subProcedures.map((s) => (
-                  <CommandIconItem
-                    key={s.id}
-                    icon={<Workflow className='size-4' />}
-                    label={s.name}
-                    value={`sub:${s.id}`}
-                    onSelect={() => go(`sub:${s.id}`)}
-                  />
-                ))}
+              {subProcedures.length > 0 && (
+                <CommandGroup aria-label='Sub-procedures'>
+                  <CommandGroupLabel>Sub-procedures</CommandGroupLabel>
+                  {subProcedures.map((s) => (
+                    <BlockRow
+                      key={s.id}
+                      icon={<Workflow className='size-4' />}
+                      label={s.name}
+                      value={`sub:${s.id}`}
+                      count={refCount('sub', s.id)}
+                      onSelect={() => go(`sub:${s.id}`)}
+                      onDelete={() => remove('sub', s.id, s.name)}
+                    />
+                  ))}
+                </CommandGroup>
+              )}
+
+              {codeBlocks.length > 0 && (
+                <CommandGroup aria-label='Code blocks'>
+                  <CommandGroupLabel>Code blocks</CommandGroupLabel>
+                  {codeBlocks.map((c) => (
+                    <BlockRow
+                      key={c.id}
+                      icon={<Code2 className='size-4' />}
+                      label={c.name}
+                      value={`code:${c.id}`}
+                      count={refCount('code', c.id)}
+                      onSelect={() => go(`code:${c.id}`)}
+                      onDelete={() => remove('code', c.id, c.name)}
+                    />
+                  ))}
+                </CommandGroup>
+              )}
+
+              <CommandSeparator />
+
+              <CommandGroup aria-label='Create'>
+                <CommandIconItem
+                  icon={<Plus className='size-4' />}
+                  label='Create sub-procedure'
+                  value='__create-subprocedure'
+                  onSelect={() => go(`sub:${createSubProcedure('')}`)}
+                />
+                <CommandIconItem
+                  icon={<Plus className='size-4' />}
+                  label='Create code block'
+                  value='__create-code'
+                  onSelect={() => go(`code:${createCodeBlock('')}`)}
+                />
               </CommandGroup>
-            )}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {/* Outside the Popover so it survives the popover closing on delete. */}
+      <ConfirmDialog />
+    </>
+  )
+}
 
-            {codeBlocks.length > 0 && (
-              <CommandGroup aria-label='Code blocks'>
-                <CommandGroupLabel>Code blocks</CommandGroupLabel>
-                {codeBlocks.map((c) => (
-                  <CommandIconItem
-                    key={c.id}
-                    icon={<Code2 className='size-4' />}
-                    label={c.name}
-                    value={`code:${c.id}`}
-                    onSelect={() => go(`code:${c.id}`)}
-                  />
-                ))}
-              </CommandGroup>
-            )}
-
-            <CommandSeparator />
-
-            <CommandGroup aria-label='Create'>
-              <CommandIconItem
-                icon={<Plus className='size-4' />}
-                label='Create sub-procedure'
-                value='__create-subprocedure'
-                onSelect={() => go(`sub:${createSubProcedure('')}`)}
-              />
-              <CommandIconItem
-                icon={<Plus className='size-4' />}
-                label='Create code block'
-                value='__create-code'
-                onSelect={() => go(`code:${createCodeBlock('')}`)}
-              />
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+/**
+ * A building-block row: icon + name (selecting drills in) with a trailing trash button
+ * revealed on hover/focus. The trash swallows the click so it deletes instead of drilling.
+ */
+function BlockRow({
+  icon,
+  label,
+  value,
+  count,
+  onSelect,
+  onDelete,
+}: {
+  icon: ReactNode
+  label: string
+  value: string
+  count: number
+  onSelect: () => void
+  onDelete: () => void
+}) {
+  return (
+    <CommandItem value={value} onSelect={onSelect} className='group flex items-center gap-2'>
+      <span className='text-muted-foreground'>{icon}</span>
+      <span className='flex-1 truncate text-sm'>{label}</span>
+      <span
+        className='shrink-0 text-xs tabular-nums text-muted-foreground'
+        title={`${count} ${count === 1 ? 'reference' : 'references'}`}>
+        {count} {count === 1 ? 'ref' : 'refs'}
+      </span>
+      <button
+        type='button'
+        aria-label={`Delete ${label}`}
+        onMouseDown={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+        }}
+        onClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          onDelete()
+        }}
+        className='inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 hover:bg-bad-100 hover:text-bad-500 focus:opacity-100 group-hover:opacity-100'>
+        <Trash2 className='size-3.5' />
+      </button>
+    </CommandItem>
   )
 }

--- a/apps/web/src/components/agents/procedures/ui/procedure-detail-bar.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-detail-bar.tsx
@@ -3,10 +3,17 @@
 
 import { AutosizeInput, type AutosizeInputRef } from '@auxx/ui/components/autosize-input'
 import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import { useNavStack } from '@auxx/ui/components/nav-stack'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ChevronLeft, ChevronRight, MoreHorizontal, Trash2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { AutosaveIndicator, type AutosaveState } from '../../ui/shared/autosave-indicator'
+import { useDeleteBuildingBlock } from '../hooks/use-delete-building-block'
 import { useProcedure } from '../hooks/use-procedure'
 import { useProcedureMutations } from '../hooks/use-procedure-mutations'
 import { useProcedureDraft } from './procedure-draft-provider'
@@ -42,6 +49,7 @@ export function ProcedureDetailBar({ procedureId, autosave, onReload }: Procedur
   const { meta } = useProcedure(procedureId)
   const { patchMeta } = useProcedureMutations()
   const draft = useProcedureDraft()
+  const { requestDelete, ConfirmDialog } = useDeleteBuildingBlock()
 
   // Which entity the bar is titling: the drilled block when drilled, else the procedure.
   const drill = draft?.drill ?? null
@@ -93,6 +101,11 @@ export function ProcedureDetailBar({ procedureId, autosave, onReload }: Procedur
     }
   }
 
+  // When drilled, the bar titles a building block — offer to delete THAT block (not the
+  // procedure; that lives in the publish cluster's `⌄` menu).
+  const blockKind = subId ? 'sub' : codeId ? 'code' : null
+  const blockId = subId ?? codeId
+
   return (
     <div className='flex h-9 items-center gap-2 px-2 no-scrollbar overflow-y-auto'>
       <Button variant='ghost' size='icon-xs' className='rounded-md' onClick={() => pop()}>
@@ -124,10 +137,31 @@ export function ProcedureDetailBar({ procedureId, autosave, onReload }: Procedur
         minWidth={40}
         maxWidth={240}
       />
+      {isDrilled && blockKind && blockId && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant='ghost'
+              size='icon-xs'
+              className='rounded-md shrink-0'
+              aria-label={subId ? 'Sub-procedure actions' : 'Code block actions'}>
+              <MoreHorizontal />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='start'>
+            <DropdownMenuItem
+              variant='destructive'
+              onClick={() => void requestDelete(blockKind, blockId, blockName ?? '')}>
+              <Trash2 /> Delete {subId ? 'sub-procedure' : 'code block'}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
       <div className='ml-auto flex items-center gap-2 pr-2 shrink-0'>
         <AutosaveIndicator state={autosave} />
         <ProcedurePublishCluster procedureId={procedureId} onReload={onReload} />
       </div>
+      <ConfirmDialog />
     </div>
   )
 }

--- a/apps/web/src/components/agents/procedures/ui/procedure-draft-provider.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-draft-provider.tsx
@@ -41,6 +41,21 @@ import type { ProcedureMeta } from '../store/procedure-store'
  * `useProcedureEditorContext()` hook (now backed by this provider).
  */
 
+/**
+ * Starter source seeded into a new code block. Matches the runtime contract: the lambda
+ * executor requires a `main(inputs)` entry point, inputs arrive as `inputs.vars.<attr>`
+ * (declared local attributes; unwritten → undefined), and declared outputs are read from
+ * the returned object's keys.
+ */
+export const DEFAULT_CODE_BLOCK_SOURCE = `function main(inputs) {
+  // Read declared attributes (unwritten → undefined):
+  //   const tier = inputs.vars.tier
+
+  // Return declared outputs (only keys bound in the Outputs tab are stored):
+  return {}
+}
+`
+
 interface SubProcedureEntry {
   id: string
   name: string
@@ -98,6 +113,8 @@ export interface ProcedureDraftContextValue {
   handleMainChange: (e: { json: JSONContent }) => void
 
   // ── drilled bodies (live, read from the save-source refs) ──
+  /** Live main-body content (read from the save-source ref) — for reference scans. */
+  getMainContent: () => JSONContent[]
   getSubContent: (id: string) => JSONContent[]
   makeSubChange: (id: string) => (e: { json: JSONContent }) => void
   getCodeEntry: (id: string) => CodeBlockEntry | undefined
@@ -113,6 +130,8 @@ export interface ProcedureDraftContextValue {
   createCodeBlock: (name: string) => string
   renameSubProcedure: (id: string, name: string) => void
   renameCodeBlock: (id: string, name: string) => void
+  deleteSubProcedure: (id: string) => void
+  deleteCodeBlock: (id: string) => void
 
   // ── the `@` picker / shared-editor seam ──
   activeEditor: Editor | null
@@ -306,7 +325,7 @@ export function ProcedureDraftProvider({
         id,
         name: name.trim() || 'Code',
         language: 'javascript',
-        code: '',
+        code: DEFAULT_CODE_BLOCK_SOURCE,
       }
       const next = [...codeRef.current, entry]
       codeRef.current = next
@@ -376,11 +395,35 @@ export function ProcedureDraftProvider({
     [patchMetaRaw, procedureId]
   )
 
+  const getMainContent = useCallback(() => mainContentRef.current, [])
   const getSubContent = useCallback(
     (id: string) => subRef.current.find((s) => s.id === id)?.content ?? [],
     []
   )
   const getCodeEntry = useCallback((id: string) => codeRef.current.find((c) => c.id === id), [])
+
+  // Drop a building block from the doc. Callers gate this on a zero-reference check
+  // (see `useDeleteBuildingBlock`), so there's no orphan badge to sweep here. If the
+  // deleted block is the one currently drilled into, pop back to the procedure level.
+  const deleteSubProcedure = useCallback(
+    (id: string) => {
+      subRef.current = subRef.current.filter((s) => s.id !== id)
+      setSubProcedures(subRef.current)
+      if (drill === `sub:${id}`) closeDrill()
+      commit()
+    },
+    [commit, drill, closeDrill]
+  )
+
+  const deleteCodeBlock = useCallback(
+    (id: string) => {
+      codeRef.current = codeRef.current.filter((c) => c.id !== id)
+      setCodeBlocks(codeRef.current)
+      if (drill === `code:${id}`) closeDrill()
+      commit()
+    },
+    [commit, drill, closeDrill]
+  )
 
   const value = useMemo<ProcedureDraftContextValue | null>(
     () =>
@@ -392,6 +435,7 @@ export function ProcedureDraftProvider({
             isLoading,
             mainContent: mainContentRef.current,
             handleMainChange,
+            getMainContent,
             getSubContent,
             makeSubChange,
             getCodeEntry,
@@ -405,6 +449,8 @@ export function ProcedureDraftProvider({
             createCodeBlock,
             renameSubProcedure,
             renameCodeBlock,
+            deleteSubProcedure,
+            deleteCodeBlock,
             activeEditor,
             handleEditorReady,
             referencePickerRef,
@@ -420,6 +466,7 @@ export function ProcedureDraftProvider({
       meta,
       isLoading,
       handleMainChange,
+      getMainContent,
       getSubContent,
       makeSubChange,
       getCodeEntry,
@@ -433,6 +480,8 @@ export function ProcedureDraftProvider({
       createCodeBlock,
       renameSubProcedure,
       renameCodeBlock,
+      deleteSubProcedure,
+      deleteCodeBlock,
       activeEditor,
       handleEditorReady,
       insertBlock,

--- a/apps/web/src/components/agents/procedures/ui/reference-usage.ts
+++ b/apps/web/src/components/agents/procedures/ui/reference-usage.ts
@@ -1,0 +1,62 @@
+// apps/web/src/components/agents/procedures/ui/reference-usage.ts
+import type { JSONContent } from '@tiptap/core'
+
+export interface ReferenceUsage {
+  /** Total number of inline badges pointing at the target across the whole draft. */
+  count: number
+  /** Human-readable containers, e.g. ['the main procedure', 'sub-procedure “Refund”']. */
+  locations: string[]
+}
+
+interface SubProcedureWithContent {
+  id: string
+  name: string
+  content: JSONContent[]
+}
+
+/** Count `reference` nodes whose `attrs.id` equals `refId` within a content tree. */
+function countInTree(nodes: JSONContent[], refId: string): number {
+  let count = 0
+  const walk = (node: JSONContent) => {
+    if (node.type === 'reference' && node.attrs?.id === refId) count++
+    if (Array.isArray(node.content)) for (const child of node.content) walk(child)
+  }
+  for (const node of nodes) walk(node)
+  return count
+}
+
+/**
+ * Scan the whole procedure draft (main prose + every sub-procedure body) for inline
+ * badges referencing `refId` (`code:<id>` or `subprocedure:<id>`). Used to block the
+ * deletion of a building block while it's still wired into the procedure — so a delete
+ * never leaves a dangling badge behind.
+ */
+export function countReferences(
+  refId: string,
+  opts: {
+    mainContent: JSONContent[]
+    subProcedures: SubProcedureWithContent[]
+    /** Skip this sub-procedure's own body (when deleting that sub-procedure itself). */
+    excludeSubId?: string
+  }
+): ReferenceUsage {
+  const locations: string[] = []
+  let count = 0
+
+  const inMain = countInTree(opts.mainContent, refId)
+  if (inMain > 0) {
+    count += inMain
+    locations.push('the main procedure')
+  }
+
+  for (const sub of opts.subProcedures) {
+    if (sub.id === opts.excludeSubId) continue
+    const n = countInTree(sub.content, refId)
+    if (n > 0) {
+      count += n
+      locations.push(`sub-procedure “${sub.name.trim() || 'Untitled'}”`)
+    }
+  }
+
+  return { count, locations }
+}

--- a/apps/web/src/components/conditions/components/condition-add.tsx
+++ b/apps/web/src/components/conditions/components/condition-add.tsx
@@ -9,6 +9,7 @@ import { memo, useCallback, useState } from 'react'
 import { useConditionContext } from '../condition-context'
 import type { ConditionAddProps, FieldDefinition } from '../types'
 import { NavigableFieldSelector } from './navigable-field-selector'
+import { ProcedureFieldSelector } from './procedure-field-selector'
 import ResourceFieldSelector from './resource-field-selector'
 import VariableFieldSelector from './variable-field-selector'
 
@@ -28,6 +29,7 @@ const ConditionAdd = memo(
     const { config, addCondition, getAvailableFields, nodeId } = useConditionContext()
 
     const useNavigable = config.mode === 'resource' && !!config.entityDefinitionId
+    const useMultiRoot = config.mode === 'resource' && !!config.rootEntities?.length
 
     /** Handle field selection from legacy selectors */
     const handleFieldSelect = useCallback(
@@ -69,6 +71,20 @@ const ConditionAdd = memo(
           value=''
           onChange={handleFieldSelect}
           nodeId={nodeId}
+          renderTrigger={renderTrigger}
+        />
+      )
+    }
+
+    if (useMultiRoot) {
+      return (
+        <ProcedureFieldSelector
+          rootEntities={config.rootEntities!}
+          tempFields={getAvailableFields().filter((f) => f.id.startsWith('var:'))}
+          onSelect={handleNavigableFieldSelect}
+          disabled={disabled}
+          open={open}
+          onOpenChange={setOpen}
           renderTrigger={renderTrigger}
         />
       )

--- a/apps/web/src/components/conditions/components/field-def-helpers.ts
+++ b/apps/web/src/components/conditions/components/field-def-helpers.ts
@@ -1,0 +1,33 @@
+// apps/web/src/components/conditions/components/field-def-helpers.ts
+
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { getFieldOperators } from '@auxx/lib/resources/client'
+import { getRelatedEntityDefinitionId, type RelationshipConfig } from '@auxx/types/custom-field'
+import type { FieldReference } from '@auxx/types/field'
+import type { FieldDefinition } from '../types'
+
+/**
+ * Convert a {@link ResourceField} surfaced by the field picker into the condition
+ * system's {@link FieldDefinition}. Shared by `NavigableFieldSelector` (single-root)
+ * and `ProcedureFieldSelector` (multi-root) so the two never diverge.
+ */
+export function resourceFieldToFieldDef(
+  field: ResourceField,
+  fieldReference: FieldReference
+): FieldDefinition {
+  const id = Array.isArray(fieldReference) ? fieldReference.join('::') : (fieldReference as string)
+
+  return {
+    id,
+    label: field.label,
+    type: field.type,
+    fieldType: field.fieldType,
+    operators: getFieldOperators(field) as any[],
+    options: field.options,
+    fieldKey: field.key,
+    fieldReference: field.resourceFieldId,
+    targetEntityDefinitionId: field.relationship
+      ? (getRelatedEntityDefinitionId(field.relationship as RelationshipConfig) ?? undefined)
+      : undefined,
+  }
+}

--- a/apps/web/src/components/conditions/components/navigable-field-selector.tsx
+++ b/apps/web/src/components/conditions/components/navigable-field-selector.tsx
@@ -3,8 +3,6 @@
 'use client'
 
 import type { ResourceField } from '@auxx/lib/resources/client'
-import { getFieldOperators } from '@auxx/lib/resources/client'
-import { getRelatedEntityDefinitionId, type RelationshipConfig } from '@auxx/types/custom-field'
 import type { FieldReference, ResourceFieldId } from '@auxx/types/field'
 import { isFieldPath } from '@auxx/types/field'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
@@ -14,6 +12,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { FieldPickerContent } from '~/components/pickers/field-picker'
 import { useFields } from '~/components/resources/hooks/use-field'
 import type { FieldDefinition } from '../types'
+import { resourceFieldToFieldDef } from './field-def-helpers'
 
 interface NavigableFieldSelectorProps {
   /** Current condition fieldId — real FieldReference, NOT encoded */
@@ -31,30 +30,6 @@ interface NavigableFieldSelectorProps {
   /** Controlled open state */
   open?: boolean
   onOpenChange?: (open: boolean) => void
-}
-
-/**
- * Convert a ResourceField from the picker into a FieldDefinition for the condition system.
- */
-function resourceFieldToFieldDef(
-  field: ResourceField,
-  fieldReference: FieldReference
-): FieldDefinition {
-  const id = Array.isArray(fieldReference) ? fieldReference.join('::') : (fieldReference as string)
-
-  return {
-    id,
-    label: field.label,
-    type: field.type,
-    fieldType: field.fieldType,
-    operators: getFieldOperators(field) as any[],
-    options: field.options,
-    fieldKey: field.key,
-    fieldReference: field.resourceFieldId,
-    targetEntityDefinitionId: field.relationship
-      ? (getRelatedEntityDefinitionId(field.relationship as RelationshipConfig) ?? undefined)
-      : undefined,
-  }
 }
 
 /**

--- a/apps/web/src/components/conditions/components/procedure-field-selector.tsx
+++ b/apps/web/src/components/conditions/components/procedure-field-selector.tsx
@@ -1,0 +1,202 @@
+// apps/web/src/components/conditions/components/procedure-field-selector.tsx
+
+'use client'
+
+import type { ResourceField } from '@auxx/lib/resources/client'
+import type { FieldReference } from '@auxx/types/field'
+import {
+  Command,
+  CommandBreadcrumb,
+  CommandGroup,
+  CommandGroupLabel,
+  CommandItem,
+  CommandList,
+  CommandNavigation,
+  CommandSeparator,
+  type NavigationItem,
+  useCommandNavigation,
+} from '@auxx/ui/components/command'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { Variable } from 'lucide-react'
+import { useMemo } from 'react'
+import {
+  FieldPickerInnerContent,
+  type FieldPickerNavigationItem,
+} from '~/components/pickers/field-picker'
+import { useResourceProperty } from '~/components/resources'
+import type { ConditionRootEntity, FieldDefinition } from '../types'
+import { resourceFieldToFieldDef } from './field-def-helpers'
+
+/** Top-level nav marker for an entity root (Contact, Thread, …) the user drilled into. */
+interface EntityRootNavItem extends NavigationItem {
+  id: string
+  label: string
+  kind: 'entity-root'
+  entityDefinitionId: string
+}
+
+type ProcedureNavItem = EntityRootNavItem | FieldPickerNavigationItem
+
+const isEntityRoot = (item: ProcedureNavItem | null): item is EntityRootNavItem =>
+  !!item && 'kind' in item && item.kind === 'entity-root'
+
+interface ProcedureFieldSelectorProps {
+  /** Top-level entities the picker offers (e.g. Contact, Thread). */
+  rootEntities: ConditionRootEntity[]
+  /** Procedure-local `var:*` attributes — the "Temporary" group. */
+  tempFields: FieldDefinition[]
+  /** Called when the user selects a field (CRM `ResourceFieldId`/`FieldPath` or a `var:*`). */
+  onSelect: (fieldReference: FieldReference, fieldDef: FieldDefinition) => void
+  /** Accepted for API parity with the other selectors; the trigger button owns the disabled state. */
+  disabled?: boolean
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  renderTrigger: (props: { isOpen: boolean; onClick: () => void }) => React.ReactNode
+}
+
+/**
+ * Multi-root field picker for procedure rules. Unlike `NavigableFieldSelector`
+ * (single `entityDefinitionId`), the root level lists every {@link ConditionRootEntity}
+ * — Contact, Thread — plus a "Temporary" group of `var:*` locals, and drilling into an
+ * entity delegates to the shared `FieldPickerInnerContent` (relationship drill-down +
+ * search) via an external-navigation adapter, mirroring `add-column-stack.tsx`.
+ *
+ * Selecting a CRM field emits its entity-scoped `ResourceFieldId` (`contact:email`) or a
+ * `FieldPath` for a relationship hop — exactly the form the runtime resolver
+ * (`agents/procedures/context.ts`) roots at a subject anchor.
+ */
+export function ProcedureFieldSelector({
+  rootEntities,
+  tempFields,
+  onSelect,
+  open,
+  onOpenChange,
+  renderTrigger,
+}: ProcedureFieldSelectorProps) {
+  const handlePick = (fieldReference: FieldReference, fieldDef: FieldDefinition) => {
+    onSelect(fieldReference, fieldDef)
+    onOpenChange(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        {renderTrigger({ isOpen: open, onClick: () => onOpenChange(!open) })}
+      </PopoverTrigger>
+      <PopoverContent className='min-w-[260px] p-0' align='start'>
+        <CommandNavigation<ProcedureNavItem>>
+          <Command shouldFilter={false}>
+            <CommandBreadcrumb rootLabel='Fields' />
+            <ProcedureFieldContent
+              rootEntities={rootEntities}
+              tempFields={tempFields}
+              onPick={handlePick}
+            />
+          </Command>
+        </CommandNavigation>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+interface ProcedureFieldContentProps {
+  rootEntities: ConditionRootEntity[]
+  tempFields: FieldDefinition[]
+  onPick: (fieldReference: FieldReference, fieldDef: FieldDefinition) => void
+}
+
+/** Routes between the entity root list and the per-entity field picker on nav state. */
+function ProcedureFieldContent({ rootEntities, tempFields, onPick }: ProcedureFieldContentProps) {
+  const { stack, push, pop } = useCommandNavigation<ProcedureNavItem>()
+
+  // The entity root sits at the bottom of the stack; relationship drills pile on top.
+  const entityRoot = stack.find(isEntityRoot)
+
+  // External-navigation adapter for FieldPickerInnerContent: it only sees the
+  // relationship hops ABOVE the entity marker, so "at root" means the entity's own
+  // fields (no relationship drilled). Popping past them removes the entity marker →
+  // back to the entity list. Mirrors add-column-stack.tsx.
+  const fieldStack = useMemo(
+    () => stack.filter((i): i is FieldPickerNavigationItem => 'resourceFieldId' in i),
+    [stack]
+  )
+  const externalNavigation = useMemo(
+    () => ({
+      push: (item: FieldPickerNavigationItem) => push(item),
+      pop,
+      stack: fieldStack,
+      current: fieldStack[fieldStack.length - 1] ?? null,
+      isAtRoot: fieldStack.length === 0,
+    }),
+    [push, pop, fieldStack]
+  )
+
+  if (entityRoot) {
+    return (
+      <FieldPickerInnerContent
+        entityDefinitionId={entityRoot.entityDefinitionId}
+        mode='single'
+        closeOnSelect={false}
+        onSelect={(fieldReference, field: ResourceField) =>
+          onPick(fieldReference, resourceFieldToFieldDef(field, fieldReference))
+        }
+        searchPlaceholder='Search fields...'
+        externalNavigation={externalNavigation}
+      />
+    )
+  }
+
+  return (
+    <CommandList>
+      <CommandGroup>
+        {rootEntities.map((entity) => (
+          <EntityRootItem
+            key={entity.entityDefinitionId}
+            entity={entity}
+            onSelect={() =>
+              push({
+                id: entity.entityDefinitionId,
+                kind: 'entity-root',
+                label: entity.label,
+                entityDefinitionId: entity.entityDefinitionId,
+              })
+            }
+          />
+        ))}
+      </CommandGroup>
+
+      {tempFields.length > 0 && (
+        <>
+          <CommandSeparator />
+          <CommandGroup>
+            <CommandGroupLabel>Temporary</CommandGroupLabel>
+            {tempFields.map((field) => (
+              <CommandItem key={field.id} value={field.id} onSelect={() => onPick(field.id, field)}>
+                <Variable className='size-4 text-accent-500' />
+                <span>{field.label}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </>
+      )}
+    </CommandList>
+  )
+}
+
+/** Root-level entity row — its own component so each resolves its icon/color via the store. */
+function EntityRootItem({
+  entity,
+  onSelect,
+}: {
+  entity: ConditionRootEntity
+  onSelect: () => void
+}) {
+  const props = useResourceProperty(entity.entityDefinitionId, ['icon', 'color'])
+  return (
+    <CommandItem value={entity.entityDefinitionId} onSelect={onSelect}>
+      <EntityIcon iconId={props?.icon} color={props?.color} size='xs' />
+      <span>{entity.label}</span>
+    </CommandItem>
+  )
+}

--- a/apps/web/src/components/conditions/index.ts
+++ b/apps/web/src/components/conditions/index.ts
@@ -43,6 +43,7 @@ export type {
   ConditionGroupMetadata,
   ConditionGroupProps,
   ConditionItemProps,
+  ConditionRootEntity,
   ConditionSystemConfig,
   FieldDefinition,
   FieldSelectorProps,

--- a/apps/web/src/components/conditions/types.ts
+++ b/apps/web/src/components/conditions/types.ts
@@ -82,6 +82,14 @@ export interface FieldDefinition {
 }
 
 /**
+ * A top-level entity offered by the multi-root field picker (procedure rules).
+ */
+export interface ConditionRootEntity {
+  entityDefinitionId: string
+  label: string
+}
+
+/**
  * Configuration for condition system behavior
  */
 export interface ConditionSystemConfig {
@@ -89,6 +97,13 @@ export interface ConditionSystemConfig {
   fields: FieldDefinition[] | 'dynamic'
   /** When set with mode:'resource', enables NavigableFieldSelector with drill-down */
   entityDefinitionId?: string
+  /**
+   * Multi-root drill-down (procedures span Contact + Thread). When set with
+   * mode:'resource', ConditionAdd renders the multi-root `ProcedureFieldSelector`
+   * (entity list → fields) instead of the single-root selectors. Each selection
+   * stores an entity-scoped `ResourceFieldId` so the runtime resolver can root it.
+   */
+  rootEntities?: ConditionRootEntity[]
   allowNesting?: boolean
   allowReordering?: boolean
   showLogicalOperators?: boolean

--- a/packages/lib/src/agents/procedures/context.ts
+++ b/packages/lib/src/agents/procedures/context.ts
@@ -26,6 +26,15 @@ import type { LocalAttribute, ProcedureFrame } from './types'
  * name. This MUST stay byte-for-byte aligned with `evaluate.ts`'s `extractFieldId` /
  * `extractSimpleField`, or the pre-resolved map is keyed differently than the
  * evaluator reads it and every lookup silently returns `undefined`.
+ *
+ * KNOWN LIMITATION (narrow): two ruleset conditions on same-simple-name fields of
+ * DIFFERENT entities (`contact:email` + `thread:email`) collapse to one map key, so the
+ * `seen` dedupe below resolves the first and the second silently reuses its value.
+ * Custom fields use unique cuids so they never collide; only system fields sharing a
+ * simple name do. Fixing it properly means evolving the shared `FieldResolver` contract
+ * (`evaluate.ts`) to pass the un-stripped `fieldId`, which ripples across every
+ * conditions consumer — deferred until a procedure actually needs to gate on the same
+ * simple field name across two entities.
  */
 function simpleKey(fieldId: string | string[]): string {
   if (Array.isArray(fieldId)) return stripEntityDef(fieldId[fieldId.length - 1] ?? '')


### PR DESCRIPTION
## Summary

Two related improvements to the agent procedures editor.

### Building-block deletion
- Shared `useDeleteBuildingBlock` flow for code blocks and sub-procedures, used by both the **Building blocks** popover and the drill-header `⋯` menu so both surfaces behave identically.
- A delete is **refused while the block is still referenced** in the prose (toast names where), otherwise it asks for a destructive confirm before removing it via the draft owner.
- New `reference-usage.ts` scans the whole draft (main prose + every sub-procedure body) and counts inline reference badges; the popover now shows a live `N refs` count per block.
- Deleting the currently-drilled block pops back to the procedure level.

### Multi-root condition fields
- Procedure rules can now build conditions across **Contact + Thread** via a new `ProcedureFieldSelector` (entity list → per-entity field drill-down, reusing `FieldPickerInnerContent`).
- `ConditionSystemConfig.rootEntities` drives this; `ConditionAdd` renders the multi-root selector when it's set.
- Each selection stores an **entity-scoped `ResourceFieldId`** (`contact:email`) so the runtime resolver (`agents/procedures/context.ts`) roots it at a subject anchor — bare keys collide across entities.
- Extracted the shared `resourceFieldToFieldDef` helper (`field-def-helpers.ts`) so the single-root and multi-root selectors don't diverge.

### Misc
- New code blocks seed a `main(inputs)` starter matching the lambda executor contract.
- Documented the narrow same-simple-name cross-entity collision limitation in `context.ts`.
- Restyled the condition predicate node as dashed/muted.

## Test plan
- [ ] Create/delete code blocks and sub-procedures from both the popover and the `⋯` menu.
- [ ] Confirm delete is blocked (with toast) while a block is referenced, allowed once references are removed.
- [ ] Build a procedure condition spanning Contact and Thread fields; verify it resolves at runtime.