### PR TITLE
feat(procedures): validate triggerExamples server-side

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/trigger-examples.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/trigger-examples.test.ts
@@ -1,0 +1,33 @@
+// packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/trigger-examples.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { validateTriggerExamples } from '../trigger-examples'
+
+describe('validateTriggerExamples', () => {
+  it('accepts an empty array and well-formed entries', () => {
+    expect(validateTriggerExamples([])).toBeNull()
+    expect(
+      validateTriggerExamples([
+        { text: 'I want a refund', behavior: 'use' },
+        { text: 'where is my order', behavior: 'avoid' },
+      ])
+    ).toBeNull()
+  })
+
+  it('rejects a non-array', () => {
+    expect(validateTriggerExamples('nope')).toMatch(/must be an array/)
+  })
+
+  it('rejects a null element (the case that throws in the runtime classifier)', () => {
+    expect(validateTriggerExamples([null])).toMatch(/triggerExamples\[0\]/)
+  })
+
+  it('rejects a missing/empty text', () => {
+    expect(validateTriggerExamples([{ behavior: 'use' }])).toMatch(/text/)
+    expect(validateTriggerExamples([{ text: '  ', behavior: 'use' }])).toMatch(/text/)
+  })
+
+  it('rejects an invalid behavior', () => {
+    expect(validateTriggerExamples([{ text: 'x', behavior: 'maybe' }])).toMatch(/behavior/)
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-create.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-create.ts
@@ -14,6 +14,7 @@ import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
 import { resolveProcedureAuthoring } from './procedure-authoring-guard'
 import { validateSchemaReferences } from './schema-references'
+import { validateTriggerExamples } from './trigger-examples'
 
 const triggerExampleSchema = {
   type: 'object',
@@ -73,6 +74,10 @@ Optionally pass \`body\` (the step DSL) to seed the procedure now, or omit it an
       if (!name) return { success: false, output: null, error: 'name must be a non-empty string.' }
 
       const whenToUse = typeof args.whenToUse === 'string' ? args.whenToUse : undefined
+      if (args.triggerExamples !== undefined) {
+        const teError = validateTriggerExamples(args.triggerExamples)
+        if (teError) return { success: false, output: null, error: teError }
+      }
       const triggerExamples = Array.isArray(args.triggerExamples)
         ? (args.triggerExamples as unknown[])
         : undefined

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-update-criteria.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-update-criteria.ts
@@ -5,6 +5,7 @@ import { getAttachedProcedureDraft } from '../../../../../agents/procedures/auth
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
 import { resolveProcedureAuthoring } from './procedure-authoring-guard'
+import { validateTriggerExamples } from './trigger-examples'
 
 /**
  * Update a procedure's name / selection criteria (`whenToUse` / `triggerExamples`).
@@ -49,6 +50,10 @@ export function createUpdateProcedureCriteriaTool(getDeps: GetToolDeps): AgentTo
 
       const name = typeof args.name === 'string' ? args.name : undefined
       const whenToUse = typeof args.whenToUse === 'string' ? args.whenToUse : undefined
+      if (args.triggerExamples !== undefined) {
+        const teError = validateTriggerExamples(args.triggerExamples)
+        if (teError) return { success: false, output: null, error: teError }
+      }
       const triggerExamples = Array.isArray(args.triggerExamples)
         ? (args.triggerExamples as unknown[])
         : undefined

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/trigger-examples.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/trigger-examples.ts
@@ -1,0 +1,28 @@
+// packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/trigger-examples.ts
+
+/**
+ * Validate model-supplied `triggerExamples` before they're persisted. The tool
+ * JSON Schema is only a hint to the provider — the runtime classifier consumes
+ * these few-shot examples directly (`procedures/classify.ts`), where a malformed
+ * entry (a `null` element, or a missing/invalid `behavior`) either THROWS during
+ * live procedure selection or pollutes the prompt with `- undefined`. So we
+ * validate the shape server-side, the same way `validateProcedureDsl` does for the
+ * body. Returns a human-readable error string, or `null` when valid.
+ */
+export function validateTriggerExamples(value: unknown): string | null {
+  if (!Array.isArray(value)) return 'triggerExamples must be an array.'
+  for (let i = 0; i < value.length; i++) {
+    const entry = value[i]
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+      return `triggerExamples[${i}] must be an object with "text" and "behavior".`
+    }
+    const { text, behavior } = entry as Record<string, unknown>
+    if (typeof text !== 'string' || text.trim() === '') {
+      return `triggerExamples[${i}].text must be a non-empty string.`
+    }
+    if (behavior !== 'use' && behavior !== 'avoid') {
+      return `triggerExamples[${i}].behavior must be "use" or "avoid".`
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Why
The tool JSON Schema is only a hint to the model provider. The runtime classifier (`procedures/classify.ts`) consumes `triggerExamples` directly as few-shot examples, where a malformed entry — a `null` element, or a missing/invalid `behavior` — either **throws** during live procedure selection or pollutes the prompt with `- undefined`.

## What
- `tools/trigger-examples.ts` — new `validateTriggerExamples`: each entry must be an object with a non-empty `text` and `behavior` of `use`/`avoid`. Returns a human-readable error string or `null`, same shape as `validateProcedureDsl`.
- `procedure-create.ts` / `procedure-update-criteria.ts` — run it before persisting and return the error to the model.
- `__tests__/trigger-examples.test.ts` — unit tests.