### PR TITLE
fix(security): org-scope the procedure authoring guard

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-authoring-guard.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-authoring-guard.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/procedure-authoring-guard.ts
 
+import { getCachedAgentById } from '../../../../../cache'
 import { isAdminOrOwner } from '../../../../../members'
 import { FeaturePermissionService } from '../../../../../permissions'
 import { FeatureKey } from '../../../../../permissions/client'
@@ -38,6 +39,15 @@ export async function resolveProcedureAuthoring(
   const admin = await isAdminOrOwner(agentDeps.organizationId, agentDeps.userId)
   if (!admin) {
     return { ok: false, error: 'Only an admin or owner can author procedures.' }
+  }
+
+  // The agent id comes from client-supplied session refs — verify it belongs to
+  // THIS org before any tool acts on it. The read/edit paths are also guarded by
+  // the org-scoped AgentProcedure filter, but `create_procedure` attaches a new
+  // link, so without this check it could attach to another org's agent.
+  const agent = await getCachedAgentById(agentDeps.organizationId, agentRef.id)
+  if (!agent) {
+    return { ok: false, error: 'Agent not found in this workspace.' }
   }
 
   return { ok: true, agentId: agentRef.id }


### PR DESCRIPTION
## Problem
The agent id passed to the procedure-authoring tools comes from client-supplied session refs. The read/edit paths are covered by the org-scoped `AgentProcedure` filter, but `create_procedure` **attaches a new link** — so without an ownership check it could attach a procedure to another org's agent.

## Fix
`resolveProcedureAuthoring` now verifies the agent belongs to the caller's org via `getCachedAgentById(organizationId, agentRef.id)` before returning `ok`, failing with "Agent not found in this workspace." otherwise.