### PR TITLE
fix(kopilot): builder sessions never carry a DM trigger

### DIFF
--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -232,7 +232,7 @@ export async function POST(request: NextRequest) {
           // the DM kind on subsequent sends without re-reading the agent.
           let createAgentTriggerId: string | null = null
           let createTriggerContext: Record<string, unknown> | null = null
-          if (body.triggerKind === 'dm' && sessionAgentId) {
+          if (body.triggerKind === 'dm' && sessionType !== 'builder' && sessionAgentId) {
             const cachedAgent = await getCachedAgentById(organizationId, sessionAgentId)
             if (!cachedAgent) {
               send({ type: 'turn-error', error: 'Agent not found', code: 'not_found' })
@@ -289,7 +289,16 @@ export async function POST(request: NextRequest) {
 
         // Existing-session DM gate: re-resolve the cached agent on every send
         // so disabling DM mid-thread surfaces a fresh 403, not a stale OK.
-        if (body.triggerKind === 'dm' && sessionAgentId && !inProcessTriggerContext) {
+        // Builder sessions can never carry a DM trigger — their agentConfig is
+        // forced to the master sentinel (agentId null), which `buildKopilotPrompt`
+        // rejects alongside a triggerContext. A `dm` flag on a builder session is
+        // always a stale-client artifact; drop it and run a normal builder turn.
+        if (
+          body.triggerKind === 'dm' &&
+          sessionType !== 'builder' &&
+          sessionAgentId &&
+          !inProcessTriggerContext
+        ) {
           const cachedAgent = await getCachedAgentById(organizationId, sessionAgentId)
           if (!cachedAgent) {
             send({ type: 'turn-error', error: 'Agent not found', code: 'not_found' })

--- a/apps/web/src/components/kopilot/ui/kopilot-composer.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-composer.tsx
@@ -395,7 +395,13 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
 
     // Sender pick — lock takes precedence over in-flight selection. Master
     // Kopilot leaves both null and sends without `agentId` / `triggerKind`.
-    const senderAgentId = displayActorId ? parseActorId(displayActorId).id : null
+    // Gated on `allowSenderPicker`: only the master surface infers a DM sender
+    // from the session. The docked tabs disable the picker — Build never DMs,
+    // and Chat passes `triggerKind` via prop. Without this gate a builder
+    // session (whose `agentId` is the edit subject, not a responder) would lock
+    // the sender and stamp every build turn as `triggerKind: 'dm'`.
+    const senderAgentId =
+      allowSenderPicker && displayActorId ? parseActorId(displayActorId).id : null
 
     onSend({
       sessionId: activeSessionId ?? undefined,
@@ -427,6 +433,7 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
     templateDisplayMap,
     selectedModelId,
     allowReferencePicker,
+    allowSenderPicker,
     displayActorId,
   ])
 


### PR DESCRIPTION
## Problem
A builder session's `agentConfig` is forced to the master sentinel (`agentId: null`), which `buildKopilotPrompt` rejects alongside a `triggerContext`. But a stale client could still send `triggerKind: 'dm'` on a builder session, and the composer inferred a DM sender from the session's display actor — stamping every **build** turn as a DM (the builder's `agentId` is the edit subject, not a responder).

## Fix
- `api/kopilot/stream/route.ts` — gate both DM-resolution paths on `sessionType !== 'builder'`; a `dm` flag on a builder session is dropped and the turn runs as a normal builder turn.
- `kopilot-composer.tsx` — gate sender inference on `allowSenderPicker` (only the master surface infers a DM sender; docked Build never DMs, Chat passes `triggerKind` via prop).