### PR TITLE
fix(procedures): jsonb-stable content hash for procedure docs

### DIFF
--- a/packages/lib/src/agents/procedures/__tests__/compile.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/compile.test.ts
@@ -2,7 +2,13 @@
 
 import { describe, expect, it } from 'vitest'
 import { compileProcedure } from '../compile'
-import type { CodeBlockMapEntry, SubProcedureMapEntry, TiptapDoc, TiptapNode } from '../nodes'
+import {
+  type CodeBlockMapEntry,
+  type SubProcedureMapEntry,
+  stableStringify,
+  type TiptapDoc,
+  type TiptapNode,
+} from '../nodes'
 import type { ProcedureStep } from '../types'
 
 const prose = (text: string): TiptapNode => ({
@@ -382,5 +388,42 @@ describe('compileProcedure', () => {
     expect(a.contentHash).toBe(b.contentHash)
     const c = compileProcedure(doc([prose('different')]))
     expect(c.contentHash).not.toBe(a.contentHash)
+  })
+
+  // jsonb reorders object keys on the DB round-trip, so the contentHash must be
+  // key-order-independent or the tools' compare-and-set false-staleses every edit.
+  it('produces the same contentHash regardless of object key order (jsonb round-trip)', () => {
+    const inMem = {
+      type: 'doc',
+      content: [prose('hi')],
+      localAttributes: [],
+      codeBlocks: [],
+      subProcedures: [],
+    } as unknown as TiptapDoc
+    const reordered = {
+      subProcedures: [],
+      codeBlocks: [],
+      content: [prose('hi')],
+      localAttributes: [],
+      type: 'doc',
+    } as unknown as TiptapDoc
+    expect(compileProcedure(inMem).contentHash).toBe(compileProcedure(reordered).contentHash)
+  })
+})
+
+describe('stableStringify', () => {
+  it('is independent of object key order at every depth', () => {
+    const a = { type: 'doc', attrs: { id: '1', mode: 'text' }, content: [{ a: 1, b: 2 }] }
+    const b = { content: [{ b: 2, a: 1 }], attrs: { mode: 'text', id: '1' }, type: 'doc' }
+    expect(stableStringify(a)).toBe(stableStringify(b))
+  })
+
+  it('preserves array order and distinguishes different values', () => {
+    expect(stableStringify([1, 2, 3])).not.toBe(stableStringify([3, 2, 1]))
+    expect(stableStringify({ a: 1 })).not.toBe(stableStringify({ a: 2 }))
+  })
+
+  it('drops undefined object values like JSON.stringify', () => {
+    expect(stableStringify({ a: 1, b: undefined })).toBe(stableStringify({ a: 1 }))
   })
 })

--- a/packages/lib/src/agents/procedures/authoring/queries.ts
+++ b/packages/lib/src/agents/procedures/authoring/queries.ts
@@ -5,7 +5,7 @@ import { database, schema } from '@auxx/database'
 import { fromDatabase } from '@auxx/services/shared/utils'
 import { and, eq } from 'drizzle-orm'
 import { err, ok } from 'neverthrow'
-import type { TiptapDoc } from '../nodes'
+import { stableStringify, type TiptapDoc } from '../nodes'
 import {
   attachProcedureTx,
   createProcedureTx,
@@ -22,9 +22,15 @@ import {
  * guard). All return `neverthrow` Results, mirroring `../queries`.
  */
 
-/** SHA-256 of a draft doc — the content hash used for the tools' compare-and-set. Matches `compileProcedure().contentHash`. */
+/**
+ * SHA-256 of a draft doc — the content hash used for the tools' compare-and-set.
+ * Matches `compileProcedure().contentHash`. Serializes with {@link stableStringify}
+ * (sorted keys) so the hash is stable across the `jsonb` round-trip: a write
+ * returns the hash of the in-memory doc, and the next read recomputes it from the
+ * key-reordered jsonb column — they must agree or the model gets a false stale.
+ */
 export function hashDoc(doc: TiptapDoc): string {
-  return createHash('sha256').update(JSON.stringify(doc), 'utf8').digest('hex')
+  return createHash('sha256').update(stableStringify(doc), 'utf8').digest('hex')
 }
 
 export interface AttachedProcedureDraft {

--- a/packages/lib/src/agents/procedures/compile.ts
+++ b/packages/lib/src/agents/procedures/compile.ts
@@ -8,6 +8,7 @@ import {
   type ParsedStepBadge,
   PROCEDURE_NODE_TYPES,
   parseCodeBindings,
+  stableStringify,
   type TiptapDoc,
   type TiptapNode,
 } from './nodes'
@@ -72,7 +73,8 @@ export interface CompileResult {
 }
 
 export function compileProcedure(doc: TiptapDoc): CompileResult {
-  const contentHash = createHash('sha256').update(JSON.stringify(doc), 'utf8').digest('hex')
+  // Stable across the jsonb round-trip (sorted keys) — see `stableStringify`.
+  const contentHash = createHash('sha256').update(stableStringify(doc), 'utf8').digest('hex')
 
   const steps: Record<StepId, ProcedureStep> = {}
   const codeBlocks: CompiledProcedure['codeBlocks'] = {}

--- a/packages/lib/src/agents/procedures/nodes.ts
+++ b/packages/lib/src/agents/procedures/nodes.ts
@@ -194,3 +194,27 @@ export const PROCEDURE_NODE_TYPES = {
 } as const
 
 export type ProcedureNodeType = (typeof PROCEDURE_NODE_TYPES)[keyof typeof PROCEDURE_NODE_TYPES]
+
+/**
+ * Deterministic, key-order-independent JSON serialization — used to content-hash
+ * a {@link TiptapDoc} so the hash is stable across a Postgres `jsonb` round-trip.
+ * `jsonb` does NOT preserve object key insertion order (it stores keys sorted by
+ * length then bytewise), so a plain `JSON.stringify` hash of an in-memory doc
+ * won't match the hash of the same doc read back from the column. This sorts
+ * object keys recursively so both serializations are identical. Mirrors
+ * `JSON.stringify` (drops `undefined` object values); array order is preserved
+ * (jsonb preserves it too). PURE.
+ */
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null'
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => stableStringify(v === undefined ? null : v)).join(',')}]`
+  }
+  const obj = value as Record<string, unknown>
+  const parts: string[] = []
+  for (const key of Object.keys(obj).sort()) {
+    if (obj[key] === undefined) continue
+    parts.push(`${JSON.stringify(key)}:${stableStringify(obj[key])}`)
+  }
+  return `{${parts.join(',')}}`
+}


### PR DESCRIPTION
## Problem
Postgres `jsonb` stores object keys sorted (length, then bytewise), not in insertion order. So the SHA-256 content hash computed via `JSON.stringify` on an in-memory doc never matched the hash recomputed after reading the same doc back from the `jsonb` column — which false-staled the procedure-authoring tools' compare-and-set on **every** edit.

## Fix
- `nodes.ts` — add `stableStringify`: recursive sorted-key serialization, mirrors `JSON.stringify` (drops `undefined` object values, preserves array order).
- `compile.ts` (`compileProcedure`) and `authoring/queries.ts` (`hashDoc`) — hash via `stableStringify` so the in-memory write hash and the read-back hash agree.

## Tests
`compile.test.ts` — key-order-independent hash round-trip + `stableStringify` unit tests (depth-independence, array-order preservation, undefined-dropping).