### PR TITLE
feat(evals): ai simulation suggester + draft-mode runs

### DIFF
--- a/apps/web/src/components/evals/stores/use-eval-suggestions-store.ts
+++ b/apps/web/src/components/evals/stores/use-eval-suggestions-store.ts
@@ -1,0 +1,98 @@
+// apps/web/src/components/evals/stores/use-eval-suggestions-store.ts
+'use client'
+
+import { create } from 'zustand'
+import { useShallow } from 'zustand/react/shallow'
+import type { RouterOutputs } from '~/trpc/react'
+
+/**
+ * Session cache for procedure-scoped simulation suggestions. `eval.suggest` spends
+ * tokens, so its result is held here keyed by `procedureId` instead of in the
+ * section's component state — which is lost whenever the list panel unmounts
+ * (drilling into a case, switching tabs) and would otherwise re-run the model on
+ * every re-expand. Survives remounts; resets on reload (the v1 "ephemeral, cached
+ * per draft revision" contract — see plans/evals/phase-3-suggester.md §3.4).
+ *
+ * Staleness after a draft edit is handled by the explicit **Refresh** action
+ * (`setResult` overwrites the entry); the result carries the `draftHash` it ran
+ * against. Selectors only (CLAUDE.md Zustand rule).
+ */
+
+type SuggestResult = RouterOutputs['eval']['suggest']
+
+export interface SuggestionsEntry {
+  result: SuggestResult
+  /** Session-only dismissals, kept here so they survive a section remount too. */
+  dismissed: Set<string>
+}
+
+interface EvalSuggestionsStore {
+  byProcedure: Record<string, SuggestionsEntry>
+  /**
+   * Procedures a generation has been kicked off for this session — so the
+   * default-open section auto-generates exactly once and a *failed* attempt
+   * doesn't re-fire on every remount (the user re-runs it with Refresh).
+   */
+  requested: Record<string, boolean>
+  /** Record that a generation was started for this procedure. */
+  markRequested: (procedureId: string) => void
+  /** Cache (or overwrite, on Refresh) a generation, preserving any dismissals. */
+  setResult: (procedureId: string, result: SuggestResult) => void
+  dismiss: (procedureId: string, suggestionId: string) => void
+}
+
+export const useEvalSuggestionsStore = create<EvalSuggestionsStore>((set) => ({
+  byProcedure: {},
+  requested: {},
+
+  markRequested: (procedureId) =>
+    set((s) => ({ requested: { ...s.requested, [procedureId]: true } })),
+
+  setResult: (procedureId, result) =>
+    set((s) => ({
+      byProcedure: {
+        ...s.byProcedure,
+        [procedureId]: { result, dismissed: s.byProcedure[procedureId]?.dismissed ?? new Set() },
+      },
+    })),
+
+  dismiss: (procedureId, suggestionId) =>
+    set((s) => {
+      const cur = s.byProcedure[procedureId]
+      if (!cur) return s
+      const dismissed = new Set(cur.dismissed)
+      dismissed.add(suggestionId)
+      return { byProcedure: { ...s.byProcedure, [procedureId]: { ...cur, dismissed } } }
+    }),
+}))
+
+const EMPTY_DISMISSED: ReadonlySet<string> = new Set()
+
+/** Selector: the cached generation, dismissals, and request flag for one procedure. */
+export function useSuggestionsEntry(procedureId: string): {
+  result: SuggestResult | null
+  dismissed: ReadonlySet<string>
+  requested: boolean
+} {
+  return useEvalSuggestionsStore(
+    useShallow((s) => {
+      const entry = s.byProcedure[procedureId]
+      return {
+        result: entry?.result ?? null,
+        dismissed: entry?.dismissed ?? EMPTY_DISMISSED,
+        requested: s.requested[procedureId] ?? false,
+      }
+    })
+  )
+}
+
+/** Selector: the store actions (shallow-compared so the object ref stays stable). */
+export function useEvalSuggestionsActions() {
+  return useEvalSuggestionsStore(
+    useShallow((s) => ({
+      setResult: s.setResult,
+      dismiss: s.dismiss,
+      markRequested: s.markRequested,
+    }))
+  )
+}

--- a/apps/web/src/components/evals/ui/eval-assertion-result-row.tsx
+++ b/apps/web/src/components/evals/ui/eval-assertion-result-row.tsx
@@ -55,15 +55,18 @@ function formatValue(value: unknown): string {
 
 interface EvalAssertionResultRowProps {
   result: AssertionResult
+  /** 0-based indent; also aligns the expanded detail under the row title. */
+  depth?: number
 }
 
-export function EvalAssertionResultRow({ result }: EvalAssertionResultRowProps) {
+export function EvalAssertionResultRow({ result, depth = 0 }: EvalAssertionResultRowProps) {
   const [open, setOpen] = useState(false)
   const expected = expectedSummary(result)
   const hasDetail = Boolean(result.note) || result.actual !== undefined
 
   return (
     <TreeRow
+      depth={depth}
       icon={<EvalStatusDot status={result.status} />}
       title={typeLabel(result.type)}
       secondary={
@@ -75,7 +78,9 @@ export function EvalAssertionResultRow({ result }: EvalAssertionResultRowProps) 
       expandable={hasDetail}
       isOpen={open}
       onToggleOpen={() => setOpen((v) => !v)}>
-      <div className='space-y-2 px-2 py-1.5 text-xs'>
+      <div
+        className='space-y-2 py-1.5 pe-2 text-xs'
+        style={{ paddingLeft: `${0.5 + (depth + 1) * 1.5}rem` }}>
         {result.actual !== undefined ? (
           <div>
             <span className='text-muted-foreground'>Actual: </span>

--- a/apps/web/src/components/evals/ui/eval-case-drawer.tsx
+++ b/apps/web/src/components/evals/ui/eval-case-drawer.tsx
@@ -268,7 +268,8 @@ function EvalCaseForm({
 
   const runNow = async () => {
     const id = await saveNow()
-    if (id) run.mutate({ id })
+    // The drawer is the editor surface — always run the current draft.
+    if (id) run.mutate({ id, useDraft: true })
   }
 
   return (

--- a/apps/web/src/components/evals/ui/eval-case-row.tsx
+++ b/apps/web/src/components/evals/ui/eval-case-row.tsx
@@ -3,60 +3,73 @@
 
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { formatRelativeTime } from '@auxx/utils'
-import { FlaskConical, Play, Trash2 } from 'lucide-react'
-import type { RouterOutputs } from '~/trpc/react'
-import { EvalStatusPill } from './eval-status-pill'
+import { ChevronRight, Cog, FlaskConical, Play, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { api, type RouterOutputs } from '~/trpc/react'
+import { EvalStatusDot, EvalStatusPill, evalStatusVisual } from './eval-status-pill'
 
 /** One enriched case from `eval.list` (carries its latest-run summary). */
 export type EvalCaseListItem = RouterOutputs['eval']['list'][number]
 
 interface EvalCaseRowProps {
   item: EvalCaseListItem
-  /** Human label for the case scope ("Whole agent" or the procedure name). */
-  scopeLabel: string
-  onOpen: () => void
+  /** 0-based indent — procedure-scoped cases sit one level under their group. */
+  depth?: number
+  /** Cog → opens the case editor drawer. */
+  onEdit: () => void
   onRun: () => void
   onDelete: () => void
+  /** Drill into a single run's detail view. */
+  onOpenRun: (runId: string) => void
   isRunning?: boolean
   isDeleting?: boolean
 }
 
 /**
- * A saved simulation case in the suite list. A leaf `TreeRow` (no chevron — the
- * drill is the title click); secondary reads "<status> · <scope> · <last run>".
- * Run / Delete hover-reveal in the actions slot. See plans/evals/ui-plan.md
- * §"Level 1 — suite list".
+ * A saved simulation case in the suite list. An expandable `TreeRow`: the row
+ * shows the latest verdict + when it ran; expanding reveals the run history
+ * (verdict + time per run), and clicking a run drills to its detail view. The
+ * Cog opens the editor; Run / Delete hover-reveal alongside. See
+ * plans/evals/ui-plan.md §"Level 1 — suite list".
  */
 export function EvalCaseRow({
   item,
-  scopeLabel,
-  onOpen,
+  depth = 0,
+  onEdit,
   onRun,
   onDelete,
+  onOpenRun,
   isRunning,
   isDeleting,
 }: EvalCaseRowProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const runsQuery = api.eval.listRuns.useQuery({ caseId: item.id }, { enabled: isOpen })
   const lastRun = item.latestRun
+
   return (
     <TreeRow
       icon={<FlaskConical className='size-4 text-muted-foreground' />}
       title={item.name}
-      onTitleClick={onOpen}
+      depth={depth}
+      rowClassName='hover:bg-primary-100'
+      expandable
+      isOpen={isOpen}
+      onToggleOpen={() => setIsOpen((o) => !o)}
       secondary={
-        <span className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+        <span className='flex items-center gap-1.5'>
           <EvalStatusPill status={lastRun?.status ?? null} />
-          <span aria-hidden>·</span>
-          <span className='truncate'>{scopeLabel}</span>
           {lastRun ? (
-            <>
-              <span aria-hidden>·</span>
-              <span>{formatRelativeTime(lastRun.at, true)}</span>
-            </>
+            <span className='text-xs text-muted-foreground'>
+              {formatRelativeTime(lastRun.at, true)}
+            </span>
           ) : null}
         </span>
       }
       actions={
-        <>
+        <div className='flex items-center gap-0'>
+          <TreeRowButton tooltipText='Edit' onClick={onEdit} aria-label='Edit simulation'>
+            <Cog />
+          </TreeRowButton>
           <TreeRowButton
             tooltipText='Run'
             onClick={onRun}
@@ -72,8 +85,43 @@ export function EvalCaseRow({
             aria-label='Delete simulation'>
             <Trash2 />
           </TreeRowButton>
-        </>
-      }
-    />
+        </div>
+      }>
+      {runsQuery.isLoading ? (
+        <TreeRow
+          depth={depth + 1}
+          title={<span className='text-xs text-muted-foreground'>Loading runs…</span>}
+        />
+      ) : runsQuery.data?.runs.length ? (
+        runsQuery.data.runs.map((run) => (
+          <TreeRow
+            key={run.id}
+            depth={depth + 1}
+            rowClassName='hover:bg-primary-100'
+            icon={<EvalStatusDot status={run.status} />}
+            title={evalStatusVisual(run.status).label}
+            secondary={
+              <span className='text-xs text-muted-foreground'>
+                {formatRelativeTime(run.createdAt, true)}
+              </span>
+            }
+            onTitleClick={() => onOpenRun(run.id)}
+            actions={
+              <TreeRowButton
+                tooltipText='View run'
+                onClick={() => onOpenRun(run.id)}
+                aria-label='View run detail'>
+                <ChevronRight />
+              </TreeRowButton>
+            }
+          />
+        ))
+      ) : (
+        <TreeRow
+          depth={depth + 1}
+          title={<span className='text-xs text-muted-foreground'>No runs yet.</span>}
+        />
+      )}
+    </TreeRow>
   )
 }

--- a/apps/web/src/components/evals/ui/eval-run-detail.tsx
+++ b/apps/web/src/components/evals/ui/eval-run-detail.tsx
@@ -3,11 +3,11 @@
 
 import type { EvalRunStatus } from '@auxx/types/evals'
 import { Alert, AlertDescription } from '@auxx/ui/components/alert'
+import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
-import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
-import { EmptySection } from '@auxx/ui/components/section'
+import { EmptySection, Section } from '@auxx/ui/components/section'
 import { Spinner } from '@auxx/ui/components/spinner'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatRelativeTime } from '@auxx/utils'
@@ -34,6 +34,12 @@ const TERMINAL: ReadonlySet<EvalRunStatus> = new Set<EvalRunStatus>([
   'timed_out',
 ])
 
+/**
+ * Bleeds a `Section`'s content past its `p-3` padding so tree rows span full
+ * width; the inner `ps-2 pe-4` div re-pads. Mirrors the suite panel.
+ */
+const SECTION_BLEED = '[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
+
 type AlertVariant = 'good' | 'destructive' | 'warning' | 'blue' | 'default'
 
 const BANNER: Record<EvalRunStatus, { variant: AlertVariant; sentence: string }> = {
@@ -49,8 +55,6 @@ const BANNER: Record<EvalRunStatus, { variant: AlertVariant; sentence: string }>
   timed_out: { variant: 'warning', sentence: 'Timed out before reaching a verdict.' },
 }
 
-type Tab = 'verdict' | 'trace' | 'snapshot'
-
 interface EvalRunDetailProps {
   runId: string
   /** Switches the detail to another run from the same case's history. */
@@ -58,7 +62,6 @@ interface EvalRunDetailProps {
 }
 
 export function EvalRunDetail({ runId, onSelectRun }: EvalRunDetailProps) {
-  const [tab, setTab] = useState<Tab>('verdict')
   const runQuery = api.eval.getRun.useQuery({ runId })
   const live = useEvalRunState(runId)
   const { connect, hydrateFromRun } = useEvalRunActions()
@@ -107,62 +110,73 @@ export function EvalRunDetail({ runId, onSelectRun }: EvalRunDetailProps) {
   const isLive = !TERMINAL.has(status)
   const banner = BANNER[status]
   const assertions = live.assertionResults.length ? live.assertionResults : []
+  // The run executed the draft (not the pinned version) when prepared in draft mode.
+  const ranDraft = (row.runtimeSnapshot as { runMode?: string }).runMode === 'draft'
 
   return (
-    <div className='space-y-3 p-3'>
+    <div>
       {/* Verdict banner + run-history switcher */}
-      <Alert variant={banner.variant} className='flex items-start justify-between gap-2'>
-        <AlertDescription className='flex items-center gap-2'>
-          <EvalStatusPill status={status} />
-          <span>{row.error ? `${banner.sentence} ${row.error}` : banner.sentence}</span>
-        </AlertDescription>
-        {caseId ? (
-          <RunHistoryPopover caseId={caseId} activeRunId={runId} onSelectRun={onSelectRun} />
-        ) : null}
-      </Alert>
+      <div className='p-3'>
+        <Alert variant={banner.variant} className='flex items-start justify-between gap-2'>
+          <AlertDescription className='flex items-center gap-2'>
+            <EvalStatusPill status={status} />
+            {ranDraft ? (
+              <Badge variant='pill' size='sm'>
+                Draft
+              </Badge>
+            ) : null}
+            <span>{row.error ? `${banner.sentence} ${row.error}` : banner.sentence}</span>
+          </AlertDescription>
+          {caseId ? (
+            <RunHistoryPopover caseId={caseId} activeRunId={runId} onSelectRun={onSelectRun} />
+          ) : null}
+        </Alert>
+      </div>
 
-      <RadioTab
-        value={tab}
-        onValueChange={(v) => setTab(v as Tab)}
-        size='sm'
-        radioGroupClassName='grid w-full grid-cols-3'
-        className='h-8 w-full'>
-        <RadioTabItem value='verdict' size='sm' className='gap-1'>
-          <ListChecks className='size-3.5!' />
-          Verdict
-        </RadioTabItem>
-        <RadioTabItem value='trace' size='sm' className='gap-1'>
-          <History className='size-3.5!' />
-          Trace
-        </RadioTabItem>
-        <RadioTabItem value='snapshot' size='sm' className='gap-1'>
-          <FileJson className='size-3.5!' />
-          Snapshot
-        </RadioTabItem>
-      </RadioTab>
+      <Section
+        title='Verdict'
+        icon={<ListChecks className='size-4' />}
+        description='Per-assertion pass/fail for this run.'
+        className={SECTION_BLEED}
+        collapsible>
+        <div className='flex flex-col ps-2 pe-4'>
+          {assertions.length ? (
+            assertions.map((r) => <EvalAssertionResultRow key={r.assertionId} result={r} />)
+          ) : (
+            <EmptySection
+              icon={<ListChecks className='size-4' />}
+              title={isLive ? 'Grading pending' : 'No assertion results'}
+              description={
+                isLive ? 'Assertions are graded once the conversation completes.' : undefined
+              }
+              loading={isLive}
+            />
+          )}
+        </div>
+      </Section>
 
-      {tab === 'verdict' ? (
-        assertions.length ? (
-          <div className='space-y-0.5'>
-            {assertions.map((r) => (
-              <EvalAssertionResultRow key={r.assertionId} result={r} />
-            ))}
-          </div>
-        ) : (
-          <EmptySection
-            icon={<ListChecks className='size-4' />}
-            title={isLive ? 'Grading pending' : 'No assertion results'}
-            description={
-              isLive ? 'Assertions are graded once the conversation completes.' : undefined
-            }
-            loading={isLive}
-          />
-        )
-      ) : null}
+      <Section
+        title='Trace'
+        icon={<History className='size-4' />}
+        description='The conversation and tool calls, in order.'
+        className={SECTION_BLEED}
+        collapsible>
+        <div className='flex flex-col ps-2 pe-4'>
+          <EvalTraceView trace={live.trace} isLive={isLive} />
+        </div>
+      </Section>
 
-      {tab === 'trace' ? <EvalTraceView trace={live.trace} isLive={isLive} /> : null}
-
-      {tab === 'snapshot' ? <SnapshotTab runtimeSnapshot={row.runtimeSnapshot} /> : null}
+      <Section
+        title='Snapshot'
+        icon={<FileJson className='size-4' />}
+        description='The exact runtime that executed — models, limits, mock policy.'
+        className={SECTION_BLEED}
+        collapsible
+        initialOpen={false}>
+        <div className='flex flex-col ps-2 pe-4'>
+          <SnapshotTab runtimeSnapshot={row.runtimeSnapshot} />
+        </div>
+      </Section>
     </div>
   )
 }
@@ -182,6 +196,8 @@ interface RuntimeSnapshotView {
   mockPolicy?: string
   limits?: { maxCustomerTurns?: number; maxReinvokes?: number; maxIterations?: number }
   time?: { frozenAt?: string | null }
+  runMode?: string
+  draftContentHash?: string
 }
 
 function modelLabel(m?: ProviderModel): string {
@@ -194,6 +210,7 @@ function SnapshotTab({ runtimeSnapshot }: { runtimeSnapshot: Record<string, unkn
   const rows: { label: string; value: string }[] = [
     { label: 'Code revision', value: s.codeRevision ?? '—' },
     { label: 'Scope', value: s.scope ?? '—' },
+    { label: 'Run mode', value: s.runMode ?? 'pinned' },
     { label: 'Agent model', value: modelLabel(s.agent?.model) },
     { label: 'Utility model', value: modelLabel(s.agent?.utilityModel) },
     { label: 'Customer (persona)', value: modelLabel(s.personaModel) },

--- a/apps/web/src/components/evals/ui/eval-suggestions-section.tsx
+++ b/apps/web/src/components/evals/ui/eval-suggestions-section.tsx
@@ -1,0 +1,225 @@
+// apps/web/src/components/evals/ui/eval-suggestions-section.tsx
+'use client'
+
+import type { AgentEvalTarget } from '@auxx/types/evals'
+import { Button } from '@auxx/ui/components/button'
+import { EmptySection, Section } from '@auxx/ui/components/section'
+import { toastError } from '@auxx/ui/components/toast'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { Plus, RefreshCw, Sparkles, Trash2 } from 'lucide-react'
+import { useEffect } from 'react'
+import { api, type RouterOutputs } from '~/trpc/react'
+import {
+  useEvalSuggestionsActions,
+  useSuggestionsEntry,
+} from '../stores/use-eval-suggestions-store'
+
+/** One proposed simulation from `eval.suggest`. */
+type Suggestion = RouterOutputs['eval']['suggest']['suggestions'][number]
+
+const SECTION_BLEED = '[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
+
+interface EvalSuggestionsSectionProps {
+  agentId: string
+  procedureId: string
+  onOpenCase: (caseId: string) => void
+  /** suggestionIds already accepted into saved cases (filtered out). */
+  acceptedSuggestionIds: Set<string>
+  /** Invalidate the saved-case list after an accept. */
+  onAccepted: () => void
+}
+
+/**
+ * Suggested Simulations: the system reads the procedure draft and proposes
+ * ready-to-run cases. Open by default and auto-generates once per procedure —
+ * cheap on a reload because the backend caches by draft hash. Its result +
+ * dismissals are held in a session store keyed by `procedureId`, surviving the
+ * section's remounts instead of re-running the model. **Add** accepts a proposal
+ * via `eval.create` and drills into its drawer; the X dismisses it for the session.
+ *
+ * See plans/evals/phase-3-suggester.md §3.4.
+ */
+export function EvalSuggestionsSection({
+  agentId,
+  procedureId,
+  onOpenCase,
+  acceptedSuggestionIds,
+  onAccepted,
+}: EvalSuggestionsSectionProps) {
+  // Cached per procedure in a session store so a remount reuses the generation
+  // rather than spending tokens again; Refresh overwrites it.
+  const { result, dismissed, requested } = useSuggestionsEntry(procedureId)
+  const { setResult, dismiss: dismissInStore, markRequested } = useEvalSuggestionsActions()
+
+  // A new procedure-scoped case pins the procedure's active (published) version —
+  // the same resolution the New-simulation flow uses.
+  const procedureQuery = api.procedure.getById.useQuery({ id: procedureId })
+  const activeVersionId = procedureQuery.data?.activeVersionId ?? null
+
+  const suggest = api.eval.suggest.useMutation({
+    onSuccess: (data) => setResult(procedureId, data),
+    onError: (err) =>
+      toastError({ title: 'Could not generate suggestions', description: err.message }),
+  })
+
+  const create = api.eval.create.useMutation()
+
+  // `force` bypasses the backend draft-hash cache — Refresh regenerates; the auto
+  // run uses the cache (a reload then reuses a prior generation, no token spend).
+  const generate = (force = false) => {
+    markRequested(procedureId)
+    suggest.mutate({ agentId, procedureId, force })
+  }
+
+  // Auto-generate once per procedure per session: nothing cached, not already
+  // attempted (so a failed run doesn't re-fire on remount), nothing in flight.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `generate` uses stable store/mutation refs; gated by result/requested
+  useEffect(() => {
+    if (!result && !requested && !suggest.isPending) generate()
+  }, [procedureId, result, requested, suggest.isPending])
+
+  const accept = (s: Suggestion) => {
+    if (!activeVersionId) {
+      toastError({
+        title: 'Cannot add simulation',
+        description: 'Publish the procedure once so a version exists to pin.',
+      })
+      return
+    }
+    const target: AgentEvalTarget = {
+      kind: 'agent_simulation',
+      scope: 'procedure',
+      agentId,
+      procedureId,
+      procedureVersionId: activeVersionId,
+    }
+    create.mutate(
+      {
+        name: s.name,
+        target,
+        config: s.config,
+        assertions: s.assertions,
+        suggestionId: s.suggestionId,
+      },
+      {
+        onSuccess: ({ id }) => {
+          // Drop the accepted row immediately and refresh the saved list.
+          dismissInStore(procedureId, s.suggestionId)
+          onAccepted()
+          onOpenCase(id)
+        },
+        onError: (err) =>
+          toastError({ title: 'Could not add simulation', description: err.message }),
+      }
+    )
+  }
+
+  const dismiss = (suggestionId: string) => dismissInStore(procedureId, suggestionId)
+
+  // Hide the session-dismissed and already-accepted (cross-session) proposals.
+  const visible = (result?.suggestions ?? []).filter(
+    (s) => !dismissed.has(s.suggestionId) && !acceptedSuggestionIds.has(s.suggestionId)
+  )
+
+  return (
+    <Section
+      title='Suggested simulations'
+      icon={<Sparkles className='size-4' />}
+      className={SECTION_BLEED}
+      actions={
+        <Button
+          variant='ghost'
+          size='xs'
+          loading={suggest.isPending}
+          loadingText='Generating…'
+          onClick={() => generate(true)}>
+          <RefreshCw />
+          Refresh
+        </Button>
+      }>
+      <div className='flex flex-col ps-2 pe-4'>
+        {suggest.isPending ? (
+          <EmptySection
+            icon={<Sparkles className='size-4' />}
+            title='Reading the procedure…'
+            loading
+          />
+        ) : visible.length === 0 ? (
+          <EmptySection
+            icon={<Sparkles className='size-4' />}
+            title={result ? 'No new suggestions' : 'No suggestions'}
+            description={
+              result
+                ? 'The proposed cases are already covered. Edit the procedure and refresh.'
+                : 'Nothing was generated — hit Refresh to try again.'
+            }
+          />
+        ) : (
+          <>
+            {visible.map((s) => (
+              <SuggestionRow
+                key={s.suggestionId}
+                suggestion={s}
+                onAdd={() => accept(s)}
+                onDismiss={() => dismiss(s.suggestionId)}
+                isAdding={create.isPending && create.variables?.suggestionId === s.suggestionId}
+              />
+            ))}
+            {result && result.dropped > 0 ? (
+              <p className='px-2 py-1.5 text-xs text-muted-foreground'>
+                {result.dropped} proposal{result.dropped === 1 ? ' was' : 's were'} invalid and
+                skipped.
+              </p>
+            ) : null}
+          </>
+        )}
+      </div>
+    </Section>
+  )
+}
+
+interface SuggestionRowProps {
+  suggestion: Suggestion
+  onAdd: () => void
+  onDismiss: () => void
+  isAdding: boolean
+}
+
+function SuggestionRow({ suggestion, onAdd, onDismiss, isAdding }: SuggestionRowProps) {
+  const mockedTools = suggestion.config.connectorMocks.length
+  const assertionCount = suggestion.assertions.length
+  const hint = [
+    `${assertionCount} check${assertionCount === 1 ? '' : 's'}`,
+    mockedTools > 0 ? `${mockedTools} mocked tool${mockedTools === 1 ? '' : 's'}` : null,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <TreeRow
+      icon={<Sparkles className='size-4 text-muted-foreground/60 shrink-0' />}
+      title={suggestion.name}
+      description={suggestion.rationale}
+      rowClassName='hover:bg-primary-100'
+      secondary={<span className='truncate text-xs text-muted-foreground'>{hint}</span>}
+      actions={
+        <div className='flex items-center gap-0'>
+          <TreeRowButton
+            tooltipText='Add simulation'
+            onClick={onAdd}
+            disabled={isAdding}
+            aria-label='Add simulation'>
+            <Plus />
+          </TreeRowButton>
+          <TreeRowButton
+            variant='destructive'
+            tooltipText='Dismiss'
+            onClick={onDismiss}
+            aria-label='Dismiss suggestion'>
+            <Trash2 />
+          </TreeRowButton>
+        </div>
+      }
+    />
+  )
+}

--- a/apps/web/src/components/evals/ui/eval-suite-panel.tsx
+++ b/apps/web/src/components/evals/ui/eval-suite-panel.tsx
@@ -1,8 +1,13 @@
 // apps/web/src/components/evals/ui/eval-suite-panel.tsx
 'use client'
 
-import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import { EmptySection, Section } from '@auxx/ui/components/section'
 import { toastError } from '@auxx/ui/components/toast'
 import { TreeRow } from '@auxx/ui/components/tree-row'
@@ -11,43 +16,50 @@ import { useMemo, useState } from 'react'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { EvalCaseRow } from './eval-case-row'
+import { EvalSuggestionsSection } from './eval-suggestions-section'
 
 /**
- * Level 1 of the Simulations drill: the saved-case list for an agent, scoped by
- * the shared `?procedure` param. At the agent root, agent-scoped cases list
- * first, then procedure-scoped cases roll up under collapsible per-procedure
- * groups. Run / Run all / New live in the `Section` header. The `Section` owns
- * its own padding — it is rendered directly, never wrapped. See
- * plans/evals/ui-plan.md §"Level 1 — suite list".
+ * Level 1 of the Simulations drill: the saved-case list for an agent, split into
+ * two stacked sections — **Agent simulations** (whole-conversation tests) and
+ * **Procedure simulations** (per-procedure, pinned to a version). Both list
+ * regardless of the page's `?procedure` selection. Each section owns its own
+ * New / Run-all. See plans/evals/ui-plan.md §"Level 1 — suite list".
  */
+
+/**
+ * Bleeds the `Section`'s `data-slot=section-content` past the section's `p-3`
+ * padding so the tree rows span full width; an inner `ps-2 pe-4` div re-pads.
+ */
+const SECTION_BLEED = '[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'
 
 interface EvalSuitePanelProps {
   agentId: string
-  procedureId: string | null
   onOpenCase: (caseId: string) => void
-  onNewCase: () => void
+  /** `procedureId` pins a new procedure-scoped case; `null` ⇒ agent scope. */
+  onNewCase: (procedureId: string | null) => void
   onOpenRun: (runId: string) => void
+  /** The page's `?procedure` selection — gates the Suggested Simulations section. */
+  selectedProcedureId?: string | null
 }
 
 export function EvalSuitePanel({
   agentId,
-  procedureId,
   onOpenCase,
   onNewCase,
   onOpenRun,
+  selectedProcedureId,
 }: EvalSuitePanelProps) {
   const utils = api.useUtils()
   const [confirm, ConfirmDialog] = useConfirm()
-  const [openGroups, setOpenGroups] = useState<Set<string>>(new Set())
+  // Procedure groups default to open; track the ones the user has collapsed.
+  const [closedGroups, setClosedGroups] = useState<Set<string>>(new Set())
 
-  const casesQuery = api.eval.list.useQuery({
-    agentId,
-    procedureId: procedureId ?? undefined,
-  })
+  const casesQuery = api.eval.list.useQuery({ agentId })
   const proceduresQuery = api.agentProcedure.list.useQuery({ agentId })
+  const procedures = proceduresQuery.data ?? []
   const procedureNames = useMemo(
-    () => new Map((proceduresQuery.data ?? []).map((p) => [p.procedureId, p.name])),
-    [proceduresQuery.data]
+    () => new Map(procedures.map((p) => [p.procedureId, p.name])),
+    [procedures]
   )
 
   const invalidate = () => utils.eval.list.invalidate({ agentId })
@@ -75,7 +87,14 @@ export function EvalSuitePanel({
   const agentScoped = cases.filter((c) => c.scope === 'agent')
   const procedureScoped = cases.filter((c) => c.scope === 'procedure')
 
-  // Group procedure-scoped cases by procedure (agent-root view only).
+  // suggestionIds already accepted into saved cases — so re-generated proposals
+  // for the same provenance are filtered out client-side.
+  const acceptedSuggestionIds = useMemo(
+    () => new Set(cases.map((c) => c.suggestionId).filter((id): id is string => id != null)),
+    [cases]
+  )
+
+  // Group procedure-scoped cases by procedure.
   const groups = useMemo(() => {
     const map = new Map<string, typeof procedureScoped>()
     for (const c of procedureScoped) {
@@ -98,96 +117,156 @@ export function EvalSuitePanel({
     if (confirmed) deleteCase.mutate({ id })
   }
 
-  const scopeLabel = (c: (typeof cases)[number]) =>
-    c.scope === 'agent' ? 'Whole agent' : (procedureNames.get(c.procedureId ?? '') ?? 'Procedure')
-
-  const renderRow = (c: (typeof cases)[number]) => (
+  const renderRow = (c: (typeof cases)[number], depth: number) => (
     <EvalCaseRow
       key={c.id}
       item={c}
-      scopeLabel={scopeLabel(c)}
-      onOpen={() => onOpenCase(c.id)}
-      onRun={() => runCase.mutate({ id: c.id })}
+      depth={depth}
+      onEdit={() => onOpenCase(c.id)}
+      onRun={() => runCase.mutate({ id: c.id, useDraft: true })}
       onDelete={() => handleDelete(c.id, c.name)}
+      onOpenRun={onOpenRun}
       isRunning={runCase.isPending && runCase.variables?.id === c.id}
       isDeleting={deleteCase.isPending && deleteCase.variables?.id === c.id}
     />
   )
 
-  const isEmpty = cases.length === 0
   const isLoading = casesQuery.isLoading
+  const runningAll = runAll.isPending
 
   return (
     <>
       <ConfirmDialog />
+
+      {/* Agent simulations — whole-conversation tests */}
       <Section
-        title='Simulations'
+        title='Agent simulations'
         icon={<FlaskConical className='size-4' />}
         collapsible={false}
+        className={SECTION_BLEED}
         actions={
           <div className='flex items-center gap-1.5'>
-            {runAll.isPending ? (
-              <Badge variant='secondary' className='gap-1'>
-                <Play className='size-3 animate-pulse' />
-                Running…
-              </Badge>
-            ) : null}
             <Button
               variant='ghost'
               size='xs'
-              disabled={isEmpty || runAll.isPending}
-              loading={runAll.isPending}
-              onClick={() => runAll.mutate({ agentId, procedureId: procedureId ?? undefined })}>
+              disabled={agentScoped.length === 0 || runningAll}
+              loading={runningAll}
+              onClick={() =>
+                runAll.mutate({ agentId, caseIds: agentScoped.map((c) => c.id), useDraft: true })
+              }>
               <Play />
               Run all
             </Button>
-            <Button variant='ghost' size='xs' onClick={onNewCase}>
+            <Button variant='ghost' size='xs' onClick={() => onNewCase(null)}>
               <Plus />
-              New simulation
+              New
             </Button>
           </div>
         }>
-        {isLoading || isEmpty ? (
-          <EmptySection
-            icon={<FlaskConical className='size-4' />}
-            title='No simulations yet'
-            description='Add one to test how this agent handles a conversation.'
-            loading={isLoading}
-          />
-        ) : (
-          <div className='space-y-0.5'>
-            {agentScoped.map(renderRow)}
-
-            {/* Procedure groups only at the agent root (a procedure view is already scoped). */}
-            {!procedureId &&
-              groups.map(([pid, list]) => {
-                const open = openGroups.has(pid)
-                return (
-                  <TreeRow
-                    key={pid}
-                    icon={<FlaskConical className='size-4 text-muted-foreground/60' />}
-                    title={procedureNames.get(pid) ?? 'Procedure'}
-                    secondary={<span className='text-xs text-muted-foreground'>{list.length}</span>}
-                    expandable
-                    isOpen={open}
-                    onToggleOpen={() =>
-                      setOpenGroups((s) => {
-                        const next = new Set(s)
-                        if (next.has(pid)) next.delete(pid)
-                        else next.add(pid)
-                        return next
-                      })
-                    }>
-                    {list.map(renderRow)}
-                  </TreeRow>
-                )
-              })}
-
-            {/* In a procedure-scoped view, procedure cases render flat. */}
-            {procedureId ? procedureScoped.map(renderRow) : null}
-          </div>
-        )}
+        <div className='flex flex-col ps-2 pe-4'>
+          {isLoading ? (
+            <EmptySection icon={<FlaskConical className='size-4' />} title='Loading…' loading />
+          ) : agentScoped.length === 0 ? (
+            <EmptySection
+              icon={<FlaskConical className='size-4' />}
+              title='No agent simulations yet'
+              description='Test how this agent handles a whole conversation.'
+            />
+          ) : (
+            agentScoped.map((c) => renderRow(c, 0))
+          )}
+        </div>
       </Section>
+
+      {/* Procedure simulations — per-procedure, pinned to a version */}
+      <Section
+        title='Procedure simulations'
+        icon={<FlaskConical className='size-4' />}
+        collapsible={false}
+        className={SECTION_BLEED}
+        actions={
+          <div className='flex items-center gap-1.5'>
+            <Button
+              variant='ghost'
+              size='xs'
+              disabled={procedureScoped.length === 0 || runningAll}
+              loading={runningAll}
+              onClick={() =>
+                runAll.mutate({
+                  agentId,
+                  caseIds: procedureScoped.map((c) => c.id),
+                  useDraft: true,
+                })
+              }>
+              <Play />
+              Run all
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant='ghost' size='xs' disabled={procedures.length === 0}>
+                  <Plus />
+                  New
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align='end'>
+                {procedures.map((p) => (
+                  <DropdownMenuItem key={p.procedureId} onClick={() => onNewCase(p.procedureId)}>
+                    {p.name}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        }>
+        <div className='flex flex-col ps-2 pe-4'>
+          {isLoading ? (
+            <EmptySection icon={<FlaskConical className='size-4' />} title='Loading…' loading />
+          ) : procedureScoped.length === 0 ? (
+            <EmptySection
+              icon={<FlaskConical className='size-4' />}
+              title='No procedure simulations yet'
+              description='Pin a procedure and test it in isolation.'
+            />
+          ) : (
+            groups.map(([pid, list]) => {
+              const open = !closedGroups.has(pid)
+              return (
+                <TreeRow
+                  key={pid}
+                  depth={0}
+                  rowClassName='hover:bg-primary-100'
+                  icon={<FlaskConical className='size-4 text-muted-foreground/60' />}
+                  title={procedureNames.get(pid) ?? 'Procedure'}
+                  secondary={<span className='text-xs text-muted-foreground'>{list.length}</span>}
+                  expandable
+                  isOpen={open}
+                  onToggleOpen={() =>
+                    setClosedGroups((s) => {
+                      const next = new Set(s)
+                      if (next.has(pid)) next.delete(pid)
+                      else next.add(pid)
+                      return next
+                    })
+                  }>
+                  {list.map((c) => renderRow(c, 1))}
+                </TreeRow>
+              )
+            })
+          )}
+        </div>
+      </Section>
+
+      {/* Suggested simulations — procedure-scoped view only (`?procedure` set). */}
+      {selectedProcedureId ? (
+        <EvalSuggestionsSection
+          key={selectedProcedureId}
+          agentId={agentId}
+          procedureId={selectedProcedureId}
+          onOpenCase={onOpenCase}
+          acceptedSuggestionIds={acceptedSuggestionIds}
+          onAccepted={invalidate}
+        />
+      ) : null}
     </>
   )
 }

--- a/apps/web/src/components/evals/ui/simulations-tab.tsx
+++ b/apps/web/src/components/evals/ui/simulations-tab.tsx
@@ -13,17 +13,22 @@ import { EvalSuitePanel } from './eval-suite-panel'
 
 /**
  * The **Simulations** tab body: a NavStack drill that keeps the narrow agent
- * drawer single-column (list → case editor → run detail). Procedure scope comes
- * from the shared `?procedure` URL param the main detail panel already owns —
- * selecting a procedure there scopes this list automatically. The `'new'`
- * sentinel opens the editor in create mode.
+ * drawer single-column (list → case editor → run detail). The list shows both
+ * agent- and procedure-scoped cases (the `?procedure` page param does not filter
+ * it). The `'new'` sentinel opens the editor in create mode; a new case's scope
+ * comes from `newCaseProcedureId` (a chosen procedure, or `null` for agent).
  *
  * See plans/evals/ui-plan.md §"Agent Simulations (Phase 1B)".
  */
 export function SimulationsTab({ agentId }: { agentId: string }) {
-  const [procedureId] = useQueryState('procedure')
   const [caseId, setCaseId] = useState<string | null>(null)
+  // Procedure pinned for a NEW case (chosen from the Procedure-section "New"
+  // menu); `null` ⇒ agent scope. Only meaningful while `caseId === 'new'`.
+  const [newCaseProcedureId, setNewCaseProcedureId] = useState<string | null>(null)
   const [runId, setRunId] = useState<string | null>(null)
+  // The page's selected procedure (shared `?procedure` param) — gates the
+  // Suggested Simulations section to the procedure-scoped view.
+  const [selectedProcedureId] = useQueryState('procedure')
   const utils = api.useUtils()
 
   // Stack shape: a run can be reached from a case (list→case→run) or straight
@@ -54,10 +59,13 @@ export function SimulationsTab({ agentId }: { agentId: string }) {
           <ScrollArea className='h-full' scrollbarClassName='w-1.5'>
             <EvalSuitePanel
               agentId={agentId}
-              procedureId={procedureId}
               onOpenCase={setCaseId}
-              onNewCase={() => setCaseId('new')}
+              onNewCase={(pid) => {
+                setNewCaseProcedureId(pid)
+                setCaseId('new')
+              }}
               onOpenRun={setRunId}
+              selectedProcedureId={selectedProcedureId}
             />
           </ScrollArea>
         </NavStackPanel>
@@ -65,10 +73,10 @@ export function SimulationsTab({ agentId }: { agentId: string }) {
         <NavStackPanel value='case' className='flex h-full flex-col'>
           {caseId ? (
             <EvalCaseDrawer
-              key={caseId}
+              key={caseId === 'new' ? `new-${newCaseProcedureId ?? 'agent'}` : caseId}
               agentId={agentId}
               caseId={caseId === 'new' ? null : caseId}
-              procedureId={procedureId}
+              procedureId={caseId === 'new' ? newCaseProcedureId : null}
               onSaved={() => void utils.eval.list.invalidate({ agentId })}
               onOpenRun={setRunId}
             />

--- a/apps/web/src/server/api/routers/eval.ts
+++ b/apps/web/src/server/api/routers/eval.ts
@@ -17,6 +17,7 @@ import {
   listEvalRuns,
   type PreparedRunSnapshots,
   prepareRunSnapshots,
+  suggestAgentSimulations,
   updateEvalCase,
   validateAgentToolMock,
   validateEvalCase,
@@ -85,6 +86,8 @@ export const evalRouter = createTRPCRouter({
           name: row.name,
           scope: target.scope,
           procedureId: target.scope === 'procedure' ? target.procedureId : null,
+          // Provenance for client-side dedup of already-accepted suggestions.
+          suggestionId: row.suggestionId ?? null,
           createdAt: row.createdAt.toISOString(),
           updatedAt: row.updatedAt.toISOString(),
           latestRun: run
@@ -116,6 +119,8 @@ export const evalRouter = createTRPCRouter({
         target: agentEvalTargetSchema,
         config: simulationConfigSchema,
         assertions: agentEvalAssertionsSchema,
+        /** Provenance when the case was accepted from a suggestion. */
+        suggestionId: z.string().min(1).optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -127,6 +132,7 @@ export const evalRouter = createTRPCRouter({
           target: input.target,
           config: input.config,
           assertions: input.assertions,
+          suggestionId: input.suggestionId,
         }),
         'create eval case'
       )
@@ -263,14 +269,21 @@ export const evalRouter = createTRPCRouter({
 
   // ── Execute ───────────────────────────────────────────────────────────────
   run: evalAdminProcedure
-    .input(z.object({ id: z.string().min(1) }))
+    // `useDraft`: run the current draft (the Simulations editor surface always
+    // passes true); headless/CI default to the pinned version (regression gate).
+    .input(z.object({ id: z.string().min(1), useDraft: z.boolean().optional() }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
       const found = unwrap(await getEvalCaseById({ organizationId, id: input.id }), 'get eval case')
       if (!found) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval case not found' })
       const parsed = parseCase(found)
 
-      const prepared = await prepareRunSnapshots({ organizationId, userId, case: parsed })
+      const prepared = await prepareRunSnapshots({
+        organizationId,
+        userId,
+        case: parsed,
+        mode: input.useDraft ? 'draft' : 'pinned',
+      })
       if (prepared.isErr()) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
@@ -312,6 +325,7 @@ export const evalRouter = createTRPCRouter({
         agentId: z.string().min(1),
         procedureId: z.string().min(1).optional(),
         caseIds: z.array(z.string().min(1)).optional(),
+        useDraft: z.boolean().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -336,7 +350,12 @@ export const evalRouter = createTRPCRouter({
         []
       for (const row of selected) {
         const prepared: PreparedRunSnapshots = unwrap(
-          await prepareRunSnapshots({ organizationId, userId, case: parseCase(row) }),
+          await prepareRunSnapshots({
+            organizationId,
+            userId,
+            case: parseCase(row),
+            mode: input.useDraft ? 'draft' : 'pinned',
+          }),
           `prepare eval run for case ${row.id}`
         )
         children.push({
@@ -383,4 +402,31 @@ export const evalRouter = createTRPCRouter({
       if (!cancelled) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval run not found' })
       return { status: cancelled.status }
     }),
+
+  // ── Suggestions ───────────────────────────────────────────────────────────
+  // Mutation, not query: it spends tokens and is non-idempotent. The client holds
+  // the result keyed by the returned `draftHash` rather than auto-refetching.
+  // `evalAdminProcedure` gates the spend; org/agent scoping is enforced inside the
+  // service by `getAttachedProcedureDraft`.
+  suggest: evalAdminProcedure
+    .input(
+      z.object({
+        agentId: z.string().min(1),
+        procedureId: z.string().min(1),
+        /** Bypass the draft-hash cache and regenerate (Refresh). */
+        force: z.boolean().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) =>
+      unwrap(
+        await suggestAgentSimulations({
+          organizationId: ctx.session.organizationId,
+          userId: ctx.session.userId,
+          agentId: input.agentId,
+          procedureId: input.procedureId,
+          force: input.force,
+        }),
+        'suggest simulations'
+      )
+    ),
 })

--- a/packages/lib/src/evals/__tests__/prepare-run.test.ts
+++ b/packages/lib/src/evals/__tests__/prepare-run.test.ts
@@ -1,0 +1,144 @@
+// packages/lib/src/evals/__tests__/prepare-run.test.ts
+
+import type { AgentEvalAssertion, AgentEvalTarget, SimulationConfig } from '@auxx/types/evals'
+import { err, ok } from 'neverthrow'
+
+vi.mock('../../agents/procedures', () => ({
+  compileProcedure: vi.fn(),
+  getProcedureVersionById: vi.fn(),
+  readCompiled: vi.fn(),
+}))
+vi.mock('../../agents/procedures/authoring/queries', () => ({
+  getAttachedProcedureDraft: vi.fn(),
+}))
+vi.mock('../../ai/agent-framework/effective-runtime', () => ({
+  buildEffectiveAgentRuntime: vi.fn(),
+}))
+vi.mock('../../cache', () => ({
+  getCachedAgentById: vi.fn(),
+}))
+
+import { compileProcedure, getProcedureVersionById, readCompiled } from '../../agents/procedures'
+import { getAttachedProcedureDraft } from '../../agents/procedures/authoring/queries'
+import { buildEffectiveAgentRuntime } from '../../ai/agent-framework/effective-runtime'
+import { getCachedAgentById } from '../../cache'
+import { prepareRunSnapshots } from '../prepare-run'
+
+const mockedCompile = compileProcedure as unknown as ReturnType<typeof vi.fn>
+const mockedGetVersion = getProcedureVersionById as unknown as ReturnType<typeof vi.fn>
+const mockedReadCompiled = readCompiled as unknown as ReturnType<typeof vi.fn>
+const mockedDraft = getAttachedProcedureDraft as unknown as ReturnType<typeof vi.fn>
+const mockedRuntime = buildEffectiveAgentRuntime as unknown as ReturnType<typeof vi.fn>
+const mockedAgent = getCachedAgentById as unknown as ReturnType<typeof vi.fn>
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal CompiledProcedure stand-ins
+const PINNED_COMPILED = { steps: {}, entryStepId: null, tag: 'pinned' } as any
+// biome-ignore lint/suspicious/noExplicitAny: minimal CompiledProcedure stand-ins
+const DRAFT_COMPILED = { steps: {}, entryStepId: null, tag: 'draft' } as any
+
+const TARGET: AgentEvalTarget = {
+  kind: 'agent_simulation',
+  scope: 'procedure',
+  agentId: 'a',
+  procedureId: 'p',
+  procedureVersionId: 'v1',
+}
+
+const CONFIG: SimulationConfig = {
+  openingMessage: 'hi',
+  customerContext: null,
+  channel: 'chat',
+  timeFrozenAt: null,
+  maxCustomerTurns: 3,
+  subject: { recordIds: [], identityVerified: false },
+  startingFields: [],
+  unmatchedToolPolicy: 'error',
+  connectorMocks: [],
+}
+
+const ASSERTIONS: AgentEvalAssertion[] = [
+  { id: 'x', type: 'terminal_outcome', data: { outcome: 'finished' } },
+]
+
+const CASE = {
+  id: 'c1',
+  name: 'Case',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  target: TARGET,
+  config: CONFIG,
+  assertions: ASSERTIONS,
+}
+
+function prepare(mode?: 'pinned' | 'draft') {
+  return prepareRunSnapshots({ organizationId: 'org', userId: 'u', case: CASE, mode })
+}
+
+beforeEach(() => {
+  for (const m of [
+    mockedCompile,
+    mockedGetVersion,
+    mockedReadCompiled,
+    mockedDraft,
+    mockedRuntime,
+    mockedAgent,
+  ]) {
+    m.mockReset()
+  }
+  mockedRuntime.mockResolvedValue({
+    tools: [],
+    model: { provider: 'p', model: 'm' },
+    utilityModel: { provider: 'p', model: 'mu' },
+    agentConfig: { appAccounts: {}, toolRestrictions: null },
+  })
+  mockedAgent.mockResolvedValue({ kind: 'internal', procedures: [] })
+  mockedGetVersion.mockResolvedValue(ok({ id: 'v1' }))
+  mockedReadCompiled.mockReturnValue(PINNED_COMPILED)
+})
+
+describe('prepareRunSnapshots — run mode', () => {
+  it('pins the published version by default (byte-identical to pinned mode)', async () => {
+    const result = await prepare()
+    expect(result.isOk()).toBe(true)
+    const snap = result._unsafeUnwrap().runtimeSnapshot
+    expect(snap.runMode).toBe('pinned')
+    expect(snap.draftContentHash).toBeUndefined()
+    expect(snap.procedures).toEqual([{ id: 'p', versionId: 'v1', compiled: PINNED_COMPILED }])
+    expect(mockedDraft).not.toHaveBeenCalled()
+  })
+
+  it('compiles and pins the draft in draft mode, stamping runMode + content hash', async () => {
+    mockedDraft.mockResolvedValue(ok({ draftDoc: { type: 'doc', content: [] } }))
+    mockedCompile.mockReturnValue({ compiled: DRAFT_COMPILED, contentHash: 'dhash', errors: [] })
+
+    const result = await prepare('draft')
+    expect(result.isOk()).toBe(true)
+    const snap = result._unsafeUnwrap().runtimeSnapshot
+    expect(snap.runMode).toBe('draft')
+    expect(snap.draftContentHash).toBe('dhash')
+    // The pinned versionId remains the record-keeping anchor; the compiled graph is the draft's.
+    expect(snap.procedures).toEqual([{ id: 'p', versionId: 'v1', compiled: DRAFT_COMPILED }])
+  })
+
+  it('fails with EVAL_VALIDATION when the draft does not compile', async () => {
+    mockedDraft.mockResolvedValue(ok({ draftDoc: { type: 'doc', content: [] } }))
+    mockedCompile.mockReturnValue({
+      compiled: DRAFT_COMPILED,
+      contentHash: 'dhash',
+      errors: [{ code: 'CYCLE', message: 'cycle detected' }],
+    })
+
+    const result = await prepare('draft')
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().code).toBe('EVAL_VALIDATION')
+  })
+
+  it('falls back to the pinned version when no draft is available', async () => {
+    mockedDraft.mockResolvedValue(err({ code: 'DB', message: 'PROCEDURE_OR_DRAFT_NOT_FOUND' }))
+
+    const result = await prepare('draft')
+    expect(result.isOk()).toBe(true)
+    const snap = result._unsafeUnwrap().runtimeSnapshot
+    expect(snap.runMode).toBe('pinned')
+    expect(snap.procedures[0]?.compiled).toBe(PINNED_COMPILED)
+  })
+})

--- a/packages/lib/src/evals/__tests__/suggestions.test.ts
+++ b/packages/lib/src/evals/__tests__/suggestions.test.ts
@@ -1,0 +1,393 @@
+// packages/lib/src/evals/__tests__/suggestions.test.ts
+
+import { err, ok } from 'neverthrow'
+import { z } from 'zod'
+
+vi.mock('../../agents/procedures/authoring/queries', () => ({
+  getAttachedProcedureDraft: vi.fn(),
+}))
+vi.mock('../../cache', () => ({
+  getCachedAgentById: vi.fn(),
+}))
+vi.mock('../../ai/agent-framework/effective-runtime', () => ({
+  buildEffectiveAgentRuntime: vi.fn(),
+}))
+vi.mock('../../ai/agent-framework/llm-adapter', () => ({
+  createCallModel: vi.fn(),
+}))
+vi.mock('../queries', () => ({
+  listEvalCasesByAgent: vi.fn(),
+}))
+
+// Stateful in-memory Redis fake so the draft-hash cache can be exercised.
+const redisStore = new Map<string, string>()
+const fakeRedis = {
+  get: vi.fn(async (k: string) => redisStore.get(k) ?? null),
+  setex: vi.fn(async (k: string, _ttl: number, v: string) => {
+    redisStore.set(k, v)
+    return 'OK'
+  }),
+}
+vi.mock('@auxx/redis', () => ({ getRedisClient: vi.fn(async () => fakeRedis) }))
+
+import { getAttachedProcedureDraft } from '../../agents/procedures/authoring/queries'
+import { buildEffectiveAgentRuntime } from '../../ai/agent-framework/effective-runtime'
+import type { AgentToolDefinition } from '../../ai/agent-framework/types'
+import { getCachedAgentById } from '../../cache'
+import { listEvalCasesByAgent } from '../queries'
+import type { CallModel } from '../simulation/persona'
+import { renderProcedureText, suggestAgentSimulations } from '../suggestions'
+
+const mockedDraft = getAttachedProcedureDraft as unknown as ReturnType<typeof vi.fn>
+const mockedAgent = getCachedAgentById as unknown as ReturnType<typeof vi.fn>
+const mockedRuntime = buildEffectiveAgentRuntime as unknown as ReturnType<typeof vi.fn>
+const mockedCases = listEvalCasesByAgent as unknown as ReturnType<typeof vi.fn>
+
+// A small effective toolset: a tool with a schema + example, a schema-less tool,
+// and a control tool (filtered out of the mockEditor projection).
+const TOOLS = [
+  {
+    name: 'get_order',
+    displayName: 'Get order',
+    description: 'Fetch an order by number',
+    outputSchema: z.object({ status: z.string() }),
+    exampleOutput: { status: 'shipped' },
+  },
+  {
+    name: 'issue_refund',
+    displayName: 'Issue refund',
+    description: 'Refund an order',
+  },
+  {
+    name: 'advance_procedure',
+    displayName: 'Advance procedure',
+    description: 'control signal',
+    category: 'control',
+  },
+] as unknown as AgentToolDefinition[]
+
+function stubModel(content: string, finishReason?: string): CallModel {
+  return async function* () {
+    yield {
+      type: 'done' as const,
+      content,
+      toolCalls: [],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      finishReason,
+    }
+  }
+}
+
+function validItem(over: Record<string, unknown> = {}) {
+  return {
+    name: 'Happy path',
+    rationale: 'exercises step 1',
+    openingMessage: 'hi I need help with my order',
+    customerContext: 'a frustrated customer',
+    channel: 'chat',
+    maxCustomerTurns: 3,
+    mocks: [],
+    assertions: [{ type: 'terminal_outcome', outcome: 'finished' }],
+    ...over,
+  }
+}
+
+function envelope(items: unknown[]): string {
+  return JSON.stringify({ suggestions: items })
+}
+
+const INPUT = { organizationId: 'org', userId: 'user', agentId: 'agent', procedureId: 'proc' }
+
+function run(content: string | CallModel, finishReason?: string) {
+  const callModel = typeof content === 'string' ? stubModel(content, finishReason) : content
+  return suggestAgentSimulations({ ...INPUT, callModel })
+}
+
+// biome-ignore lint/correctness/useYield: deliberately throws before yielding
+const throwingModel: CallModel = async function* () {
+  throw new Error('boom')
+}
+
+beforeEach(() => {
+  redisStore.clear()
+  mockedDraft.mockReset()
+  mockedAgent.mockReset()
+  mockedRuntime.mockReset()
+  mockedCases.mockReset()
+
+  mockedDraft.mockResolvedValue(
+    ok({
+      procedureId: 'proc',
+      name: 'Refund policy',
+      whenToUse: 'customer wants a refund',
+      triggerExamples: [],
+      ruleset: [],
+      hasUnpublishedChanges: false,
+      activeVersionId: 'v1',
+      enabled: true,
+      draftDoc: { type: 'doc', content: [] },
+      draftContentHash: 'hash123',
+    })
+  )
+  mockedAgent.mockResolvedValue({ procedures: [] })
+  mockedRuntime.mockResolvedValue({ tools: TOOLS, utilityModel: { provider: 'p', model: 'm' } })
+  mockedCases.mockResolvedValue(ok([]))
+})
+
+describe('suggestAgentSimulations — call + envelope', () => {
+  it('returns validated suggestions with generated ids and the draft hash', async () => {
+    const result = await run(envelope([validItem(), validItem({ name: 'Edge case' })]))
+    expect(result.isOk()).toBe(true)
+    const value = result._unsafeUnwrap()
+    expect(value.draftHash).toBe('hash123')
+    expect(value.dropped).toBe(0)
+    expect(value.suggestions).toHaveLength(2)
+    for (const s of value.suggestions) {
+      expect(s.suggestionId).toBeTruthy()
+      expect(s.assertions[0]?.id).toBeTruthy()
+      expect(s.config.unmatchedToolPolicy).toBe('error')
+    }
+  })
+
+  it('fails on non-JSON content', async () => {
+    const result = await run('not json at all')
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().code).toBe('EVAL_SUGGESTION_FAILED')
+  })
+
+  it('fails when the model output was truncated (finishReason length)', async () => {
+    const result = await run(envelope([validItem()]), 'length')
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toMatch(/truncated/)
+  })
+
+  it('fails on empty content', async () => {
+    const result = await run('')
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().code).toBe('EVAL_SUGGESTION_FAILED')
+  })
+
+  it('fails with a cause when the stream throws', async () => {
+    const result = await run(throwingModel)
+    expect(result.isErr()).toBe(true)
+    const error = result._unsafeUnwrapErr()
+    expect(error.code).toBe('EVAL_SUGGESTION_FAILED')
+    expect((error as { cause?: unknown }).cause).toBeInstanceOf(Error)
+  })
+
+  it('fails when the envelope lacks a suggestions array', async () => {
+    const result = await run(JSON.stringify({ foo: 1 }))
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().code).toBe('EVAL_SUGGESTION_FAILED')
+  })
+
+  it('slices to 5 when the model returns more', async () => {
+    const result = await run(envelope(Array.from({ length: 7 }, () => validItem())))
+    const value = result._unsafeUnwrap()
+    expect(value.suggestions).toHaveLength(5)
+    expect(value.dropped).toBe(0)
+  })
+
+  it('returns an empty list (not an error) when the model returns 0 items', async () => {
+    const result = await run(envelope([]))
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().suggestions).toHaveLength(0)
+  })
+
+  it('surfaces a draft-load failure as EVAL_VALIDATION', async () => {
+    mockedDraft.mockResolvedValue(err({ code: 'DB', message: 'PROCEDURE_NOT_ATTACHED' }))
+    const result = await run(envelope([validItem()]))
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().code).toBe('EVAL_VALIDATION')
+  })
+})
+
+describe('suggestAgentSimulations — drop pipeline', () => {
+  async function dropCase(bad: unknown) {
+    const result = await run(envelope([validItem(), bad]))
+    const value = result._unsafeUnwrap()
+    expect(value.suggestions).toHaveLength(1)
+    expect(value.dropped).toBe(1)
+    return value
+  }
+
+  it('drops a terminal_outcome missing its outcome', async () => {
+    await dropCase(validItem({ assertions: [{ type: 'terminal_outcome' }] }))
+  })
+
+  it('drops a stray crm_field assertion type', async () => {
+    await dropCase(
+      validItem({ assertions: [{ type: 'crm_field', ref: 'x', comparator: { op: 'equals' } }] })
+    )
+  })
+
+  it('drops an item carrying a stray startingFields key', async () => {
+    await dropCase(validItem({ startingFields: [] }))
+  })
+
+  it('drops a mock referencing an unknown tool', async () => {
+    await dropCase(validItem({ mocks: [{ toolName: 'nope', output: '{}' }] }))
+  })
+
+  it('drops a mock referencing a control tool (not in the projection)', async () => {
+    await dropCase(validItem({ mocks: [{ toolName: 'advance_procedure', output: '{}' }] }))
+  })
+
+  it('drops an unknown tool_called toolName', async () => {
+    await dropCase(validItem({ assertions: [{ type: 'tool_called', toolName: 'nope' }] }))
+  })
+
+  it('drops a mock whose output is not a JSON string', async () => {
+    await dropCase(validItem({ mocks: [{ toolName: 'get_order', output: 'not json' }] }))
+  })
+
+  it('drops a mock output that fails the tool output schema', async () => {
+    await dropCase(
+      validItem({ mocks: [{ toolName: 'get_order', output: JSON.stringify({ status: 123 }) }] })
+    )
+  })
+
+  it('keeps a mock for a schema-less tool (validation warning only)', async () => {
+    const result = await run(
+      envelope([
+        validItem({ mocks: [{ toolName: 'issue_refund', output: JSON.stringify({ ok: true }) }] }),
+      ])
+    )
+    const value = result._unsafeUnwrap()
+    expect(value.suggestions).toHaveLength(1)
+    expect(value.dropped).toBe(0)
+    expect(value.suggestions[0]?.config.connectorMocks).toHaveLength(1)
+  })
+
+  it('dedupes multiple mocks for one tool to the first, parsing the JSON output', async () => {
+    const result = await run(
+      envelope([
+        validItem({
+          mocks: [
+            { toolName: 'get_order', output: JSON.stringify({ status: 'shipped' }) },
+            { toolName: 'get_order', output: JSON.stringify({ status: 'pending' }) },
+          ],
+        }),
+      ])
+    )
+    const value = result._unsafeUnwrap()
+    expect(value.suggestions).toHaveLength(1)
+    const mocks = value.suggestions[0]?.config.connectorMocks ?? []
+    expect(mocks).toHaveLength(1)
+    expect(mocks[0]?.output).toEqual({ status: 'shipped' })
+    expect(mocks[0]?.usage).toBe('repeat')
+  })
+
+  it('clamps maxCustomerTurns into 1–8', async () => {
+    const result = await run(
+      envelope([validItem({ maxCustomerTurns: 50 }), validItem({ maxCustomerTurns: 0 })])
+    )
+    const value = result._unsafeUnwrap()
+    expect(value.suggestions.map((s) => s.config.maxCustomerTurns).sort()).toEqual([1, 8])
+  })
+
+  it('drops an item with no assertions', async () => {
+    await dropCase(validItem({ assertions: [] }))
+  })
+})
+
+describe('suggestAgentSimulations — draft-hash cache', () => {
+  it('serves a second call from cache without re-invoking the model', async () => {
+    const first = await run(envelope([validItem()]))
+    expect(first._unsafeUnwrap().suggestions).toHaveLength(1)
+
+    // A model that throws if called — proves the cached result was served.
+    const second = await suggestAgentSimulations({ ...INPUT, callModel: throwingModel })
+    expect(second.isOk()).toBe(true)
+    expect(second._unsafeUnwrap()).toEqual(first._unsafeUnwrap())
+  })
+
+  it('force bypasses the cache and regenerates', async () => {
+    await run(envelope([validItem({ name: 'Cached' })]))
+    const refreshed = await suggestAgentSimulations({
+      ...INPUT,
+      force: true,
+      callModel: stubModel(envelope([validItem({ name: 'A' }), validItem({ name: 'B' })])),
+    })
+    expect(refreshed._unsafeUnwrap().suggestions).toHaveLength(2)
+  })
+
+  it('regenerates when the draft hash changes (new cache key)', async () => {
+    await run(envelope([validItem()]))
+    mockedDraft.mockResolvedValue(
+      ok({
+        procedureId: 'proc',
+        name: 'Refund policy',
+        whenToUse: 'customer wants a refund',
+        triggerExamples: [],
+        ruleset: [],
+        hasUnpublishedChanges: false,
+        activeVersionId: 'v1',
+        enabled: true,
+        draftDoc: { type: 'doc', content: [] },
+        draftContentHash: 'hash999',
+      })
+    )
+    const next = await suggestAgentSimulations({
+      ...INPUT,
+      callModel: stubModel(envelope([validItem(), validItem()])),
+    })
+    expect(next._unsafeUnwrap().draftHash).toBe('hash999')
+    expect(next._unsafeUnwrap().suggestions).toHaveLength(2)
+  })
+})
+
+describe('renderProcedureText', () => {
+  it('renders the header, steps, conditions, routes, calls, opaque, and sub-procedures', () => {
+    const longText = 'x'.repeat(600)
+    const dsl = {
+      steps: [
+        { id: 's1', kind: 'instruction' as const, text: longText },
+        {
+          id: 'c1',
+          kind: 'condition' as const,
+          cases: [
+            {
+              id: 'ca1',
+              when: 'the order has shipped',
+              steps: [{ id: 'a1', kind: 'route' as const, outcome: 'finished' as const }],
+            },
+          ],
+          else: [{ id: 'e1', kind: 'route' as const, outcome: 'handoff' as const }],
+        },
+        {
+          id: 'sw',
+          kind: 'route' as const,
+          outcome: 'switch' as const,
+          switchToProcedureId: 'proc-9',
+        },
+        { id: 'cl', kind: 'call' as const, subProcedureId: 'sub-1' },
+        { id: 'op', kind: 'opaque' as const, label: 'code: compute total' },
+      ],
+      subProcedures: [
+        {
+          id: 'sub-1',
+          name: 'Verify identity',
+          steps: [{ id: 'v1', kind: 'instruction' as const, text: 'ask for the order number' }],
+        },
+      ],
+    }
+
+    const text = renderProcedureText(dsl, 'Refunds', 'when a refund is requested')
+
+    expect(text).toContain('Procedure: Refunds')
+    expect(text).toContain('When to use: when a refund is requested')
+    expect(text).toContain('1. ')
+    expect(text).toContain('…') // long instruction truncated
+    expect(text).not.toContain(longText) // full text not present
+    expect(text).toContain('IF the order has shipped')
+    expect(text).toContain('→ finish')
+    expect(text).toContain('ELSE')
+    expect(text).toContain('→ hand off')
+    expect(text).toContain('→ switch to procedure "proc-9"')
+    expect(text).toContain('→ run sub-procedure "Verify identity"')
+    expect(text).toContain('[code: compute total]')
+    expect(text).toContain('Sub-procedure "Verify identity":')
+    expect(text).toContain('ask for the order number')
+  })
+})

--- a/packages/lib/src/evals/editor-support.ts
+++ b/packages/lib/src/evals/editor-support.ts
@@ -54,16 +54,14 @@ async function resolveToolset(input: {
 }
 
 /**
- * The editor-facing projection of the agent's effective toolset: enough to list
- * each tool, seed a mock (example → scaffold), and flag read-only tools. Schemas
- * themselves never cross the wire; example/scaffold are precomputed here.
+ * Pure projection of an effective toolset into editor entries (mockEditor-visible
+ * only): enough to list each tool, seed a mock (example → scaffold), and flag
+ * read-only tools. Control tools are dropped. Schemas never cross the wire;
+ * example/scaffold are precomputed here. Extracted so the suggester (which
+ * resolves the runtime once for tools + `utilityModel` together) can reuse it
+ * without re-resolving the runtime.
  */
-export async function listAgentEffectiveTools(input: {
-  organizationId: string
-  userId: string
-  agentId: string
-}): Promise<EditorToolEntry[]> {
-  const tools = await resolveToolset(input)
+export function projectEditorToolEntries(tools: AgentToolDefinition[]): EditorToolEntry[] {
   const entries = tools
     // Drop control tools — they have no meaningful mock and run unwrapped in sims.
     .filter((t) => isToolVisibleOn(t, 'mockEditor'))
@@ -87,6 +85,19 @@ export async function listAgentEffectiveTools(input: {
     if (a.category !== b.category) return a.category === 'system' ? 1 : -1
     return a.displayName.localeCompare(b.displayName)
   })
+}
+
+/**
+ * The editor-facing projection of the agent's effective toolset: enough to list
+ * each tool, seed a mock (example → scaffold), and flag read-only tools. Schemas
+ * themselves never cross the wire; example/scaffold are precomputed here.
+ */
+export async function listAgentEffectiveTools(input: {
+  organizationId: string
+  userId: string
+  agentId: string
+}): Promise<EditorToolEntry[]> {
+  return projectEditorToolEntries(await resolveToolset(input))
 }
 
 /** Validate one authored mock output against its tool's declared `outputSchema`. */

--- a/packages/lib/src/evals/index.ts
+++ b/packages/lib/src/evals/index.ts
@@ -22,6 +22,7 @@ export { type CompareOutcome, evaluateComparator, MISSING } from './comparators'
 export {
   type EditorToolEntry,
   listAgentEffectiveTools,
+  projectEditorToolEntries,
   validateAgentToolMock,
 } from './editor-support'
 export {
@@ -109,6 +110,13 @@ export {
   stableHash,
   stripSecrets,
 } from './snapshots'
+export {
+  renderProcedureText,
+  type SimulationSuggestion,
+  type SuggestAgentSimulationsInput,
+  type SuggestResult,
+  suggestAgentSimulations,
+} from './suggestions'
 export { getToolExampleOutput } from './tool-examples'
 export type {
   EvalRunErrorCode,

--- a/packages/lib/src/evals/prepare-run.ts
+++ b/packages/lib/src/evals/prepare-run.ts
@@ -8,7 +8,8 @@
 
 import type { AgentEvalAssertion, AgentEvalTarget, SimulationConfig } from '@auxx/types/evals'
 import { err, ok, type Result } from 'neverthrow'
-import { getProcedureVersionById, readCompiled } from '../agents/procedures'
+import { compileProcedure, getProcedureVersionById, readCompiled } from '../agents/procedures'
+import { getAttachedProcedureDraft } from '../agents/procedures/authoring/queries'
 import { buildEffectiveAgentRuntime } from '../ai/agent-framework/effective-runtime'
 import { getCachedAgentById } from '../cache'
 import {
@@ -35,6 +36,14 @@ export interface PrepareRunInput {
     config: SimulationConfig
     assertions: AgentEvalAssertion[]
   }
+  /**
+   * `'pinned'` (default) runs the case's pinned `procedureVersionId` — the
+   * regression-gate semantics headless/CI callers rely on. `'draft'` (the
+   * Simulations editor surface) compiles the attached draft in-memory and runs
+   * that, stamping the snapshot so the run stays attributable. `scope: 'agent'`
+   * is unaffected by the mode in v1.
+   */
+  mode?: 'pinned' | 'draft'
 }
 
 /**
@@ -49,11 +58,12 @@ export async function prepareRunSnapshots(
   const { organizationId, userId } = input
   const { id, name, createdAt, target, config, assertions } = input.case
   const agentId = target.agentId
+  const mode = input.mode ?? 'pinned'
 
-  // Pin the compiled procedure set.
-  const procResult = await resolvePinnedProcedures(organizationId, target)
+  // Pin the compiled procedure set (or the compiled draft, in draft mode).
+  const procResult = await resolveProcedures(organizationId, target, mode)
   if (procResult.isErr()) return err(procResult.error)
-  const procedures = procResult.value
+  const { procedures, runMode, draftContentHash } = procResult.value
 
   // Resolve the effective runtime via the shared builder (no divergent copy).
   const runtime = await buildEffectiveAgentRuntime({
@@ -82,6 +92,8 @@ export async function prepareRunSnapshots(
     limits: { maxCustomerTurns: config.maxCustomerTurns, maxReinvokes: 8, maxIterations: 100 },
     time: { frozenAt: config.timeFrozenAt },
     codeRevision: getCodeRevision(),
+    runMode,
+    draftContentHash,
   })
 
   const definitionSnapshot = buildDefinitionSnapshot({
@@ -96,12 +108,28 @@ export async function prepareRunSnapshots(
   return ok({ definitionSnapshot, runtimeSnapshot })
 }
 
-/** Pin the compiled procedure(s) the run executes against. */
-async function resolvePinnedProcedures(
+interface ResolvedProcedures {
+  procedures: AgentRuntimeSnapshotV1['procedures']
+  runMode: 'pinned' | 'draft'
+  /** Present only when a draft was actually compiled and pinned. */
+  draftContentHash?: string
+}
+
+/** Resolve the compiled procedure(s) the run executes against, honoring `mode`. */
+async function resolveProcedures(
   organizationId: string,
-  target: AgentEvalTarget
-): Promise<Result<AgentRuntimeSnapshotV1['procedures'], EvalServiceError>> {
+  target: AgentEvalTarget,
+  mode: 'pinned' | 'draft'
+): Promise<Result<ResolvedProcedures, EvalServiceError>> {
   if (target.scope === 'procedure') {
+    // Draft mode: compile the attached draft in-memory and pin THAT, leaving the
+    // case's pinned `procedureVersionId` untouched as the record-keeping anchor.
+    if (mode === 'draft') {
+      const drafted = await resolveDraftProcedure(organizationId, target)
+      // No draft / not attached → fall back to pinned (preserves regression-gate).
+      if (drafted) return drafted
+    }
+
     const version = await getProcedureVersionById({
       organizationId,
       procedureVersionId: target.procedureVersionId,
@@ -120,16 +148,50 @@ async function resolvePinnedProcedures(
         message: `Pinned procedure version is not compiled: ${target.procedureVersionId}`,
       })
     }
-    return ok([{ id: target.procedureId, versionId: target.procedureVersionId, compiled }])
+    return ok({
+      procedures: [{ id: target.procedureId, versionId: target.procedureVersionId, compiled }],
+      runMode: 'pinned',
+    })
   }
 
   // Agent scope: pin every procedure the agent can select, each at its run-time
   // (currently active) compiled version — read from the org cache projection.
+  // Unchanged by the run mode in v1.
   const agent = await getCachedAgentById(organizationId, target.agentId)
   const procedures = (agent?.procedures ?? []).map((p) => ({
     id: p.procedureId,
     versionId: p.activeVersionId,
     compiled: p.compiled,
   }))
-  return ok(procedures)
+  return ok({ procedures, runMode: 'pinned' })
+}
+
+/**
+ * Compile the attached draft for a procedure-scope target and pin it. Returns
+ * `null` when no usable draft exists (the caller then falls back to the pinned
+ * version); a draft that fails to compile is a hard `EVAL_VALIDATION` so the run
+ * doesn't silently execute a different graph.
+ */
+async function resolveDraftProcedure(
+  organizationId: string,
+  target: Extract<AgentEvalTarget, { scope: 'procedure' }>
+): Promise<Result<ResolvedProcedures, EvalServiceError> | null> {
+  const draftResult = await getAttachedProcedureDraft({
+    organizationId,
+    agentId: target.agentId,
+    procedureId: target.procedureId,
+  })
+  if (draftResult.isErr()) return null
+  const { compiled, contentHash, errors } = compileProcedure(draftResult.value.draftDoc)
+  if (errors && errors.length > 0) {
+    return err({
+      code: 'EVAL_VALIDATION',
+      message: `Draft does not compile: ${errors.map((e) => e.message).join('; ')}`,
+    })
+  }
+  return ok({
+    procedures: [{ id: target.procedureId, versionId: target.procedureVersionId, compiled }],
+    runMode: 'draft',
+    draftContentHash: contentHash,
+  })
 }

--- a/packages/lib/src/evals/runtime-snapshot.ts
+++ b/packages/lib/src/evals/runtime-snapshot.ts
@@ -62,6 +62,15 @@ export interface AgentRuntimeSnapshotV1 {
   mockPolicy: 'error' | 'passthrough_readonly'
   limits: { maxCustomerTurns: number; maxReinvokes: number; maxIterations: number }
   time: { frozenAt: string | null; scope: 'framework_visible' }
+  /**
+   * Which procedure source the run executed. `'pinned'` (default) runs the case's
+   * pinned `procedureVersionId`; `'draft'` runs the attached draft compiled
+   * in-memory at prepare time. Stamped so historical runs stay attributable
+   * (like `test_version_id`); the run detail shows a Draft badge from this.
+   */
+  runMode: 'pinned' | 'draft'
+  /** The compiler's stable `contentHash` of the draft, present only for `runMode: 'draft'`. */
+  draftContentHash?: string
 }
 
 /** Deployed code revision, read from the standard platform env vars (best-effort). */
@@ -103,6 +112,10 @@ export interface CreateAgentRuntimeSnapshotInput {
   limits: { maxCustomerTurns: number; maxReinvokes: number; maxIterations: number }
   time: { frozenAt: string | null }
   codeRevision?: string
+  /** Defaults to `'pinned'`. */
+  runMode?: 'pinned' | 'draft'
+  /** The compiler's stable `contentHash` of the draft (draft mode only). */
+  draftContentHash?: string
 }
 
 /**
@@ -135,6 +148,8 @@ export function createAgentRuntimeSnapshot(
     mockPolicy: input.mockPolicy,
     limits: input.limits,
     time: { frozenAt: input.time.frozenAt, scope: 'framework_visible' },
+    runMode: input.runMode ?? 'pinned',
+    ...(input.draftContentHash ? { draftContentHash: input.draftContentHash } : {}),
   }
 }
 

--- a/packages/lib/src/evals/suggestions.ts
+++ b/packages/lib/src/evals/suggestions.ts
@@ -1,0 +1,706 @@
+// packages/lib/src/evals/suggestions.ts
+//
+// LLM-first suggester for agent Simulations (plans/evals/phase-3-suggester.md v1,
+// file-by-file in phase-3a-suggester-backend.md). One utility-model call reads the
+// draft procedure + effective toolset + existing cases and emits a flat authoring
+// shape; the server maps that into the persisted `SimulationConfig` /
+// `AgentEvalAssertion` contracts and drops anything that fails validation. Nothing
+// is persisted — suggestions live only in this response until the UI accepts one
+// via `eval.create`.
+
+import type { EvalCaseEntity } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getRedisClient } from '@auxx/redis'
+import type { AgentEvalAssertion, SimulationConfig, SimulationToolMock } from '@auxx/types/evals'
+import { agentEvalAssertionsSchema, simulationConfigSchema } from '@auxx/types/evals/schema'
+import { generateId } from '@auxx/utils'
+import { err, ok, type Result } from 'neverthrow'
+import { z } from 'zod'
+import { docToDsl } from '../agents/procedures/authoring/doc-to-dsl'
+import type { ProcedureDsl, ProcedureDslStep } from '../agents/procedures/authoring/dsl'
+import { getAttachedProcedureDraft } from '../agents/procedures/authoring/queries'
+import { isToolVisibleOn } from '../agents/tool-visibility'
+import { buildEffectiveAgentRuntime } from '../ai/agent-framework/effective-runtime'
+import { createCallModel } from '../ai/agent-framework/llm-adapter'
+import type { AgentToolDefinition, LLMCallParams } from '../ai/agent-framework/types'
+import type { Message } from '../ai/clients/base/types'
+import { getCachedAgentById } from '../cache'
+import { type EditorToolEntry, projectEditorToolEntries } from './editor-support'
+import { listEvalCasesByAgent } from './queries'
+import { validateMockOutput } from './simulation/mock-tools'
+import type { CallModel } from './simulation/persona'
+import type { EvalServiceError } from './types'
+
+const logger = createScopedLogger('eval-suggester')
+
+/** A complete, schema-valid proposed simulation case, ready for `eval.create`. */
+export interface SimulationSuggestion {
+  /** Ephemeral provenance — stamped onto the case when accepted. */
+  suggestionId: string
+  name: string
+  /** One line: which path/behavior this exercises. */
+  rationale: string
+  config: SimulationConfig
+  assertions: AgentEvalAssertion[]
+}
+
+export interface SuggestResult {
+  /** Content hash of the draft these suggestions were generated from (cache key). */
+  draftHash: string
+  suggestions: SimulationSuggestion[]
+  /** How many emitted items failed validation and were discarded. */
+  dropped: number
+}
+
+export interface SuggestAgentSimulationsInput {
+  organizationId: string
+  userId: string
+  agentId: string
+  procedureId: string
+  /** Bypass the Redis cache and regenerate (the UI's Refresh action). */
+  force?: boolean
+  /** DI seam for tests — defaults to `createCallModel(...)`. */
+  callModel?: CallModel
+  signal?: AbortSignal
+}
+
+/**
+ * Generate up to 5 validated simulation suggestions for the procedure the author
+ * is editing. A failed/unusable model call returns `EVAL_SUGGESTION_FAILED`;
+ * per-item problems never throw — they increment `dropped`. Zero valid items is a
+ * success with an empty list.
+ */
+export async function suggestAgentSimulations(
+  input: SuggestAgentSimulationsInput
+): Promise<Result<SuggestResult, EvalServiceError>> {
+  const { organizationId, userId, agentId, procedureId } = input
+
+  // 1. Draft doc + metadata (enforces attachment / cross-org via the query).
+  const draftResult = await getAttachedProcedureDraft({ organizationId, agentId, procedureId })
+  if (draftResult.isErr()) {
+    return err({
+      code: 'EVAL_VALIDATION',
+      message: errorMessage(draftResult.error, 'Could not load the procedure draft'),
+      cause: draftResult.error,
+    })
+  }
+  const draft = draftResult.value
+  const draftHash = draft.draftContentHash
+
+  // Content-keyed cache: identical draft → reuse the generation across reloads and
+  // users instead of re-spending tokens. Refresh (`force`) bypasses it.
+  const cacheKey = suggestionCacheKey(organizationId, agentId, procedureId, draftHash)
+  if (!input.force) {
+    const cached = await readCachedSuggestions(cacheKey)
+    if (cached) {
+      logger.info('suggestions cache hit', { procedureId, draftHash })
+      return ok(cached)
+    }
+  }
+
+  // 2. Effective runtime, resolved ONCE — tools + utilityModel come from the same
+  //    build `prepare-run` uses. Runtime build is infra, not user input.
+  let toolMap: Map<string, AgentToolDefinition>
+  let toolEntries: EditorToolEntry[]
+  let utilityModel: { provider: string; model: string }
+  try {
+    const agent = await getCachedAgentById(organizationId, agentId)
+    const hasProcedures = (agent?.procedures ?? []).length > 0
+    const runtime = await buildEffectiveAgentRuntime({
+      organizationId,
+      userId,
+      sessionId: `eval-suggest-${agentId}`,
+      agentId,
+      domain: 'kopilot',
+      hasProcedures,
+    })
+    // Map over the mockEditor-visible (projected) names only — control tools are
+    // invalid mock/assertion targets by construction.
+    const visibleTools = runtime.tools.filter((t) => isToolVisibleOn(t, 'mockEditor'))
+    toolMap = new Map(visibleTools.map((t) => [t.name, t]))
+    toolEntries = projectEditorToolEntries(runtime.tools)
+    utilityModel = runtime.utilityModel
+  } catch (cause) {
+    return err({
+      code: 'EVAL_SUGGESTION_FAILED',
+      message: 'Could not build the agent runtime',
+      cause,
+    })
+  }
+
+  // 3. Existing cases for the procedure — fed to the prompt so the model proposes
+  //    what is not yet covered (the LLM-native replacement for structural dedup).
+  const casesResult = await listEvalCasesByAgent({ organizationId, agentId, procedureId })
+  if (casesResult.isErr()) {
+    return err({
+      code: 'EVAL_SUGGESTION_FAILED',
+      message: 'Could not list existing eval cases',
+      cause: casesResult.error,
+    })
+  }
+  const existing = projectExistingCases(casesResult.value)
+
+  // Render the draft DSL into an indented outline the model can read.
+  const procedureText = renderProcedureText(docToDsl(draft.draftDoc), draft.name, draft.whenToUse)
+
+  // 4. The single structured call.
+  const callModel =
+    input.callModel ??
+    createCallModel({ organizationId, userId, source: 'eval', sourceId: `suggest-${procedureId}` })
+  const messages: Message[] = [
+    { role: 'system', content: SYSTEM_PROMPT },
+    { role: 'user', content: buildUserMessage(procedureText, toolEntries, existing) },
+  ]
+  const params: LLMCallParams = {
+    provider: utilityModel.provider,
+    model: utilityModel.model,
+    messages,
+    responseFormat: SUGGESTIONS_RESPONSE_SCHEMA,
+    signal: input.signal,
+  }
+
+  let content = ''
+  let finishReason: string | undefined
+  let usage: unknown
+  try {
+    for await (const event of callModel(params)) {
+      if (event.type === 'done') {
+        content = event.content
+        finishReason = event.finishReason
+        usage = event.usage
+      }
+    }
+  } catch (cause) {
+    return err({ code: 'EVAL_SUGGESTION_FAILED', message: 'Suggestion model call failed', cause })
+  }
+
+  // A truncated JSON array must not be repaired — fail the whole call.
+  if (finishReason === 'length') {
+    return err({ code: 'EVAL_SUGGESTION_FAILED', message: 'model output truncated' })
+  }
+  if (!content.trim()) {
+    return err({ code: 'EVAL_SUGGESTION_FAILED', message: 'model returned empty output' })
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch (cause) {
+    return err({ code: 'EVAL_SUGGESTION_FAILED', message: 'model returned non-JSON', cause })
+  }
+
+  // Lenient outer parse — item strictness is per-item so one bad item can't sink
+  // the batch.
+  const envelope = z.object({ suggestions: z.array(z.unknown()) }).safeParse(parsed)
+  if (!envelope.success) {
+    return err({
+      code: 'EVAL_SUGGESTION_FAILED',
+      message: 'model output is missing a suggestions array',
+      cause: envelope.error,
+    })
+  }
+
+  // Belt for a prompt-ignoring model.
+  const rawItems = envelope.data.suggestions.slice(0, 5)
+  const suggestions: SimulationSuggestion[] = []
+  let dropped = 0
+  for (let i = 0; i < rawItems.length; i++) {
+    const mapped = mapAndValidateItem(rawItems[i], toolMap, i)
+    if (mapped) suggestions.push(mapped)
+    else dropped++
+  }
+
+  logger.info('suggestions generated', { kept: suggestions.length, dropped, usage })
+  const out: SuggestResult = { draftHash, suggestions, dropped }
+  await writeCachedSuggestions(cacheKey, out)
+  return ok(out)
+}
+
+// ── Redis cache (content-keyed by draftHash; degrades to no-op) ─────────────
+
+/** TTL for a cached generation — content-keyed, so edits naturally rotate the key. */
+const SUGGESTION_CACHE_TTL_SECONDS = 60 * 60 // 1 hour
+
+function suggestionCacheKey(
+  orgId: string,
+  agentId: string,
+  procedureId: string,
+  draftHash: string
+): string {
+  return `eval:suggest:${orgId}:${agentId}:${procedureId}:${draftHash}`
+}
+
+/** Read a cached result; any Redis problem (incl. unavailable) is a cache miss. */
+async function readCachedSuggestions(key: string): Promise<SuggestResult | null> {
+  try {
+    const client = await getRedisClient(false)
+    if (!client) return null
+    const raw = await client.get(key)
+    return raw ? (JSON.parse(raw) as SuggestResult) : null
+  } catch (error) {
+    logger.warn('suggestion cache read failed', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+/** Cache a result under its draft-hash key; failures are swallowed (best-effort). */
+async function writeCachedSuggestions(key: string, value: SuggestResult): Promise<void> {
+  try {
+    const client = await getRedisClient(false)
+    if (!client) return
+    await client.setex(key, SUGGESTION_CACHE_TTL_SECONDS, JSON.stringify(value))
+  } catch (error) {
+    logger.warn('suggestion cache write failed', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+// ── Existing-case projection ───────────────────────────────────────────────
+
+interface ExistingCaseHint {
+  name: string
+  openingMessage: string
+  assertionTypes: string[]
+}
+
+/** Project saved cases to the prompt hint, skipping rows that don't parse. */
+function projectExistingCases(rows: EvalCaseEntity[]): ExistingCaseHint[] {
+  const out: ExistingCaseHint[] = []
+  for (const row of rows) {
+    const config = simulationConfigSchema.safeParse(row.config)
+    const assertions = agentEvalAssertionsSchema.safeParse(row.assertions)
+    if (!config.success || !assertions.success) continue
+    out.push({
+      name: row.name,
+      openingMessage: config.data.openingMessage,
+      assertionTypes: [...new Set(assertions.data.map((a) => a.type))],
+    })
+  }
+  return out
+}
+
+// ── DSL rendering (pure) ───────────────────────────────────────────────────
+
+const MAX_INSTRUCTION_CHARS = 500
+const MAX_EXAMPLE_CHARS = 1000
+
+/**
+ * Render a {@link ProcedureDsl} tree into an indented, numbered outline. The
+ * numbering gives the model stable referents for `rationale`. Pure — no I/O.
+ */
+export function renderProcedureText(dsl: ProcedureDsl, name: string, whenToUse: string): string {
+  const lines: string[] = [`Procedure: ${name}`, `When to use: ${whenToUse}`, '']
+  renderSteps(dsl.steps, '', lines, dsl)
+  for (const sp of dsl.subProcedures ?? []) {
+    lines.push('', `Sub-procedure "${sp.name || sp.id}":`)
+    renderSteps(sp.steps, '', lines, dsl)
+  }
+  return lines.join('\n')
+}
+
+function renderSteps(
+  steps: ProcedureDslStep[],
+  prefix: string,
+  lines: string[],
+  dsl: ProcedureDsl
+): void {
+  steps.forEach((step, i) => renderStep(step, `${prefix}${i + 1}`, lines, dsl))
+}
+
+function renderStep(step: ProcedureDslStep, num: string, lines: string[], dsl: ProcedureDsl): void {
+  const depth = (num.match(/\./g) ?? []).length
+  const indent = '  '.repeat(depth)
+
+  switch (step.kind) {
+    case 'instruction':
+      lines.push(`${indent}${num}. ${truncate(step.text, MAX_INSTRUCTION_CHARS)}`)
+      return
+    case 'route':
+      lines.push(`${indent}${num}. ${renderRoute(step)}`)
+      return
+    case 'call': {
+      const sub = dsl.subProcedures?.find((s) => s.id === step.subProcedureId)
+      lines.push(`${indent}${num}. → run sub-procedure "${sub?.name || step.subProcedureId}"`)
+      return
+    }
+    case 'opaque':
+      lines.push(`${indent}${num}. [${step.label}]`)
+      return
+    case 'condition': {
+      step.cases.forEach((c, ci) => {
+        lines.push(`${indent}${num}. ${ci === 0 ? 'IF' : 'ELSE IF'} ${c.when}`)
+        renderSteps(c.steps, `${num}.`, lines, dsl)
+      })
+      if (step.else !== undefined) {
+        lines.push(`${indent}ELSE`)
+        renderSteps(step.else, `${num}.`, lines, dsl)
+      }
+      return
+    }
+  }
+}
+
+function renderRoute(step: Extract<ProcedureDslStep, { kind: 'route' }>): string {
+  switch (step.outcome) {
+    case 'finished':
+      return '→ finish'
+    case 'handoff':
+      return '→ hand off'
+    case 'switch':
+      return `→ switch to procedure "${step.switchToProcedureId}"`
+  }
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text
+}
+
+// ── Prompt ─────────────────────────────────────────────────────────────────
+
+const SYSTEM_PROMPT = [
+  'You design test simulations for an AI customer-support agent that follows a',
+  'written procedure.',
+  '',
+  'How a simulation runs: a synthetic customer persona improvises a conversation',
+  'starting from the opening message, guided by the customer context (their',
+  "situation, tone, and what information they do or don't have). When the agent",
+  'calls a tool, the simulation answers with the mock output you provide instead',
+  'of a live system. After the conversation ends, each assertion is checked.',
+  '',
+  'Assertion types:',
+  '- terminal_outcome: how the procedure ends — finished | handoff | switch',
+  "- response_criteria: statements about what the agent's replies must contain;",
+  '  write each criterion as ONE independently checkable statement',
+  '- tool_called / tool_not_called: whether the agent invoked a named tool',
+  '',
+  'Rules:',
+  '- Propose at most 5 simulations; fewer if the procedure is trivial.',
+  '- Each simulation must exercise a DISTINCT path: the happy path, each major',
+  '  condition arm, a customer missing required information, an edge/refusal case.',
+  '- Do not duplicate the existing simulations listed.',
+  '- toolName values must come from the tool list, exactly as written.',
+  '- Each mock "output" must be a JSON STRING following the tool\'s example output',
+  '  shape, e.g. "{\\"status\\":\\"shipped\\"}".',
+  '- Set customerContext so the persona can actually play the path (what they',
+  '  know, what they want, what they refuse to provide).',
+  '- channel is "chat" unless the procedure is clearly about email.',
+  '- rationale: one line naming the step/branch the simulation exercises.',
+  '- Every simulation must include at least one assertion.',
+].join('\n')
+
+function buildUserMessage(
+  procedureText: string,
+  toolEntries: EditorToolEntry[],
+  existing: ExistingCaseHint[]
+): string {
+  const toolsBlock =
+    toolEntries.length > 0
+      ? toolEntries
+          .map((t) => {
+            const example = t.example ?? t.scaffold
+            const exampleText =
+              example === undefined
+                ? 'none declared'
+                : truncate(JSON.stringify(example), MAX_EXAMPLE_CHARS)
+            return `### ${t.displayName} (\`${t.name}\`)\n${t.description}\nExample output: ${exampleText}`
+          })
+          .join('\n\n')
+      : 'No tools are available to this agent.'
+
+  const existingBlock =
+    existing.length > 0
+      ? existing
+          .map(
+            (c) =>
+              `- "${c.name}" — opens with: "${c.openingMessage}" — checks: ${c.assertionTypes.join(', ')}`
+          )
+          .join('\n')
+      : 'None yet.'
+
+  return [
+    '## Procedure (what the agent follows)',
+    procedureText,
+    '',
+    '## Tools available to the agent',
+    toolsBlock,
+    '',
+    '## Existing simulations (do not duplicate)',
+    existingBlock,
+  ].join('\n')
+}
+
+// ── Structured-output contracts (provider literal + Zod twin, kept adjacent) ──
+
+/**
+ * Provider-facing JSON-schema literal (same pattern as `JUDGE_RESPONSE_SCHEMA`).
+ * Assertions are ONE object shape with optional per-type fields — provider
+ * `oneOf` support is inconsistent. Only a hint: {@link authoringSuggestionSchema}
+ * is authoritative.
+ */
+const SUGGESTIONS_RESPONSE_SCHEMA = {
+  type: 'json_schema' as const,
+  jsonSchema: {
+    name: 'simulation_suggestions',
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['suggestions'],
+      properties: {
+        suggestions: {
+          type: 'array',
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            required: [
+              'name',
+              'rationale',
+              'openingMessage',
+              'customerContext',
+              'channel',
+              'maxCustomerTurns',
+              'mocks',
+              'assertions',
+            ],
+            properties: {
+              name: { type: 'string' },
+              rationale: { type: 'string' },
+              openingMessage: { type: 'string' },
+              customerContext: { type: ['string', 'null'] },
+              channel: { type: 'string', enum: ['chat', 'email'] },
+              maxCustomerTurns: { type: 'integer' },
+              mocks: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['toolName', 'output'],
+                  properties: {
+                    toolName: { type: 'string' },
+                    // A JSON-encoded string — structured-output providers (OpenAI)
+                    // reject a schemaless "any" property, so the mock output rides
+                    // as text and is JSON.parsed + schema-checked server-side.
+                    output: {
+                      type: 'string',
+                      description: "The tool's mock output, encoded as a JSON string.",
+                    },
+                  },
+                },
+              },
+              assertions: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  additionalProperties: false,
+                  // Strict structured output requires EVERY key in `required`, so
+                  // the per-type fields are nullable rather than optional — the
+                  // model emits `null` for the ones its `type` doesn't use, and the
+                  // Zod twin validates which field each type actually needs.
+                  required: ['type', 'outcome', 'criteria', 'toolName'],
+                  properties: {
+                    type: {
+                      type: 'string',
+                      enum: [
+                        'terminal_outcome',
+                        'response_criteria',
+                        'tool_called',
+                        'tool_not_called',
+                      ],
+                    },
+                    outcome: { type: ['string', 'null'] },
+                    criteria: { type: ['array', 'null'], items: { type: 'string' } },
+                    toolName: { type: ['string', 'null'] },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+/**
+ * Zod twin used to parse each emitted item. The assertion is a single `.strict()`
+ * object whose per-type fields are nullable (mirroring the strict provider schema),
+ * with a `superRefine` that requires exactly the field each `type` needs — so a
+ * `terminal_outcome` without `outcome` fails. `type` is a closed enum (no
+ * `crm_field`/`local_variable`/`procedure_selected`) and the suggestion object is
+ * `.strict()` (no `startingFields`/`subject`/`timeFrozenAt`), so any stray output
+ * fails the item's parse and is dropped. This IS the v1 allowlist; no strip pass.
+ */
+const authoringAssertionSchema = z
+  .object({
+    type: z.enum(['terminal_outcome', 'response_criteria', 'tool_called', 'tool_not_called']),
+    outcome: z.enum(['finished', 'handoff', 'switch']).nullish(),
+    criteria: z.array(z.string().min(1)).nullish(),
+    toolName: z.string().min(1).nullish(),
+  })
+  .strict()
+  .superRefine((a, ctx) => {
+    if (a.type === 'terminal_outcome' && !a.outcome) {
+      ctx.addIssue({ code: 'custom', message: 'terminal_outcome requires an outcome' })
+    }
+    if (a.type === 'response_criteria' && (!a.criteria || a.criteria.length === 0)) {
+      ctx.addIssue({ code: 'custom', message: 'response_criteria requires criteria' })
+    }
+    if ((a.type === 'tool_called' || a.type === 'tool_not_called') && !a.toolName) {
+      ctx.addIssue({ code: 'custom', message: `${a.type} requires a toolName` })
+    }
+  })
+
+const authoringSuggestionSchema = z
+  .object({
+    name: z.string().min(1),
+    rationale: z.string().min(1),
+    openingMessage: z.string().min(1),
+    customerContext: z.string().nullable(),
+    channel: z.enum(['chat', 'email']),
+    maxCustomerTurns: z.number().int(),
+    mocks: z.array(
+      z
+        .object({
+          toolName: z.string().min(1),
+          // The model emits the output as a JSON string (provider schema constraint);
+          // parse it here so a malformed string drops the item at this gate.
+          output: z.string().transform((s, ctx): unknown => {
+            try {
+              return JSON.parse(s)
+            } catch {
+              ctx.addIssue({ code: 'custom', message: 'mock output must be a JSON string' })
+              return z.NEVER
+            }
+          }),
+        })
+        .strict()
+    ),
+    assertions: z.array(authoringAssertionSchema).min(1),
+  })
+  .strict()
+
+type AuthoringSuggestion = z.infer<typeof authoringSuggestionSchema>
+
+// ── Per-item mapping + validation (the drop pipeline) ──────────────────────
+
+/**
+ * Map+validate one raw item into a persisted-shape suggestion. First failure
+ * drops the item (returns null) and logs `{ index, reason }`. Order matches
+ * phase-3a §3.6.
+ */
+function mapAndValidateItem(
+  raw: unknown,
+  toolMap: Map<string, AgentToolDefinition>,
+  index: number
+): SimulationSuggestion | null {
+  // 1. Shape + allowlist.
+  const parsed = authoringSuggestionSchema.safeParse(raw)
+  if (!parsed.success)
+    return drop(index, `invalid shape: ${parsed.error.issues[0]?.message ?? 'parse error'}`)
+  const item: AuthoringSuggestion = parsed.data
+
+  // 2. Tool-name existence (mocks + tool_(not_)called assertions).
+  for (const mock of item.mocks) {
+    if (!toolMap.has(mock.toolName)) return drop(index, `unknown mock tool "${mock.toolName}"`)
+  }
+  for (const a of item.assertions) {
+    if (a.type === 'tool_called' || a.type === 'tool_not_called') {
+      // toolName presence is guaranteed by the schema's superRefine.
+      if (!a.toolName || !toolMap.has(a.toolName)) {
+        return drop(index, `unknown assertion tool "${a.toolName}"`)
+      }
+    }
+  }
+
+  // 3. Mock outputs against each tool's declared outputSchema (warning is fine).
+  for (const mock of item.mocks) {
+    const tool = toolMap.get(mock.toolName)!
+    const validation = validateMockOutput(tool, mock.output)
+    if (!validation.ok)
+      return drop(index, `bad mock output for "${mock.toolName}": ${validation.error}`)
+  }
+
+  // 4. Dedupe mocks by toolName (first wins — drawer's one-mock-per-tool model).
+  const seenTools = new Set<string>()
+  const connectorMocks: SimulationToolMock[] = []
+  for (const mock of item.mocks) {
+    if (seenTools.has(mock.toolName)) continue
+    seenTools.add(mock.toolName)
+    connectorMocks.push({
+      id: generateId(),
+      toolName: mock.toolName,
+      output: mock.output,
+      usage: 'repeat',
+    })
+  }
+
+  // 5. Map to persisted shapes.
+  const assertions: AgentEvalAssertion[] = item.assertions.map((a) => mapAssertion(a))
+  const config: SimulationConfig = {
+    openingMessage: item.openingMessage,
+    customerContext: item.customerContext,
+    channel: item.channel,
+    timeFrozenAt: null,
+    maxCustomerTurns: Math.min(8, Math.max(1, item.maxCustomerTurns)),
+    subject: { recordIds: [], identityVerified: false },
+    startingFields: [],
+    // Mocked-path suggestions should fail loudly on an unexpected tool call.
+    unmatchedToolPolicy: 'error',
+    connectorMocks,
+  }
+
+  // 6. Final gate — the same contracts `eval.create` enforces. Failure here is a
+  //    mapping bug, not a model problem: drop AND warn.
+  const configCheck = simulationConfigSchema.safeParse(config)
+  const assertionsCheck = agentEvalAssertionsSchema.safeParse(assertions)
+  if (!configCheck.success || !assertionsCheck.success) {
+    logger.warn('mapped suggestion failed the final schema gate', {
+      index,
+      config: configCheck.success ? undefined : configCheck.error.issues,
+      assertions: assertionsCheck.success ? undefined : assertionsCheck.error.issues,
+    })
+    return null
+  }
+
+  return {
+    suggestionId: generateId(),
+    name: item.name,
+    rationale: item.rationale,
+    config: configCheck.data,
+    assertions: assertionsCheck.data,
+  }
+}
+
+/**
+ * Wrap one authoring assertion into the persisted discriminated-union envelope.
+ * The per-type field is guaranteed present by the schema's superRefine, so the
+ * non-null assertions here can never fire at runtime.
+ */
+function mapAssertion(a: AuthoringSuggestion['assertions'][number]): AgentEvalAssertion {
+  const id = generateId()
+  switch (a.type) {
+    case 'terminal_outcome':
+      return { id, type: 'terminal_outcome', data: { outcome: a.outcome! } }
+    case 'response_criteria':
+      return { id, type: 'response_criteria', data: { criteria: a.criteria! } }
+    case 'tool_called':
+      return { id, type: 'tool_called', data: { toolName: a.toolName! } }
+    case 'tool_not_called':
+      return { id, type: 'tool_not_called', data: { toolName: a.toolName! } }
+  }
+}
+
+function drop(index: number, reason: string): null {
+  logger.info('dropped suggestion', { index, reason })
+  return null
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error
+    ? error.message
+    : typeof (error as { message?: unknown })?.message === 'string'
+      ? (error as { message: string }).message
+      : fallback
+}

--- a/packages/lib/src/evals/types.ts
+++ b/packages/lib/src/evals/types.ts
@@ -12,6 +12,13 @@ export type EvalServiceError =
   | { code: 'EVAL_CASE_NOT_FOUND'; message: string }
   | { code: 'EVAL_RUN_NOT_FOUND'; message: string }
   | { code: 'EVAL_SUITE_RUN_NOT_FOUND'; message: string }
+  /**
+   * The suggestion call itself was unusable — model error, truncated output, or
+   * unparseable top-level JSON. Per-item problems never produce this; they
+   * increment the result's `dropped` count. Zero valid suggestions is NOT an
+   * error: that returns `{ suggestions: [], dropped: n }`.
+   */
+  | { code: 'EVAL_SUGGESTION_FAILED'; message: string; cause?: unknown }
 
 /**
  * Run-level execution/grading failure codes (persisted to `EvalRun.errorCode`).

--- a/packages/ui/src/components/tree-row.tsx
+++ b/packages/ui/src/components/tree-row.tsx
@@ -112,13 +112,15 @@ export function TreeRow({
           onClick={expandable ? onToggleOpen : undefined}>
           <div className='flex items-center flex-1 min-w-0'>
             {icon !== undefined && (
-              <span className='flex items-center justify-center px-1 size-7 text-muted-foreground'>
+              <span className='flex items-center justify-center px-1 size-7 text-muted-foreground shrink-0'>
                 {icon}
               </span>
             )}
 
             {titleNode}
-            {description && <TooltipExplanation text={description} className='text-primary-400' />}
+            {description && (
+              <TooltipExplanation text={description} className='text-primary-400 shrink-0' />
+            )}
             {secondary && (
               <span className='ml-1 truncate text-primary-400 text-sm'>{secondary}</span>
             )}


### PR DESCRIPTION
## What

Procedure-scoped Simulations now get **AI-proposed test cases** and can **run against the attached draft** straight from the editor surface.

## Suggester (`eval.suggest`)

- One utility-model call reads the draft procedure (rendered as an indented outline), the effective toolset, and existing cases, then emits validated simulation cases.
- Per-item **drop pipeline**: shape allowlist → tool-name existence → mock-output schema check → mock dedup. One bad item can't sink the batch; **zero valid items is success**, not an error. A truncated/unparseable top-level response fails the whole call (`EVAL_SUGGESTION_FAILED`).
- Content-keyed **Redis cache** by draft hash (degrades to no-op if Redis is down); **Refresh** forces regeneration.
- Exposed as a mutation (spends tokens, non-idempotent); gated by `evalAdminProcedure`.

## Draft-mode runs

- `prepareRunSnapshots` gains `mode: 'pinned' | 'draft'`. Draft compiles the attached procedure draft in-memory and pins **that**, stamping `runMode` + `draftContentHash` on the runtime snapshot — the pinned `procedureVersionId` stays the record-keeping anchor.
- Falls back to pinned when no draft is attached; **hard `EVAL_VALIDATION`** when the draft won't compile (never silently runs a different graph).
- `eval.run` / `eval.runAll` take `useDraft`. The Simulations editor always passes `true`; headless/CI default to `pinned` (the regression gate).

## UI

- Suite split into **Agent simulations** and **Procedure simulations** sections, each with its own New / Run-all.
- Case rows are now expandable with **per-run history**; clicking a run drills to its detail.
- New **Suggested simulations** section (procedure-scoped view): auto-generates once per procedure, cached in a session Zustand store so remounts don't re-spend tokens.
- Run detail switches from tabs to stacked collapsible sections; a **Draft** badge marks draft runs.

## Tests

- `suggestions.test.ts` — drop pipeline, slicing, cache hit/force/hash-change, `renderProcedureText` (25 tests).
- `prepare-run.test.ts` — pinned default, draft compile+stamp, compile failure, no-draft fallback (4 tests).

Both new files pass (29 tests). Pre-existing unrelated failures (search-knowledge, redact) are untouched by this branch.