### PR TITLE
refactor(utils): shared json/hash/redact helpers + tRPC unwrap

### DIFF
--- a/apps/web/src/server/api/routers/agent-procedure.ts
+++ b/apps/web/src/server/api/routers/agent-procedure.ts
@@ -14,6 +14,7 @@ import { FeatureKey } from '@auxx/lib/permissions/client'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { adminProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
+import { unwrap } from '../unwrap'
 
 /** adminProcedure + a beta gate: requires the `agentProcedures` feature on the org's plan. */
 const agentProceduresAdminProcedure = adminProcedure.use(async ({ ctx, next }) => {
@@ -23,19 +24,6 @@ const agentProceduresAdminProcedure = adminProcedure.use(async ({ ctx, next }) =
   )
   return next()
 })
-
-/** Unwrap a neverthrow Result, mapping an error to a TRPCError. */
-function unwrap<T>(
-  result: { isErr(): boolean; value?: T; error?: { message?: string } | Error },
-  message: string
-): T {
-  if (result.isErr()) {
-    const detail =
-      (result.error as { message?: string } | undefined)?.message ?? String(result.error)
-    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: `${message}: ${detail}` })
-  }
-  return result.value as T
-}
 
 async function ensureAgentInOrg(organizationId: string, agentId: string): Promise<void> {
   if (!(await agentExistsInOrg(organizationId, agentId))) {

--- a/apps/web/src/server/api/routers/calendar.ts
+++ b/apps/web/src/server/api/routers/calendar.ts
@@ -18,6 +18,7 @@ import crypto from 'crypto'
 import { and, count, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { type createTRPCContext, createTRPCRouter, notDemo, protectedProcedure } from '../trpc'
+import { unwrap } from '../unwrap'
 
 /**
  * Shared pagination input for calendar event listings.
@@ -38,7 +39,7 @@ export const calendarRouter = createTRPCRouter({
    */
   list: protectedProcedure.input(listCalendarEventsInputSchema).query(async ({ ctx, input }) => {
     const result = await listCalendarEvents(ctx.session.organizationId, input)
-    return unwrapResult(result, 'Failed to list calendar events')
+    return unwrap(result, 'Failed to list calendar events')
   }),
 
   /**
@@ -50,7 +51,7 @@ export const calendarRouter = createTRPCRouter({
       const result = await getUpcomingMeetings(ctx.session.organizationId, {
         limit: input?.limit ?? 5,
       })
-      return unwrapResult(result, 'Failed to load upcoming meetings')
+      return unwrap(result, 'Failed to load upcoming meetings')
     }),
 
   /**
@@ -58,7 +59,7 @@ export const calendarRouter = createTRPCRouter({
    */
   getById: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
     const result = await getCalendarEventById(input.id, ctx.session.organizationId)
-    return unwrapResult(result, 'Failed to load calendar event')
+    return unwrap(result, 'Failed to load calendar event')
   }),
 
   /**
@@ -71,7 +72,7 @@ export const calendarRouter = createTRPCRouter({
         input.calendarEventId,
         ctx.session.organizationId
       )
-      return unwrapResult(result, 'Failed to load calendar participants')
+      return unwrap(result, 'Failed to load calendar participants')
     }),
 
   /**
@@ -251,7 +252,7 @@ export const calendarRouter = createTRPCRouter({
         ctx.session.organizationId
       )
 
-      return unwrapResult(result, 'Failed to link calendar event to meeting')
+      return unwrap(result, 'Failed to link calendar event to meeting')
     }),
 
   /**
@@ -308,27 +309,6 @@ async function assertGoogleIntegration(
   }
 
   return integration
-}
-
-/**
- * Convert a neverthrow Result into a plain tRPC payload or throw a typed error.
- */
-function unwrapResult<T>(result: unknown, message: string): T {
-  const candidate = result as {
-    isErr(): boolean
-    error?: Error
-    value?: T
-  }
-
-  if (candidate.isErr()) {
-    throw new TRPCError({
-      code: 'INTERNAL_SERVER_ERROR',
-      message: message,
-      cause: candidate.error,
-    })
-  }
-
-  return candidate.value as T
 }
 
 /**

--- a/apps/web/src/server/api/routers/procedure.ts
+++ b/apps/web/src/server/api/routers/procedure.ts
@@ -23,6 +23,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { adminProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
+import { unwrap } from '../unwrap'
 
 const logger = createScopedLogger('procedure-router')
 
@@ -34,19 +35,6 @@ const agentProceduresAdminProcedure = adminProcedure.use(async ({ ctx, next }) =
   )
   return next()
 })
-
-/** Unwrap a neverthrow Result, mapping an error to a TRPCError. */
-function unwrap<T>(
-  result: { isErr(): boolean; value?: T; error?: { message?: string } | Error },
-  message: string
-): T {
-  if (result.isErr()) {
-    const detail =
-      (result.error as { message?: string } | undefined)?.message ?? String(result.error)
-    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: `${message}: ${detail}` })
-  }
-  return result.value as T
-}
 
 const triggerExampleSchema = z.object({
   text: z.string(),

--- a/apps/web/src/server/api/unwrap.ts
+++ b/apps/web/src/server/api/unwrap.ts
@@ -1,0 +1,24 @@
+// apps/web/src/server/api/unwrap.ts
+
+import { TRPCError } from '@trpc/server'
+
+/**
+ * Unwrap a neverthrow `Result`, mapping an error to a `TRPCError`. On error,
+ * throws `INTERNAL_SERVER_ERROR` with `"<message>: <error detail>"`. Structurally
+ * typed so callers don't have to import neverthrow's `Result`.
+ */
+export function unwrap<T>(
+  result: { isErr(): boolean; value?: T; error?: { message?: string } | Error },
+  message: string
+): T {
+  if (result.isErr()) {
+    const detail =
+      (result.error as { message?: string } | undefined)?.message ?? String(result.error)
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: `${message}: ${detail}`,
+      cause: result.error,
+    })
+  }
+  return result.value as T
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -82,6 +82,18 @@
       "import": "./dist/headers.js",
       "default": "./src/headers.ts"
     },
+    "./json": {
+      "types": "./src/json.ts",
+      "source": "./src/json.ts",
+      "import": "./dist/json.js",
+      "default": "./src/json.ts"
+    },
+    "./hash": {
+      "types": "./src/hash.ts",
+      "source": "./src/hash.ts",
+      "import": "./dist/hash.js",
+      "default": "./src/hash.ts"
+    },
     "./mime": {
       "types": "./src/mime.ts",
       "source": "./src/mime.ts",
@@ -99,6 +111,12 @@
       "source": "./src/parse.ts",
       "import": "./dist/parse.js",
       "default": "./src/parse.ts"
+    },
+    "./redact": {
+      "types": "./src/redact.ts",
+      "source": "./src/redact.ts",
+      "import": "./dist/redact.js",
+      "default": "./src/redact.ts"
     },
     "./retry": {
       "types": "./src/retry.ts",

--- a/packages/utils/src/__tests__/objects.test.ts
+++ b/packages/utils/src/__tests__/objects.test.ts
@@ -1,0 +1,45 @@
+// packages/utils/src/__tests__/objects.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { deepEqual } from '../objects'
+
+describe('deepEqual', () => {
+  it('compares object keys order-independently', () => {
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true)
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false)
+  })
+
+  it('compares arrays order-sensitively', () => {
+    expect(deepEqual([1, 2], [1, 2])).toBe(true)
+    expect(deepEqual([1, 2], [2, 1])).toBe(false)
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false)
+  })
+
+  it('recurses through nested arrays and objects', () => {
+    expect(deepEqual({ a: [{ x: 1 }] }, { a: [{ x: 1 }] })).toBe(true)
+    expect(deepEqual({ a: [{ x: 1 }] }, { a: [{ x: 2 }] })).toBe(false)
+  })
+
+  it('compares Dates by timestamp', () => {
+    expect(deepEqual(new Date('2024-01-01'), new Date('2024-01-01'))).toBe(true)
+    expect(deepEqual(new Date('2024-01-01'), new Date('2024-01-02'))).toBe(false)
+    expect(deepEqual(new Date('2024-01-01'), { foo: 1 })).toBe(false)
+  })
+
+  it('treats undefined and a missing key as distinct from null', () => {
+    expect(deepEqual(undefined, null)).toBe(false)
+    expect(deepEqual(null, null)).toBe(true)
+    expect(deepEqual({ a: undefined }, {})).toBe(false)
+  })
+
+  it('distinguishes arrays from non-array objects', () => {
+    expect(deepEqual([], {})).toBe(false)
+  })
+
+  it('compares symbols by identity', () => {
+    const s = Symbol('x')
+    expect(deepEqual(s, s)).toBe(true)
+    expect(deepEqual(s, Symbol('x'))).toBe(false)
+    expect(deepEqual(s, null)).toBe(false)
+  })
+})

--- a/packages/utils/src/__tests__/parse.test.ts
+++ b/packages/utils/src/__tests__/parse.test.ts
@@ -1,0 +1,43 @@
+// packages/utils/src/__tests__/parse.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { parseBoolean, toNumeric } from '../parse'
+
+describe('parseBoolean', () => {
+  it('coerces truthy and falsy tokens', () => {
+    expect(parseBoolean('yes')).toBe(true)
+    expect(parseBoolean('0')).toBe(false)
+    expect(parseBoolean(true)).toBe(true)
+  })
+
+  it('returns undefined for unknown input', () => {
+    expect(parseBoolean(null)).toBeUndefined()
+    expect(parseBoolean('maybe')).toBeUndefined()
+  })
+})
+
+describe('toNumeric', () => {
+  it('passes numbers through, rejecting NaN', () => {
+    expect(toNumeric(42)).toBe(42)
+    expect(toNumeric(Number.NaN)).toBeNull()
+  })
+
+  it('parses ISO date strings to epoch ms', () => {
+    expect(toNumeric('2024-01-01T00:00:00.000Z')).toBe(Date.parse('2024-01-01T00:00:00.000Z'))
+  })
+
+  it('falls back to Number only for strings Date.parse rejects', () => {
+    // Date.parse is greedy: bare decimals/integers are interpreted as dates first.
+    expect(toNumeric('3.5')).toBe(Date.parse('3.5'))
+    // Exotic numeric formats Date.parse cannot read fall through to Number.
+    expect(toNumeric('1e3')).toBe(1000)
+  })
+
+  it('returns null for empty or non-numeric strings and other types', () => {
+    expect(toNumeric('')).toBeNull()
+    expect(toNumeric('   ')).toBeNull()
+    expect(toNumeric('hello')).toBeNull()
+    expect(toNumeric(null)).toBeNull()
+    expect(toNumeric({})).toBeNull()
+  })
+})

--- a/packages/utils/src/hash.ts
+++ b/packages/utils/src/hash.ts
@@ -1,0 +1,17 @@
+// packages/utils/src/hash.ts
+
+import { createHash } from 'node:crypto'
+import { stableStringify } from './json'
+
+/**
+ * Stable SHA-256 (hex) of a value's canonical serialization. Key-order- and
+ * insertion-order-independent, so the same logical value hashes identically
+ * before and after a Postgres `jsonb` round-trip — see {@link stableStringify}.
+ *
+ * Server-only (`node:crypto`); intentionally NOT re-exported from the package
+ * barrel so it can never leak into a browser bundle. Import it explicitly from
+ * `@auxx/utils/hash`.
+ */
+export function stableHash(value: unknown): string {
+  return createHash('sha256').update(stableStringify(value), 'utf8').digest('hex')
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -129,7 +129,7 @@ export { validateRedirectPath } from './oauth'
 // Object utilities
 export { cloneDeep, deepMerge, getByPath } from './objects'
 // Parse utilities
-export { parseBoolean } from './parse'
+export { parseBoolean, toNumeric } from './parse'
 // Relationship utilities
 export {
   getInverseCardinality,

--- a/packages/utils/src/json.ts
+++ b/packages/utils/src/json.ts
@@ -1,0 +1,52 @@
+// packages/utils/src/json.ts
+
+/**
+ * Deterministic, key-order-independent JSON serialization. Recursively sorts
+ * object keys (bytewise) and drops `undefined` object values, so two
+ * structurally-equal values serialize to the identical string regardless of key
+ * insertion order. Array order is preserved.
+ *
+ * This is the canonical fix for Postgres `jsonb` round-trips: `jsonb` does NOT
+ * preserve object key insertion order, so a plain `JSON.stringify` of an
+ * in-memory value won't match the same value read back from a `jsonb` column.
+ * Serialize both sides with this and they match. Single-pass — no intermediate
+ * object is allocated (use {@link canonicalize} when you need the object form).
+ *
+ * PURE. Top-level `undefined` serializes to `'null'`; mirrors `JSON.stringify`
+ * for every other primitive. Does not handle circular references, `Map`/`Set`,
+ * or class instances.
+ */
+export function stableStringify(value: unknown): string {
+  if (value === undefined) return 'null'
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+  const obj = value as Record<string, unknown>
+  const parts: string[] = []
+  for (const key of Object.keys(obj).sort()) {
+    if (obj[key] === undefined) continue
+    parts.push(`${JSON.stringify(key)}:${stableStringify(obj[key])}`)
+  }
+  return `{${parts.join(',')}}`
+}
+
+/**
+ * Recursively produce a canonical clone with object keys sorted (bytewise) and
+ * `undefined` object values dropped, so structurally-equal values become
+ * deep-equal regardless of key insertion order. Array order is preserved. The
+ * input is not mutated.
+ *
+ * Use this when you need the canonical *object* (to store, diff, or redact); use
+ * {@link stableStringify} when you only need a canonical string. PURE.
+ */
+export function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value
+  if (Array.isArray(value)) return value.map(canonicalize)
+  const obj = value as Record<string, unknown>
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(obj).sort()) {
+    const v = obj[key]
+    if (v === undefined) continue
+    out[key] = canonicalize(v)
+  }
+  return out
+}

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -129,14 +129,37 @@ export function shallowEqual(a: any, b: any): boolean {
 }
 
 /**
- * Deep equality check using JSON serialization.
- * Fast but doesn't handle functions, undefined values, or circular references.
- * Good enough for comparing plain data structures.
+ * Order-independent structural deep equality for JSON-like values.
+ *
+ * - Object key order does NOT matter; array order does.
+ * - `Date`s compare by timestamp.
+ * - Differing `typeof`, a lone `null`, or array-vs-non-array all fail fast.
+ * - Symbols (and other primitives) compare by identity via the `Object.is`
+ *   short-circuit, so sentinel symbols are only ever equal to themselves.
+ *
+ * Does not handle circular references, `Map`/`Set`, or class instances.
  */
-export function deepEqual(a: any, b: any): boolean {
-  if (a === b) return true
-  if (a === null || a === undefined || b === null || b === undefined) {
-    return a === b
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true
+  if (typeof a !== typeof b) return false
+  if (a === null || b === null || typeof a !== 'object') return false
+
+  if (a instanceof Date || b instanceof Date) {
+    return a instanceof Date && b instanceof Date && a.getTime() === b.getTime()
   }
-  return JSON.stringify(a) === JSON.stringify(b)
+
+  const aArr = Array.isArray(a)
+  const bArr = Array.isArray(b)
+  if (aArr !== bArr) return false
+  if (aArr && bArr) {
+    if (a.length !== b.length) return false
+    return a.every((v, i) => deepEqual(v, b[i]))
+  }
+
+  const ao = a as Record<string, unknown>
+  const bo = b as Record<string, unknown>
+  const aKeys = Object.keys(ao)
+  const bKeys = Object.keys(bo)
+  if (aKeys.length !== bKeys.length) return false
+  return aKeys.every((k) => Object.hasOwn(bo, k) && deepEqual(ao[k], bo[k]))
 }

--- a/packages/utils/src/parse.ts
+++ b/packages/utils/src/parse.ts
@@ -6,3 +6,20 @@ export const parseBoolean = (value: unknown): boolean | undefined => {
   if (['false', '0', 'no', 'n'].includes(normalized)) return false
   return undefined
 }
+
+/**
+ * Coerce a value to a comparable number. Numbers pass through; ISO date strings
+ * become epoch milliseconds (so timestamp comparisons work), then plain numeric
+ * strings are parsed. Returns `null` when the value is not comparably numeric.
+ */
+export function toNumeric(v: unknown): number | null {
+  if (typeof v === 'number' && !Number.isNaN(v)) return v
+  if (typeof v === 'string') {
+    // Try a date first (so `gt` over timestamps works), then a plain number.
+    const t = Date.parse(v)
+    if (!Number.isNaN(t)) return t
+    const n = Number(v)
+    if (v.trim() !== '' && !Number.isNaN(n)) return n
+  }
+  return null
+}

--- a/packages/utils/src/redact.ts
+++ b/packages/utils/src/redact.ts
@@ -1,0 +1,47 @@
+// packages/utils/src/redact.ts
+
+/** Options for {@link redactSecrets}. */
+export interface RedactSecretsOptions {
+  /** Keys matching this pattern are redacted. Defaults to common secret markers. */
+  secretKeyPattern?: RegExp
+  /**
+   * Keys matching this pattern are preserved even when they match
+   * `secretKeyPattern` — reference pointers like `credId`, `providerName`, etc.
+   * Defaults to id/ref/name/provider/slug/kind/type suffixes.
+   */
+  safeKeyPattern?: RegExp
+  /** Replacement marker for redacted values. Defaults to `'[redacted]'`. */
+  placeholder?: string
+}
+
+const DEFAULT_SECRET_KEY_RE =
+  /(secret|password|token|apikey|api_key|privatekey|private_key|credential)/i
+// Reference-shaped keys are non-secret pointers and must survive redaction.
+const DEFAULT_SAFE_KEY_RE = /(id|ref|name|provider|slug|kind|type)$/i
+
+/**
+ * Defensive deep redaction: any object key that *looks* like a secret (and isn't
+ * a reference-shaped key) is replaced with a marker, recursively. Returns a new
+ * value; the input is not mutated. Array order is preserved.
+ *
+ * Use as belt-and-suspenders so a stray decrypted value can never be persisted
+ * in a snapshot, trace, log, or note even if it slips past upstream filtering.
+ * PURE.
+ */
+export function redactSecrets<T>(value: T, options?: RedactSecretsOptions): T {
+  const secretRe = options?.secretKeyPattern ?? DEFAULT_SECRET_KEY_RE
+  const safeRe = options?.safeKeyPattern ?? DEFAULT_SAFE_KEY_RE
+  const placeholder = options?.placeholder ?? '[redacted]'
+
+  const redact = (val: unknown): unknown => {
+    if (val === null || typeof val !== 'object') return val
+    if (Array.isArray(val)) return val.map(redact)
+    const out: Record<string, unknown> = {}
+    for (const [key, v] of Object.entries(val as Record<string, unknown>)) {
+      out[key] = secretRe.test(key) && !safeRe.test(key) ? placeholder : redact(v)
+    }
+    return out
+  }
+
+  return redact(value) as T
+}


### PR DESCRIPTION
## What

Foundation PR (1 of 3 stacked). Low-level shared helpers consumed by the agent-runtime and evals PRs that stack on top.

### `@auxx/utils`
- New subpath exports: `./json` (`canonicalize`, `stableStringify`), `./hash` (`stableHash`), `./redact` (deep secret redaction)
- `./parse`: add `toNumeric` (number / ISO-date / numeric-string → comparable number)
- `./objects`: rewrite `deepEqual` as order-independent structural compare (key order ignored, array order respected, `Date`-aware) instead of `JSON.stringify`
- Tests for `objects` and `parse`

### Shared tRPC unwrap
- Extract `apps/web/src/server/api/unwrap.ts` — unwrap a neverthrow `Result` into a payload or typed `TRPCError`
- Adopt it in `calendar`, `procedure`, `agent-procedure` routers; drop their duplicated local copies

## Stack
1. **this PR** → `main`
2. `refactor/agent-runtime-procedures` → this branch
3. `feat/evals-phase1` → PR 2's branch

## Notes
- No production users yet; no backcompat shims.