### PR TITLE
feat(evals): simulations tab UI with eval editor support

### DIFF
--- a/apps/web/src/components/agents/ui/detail/agent-docked-chat.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-docked-chat.tsx
@@ -3,10 +3,11 @@
 
 import { agentTemplates } from '@auxx/lib/agents/client'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
-import { MessageSquareOff, Settings2 } from 'lucide-react'
+import { FlaskConical, MessageSquare, MessageSquareOff, Settings2 } from 'lucide-react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useEffect, useState } from 'react'
+import { SimulationsTab } from '~/components/evals/ui/simulations-tab'
 import { KopilotContext } from '~/components/kopilot/context'
 import { KopilotChatProvider } from '~/components/kopilot/options'
 import { KopilotSuggestion } from '~/components/kopilot/suggestions/kopilot-suggestion'
@@ -18,8 +19,8 @@ interface AgentDockedChatProps {
   agentId: string
 }
 
-type Panel = 'build' | 'chat'
-const PANELS: readonly Panel[] = ['build', 'chat'] as const
+type Panel = 'build' | 'chat' | 'simulations'
+const PANELS: readonly Panel[] = ['build', 'chat', 'simulations'] as const
 
 /**
  * Docked Kopilot chat scoped to one agent. Two tabs:
@@ -57,10 +58,16 @@ export function AgentDockedChat({ agentId }: AgentDockedChatProps) {
       {!isFreshAgent && (
         <TabsList variant='outline'>
           <TabsTrigger value='build' variant='outline'>
+            <Settings2 />
             Build
           </TabsTrigger>
           <TabsTrigger value='chat' variant='outline'>
+            <MessageSquare />
             Chat
+          </TabsTrigger>
+          <TabsTrigger value='simulations' variant='outline'>
+            <FlaskConical />
+            Simulations
           </TabsTrigger>
         </TabsList>
       )}
@@ -75,6 +82,9 @@ export function AgentDockedChat({ agentId }: AgentDockedChatProps) {
           isFreshAgent={isFreshAgent}
           onJumpToBuild={() => setPanel('build')}
         />
+      </TabsContent>
+      <TabsContent value='simulations' className='flex-1 overflow-hidden'>
+        <SimulationsTab agentId={agentId} />
       </TabsContent>
     </Tabs>
   )

--- a/apps/web/src/components/evals/hooks/use-tool-icon-map.ts
+++ b/apps/web/src/components/evals/hooks/use-tool-icon-map.ts
@@ -1,0 +1,32 @@
+// apps/web/src/components/evals/hooks/use-tool-icon-map.ts
+'use client'
+
+import { flattenCatalogToToolsets } from '@auxx/lib/agents/client'
+import { useMemo } from 'react'
+import { useToolCatalog } from '~/components/agents/hooks/use-tool-catalog'
+
+export interface ToolIcon {
+  /** Already-resolved icon id (toolset's own, falling back to its app ancestor). */
+  iconId: string
+  /** Resolved color, or empty string. */
+  color: string
+}
+
+/**
+ * Maps each tool `name` → its catalog icon (the owning toolset/app icon), so the
+ * eval editor can show real app icons instead of a generic wrench. Built
+ * client-side from the same installed-app catalog the Tools tab uses — no extra
+ * round-trip; `AgentToolDefinition` itself carries no icon.
+ */
+export function useToolIconMap(): Map<string, ToolIcon> {
+  const { catalog } = useToolCatalog()
+  return useMemo(() => {
+    const map = new Map<string, ToolIcon>()
+    for (const toolset of flattenCatalogToToolsets(catalog)) {
+      for (const tool of toolset.tools) {
+        map.set(tool.name, { iconId: toolset.iconId, color: toolset.color })
+      }
+    }
+    return map
+  }, [catalog])
+}

--- a/apps/web/src/components/evals/stores/use-eval-run-store.ts
+++ b/apps/web/src/components/evals/stores/use-eval-run-store.ts
@@ -1,0 +1,172 @@
+// apps/web/src/components/evals/stores/use-eval-run-store.ts
+'use client'
+
+import type { AssertionResult, EvalRunStatus, EvalTraceEvent } from '@auxx/types/evals'
+import { create } from 'zustand'
+import { useShallow } from 'zustand/react/shallow'
+
+/**
+ * Run-keyed live state for an eval run, fed by the SSE recovery route
+ * (`/api/eval/run/[runId]/events`). The store owns the `EventSource`, dedupes
+ * trace events by id, and tracks the resume cursor (`lastSequence`). It never
+ * decides run status from a transport failure: `connectionStatus` is separate
+ * from `status`, and on error/close the caller falls back to `eval.getRun` and
+ * pushes the authoritative row in via {@link hydrateFromRun}.
+ *
+ * Selectors only (CLAUDE.md Zustand rule) — every consumer reads through
+ * {@link useEvalRunState} / {@link useEvalRunActions}, never the whole store.
+ */
+
+export type EvalConnectionStatus = 'idle' | 'connecting' | 'connected' | 'error' | 'closed'
+
+export interface EvalRunLiveState {
+  status: EvalRunStatus | null
+  trace: EvalTraceEvent[]
+  assertionResults: AssertionResult[]
+  lastSequence: number
+  connectionStatus: EvalConnectionStatus
+}
+
+const EMPTY_STATE: EvalRunLiveState = {
+  status: null,
+  trace: [],
+  assertionResults: [],
+  lastSequence: -1,
+  connectionStatus: 'idle',
+}
+
+interface InternalRunState extends EvalRunLiveState {
+  source: EventSource | null
+  /** Trace event ids already merged — dedupes the persisted/live overlap. */
+  seen: Set<string>
+}
+
+interface EvalRunStore {
+  runs: Record<string, InternalRunState>
+  connect: (runId: string) => void
+  disconnect: (runId: string) => void
+  /** Merge the authoritative persisted row (initial seed + SSE-failure fallback). */
+  hydrateFromRun: (
+    runId: string,
+    row: { status: EvalRunStatus; trace: EvalTraceEvent[]; assertionResults: AssertionResult[] }
+  ) => void
+}
+
+function ensure(state: EvalRunStore['runs'], runId: string): InternalRunState {
+  return state[runId] ?? { ...EMPTY_STATE, source: null, seen: new Set() }
+}
+
+const TERMINAL: ReadonlySet<EvalRunStatus> = new Set<EvalRunStatus>([
+  'passed',
+  'failed',
+  'error',
+  'cancelled',
+  'timed_out',
+])
+
+export const useEvalRunStore = create<EvalRunStore>((set, get) => {
+  /** Patch one run's slice immutably. */
+  const patch = (runId: string, next: Partial<InternalRunState>) => {
+    set((s) => ({ runs: { ...s.runs, [runId]: { ...ensure(s.runs, runId), ...next } } }))
+  }
+
+  /** Merge a batch of trace events, deduping by id and advancing the cursor. */
+  const mergeTrace = (runId: string, events: EvalTraceEvent[]) => {
+    const cur = ensure(get().runs, runId)
+    const seen = new Set(cur.seen)
+    const fresh: EvalTraceEvent[] = []
+    let maxSeq = cur.lastSequence
+    for (const e of events) {
+      if (seen.has(e.id)) continue
+      seen.add(e.id)
+      fresh.push(e)
+      if (e.sequence > maxSeq) maxSeq = e.sequence
+    }
+    if (fresh.length === 0 && maxSeq === cur.lastSequence) return
+    const trace = [...cur.trace, ...fresh].sort((a, b) => a.sequence - b.sequence)
+    patch(runId, { trace, seen, lastSequence: maxSeq })
+  }
+
+  return {
+    runs: {},
+
+    connect: (runId) => {
+      const existing = get().runs[runId]
+      if (existing?.source) return // already streaming
+      const after = existing?.lastSequence ?? -1
+      patch(runId, { connectionStatus: 'connecting' })
+
+      const source = new EventSource(`/api/eval/run/${runId}/events?afterSequence=${after}`)
+      patch(runId, { source })
+
+      source.addEventListener('connected', () => patch(runId, { connectionStatus: 'connected' }))
+
+      source.addEventListener('trace', (ev) => {
+        const data = JSON.parse((ev as MessageEvent).data) as { event: EvalTraceEvent }
+        mergeTrace(runId, [data.event])
+      })
+
+      source.addEventListener('status', (ev) => {
+        const data = JSON.parse((ev as MessageEvent).data) as {
+          status: EvalRunStatus
+          assertionResults?: AssertionResult[]
+        }
+        patch(runId, {
+          status: data.status,
+          ...(data.assertionResults ? { assertionResults: data.assertionResults } : {}),
+        })
+      })
+
+      source.addEventListener('done', () => {
+        source.close()
+        patch(runId, { source: null, connectionStatus: 'closed' })
+      })
+
+      source.onerror = () => {
+        // A terminal run's stream closes normally; only flag mid-run drops as errors.
+        const cur = ensure(get().runs, runId)
+        const terminal = cur.status != null && TERMINAL.has(cur.status)
+        source.close()
+        patch(runId, { source: null, connectionStatus: terminal ? 'closed' : 'error' })
+      }
+    },
+
+    disconnect: (runId) => {
+      const cur = get().runs[runId]
+      cur?.source?.close()
+      if (cur) patch(runId, { source: null, connectionStatus: 'idle' })
+    },
+
+    hydrateFromRun: (runId, row) => {
+      const cur = ensure(get().runs, runId)
+      const seen = new Set(cur.seen)
+      const fresh = row.trace.filter((e) => !seen.has(e.id))
+      for (const e of fresh) seen.add(e.id)
+      const trace = [...cur.trace, ...fresh].sort((a, b) => a.sequence - b.sequence)
+      const lastSequence = trace.reduce((m, e) => Math.max(m, e.sequence), cur.lastSequence)
+      patch(runId, {
+        status: row.status,
+        assertionResults: row.assertionResults,
+        trace,
+        seen,
+        lastSequence,
+      })
+    },
+  }
+})
+
+/** Selector: the public live state for one run (stable empty default when absent). */
+export function useEvalRunState(runId: string | null): EvalRunLiveState {
+  return useEvalRunStore((s) => (runId ? (s.runs[runId] ?? EMPTY_STATE) : EMPTY_STATE))
+}
+
+/** Selector: the store actions (shallow-compared so the object ref stays stable). */
+export function useEvalRunActions() {
+  return useEvalRunStore(
+    useShallow((s) => ({
+      connect: s.connect,
+      disconnect: s.disconnect,
+      hydrateFromRun: s.hydrateFromRun,
+    }))
+  )
+}

--- a/apps/web/src/components/evals/ui/eval-assertion-result-row.tsx
+++ b/apps/web/src/components/evals/ui/eval-assertion-result-row.tsx
@@ -1,0 +1,94 @@
+// apps/web/src/components/evals/ui/eval-assertion-result-row.tsx
+'use client'
+
+import type { AssertionResult } from '@auxx/types/evals'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { useState } from 'react'
+import { EvalStatusDot, EvalStatusPill } from './eval-status-pill'
+
+/**
+ * One graded assertion in a run's Verdict list. Shared by agent Simulations and
+ * workflow Tests (the assertion-result envelope is kind-agnostic). `error`
+ * renders amber via the shared pill and reads "grading could not complete" —
+ * never as a soft fail. The judge rationale / error note expands inline.
+ *
+ * See plans/evals/ui-plan.md §"Level 3 — run detail + trace".
+ */
+
+const TYPE_LABELS: Record<string, string> = {
+  terminal_outcome: 'Terminal outcome',
+  procedure_selected: 'Procedure selected',
+  response_criteria: 'Response criteria',
+  crm_field: 'CRM field',
+  local_variable: 'Local variable',
+  tool_called: 'Tool called',
+  tool_not_called: 'Tool not called',
+  // workflow kinds (Phase 2B) reuse this row:
+  workflow_status: 'Workflow status',
+  node_output: 'Node output',
+  execution_count: 'Execution count',
+  no_errors: 'No errors',
+}
+
+function typeLabel(type: string): string {
+  return TYPE_LABELS[type] ?? type
+}
+
+/** Best-effort one-line description of what the assertion expected. */
+function expectedSummary(result: AssertionResult): string | null {
+  const def = result.definition as { data?: Record<string, unknown> } | null
+  const data = def?.data
+  if (!data) return null
+  if (typeof data.outcome === 'string') return `expects ${data.outcome}`
+  if (typeof data.toolName === 'string') return data.toolName
+  if (typeof data.name === 'string') return data.name
+  if (Array.isArray(data.criteria)) return `${data.criteria.length} criteria`
+  if ('expected' in data) return `expects ${formatValue(data.expected)}`
+  return null
+}
+
+function formatValue(value: unknown): string {
+  if (value == null) return '—'
+  if (typeof value === 'string') return value
+  return JSON.stringify(value)
+}
+
+interface EvalAssertionResultRowProps {
+  result: AssertionResult
+}
+
+export function EvalAssertionResultRow({ result }: EvalAssertionResultRowProps) {
+  const [open, setOpen] = useState(false)
+  const expected = expectedSummary(result)
+  const hasDetail = Boolean(result.note) || result.actual !== undefined
+
+  return (
+    <TreeRow
+      icon={<EvalStatusDot status={result.status} />}
+      title={typeLabel(result.type)}
+      secondary={
+        <span className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+          {expected ? <span className='truncate'>{expected}</span> : null}
+          <EvalStatusPill status={result.status} />
+        </span>
+      }
+      expandable={hasDetail}
+      isOpen={open}
+      onToggleOpen={() => setOpen((v) => !v)}>
+      <div className='space-y-2 px-2 py-1.5 text-xs'>
+        {result.actual !== undefined ? (
+          <div>
+            <span className='text-muted-foreground'>Actual: </span>
+            <span className='font-mono break-all'>{formatValue(result.actual)}</span>
+          </div>
+        ) : null}
+        {result.note ? (
+          <p className={result.status === 'error' ? 'text-amber-600' : 'text-muted-foreground'}>
+            {result.status === 'error' ? 'Grading could not complete: ' : ''}
+            {result.note}
+          </p>
+        ) : null}
+      </div>
+    </TreeRow>
+  )
+}

--- a/apps/web/src/components/evals/ui/eval-case-drawer.tsx
+++ b/apps/web/src/components/evals/ui/eval-case-drawer.tsx
@@ -1,0 +1,517 @@
+// apps/web/src/components/evals/ui/eval-case-drawer.tsx
+'use client'
+
+import { FieldType } from '@auxx/database/enums'
+import type { AgentEvalAssertion, AgentEvalTarget, SimulationConfig } from '@auxx/types/evals'
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { EmptySection, Section } from '@auxx/ui/components/section'
+import { Switch } from '@auxx/ui/components/switch'
+import { toastError } from '@auxx/ui/components/toast'
+import { generateId } from '@auxx/utils'
+import { FlaskConical, ListChecks, Play, Plus, User, Wrench } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
+import { api } from '~/trpc/react'
+import { AutosaveIndicator, type AutosaveState } from '../../agents/ui/shared/autosave-indicator'
+import { useToolIconMap } from '../hooks/use-tool-icon-map'
+import { EvalDrillBar } from './eval-drill-bar'
+import { EvalToolResponses } from './eval-tool-responses'
+
+/**
+ * Level 2 of the Simulations drill: the case editor. Inline, stacked `Section`s
+ * (no modal) with autosave — edits persist on a debounce, mirroring the
+ * procedure editor; a `Run` button flushes then enqueues.
+ *
+ * Covers Customer, Execution policy, Tool responses, and the assertion types
+ * that don't need a field-ref widget. Field-typed inputs (starting fields,
+ * `crm_field`/`local_variable`, `procedure_selected`, subject pickers) are a
+ * follow-up. See plans/evals/ui-plan.md §"Level 2 — case editor".
+ */
+
+const DEFAULT_CONFIG: SimulationConfig = {
+  openingMessage: '',
+  customerContext: null,
+  channel: 'chat',
+  timeFrozenAt: null,
+  maxCustomerTurns: 8,
+  subject: { recordIds: [], identityVerified: false },
+  startingFields: [],
+  unmatchedToolPolicy: 'error',
+  connectorMocks: [],
+}
+
+const CHANNEL_OPTIONS = [
+  { value: 'chat', label: 'Chat' },
+  { value: 'email', label: 'Email' },
+]
+
+const OUTCOME_OPTIONS = [
+  { value: 'finished', label: 'Finished' },
+  { value: 'handoff', label: 'Handoff' },
+  { value: 'switch', label: 'Switch' },
+]
+
+interface EvalCaseDrawerProps {
+  agentId: string
+  /** `null` ⇒ create mode. */
+  caseId: string | null
+  /** Shared `?procedure` scope — pins a procedure version on new cases when set. */
+  procedureId: string | null
+  /** Fires after any successful persist (used to refresh the suite list). */
+  onSaved: () => void
+  onOpenRun: (runId: string) => void
+}
+
+export function EvalCaseDrawer({
+  agentId,
+  caseId,
+  procedureId,
+  onSaved,
+  onOpenRun,
+}: EvalCaseDrawerProps) {
+  const isCreate = caseId == null
+
+  const caseQuery = api.eval.getById.useQuery({ id: caseId! }, { enabled: !isCreate })
+  // A new procedure-scoped case pins the procedure's active version.
+  const procedureQuery = api.procedure.getById.useQuery(
+    { id: procedureId! },
+    { enabled: isCreate && procedureId != null }
+  )
+
+  // Wait for whichever async dependency this mode needs before mounting the form
+  // (so autosave never races a half-resolved target or unloaded case).
+  const waitingForCase = !isCreate && caseQuery.isLoading
+  const waitingForProcedure = isCreate && procedureId != null && procedureQuery.isLoading
+
+  if (waitingForCase || waitingForProcedure) {
+    return (
+      <>
+        <EvalDrillBar title='Simulation' />
+        <EmptySection
+          icon={<FlaskConical className='size-4' />}
+          title='Loading simulation…'
+          loading
+        />
+      </>
+    )
+  }
+
+  const loaded = caseQuery.data
+  const activeVersionId = procedureQuery.data?.activeVersionId ?? null
+
+  const target: AgentEvalTarget =
+    loaded?.target ??
+    (procedureId && activeVersionId
+      ? {
+          kind: 'agent_simulation',
+          scope: 'procedure',
+          agentId,
+          procedureId,
+          procedureVersionId: activeVersionId,
+        }
+      : { kind: 'agent_simulation', scope: 'agent', agentId })
+
+  return (
+    <EvalCaseForm
+      key={caseId ?? 'new'}
+      agentId={agentId}
+      initialCaseId={caseId}
+      initialName={loaded?.name ?? ''}
+      initialConfig={loaded?.config ?? DEFAULT_CONFIG}
+      initialAssertions={loaded?.assertions ?? []}
+      target={target}
+      onSaved={onSaved}
+      onOpenRun={onOpenRun}
+    />
+  )
+}
+
+// ── Form ─────────────────────────────────────────────────────────────────────
+
+interface EvalCaseFormProps {
+  agentId: string
+  initialCaseId: string | null
+  initialName: string
+  initialConfig: SimulationConfig
+  initialAssertions: AgentEvalAssertion[]
+  target: AgentEvalTarget
+  onSaved: () => void
+  onOpenRun: (runId: string) => void
+}
+
+function EvalCaseForm({
+  agentId,
+  initialCaseId,
+  initialName,
+  initialConfig,
+  initialAssertions,
+  target,
+  onSaved,
+  onOpenRun,
+}: EvalCaseFormProps) {
+  const [caseId, setCaseId] = useState(initialCaseId)
+  const [name, setName] = useState(initialName)
+  const [config, setConfig] = useState<SimulationConfig>(initialConfig)
+  const [assertions, setAssertions] = useState<AgentEvalAssertion[]>(initialAssertions)
+  const [autosave, setAutosave] = useState<AutosaveState>({ kind: 'idle' })
+
+  const create = api.eval.create.useMutation()
+  const update = api.eval.update.useMutation()
+  const run = api.eval.run.useMutation({
+    onSuccess: ({ runId }) => onOpenRun(runId),
+    onError: (err) => toastError({ title: 'Failed to run', description: err.message }),
+  })
+
+  const canSave = name.trim().length > 0 && config.openingMessage.trim().length > 0
+
+  // Always-current snapshot for the debounced/forced saver (avoids stale closures).
+  const latest = useRef({ caseId, name, config, assertions, target })
+  latest.current = { caseId, name, config, assertions, target }
+  const onSavedRef = useRef(onSaved)
+  onSavedRef.current = onSaved
+
+  /** Persist the current snapshot now; returns the case id (creating if needed). */
+  const saveNow = useCallback(async (): Promise<string | null> => {
+    const cur = latest.current
+    if (name.trim().length === 0 || cur.config.openingMessage.trim().length === 0) return null
+    setAutosave({ kind: 'saving' })
+    try {
+      let id = cur.caseId
+      if (id == null) {
+        const res = await create.mutateAsync({
+          name: cur.name,
+          target: cur.target,
+          config: cur.config,
+          assertions: cur.assertions,
+        })
+        id = res.id
+        setCaseId(id)
+      } else {
+        await update.mutateAsync({
+          id,
+          patch: { name: cur.name, config: cur.config, assertions: cur.assertions },
+        })
+      }
+      onSavedRef.current()
+      setAutosave({ kind: 'saved', at: Date.now() })
+      return id
+    } catch (err) {
+      setAutosave({ kind: 'idle' })
+      toastError({
+        title: 'Failed to save',
+        description: err instanceof Error ? err.message : String(err),
+      })
+      return null
+    }
+    // saveNow reads from `latest`, so only `name` (gating canSave) is a real dep.
+  }, [name, create, update])
+
+  // Debounced autosave on any change (skips the initial mount). name/config/
+  // assertions are intentional change-triggers even though the body reads them
+  // through `latest` — re-running on each edit is the point.
+  const firstRun = useRef(true)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: name/config/assertions are autosave triggers
+  useEffect(() => {
+    if (firstRun.current) {
+      firstRun.current = false
+      return
+    }
+    if (!canSave) return
+    const t = setTimeout(() => void saveNow(), 800)
+    return () => clearTimeout(t)
+  }, [name, config, assertions, canSave, saveNow])
+
+  const setConfigField = <K extends keyof SimulationConfig>(key: K, value: SimulationConfig[K]) =>
+    setConfig((c) => ({ ...c, [key]: value }))
+
+  const runNow = async () => {
+    const id = await saveNow()
+    if (id) run.mutate({ id })
+  }
+
+  return (
+    <>
+      <EvalDrillBar
+        title={
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder='Simulation name'
+            className='w-full bg-transparent text-sm font-medium outline-none placeholder:text-muted-foreground'
+          />
+        }
+        actions={<AutosaveIndicator state={autosave} />}
+      />
+
+      <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
+        {/* Customer */}
+        <Section title='Customer' icon={<User className='size-4' />}>
+          <VarEditorField className='p-0'>
+            <VarEditorFieldRow title='Opening message' isRequired>
+              <FieldInputAdapter
+                fieldType={FieldType.RICH_TEXT}
+                value={config.openingMessage}
+                onChange={(v) => setConfigField('openingMessage', (v as string) ?? '')}
+                placeholder='I want to cancel my order'
+              />
+            </VarEditorFieldRow>
+            <VarEditorFieldRow title='Customer context' description='Background the persona knows.'>
+              <FieldInputAdapter
+                fieldType={FieldType.RICH_TEXT}
+                value={config.customerContext ?? ''}
+                onChange={(v) => setConfigField('customerContext', (v as string) || null)}
+                placeholder='Has not received an order confirmation.'
+              />
+            </VarEditorFieldRow>
+            <VarEditorFieldRow title='Channel'>
+              <FieldInputAdapter
+                fieldType={FieldType.SINGLE_SELECT}
+                fieldOptions={{ options: CHANNEL_OPTIONS }}
+                triggerProps={{ className: 'w-full pe-1 ps-0' }}
+                value={config.channel}
+                onChange={(v) =>
+                  setConfigField('channel', ((v as string[])[0] as 'chat' | 'email') ?? 'chat')
+                }
+              />
+            </VarEditorFieldRow>
+            <VarEditorFieldRow title='Max customer turns'>
+              <FieldInputAdapter
+                fieldType={FieldType.NUMBER}
+                value={config.maxCustomerTurns}
+                onChange={(v) => setConfigField('maxCustomerTurns', Number(v) || 1)}
+              />
+            </VarEditorFieldRow>
+          </VarEditorField>
+        </Section>
+
+        {/* Execution policy */}
+        <Section title='Execution' icon={<Wrench className='size-4' />}>
+          <div className='flex items-center justify-between px-1 py-1'>
+            <div>
+              <div className='text-sm'>Run read-only tools for real</div>
+              <p className='text-xs text-muted-foreground'>
+                Passthrough lets idempotent tools execute; writes are always mocked. Off = fully
+                offline (unmatched calls fail closed).
+              </p>
+            </div>
+            <Switch
+              size='sm'
+              checked={config.unmatchedToolPolicy === 'passthrough_readonly'}
+              onCheckedChange={(checked) =>
+                setConfigField('unmatchedToolPolicy', checked ? 'passthrough_readonly' : 'error')
+              }
+            />
+          </div>
+        </Section>
+
+        {/* Tool responses */}
+        <EvalToolResponses
+          agentId={agentId}
+          mocks={config.connectorMocks}
+          onChange={(mocks) => setConfigField('connectorMocks', mocks)}
+        />
+
+        {/* Assertions */}
+        <AssertionsSection
+          agentId={agentId}
+          scope={target.scope}
+          assertions={assertions}
+          onChange={setAssertions}
+        />
+
+        <div className='h-24' />
+      </ScrollArea>
+
+      {/* Footer */}
+      <div className='flex shrink-0 items-center justify-end gap-2 border-t bg-background px-3 py-2'>
+        <Button
+          size='sm'
+          disabled={!canSave || run.isPending}
+          loading={run.isPending}
+          loadingText='Running…'
+          onClick={runNow}>
+          <Play />
+          Run
+        </Button>
+      </div>
+    </>
+  )
+}
+
+// ── Assertions ─────────────────────────────────────────────────────────────
+
+interface AssertionsSectionProps {
+  agentId: string
+  scope: 'agent' | 'procedure'
+  assertions: AgentEvalAssertion[]
+  onChange: (next: AgentEvalAssertion[]) => void
+}
+
+function AssertionsSection({ agentId, assertions, onChange }: AssertionsSectionProps) {
+  // The agent's effective toolset, for the tool-call assertion pickers (deduped
+  // with the Tool responses query on the same key). Options carry the catalog
+  // icon so the picker shows real app icons.
+  const toolsetQuery = api.eval.agentToolset.useQuery({ agentId })
+  const iconMap = useToolIconMap()
+  const toolOptions = (toolsetQuery.data?.tools ?? []).map((t) => ({
+    value: t.name,
+    label: t.displayName,
+    icon: iconMap.get(t.name)?.iconId,
+  }))
+
+  const add = (a: AgentEvalAssertion) => onChange([...assertions, a])
+  const remove = (id: string) => onChange(assertions.filter((a) => a.id !== id))
+  const patch = (id: string, next: AgentEvalAssertion) =>
+    onChange(assertions.map((a) => (a.id === id ? next : a)))
+
+  return (
+    <Section
+      title='Assertions'
+      collapsible={false}
+      actions={
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant='ghost' size='xs'>
+              <Plus />
+              Add assertion
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='end'>
+            <DropdownMenuItem
+              onClick={() =>
+                add({
+                  id: generateId('asrt'),
+                  type: 'terminal_outcome',
+                  data: { outcome: 'finished' },
+                })
+              }>
+              Terminal outcome
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() =>
+                add({ id: generateId('asrt'), type: 'response_criteria', data: { criteria: [] } })
+              }>
+              Response criteria
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() =>
+                add({ id: generateId('asrt'), type: 'tool_called', data: { toolName: '' } })
+              }>
+              Tool called
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() =>
+                add({ id: generateId('asrt'), type: 'tool_not_called', data: { toolName: '' } })
+              }>
+              Tool not called
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      }>
+      {assertions.length === 0 ? (
+        <EmptySection
+          icon={<ListChecks className='size-4' />}
+          title='No assertions yet'
+          description='A case must assert at least one outcome before it can pass.'
+        />
+      ) : (
+        <VarEditorField orientation='vertical' className='p-0'>
+          {assertions.map((a) => (
+            <VarEditorFieldRow
+              key={a.id}
+              title={LABEL[a.type] ?? a.type}
+              onClear={() => remove(a.id)}>
+              <AssertionEditor
+                assertion={a}
+                toolOptions={toolOptions}
+                onChange={(next) => patch(a.id, next)}
+              />
+            </VarEditorFieldRow>
+          ))}
+        </VarEditorField>
+      )}
+    </Section>
+  )
+}
+
+const LABEL: Record<string, string> = {
+  terminal_outcome: 'Terminal outcome',
+  response_criteria: 'Response criteria',
+  tool_called: 'Tool called',
+  tool_not_called: 'Tool not called',
+}
+
+function AssertionEditor({
+  assertion,
+  toolOptions,
+  onChange,
+}: {
+  assertion: AgentEvalAssertion
+  toolOptions: { value: string; label: string; icon?: string }[]
+  onChange: (next: AgentEvalAssertion) => void
+}) {
+  if (assertion.type === 'terminal_outcome') {
+    return (
+      <div className='w-40'>
+        <FieldInputAdapter
+          fieldType={FieldType.SINGLE_SELECT}
+          fieldOptions={{ options: OUTCOME_OPTIONS }}
+          value={assertion.data.outcome}
+          onChange={(v) =>
+            onChange({
+              ...assertion,
+              data: {
+                outcome: ((v as string[])[0] as 'finished' | 'handoff' | 'switch') ?? 'finished',
+              },
+            })
+          }
+        />
+      </div>
+    )
+  }
+  if (assertion.type === 'response_criteria') {
+    return (
+      <FieldInputAdapter
+        fieldType={FieldType.RICH_TEXT}
+        value={assertion.data.criteria.join('\n')}
+        onChange={(v) =>
+          onChange({
+            ...assertion,
+            data: {
+              criteria: ((v as string) ?? '')
+                .split('\n')
+                .map((s) => s.trim())
+                .filter(Boolean),
+            },
+          })
+        }
+        placeholder='One criterion per line'
+      />
+    )
+  }
+  if (assertion.type === 'tool_called' || assertion.type === 'tool_not_called') {
+    return (
+      <FieldInputAdapter
+        fieldType={FieldType.SINGLE_SELECT}
+        fieldOptions={{ options: toolOptions }}
+        value={assertion.data.toolName}
+        onChange={(v) =>
+          onChange({
+            ...assertion,
+            data: { ...assertion.data, toolName: (v as string[])[0] ?? '' },
+          })
+        }
+        placeholder='Pick a tool'
+      />
+    )
+  }
+  return null
+}

--- a/apps/web/src/components/evals/ui/eval-case-row.tsx
+++ b/apps/web/src/components/evals/ui/eval-case-row.tsx
@@ -1,0 +1,79 @@
+// apps/web/src/components/evals/ui/eval-case-row.tsx
+'use client'
+
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { formatRelativeTime } from '@auxx/utils'
+import { FlaskConical, Play, Trash2 } from 'lucide-react'
+import type { RouterOutputs } from '~/trpc/react'
+import { EvalStatusPill } from './eval-status-pill'
+
+/** One enriched case from `eval.list` (carries its latest-run summary). */
+export type EvalCaseListItem = RouterOutputs['eval']['list'][number]
+
+interface EvalCaseRowProps {
+  item: EvalCaseListItem
+  /** Human label for the case scope ("Whole agent" or the procedure name). */
+  scopeLabel: string
+  onOpen: () => void
+  onRun: () => void
+  onDelete: () => void
+  isRunning?: boolean
+  isDeleting?: boolean
+}
+
+/**
+ * A saved simulation case in the suite list. A leaf `TreeRow` (no chevron — the
+ * drill is the title click); secondary reads "<status> · <scope> · <last run>".
+ * Run / Delete hover-reveal in the actions slot. See plans/evals/ui-plan.md
+ * §"Level 1 — suite list".
+ */
+export function EvalCaseRow({
+  item,
+  scopeLabel,
+  onOpen,
+  onRun,
+  onDelete,
+  isRunning,
+  isDeleting,
+}: EvalCaseRowProps) {
+  const lastRun = item.latestRun
+  return (
+    <TreeRow
+      icon={<FlaskConical className='size-4 text-muted-foreground' />}
+      title={item.name}
+      onTitleClick={onOpen}
+      secondary={
+        <span className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+          <EvalStatusPill status={lastRun?.status ?? null} />
+          <span aria-hidden>·</span>
+          <span className='truncate'>{scopeLabel}</span>
+          {lastRun ? (
+            <>
+              <span aria-hidden>·</span>
+              <span>{formatRelativeTime(lastRun.at, true)}</span>
+            </>
+          ) : null}
+        </span>
+      }
+      actions={
+        <>
+          <TreeRowButton
+            tooltipText='Run'
+            onClick={onRun}
+            disabled={isRunning}
+            aria-label='Run simulation'>
+            <Play />
+          </TreeRowButton>
+          <TreeRowButton
+            variant='destructive'
+            tooltipText='Delete'
+            onClick={onDelete}
+            disabled={isDeleting}
+            aria-label='Delete simulation'>
+            <Trash2 />
+          </TreeRowButton>
+        </>
+      }
+    />
+  )
+}

--- a/apps/web/src/components/evals/ui/eval-drill-bar.tsx
+++ b/apps/web/src/components/evals/ui/eval-drill-bar.tsx
@@ -1,0 +1,31 @@
+// apps/web/src/components/evals/ui/eval-drill-bar.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { useNavStack } from '@auxx/ui/components/nav-stack'
+import { ChevronLeft } from 'lucide-react'
+
+/**
+ * The back bar for a pushed Simulations panel (case editor / run detail),
+ * mirroring `ProcedureDetailBar`: a back chevron that pops the NavStack plus a
+ * title/breadcrumb. Lives in the panel's own children (per-panel-bar layout),
+ * so it slides with the panel.
+ */
+interface EvalDrillBarProps {
+  title: React.ReactNode
+  /** Trailing slot — autosave indicator, footer actions, etc. */
+  actions?: React.ReactNode
+}
+
+export function EvalDrillBar({ title, actions }: EvalDrillBarProps) {
+  const { pop } = useNavStack()
+  return (
+    <div className='flex h-10 shrink-0 items-center gap-1 border-b bg-primary-150 px-2'>
+      <Button variant='ghost' size='icon-xs' onClick={pop} aria-label='Back'>
+        <ChevronLeft />
+      </Button>
+      <div className='min-w-0 flex-1 truncate text-sm font-medium'>{title}</div>
+      {actions ? <div className='flex shrink-0 items-center gap-1'>{actions}</div> : null}
+    </div>
+  )
+}

--- a/apps/web/src/components/evals/ui/eval-run-detail.tsx
+++ b/apps/web/src/components/evals/ui/eval-run-detail.tsx
@@ -1,0 +1,275 @@
+// apps/web/src/components/evals/ui/eval-run-detail.tsx
+'use client'
+
+import type { EvalRunStatus } from '@auxx/types/evals'
+import { Alert, AlertDescription } from '@auxx/ui/components/alert'
+import { Button } from '@auxx/ui/components/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { EmptySection } from '@auxx/ui/components/section'
+import { Spinner } from '@auxx/ui/components/spinner'
+import { cn } from '@auxx/ui/lib/utils'
+import { formatRelativeTime } from '@auxx/utils'
+import { CircleDot, FileJson, History, ListChecks } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { api } from '~/trpc/react'
+import { useEvalRunActions, useEvalRunState } from '../stores/use-eval-run-store'
+import { EvalAssertionResultRow } from './eval-assertion-result-row'
+import { EvalStatusDot, EvalStatusPill } from './eval-status-pill'
+import { EvalTraceView } from './eval-trace-view'
+
+/**
+ * Level 3 of the Simulations drill: one run's verdict, trace, and snapshot.
+ * Status + trace + assertions come live from the run store (SSE), seeded and
+ * back-stopped by `eval.getRun`; the immutable runtime snapshot drives the
+ * audit "what ran" tab. See plans/evals/ui-plan.md §"Level 3".
+ */
+
+const TERMINAL: ReadonlySet<EvalRunStatus> = new Set<EvalRunStatus>([
+  'passed',
+  'failed',
+  'error',
+  'cancelled',
+  'timed_out',
+])
+
+type AlertVariant = 'good' | 'destructive' | 'warning' | 'blue' | 'default'
+
+const BANNER: Record<EvalRunStatus, { variant: AlertVariant; sentence: string }> = {
+  queued: { variant: 'default', sentence: 'Queued — waiting for a worker.' },
+  running: { variant: 'blue', sentence: 'Running — streaming the conversation.' },
+  passed: { variant: 'good', sentence: 'Passed — every assertion was met.' },
+  failed: { variant: 'destructive', sentence: 'Failed — one or more assertions did not pass.' },
+  error: {
+    variant: 'warning',
+    sentence: 'Error — execution or grading could not complete.',
+  },
+  cancelled: { variant: 'default', sentence: 'Cancelled.' },
+  timed_out: { variant: 'warning', sentence: 'Timed out before reaching a verdict.' },
+}
+
+type Tab = 'verdict' | 'trace' | 'snapshot'
+
+interface EvalRunDetailProps {
+  runId: string
+  /** Switches the detail to another run from the same case's history. */
+  onSelectRun?: (runId: string) => void
+}
+
+export function EvalRunDetail({ runId, onSelectRun }: EvalRunDetailProps) {
+  const [tab, setTab] = useState<Tab>('verdict')
+  const runQuery = api.eval.getRun.useQuery({ runId })
+  const live = useEvalRunState(runId)
+  const { connect, hydrateFromRun } = useEvalRunActions()
+
+  const row = runQuery.data
+  const caseId = row?.caseId ?? null
+
+  // Seed the store from the authoritative row whenever it (re)loads.
+  useEffect(() => {
+    if (!row) return
+    hydrateFromRun(runId, {
+      status: row.status,
+      trace: (row.trace ?? []) as never,
+      assertionResults: (row.assertionResults ?? []) as never,
+    })
+  }, [row, runId, hydrateFromRun])
+
+  // Stream while the run is non-terminal.
+  useEffect(() => {
+    if (row && !TERMINAL.has(row.status)) connect(runId)
+  }, [row, runId, connect])
+
+  // SSE dropped mid-run → fall back to the durable row (does not change status itself).
+  useEffect(() => {
+    if (live.connectionStatus === 'error') void runQuery.refetch()
+  }, [live.connectionStatus, runQuery])
+
+  if (runQuery.isLoading) {
+    return (
+      <div className='flex h-40 items-center justify-center'>
+        <Spinner className='size-5 text-muted-foreground' />
+      </div>
+    )
+  }
+  if (!row) {
+    return (
+      <EmptySection
+        icon={<CircleDot className='size-4' />}
+        title='Run not found'
+        description='This run may have been removed.'
+      />
+    )
+  }
+
+  const status = live.status ?? row.status
+  const isLive = !TERMINAL.has(status)
+  const banner = BANNER[status]
+  const assertions = live.assertionResults.length ? live.assertionResults : []
+
+  return (
+    <div className='space-y-3 p-3'>
+      {/* Verdict banner + run-history switcher */}
+      <Alert variant={banner.variant} className='flex items-start justify-between gap-2'>
+        <AlertDescription className='flex items-center gap-2'>
+          <EvalStatusPill status={status} />
+          <span>{row.error ? `${banner.sentence} ${row.error}` : banner.sentence}</span>
+        </AlertDescription>
+        {caseId ? (
+          <RunHistoryPopover caseId={caseId} activeRunId={runId} onSelectRun={onSelectRun} />
+        ) : null}
+      </Alert>
+
+      <RadioTab
+        value={tab}
+        onValueChange={(v) => setTab(v as Tab)}
+        size='sm'
+        radioGroupClassName='grid w-full grid-cols-3'
+        className='h-8 w-full'>
+        <RadioTabItem value='verdict' size='sm' className='gap-1'>
+          <ListChecks className='size-3.5!' />
+          Verdict
+        </RadioTabItem>
+        <RadioTabItem value='trace' size='sm' className='gap-1'>
+          <History className='size-3.5!' />
+          Trace
+        </RadioTabItem>
+        <RadioTabItem value='snapshot' size='sm' className='gap-1'>
+          <FileJson className='size-3.5!' />
+          Snapshot
+        </RadioTabItem>
+      </RadioTab>
+
+      {tab === 'verdict' ? (
+        assertions.length ? (
+          <div className='space-y-0.5'>
+            {assertions.map((r) => (
+              <EvalAssertionResultRow key={r.assertionId} result={r} />
+            ))}
+          </div>
+        ) : (
+          <EmptySection
+            icon={<ListChecks className='size-4' />}
+            title={isLive ? 'Grading pending' : 'No assertion results'}
+            description={
+              isLive ? 'Assertions are graded once the conversation completes.' : undefined
+            }
+            loading={isLive}
+          />
+        )
+      ) : null}
+
+      {tab === 'trace' ? <EvalTraceView trace={live.trace} isLive={isLive} /> : null}
+
+      {tab === 'snapshot' ? <SnapshotTab runtimeSnapshot={row.runtimeSnapshot} /> : null}
+    </div>
+  )
+}
+
+// ── Snapshot tab ─────────────────────────────────────────────────────────────
+
+interface ProviderModel {
+  provider?: string
+  model?: string
+}
+interface RuntimeSnapshotView {
+  codeRevision?: string
+  scope?: string
+  agent?: { model?: ProviderModel; utilityModel?: ProviderModel }
+  personaModel?: ProviderModel
+  graderModel?: ProviderModel
+  mockPolicy?: string
+  limits?: { maxCustomerTurns?: number; maxReinvokes?: number; maxIterations?: number }
+  time?: { frozenAt?: string | null }
+}
+
+function modelLabel(m?: ProviderModel): string {
+  if (!m?.model) return '—'
+  return m.provider ? `${m.provider} · ${m.model}` : m.model
+}
+
+function SnapshotTab({ runtimeSnapshot }: { runtimeSnapshot: Record<string, unknown> }) {
+  const s = runtimeSnapshot as RuntimeSnapshotView
+  const rows: { label: string; value: string }[] = [
+    { label: 'Code revision', value: s.codeRevision ?? '—' },
+    { label: 'Scope', value: s.scope ?? '—' },
+    { label: 'Agent model', value: modelLabel(s.agent?.model) },
+    { label: 'Utility model', value: modelLabel(s.agent?.utilityModel) },
+    { label: 'Customer (persona)', value: modelLabel(s.personaModel) },
+    { label: 'Grader', value: modelLabel(s.graderModel) },
+    {
+      label: 'Execution',
+      value: s.mockPolicy === 'passthrough_readonly' ? 'Passthrough read-only' : 'Offline (mocked)',
+    },
+    { label: 'Max customer turns', value: String(s.limits?.maxCustomerTurns ?? '—') },
+    { label: 'Frozen time', value: s.time?.frozenAt ?? 'Live clock' },
+  ]
+  return (
+    <dl className='divide-y rounded-lg border text-xs'>
+      {rows.map((r) => (
+        <div key={r.label} className='flex items-center justify-between gap-3 px-3 py-1.5'>
+          <dt className='text-muted-foreground'>{r.label}</dt>
+          <dd className='truncate font-mono'>{r.value}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}
+
+// ── Run-history popover ──────────────────────────────────────────────────────
+
+interface RunHistoryPopoverProps {
+  caseId: string
+  activeRunId: string
+  onSelectRun?: (runId: string) => void
+}
+
+function RunHistoryPopover({ caseId, activeRunId, onSelectRun }: RunHistoryPopoverProps) {
+  const [open, setOpen] = useState(false)
+  const runsQuery = api.eval.listRuns.useQuery({ caseId }, { enabled: open })
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant='ghost' size='xs'>
+          <History />
+          Runs
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align='end' className='max-h-[400px] w-72 overflow-y-auto p-2'>
+        <div className='mb-1 px-1 text-xs font-medium'>Run history</div>
+        {runsQuery.isLoading ? (
+          <div className='flex justify-center py-4'>
+            <Spinner className='size-4 text-muted-foreground' />
+          </div>
+        ) : runsQuery.data?.runs.length ? (
+          <ScrollArea className='max-h-[340px]'>
+            {runsQuery.data.runs.map((run) => (
+              <button
+                type='button'
+                key={run.id}
+                onClick={() => {
+                  onSelectRun?.(run.id)
+                  setOpen(false)
+                }}
+                className={cn(
+                  'mb-1 flex w-full items-center gap-2 rounded-lg border-[0.5px] border-border bg-secondary/30 px-2.5 py-1.5 text-left shadow-xs transition-all last-of-type:mb-0',
+                  'hover:bg-secondary/50 hover:ring-1 hover:ring-blue-500',
+                  run.id === activeRunId && 'bg-secondary/50 ring-1 ring-blue-500'
+                )}>
+                <EvalStatusDot status={run.status} />
+                <span className='flex-1 text-xs capitalize'>{run.status.replace(/_/g, ' ')}</span>
+                <span className='text-[10px] text-muted-foreground'>
+                  {formatRelativeTime(run.createdAt, true)}
+                </span>
+              </button>
+            ))}
+          </ScrollArea>
+        ) : (
+          <div className='px-1 py-2 text-xs text-muted-foreground'>No runs yet.</div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/evals/ui/eval-status-pill.tsx
+++ b/apps/web/src/components/evals/ui/eval-status-pill.tsx
@@ -1,0 +1,89 @@
+// apps/web/src/components/evals/ui/eval-status-pill.tsx
+'use client'
+
+import type { EvalRunStatus } from '@auxx/types/evals'
+import { cn } from '@auxx/ui/lib/utils'
+
+/**
+ * The single source of truth mapping an {@link EvalRunStatus} (plus the
+ * runs-never state) to a dot color + label. Both eval surfaces — agent
+ * Simulations and workflow Tests — import this so the palette stays in lockstep.
+ *
+ * `failed` (an assertion failed) and `error` (execution/grading could not
+ * complete) are deliberately distinct hues; the run-detail copy leans on that
+ * distinction. See plans/evals/ui-plan.md §"Status color mapping".
+ */
+
+/** `null` is the "never run" state — a hollow dot, no run yet. */
+export type EvalPillStatus = EvalRunStatus | null
+
+interface StatusVisual {
+  label: string
+  /** Tailwind classes for the leading status dot. */
+  dot: string
+  /** Tailwind text color for the label. */
+  text: string
+}
+
+const STATUS_VISUALS: Record<EvalRunStatus, StatusVisual> = {
+  queued: { label: 'Queued', dot: 'bg-slate-400', text: 'text-muted-foreground' },
+  running: { label: 'Running', dot: 'bg-blue-500 animate-pulse', text: 'text-blue-600' },
+  passed: { label: 'Passed', dot: 'bg-green-500', text: 'text-green-600' },
+  failed: { label: 'Failed', dot: 'bg-red-500', text: 'text-red-600' },
+  error: { label: 'Error', dot: 'bg-amber-500', text: 'text-amber-600' },
+  cancelled: { label: 'Cancelled', dot: 'bg-slate-400', text: 'text-muted-foreground' },
+  timed_out: { label: 'Timed out', dot: 'bg-orange-500', text: 'text-orange-600' },
+}
+
+const NEVER_RUN: StatusVisual = {
+  label: 'Not run',
+  dot: 'border border-muted-foreground/40 bg-transparent',
+  text: 'text-muted-foreground',
+}
+
+/** Resolve the visual for a status (or the never-run state). Exported for callers needing raw colors. */
+export function evalStatusVisual(status: EvalPillStatus): StatusVisual {
+  return status == null ? NEVER_RUN : STATUS_VISUALS[status]
+}
+
+interface EvalStatusDotProps {
+  status: EvalPillStatus
+  className?: string
+}
+
+/** Just the colored dot — for tight rows where the label lives elsewhere. */
+export function EvalStatusDot({ status, className }: EvalStatusDotProps) {
+  return (
+    <span
+      className={cn(
+        'inline-block size-2 shrink-0 rounded-full',
+        evalStatusVisual(status).dot,
+        className
+      )}
+      aria-hidden
+    />
+  )
+}
+
+interface EvalStatusPillProps {
+  status: EvalPillStatus
+  /** Override the default label (e.g. a suite "Running… 40%"). */
+  label?: string
+  className?: string
+}
+
+/** Dot + colored label. The canonical run-status chip across both eval surfaces. */
+export function EvalStatusPill({ status, label, className }: EvalStatusPillProps) {
+  const visual = evalStatusVisual(status)
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 text-xs font-medium',
+        visual.text,
+        className
+      )}>
+      <EvalStatusDot status={status} />
+      {label ?? visual.label}
+    </span>
+  )
+}

--- a/apps/web/src/components/evals/ui/eval-suite-panel.tsx
+++ b/apps/web/src/components/evals/ui/eval-suite-panel.tsx
@@ -1,0 +1,193 @@
+// apps/web/src/components/evals/ui/eval-suite-panel.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { EmptySection, Section } from '@auxx/ui/components/section'
+import { toastError } from '@auxx/ui/components/toast'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { FlaskConical, Play, Plus } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { useConfirm } from '~/hooks/use-confirm'
+import { api } from '~/trpc/react'
+import { EvalCaseRow } from './eval-case-row'
+
+/**
+ * Level 1 of the Simulations drill: the saved-case list for an agent, scoped by
+ * the shared `?procedure` param. At the agent root, agent-scoped cases list
+ * first, then procedure-scoped cases roll up under collapsible per-procedure
+ * groups. Run / Run all / New live in the `Section` header. The `Section` owns
+ * its own padding — it is rendered directly, never wrapped. See
+ * plans/evals/ui-plan.md §"Level 1 — suite list".
+ */
+
+interface EvalSuitePanelProps {
+  agentId: string
+  procedureId: string | null
+  onOpenCase: (caseId: string) => void
+  onNewCase: () => void
+  onOpenRun: (runId: string) => void
+}
+
+export function EvalSuitePanel({
+  agentId,
+  procedureId,
+  onOpenCase,
+  onNewCase,
+  onOpenRun,
+}: EvalSuitePanelProps) {
+  const utils = api.useUtils()
+  const [confirm, ConfirmDialog] = useConfirm()
+  const [openGroups, setOpenGroups] = useState<Set<string>>(new Set())
+
+  const casesQuery = api.eval.list.useQuery({
+    agentId,
+    procedureId: procedureId ?? undefined,
+  })
+  const proceduresQuery = api.agentProcedure.list.useQuery({ agentId })
+  const procedureNames = useMemo(
+    () => new Map((proceduresQuery.data ?? []).map((p) => [p.procedureId, p.name])),
+    [proceduresQuery.data]
+  )
+
+  const invalidate = () => utils.eval.list.invalidate({ agentId })
+
+  const runCase = api.eval.run.useMutation({
+    onSuccess: ({ runId }) => {
+      void invalidate()
+      onOpenRun(runId)
+    },
+    onError: (err) => toastError({ title: 'Failed to run simulation', description: err.message }),
+  })
+
+  const deleteCase = api.eval.delete.useMutation({
+    onSuccess: invalidate,
+    onError: (err) =>
+      toastError({ title: 'Failed to delete simulation', description: err.message }),
+  })
+
+  const runAll = api.eval.runAll.useMutation({
+    onSuccess: () => void invalidate(),
+    onError: (err) => toastError({ title: 'Failed to run all', description: err.message }),
+  })
+
+  const cases = casesQuery.data ?? []
+  const agentScoped = cases.filter((c) => c.scope === 'agent')
+  const procedureScoped = cases.filter((c) => c.scope === 'procedure')
+
+  // Group procedure-scoped cases by procedure (agent-root view only).
+  const groups = useMemo(() => {
+    const map = new Map<string, typeof procedureScoped>()
+    for (const c of procedureScoped) {
+      const key = c.procedureId ?? 'unknown'
+      const list = map.get(key) ?? []
+      list.push(c)
+      map.set(key, list)
+    }
+    return [...map.entries()]
+  }, [procedureScoped])
+
+  const handleDelete = async (id: string, name: string) => {
+    const confirmed = await confirm({
+      title: 'Delete simulation?',
+      description: `"${name}" and its run history will be removed. This cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) deleteCase.mutate({ id })
+  }
+
+  const scopeLabel = (c: (typeof cases)[number]) =>
+    c.scope === 'agent' ? 'Whole agent' : (procedureNames.get(c.procedureId ?? '') ?? 'Procedure')
+
+  const renderRow = (c: (typeof cases)[number]) => (
+    <EvalCaseRow
+      key={c.id}
+      item={c}
+      scopeLabel={scopeLabel(c)}
+      onOpen={() => onOpenCase(c.id)}
+      onRun={() => runCase.mutate({ id: c.id })}
+      onDelete={() => handleDelete(c.id, c.name)}
+      isRunning={runCase.isPending && runCase.variables?.id === c.id}
+      isDeleting={deleteCase.isPending && deleteCase.variables?.id === c.id}
+    />
+  )
+
+  const isEmpty = cases.length === 0
+  const isLoading = casesQuery.isLoading
+
+  return (
+    <>
+      <ConfirmDialog />
+      <Section
+        title='Simulations'
+        icon={<FlaskConical className='size-4' />}
+        collapsible={false}
+        actions={
+          <div className='flex items-center gap-1.5'>
+            {runAll.isPending ? (
+              <Badge variant='secondary' className='gap-1'>
+                <Play className='size-3 animate-pulse' />
+                Running…
+              </Badge>
+            ) : null}
+            <Button
+              variant='ghost'
+              size='xs'
+              disabled={isEmpty || runAll.isPending}
+              loading={runAll.isPending}
+              onClick={() => runAll.mutate({ agentId, procedureId: procedureId ?? undefined })}>
+              <Play />
+              Run all
+            </Button>
+            <Button variant='ghost' size='xs' onClick={onNewCase}>
+              <Plus />
+              New simulation
+            </Button>
+          </div>
+        }>
+        {isLoading || isEmpty ? (
+          <EmptySection
+            icon={<FlaskConical className='size-4' />}
+            title='No simulations yet'
+            description='Add one to test how this agent handles a conversation.'
+            loading={isLoading}
+          />
+        ) : (
+          <div className='space-y-0.5'>
+            {agentScoped.map(renderRow)}
+
+            {/* Procedure groups only at the agent root (a procedure view is already scoped). */}
+            {!procedureId &&
+              groups.map(([pid, list]) => {
+                const open = openGroups.has(pid)
+                return (
+                  <TreeRow
+                    key={pid}
+                    icon={<FlaskConical className='size-4 text-muted-foreground/60' />}
+                    title={procedureNames.get(pid) ?? 'Procedure'}
+                    secondary={<span className='text-xs text-muted-foreground'>{list.length}</span>}
+                    expandable
+                    isOpen={open}
+                    onToggleOpen={() =>
+                      setOpenGroups((s) => {
+                        const next = new Set(s)
+                        if (next.has(pid)) next.delete(pid)
+                        else next.add(pid)
+                        return next
+                      })
+                    }>
+                    {list.map(renderRow)}
+                  </TreeRow>
+                )
+              })}
+
+            {/* In a procedure-scoped view, procedure cases render flat. */}
+            {procedureId ? procedureScoped.map(renderRow) : null}
+          </div>
+        )}
+      </Section>
+    </>
+  )
+}

--- a/apps/web/src/components/evals/ui/eval-tool-responses.tsx
+++ b/apps/web/src/components/evals/ui/eval-tool-responses.tsx
@@ -1,0 +1,228 @@
+// apps/web/src/components/evals/ui/eval-tool-responses.tsx
+'use client'
+
+import type { SimulationToolMock } from '@auxx/types/evals'
+import { Alert, AlertDescription } from '@auxx/ui/components/alert'
+import { Button } from '@auxx/ui/components/button'
+import { EmptySection, Section } from '@auxx/ui/components/section'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { generateId } from '@auxx/utils'
+import { Sparkles, Trash2, Wand2, Wrench } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { AppIcon } from '~/components/apps/ui/app-icon'
+import { CodeEditor, CodeLanguage } from '~/components/workflow/ui/code-editor'
+import type { RouterOutputs } from '~/trpc/react'
+import { api } from '~/trpc/react'
+import { type ToolIcon, useToolIconMap } from '../hooks/use-tool-icon-map'
+
+/** A tool's catalog icon, falling back to a generic wrench when unknown. */
+function ToolIconView({ icon }: { icon?: ToolIcon }) {
+  if (!icon?.iconId) return <Wrench className='size-4 text-muted-foreground' />
+  return <AppIcon iconId={icon.iconId} color={icon.color || undefined} size='sm' />
+}
+
+/**
+ * The load-bearing case-editor section: per-tool mock responses over the agent's
+ * EFFECTIVE toolset. Each tool seeds from its declared `exampleOutput`, falls
+ * back to a schema scaffold, and validates against `outputSchema` on edit. One
+ * `repeat` response per tool in v1 (arg-matched multi-response is a follow-up).
+ *
+ * See plans/evals/ui-plan.md §"Tool responses".
+ */
+
+type ToolEntry = RouterOutputs['eval']['agentToolset']['tools'][number]
+
+interface EvalToolResponsesProps {
+  agentId: string
+  mocks: SimulationToolMock[]
+  onChange: (mocks: SimulationToolMock[]) => void
+}
+
+export function EvalToolResponses({ agentId, mocks, onChange }: EvalToolResponsesProps) {
+  const [openTool, setOpenTool] = useState<string | null>(null)
+  const toolsetQuery = api.eval.agentToolset.useQuery({ agentId })
+  const iconMap = useToolIconMap()
+
+  const upsert = (toolName: string, output: unknown) => {
+    const existing = mocks.find((m) => m.toolName === toolName)
+    if (existing) {
+      onChange(mocks.map((m) => (m.toolName === toolName ? { ...m, output } : m)))
+    } else {
+      onChange([...mocks, { id: generateId('mock'), toolName, output, usage: 'repeat' }])
+    }
+  }
+  const remove = (toolName: string) => onChange(mocks.filter((m) => m.toolName !== toolName))
+
+  const tools = toolsetQuery.data?.tools ?? []
+
+  return (
+    <Section title='Tool responses' icon={<Wrench className='size-4' />}>
+      {toolsetQuery.isLoading || tools.length === 0 ? (
+        <EmptySection
+          icon={<Wrench className='size-4' />}
+          title={toolsetQuery.isLoading ? 'Loading tools…' : 'No tools to mock'}
+          description={toolsetQuery.isLoading ? undefined : 'This agent has no tools.'}
+          loading={toolsetQuery.isLoading}
+        />
+      ) : (
+        <div className='space-y-0.5'>
+          {tools.map((tool) => (
+            <ToolResponseRow
+              key={tool.name}
+              agentId={agentId}
+              tool={tool}
+              icon={iconMap.get(tool.name)}
+              mock={mocks.find((m) => m.toolName === tool.name) ?? null}
+              isOpen={openTool === tool.name}
+              onToggle={() => setOpenTool((t) => (t === tool.name ? null : tool.name))}
+              onUpsert={(output) => upsert(tool.name, output)}
+              onRemove={() => remove(tool.name)}
+            />
+          ))}
+        </div>
+      )}
+    </Section>
+  )
+}
+
+// ── Per-tool row ─────────────────────────────────────────────────────────────
+
+interface ToolResponseRowProps {
+  agentId: string
+  tool: ToolEntry
+  icon?: ToolIcon
+  mock: SimulationToolMock | null
+  isOpen: boolean
+  onToggle: () => void
+  onUpsert: (output: unknown) => void
+  onRemove: () => void
+}
+
+function ToolResponseRow({
+  agentId,
+  tool,
+  icon,
+  mock,
+  isOpen,
+  onToggle,
+  onUpsert,
+  onRemove,
+}: ToolResponseRowProps) {
+  const utils = api.useUtils()
+  const [draft, setDraft] = useState(() => (mock ? JSON.stringify(mock.output, null, 2) : ''))
+  const [parseError, setParseError] = useState<string | null>(null)
+  const [validation, setValidation] = useState<{ error?: string; warning?: string } | null>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const seedExample = tool.example !== undefined
+  const seedScaffold = !seedExample && tool.scaffold !== undefined && tool.scaffold !== null
+
+  const applyDraft = (text: string) => {
+    setDraft(text)
+    if (text.trim() === '') {
+      setParseError(null)
+      return
+    }
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      setParseError('Invalid JSON')
+      return
+    }
+    setParseError(null)
+    onUpsert(parsed)
+
+    // Debounced schema validation against the tool's declared outputSchema.
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      void utils.eval.validateMock
+        .fetch({ agentId, toolName: tool.name, output: parsed })
+        .then((res) => setValidation(res.ok ? { warning: res.warning } : { error: res.error }))
+        .catch(() => setValidation(null))
+    }, 500)
+  }
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [])
+
+  const seed = (value: unknown) => {
+    const text = JSON.stringify(value, null, 2)
+    applyDraft(text)
+  }
+
+  return (
+    <TreeRow
+      icon={<ToolIconView icon={icon} />}
+      title={tool.displayName}
+      secondary={
+        <span className='flex items-center gap-1.5 text-xs'>
+          <span className={cn(mock ? 'text-green-600' : 'text-muted-foreground')}>
+            {mock ? 'mocked' : 'no response'}
+          </span>
+          {mock && tool.example !== undefined ? (
+            <span className='text-muted-foreground/70'>(example)</span>
+          ) : null}
+          {tool.idempotent ? <span className='text-muted-foreground/70'>· read-only</span> : null}
+        </span>
+      }
+      expandable
+      isOpen={isOpen}
+      onToggleOpen={onToggle}
+      actions={
+        mock ? (
+          <TreeRowButton variant='destructive' tooltipText='Clear response' onClick={onRemove}>
+            <Trash2 />
+          </TreeRowButton>
+        ) : undefined
+      }>
+      <div className='space-y-2 px-2 py-1.5'>
+        {!mock && draft.trim() === '' ? (
+          <div className='flex flex-wrap items-center gap-2'>
+            {seedExample ? (
+              <Button variant='outline' size='xs' onClick={() => seed(tool.example)}>
+                <Sparkles />
+                From example
+              </Button>
+            ) : null}
+            {seedScaffold ? (
+              <Button variant='outline' size='xs' onClick={() => seed(tool.scaffold)}>
+                <Wand2 />
+                Scaffold
+              </Button>
+            ) : null}
+            <Button variant='ghost' size='xs' onClick={() => applyDraft('{}')}>
+              Start blank
+            </Button>
+          </div>
+        ) : null}
+
+        {draft.trim() !== '' || mock ? (
+          <CodeEditor
+            language={CodeLanguage.json}
+            value={draft}
+            onChange={applyDraft}
+            minHeight={120}
+            placeholder='{}'
+          />
+        ) : null}
+
+        {parseError ? (
+          <Alert variant='bad'>
+            <AlertDescription>{parseError}</AlertDescription>
+          </Alert>
+        ) : validation?.error ? (
+          <Alert variant='bad'>
+            <AlertDescription>{validation.error}</AlertDescription>
+          </Alert>
+        ) : validation?.warning ? (
+          <p className='text-xs text-muted-foreground'>{validation.warning}</p>
+        ) : null}
+      </div>
+    </TreeRow>
+  )
+}

--- a/apps/web/src/components/evals/ui/eval-trace-event-card.tsx
+++ b/apps/web/src/components/evals/ui/eval-trace-event-card.tsx
@@ -1,0 +1,183 @@
+// apps/web/src/components/evals/ui/eval-trace-event-card.tsx
+'use client'
+
+import type { EvalTraceEvent } from '@auxx/types/evals'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { useCopy } from '@auxx/ui/hooks/use-copy'
+import { cn } from '@auxx/ui/lib/utils'
+import {
+  AlertTriangle,
+  Check,
+  ChevronRight,
+  Copy,
+  Flag,
+  MessageSquare,
+  User,
+  Wrench,
+} from 'lucide-react'
+import { useState } from 'react'
+
+/**
+ * One chronological event in an agent simulation trace. Reuses the
+ * `NodeExecutionCard` visual language (status-hued border, expandable, payload
+ * block) but with agent event kinds — customer turn, agent reply, tool call
+ * (mock badge), system warning/error, terminal. Unknown event types fall back
+ * to a generic JSON card so a new emit never renders blank.
+ *
+ * See plans/evals/ui-plan.md §"Level 3 — run detail + trace".
+ */
+
+type Tone = 'neutral' | 'agent' | 'tool' | 'good' | 'warn' | 'error'
+
+const TONE_BORDER: Record<Tone, string> = {
+  neutral: 'border-border',
+  agent: 'border-blue-500/40',
+  tool: 'border-violet-500/40',
+  good: 'border-good-400/50',
+  warn: 'border-amber-500/40 bg-amber-500/5',
+  error: 'border-destructive/30 bg-destructive/5',
+}
+
+interface Presentation {
+  icon: React.ReactNode
+  title: string
+  tone: Tone
+  /** Inline one-liner shown collapsed; the full payload expands below. */
+  summary?: string
+  badge?: { label: string; className?: string }
+}
+
+function present(event: EvalTraceEvent): Presentation {
+  const data = event.data as Record<string, unknown>
+  const text = typeof data.text === 'string' ? data.text : undefined
+  const message = typeof data.message === 'string' ? data.message : undefined
+
+  switch (event.type) {
+    case 'customer_message':
+      return {
+        icon: <User className='size-3.5' />,
+        title: 'Customer',
+        tone: 'neutral',
+        summary: text,
+      }
+    case 'agent_message':
+      return {
+        icon: <MessageSquare className='size-3.5' />,
+        title: 'Agent',
+        tone: 'agent',
+        summary: text,
+      }
+    case 'tool_call': {
+      const resolution = typeof data.resolution === 'string' ? data.resolution : 'mock'
+      const captured = data.captured === true
+      return {
+        icon: <Wrench className='size-3.5' />,
+        title: typeof data.toolName === 'string' ? data.toolName : 'Tool call',
+        tone: 'tool',
+        summary: typeof data.outputSummary === 'string' ? data.outputSummary : undefined,
+        badge: {
+          label: captured ? 'captured' : resolution === 'passthrough' ? 'live' : 'mock',
+          className:
+            resolution === 'passthrough'
+              ? 'border-amber-500/40 text-amber-600'
+              : 'text-muted-foreground',
+        },
+      }
+    }
+    case 'terminal': {
+      const outcome = typeof data.terminalOutcome === 'string' ? data.terminalOutcome : 'none'
+      const capExceeded = data.capExceeded === true
+      return {
+        icon: <Flag className='size-3.5' />,
+        title: 'Terminal',
+        tone: capExceeded ? 'warn' : 'good',
+        summary: capExceeded ? 'Customer-turn cap reached' : `Outcome: ${outcome}`,
+      }
+    }
+    case 'execution_error':
+      return {
+        icon: <AlertTriangle className='size-3.5' />,
+        title: 'Execution error',
+        tone: 'error',
+        summary: message,
+      }
+    case 'config_invalid':
+    case 'snapshot_incompatible':
+    case 'code_revision_drift':
+      return {
+        icon: <AlertTriangle className='size-3.5' />,
+        title: event.type.replace(/_/g, ' '),
+        tone: 'warn',
+        summary: message,
+      }
+    default:
+      return { icon: <ChevronRight className='size-3.5' />, title: event.type, tone: 'neutral' }
+  }
+}
+
+interface EvalTraceEventCardProps {
+  event: EvalTraceEvent
+}
+
+export function EvalTraceEventCard({ event }: EvalTraceEventCardProps) {
+  const [open, setOpen] = useState(false)
+  const copy = useCopy({ toastMessage: 'Event data copied' })
+  const p = present(event)
+  const payload = JSON.stringify(event.data, null, 2)
+  const hasPayload = Object.keys(event.data).length > 0
+
+  return (
+    <div className={cn('relative rounded-lg border bg-card', TONE_BORDER[p.tone])}>
+      <button
+        type='button'
+        onClick={() => hasPayload && setOpen((v) => !v)}
+        className={cn(
+          'flex w-full items-center gap-2 px-2.5 py-1.5 text-left',
+          hasPayload && 'cursor-pointer'
+        )}>
+        {hasPayload ? (
+          <ChevronRight
+            className={cn(
+              'size-3 shrink-0 text-muted-foreground transition-transform',
+              open && 'rotate-90'
+            )}
+          />
+        ) : (
+          <span className='w-3 shrink-0' />
+        )}
+        <span className='text-muted-foreground'>{p.icon}</span>
+        <span className='shrink-0 text-xs font-medium capitalize'>{p.title}</span>
+        {p.badge ? (
+          <Badge variant='outline' className={cn('h-4 px-1 text-[10px]', p.badge.className)}>
+            {p.badge.label}
+          </Badge>
+        ) : null}
+        {p.summary ? (
+          <span className='min-w-0 flex-1 truncate text-xs text-muted-foreground'>{p.summary}</span>
+        ) : (
+          <span className='flex-1' />
+        )}
+        <span className='shrink-0 font-mono text-[10px] text-muted-foreground/60'>
+          #{event.sequence}
+        </span>
+      </button>
+
+      {open && hasPayload ? (
+        <div className='relative border-t px-2.5 py-2'>
+          <Button
+            variant='ghost'
+            size='icon-xs'
+            className='absolute right-1.5 top-1.5 text-muted-foreground'
+            onClick={() => copy.copy(payload)}
+            aria-label='Copy event data'>
+            {copy.copied ? <Check /> : <Copy />}
+          </Button>
+          <pre className='max-h-[280px] overflow-auto font-mono text-[11px] leading-relaxed'>
+            {payload}
+          </pre>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/components/evals/ui/eval-trace-view.tsx
+++ b/apps/web/src/components/evals/ui/eval-trace-view.tsx
@@ -1,0 +1,53 @@
+// apps/web/src/components/evals/ui/eval-trace-view.tsx
+'use client'
+
+import type { EvalTraceEvent } from '@auxx/types/evals'
+import { EmptySection } from '@auxx/ui/components/section'
+import { Activity } from 'lucide-react'
+import { EvalTraceEventCard } from './eval-trace-event-card'
+
+/**
+ * The chronological trace of an agent simulation run — a stacked list of
+ * {@link EvalTraceEventCard}s in sequence order. Live (via the run store) or
+ * replayed from the persisted row; the view itself is a pure render of whatever
+ * events it's handed.
+ */
+
+interface EvalTraceViewProps {
+  trace: EvalTraceEvent[]
+  /** True while the run is still streaming — shows a trailing pulse. */
+  isLive?: boolean
+}
+
+export function EvalTraceView({ trace, isLive }: EvalTraceViewProps) {
+  if (trace.length === 0) {
+    return (
+      <EmptySection
+        icon={<Activity className='size-4' />}
+        title={isLive ? 'Waiting for events…' : 'No trace'}
+        description={
+          isLive
+            ? 'The run is starting up. Events will appear here as they happen.'
+            : 'This run recorded no trace events.'
+        }
+        loading={isLive}
+      />
+    )
+  }
+
+  const ordered = [...trace].sort((a, b) => a.sequence - b.sequence)
+
+  return (
+    <div className='space-y-1.5'>
+      {ordered.map((event) => (
+        <EvalTraceEventCard key={event.id} event={event} />
+      ))}
+      {isLive ? (
+        <div className='flex items-center gap-2 px-2.5 py-1.5 text-xs text-muted-foreground'>
+          <span className='inline-block size-2 animate-pulse rounded-full bg-blue-500' />
+          Running…
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/components/evals/ui/simulations-tab.tsx
+++ b/apps/web/src/components/evals/ui/simulations-tab.tsx
@@ -1,0 +1,87 @@
+// apps/web/src/components/evals/ui/simulations-tab.tsx
+'use client'
+
+import { NavStack, NavStackPanel, NavStackPanels } from '@auxx/ui/components/nav-stack'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { useQueryState } from 'nuqs'
+import { useState } from 'react'
+import { api } from '~/trpc/react'
+import { EvalCaseDrawer } from './eval-case-drawer'
+import { EvalDrillBar } from './eval-drill-bar'
+import { EvalRunDetail } from './eval-run-detail'
+import { EvalSuitePanel } from './eval-suite-panel'
+
+/**
+ * The **Simulations** tab body: a NavStack drill that keeps the narrow agent
+ * drawer single-column (list → case editor → run detail). Procedure scope comes
+ * from the shared `?procedure` URL param the main detail panel already owns —
+ * selecting a procedure there scopes this list automatically. The `'new'`
+ * sentinel opens the editor in create mode.
+ *
+ * See plans/evals/ui-plan.md §"Agent Simulations (Phase 1B)".
+ */
+export function SimulationsTab({ agentId }: { agentId: string }) {
+  const [procedureId] = useQueryState('procedure')
+  const [caseId, setCaseId] = useState<string | null>(null)
+  const [runId, setRunId] = useState<string | null>(null)
+  const utils = api.useUtils()
+
+  // Stack shape: a run can be reached from a case (list→case→run) or straight
+  // from a list row (list→run). Derive purely from the two selections.
+  const stack = runId
+    ? caseId
+      ? ['list', 'case', 'run']
+      : ['list', 'run']
+    : caseId
+      ? ['list', 'case']
+      : ['list']
+
+  return (
+    <NavStack
+      stack={stack}
+      onStackChange={(next) => {
+        const top = next[next.length - 1]
+        if (top === 'list') {
+          setCaseId(null)
+          setRunId(null)
+        } else if (top === 'case') {
+          setRunId(null)
+        }
+      }}
+      className='flex h-full flex-col'>
+      <NavStackPanels className='min-h-0 flex-1'>
+        <NavStackPanel value='list' className='h-full'>
+          <ScrollArea className='h-full' scrollbarClassName='w-1.5'>
+            <EvalSuitePanel
+              agentId={agentId}
+              procedureId={procedureId}
+              onOpenCase={setCaseId}
+              onNewCase={() => setCaseId('new')}
+              onOpenRun={setRunId}
+            />
+          </ScrollArea>
+        </NavStackPanel>
+
+        <NavStackPanel value='case' className='flex h-full flex-col'>
+          {caseId ? (
+            <EvalCaseDrawer
+              key={caseId}
+              agentId={agentId}
+              caseId={caseId === 'new' ? null : caseId}
+              procedureId={procedureId}
+              onSaved={() => void utils.eval.list.invalidate({ agentId })}
+              onOpenRun={setRunId}
+            />
+          ) : null}
+        </NavStackPanel>
+
+        <NavStackPanel value='run' className='flex h-full flex-col'>
+          <EvalDrillBar title='Run detail' />
+          <ScrollArea className='min-h-0 flex-1' scrollbarClassName='w-1.5'>
+            {runId ? <EvalRunDetail runId={runId} onSelectRun={setRunId} /> : null}
+          </ScrollArea>
+        </NavStackPanel>
+      </NavStackPanels>
+    </NavStack>
+  )
+}

--- a/apps/web/src/server/api/routers/eval.ts
+++ b/apps/web/src/server/api/routers/eval.ts
@@ -11,11 +11,14 @@ import {
   getEvalCaseById,
   getEvalRun,
   getEvalSuiteRun,
+  getLatestRunsByCaseIds,
+  listAgentEffectiveTools,
   listEvalCasesByAgent,
   listEvalRuns,
   type PreparedRunSnapshots,
   prepareRunSnapshots,
   updateEvalCase,
+  validateAgentToolMock,
   validateEvalCase,
 } from '@auxx/lib/evals'
 import { enqueueEvalRun } from '@auxx/lib/evals/worker'
@@ -57,15 +60,42 @@ export const evalRouter = createTRPCRouter({
   list: protectedProcedure
     .input(z.object({ agentId: z.string().min(1), procedureId: z.string().min(1).optional() }))
     .query(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
       const cases = unwrap(
         await listEvalCasesByAgent({
-          organizationId: ctx.session.organizationId,
+          organizationId,
           agentId: input.agentId,
           procedureId: input.procedureId,
         }),
         'list eval cases'
       )
-      return cases
+
+      // One extra query attaches each case's most recent run (status pill + last-run time).
+      const latest = unwrap(
+        await getLatestRunsByCaseIds({ organizationId, caseIds: cases.map((c) => c.id) }),
+        'list latest eval runs'
+      )
+      const byCase = new Map(latest.map((r) => [r.caseId, r]))
+
+      return cases.map((row) => {
+        const target = agentEvalTargetSchema.parse(row.target)
+        const run = byCase.get(row.id)
+        return {
+          id: row.id,
+          name: row.name,
+          scope: target.scope,
+          procedureId: target.scope === 'procedure' ? target.procedureId : null,
+          createdAt: row.createdAt.toISOString(),
+          updatedAt: row.updatedAt.toISOString(),
+          latestRun: run
+            ? {
+                runId: run.runId,
+                status: run.status,
+                at: (run.completedAt ?? run.createdAt).toISOString(),
+              }
+            : null,
+        }
+      })
     }),
 
   getById: protectedProcedure
@@ -76,7 +106,7 @@ export const evalRouter = createTRPCRouter({
         'get eval case'
       )
       if (!found) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval case not found' })
-      return found
+      return parseCase(found)
     }),
 
   create: evalAdminProcedure
@@ -136,6 +166,36 @@ export const evalRouter = createTRPCRouter({
       )
       return { ok: true as const }
     }),
+
+  // ── Editor support (tool responses) ───────────────────────────────────────
+  agentToolset: protectedProcedure
+    .input(z.object({ agentId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const tools = await listAgentEffectiveTools({
+        organizationId: ctx.session.organizationId,
+        userId: ctx.session.userId,
+        agentId: input.agentId,
+      })
+      return { tools }
+    }),
+
+  validateMock: protectedProcedure
+    .input(
+      z.object({
+        agentId: z.string().min(1),
+        toolName: z.string().min(1),
+        output: z.unknown(),
+      })
+    )
+    .query(async ({ ctx, input }) =>
+      validateAgentToolMock({
+        organizationId: ctx.session.organizationId,
+        userId: ctx.session.userId,
+        agentId: input.agentId,
+        toolName: input.toolName,
+        output: input.output,
+      })
+    ),
 
   // ── Validation ──────────────────────────────────────────────────────────
   validate: protectedProcedure

--- a/packages/lib/src/evals/editor-support.ts
+++ b/packages/lib/src/evals/editor-support.ts
@@ -1,0 +1,89 @@
+// packages/lib/src/evals/editor-support.ts
+//
+// Read-only support for the Simulation case editor's tool-responses section. The
+// editor lists the agent's EFFECTIVE toolset (the same builder production and
+// `prepare-run` use) and, per tool, offers schema-driven mock authoring:
+// seed-from-example, scaffold-from-schema, and validate-on-save. `outputSchema`
+// is a `z.ZodType` (non-serializable), so scaffolding and validation must happen
+// server-side — the wire carries only JSON. See plans/evals/phase-1-agent-simulation.md
+// §1.6 and ui-plan.md §"Tool responses".
+
+import { buildEffectiveAgentRuntime } from '../ai/agent-framework/effective-runtime'
+import type { AgentToolDefinition } from '../ai/agent-framework/types'
+import { getCachedAgentById } from '../cache'
+import { scaffoldFromSchema, validateMockOutput } from './simulation/mock-tools'
+import { getToolExampleOutput } from './tool-examples'
+
+export interface EditorToolEntry {
+  name: string
+  displayName: string
+  description: string
+  /** Read-only tools may run for real under `passthrough_readonly`. */
+  idempotent: boolean
+  hasOutputSchema: boolean
+  /** Declared `exampleOutput`, if any — the preferred autofill seed. */
+  example?: unknown
+  /** Valid-shaped skeleton from `outputSchema`, used when there's no example. */
+  scaffold?: unknown
+}
+
+/** Resolve the agent's effective toolset via the shared production runtime builder. */
+async function resolveToolset(input: {
+  organizationId: string
+  userId: string
+  agentId: string
+}): Promise<AgentToolDefinition[]> {
+  const agent = await getCachedAgentById(input.organizationId, input.agentId)
+  const hasProcedures = (agent?.procedures ?? []).length > 0
+  const runtime = await buildEffectiveAgentRuntime({
+    organizationId: input.organizationId,
+    userId: input.userId,
+    sessionId: `eval-editor-${input.agentId}`,
+    agentId: input.agentId,
+    domain: 'kopilot',
+    hasProcedures,
+  })
+  return runtime.tools
+}
+
+/**
+ * The editor-facing projection of the agent's effective toolset: enough to list
+ * each tool, seed a mock (example → scaffold), and flag read-only tools. Schemas
+ * themselves never cross the wire; example/scaffold are precomputed here.
+ */
+export async function listAgentEffectiveTools(input: {
+  organizationId: string
+  userId: string
+  agentId: string
+}): Promise<EditorToolEntry[]> {
+  const tools = await resolveToolset(input)
+  return tools.map((t) => {
+    const example = getToolExampleOutput(t)
+    return {
+      name: t.name,
+      displayName: t.displayName,
+      description: t.description,
+      idempotent: t.idempotent ?? false,
+      hasOutputSchema: t.outputSchema != null,
+      example,
+      scaffold:
+        example === undefined && t.outputSchema ? scaffoldFromSchema(t.outputSchema) : undefined,
+    }
+  })
+}
+
+/** Validate one authored mock output against its tool's declared `outputSchema`. */
+export async function validateAgentToolMock(input: {
+  organizationId: string
+  userId: string
+  agentId: string
+  toolName: string
+  output: unknown
+}): Promise<{ ok: boolean; error?: string; warning?: string }> {
+  const tools = await resolveToolset(input)
+  const tool = tools.find((t) => t.name === input.toolName)
+  if (!tool) {
+    return { ok: false, error: `Tool "${input.toolName}" is not in the agent's toolset` }
+  }
+  return validateMockOutput(tool, input.output)
+}

--- a/packages/lib/src/evals/index.ts
+++ b/packages/lib/src/evals/index.ts
@@ -20,6 +20,11 @@ export {
 } from './agent-grader'
 export { type CompareOutcome, evaluateComparator, MISSING } from './comparators'
 export {
+  type EditorToolEntry,
+  listAgentEffectiveTools,
+  validateAgentToolMock,
+} from './editor-support'
+export {
   cancelEvalRun,
   checkpointEvalTrace,
   claimEvalRun,
@@ -45,6 +50,8 @@ export {
   getEvalCaseById,
   getEvalRun,
   getEvalSuiteRun,
+  getLatestRunsByCaseIds,
+  type LatestRunSummary,
   listEvalCasesByAgent,
   listEvalRuns,
   type UpdateEvalCaseInput,

--- a/packages/lib/src/evals/queries.ts
+++ b/packages/lib/src/evals/queries.ts
@@ -20,7 +20,7 @@ import {
   agentEvalTargetSchema,
   simulationConfigSchema,
 } from '@auxx/types/evals/schema'
-import { and, desc, eq, lt } from 'drizzle-orm'
+import { and, desc, eq, inArray, lt } from 'drizzle-orm'
 import { err, ok } from 'neverthrow'
 import { hashSnapshots } from './snapshots'
 import type { EvalServiceError } from './types'
@@ -320,6 +320,50 @@ export async function listEvalRuns(input: {
   )
   if (result.isErr()) return err(result.error)
   return ok(result.value as EvalRunEntity[])
+}
+
+/** A compact latest-run summary for the suite-list rows (status pill + last-run time). */
+export interface LatestRunSummary {
+  caseId: string
+  runId: string
+  status: EvalRunEntity['status']
+  createdAt: Date
+  completedAt: Date | null
+}
+
+/**
+ * The most recent run per case for a set of case ids, in ONE query
+ * (`DISTINCT ON (caseId) … ORDER BY caseId, createdAt DESC`). Powers the suite
+ * list's status pills without an N+1 over `listEvalRuns`. Cases with no runs are
+ * simply absent from the result.
+ */
+export async function getLatestRunsByCaseIds(input: { organizationId: string; caseIds: string[] }) {
+  if (input.caseIds.length === 0) return ok([] as LatestRunSummary[])
+
+  const result = await fromDatabase(
+    database
+      .selectDistinctOn([schema.EvalRun.caseId], {
+        caseId: schema.EvalRun.caseId,
+        runId: schema.EvalRun.id,
+        status: schema.EvalRun.status,
+        createdAt: schema.EvalRun.createdAt,
+        completedAt: schema.EvalRun.completedAt,
+      })
+      .from(schema.EvalRun)
+      .where(
+        and(
+          eq(schema.EvalRun.organizationId, input.organizationId),
+          inArray(schema.EvalRun.caseId, input.caseIds)
+        )
+      )
+      .orderBy(schema.EvalRun.caseId, desc(schema.EvalRun.createdAt)),
+    'latest-runs-by-case-ids'
+  )
+  if (result.isErr()) return err(result.error)
+  // `caseId` is nullable on the column type but never null here (we filter by ids).
+  return ok(
+    result.value.filter((r): r is LatestRunSummary => r.caseId != null) as LatestRunSummary[]
+  )
 }
 
 export async function getEvalRun(input: { organizationId: string; runId: string }) {


### PR DESCRIPTION
## Summary
- Adds a **Simulations** tab to the agent docked chat alongside Build and Chat: suite panel with case rows and status pills, case drawer for editing, run detail with assertion results, trace view, and a tool-responses editor for mocking tool outputs
- New `eval` router endpoints for the case editor: `agentToolset` (lists the agent's effective tools) and `validateMock` (validates a mocked tool output against the tool's schema), backed by a new `lib/evals/editor-support` module
- `eval.list` now attaches each case's latest run (status + timestamp) via a single `DISTINCT ON` query (`getLatestRunsByCaseIds`) instead of an N+1 over `listEvalRuns`
- `eval.getById` returns the parsed case shape (typed `target`) so the client doesn't re-parse

## Test plan
- [ ] Open an agent detail page → Simulations tab renders the suite list
- [ ] Create/edit a case in the drawer; tool mocks validate against the agent's toolset
- [ ] Run a case and verify the status pill, run detail, and trace view update