### PR TITLE
refactor(agents): extract effective-runtime + procedure transition observer

### DIFF
--- a/apps/api/public/app-runtime/index.html
+++ b/apps/api/public/app-runtime/index.html
@@ -73,7 +73,7 @@
 
     <!-- Platform Runtime Bundle (same for ALL extensions) -->
     <!-- Hash is replaced during build: platform.{HASH}.js -->
-    <script src="/api/v1/app-runtime/platform.a151919c.js"></script>
+    <script src="/api/v1/app-runtime/platform.3e4f1fab.js"></script>
 
     <!-- Extension bundle will be loaded dynamically by platform runtime -->
   </body>

--- a/apps/web/src/components/dynamic-table/utils/view-config.ts
+++ b/apps/web/src/components/dynamic-table/utils/view-config.ts
@@ -1,6 +1,7 @@
 // apps/web/src/components/dynamic-table/utils/view-config.ts
 
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { deepEqual } from '@auxx/utils/objects'
 import type {
   ColumnOrderState,
   ColumnPinningState,
@@ -228,59 +229,4 @@ function resolveColumnId(column: ExtendedColumnDef): string | undefined {
     return column.accessorKey
   }
   return undefined
-}
-
-/**
- * Deep comparison helper for the small collection-like structures used in view configs.
- */
-function deepEqual(left: unknown, right: unknown): boolean {
-  if (Object.is(left, right)) {
-    return true
-  }
-
-  if (typeof left !== typeof right) {
-    return false
-  }
-
-  if (left === null || right === null || typeof left !== 'object') {
-    return false
-  }
-
-  if (left instanceof Date && right instanceof Date) {
-    return left.getTime() === right.getTime()
-  }
-
-  if (Array.isArray(left) && Array.isArray(right)) {
-    if (left.length !== right.length) {
-      return false
-    }
-    for (let index = 0; index < left.length; index += 1) {
-      if (!deepEqual(left[index], right[index])) {
-        return false
-      }
-    }
-    return true
-  }
-
-  if (Array.isArray(left) || Array.isArray(right)) {
-    return false
-  }
-
-  const leftEntries = Object.entries(left as Record<string, unknown>)
-  const rightEntries = Object.entries(right as Record<string, unknown>)
-
-  if (leftEntries.length !== rightEntries.length) {
-    return false
-  }
-
-  for (const [key, value] of leftEntries) {
-    if (!Object.hasOwn(right, key)) {
-      return false
-    }
-    if (!deepEqual(value, (right as Record<string, unknown>)[key])) {
-      return false
-    }
-  }
-
-  return true
 }

--- a/apps/web/src/components/editor/inline-picker/hooks/use-external-content-sync.ts
+++ b/apps/web/src/components/editor/inline-picker/hooks/use-external-content-sync.ts
@@ -162,21 +162,8 @@ export function makeContentApplier<TContent>(
   }
 }
 
-/**
- * Stable, key-order-insensitive stringify for use as a canonical key in
- * `useExternalContentSync` / `makeContentApplier`. Required because the
- * server round-trips `contentJson` through a JSONB column, which doesn't
- * preserve insertion order — plain `JSON.stringify` returns different
- * strings for the same logical doc and breaks the inbound-skip path.
- */
-export function stableStringify(value: unknown): string {
-  if (value === null || value === undefined) return JSON.stringify(value ?? null)
-  if (typeof value !== 'object') return JSON.stringify(value)
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(',')}]`
-  }
-  const entries = Object.keys(value as Record<string, unknown>)
-    .sort()
-    .map((k) => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`)
-  return `{${entries.join(',')}}`
-}
+// Stable, key-order-insensitive stringify used as a canonical key here and in
+// `makeContentApplier` — required because the server round-trips `contentJson`
+// through a JSONB column, which doesn't preserve key insertion order. Lives in
+// @auxx/utils/json now; re-exported so the inline-picker barrel keeps exposing it.
+export { stableStringify } from '@auxx/utils/json'

--- a/packages/lib/src/agents/bindings/resolve.ts
+++ b/packages/lib/src/agents/bindings/resolve.ts
@@ -1,7 +1,13 @@
 // packages/lib/src/agents/bindings/resolve.ts
 
 import { extractValue, type TypedFieldValue } from '@auxx/types'
-import type { FieldPath, ResourceFieldId, VarRef, VarSource } from '@auxx/types/field'
+import type {
+  FieldPath,
+  FieldReference,
+  ResourceFieldId,
+  VarRef,
+  VarSource,
+} from '@auxx/types/field'
 import {
   getFieldDefinitionId,
   getFieldId,
@@ -66,6 +72,35 @@ export function buildResolveVarSource(
       fieldReferences: [ref],
     })
     return firstScalar(result.values)
+  }
+}
+
+/**
+ * The single field-resolution helper that BOTH the kopilot context store
+ * ({@link buildFieldSource}) and procedure refs ({@link readProcedureRef}) go
+ * through, so production and the eval Simulation never diverge. Returns a
+ * resolver closure built once per consumer.
+ *
+ * - Production: no overlay — a bare `FieldReference` resolves off
+ *   `subject.anchors` via {@link buildResolveVarSource}; a missing subject (or
+ *   absent anchor) gates to `undefined`, exactly as before.
+ * - Simulation: `ctx.evalFieldResolver` is set, so the whole subject path is
+ *   short-circuited to the overlay — which layers `startingFields` and then
+ *   delegates to the subject resolver itself (see the Simulation field
+ *   resolver). plans/evals/phase-1-agent-simulation.md §1.5.
+ */
+export function buildSubjectFieldResolver(
+  ctx: ToolContext
+): (ref: FieldReference) => Promise<unknown> {
+  if (ctx.evalFieldResolver) {
+    const overlay = ctx.evalFieldResolver
+    return (ref) => overlay(ref)
+  }
+  const resolve = buildResolveVarSource(ctx)
+  return async (ref) => {
+    // No subject → no anchors to resolve against → gate by absence.
+    if (!ctx.subject) return undefined
+    return resolve({ kind: 'var', ref: ref as VarRef }, ctx.subject)
   }
 }
 

--- a/packages/lib/src/agents/procedures/__tests__/context.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/context.test.ts
@@ -9,13 +9,27 @@ import type { ProcedureFrame } from '../types'
 
 // The v8 binding resolver is mocked: it returns whatever `resolveMap` holds for the
 // ref (joined for FieldPath), so the test controls "what the subject resolves to".
+// `buildSubjectFieldResolver` (the shared helper readProcedureRef now goes through)
+// is mirrored faithfully so it routes back through the mocked `buildResolveVarSource`.
 const { resolveMap } = vi.hoisted(() => ({ resolveMap: {} as Record<string, unknown> }))
-vi.mock('../../bindings/resolve', () => ({
-  buildResolveVarSource: vi.fn(
+vi.mock('../../bindings/resolve', () => {
+  const buildResolveVarSource = vi.fn(
     () => async (source: { kind: string; ref: string | string[] }) =>
       resolveMap[Array.isArray(source.ref) ? source.ref.join('|') : source.ref]
-  ),
-}))
+  )
+  const buildSubjectFieldResolver = (ctx: ToolContext) => {
+    if (ctx.evalFieldResolver) {
+      const overlay = ctx.evalFieldResolver
+      return (ref: unknown) => overlay(ref as never)
+    }
+    const resolve = buildResolveVarSource(ctx as never)
+    return async (ref: string | string[]) => {
+      if (!ctx.subject) return undefined
+      return resolve({ kind: 'var', ref })
+    }
+  }
+  return { buildResolveVarSource, buildSubjectFieldResolver }
+})
 
 const ctx = {} as ToolContext
 const subject: Subject = { anchors: {}, identityVerified: false }

--- a/packages/lib/src/agents/procedures/__tests__/stepper-observer.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/stepper-observer.test.ts
@@ -1,0 +1,161 @@
+// packages/lib/src/agents/procedures/__tests__/stepper-observer.test.ts
+//
+// The eval-only stepper transition observer (§1.7). Verifies the explicit
+// step_entered / routing / procedure_finished events the AgentSimExecutor derives
+// terminal outcomes from. Production omits the observer (no-op).
+
+import { describe, expect, it, vi } from 'vitest'
+import type { ToolContext } from '../../../ai/agent-framework/tool-context'
+import type { ProcedureObserver, ProcedureTransitionEvent } from '../observer'
+import { prepareTurn, type StepperDeps } from '../stepper'
+import type { CompiledProcedure, ProcedureStack, ProcedureStep } from '../types'
+
+// CRM field resolution routes through the v8 subject resolver — both exports must
+// be stubbed or the missing one resolves `undefined` and breaks resolution.
+vi.mock('../../bindings/resolve', () => ({
+  buildResolveVarSource: vi.fn(() => async () => undefined),
+  buildSubjectFieldResolver: vi.fn(() => async () => undefined),
+}))
+
+const instruction = (id: string, next: string | null): ProcedureStep => ({
+  id,
+  kind: 'instruction',
+  doc: { type: 'fragment', content: [] },
+  next,
+})
+
+const routing = (
+  id: string,
+  outcome: 'finished' | 'handoff' | 'switch' | 'call',
+  opts: { next?: string | null; subProcedureId?: string; switchToProcedureId?: string } = {}
+): ProcedureStep => ({
+  id,
+  kind: 'routing',
+  outcome,
+  next: opts.next ?? null,
+  ...(opts.subProcedureId ? { subProcedureId: opts.subProcedureId } : {}),
+  ...(opts.switchToProcedureId ? { switchToProcedureId: opts.switchToProcedureId } : {}),
+})
+
+const build = (
+  entryStepId: string,
+  steps: ProcedureStep[],
+  subProcedures: CompiledProcedure['subProcedures'] = {}
+): CompiledProcedure => ({
+  entryStepId,
+  steps: Object.fromEntries(steps.map((s) => [s.id, s])),
+  codeBlocks: {},
+  subProcedures,
+  localAttributes: [],
+})
+
+const stackAt = (cursor: string | null): ProcedureStack => ({
+  frames: [
+    {
+      procedureId: 'p1',
+      procedureVersionId: 'v1',
+      cursor,
+      status: 'running',
+      history: [],
+      pushedBy: 'selection',
+    },
+  ],
+})
+
+function makeDeps(compiled: CompiledProcedure, observer: ProcedureObserver): StepperDeps {
+  return {
+    ctx: {
+      subject: { anchors: {}, identityVerified: false },
+      context: { read: async () => undefined, write: async () => {} },
+    } as unknown as ToolContext,
+    readVersion: async (id) => (id === 'v1' ? { compiled } : null),
+    loadActiveVersion: async (procedureId) => ({
+      procedureVersionId: 'v2',
+      compiled: build('s2', [instruction('s2', null)]),
+    }),
+    selectOther: async () => null,
+    pickTextBranch: async () => null,
+    checkGoalMet: async () => true,
+    classifyBackstop: async () => ({ onProcedure: true, multiTurn: false }),
+    runCode: async () => ({ ok: true, result: {} }),
+    onTransition: observer,
+  }
+}
+
+function collect() {
+  const events: ProcedureTransitionEvent[] = []
+  return { events, observer: ((e) => events.push(e)) as ProcedureObserver }
+}
+
+describe('stepper transition observer', () => {
+  it('emits step_entered when an instruction is injected', async () => {
+    const { events, observer } = collect()
+    await prepareTurn(stackAt('i1'), makeDeps(build('i1', [instruction('i1', null)]), observer))
+    expect(events).toContainEqual({
+      type: 'step_entered',
+      procedureId: 'p1',
+      procedureVersionId: 'v1',
+      stepId: 'i1',
+    })
+  })
+
+  it('emits routing(finished) then procedure_finished(routing) on a finished outcome', async () => {
+    const { events, observer } = collect()
+    await prepareTurn(stackAt('r'), makeDeps(build('r', [routing('r', 'finished')]), observer))
+    const types = events.map(
+      (e) => `${e.type}:${'outcome' in e ? e.outcome : 'reason' in e ? e.reason : ''}`
+    )
+    expect(types).toContain('routing:finished')
+    expect(types).toContain('procedure_finished:routing')
+  })
+
+  it('emits routing(handoff) on a handoff outcome', async () => {
+    const { events, observer } = collect()
+    await prepareTurn(stackAt('r'), makeDeps(build('r', [routing('r', 'handoff')]), observer))
+    expect(events.some((e) => e.type === 'routing' && e.outcome === 'handoff')).toBe(true)
+  })
+
+  it('emits routing(switch) with the target id', async () => {
+    const { events, observer } = collect()
+    await prepareTurn(
+      stackAt('r'),
+      makeDeps(build('r', [routing('r', 'switch', { switchToProcedureId: 'pX' })]), observer)
+    )
+    expect(events).toContainEqual({
+      type: 'routing',
+      procedureId: 'p1',
+      procedureVersionId: 'v1',
+      stepId: 'r',
+      outcome: 'switch',
+      targetId: 'pX',
+    })
+  })
+
+  it('emits routing(call) with the sub-procedure id', async () => {
+    const { events, observer } = collect()
+    const compiled = build('r', [routing('r', 'call', { subProcedureId: 'sub1', next: null })], {
+      sub1: { name: 'Sub', entryStepId: 'si', steps: { si: instruction('si', null) } } as never,
+    })
+    await prepareTurn(stackAt('r'), makeDeps(compiled, observer))
+    expect(
+      events.some((e) => e.type === 'routing' && e.outcome === 'call' && e.targetId === 'sub1')
+    ).toBe(true)
+  })
+
+  it('emits procedure_finished(chain_end) when the chain ends with no terminal', async () => {
+    const { events, observer } = collect()
+    // instruction i1 → next null; resume PAST it by parking the cursor at its `next`.
+    await prepareTurn(stackAt(null), makeDeps(build('i1', [instruction('i1', null)]), observer))
+    expect(events.some((e) => e.type === 'procedure_finished' && e.reason === 'chain_end')).toBe(
+      true
+    )
+  })
+
+  it('emits procedure_finished(missing_step) when the cursor dangles', async () => {
+    const { events, observer } = collect()
+    await prepareTurn(stackAt('nope'), makeDeps(build('i1', [instruction('i1', null)]), observer))
+    expect(events.some((e) => e.type === 'procedure_finished' && e.reason === 'missing_step')).toBe(
+      true
+    )
+  })
+})

--- a/packages/lib/src/agents/procedures/__tests__/stepper.test.ts
+++ b/packages/lib/src/agents/procedures/__tests__/stepper.test.ts
@@ -15,6 +15,12 @@ vi.mock('../../bindings/resolve', () => ({
     () => async (source: { kind: string; ref: string | string[] }) =>
       resolveMap[Array.isArray(source.ref) ? source.ref.join('|') : source.ref]
   ),
+  // CRM `FieldReference` reads now route through the v8 subject resolver (the 1.5
+  // shared seam). This wholesale mock must stub EVERY export `context.ts` imports
+  // or the missing one resolves `undefined` and silently breaks field resolution.
+  buildSubjectFieldResolver: vi.fn(
+    () => async (ref: string | string[]) => resolveMap[Array.isArray(ref) ? ref.join('|') : ref]
+  ),
 }))
 
 // ── fixture builders ───────────────────────────────────────────────────────

--- a/packages/lib/src/agents/procedures/context.ts
+++ b/packages/lib/src/agents/procedures/context.ts
@@ -1,10 +1,10 @@
 // packages/lib/src/agents/procedures/context.ts
 
-import type { VarRef } from '@auxx/types/field'
+import type { FieldReference, VarRef } from '@auxx/types/field'
 import type { Subject, ToolContext } from '../../ai/agent-framework/tool-context'
 import type { FieldResolver } from '../../conditions/evaluate'
 import type { ConditionGroup } from '../../conditions/types'
-import { buildResolveVarSource } from '../bindings/resolve'
+import { buildResolveVarSource, buildSubjectFieldResolver } from '../bindings/resolve'
 import type { LocalAttribute, ProcedureFrame } from './types'
 
 /**
@@ -91,6 +91,13 @@ export async function buildProcedureFieldResolver(
   allGroups: ConditionGroup[]
 ): Promise<FieldResolver<Subject>> {
   const resolveVar = buildResolveVarSource(ctx)
+  // Simulation overlay: when an eval sets `ctx.evalFieldResolver`, route selection
+  // ruleset reads through it too, so a case's `startingFields` gate agent-scope
+  // routing exactly as they gate in-procedure conditions. Undefined on production,
+  // where the `resolveVar` path is byte-identical to before. (The overlay and the
+  // passed `subject` resolve against the same anchors — identical at the eval call
+  // site.) See plans/evals/phase-1-agent-simulation.md §1.5/§1.7.
+  const overlay = ctx.evalFieldResolver
   const values = new Map<string, unknown>()
   const seen = new Set<string>()
 
@@ -104,7 +111,12 @@ export async function buildProcedureFieldResolver(
       continue
     }
     try {
-      values.set(key, await resolveVar({ kind: 'var', ref }, subject))
+      values.set(
+        key,
+        overlay
+          ? await overlay(fieldId as FieldReference)
+          : await resolveVar({ kind: 'var', ref }, subject)
+      )
     } catch {
       // Selection is best-effort routing — a resolver misconfig gates by absence
       // rather than throwing the whole turn.
@@ -169,9 +181,13 @@ export async function readProcedureRef(
     }
   }
   const varRef = toVarRef(ref)
-  if (!varRef || !ctx.subject) return undefined
+  if (!varRef) return undefined
   try {
-    return await buildResolveVarSource(ctx)({ kind: 'var', ref: varRef }, ctx.subject)
+    // The shared subject resolver: production reads `ctx.subject.anchors`; a
+    // Simulation overlay (`ctx.evalFieldResolver`) short-circuits here, so a
+    // case's `startingFields` apply to in-procedure conditions and code inputs
+    // too — without the `!ctx.subject` gate hiding them.
+    return await buildSubjectFieldResolver(ctx)(varRef)
   } catch {
     // Best-effort — a resolver misconfig gates by absence rather than throwing the turn.
     return undefined

--- a/packages/lib/src/agents/procedures/index.ts
+++ b/packages/lib/src/agents/procedures/index.ts
@@ -49,6 +49,7 @@ export {
   type TiptapDoc,
   type TiptapNode,
 } from './nodes'
+export type { ProcedureObserver, ProcedureTransitionEvent } from './observer'
 export {
   PROCEDURE_SLICE_KEY,
   PROCEDURE_STEP_KEY,

--- a/packages/lib/src/agents/procedures/nodes.ts
+++ b/packages/lib/src/agents/procedures/nodes.ts
@@ -195,26 +195,8 @@ export const PROCEDURE_NODE_TYPES = {
 
 export type ProcedureNodeType = (typeof PROCEDURE_NODE_TYPES)[keyof typeof PROCEDURE_NODE_TYPES]
 
-/**
- * Deterministic, key-order-independent JSON serialization — used to content-hash
- * a {@link TiptapDoc} so the hash is stable across a Postgres `jsonb` round-trip.
- * `jsonb` does NOT preserve object key insertion order (it stores keys sorted by
- * length then bytewise), so a plain `JSON.stringify` hash of an in-memory doc
- * won't match the hash of the same doc read back from the column. This sorts
- * object keys recursively so both serializations are identical. Mirrors
- * `JSON.stringify` (drops `undefined` object values); array order is preserved
- * (jsonb preserves it too). PURE.
- */
-export function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null'
-  if (Array.isArray(value)) {
-    return `[${value.map((v) => stableStringify(v === undefined ? null : v)).join(',')}]`
-  }
-  const obj = value as Record<string, unknown>
-  const parts: string[] = []
-  for (const key of Object.keys(obj).sort()) {
-    if (obj[key] === undefined) continue
-    parts.push(`${JSON.stringify(key)}:${stableStringify(obj[key])}`)
-  }
-  return `{${parts.join(',')}}`
-}
+// Deterministic, key-order-independent JSON serialization — used to content-hash
+// a {@link TiptapDoc} so the hash is stable across a Postgres `jsonb` round-trip.
+// Lives in @auxx/utils/json now; re-exported so existing `import { stableStringify }
+// from './nodes'` call sites keep working.
+export { stableStringify } from '@auxx/utils/json'

--- a/packages/lib/src/agents/procedures/observer.ts
+++ b/packages/lib/src/agents/procedures/observer.ts
@@ -1,0 +1,36 @@
+// packages/lib/src/agents/procedures/observer.ts
+//
+// Optional stepper transition observer. Production never supplies one (the seam
+// is a no-op when absent); the eval Simulation executor installs an observer so
+// it can derive an EXPLICIT terminal outcome (natural finish vs handoff vs switch)
+// and the selected procedure — distinctions the post-turn stack state alone
+// cannot make once a transition has been consumed.
+//
+// See plans/evals/phase-1-agent-simulation.md §1.7 (stepper observer).
+
+/** A deterministic procedure-control transition the stepper emits as it walks the stack. */
+export type ProcedureTransitionEvent =
+  | {
+      type: 'step_entered'
+      procedureId: string
+      procedureVersionId: string
+      stepId: string
+    }
+  | {
+      type: 'routing'
+      procedureId: string
+      procedureVersionId: string
+      stepId: string
+      outcome: 'finished' | 'handoff' | 'switch' | 'call'
+      /** Target procedure (switch) or sub-procedure (call) id, when applicable. */
+      targetId?: string
+    }
+  | {
+      type: 'procedure_finished'
+      procedureId: string
+      procedureVersionId: string
+      reason: 'routing' | 'chain_end' | 'missing_step'
+    }
+
+/** Sink for {@link ProcedureTransitionEvent}s. Synchronous + best-effort; never throws. */
+export type ProcedureObserver = (event: ProcedureTransitionEvent) => void

--- a/packages/lib/src/agents/procedures/stepper.ts
+++ b/packages/lib/src/agents/procedures/stepper.ts
@@ -4,6 +4,7 @@ import type { ToolContext } from '../../ai/agent-framework/tool-context'
 import { evaluateConditions } from '../../conditions/evaluate'
 import { buildCodeInputs, buildProcedurePredicateResolver, writeProcedureVar } from './context'
 import { PROC_SIGNAL_KEY, type ProcedureSignal } from './control-tools'
+import type { ProcedureObserver } from './observer'
 import { buildReanchorBreadcrumb } from './re-anchor'
 import { atDepthCap, clear, pop, push, replaceTop, top } from './stack'
 import type {
@@ -99,6 +100,12 @@ export interface StepperDeps {
     block: { code: string },
     codeInput: Record<string, unknown>
   ) => Promise<{ ok: true; result: Record<string, unknown> } | { ok: false; error: string }>
+  /**
+   * Optional, eval-only transition observer. Production omits it (no-op). The
+   * Simulation executor installs one to derive an explicit terminal outcome and
+   * the selected procedure. Best-effort and synchronous — must never throw.
+   */
+  onTransition?: ProcedureObserver
 }
 
 /** A surfaced (`surfaceToModel`) code output the walk produced on its way to the landed step (D4). */
@@ -267,14 +274,34 @@ async function advanceFrame(
   const predicate = buildProcedurePredicateResolver(deps.ctx, frame)
   const entity = deps.ctx.subject ?? {}
   let cursor: StepId | null = frame.cursor
+  const emit = deps.onTransition
+  const finished = (reason: 'routing' | 'chain_end' | 'missing_step'): FrameAction => {
+    emit?.({
+      type: 'procedure_finished',
+      procedureId: frame.procedureId,
+      procedureVersionId: frame.procedureVersionId,
+      reason,
+    })
+    return { type: 'pop' }
+  }
 
   for (let i = 0; i < MAX_STEPS_PER_FRAME; i++) {
     if (cursor === null) break
     const step = compiled.steps[cursor]
-    if (!step) break // dangling ref → treat as finished
+    if (!step) {
+      // dangling ref → treat as finished
+      frame.cursor = null
+      return finished('missing_step')
+    }
 
     if (step.kind === 'instruction') {
       frame.cursor = cursor
+      emit?.({
+        type: 'step_entered',
+        procedureId: frame.procedureId,
+        procedureVersionId: frame.procedureVersionId,
+        stepId: cursor,
+      })
       return { type: 'instruction', step }
     }
 
@@ -285,9 +312,17 @@ async function advanceFrame(
     }
 
     if (step.kind === 'routing') {
+      emit?.({
+        type: 'routing',
+        procedureId: frame.procedureId,
+        procedureVersionId: frame.procedureVersionId,
+        stepId: step.id,
+        outcome: step.outcome,
+        targetId: step.switchToProcedureId ?? step.subProcedureId,
+      })
       switch (step.outcome) {
         case 'finished':
-          return { type: 'pop' }
+          return finished('routing')
         case 'handoff':
           return { type: 'handoff' }
         case 'switch':
@@ -303,7 +338,7 @@ async function advanceFrame(
   }
 
   frame.cursor = null
-  return { type: 'pop' } // chain ended without a terminal → frame finished
+  return finished('chain_end') // chain ended without a terminal → frame finished
 }
 
 /**

--- a/packages/lib/src/agents/procedures/turn-wiring.ts
+++ b/packages/lib/src/agents/procedures/turn-wiring.ts
@@ -8,6 +8,7 @@ import type { ProcedureStepInput } from '../../ai/kopilot/prompts/sections/types
 import type { CachedAgentProcedure } from '../../cache/org-cache-keys'
 import { backstopClassify, classifyTextBranch, goalMetCheck } from './classifier'
 import type { ClassifyDeps, ConversationMessage } from './classify'
+import type { ProcedureObserver } from './observer'
 import { PROCEDURE_STEP_KEY, readProcedureSlice, writeProcedureSlice } from './persist'
 import type { AgentProcedureEntity, ProcedureEntity, ProcedureVersionEntity } from './queries'
 import { getProcedureById, getProcedureVersionById, readCompiled } from './queries'
@@ -130,6 +131,8 @@ export interface BuildStepperDepsArgs {
   conversation: ConversationMessage[]
   /** Model/provider/org/user resolved by the caller (turn model — BYO-model). */
   classifyDeps: ClassifyDeps
+  /** Optional eval-only transition observer (no-op in production). */
+  observer?: ProcedureObserver
 }
 
 /**
@@ -140,7 +143,7 @@ export interface BuildStepperDepsArgs {
  * conversation + model.
  */
 export function buildStepperDeps(args: BuildStepperDepsArgs): StepperDeps {
-  const { ctx, subject, candidates, conversation, classifyDeps } = args
+  const { ctx, subject, candidates, conversation, classifyDeps, observer } = args
   const { organizationId } = classifyDeps
 
   // Pinned-version read: projection hit when the pin == an attached procedure's
@@ -208,6 +211,7 @@ export function buildStepperDeps(args: BuildStepperDepsArgs): StepperDeps {
     checkGoalMet: (reply, activeStep) => goalMetCheck(reply, activeStep, classifyDeps),
     classifyBackstop: (reply, activeStep) => backstopClassify(reply, activeStep, classifyDeps),
     runCode,
+    ...(observer ? { onTransition: observer } : {}),
   }
 }
 
@@ -283,6 +287,11 @@ export interface RunProcedureTurnArgs {
    * and omit it. The stack is already cleared by the stepper. See §6 reconciliation.
    */
   onHandoff?: () => Promise<void> | void
+  /**
+   * Optional eval-only transition observer (no-op in production). Threaded into
+   * the stepper deps so a Simulation can derive the explicit terminal outcome.
+   */
+  observer?: ProcedureObserver
 }
 
 /**
@@ -307,7 +316,14 @@ export async function runProcedureTurn(args: RunProcedureTurnArgs): Promise<stri
   const liveDomainState = () => engine.getState().domainState as Record<string, unknown>
 
   const makeDeps = (ctx: ToolContext): StepperDeps =>
-    buildStepperDeps({ ctx, subject, candidates, conversation, classifyDeps })
+    buildStepperDeps({
+      ctx,
+      subject,
+      candidates,
+      conversation,
+      classifyDeps,
+      observer: args.observer,
+    })
 
   // 1. selection — sticky resume / fresh frame 0 / none.
   let stack = readProcedureSlice(liveDomainState()) ?? emptyStack()

--- a/packages/lib/src/ai/agent-framework/__tests__/effective-runtime.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/effective-runtime.test.ts
@@ -1,0 +1,32 @@
+// packages/lib/src/ai/agent-framework/__tests__/effective-runtime.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { parseProviderModel } from '../effective-runtime'
+
+describe('parseProviderModel', () => {
+  it('splits a well-formed provider:model id', () => {
+    expect(parseProviderModel('anthropic:claude-opus-4-8')).toEqual({
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+    })
+  })
+
+  it('keeps colons inside the model segment', () => {
+    expect(parseProviderModel('openai:gpt-5.4:preview')).toEqual({
+      provider: 'openai',
+      model: 'gpt-5.4:preview',
+    })
+  })
+
+  it('returns null for unset values so callers fall to the next tier', () => {
+    expect(parseProviderModel(null)).toBeNull()
+    expect(parseProviderModel(undefined)).toBeNull()
+    expect(parseProviderModel('')).toBeNull()
+  })
+
+  it('returns null for malformed ids (no colon, leading/trailing colon)', () => {
+    expect(parseProviderModel('claude-opus-4-8')).toBeNull()
+    expect(parseProviderModel(':model')).toBeNull()
+    expect(parseProviderModel('provider:')).toBeNull()
+  })
+})

--- a/packages/lib/src/ai/agent-framework/context/sources/field-source.ts
+++ b/packages/lib/src/ai/agent-framework/context/sources/field-source.ts
@@ -1,25 +1,20 @@
 // packages/lib/src/ai/agent-framework/context/sources/field-source.ts
 
-import type { FieldReference, VarRef } from '@auxx/types/field'
-import { buildResolveVarSource } from '../../../../agents/bindings/resolve'
+import type { FieldReference } from '@auxx/types/field'
+import { buildSubjectFieldResolver } from '../../../../agents/bindings/resolve'
 import type { ToolContext } from '../../tool-context'
 
 /**
  * The `FieldReference` source for the kopilot context store — the v8 resolver
- * adapter. Wraps {@link buildResolveVarSource} (plans/chat/v8 phase-2): a bare
- * `FieldReference` becomes a `{ kind: 'var', ref }` source and is resolved off
- * `ctx.subject.anchors`, so a missing anchor (or no subject at all — internal /
- * kopilot runs) gates to `undefined`. No model/visitor input can pick the
- * record; identity is derived from the ref's root entity.
+ * adapter. Delegates to the shared {@link buildSubjectFieldResolver}: in
+ * production a bare `FieldReference` resolves off `ctx.subject.anchors` (a
+ * missing anchor or no subject gates to `undefined`); under an eval Simulation
+ * the same call short-circuits to the `startingFields` overlay. No model/visitor
+ * input can pick the record; identity is derived from the ref's root entity.
  *
  * Returns the raw resolver; the store layers per-turn memoization on top so a
  * repeated field read hits the cache instead of `batchGetValues`.
  */
 export function buildFieldSource(ctx: ToolContext): (ref: FieldReference) => Promise<unknown> {
-  const resolve = buildResolveVarSource(ctx)
-  return async (ref) => {
-    // No subject → no anchors to resolve against → gate by absence.
-    if (!ctx.subject) return undefined
-    return resolve({ kind: 'var', ref: ref as VarRef }, ctx.subject)
-  }
+  return buildSubjectFieldResolver(ctx)
 }

--- a/packages/lib/src/ai/agent-framework/effective-runtime.ts
+++ b/packages/lib/src/ai/agent-framework/effective-runtime.ts
@@ -1,0 +1,206 @@
+// packages/lib/src/ai/agent-framework/effective-runtime.ts
+//
+// Shared effective-agent runtime builder. The model precedence, capability
+// registry, tool filtering, binding projection, and binding clamp that used to
+// live inline in `process-agent-job.ts` are extracted here so BOTH production
+// and the eval Simulation engine construct the agent from one source — never a
+// divergent second copy (plans/evals/phase-1-agent-simulation.md §1.4,
+// conventions.md §5).
+
+import { filterToolsByToolsets, type ResolvedAgentConfig, resolveAgentConfig } from '../../agents'
+import {
+  buildApplyBindings,
+  computeEffectiveBindings,
+  projectBindingSchemas,
+} from '../../agents/bindings'
+import { PROCEDURE_CONTROL_TOOLS } from '../../agents/procedures'
+import {
+  createAppCapabilities,
+  createCapabilityRegistry,
+  createEntityCapabilities,
+  createKopilotCapabilities,
+  createKopilotDomainConfig,
+  createMailCapabilities,
+  createToolDepsFactory,
+} from '../kopilot'
+import type { TriggerContext } from '../kopilot/prompts/trigger-context'
+import { BUILDER_MODEL } from './builder-model'
+import type { AgentDomainConfig, AgentEngineConfig, AgentToolDefinition } from './types'
+
+/** The two agent surfaces that build a Kopilot-shaped runtime. */
+export type AgentRuntimeDomain = 'kopilot' | 'builder'
+
+export interface EffectiveAgentRuntime {
+  domainConfig: AgentDomainConfig
+  /** The resolved, binding-projected effective toolset (post toolset filtering). */
+  tools: AgentToolDefinition[]
+  /** Clamp tool args per effective bindings (override ?? author-default). */
+  applyToolRestrictions: NonNullable<AgentEngineConfig['applyToolRestrictions']>
+  agentConfig: ResolvedAgentConfig
+  model: { provider: string; model: string }
+  utilityModel: { provider: string; model: string }
+}
+
+export interface BuildEffectiveAgentRuntimeArgs {
+  organizationId: string
+  /** Real acting user (threaded into tool deps). App capabilities are still scoped autonomously. */
+  userId: string
+  sessionId: string
+  agentId: string | null
+  domain: AgentRuntimeDomain
+  signal?: AbortSignal
+  /** Per-turn/per-session model pin (`provider:model`). Highest precedence for kopilot. */
+  modelId?: string
+  /** Mount the v9 procedure-control tools (inert without an active step). */
+  hasProcedures: boolean
+  /** Page for page-scoped tool resolution; defaults to `__none__`. */
+  page?: string
+  /** Present iff kicked off by an AgentTrigger — renders the autonomous-run prompt section. */
+  triggerContext?: TriggerContext
+  /**
+   * Eval-only seam: transform the resolved effective toolset before it is baked
+   * into the domain config — the Simulation engine wraps each tool with its mock
+   * resolver here so the domain agents execute mocks, not real backends. Omitted
+   * on production (the tools pass through unchanged). Name/parameters/outputSchema
+   * are preserved by the wrapper, so binding clamps and schema digests are invariant.
+   */
+  wrapTools?: (tools: AgentToolDefinition[]) => AgentToolDefinition[]
+}
+
+/**
+ * Split a stored `provider:model` id. Returns null for unset/malformed values so
+ * callers fall through to the next precedence tier (system default).
+ */
+export function parseProviderModel(
+  pinned: string | null | undefined
+): { provider: string; model: string } | null {
+  if (!pinned) return null
+  const idx = pinned.indexOf(':')
+  if (idx <= 0 || idx === pinned.length - 1) return null
+  return { provider: pinned.slice(0, idx), model: pinned.slice(idx + 1) }
+}
+
+/**
+ * Resolve the default model:
+ *   builder → pinned `BUILDER_MODEL`.
+ *   kopilot → per-turn `modelId` → agent/master pin → org system default.
+ * Returns possibly-undefined parts; `createKopilotDomainConfig` supplies the
+ * final framework defaults so a malformed pin degrades gracefully (matching the
+ * pre-extraction behavior exactly).
+ */
+async function resolveModelDefaults(
+  domain: AgentRuntimeDomain,
+  args: { organizationId: string; agentId: string | null; modelId?: string }
+): Promise<{ provider?: string; model?: string }> {
+  if (domain === 'builder') {
+    return { provider: BUILDER_MODEL.provider, model: BUILDER_MODEL.model }
+  }
+
+  const pinned = args.modelId ?? null
+  if (pinned) {
+    const parsed = parseProviderModel(pinned)
+    // Malformed pin: leave both undefined (no fallthrough), as production did.
+    return parsed ? { provider: parsed.provider, model: parsed.model } : {}
+  }
+
+  const agentConfigForModel = await resolveAgentConfig(args.organizationId, args.agentId)
+  const fromConfig = parseProviderModel(agentConfigForModel.modelId)
+  if (fromConfig) return { provider: fromConfig.provider, model: fromConfig.model }
+
+  const { getCachedDefaultModel } = await import('../../cache/org-cache-helpers')
+  const { ModelType } = await import('../providers/types')
+  const systemDefault = await getCachedDefaultModel(args.organizationId, ModelType.LLM)
+  return systemDefault ? { provider: systemDefault.provider, model: systemDefault.model } : {}
+}
+
+/**
+ * Build the effective agent runtime: registry + capabilities, toolset-filtered
+ * and binding-projected tools, the domain config, and the binding clamp. Used by
+ * the production job and the eval Simulation executor alike.
+ *
+ * Note: the binding clamp (`applyToolRestrictions`) is built from the resolved
+ * effective `tools`. The pre-extraction job read a non-existent
+ * `domainConfig.tools` (always `undefined`), which threw at engine construction;
+ * threading the real tool list through here is the intended behavior and fixes
+ * that latent crash on the autonomous-agent path.
+ */
+export async function buildEffectiveAgentRuntime(
+  args: BuildEffectiveAgentRuntimeArgs
+): Promise<EffectiveAgentRuntime> {
+  const { organizationId, userId, sessionId, agentId, domain, signal, hasProcedures } = args
+
+  const defaults = await resolveModelDefaults(domain, {
+    organizationId,
+    agentId,
+    modelId: args.modelId,
+  })
+
+  const getToolDeps = createToolDepsFactory({ organizationId, userId, sessionId, signal })
+
+  const registry = createCapabilityRegistry()
+  registry.register(createEntityCapabilities(getToolDeps))
+  registry.register(createMailCapabilities(getToolDeps))
+  registry.register(createKopilotCapabilities(getToolDeps))
+  registry.register(
+    await createAppCapabilities({
+      organizationId,
+      // Background/eval agent runs are autonomous — no human in the loop.
+      // User-scope tools are hidden by the bridge (decision A2).
+      userId: null,
+      agentId,
+      triggerId: null,
+      sessionId,
+      getToolDeps,
+    })
+  )
+
+  const agentConfig = await resolveAgentConfig(organizationId, agentId)
+  const resolvedPage = args.page ?? '__none__'
+  const filteredTools = filterToolsByToolsets(registry.getTools(resolvedPage), agentConfig)
+  // Mount procedure-control tools when this agent has procedures — inert without
+  // an active step, so zero-procedure runs keep the unchanged tool list.
+  const allTools = hasProcedures ? [...filteredTools, ...PROCEDURE_CONTROL_TOOLS] : filteredTools
+
+  // Project tool schemas per the effective bindings (author defaults ⊕ admin
+  // overrides). `computeEffectiveBindings` reads only name + inputBindings, so it
+  // is invariant under schema projection — one computation serves both the
+  // projected schemas and the runtime clamp.
+  const effectiveBindings = computeEffectiveBindings(allTools, agentConfig.toolRestrictions)
+  const projected = projectBindingSchemas(allTools, effectiveBindings)
+  // Eval-only: wrap the projected toolset with mock execution before it's baked into
+  // the domain config. Identity (name/parameters/outputSchema) is preserved, so the
+  // binding clamp below and snapshot digests are unaffected. No-op in production.
+  const tools = args.wrapTools ? args.wrapTools(projected) : projected
+
+  const domainConfig = createKopilotDomainConfig({
+    capabilityRegistry: registry,
+    page: resolvedPage,
+    tools,
+    defaultModel: defaults.model,
+    defaultProvider: defaults.provider,
+    agentConfig,
+    triggerContext: args.triggerContext,
+    // Long-running plans (≥30 steps × ~1–2 LLM rounds each) need headroom past
+    // the framework's small-loop default.
+    maxIterations: 30,
+  })
+
+  return {
+    // The engine treats domain state as opaque `Record<string, unknown>`, but
+    // `AgentDomainConfig` is invariant in its state generic — widen the concrete
+    // `KopilotDomainState` config at this single boundary (the pre-extraction job
+    // carried this same conversion as an unchecked error).
+    domainConfig: domainConfig as unknown as AgentDomainConfig,
+    tools,
+    applyToolRestrictions: buildApplyBindings(effectiveBindings),
+    agentConfig,
+    model: {
+      provider: domainConfig.defaultProvider,
+      model: domainConfig.defaultModel,
+    },
+    utilityModel: {
+      provider: domainConfig.utilityProvider ?? domainConfig.defaultProvider,
+      model: domainConfig.utilityModel ?? domainConfig.defaultModel,
+    },
+  }
+}

--- a/packages/lib/src/ai/agent-framework/engine.ts
+++ b/packages/lib/src/ai/agent-framework/engine.ts
@@ -432,7 +432,8 @@ export class AgentEngine {
         subject: config.subject,
         appAccounts: config.appAccounts,
         agentName: pending.agentName,
-        now: Date.now(),
+        now: config.nowMs ?? Date.now(),
+        evalFieldResolver: config.evalFieldResolver,
       }
       // Fresh ctx on resume — rehydrate the context store from the persisted
       // slice so captures made before the approval pause survive the resume.

--- a/packages/lib/src/ai/agent-framework/process-agent-job.ts
+++ b/packages/lib/src/ai/agent-framework/process-agent-job.ts
@@ -4,42 +4,22 @@ import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { getSessionById, saveSessionMessages, updateSessionDomainState } from '@auxx/services'
 import { and, eq } from 'drizzle-orm'
-import {
-  filterToolsByToolsets,
-  getOrgToolCatalog,
-  getOrgToolsetCatalog,
-  resolveAgentConfig,
-} from '../../agents'
-import {
-  buildApplyBindings,
-  computeEffectiveBindings,
-  projectBindingSchemas,
-} from '../../agents/bindings'
+import { getOrgToolCatalog, getOrgToolsetCatalog } from '../../agents'
 import {
   type ConversationMessage,
-  PROCEDURE_CONTROL_TOOLS,
   runProcedureTurn,
   sessionMessagesToConversation,
 } from '../../agents/procedures'
 import { getCachedAgentById } from '../../cache'
 import type { JobContext } from '../../jobs/types'
 import { docToText } from '../../tiptap'
-import {
-  createAppCapabilities,
-  createCapabilityRegistry,
-  createEntityCapabilities,
-  createKopilotCapabilities,
-  createKopilotDomainConfig,
-  createMailCapabilities,
-  createToolDepsFactory,
-} from '../kopilot'
 import { buildInstructionReferenceResolver } from '../kopilot/prompts/resolve-instruction-references'
 import type { TriggerContext, TriggerKind } from '../kopilot/prompts/trigger-context'
 import type { UsageTrackingRequest } from '../orchestrator/types'
 import { getModelCreditMultiplier } from '../quota/credit-multiplier'
 import { UsageTrackingService } from '../usage/usage-tracking-service'
-import { BUILDER_MODEL } from './builder-model'
 import { KopilotContextStore, readContextSlice } from './context'
+import { type AgentRuntimeDomain, buildEffectiveAgentRuntime } from './effective-runtime'
 import { AgentEngine } from './engine'
 import type { AgentJobPayload } from './enqueue-agent-job'
 import { createAgentEventPublisher } from './event-publisher'
@@ -49,20 +29,6 @@ import type { Subject, ToolContext } from './tool-context'
 import type { AgentEngineConfig, AgentEvent, SessionMessage } from './types'
 
 const logger = createScopedLogger('agent-job')
-
-/**
- * Split a stored `provider:model` model id into its parts. Returns null for
- * unset or malformed values so callers fall through to the next precedence
- * tier (system default).
- */
-function parseProviderModel(
-  pinned: string | null | undefined
-): { provider: string; model: string } | null {
-  if (!pinned) return null
-  const idx = pinned.indexOf(':')
-  if (idx <= 0 || idx === pinned.length - 1) return null
-  return { provider: pinned.slice(0, idx), model: pinned.slice(idx + 1) }
-}
 
 /**
  * BullMQ job handler for processing agent messages.
@@ -138,21 +104,28 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
     sessionTriggerContext: session.triggerContext as Record<string, unknown> | null,
   })
 
-  // 2. Build domain config based on domain type
-  const domainConfig = await buildDomainConfig(domain, {
+  // 2. Build the effective agent runtime (model precedence, capability registry,
+  // toolset-filtered + binding-projected tools, domain config, and binding
+  // clamp) — the shared builder used by both this job and the eval Simulation
+  // engine, so there is no divergent second copy.
+  if (domain !== 'kopilot' && domain !== 'builder') {
+    throw new Error(`Unknown agent domain: ${domain}`)
+  }
+  const runtime = await buildEffectiveAgentRuntime({
     organizationId,
     userId,
     sessionId,
-    page,
-    context,
+    agentId,
+    domain: domain as AgentRuntimeDomain,
     signal,
     modelId,
-    agentId,
-    triggerContext,
     // Mount the procedure control tools when this agent has procedures (inert
     // without an active step in the prompt — same gating as the chat path).
     hasProcedures,
+    page,
+    triggerContext,
   })
+  const { domainConfig, agentConfig } = runtime
 
   // 3. Create LLM adapter
   const callModel = createCallModel({
@@ -162,11 +135,6 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
     sourceId: sessionId,
     forceSystem: domain === 'builder',
   })
-
-  // 3b. Resolve the agent's binding override map (cached read; empty for
-  // master). Combined with each tool's author defaults to clamp args per call.
-  const agentConfig = await resolveAgentConfig(organizationId, agentId)
-  const { toolRestrictions } = agentConfig
 
   // 4. Create engine with saved state
   const engineConfig: AgentEngineConfig = {
@@ -182,9 +150,7 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
     // the input falls through to the model; a `const` override still applies.
     // No-op for master Kopilot (no tools declare bindings + empty overrides).
     // See plans/chat/v8 phase-4.
-    applyToolRestrictions: buildApplyBindings(
-      computeEffectiveBindings(domainConfig.tools, toolRestrictions)
-    ),
+    applyToolRestrictions: runtime.applyToolRestrictions,
     // Kopilot domain: long-running plans routinely chain >5 approvals
     // (one per ticket reply, etc.) and need iteration headroom for plan
     // step churn. Other domains stay on framework defaults.
@@ -369,145 +335,6 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
   }
 
   logger.info('Agent message processed', { sessionId, domain })
-}
-
-/**
- * Build the appropriate domain config based on the session type.
- */
-async function buildDomainConfig(
-  domain: string,
-  params: {
-    organizationId: string
-    userId: string
-    sessionId: string
-    page?: string
-    context?: Record<string, unknown>
-    signal?: AbortSignal
-    modelId?: string
-    agentId: string | null
-    triggerContext: TriggerContext | undefined
-    hasProcedures?: boolean
-  }
-) {
-  switch (domain) {
-    case 'kopilot': {
-      // Resolve model precedence:
-      //   per-turn/per-session (`params.modelId`)
-      //     → agent/master pin (`agentConfig.modelId`)
-      //     → org system default
-      // Master pin is provider:model (see plans/kopilot/settings/04-runtime-activation.md
-      // §C5); agent pins follow the same shape.
-      let defaultModel: string | undefined
-      let defaultProvider: string | undefined
-      const pinned = params.modelId ?? null
-      if (pinned) {
-        const parsed = parseProviderModel(pinned)
-        if (parsed) {
-          defaultProvider = parsed.provider
-          defaultModel = parsed.model
-        }
-      } else {
-        const agentConfigForModel = await resolveAgentConfig(params.organizationId, params.agentId)
-        const fromConfig = parseProviderModel(agentConfigForModel.modelId)
-        if (fromConfig) {
-          defaultProvider = fromConfig.provider
-          defaultModel = fromConfig.model
-        } else {
-          const { getCachedDefaultModel } = await import('../../cache/org-cache-helpers')
-          const { ModelType } = await import('../providers/types')
-          const systemDefault = await getCachedDefaultModel(params.organizationId, ModelType.LLM)
-          if (systemDefault) {
-            defaultProvider = systemDefault.provider
-            defaultModel = systemDefault.model
-          }
-        }
-      }
-
-      return buildKopilotShapedConfig(params, {
-        provider: defaultProvider,
-        model: defaultModel,
-      })
-    }
-    case 'builder': {
-      // Builder pins BUILDER_MODEL and ignores params.modelId — paired with
-      // forceSystem on the call-model side so SYSTEM credentials are used
-      // regardless of the org's provider-type preference.
-      return buildKopilotShapedConfig(params, {
-        provider: BUILDER_MODEL.provider,
-        model: BUILDER_MODEL.model,
-      })
-    }
-    default:
-      throw new Error(`Unknown agent domain: ${domain}`)
-  }
-}
-
-async function buildKopilotShapedConfig(
-  params: {
-    organizationId: string
-    userId: string
-    sessionId: string
-    page?: string
-    signal?: AbortSignal
-    agentId: string | null
-    triggerContext: TriggerContext | undefined
-    hasProcedures?: boolean
-  },
-  defaults: { provider: string | undefined; model: string | undefined }
-) {
-  const getToolDeps = createToolDepsFactory({
-    organizationId: params.organizationId,
-    userId: params.userId,
-    sessionId: params.sessionId,
-    signal: params.signal,
-  })
-
-  const registry = createCapabilityRegistry()
-  registry.register(createEntityCapabilities(getToolDeps))
-  registry.register(createMailCapabilities(getToolDeps))
-  registry.register(createKopilotCapabilities(getToolDeps))
-  registry.register(
-    await createAppCapabilities({
-      organizationId: params.organizationId,
-      // Background agent jobs run autonomously — no human in the loop.
-      // User-scope tools are hidden by the bridge (decision A2).
-      userId: null,
-      agentId: params.agentId,
-      triggerId: null,
-      sessionId: params.sessionId,
-      getToolDeps,
-    })
-  )
-
-  const agentConfig = await resolveAgentConfig(params.organizationId, params.agentId)
-  const resolvedPage = params.page ?? '__none__'
-  const filteredTools = filterToolsByToolsets(registry.getTools(resolvedPage), agentConfig)
-  // Mount the v9 procedure control tools when this agent has procedures — inert
-  // without an active step in the prompt, so gating keeps zero-procedure runs on
-  // the unchanged tool list (mirrors `buildChatEngineConfig`).
-  const allTools = params.hasProcedures
-    ? [...filteredTools, ...PROCEDURE_CONTROL_TOOLS]
-    : filteredTools
-  // Project tool schemas per the effective bindings (author defaults ⊕ admin
-  // overrides). Internal turns have no subject, so bound inputs fall through to
-  // the model at clamp time — but a `const` override still drops from required.
-  // For master sessions there are no bindings, so this is a no-op. See
-  // plans/chat/v8 phase-4.
-  const effectiveBindings = computeEffectiveBindings(allTools, agentConfig.toolRestrictions)
-  const tools = projectBindingSchemas(allTools, effectiveBindings)
-
-  return createKopilotDomainConfig({
-    capabilityRegistry: registry,
-    page: resolvedPage,
-    tools,
-    defaultModel: defaults.model,
-    defaultProvider: defaults.provider,
-    agentConfig,
-    triggerContext: params.triggerContext,
-    // Long-running plans (≥30 steps × ~1–2 LLM rounds each) need
-    // headroom past the framework's small-loop default.
-    maxIterations: 30,
-  })
 }
 
 /**

--- a/packages/lib/src/ai/agent-framework/query-loop.ts
+++ b/packages/lib/src/ai/agent-framework/query-loop.ts
@@ -102,7 +102,10 @@ export async function* agentQueryLoop(
     subject: config.subject,
     appAccounts: config.appAccounts,
     agentName: agent.name,
-    now: Date.now(),
+    // Eval Simulations pin a frozen clock (`timeFrozenAt`); production uses the wall clock.
+    now: config.nowMs ?? Date.now(),
+    // Eval-only `startingFields` overlay; undefined on production (subject resolver reads anchors).
+    evalFieldResolver: config.evalFieldResolver,
   }
   const ctx: ToolContext = {
     ...baseCtx,

--- a/packages/lib/src/ai/agent-framework/tool-context.ts
+++ b/packages/lib/src/ai/agent-framework/tool-context.ts
@@ -1,9 +1,21 @@
 // packages/lib/src/ai/agent-framework/tool-context.ts
 
 import type { Database } from '@auxx/database'
+import type { FieldReference } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
 import type { ContextManager } from './context/context-manager'
 import type { AgentDeps } from './types'
+
+/**
+ * Eval-only field overlay. When present on a {@link ToolContext}, the shared
+ * subject field resolver short-circuits to this resolver instead of reading
+ * `subject.anchors` directly — the Simulation overlay layers a case's
+ * `startingFields` over the configured subject records WITHOUT writing CRM data,
+ * then delegates the rest to the normal subject resolver. Absent on every
+ * production run, so current behavior is preserved. See
+ * plans/evals/phase-1-agent-simulation.md §1.5.
+ */
+export type EvalFieldResolver = (ref: FieldReference) => Promise<unknown>
 
 /**
  * Caller-agnostic context every tool's `execute()` receives. Built fresh by
@@ -66,6 +78,12 @@ export interface ToolContext extends AgentDeps {
    * ctx-build so every `sys:now` read within a turn is stable.
    */
   now?: number
+  /**
+   * Eval-only field overlay (see {@link EvalFieldResolver}). Set by the
+   * Simulation executor so `startingFields` override CRM reads; `undefined` on
+   * every production run, where the subject resolver reads `subject.anchors`.
+   */
+  evalFieldResolver?: EvalFieldResolver
 }
 
 /**

--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -6,7 +6,7 @@ import type { z } from 'zod'
 import type { AgentSurface } from '../../agents/client'
 import type { Message, ModelParameters, Tool, ToolCall, UsageMetrics } from '../clients/base/types'
 import type { ContextManager } from './context/context-manager'
-import type { Subject, ToolContext, WorkflowToolContext } from './tool-context'
+import type { EvalFieldResolver, Subject, ToolContext, WorkflowToolContext } from './tool-context'
 
 // ===== CONTENT PARTS =====
 
@@ -805,6 +805,18 @@ export interface AgentEngineConfig {
     args: Record<string, unknown>,
     ctx: ToolContext
   ) => Promise<{ ok: true; args: Record<string, unknown> } | { ok: false; error: string }>
+  /**
+   * Eval-only frozen framework clock (epoch ms). When set, every tool `ToolContext.now`
+   * and the framework `sys:now` read this instead of the wall clock, so a Simulation's
+   * `timeFrozenAt` makes time deterministic. Absent on every production run.
+   */
+  nowMs?: number
+  /**
+   * Eval-only subject field overlay. When set, the engine copies it onto every tool's
+   * `ToolContext.evalFieldResolver` so `startingFields` override CRM reads without a
+   * write. Absent on every production run (the subject resolver reads `subject.anchors`).
+   */
+  evalFieldResolver?: EvalFieldResolver
 }
 
 // ===== AGENT DEPENDENCIES =====

--- a/packages/lib/src/ai/agent-framework/utils.ts
+++ b/packages/lib/src/ai/agent-framework/utils.ts
@@ -312,16 +312,8 @@ function findLastFinalAssistantIdx(messages: SessionMessage[]): number {
   return -1
 }
 
-/**
- * Deterministic JSON.stringify — sorts object keys so `{a:1,b:2}` and
- * `{b:2,a:1}` produce the same cache key. Used to key the per-turn idempotent
- * cache for read-only tool calls.
- */
-export function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== 'object') return JSON.stringify(value)
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
-  const entries = Object.entries(value as Record<string, unknown>)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`)
-  return `{${entries.join(',')}}`
-}
+// Deterministic, key-order-independent JSON.stringify — used to key the per-turn
+// idempotent cache for read-only tool calls. Lives in @auxx/utils now;
+// re-exported so existing `import { stableStringify } from './utils'` call sites
+// keep working.
+export { stableStringify } from '@auxx/utils/json'

--- a/packages/lib/src/field-values/formatter.ts
+++ b/packages/lib/src/field-values/formatter.ts
@@ -9,6 +9,7 @@ import {
   isArrayReturnFieldType as isArrayReturnType,
   isMultiValueFieldType as isMultiValueType,
 } from '@auxx/types/field-value'
+import { deepEqual } from '@auxx/utils/objects'
 
 /**
  * Options for field type checking.
@@ -292,29 +293,6 @@ export function areValuesEqual(value1: unknown, value2: unknown, fieldType: Fiel
 
   // Primitive comparison
   return raw1 === raw2
-}
-
-/**
- * Deep equality check for objects and arrays.
- */
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true
-  if (a === null || b === null) return false
-  if (typeof a !== 'object' || typeof b !== 'object') return a === b
-
-  const keysA = Object.keys(a as object)
-  const keysB = Object.keys(b as object)
-
-  if (keysA.length !== keysB.length) return false
-
-  for (const key of keysA) {
-    if (!keysB.includes(key)) return false
-    if (!deepEqual((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])) {
-      return false
-    }
-  }
-
-  return true
 }
 
 // Re-export types for convenience

--- a/packages/lib/src/kb/markdown/hash.ts
+++ b/packages/lib/src/kb/markdown/hash.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/kb/markdown/hash.ts
 
 import { createHash } from 'node:crypto'
+import { stableHash } from '@auxx/utils/hash'
 import type { ArticleNodeJSON } from './types'
 
 /** sha256 hex of the markdown content. Used to skip re-embedding when an article hasn't changed. */
@@ -9,13 +10,12 @@ export function computeContentHash(markdown: string): string {
 }
 
 /**
- * sha256 hex of the canonical JSON representation of an article body.
- * Used by the realtime sync protocol so server and client can detect
- * doc divergence (e.g. agent and manual edits crossing) without
- * re-marshalling through markdown.
+ * Stable sha256 hex of an article body's canonical JSON. Key-order-independent,
+ * so an in-memory doc and the same doc read back from the `contentJson` jsonb
+ * column hash identically (a plain `JSON.stringify` hash would diverge across
+ * the round-trip). Used by the realtime sync protocol and draft/published
+ * divergence checks to detect when content actually changed.
  */
 export function computeArticleJsonHash(content: ArticleNodeJSON[] | null | undefined): string {
-  return createHash('sha256')
-    .update(JSON.stringify(content ?? []), 'utf8')
-    .digest('hex')
+  return stableHash(content ?? [])
 }

--- a/packages/lib/vitest.config.ts
+++ b/packages/lib/vitest.config.ts
@@ -76,6 +76,7 @@ export default defineConfig(({ mode }) => {
       alias: {
         '@auxx/database': path.resolve(__dirname, '../database/src'),
         '@auxx/lib': path.resolve(__dirname, './src'),
+        '@auxx/utils': path.resolve(__dirname, '../utils/src'),
         '@auxx/logger': path.resolve(__dirname, '../logger/src'),
         '@auxx/config': path.resolve(__dirname, '../config/src'),
         '@auxx/workflow-nodes': path.resolve(__dirname, '../workflow-nodes/src'),


### PR DESCRIPTION
## What

PR 2 of 3 (stacked on #772). Production agent-runtime refactor that the evals PR builds on, plus a few unrelated drive-bys.

### agent-framework
- Extract `effective-runtime.ts` (`buildEffectiveAgentRuntime`) out of `process-agent-job.ts`; the agent job path now calls it
- `tool-context.ts`: add `EvalFieldResolver` + `Subject` (optional, no-op in production)
- `engine`, `query-loop`, `types`, `field-source`, `utils` cleanups (`stableStringify` now re-exported from `@auxx/utils/json`)

### procedures
- New `observer.ts` — optional `ProcedureObserver` transition hook, threaded through `stepper` / `turn-wiring` (no-op in production)
- `context`, `nodes`, `bindings/resolve` cleanups + tests

### Other
- `field-values/formatter` + `kb/markdown/hash` adopt the reworked `@auxx/utils` helpers
- `vitest.config`: alias `@auxx/utils` for lib tests
- Misc drive-bys: app-runtime html, dynamic-table view-config, editor content-sync hook

## Stack
- Base: #772 (utils). **Merge #772 first**, then this PR.
- Next: `feat/evals-phase1` stacks on this branch.

## Notes
- `effective-runtime` and the observer hook are real production-path changes (used by the agent job / stepper); they exist here independently of evals.