### PR TITLE
feat(procedures): forbid nested conditions; surface tool catalog in builder prompt

### DIFF
--- a/packages/lib/src/agents/procedures/__tests__/authoring-dsl.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/authoring-dsl.test.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/agents/procedures/__tests__/authoring-dsl.test.ts
 
 import { describe, expect, it } from 'vitest'
-import { DSL_MAX_DEPTH, type ProcedureDsl, validateProcedureDsl } from '../authoring/dsl'
+import { type ProcedureDsl, validateProcedureDsl } from '../authoring/dsl'
 
 const valid: ProcedureDsl = {
   steps: [
@@ -82,17 +82,65 @@ describe('validateProcedureDsl', () => {
     expect(errs.some((e) => e.includes('non-empty array'))).toBe(true)
   })
 
-  it('rejects nesting beyond the depth cap', () => {
-    let inner: ProcedureDsl['steps'][number] = { id: 'leaf', kind: 'instruction', text: 'x' }
-    for (let i = 0; i < DSL_MAX_DEPTH + 2; i++) {
-      inner = {
-        id: `c${i}`,
-        kind: 'condition',
-        cases: [{ id: `k${i}`, when: 'w', steps: [inner] }],
-      }
+  it('rejects a condition nested inside a condition case', () => {
+    const errs = validateProcedureDsl({
+      steps: [
+        {
+          id: 'outer',
+          kind: 'condition',
+          cases: [
+            {
+              id: 'k1',
+              when: 'a',
+              steps: [
+                {
+                  id: 'inner',
+                  kind: 'condition',
+                  cases: [{ id: 'k2', when: 'b', steps: [] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    expect(errs.some((e) => e.includes('cannot be nested inside another condition'))).toBe(true)
+  })
+
+  it('rejects a condition nested inside a condition else', () => {
+    const errs = validateProcedureDsl({
+      steps: [
+        {
+          id: 'outer',
+          kind: 'condition',
+          cases: [{ id: 'k1', when: 'a', steps: [] }],
+          else: [{ id: 'inner', kind: 'condition', cases: [{ id: 'k2', when: 'b', steps: [] }] }],
+        },
+      ],
+    })
+    expect(errs.some((e) => e.includes('cannot be nested inside another condition'))).toBe(true)
+  })
+
+  it('accepts a condition inside a sub-procedure invoked from a condition arm', () => {
+    const doc: ProcedureDsl = {
+      steps: [
+        {
+          id: 'outer',
+          kind: 'condition',
+          cases: [
+            { id: 'k1', when: 'a', steps: [{ id: 'c1', kind: 'call', subProcedureId: 'sp1' }] },
+          ],
+        },
+      ],
+      subProcedures: [
+        {
+          id: 'sp1',
+          name: 'Nested',
+          steps: [{ id: 's1', kind: 'condition', cases: [{ id: 'k2', when: 'b', steps: [] }] }],
+        },
+      ],
     }
-    const errs = validateProcedureDsl({ steps: [inner] })
-    expect(errs.some((e) => e.includes('max depth'))).toBe(true)
+    expect(validateProcedureDsl(doc)).toEqual([])
   })
 
   it('accepts an opaque step (shape only — resolution checked at build time)', () => {

--- a/packages/lib/src/agents/procedures/authoring/dsl.ts
+++ b/packages/lib/src/agents/procedures/authoring/dsl.ts
@@ -53,9 +53,7 @@ export interface ProcedureDsl {
 
 // ── invariants ─────────────────────────────────────────────────────────────
 
-/** Max nesting depth of condition arms (a guard against pathological model output). */
-export const DSL_MAX_DEPTH = 8
-/** Max total authored steps across the whole document (main + all sub-procedures + nesting). */
+/** Max total authored steps across the whole document (main + all sub-procedures + arm bodies). */
 export const DSL_MAX_STEPS = 400
 /** Max number of named sub-procedures. */
 export const DSL_MAX_SUBPROCEDURES = 50
@@ -87,9 +85,10 @@ const ALLOWED_KEYS: Record<string, ReadonlySet<string>> = {
  * Validate a value as a {@link ProcedureDsl}. Returns `[]` when valid, else a
  * list of human-readable error strings. Enforces the §3.1 invariants: known
  * discriminants, non-empty ids/text/predicates, globally-unique ids, valid route
- * fields, calls targeting a declared sub-procedure, bounded nesting/total step
- * count, and no unknown properties. Do NOT rely on the model provider to honor
- * the tool JSON Schema — this runs server-side before lowering.
+ * fields, calls targeting a declared sub-procedure, no condition nested inside
+ * another condition (extract into a sub-procedure), a bounded total step count,
+ * and no unknown properties. Do NOT rely on the model provider to honor the tool
+ * JSON Schema — this runs server-side before lowering.
  *
  * Opaque occurrence-key resolution against the persisted draft (unknown /
  * duplicate / missing keys) is validated separately in `buildProcedureDoc`,
@@ -140,12 +139,8 @@ export function validateProcedureDsl(value: unknown): string[] {
     if (isPlainObject(sp) && typeof sp.id === 'string') declaredSubProcIds.add(sp.id)
   }
 
-  const validateStep = (raw: unknown, where: string, depth: number): void => {
+  const validateStep = (raw: unknown, where: string, insideCondition: boolean): void => {
     stepCount++
-    if (depth > DSL_MAX_DEPTH) {
-      errors.push(`${where}: nesting exceeds the max depth of ${DSL_MAX_DEPTH}.`)
-      return
-    }
     if (!isPlainObject(raw)) {
       errors.push(`${where} must be an object.`)
       return
@@ -196,6 +191,16 @@ export function validateProcedureDsl(value: unknown): string[] {
       }
     } else if (kind === 'condition') {
       assertKeys(step, ALLOWED_KEYS.condition, here, errors)
+      // Conditions cannot be nested: the editor renders a single level of
+      // branching (a case body holds only instruction/route/call nodes, never
+      // another condition). Reject it here so the model gets a retry signal and
+      // extracts the inner branching into a sub-procedure instead.
+      if (insideCondition) {
+        errors.push(
+          `${here}: a condition cannot be nested inside another condition. Extract this branch into a named entry in "subProcedures" and run it with a "call" step.`
+        )
+        return
+      }
       if (!Array.isArray(step.cases) || step.cases.length === 0) {
         errors.push(`${here}: condition "cases" must be a non-empty array.`)
       } else {
@@ -223,7 +228,7 @@ export function validateProcedureDsl(value: unknown): string[] {
             if (!Array.isArray(armSteps)) {
               errors.push(`${cWhere}: "steps" must be an array when present.`)
             } else {
-              for (const s of armSteps) validateStep(s, `${cWhere} step`, depth + 1)
+              for (const s of armSteps) validateStep(s, `${cWhere} step`, true)
             }
           }
         }
@@ -232,14 +237,14 @@ export function validateProcedureDsl(value: unknown): string[] {
         if (!Array.isArray(step.else)) {
           errors.push(`${here}: "else" must be an array when present.`)
         } else {
-          for (const s of step.else) validateStep(s, `${here} else step`, depth + 1)
+          for (const s of step.else) validateStep(s, `${here} else step`, true)
         }
       }
     }
   }
 
   if (Array.isArray(root.steps)) {
-    for (const s of root.steps) validateStep(s, 'top-level step', 0)
+    for (const s of root.steps) validateStep(s, 'top-level step', false)
   }
 
   for (let i = 0; i < subProcedures.length; i++) {
@@ -262,7 +267,7 @@ export function validateProcedureDsl(value: unknown): string[] {
     if (!Array.isArray(record.steps)) {
       errors.push(`${where}: "steps" must be an array.`)
     } else {
-      for (const s of record.steps) validateStep(s, `${where} step`, 0)
+      for (const s of record.steps) validateStep(s, `${where} step`, false)
     }
   }
 
@@ -363,13 +368,19 @@ export const PROCEDURE_DSL_SCHEMA = {
                 description:
                   'Plain-English test the runtime evaluates, e.g. "the order has shipped".',
               },
-              steps: { type: 'array', items: { $ref: '#/$defs/step' } },
+              steps: {
+                type: 'array',
+                description:
+                  'Arm body — instruction/route/call steps only. A condition may NOT be nested here; extract nested branching into a sub-procedure and invoke it with a "call" step.',
+                items: { $ref: '#/$defs/step' },
+              },
             },
           },
         },
         else: {
           type: 'array',
-          description: 'condition: the fallthrough body when no case matches.',
+          description:
+            'condition: the fallthrough body when no case matches. instruction/route/call steps only — no nested condition (use a sub-procedure + "call").',
           items: { $ref: '#/$defs/step' },
         },
       },

--- a/packages/lib/src/agents/procedures/authoring/index.ts
+++ b/packages/lib/src/agents/procedures/authoring/index.ts
@@ -3,7 +3,6 @@
 export { buildProcedureDoc, emptyDoc, ProcedureBuildError } from './build-doc'
 export { docToDsl } from './doc-to-dsl'
 export {
-  DSL_MAX_DEPTH,
   DSL_MAX_STEPS,
   DSL_MAX_SUBPROCEDURES,
   DSL_MAX_TEXT_LEN,

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/persona-prompt.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/persona-prompt.ts
@@ -12,11 +12,32 @@ import type { ToolsetCatalogEntry } from '../../../../agents/toolset-catalog'
  * `chat` uses the visitor-safe tools the agent has) and how `handoff` reads.
  */
 function buildProceduresSection(deps: {
+  catalog: ToolsetCatalogEntry[]
   procedures: AuthoringProcedureSummary[]
   variant: 'internal' | 'chat'
 }): string {
-  const { procedures, variant } = deps
+  const { catalog, procedures, variant } = deps
   const isChat = variant === 'chat'
+
+  // The model authors `@[tool:…]` chips in instruction steps, so it needs the
+  // tool names right here — not just up in the `set_agent_toolsets` section. We
+  // inline the SAME catalog the persona section uses: during the setup phase no
+  // toolset is enabled on the agent yet, so the full org catalog is the only
+  // useful surface. For a chat agent this `catalog` is already surface-filtered
+  // (`getOrgToolsetCatalogForSurface(..., 'chat')`), so app actions that don't
+  // run for an anonymous visitor are already dropped.
+  const toolCatalogBlock = catalog.length
+    ? catalog
+        .map((entry) => {
+          const toolNames = entry.tools.map((t) => t.name).join(', ')
+          return `- \`${entry.slug}\` — ${entry.label}\n    tools: ${toolNames}`
+        })
+        .join('\n')
+    : '_(no tools installed yet)_'
+
+  const toolCatalogIntro = isChat
+    ? 'Tools you may chip (`@[tool:<name>]`) in an `instruction` step — the **visitor-safe** tools available to a chat agent. Tools not listed here aren’t available on the chat surface (some app actions only run for internal agents). Don’t invent a tool name that isn’t below.'
+    : 'Tools you may chip (`@[tool:<name>]`) in an `instruction` step. The agent runs each step with the tools from the toolsets it’s been given; this is the full installed catalog to draw from. If a step needs a tool from a toolset the agent doesn’t have yet (e.g. a Shopify action), tell the admin to enable that toolset via `set_agent_toolsets`. Don’t invent a tool name that isn’t below.'
 
   const procedureList = procedures.length
     ? procedures
@@ -48,11 +69,41 @@ Procedures attached to THIS agent (edit one of these, or create a new one — ne
 
 ${procedureList}
 
+**${toolCatalogIntro}**
+
+${toolCatalogBlock}
+
 **Authoring a procedure body (the step DSL).** Pass \`body\` as an array of steps. Step kinds:
 ${instructionStep}
 - \`condition\` — text-mode branching: each case's \`when\` is a plain-English test the runtime evaluates; optional \`else\` is the fallthrough.
 - \`route\` — \`finished\` ends the procedure, ${handoffClause}, \`switch\` jumps to another procedure by id (only one you've been given above — if the admin wants a procedure you have no id for, ask them to attach it first).
-- \`call\` — run a named \`sub-procedure\` (reusable named bodies; use them for a sequence shared across branches).
+- \`call\` — run a named \`sub-procedure\` (a reusable body declared in the top-level \`subProcedures\` array; use them for a sequence shared across branches or to hold branching that can't be nested — see next rule).
+
+**Conditions cannot be nested.** A \`condition\` arm (each case's \`steps\`, and \`else\`) may contain only \`instruction\`, \`route\`, and \`call\` steps — **never another \`condition\`**. The editor renders a single level of branching, and the compiler rejects a nested condition. When a branch needs its own branching, declare a named body in the top-level \`subProcedures\` array and invoke it from the arm with a \`call\` step. That sub-procedure body may have its own top-level \`condition\` (which likewise can't nest — chain another \`call\` to go deeper).
+
+Extracting a nested branch into a sub-procedure:
+\`\`\`json
+{
+  "steps": [
+    { "id": "s1", "kind": "condition", "cases": [
+      { "id": "k1", "when": "the customer wants a return", "steps": [
+        { "id": "s2", "kind": "call", "subProcedureId": "sp_returns" }
+      ]}
+    ]}
+  ],
+  "subProcedures": [
+    { "id": "sp_returns", "name": "Returns flow", "steps": [
+      { "id": "s3", "kind": "condition", "cases": [
+        { "id": "k2", "when": "within the 30-day window", "steps": [
+          { "id": "s4", "kind": "instruction", "text": "Send a prepaid return label." }
+        ]}
+      ], "else": [
+        { "id": "s5", "kind": "instruction", "text": "Explain the window has closed and offer store credit." }
+      ]}
+    ]}
+  ]
+}
+\`\`\`
 
 **Code steps are NOT available here** — if the admin needs computation, tell them to add a code block in the procedure editor.
 
@@ -184,7 +235,7 @@ Triage every @[entity:ticket] this workspace receives.
 
 Default to none. If the admin wants autonomous runs, ask schedule vs event. \`scheduled\` takes \`cron\` or \`everyMinutes/everyHours/everyDays\`; \`event\` takes \`triggerType\` (\`created\`/\`updated\`/\`deleted\`) and \`entityDefinitionSlug\`.
 
-${buildProceduresSection({ procedures, variant: 'internal' })}
+${buildProceduresSection({ catalog, procedures, variant: 'internal' })}
 
 ## Identity & limits
 
@@ -300,7 +351,7 @@ You're the friendly support assistant on our website. Answer visitor questions a
 Hand off to a teammate if the visitor asks for a person, you can't answer from the knowledge base, or they need help with a specific order or account. Tell them a teammate will follow up, then stop.
 \`\`\`
 
-${buildProceduresSection({ procedures, variant: 'chat' })}
+${buildProceduresSection({ catalog, procedures, variant: 'chat' })}
 
 ## Identity & limits
 


### PR DESCRIPTION
Two related improvements to how the agents-builder authors procedures.

## 1. Conditions can no longer be nested
A `condition` arm (each case's `steps`, and `else`) may contain only `instruction`, `route`, and `call` steps — never another `condition`. The editor only renders a single level of branching and the compiler already rejected nested conditions, so the gap was that `validateProcedureDsl` accepted them (bounded only by the old `DSL_MAX_DEPTH`).

- `authoring/dsl.ts` — replace the depth cap with an `insideCondition` check that rejects a nested condition and tells the model to extract the inner branching into a named `subProcedures` entry invoked via a `call` step. Schema descriptions updated to match.
- `authoring/index.ts` — drop the now-unused `DSL_MAX_DEPTH` export.

## 2. Tool catalog inlined in the builder persona prompt
The model authors `@[tool:...]` chips in instruction steps, so it needs the tool names in the procedures section — not just in `set_agent_toolsets`. Inline the same catalog the persona section uses; the chat variant receives the surface-filtered (visitor-safe) catalog.

## Tests
`authoring-dsl.test.ts` — rejects a condition nested in a case and in an `else`; accepts a condition inside a sub-procedure invoked from a condition arm.

> Bundled because both edits touch `persona-prompt.ts` (the no-nesting doc + the catalog block).