### PR TITLE
fix(editor): keep bubble menu open on internal focus, close on outside click

### DIFF
--- a/apps/web/src/components/editor/bubble-menu/bubble-menu.tsx
+++ b/apps/web/src/components/editor/bubble-menu/bubble-menu.tsx
@@ -51,10 +51,13 @@ export function EditorBubbleMenu({
     setSubPopoverCount((n) => Math.max(0, open ? n + 1 : n - 1))
   }, [])
 
+  const contentRef = useRef<HTMLDivElement>(null)
+
   const state = useBubbleMenuState({
     editor,
     shouldShow,
     forceOpen: subPopoverCount > 0,
+    getMenuEl: () => contentRef.current,
   })
 
   const virtualRef = useRef<{ getBoundingClientRect: () => DOMRect }>({
@@ -75,6 +78,7 @@ export function EditorBubbleMenu({
         <Popover open={state.open} onOpenChange={() => {}}>
           <PopoverAnchor virtualRef={virtualRef} />
           <PopoverContentDialogAware
+            ref={contentRef}
             side='top'
             align='start'
             sideOffset={8}

--- a/apps/web/src/components/editor/bubble-menu/use-bubble-menu-state.ts
+++ b/apps/web/src/components/editor/bubble-menu/use-bubble-menu-state.ts
@@ -2,7 +2,7 @@
 'use client'
 
 import type { Editor } from '@tiptap/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export interface BubbleMenuRange {
   from: number
@@ -22,6 +22,10 @@ interface UseBubbleMenuStateOptions {
    *  the editor loses focus — used while a nested popover (color picker, turn
    *  into menu) is open and steals focus from the editor. */
   forceOpen?: boolean
+  /** Returns the bubble popover content element. Used to keep the menu open
+   *  when focus lives inside it (e.g. focus returned to a bubble button after a
+   *  sub-popover closed) and to ignore clicks landing on it. */
+  getMenuEl?: () => HTMLElement | null
 }
 
 let emptyRect: DOMRect | null = null
@@ -67,6 +71,7 @@ export function useBubbleMenuState({
   editor,
   shouldShow = defaultShouldShow,
   forceOpen = false,
+  getMenuEl,
 }: UseBubbleMenuStateOptions): BubbleMenuState {
   const [state, setState] = useState<BubbleMenuState>({
     open: false,
@@ -74,16 +79,32 @@ export function useBubbleMenuState({
     range: { from: 0, to: 0 },
   })
 
+  // Read latest values inside the effect's listeners without re-subscribing.
+  const forceOpenRef = useRef(forceOpen)
+  forceOpenRef.current = forceOpen
+  const getMenuElRef = useRef(getMenuEl)
+  getMenuElRef.current = getMenuEl
+
   useEffect(() => {
     if (!editor) return
 
     let rafId: number | null = null
 
+    // The bubble follows the text selection, which ProseMirror keeps intact on
+    // blur — so selection alone can't tell us the user clicked away. Keep it
+    // open only while focus is in the editor, a sub-popover is open, or focus
+    // returned to the bubble itself.
+    const hasFocus = () => {
+      if (editor.isFocused || forceOpenRef.current) return true
+      const active = typeof document !== 'undefined' ? document.activeElement : null
+      return !!(active && getMenuElRef.current?.()?.contains(active))
+    }
+
     const compute = () => {
       rafId = null
       if (editor.isDestroyed) return
       const { from, to } = editor.state.selection
-      const ok = shouldShow({ editor, from, to })
+      const ok = hasFocus() && shouldShow({ editor, from, to })
       if (!ok) {
         setState((prev) => (prev.open ? { ...prev, open: false } : prev))
         return
@@ -101,6 +122,21 @@ export function useBubbleMenuState({
       rafId = window.requestAnimationFrame(compute)
     }
 
+    // Close on a click outside the editor and outside any popover (the bubble
+    // itself or a sub-popover). Needed because when the editor is already
+    // blurred — e.g. focus sits on a bubble button after a sub-popover closed —
+    // clicking away fires no editor `blur`, so `compute` would never run.
+    const onPointerDown = (e: PointerEvent) => {
+      if (editor.isDestroyed) return
+      const target = e.target as Element | null
+      if (!target) return
+      if (editor.view.dom.contains(target)) return
+      if (getMenuElRef.current?.()?.contains(target)) return
+      // Radix portals popovers to <body>; ignore clicks inside any of them.
+      if (target.closest('[data-radix-popper-content-wrapper]')) return
+      setState((prev) => (prev.open ? { ...prev, open: false } : prev))
+    }
+
     editor.on('selectionUpdate', schedule)
     editor.on('transaction', schedule)
     editor.on('blur', schedule)
@@ -109,6 +145,7 @@ export function useBubbleMenuState({
     // Reposition on viewport changes too.
     window.addEventListener('scroll', schedule, true)
     window.addEventListener('resize', schedule)
+    document.addEventListener('pointerdown', onPointerDown, true)
 
     schedule()
 
@@ -120,6 +157,7 @@ export function useBubbleMenuState({
       editor.off('focus', schedule)
       window.removeEventListener('scroll', schedule, true)
       window.removeEventListener('resize', schedule)
+      document.removeEventListener('pointerdown', onPointerDown, true)
     }
   }, [editor, shouldShow])
 


### PR DESCRIPTION
## Problem
The editor bubble menu follows the text selection, which ProseMirror keeps intact on blur — so selection alone can't tell the menu the user clicked away. Two symptoms: the menu could close while focus legitimately sat inside it (e.g. focus returned to a bubble button after a color-picker sub-popover closed), and it could stay open after a click away because no editor `blur` fires when focus already sits on a bubble button.

## Fix
- `use-bubble-menu-state.ts` — a `hasFocus()` check (editor focused, sub-popover open via `forceOpen`, or focus inside the menu via a new `getMenuEl` ref) gates `shouldShow`; add a capturing `document` `pointerdown` listener that closes on a click outside the editor and outside any Radix-portaled popover. Latest `forceOpen`/`getMenuEl` read through refs so the effect doesn't re-subscribe.
- `bubble-menu.tsx` — pass the popover content element via `getMenuEl`.