### PR TITLE
feat(evals): tool-declared exampleOutput for autofill

### DIFF
--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -30,6 +30,13 @@ export interface CatalogTool {
   timeoutMs: number
   streaming: boolean
   refs: Array<{ path: string[]; kind: string }>
+  /**
+   * One realistic example of the tool's success output, carried verbatim from
+   * the SDK `tool.exampleOutput` (validated against `outputs` at author time).
+   * JSON value (object or array). Absent ⇒ consumers fall back (scaffold / AI /
+   * record). See plans/evals/tool-example-outputs.md.
+   */
+  exampleOutput?: unknown
 }
 
 /** Where an agent tool may run — mirrors `@auxx/lib` `AgentSurface`. */

--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -251,6 +251,15 @@ export interface AgentToolDefinition {
    */
   outputSchema?: z.ZodType
   /**
+   * One realistic example of this tool's success `output` — the same shape as
+   * `outputSchema` describes. Authored once by the tool owner; consumed by eval
+   * autofill (seeds a tool-response mock) via `getToolExampleOutput`. Must be
+   * JSON-serializable; for app-backed tools it is carried verbatim from the
+   * SDK `tool.exampleOutput` through the catalog. Declarative, optional, and
+   * never enforced at runtime. See plans/evals/tool-example-outputs.md.
+   */
+  exampleOutput?: unknown
+  /**
    * Build the small display projection of the tool's output. Called once at
    * tool-completion time; the result is persisted on `ToolCallPart.digest` and
    * re-emitted on session reload — status pills and approval/result cards render

--- a/packages/lib/src/ai/kopilot/capabilities/__tests__/native-example-outputs.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/__tests__/native-example-outputs.test.ts
@@ -1,0 +1,30 @@
+// packages/lib/src/ai/kopilot/capabilities/__tests__/native-example-outputs.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { createSearchEntitiesTool } from '../entities/tools/search-entities'
+import { createFindThreadsTool } from '../mail/tools/find-threads'
+import { createGetThreadDetailTool } from '../mail/tools/get-thread-detail'
+import type { GetToolDeps } from '../types'
+
+// Factories never call getDeps at construction time — only inside `execute`.
+const getDeps = (() => ({})) as unknown as GetToolDeps
+
+// Guards against schema drift: a populated native `exampleOutput` must keep
+// satisfying its own `outputSchema`. See plans/evals/tool-example-outputs.md §7.
+describe('native exampleOutput conforms to outputSchema', () => {
+  const tools = [
+    createFindThreadsTool(getDeps),
+    createGetThreadDetailTool(getDeps),
+    createSearchEntitiesTool(getDeps),
+  ]
+
+  for (const tool of tools) {
+    it(`${tool.name} has a schema-valid, JSON-serializable example`, () => {
+      expect(tool.exampleOutput).toBeDefined()
+      expect(tool.outputSchema).toBeDefined()
+      const parsed = tool.outputSchema!.safeParse(tool.exampleOutput)
+      expect(parsed.success).toBe(true)
+      expect(() => JSON.stringify(tool.exampleOutput)).not.toThrow()
+    })
+  }
+})

--- a/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
@@ -227,11 +227,25 @@ export async function createAppCapabilities(deps: {
         }
       }
 
+      // Author-declared realistic success output (from the SDK catalog). Used
+      // to seed eval tool-response mocks (via getToolExampleOutput) and, when
+      // present, as the capture-mode synthesizer. NOTE: app tools are
+      // `requiresApproval: false`, and capture-mode only invokes `captureMint`
+      // for approval-required tools — so this is inert in real headless capture
+      // today. It's wired here so the field is the single capture source if an
+      // app tool ever becomes approval-gated. See plans/evals/tool-example-outputs.md.
+      const exampleOutput = tool.exampleOutput
+
       const buildAgentTool = (execute: AgentToolDefinition['execute']): AgentToolDefinition => ({
         name: registeredName,
         displayName: tool.name || registeredName,
         description: tool.description,
         parameters: tool.inputsJsonSchema,
+        exampleOutput,
+        // App tools have no native captureMint; fall back to the declared
+        // example (args-agnostic) so capture mode can predict output. The
+        // engine wraps the return value with `_captured: true`.
+        ...(exampleOutput !== undefined ? { captureMint: () => exampleOutput } : {}),
         // App-backed tools never require per-call approval — toolset enablement
         // at agent-creation time is the approval gate. See
         // plans/kopilot/apps/gog-calendar-overhaul.md §3 decision #3 and

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/search-entities.ts
@@ -43,6 +43,23 @@ export function createSearchEntitiesTool(getDeps: GetToolDeps): AgentToolDefinit
     toolsetSlug: 'auxx:entities:search',
     idempotent: true,
     outputSchema: SearchEntitiesOutput,
+    exampleOutput: {
+      items: [
+        {
+          recordId: 'contact:9aB3xY',
+          displayName: 'Jane Cooper',
+          entityType: 'contact',
+          secondaryInfo: 'jane@example.com',
+        },
+        {
+          recordId: 'contact:4dF7mN',
+          displayName: 'Jane Doe',
+          entityType: 'contact',
+          secondaryInfo: 'jane.doe@acme.com',
+        },
+      ],
+      count: 2,
+    } satisfies z.output<typeof SearchEntitiesOutput>,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         items?: Array<Record<string, unknown>>

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/find-threads.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/find-threads.ts
@@ -115,6 +115,33 @@ export function createFindThreadsTool(getDeps: GetToolDeps): AgentToolDefinition
     toolsetSlug: 'auxx:mail:threads',
     idempotent: true,
     outputSchema: FindThreadsOutput,
+    exampleOutput: {
+      threads: [
+        {
+          id: 'thread_8fK2pQ',
+          subject: 'Where is my order #1042?',
+          status: 'OPEN',
+          assigneeId: null,
+          lastMessageAt: '2026-06-05T14:22:00.000Z',
+          messageCount: 2,
+          isUnread: true,
+          tagIds: ['tag_shipping'],
+          tags: [{ id: 'tag_shipping', name: 'Shipping', color: 'blue', emoji: null }],
+        },
+        {
+          id: 'thread_3aZ9rL',
+          subject: 'Request to change delivery address',
+          status: 'OPEN',
+          assigneeId: 'user_7Hd2',
+          lastMessageAt: '2026-06-04T09:10:00.000Z',
+          messageCount: 4,
+          isUnread: false,
+          tagIds: [],
+          tags: [],
+        },
+      ],
+      count: 2,
+    } satisfies z.output<typeof FindThreadsOutput>,
     buildDigest: (output) => {
       const out = (output ?? {}) as { threads?: Array<Record<string, unknown>>; count?: number }
       const threads = Array.isArray(out.threads) ? out.threads : []

--- a/packages/lib/src/ai/kopilot/capabilities/mail/tools/get-thread-detail.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/tools/get-thread-detail.ts
@@ -60,6 +60,45 @@ export function createGetThreadDetailTool(getDeps: GetToolDeps): AgentToolDefini
     toolsetSlug: 'auxx:mail:threads',
     idempotent: true,
     outputSchema: GetThreadDetailOutput,
+    exampleOutput: {
+      thread: {
+        id: 'thread_8fK2pQ',
+        subject: 'Where is my order #1042?',
+        status: 'OPEN',
+        assigneeId: null,
+        lastMessageAt: '2026-06-05T14:22:00.000Z',
+        messageCount: 2,
+        isUnread: true,
+        tagIds: ['tag_shipping'],
+        tags: [{ id: 'tag_shipping', name: 'Shipping', color: 'blue', emoji: null }],
+        integrationId: 'gmail_AbC123',
+      },
+      messages: [
+        {
+          id: 'msg_01',
+          subject: 'Where is my order #1042?',
+          snippet: "Hi, I ordered last week and haven't received any shipping update…",
+          textPlain:
+            "Hi, I ordered last week and haven't received any shipping update yet. Order number is 1042. Can you tell me when it will arrive?",
+          isInbound: true,
+          hasAttachments: false,
+          sentAt: '2026-06-05T13:40:00.000Z',
+          participants: ['jane@example.com', 'support@store.com'],
+        },
+        {
+          id: 'msg_02',
+          subject: 'Re: Where is my order #1042?',
+          snippet: 'Thanks for reaching out — let me check on that for you…',
+          textPlain:
+            'Thanks for reaching out — let me check on that for you and get back with a tracking update shortly.',
+          isInbound: false,
+          hasAttachments: false,
+          sentAt: '2026-06-05T14:22:00.000Z',
+          participants: ['support@store.com', 'jane@example.com'],
+        },
+      ],
+      totalMessages: 2,
+    } satisfies z.output<typeof GetThreadDetailOutput>,
     buildDigest: (output) => {
       const out = (output ?? {}) as {
         thread?: { id?: string; subject?: string | null; lastMessageAt?: string | null }

--- a/packages/lib/src/evals/__tests__/tool-examples.test.ts
+++ b/packages/lib/src/evals/__tests__/tool-examples.test.ts
@@ -1,0 +1,25 @@
+// packages/lib/src/evals/__tests__/tool-examples.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { AgentToolDefinition } from '../../ai/agent-framework/types'
+import { getToolExampleOutput } from '../tool-examples'
+
+const stub = (over: Partial<AgentToolDefinition>): AgentToolDefinition => ({
+  name: 'tool',
+  displayName: 'Tool',
+  description: '',
+  parameters: {},
+  execute: async () => ({ success: true, output: null }),
+  ...over,
+})
+
+describe('getToolExampleOutput', () => {
+  it('returns the declared example when present', () => {
+    const example = { id: 'abc', label: 'Widget' }
+    expect(getToolExampleOutput(stub({ exampleOutput: example }))).toEqual(example)
+  })
+
+  it('returns undefined when the tool has no example', () => {
+    expect(getToolExampleOutput(stub({}))).toBeUndefined()
+  })
+})

--- a/packages/lib/src/evals/tool-examples.ts
+++ b/packages/lib/src/evals/tool-examples.ts
@@ -1,0 +1,20 @@
+// packages/lib/src/evals/tool-examples.ts
+
+import type { AgentToolDefinition } from '../ai/agent-framework/types'
+
+/**
+ * Read a tool's declared example success output, regardless of whether it is a
+ * native capability or an app-backed tool (both expose `exampleOutput` on the
+ * built `AgentToolDefinition` — app tools carry it verbatim from the SDK
+ * catalog through the kopilot bridge).
+ *
+ * Returns `undefined` when the tool has no example; the caller then falls back
+ * to the other autofill sources (schema-scaffold / AI-generate / record). The
+ * eval tool-response editor seeds a new mock from this when present, labels the
+ * row "from example," and still validates it against `outputSchema`.
+ *
+ * See plans/evals/tool-example-outputs.md and plans/evals/phase-1-agent-simulation.md §1.6.
+ */
+export function getToolExampleOutput(tool: AgentToolDefinition): unknown | undefined {
+  return tool.exampleOutput
+}

--- a/packages/sdk/__fixtures__/tool-app/src/app.ts
+++ b/packages/sdk/__fixtures__/tool-app/src/app.ts
@@ -26,6 +26,9 @@ export const app = {
       outputs: z.object({
         messageId: z.string(),
       }),
+      exampleOutput: {
+        messageId: 'msg_abc123',
+      },
       config: {
         requiresConnection: true,
         timeout: 20000,

--- a/packages/sdk/src/root/tools/__tests__/define-tool.test.ts
+++ b/packages/sdk/src/root/tools/__tests__/define-tool.test.ts
@@ -1,0 +1,41 @@
+// packages/sdk/src/root/tools/__tests__/define-tool.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod/v4'
+import { defineTool } from '../define-tool.js'
+
+const baseTool = {
+  id: 'get_thing',
+  name: 'Get thing',
+  description: 'Gets a thing.',
+  inputs: z.object({ id: z.string() }),
+  outputs: z.object({ id: z.string(), label: z.string() }),
+  execute: async () => ({ id: 'x', label: 'y' }),
+}
+
+describe('defineTool exampleOutput validation', () => {
+  it('accepts a tool with no example', () => {
+    expect(() => defineTool(baseTool)).not.toThrow()
+  })
+
+  it('accepts an example that satisfies the outputs schema', () => {
+    expect(() =>
+      defineTool({ ...baseTool, exampleOutput: { id: 'abc', label: 'Widget' } })
+    ).not.toThrow()
+  })
+
+  it('rejects an example that fails outputs.safeParse', () => {
+    expect(() =>
+      // Missing required `label`.
+      defineTool({ ...baseTool, exampleOutput: { id: 'abc' } as never })
+    ).toThrow(/does not satisfy its outputs schema/)
+  })
+
+  it('rejects a non-JSON-serializable example (circular ref)', () => {
+    const circular: Record<string, unknown> = { id: 'abc', label: 'Widget' }
+    circular.self = circular
+    expect(() => defineTool({ ...baseTool, exampleOutput: circular as never })).toThrow(
+      /not JSON-serializable/
+    )
+  })
+})

--- a/packages/sdk/src/root/tools/define-tool.ts
+++ b/packages/sdk/src/root/tools/define-tool.ts
@@ -25,5 +25,28 @@ export function defineTool<TInput extends z.ZodTypeAny, TOutput extends z.ZodTyp
   if (!TOOL_ID_RE.test(tool.id)) {
     throw new Error(`defineTool: invalid id "${tool.id}" — must match ${TOOL_ID_RE.source}`)
   }
+
+  if (tool.exampleOutput !== undefined) {
+    const parsed = tool.outputs.safeParse(tool.exampleOutput)
+    if (!parsed.success) {
+      throw new Error(
+        `defineTool: tool "${tool.id}" exampleOutput does not satisfy its outputs schema — ${parsed.error.message}`
+      )
+    }
+    // JSON-serializability guard — examples ride the catalog jsonb, so a
+    // circular ref / BigInt would only fail at deploy time without this.
+    try {
+      if (JSON.stringify(tool.exampleOutput) === undefined) {
+        throw new Error('serializes to undefined (function or top-level undefined)')
+      }
+    } catch (err) {
+      throw new Error(
+        `defineTool: tool "${tool.id}" exampleOutput is not JSON-serializable — ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      )
+    }
+  }
+
   return tool
 }

--- a/packages/sdk/src/root/tools/types.ts
+++ b/packages/sdk/src/root/tools/types.ts
@@ -209,6 +209,15 @@ export interface ToolDefinition<
   /** Zod output schema. Output refs marker-fields are mined for fences. */
   readonly outputs: TOutput
 
+  /**
+   * One realistic example of this tool's success output. Authored once by the
+   * tool owner; reused by eval autofill, capture/headless mode, and docs.
+   * Must satisfy `outputs` (validated at compile/extract time) and be
+   * JSON-serializable. For outputs containing `refs.entity(...)` marker fields,
+   * use `null` or a sample `RecordId`. See plans/evals/tool-example-outputs.md.
+   */
+  readonly exampleOutput?: z.output<TOutput>
+
   /** Runtime/auth configuration. */
   readonly config?: ToolConfig
 

--- a/packages/sdk/src/util/__tests__/compile-and-extract-catalog.test.ts
+++ b/packages/sdk/src/util/__tests__/compile-and-extract-catalog.test.ts
@@ -51,6 +51,11 @@ describe('compileAndExtractCatalog', () => {
       },
     })
 
+    // exampleOutput rides the catalog verbatim (deep-cloned, serializable).
+    expect(catalog.tools[0]?.exampleOutput).toEqual({ messageId: 'msg_abc123' })
+    // It also surfaces on the agent projection (CatalogAgentTool extends CatalogTool).
+    expect(catalog.agent.tools[0]?.exampleOutput).toEqual({ messageId: 'msg_abc123' })
+
     expect(catalog.toolsets).toEqual([
       {
         slug: 'app:fixture:messaging',

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -41,6 +41,13 @@ export interface CatalogTool {
   timeoutMs: number
   streaming: boolean
   refs: Array<{ path: string[]; kind: string }>
+  /**
+   * One realistic example of the tool's success output, carried verbatim from
+   * the SDK `tool.exampleOutput` (validated against `outputs` at author time).
+   * JSON value (object or array). Absent ⇒ consumers fall back (scaffold / AI /
+   * record). See plans/evals/tool-example-outputs.md.
+   */
+  exampleOutput?: unknown
 }
 
 export interface CatalogAgentTool extends CatalogTool {
@@ -391,6 +398,11 @@ export async function compileAndExtractCatalog(): Promise<
       timeoutMs: tool.config?.timeout ?? 15000,
       streaming: Boolean(tool.agent?.streaming ?? tool.config?.streaming),
       refs: outputs.refs,
+      // Deep-clone via JSON so the catalog carries a plain, serializable copy
+      // (the top-level JSON.stringify check below still guards the payload).
+      ...(tool.exampleOutput !== undefined
+        ? { exampleOutput: JSON.parse(JSON.stringify(tool.exampleOutput)) }
+        : {}),
     }
     cataloguedTools.push(baseTool)
 
@@ -576,6 +588,7 @@ interface RawTool {
   description: string
   inputs: unknown
   outputs: unknown
+  exampleOutput?: unknown
   config?: ToolConfig
   agent?: ToolAgentSurface
   action?: ToolActionSurface


### PR DESCRIPTION
## What

Adds an optional **`exampleOutput`** field a tool can declare once where it lives, surfaced wherever a synthetic tool output is needed. Primary consumer is eval tool-response autofill — a tool pre-fills a realistic, schema-valid example instead of a blank editor.

## Changes

- **SDK** — `ToolDefinition.exampleOutput` + `defineTool` validation (rejects an example that fails `outputs.safeParse` or isn't JSON-serializable; fails at app build, not prod).
- **Catalog** — extract + persist `CatalogTool.exampleOutput`. TS interface only on both the SDK and DB `CatalogTool` (stays in lock-step) — rides the existing `AppDeployment.catalog` jsonb, **no migration**.
- **Native** — `AgentToolDefinition.exampleOutput`; seeded on `find_threads`, `get_thread_detail`, `search_entities`.
- **Bridge** — app tools carry the example onto the built `AgentToolDefinition` + a `captureMint` fallback.
- **Consumption** — `getToolExampleOutput(tool)` helper for eval autofill.
- **Tests** — defineTool validation, catalog round-trip, native conformance, helper (10 tests, all passing).

## Notes / honest caveats

- **No runtime consumer yet.** Only `getToolExampleOutput` reads the field, and the eval autofill UI that calls it isn't built — this lands the plumbing ahead of that feature.
- **captureMint wiring is inert today.** App tools are hardwired `requiresApproval: false`, and capture-mode only invokes `captureMint` for approval-required tools, so the app-tool capture path doesn't fire in real headless mode. It's wired as the right home for when/if an app tool becomes approval-gated. The eval path doesn't depend on it (mock layer wraps `execute` directly).
- App-side examples (Shopify + 14 other apps in `auxxai-apps`) ship separately and only appear in a catalog after each app is rebuilt + redeployed.

Companion PR (app examples): Auxx-Ai/auxxai-apps#chat-extension-scaffold