### PR TITLE
feat(evals): live tool-default mocks + persona identity sync

### DIFF
--- a/apps/web/src/components/agents/ui/detail/agent-docked-chat.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-docked-chat.tsx
@@ -2,14 +2,29 @@
 'use client'
 
 import { agentTemplates } from '@auxx/lib/agents/client'
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
-import { FlaskConical, MessageSquare, MessageSquareOff, Settings2 } from 'lucide-react'
+import {
+  FlaskConical,
+  MessageSquare,
+  MessageSquareOff,
+  MoreHorizontal,
+  Settings2,
+  SquarePen,
+} from 'lucide-react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { SimulationsTab } from '~/components/evals/ui/simulations-tab'
 import { KopilotContext } from '~/components/kopilot/context'
 import { KopilotChatProvider } from '~/components/kopilot/options'
+import { useKopilotStore } from '~/components/kopilot/stores/kopilot-store'
 import { KopilotSuggestion } from '~/components/kopilot/suggestions/kopilot-suggestion'
 import { KopilotChat } from '~/components/kopilot/ui/kopilot-chat'
 import { api } from '~/trpc/react'
@@ -21,6 +36,21 @@ interface AgentDockedChatProps {
 
 type Panel = 'build' | 'chat' | 'simulations'
 const PANELS: readonly Panel[] = ['build', 'chat', 'simulations'] as const
+
+type ChatTab = Exclude<Panel, 'simulations'>
+
+/**
+ * Per-tab "start new chat" state. `epoch` keys the KopilotChat instance so a
+ * bump forces the remount its ref-guarded mount effect requires; `pending`
+ * means the fresh chat hasn't received its server-created session yet, so the
+ * panel passes `initialSessionId={null}` instead of the latest thread.
+ */
+type FreshChatState = Record<ChatTab, { epoch: number; pending: boolean }>
+
+const INITIAL_FRESH_STATE: FreshChatState = {
+  build: { epoch: 0, pending: false },
+  chat: { epoch: 0, pending: false },
+}
 
 /**
  * Docked Kopilot chat scoped to one agent. Two tabs:
@@ -34,6 +64,13 @@ const PANELS: readonly Panel[] = ['build', 'chat', 'simulations'] as const
  * Default tab follows `setupCompletedAt`: agents that finished setup land
  * on Chat (first instinct is to test); agents mid-setup land on Build.
  * The current panel is persisted in `?panel=` so a refresh round-trips.
+ *
+ * Each chat tab resolves its thread as the latest `(user, agent, type)`
+ * session (`listSessions` limit 1, `updatedAt` desc) — nothing stores a
+ * session id on the agent. The tab-bar menu's "Start new chat" simply stops
+ * pointing at that thread: the panel passes `initialSessionId={null}` and the
+ * stream route creates a new session on the first send, which then wins the
+ * latest-first lookup. Old threads stay in the DB as history.
  *
  * Build-tab specifics (preserved from the pre-tabs implementation):
  * fresh agents get two seed-prompt suggestion chips, and a templated
@@ -49,6 +86,27 @@ export function AgentDockedChat({ agentId }: AgentDockedChatProps) {
     'panel',
     parseAsStringLiteral(PANELS).withDefault(defaultPanel)
   )
+
+  const [freshChats, setFreshChats] = useState<FreshChatState>(INITIAL_FRESH_STATE)
+
+  const startNewChat = useCallback((tab: ChatTab) => {
+    setFreshChats((s) => ({ ...s, [tab]: { epoch: s[tab].epoch + 1, pending: true } }))
+  }, [])
+
+  const settleFreshChat = useCallback((tab: ChatTab) => {
+    setFreshChats((s) => (s[tab].pending ? { ...s, [tab]: { ...s[tab], pending: false } } : s))
+  }, [])
+
+  const settleBuild = useCallback(() => settleFreshChat('build'), [settleFreshChat])
+  const settleChat = useCallback(() => settleFreshChat('chat'), [settleFreshChat])
+
+  // Same input as ChatPanel's query — React Query dedupes the fetch. Used only
+  // to disable "Start new chat" on the Chat tab when DMs are off.
+  const triggersQuery = api.agentTrigger.list.useQuery(
+    { agentId },
+    { staleTime: 30_000, enabled: !isFreshAgent }
+  )
+  const dmEnabled = triggersQuery.data?.find((t) => t.kind === 'dm')?.enabled ?? false
 
   return (
     <Tabs
@@ -69,10 +127,38 @@ export function AgentDockedChat({ agentId }: AgentDockedChatProps) {
             <FlaskConical />
             Simulations
           </TabsTrigger>
+          {panel !== 'simulations' && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant='ghost'
+                  size='icon-xs'
+                  className='ml-auto rounded-md shrink-0'
+                  aria-label='Chat actions'>
+                  <MoreHorizontal />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align='end'>
+                <DropdownMenuItem
+                  disabled={panel === 'chat' && !dmEnabled}
+                  onClick={() => startNewChat(panel)}>
+                  <SquarePen />
+                  Start new chat
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </TabsList>
       )}
       <TabsContent value='build' className='flex-1 overflow-hidden'>
-        <BuildPanel agentId={agentId} isFreshAgent={isFreshAgent} agentName={agent?.name ?? null} />
+        <BuildPanel
+          agentId={agentId}
+          isFreshAgent={isFreshAgent}
+          agentName={agent?.name ?? null}
+          fresh={freshChats.build.pending}
+          epoch={freshChats.build.epoch}
+          onSessionEstablished={settleBuild}
+        />
       </TabsContent>
       <TabsContent value='chat' className='flex-1 overflow-hidden'>
         <ChatPanel
@@ -81,6 +167,9 @@ export function AgentDockedChat({ agentId }: AgentDockedChatProps) {
           agentDescription={detail?.description ?? null}
           isFreshAgent={isFreshAgent}
           onJumpToBuild={() => setPanel('build')}
+          fresh={freshChats.chat.pending}
+          epoch={freshChats.chat.epoch}
+          onSessionEstablished={settleChat}
         />
       </TabsContent>
       <TabsContent value='simulations' className='flex-1 overflow-hidden'>
@@ -90,15 +179,72 @@ export function AgentDockedChat({ agentId }: AgentDockedChatProps) {
   )
 }
 
+// ── Fresh-session tracking ─────────────────────────────────────────────────
+
+/**
+ * While a "start new chat" is pending, watches the kopilot store for the
+ * server-created session id (set by the `session-created` SSE event) and, once
+ * it appears, invalidates the panel's `limit: 1` session lookup — the SSE
+ * cache patch only covers the master list, so without this the scoped query
+ * stays stale for its 30s staleTime — then reports back so the parent clears
+ * the pending flag (keeping it set would wipe the new thread on the next
+ * remount).
+ *
+ * The store is read imperatively inside the effect rather than from the
+ * subscribed value: at the commit where `fresh` flips on, the subscription
+ * still holds whatever session another surface left behind, but KopilotChat's
+ * mount effect (a child, so it runs first) has already wiped it by the time
+ * this effect executes. Only a genuinely new id — non-null and different from
+ * the latest persisted thread — counts as established.
+ */
+function useFreshSessionEstablished({
+  fresh,
+  latestSessionId,
+  sessionType,
+  agentId,
+  onEstablished,
+}: {
+  fresh: boolean
+  latestSessionId: string | null
+  sessionType: 'kopilot' | 'builder'
+  agentId: string
+  onEstablished: () => void
+}) {
+  const utils = api.useUtils()
+
+  useEffect(() => {
+    if (!fresh) return
+    let done = false
+    const check = (current: string | null) => {
+      if (done || !current || current === latestSessionId) return
+      done = true
+      void utils.kopilot.listSessions.invalidate({ type: sessionType, agentId, limit: 1 })
+      onEstablished()
+    }
+    check(useKopilotStore.getState().activeSessionId)
+    return useKopilotStore.subscribe((state) => check(state.activeSessionId))
+  }, [fresh, latestSessionId, sessionType, agentId, utils, onEstablished])
+}
+
 // ── Build tab ──────────────────────────────────────────────────────────────
 
 interface BuildPanelProps {
   agentId: string
   isFreshAgent: boolean
   agentName: string | null
+  fresh: boolean
+  epoch: number
+  onSessionEstablished: () => void
 }
 
-function BuildPanel({ agentId, isFreshAgent, agentName }: BuildPanelProps) {
+function BuildPanel({
+  agentId,
+  isFreshAgent,
+  agentName,
+  fresh,
+  epoch,
+  onSessionEstablished,
+}: BuildPanelProps) {
   const { data, isLoading } = api.kopilot.listSessions.useQuery(
     { type: 'builder', agentId, limit: 1 },
     { staleTime: 30_000 }
@@ -120,9 +266,19 @@ function BuildPanel({ agentId, isFreshAgent, agentName }: BuildPanelProps) {
     }
   }, [pathname, router, searchParams])
 
+  const latestSessionId = data?.items[0]?.id ?? null
+
+  useFreshSessionEstablished({
+    fresh,
+    latestSessionId,
+    sessionType: 'builder',
+    agentId,
+    onEstablished: onSessionEstablished,
+  })
+
   if (isLoading) return <div className='h-full' />
 
-  const initialSessionId = data?.items[0]?.id ?? null
+  const initialSessionId = fresh ? null : latestSessionId
   const hasTemplate = isFreshAgent && capturedTemplate !== null
 
   return (
@@ -159,6 +315,7 @@ function BuildPanel({ agentId, isFreshAgent, agentName }: BuildPanelProps) {
       )}
       <div className='h-full flex flex-col'>
         <KopilotChat
+          key={epoch}
           page='agents.builder'
           agentId={agentId}
           sessionType='builder'
@@ -178,6 +335,9 @@ interface ChatPanelProps {
   agentDescription: string | null
   isFreshAgent: boolean
   onJumpToBuild: () => void
+  fresh: boolean
+  epoch: number
+  onSessionEstablished: () => void
 }
 
 function ChatPanel({
@@ -186,9 +346,12 @@ function ChatPanel({
   agentDescription,
   isFreshAgent,
   onJumpToBuild,
+  fresh,
+  epoch,
+  onSessionEstablished,
 }: ChatPanelProps) {
-  // The DM session is a kopilot session bound to (user, agent). One rolling
-  // thread per pair in v1; "Start new chat" lands later.
+  // The DM session is a kopilot session bound to (user, agent). The panel
+  // shows the latest thread; "Start new chat" in the tab-bar menu rotates it.
   const sessionsQuery = api.kopilot.listSessions.useQuery(
     { type: 'kopilot', agentId, limit: 1 },
     { staleTime: 30_000, enabled: !isFreshAgent }
@@ -197,6 +360,16 @@ function ChatPanel({
     { agentId },
     { staleTime: 30_000, enabled: !isFreshAgent }
   )
+
+  const latestSessionId = sessionsQuery.data?.items[0]?.id ?? null
+
+  useFreshSessionEstablished({
+    fresh,
+    latestSessionId,
+    sessionType: 'kopilot',
+    agentId,
+    onEstablished: onSessionEstablished,
+  })
 
   if (isFreshAgent) {
     return (
@@ -225,7 +398,7 @@ function ChatPanel({
     )
   }
 
-  const initialSessionId = sessionsQuery.data?.items[0]?.id ?? null
+  const initialSessionId = fresh ? null : latestSessionId
 
   return (
     <KopilotChatProvider
@@ -247,6 +420,7 @@ function ChatPanel({
       />
       <div className='h-full flex flex-col'>
         <KopilotChat
+          key={epoch}
           page='agents.dm'
           agentId={agentId}
           sessionType='kopilot'

--- a/apps/web/src/components/evals/ui/eval-case-drawer.tsx
+++ b/apps/web/src/components/evals/ui/eval-case-drawer.tsx
@@ -13,7 +13,8 @@ import { generateId } from '@auxx/utils'
 import { FlaskConical, Play, User, Wrench } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
-import { useRecord, useResourceProperty } from '~/components/resources'
+import { useResourceProperty } from '~/components/resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { MultiRelationInput } from '~/components/shared/multi-relation-input'
 import { AutoResolveBadge } from '~/components/workflow/nodes/core/answer/components/auto-resolve-badge'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
@@ -36,6 +37,21 @@ import { EvalToolResponses } from './eval-tool-responses'
 
 /** The contact entity slug — the subject record the persona "is". */
 const CONTACT_SLUG = 'contact'
+
+/** System attributes read off the subject contact to fill the persona identity. */
+const CONTACT_IDENTITY_ATTRS: ('full_name' | 'primary_email')[] = ['full_name', 'primary_email']
+
+/** Coerce a system value (string, or a `{ firstName, lastName }` NAME) to a line. */
+function valueToString(value: unknown): string | undefined {
+  if (typeof value === 'string') return value.trim() || undefined
+  if (Array.isArray(value)) return valueToString(value.find((v) => v != null))
+  if (value && typeof value === 'object') {
+    const n = value as { firstName?: string; lastName?: string }
+    const joined = [n.firstName, n.lastName].filter(Boolean).join(' ').trim()
+    return joined || undefined
+  }
+  return undefined
+}
 
 const DEFAULT_CONFIG: SimulationConfig = {
   openingMessage: '',
@@ -252,22 +268,20 @@ function EvalCaseForm({
   // ── Test customer (subject) ──
   const contactEntityDefId = useResourceProperty(CONTACT_SLUG, 'entityDefinitionId')
   const subjectRecordId = (config.subject.recordIds[0] as RecordId | undefined) ?? null
-  const { record: subjectRecord } = useRecord({ recordId: subjectRecordId })
+  const hasContact = subjectRecordId != null
 
-  // The picked contact's display values — used to seed a field when it's switched
-  // to manual. `displayName`/`secondaryInfo` are what RecordBadge shows; treat
-  // secondaryInfo as the email only if it reads like one.
-  const resolvedName =
-    typeof subjectRecord?.displayName === 'string' ? subjectRecord.displayName : undefined
-  const resolvedSecondary =
-    typeof subjectRecord?.secondaryInfo === 'string' ? subjectRecord.secondaryInfo : undefined
-  const resolvedEmail = resolvedSecondary?.includes('@') ? resolvedSecondary : undefined
+  // The subject contact's real name + email, read off its system fields and
+  // resolved into `claimed` while a field is auto.
+  const { values: contactValues } = useSystemValues(subjectRecordId, CONTACT_IDENTITY_ATTRS, {
+    autoFetch: true,
+    enabled: hasContact,
+  })
+  const resolvedName = valueToString(contactValues.full_name)
+  const resolvedEmail = valueToString(contactValues.primary_email)
 
   const setSubjectRecords = (recordIds: RecordId[]) =>
     setConfig((c) => ({ ...c, subject: { ...c.subject, recordIds } }))
 
-  // claimed.<key> === undefined ⇒ auto (the persona supplies its own value); a
-  // string (including '') ⇒ manual (pinned, stated verbatim).
   const setClaimed = (key: 'name' | 'email', value: string | undefined) =>
     setConfig((c) => {
       const merged = { ...c.subject.claimed, [key]: value }
@@ -278,8 +292,41 @@ function EvalCaseForm({
       return { ...c, subject: { ...c.subject, claimed: hasAny ? claimed : undefined } }
     })
 
-  const emailIsAuto = config.subject.claimed?.email === undefined
-  const nameIsAuto = config.subject.claimed?.name === undefined
+  const setClaimedManual = (key: 'name' | 'email', manual: boolean) =>
+    setConfig((c) => {
+      const next = { ...c.subject.claimedManual, [key]: manual || undefined }
+      const claimedManual = next.name || next.email ? next : undefined
+      return { ...c, subject: { ...c.subject, claimedManual } }
+    })
+
+  // A field is auto only while a contact is selected and it hasn't been flagged
+  // manual; without a contact there's nothing to resolve, so it's plain manual.
+  const emailIsAuto = hasContact && !config.subject.claimedManual?.email
+  const nameIsAuto = hasContact && !config.subject.claimedManual?.name
+
+  // Keep auto fields synced to the contact's resolved values (persisted into
+  // `claimed`, so the persona states exactly what the editor shows). Snapshot-like:
+  // re-syncs on open and whenever the contact changes. Returns the config
+  // unchanged when there's nothing to update, so it never triggers a spurious save.
+  useEffect(() => {
+    setConfig((c) => {
+      const claimed = c.subject.claimed
+      const wantEmail = emailIsAuto && resolvedEmail && claimed?.email !== resolvedEmail
+      const wantName = nameIsAuto && resolvedName && claimed?.name !== resolvedName
+      if (!wantEmail && !wantName) return c
+      return {
+        ...c,
+        subject: {
+          ...c.subject,
+          claimed: {
+            ...claimed,
+            ...(wantEmail ? { email: resolvedEmail } : {}),
+            ...(wantName ? { name: resolvedName } : {}),
+          },
+        },
+      }
+    })
+  }, [emailIsAuto, nameIsAuto, resolvedEmail, resolvedName])
 
   const runNow = async () => {
     const id = await saveNow()
@@ -343,14 +390,14 @@ function EvalCaseForm({
                 title='Email'
                 description='The email the customer gives when asked.'>
                 <div className='relative flex items-center'>
-                  <div className='z-10 me-0.5 shrink-0 @sm:absolute @sm:right-full @sm:top-1/2 @sm:-translate-y-1/2'>
-                    <AutoResolveBadge
-                      isAuto={emailIsAuto}
-                      onChange={(isAuto) =>
-                        setClaimed('email', isAuto ? undefined : (resolvedEmail ?? ''))
-                      }
-                    />
-                  </div>
+                  {hasContact && (
+                    <div className='z-10 me-0.5 shrink-0 @sm:absolute @sm:right-full @sm:top-1/2 @sm:-translate-y-1/2'>
+                      <AutoResolveBadge
+                        isAuto={emailIsAuto}
+                        onChange={(isAuto) => setClaimedManual('email', !isAuto)}
+                      />
+                    </div>
+                  )}
                   {emailIsAuto ? (
                     <span className='flex h-8 items-center gap-1.5 px-2 text-xs'>
                       {resolvedEmail ? (
@@ -374,14 +421,14 @@ function EvalCaseForm({
               </VarEditorFieldRow>
               <VarEditorFieldRow title='Name'>
                 <div className='relative flex items-center'>
-                  <div className='z-10 me-0.5 shrink-0 @sm:absolute @sm:right-full @sm:top-1/2 @sm:-translate-y-1/2'>
-                    <AutoResolveBadge
-                      isAuto={nameIsAuto}
-                      onChange={(isAuto) =>
-                        setClaimed('name', isAuto ? undefined : (resolvedName ?? ''))
-                      }
-                    />
-                  </div>
+                  {hasContact && (
+                    <div className='z-10 me-0.5 shrink-0 @sm:absolute @sm:right-full @sm:top-1/2 @sm:-translate-y-1/2'>
+                      <AutoResolveBadge
+                        isAuto={nameIsAuto}
+                        onChange={(isAuto) => setClaimedManual('name', !isAuto)}
+                      />
+                    </div>
+                  )}
                   {nameIsAuto ? (
                     <span className='flex h-8 items-center gap-1.5 px-2 text-xs'>
                       {resolvedName ? (

--- a/apps/web/src/components/evals/ui/eval-tool-responses.tsx
+++ b/apps/web/src/components/evals/ui/eval-tool-responses.tsx
@@ -21,9 +21,14 @@ import { type EditorToolGroup, useToolGroups } from '../hooks/use-tool-groups'
  * EFFECTIVE toolset, grouped by toolset. The catalog defines icons per toolset
  * (never per tool), so the icon belongs to a group header and the rows beneath
  * read as members — entity-read tools no longer render the same icon N times.
- * Each tool seeds from its declared `exampleOutput`, falls back to a schema
- * scaffold, and validates against `outputSchema` on edit. One `repeat` response
- * per tool in v1 (arg-matched multi-response is a follow-up).
+ * A tool with a declared `exampleOutput` is on its live default (the runtime
+ * returns the example when no literal mock matches — see
+ * plans/evals/live-tool-default-mocks-plan.md): the row shows a read-only
+ * preview with an Override button that pins an editable literal seeded from the
+ * current live value, and Reset to default drops the literal again. Tools
+ * without an example seed from a schema scaffold. Literal output validates
+ * against `outputSchema` on edit. One `repeat` response per tool in v1
+ * (arg-matched multi-response is a follow-up).
  *
  * `control` tools are dropped server-side; `system` (platform read) toolsets sort
  * to the bottom and collapse by default. See plans/evals/tool-responses-grouping.md
@@ -46,6 +51,9 @@ export function EvalToolResponses({ agentId, mocks, onChange }: EvalToolResponse
   const [openTool, setOpenTool] = useState<string | null>(null)
 
   const hasMock = (toolName: string) => mocks.some((m) => m.toolName === toolName)
+  // On its live default: no literal mock, but the tool declares an example the
+  // runtime will return.
+  const isDefault = (tool: ToolEntry) => !hasMock(tool.name) && tool.example !== undefined
 
   const upsert = (toolName: string, output: unknown) => {
     const existing = mocks.find((m) => m.toolName === toolName)
@@ -104,6 +112,7 @@ export function EvalToolResponses({ agentId, mocks, onChange }: EvalToolResponse
               key={group.slug}
               group={group}
               mockedCount={group.tools.filter((t) => hasMock(t.name)).length}
+              defaultCount={group.tools.filter(isDefault).length}
               isOpen={isGroupOpen(group.slug)}
               onToggle={() => toggleGroup(group.slug)}>
               {group.tools.map(renderTool)}
@@ -118,6 +127,7 @@ export function EvalToolResponses({ agentId, mocks, onChange }: EvalToolResponse
                 color: '',
               }}
               mockedCount={ungroupedTools.filter((t) => hasMock(t.name)).length}
+              defaultCount={ungroupedTools.filter(isDefault).length}
               total={ungroupedTools.length}
               isOpen={isGroupOpen('__other')}
               onToggle={() => toggleGroup('__other')}>
@@ -137,6 +147,8 @@ interface ToolGroupRowProps {
     tools?: EditorToolGroup['tools']
   }
   mockedCount: number
+  /** Tools on their live default (example, no literal mock). */
+  defaultCount: number
   /** Override the denominator (the "Other" bucket isn't a real toolset). */
   total?: number
   isOpen: boolean
@@ -147,6 +159,7 @@ interface ToolGroupRowProps {
 function ToolGroupRow({
   group,
   mockedCount,
+  defaultCount,
   total,
   isOpen,
   onToggle,
@@ -159,7 +172,7 @@ function ToolGroupRow({
       title={group.fullLabel}
       secondary={
         <span className='text-xs text-muted-foreground'>
-          {mockedCount} mocked / {count}
+          {mockedCount} mocked{defaultCount > 0 ? ` · ${defaultCount} default` : ''} / {count}
         </span>
       }
       expandable
@@ -197,8 +210,10 @@ function ToolResponseRow({
   const [validation, setValidation] = useState<{ error?: string; warning?: string } | null>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const seedExample = tool.example !== undefined
-  const seedScaffold = !seedExample && tool.scaffold !== undefined && tool.scaffold !== null
+  const hasExample = tool.example !== undefined
+  const seedScaffold = tool.scaffold !== undefined && tool.scaffold !== null
+  // No literal mock + a declared example ⇒ the runtime serves the live default.
+  const onDefault = !mock && hasExample
 
   const applyDraft = (text: string) => {
     setDraft(text)
@@ -237,6 +252,23 @@ function ToolResponseRow({
     applyDraft(text)
   }
 
+  // Drop the literal mock AND the local draft — `draft` alone keeps the editor
+  // mounted, so without clearing it the row never returns to the default view.
+  const clearMock = () => {
+    setDraft('')
+    setParseError(null)
+    setValidation(null)
+    onRemove()
+  }
+
+  const status = mock
+    ? hasExample
+      ? 'override'
+      : 'mocked'
+    : hasExample
+      ? 'default'
+      : 'no response'
+
   return (
     <TreeRow
       depth={1}
@@ -244,12 +276,12 @@ function ToolResponseRow({
       title={tool.displayName}
       secondary={
         <span className='flex items-center gap-1.5 text-xs'>
-          <span className={cn(mock ? 'text-green-600' : 'text-muted-foreground')}>
-            {mock ? 'mocked' : 'no response'}
+          <span
+            className={cn(
+              mock ? 'text-green-600' : hasExample ? 'text-blue-600' : 'text-muted-foreground'
+            )}>
+            {status}
           </span>
-          {mock && tool.example !== undefined ? (
-            <span className='text-muted-foreground/70'>(example)</span>
-          ) : null}
           {tool.idempotent ? <span className='text-muted-foreground/70'>· read-only</span> : null}
         </span>
       }
@@ -258,53 +290,81 @@ function ToolResponseRow({
       onToggleOpen={onToggle}
       actions={
         mock ? (
-          <TreeRowButton variant='destructive' tooltipText='Clear response' onClick={onRemove}>
+          <TreeRowButton
+            variant='destructive'
+            tooltipText={hasExample ? 'Reset to default' : 'Clear response'}
+            onClick={clearMock}>
             <Trash2 />
           </TreeRowButton>
         ) : undefined
       }>
       <div className='space-y-2 py-1.5 pe-2 ps-12'>
-        {!mock && draft.trim() === '' ? (
-          <div className='flex flex-wrap items-center gap-2'>
-            {seedExample ? (
+        {onDefault ? (
+          <>
+            <div className='flex items-center justify-between gap-2'>
+              <span className='text-xs text-muted-foreground'>
+                Tool default (live) — stays in sync with the tool's example
+              </span>
               <Button variant='outline' size='xs' onClick={() => seed(tool.example)}>
                 <Sparkles />
-                From example
+                Override
               </Button>
+            </div>
+            <CodeEditor
+              language={CodeLanguage.json}
+              value={JSON.stringify(tool.example, null, 2)}
+              readOnly
+              minHeight={120}
+            />
+          </>
+        ) : (
+          <>
+            {!mock && draft.trim() === '' ? (
+              <div className='flex flex-wrap items-center gap-2'>
+                {seedScaffold ? (
+                  <Button variant='outline' size='xs' onClick={() => seed(tool.scaffold)}>
+                    <Wand2 />
+                    Scaffold
+                  </Button>
+                ) : null}
+                <Button variant='ghost' size='xs' onClick={() => applyDraft('{}')}>
+                  Start blank
+                </Button>
+              </div>
             ) : null}
-            {seedScaffold ? (
-              <Button variant='outline' size='xs' onClick={() => seed(tool.scaffold)}>
-                <Wand2 />
-                Scaffold
-              </Button>
+
+            {mock && hasExample ? (
+              <div className='flex items-center justify-between gap-2'>
+                <span className='text-xs text-muted-foreground'>Override (pinned)</span>
+                <Button variant='ghost' size='xs' onClick={clearMock}>
+                  Reset to default
+                </Button>
+              </div>
             ) : null}
-            <Button variant='ghost' size='xs' onClick={() => applyDraft('{}')}>
-              Start blank
-            </Button>
-          </div>
-        ) : null}
 
-        {draft.trim() !== '' || mock ? (
-          <CodeEditor
-            language={CodeLanguage.json}
-            value={draft}
-            onChange={applyDraft}
-            minHeight={120}
-            placeholder='{}'
-          />
-        ) : null}
+            {draft.trim() !== '' || mock ? (
+              <CodeEditor
+                language={CodeLanguage.json}
+                value={draft}
+                onChange={applyDraft}
+                minHeight={120}
+                placeholder='{}'
+              />
+            ) : null}
 
-        {parseError ? (
-          <Alert variant='bad'>
-            <AlertDescription>{parseError}</AlertDescription>
-          </Alert>
-        ) : validation?.error ? (
-          <Alert variant='bad'>
-            <AlertDescription>{validation.error}</AlertDescription>
-          </Alert>
-        ) : validation?.warning ? (
-          <p className='text-xs text-muted-foreground'>{validation.warning}</p>
-        ) : null}
+            {parseError ? (
+              <Alert variant='bad'>
+                <AlertDescription>{parseError}</AlertDescription>
+              </Alert>
+            ) : validation?.error ? (
+              <Alert variant='bad'>
+                <AlertDescription>{validation.error}</AlertDescription>
+              </Alert>
+            ) : validation?.warning ? (
+              <p className='text-xs text-muted-foreground'>{validation.warning}</p>
+            ) : null}
+          </>
+        )}
       </div>
     </TreeRow>
   )

--- a/apps/web/src/components/evals/ui/messages/eval-agent-message.tsx
+++ b/apps/web/src/components/evals/ui/messages/eval-agent-message.tsx
@@ -68,7 +68,9 @@ export function EvalAgentMessage({ runs }: { runs: Run[] }) {
                           'h-4 px-1 text-[10px]',
                           call.badge.live
                             ? 'border-amber-500/40 text-amber-600'
-                            : 'text-muted-foreground'
+                            : call.badge.label === 'default'
+                              ? 'border-blue-500/40 text-blue-600'
+                              : 'text-muted-foreground'
                         )}>
                         {call.badge.label}
                       </Badge>

--- a/apps/web/src/components/evals/ui/messages/eval-trace-grouping.ts
+++ b/apps/web/src/components/evals/ui/messages/eval-trace-grouping.ts
@@ -22,7 +22,7 @@ export interface ToolCallView {
   /** One-line output preview, already coerced to a string. */
   summary?: string
   /** Where the tool result came from — drives the small trailing badge. */
-  badge: { label: 'mock' | 'live' | 'captured'; live: boolean }
+  badge: { label: 'mock' | 'default' | 'live' | 'captured'; live: boolean }
 }
 
 export type Run =
@@ -60,7 +60,15 @@ function toToolCallView(event: EvalTraceEvent): ToolCallView {
     args: (data.args as Record<string, unknown>) ?? {},
     summary: summaryString(data.outputSummary),
     badge: {
-      label: captured ? 'captured' : live ? 'live' : 'mock',
+      // `default` = the tool's live exampleOutput (offline, unauthored) — keep it
+      // distinct from `mock` so authors can see what wasn't pinned for the case.
+      label: captured
+        ? 'captured'
+        : resolution === 'tool_example'
+          ? 'default'
+          : live
+            ? 'live'
+            : 'mock',
       live,
     },
   }

--- a/packages/lib/src/evals/__tests__/mock-tools.test.ts
+++ b/packages/lib/src/evals/__tests__/mock-tools.test.ts
@@ -120,6 +120,65 @@ describe('wrapToolsWithMocks', () => {
     expect(sink.records[0]).toMatchObject({ resolution: 'mock', mockId: 'm1', captured: false })
   })
 
+  it('falls back to the live exampleOutput when no literal mock matches', async () => {
+    const sink = collect()
+    const tool = fakeTool({ exampleOutput: { threads: [] } })
+    const [wrapped] = wrapToolsWithMocks([tool], {
+      mocks: [],
+      unmatchedPolicy: 'error',
+      ...sink,
+    })
+    const res = await asResult(wrapped!.execute({ q: 'x' }, ctx))
+    expect(res).toEqual({ success: true, output: { threads: [] } })
+    expect(tool.execute).not.toHaveBeenCalled()
+    expect(sink.unmatched).toHaveLength(0)
+    expect(sink.records[0]).toMatchObject({
+      resolution: 'tool_example',
+      mockId: null,
+      captured: false,
+    })
+  })
+
+  it('a literal mock wins over the exampleOutput', async () => {
+    const sink = collect()
+    const tool = fakeTool({ exampleOutput: { from: 'example' } })
+    const [wrapped] = wrapToolsWithMocks([tool], {
+      mocks: [mock({ output: { from: 'literal' } })],
+      unmatchedPolicy: 'error',
+      ...sink,
+    })
+    const res = await asResult(wrapped!.execute({}, ctx))
+    expect(res.output).toEqual({ from: 'literal' })
+    expect(sink.records[0]).toMatchObject({ resolution: 'mock', mockId: 'm1' })
+  })
+
+  it('a consumed once mock falls through to the exampleOutput on later calls', async () => {
+    const sink = collect()
+    const tool = fakeTool({ exampleOutput: { from: 'example' } })
+    const [wrapped] = wrapToolsWithMocks([tool], {
+      mocks: [mock({ usage: 'once', output: { from: 'literal' } })],
+      unmatchedPolicy: 'error',
+      ...sink,
+    })
+    expect((await asResult(wrapped!.execute({}, ctx))).output).toEqual({ from: 'literal' })
+    expect((await asResult(wrapped!.execute({}, ctx))).output).toEqual({ from: 'example' })
+    expect(sink.records.map((r) => r.resolution)).toEqual(['mock', 'tool_example'])
+  })
+
+  it('the exampleOutput wins over passthrough_readonly — run stays offline', async () => {
+    const sink = collect()
+    const tool = fakeTool({ idempotent: true, exampleOutput: { offline: true } })
+    const [wrapped] = wrapToolsWithMocks([tool], {
+      mocks: [],
+      unmatchedPolicy: 'passthrough_readonly',
+      ...sink,
+    })
+    const res = await asResult(wrapped!.execute({}, ctx))
+    expect(res).toEqual({ success: true, output: { offline: true } })
+    expect(tool.execute).not.toHaveBeenCalled()
+    expect(sink.passthrough).toHaveLength(0)
+  })
+
   it('fails closed on unmatched under error policy', async () => {
     const sink = collect()
     const tool = fakeTool({})
@@ -161,6 +220,33 @@ describe('wrapToolsWithMocks', () => {
     expect(res.success).toBe(false)
     expect(writeTool.execute).not.toHaveBeenCalled()
     expect(sink.unmatched).toEqual(['send_reply'])
+  })
+
+  it('captureMint falls back to the exampleOutput when the tool has no own mint', () => {
+    const sink = collect()
+    const tool = fakeTool({ exampleOutput: { minted: 'example' } })
+    const [wrapped] = wrapToolsWithMocks([tool], {
+      mocks: [],
+      unmatchedPolicy: 'error',
+      ...sink,
+    })
+    expect(wrapped!.captureMint?.({}, { localIndex: 0 })).toEqual({ minted: 'example' })
+    expect(sink.records[0]).toMatchObject({ resolution: 'tool_example', captured: true })
+  })
+
+  it("captureMint prefers the tool's own (args-aware) mint over the exampleOutput", () => {
+    const sink = collect()
+    const tool = fakeTool({
+      exampleOutput: { minted: 'example' },
+      captureMint: (args) => ({ minted: args.title }),
+    })
+    const [wrapped] = wrapToolsWithMocks([tool], {
+      mocks: [],
+      unmatchedPolicy: 'error',
+      ...sink,
+    })
+    expect(wrapped!.captureMint?.({ title: 'T' }, { localIndex: 0 })).toEqual({ minted: 'T' })
+    expect(sink.records).toHaveLength(0) // own-mint path emits no record (unchanged)
   })
 
   // control tools (procedure/plan signals) must bypass wrapping entirely — they

--- a/packages/lib/src/evals/__tests__/suggestions.test.ts
+++ b/packages/lib/src/evals/__tests__/suggestions.test.ts
@@ -58,6 +58,14 @@ const TOOLS = [
     displayName: 'Issue refund',
     description: 'Refund an order',
   },
+  // App tool whose registered name doubles the app slug — the shape small models
+  // "simplify" back to the toolId tail.
+  {
+    name: 'shopify_find_shopify_order',
+    displayName: 'Find Shopify order',
+    description: 'Find an order in Shopify',
+    exampleOutput: { id: 'gid://shopify/Order/1' },
+  },
   {
     name: 'advance_procedure',
     displayName: 'Advance procedure',
@@ -289,6 +297,40 @@ describe('suggestAgentSimulations — drop pipeline', () => {
   it('drops an item with no assertions', async () => {
     await dropCase(validItem({ assertions: [] }))
   })
+
+  it('rescues a mock toolName emitted as the unprefixed tail', async () => {
+    const result = await run(
+      envelope([
+        validItem({
+          mocks: [{ toolName: 'find_shopify_order', output: JSON.stringify({ id: 'o1' }) }],
+        }),
+      ])
+    )
+    const value = result._unsafeUnwrap()
+    expect(value.dropped).toBe(0)
+    expect(value.suggestions[0]?.config.connectorMocks[0]?.toolName).toBe(
+      'shopify_find_shopify_order'
+    )
+  })
+
+  it('rescues a tool_called assertion toolName emitted as the unprefixed tail', async () => {
+    const result = await run(
+      envelope([
+        validItem({ assertions: [{ type: 'tool_called', toolName: 'find_shopify_order' }] }),
+      ])
+    )
+    const value = result._unsafeUnwrap()
+    expect(value.dropped).toBe(0)
+    expect(value.suggestions[0]?.assertions[0]).toMatchObject({
+      type: 'tool_called',
+      data: { toolName: 'shopify_find_shopify_order' },
+    })
+  })
+
+  it('drops an ambiguous tail name instead of guessing', async () => {
+    // Both get_order and shopify_find_shopify_order end with `_order`.
+    await dropCase(validItem({ mocks: [{ toolName: 'order', output: '{}' }] }))
+  })
 })
 
 describe('suggestAgentSimulations — draft-hash cache', () => {
@@ -310,6 +352,15 @@ describe('suggestAgentSimulations — draft-hash cache', () => {
       callModel: stubModel(envelope([validItem({ name: 'A' }), validItem({ name: 'B' })])),
     })
     expect(refreshed._unsafeUnwrap().suggestions).toHaveLength(2)
+  })
+
+  it('does not cache a fully-dropped generation', async () => {
+    const first = await run(envelope([validItem({ mocks: [{ toolName: 'nope', output: '{}' }] })]))
+    expect(first._unsafeUnwrap()).toMatchObject({ suggestions: [], dropped: 1 })
+
+    // The next call must re-invoke the model, not serve the empty result.
+    const second = await run(envelope([validItem()]))
+    expect(second._unsafeUnwrap().suggestions).toHaveLength(1)
   })
 
   it('regenerates when the draft hash changes (new cache key)', async () => {

--- a/packages/lib/src/evals/simulation/mock-tools.ts
+++ b/packages/lib/src/evals/simulation/mock-tools.ts
@@ -34,9 +34,9 @@ export interface ToolInvocationRecord {
   toolName: string
   args: Record<string, unknown>
   output: unknown
-  /** Which mock matched, or `null` for passthrough / unmatched. */
+  /** Which mock matched, or `null` for tool-example / passthrough / unmatched. */
   mockId: string | null
-  resolution: 'mock' | 'passthrough' | 'unmatched_error' | 'recorded'
+  resolution: 'mock' | 'tool_example' | 'passthrough' | 'unmatched_error' | 'recorded'
   /** True iff produced through the capture path (engine wraps with `_captured`). */
   captured: boolean
 }
@@ -107,11 +107,12 @@ export interface WrapToolsDeps {
 
 /**
  * Wrap a resolved effective toolset so each tool returns mocked data. The real
- * `execute` is bypassed: a matched mock returns `{ success: true, output }`. An
- * unmatched call fails closed (`error` policy) or, under `passthrough_readonly`,
- * runs for real ONLY when `tool.idempotent === true` (read-only) — writes are
- * always bypassed. Gate strictly on the tool's own `idempotent` flag, never a
- * name list (conventions §6).
+ * `execute` is bypassed. Resolution order per call: (1) a matched literal mock
+ * returns `{ success: true, output }`; (2) a tool declaring `exampleOutput`
+ * returns it (live default — repeat, any args); (3) the unmatched policy: fail
+ * closed (`error`) or, under `passthrough_readonly`, run for real ONLY when
+ * `tool.idempotent === true` (read-only) — writes are always bypassed. Gate
+ * strictly on the tool's own `idempotent` flag, never a name list (conventions §6).
  *
  * `category: 'control'` tools (procedure/plan signals) pass through UNWRAPPED:
  * their `execute` is an in-memory signal write (`PROC_SIGNAL_KEY`) the stepper
@@ -149,6 +150,23 @@ function wrapTool(
         captured: false,
       })
       return { success: true, output: match.output }
+    }
+
+    // Live default: a tool that declares an `exampleOutput` returns it when no
+    // literal mock matched. Referenced live from the rebuilt runtime (snapshots
+    // store a manifest only), so it never goes stale. Deliberately wins over
+    // `passthrough_readonly` — the offline, deterministic example beats a real
+    // read-only call. See plans/evals/live-tool-default-mocks-plan.md.
+    if (tool.exampleOutput !== undefined) {
+      deps.onInvocation({
+        toolName: tool.name,
+        args,
+        output: tool.exampleOutput,
+        mockId: null,
+        resolution: 'tool_example',
+        captured: false,
+      })
+      return { success: true, output: tool.exampleOutput }
     }
 
     // Unmatched. `passthrough_readonly` lets a genuinely read-only tool run for
@@ -198,8 +216,23 @@ function wrapTool(
       })
       return match.output
     }
-    // Fall back to the tool's own mint (or the engine's placeholder if absent).
-    return tool.captureMint?.(args, mintCtx)
+    // Prefer the tool's own mint — it can be args-aware (e.g. create-task echoes
+    // its input), which a static example can't match. App tools' bridged mint IS
+    // their example, so order only matters for native tools.
+    if (tool.captureMint) return tool.captureMint(args, mintCtx)
+    // Live-default fallback, mirroring `execute` (engine placeholder if absent).
+    if (tool.exampleOutput !== undefined) {
+      deps.onInvocation({
+        toolName: tool.name,
+        args,
+        output: tool.exampleOutput,
+        mockId: null,
+        resolution: 'tool_example',
+        captured: true,
+      })
+      return tool.exampleOutput
+    }
+    return undefined
   }
 
   return { ...tool, execute, captureMint }

--- a/packages/lib/src/evals/suggestions.ts
+++ b/packages/lib/src/evals/suggestions.ts
@@ -212,7 +212,9 @@ export async function suggestAgentSimulations(
 
   logger.info('suggestions generated', { kept: suggestions.length, dropped, usage })
   const out: SuggestResult = { draftHash, suggestions, dropped }
-  await writeCachedSuggestions(cacheKey, out)
+  // A fully-dropped generation is a model failure, not the draft's truth — don't
+  // pin an empty list to the cache for an hour; the next request retries.
+  if (suggestions.length > 0 || dropped === 0) await writeCachedSuggestions(cacheKey, out)
   return ok(out)
 }
 
@@ -381,7 +383,11 @@ const SYSTEM_PROMPT = [
   '- Each simulation must exercise a DISTINCT path: the happy path, each major',
   '  condition arm, a customer missing required information, an edge/refusal case.',
   '- Do not duplicate the existing simulations listed.',
-  '- toolName values must come from the tool list, exactly as written.',
+  '- toolName values must be the exact backticked identifier from the tool list,',
+  '  copied verbatim — never shortened, reordered, or re-derived from the label.',
+  '- A tool listed with an example output returns that example automatically; only',
+  '  provide a mock when the path needs a DIFFERENT output (e.g. order not found,',
+  '  refund ineligible). Tools with no example need a mock if the path calls them.',
   '- Each mock "output" must be a JSON STRING following the tool\'s example output',
   '  shape, e.g. "{\\"status\\":\\"shipped\\"}".',
   '- Set customerContext so the persona can actually play the path (what they',
@@ -411,7 +417,10 @@ function buildUserMessage(
               example === undefined
                 ? 'none declared'
                 : truncate(JSON.stringify(example), MAX_EXAMPLE_CHARS)
-            return `### ${t.displayName} (\`${t.name}\`)\n${t.description}\nExample output: ${exampleText}`
+            // Exact name first — models copy headings far more reliably than
+            // parentheticals, and registered app names double the app slug
+            // (`shopify_find_shopify_order`), which invites "simplification".
+            return `### \`${t.name}\` — ${t.displayName}\n${t.description}\nExample output: ${exampleText}`
           })
           .join('\n\n')
       : 'No tools are available to this agent.'
@@ -611,6 +620,20 @@ type AuthoringSuggestion = z.infer<typeof authoringSuggestionSchema>
 // ── Per-item mapping + validation (the drop pipeline) ──────────────────────
 
 /**
+ * Resolve a model-emitted tool name to a canonical registered name. App tools
+ * register as `<appSlug>_<toolId>` and the toolId often already contains the app
+ * name (`shopify_find_shopify_order`) — small utility models reliably "simplify"
+ * those to the natural tail (`find_shopify_order`) despite the exactly-as-written
+ * prompt rule. An exact hit wins; otherwise a UNIQUE `_`-boundary suffix match
+ * rescues the name. Ambiguity (or no match) stays `null` → the item is dropped.
+ */
+function resolveToolName(name: string, toolMap: Map<string, AgentToolDefinition>): string | null {
+  if (toolMap.has(name)) return name
+  const matches = [...toolMap.keys()].filter((n) => n.endsWith(`_${name}`))
+  return matches.length === 1 ? (matches[0] ?? null) : null
+}
+
+/**
  * Map+validate one raw item into a persisted-shape suggestion. First failure
  * drops the item (returns null) and logs `{ index, reason }`. Order matches
  * phase-3a §3.6.
@@ -626,21 +649,28 @@ function mapAndValidateItem(
     return drop(index, `invalid shape: ${parsed.error.issues[0]?.message ?? 'parse error'}`)
   const item: AuthoringSuggestion = parsed.data
 
-  // 2. Tool-name existence (mocks + tool_(not_)called assertions).
+  // 2. Tool-name existence + canonicalization (mocks + tool_(not_)called
+  //    assertions) — near-miss names are rescued by `resolveToolName`.
+  const mocks: AuthoringSuggestion['mocks'] = []
   for (const mock of item.mocks) {
-    if (!toolMap.has(mock.toolName)) return drop(index, `unknown mock tool "${mock.toolName}"`)
+    const canonical = resolveToolName(mock.toolName, toolMap)
+    if (!canonical) return drop(index, `unknown mock tool "${mock.toolName}"`)
+    mocks.push({ ...mock, toolName: canonical })
   }
+  const itemAssertions: AuthoringSuggestion['assertions'] = []
   for (const a of item.assertions) {
     if (a.type === 'tool_called' || a.type === 'tool_not_called') {
       // toolName presence is guaranteed by the schema's superRefine.
-      if (!a.toolName || !toolMap.has(a.toolName)) {
-        return drop(index, `unknown assertion tool "${a.toolName}"`)
-      }
+      const canonical = a.toolName ? resolveToolName(a.toolName, toolMap) : null
+      if (!canonical) return drop(index, `unknown assertion tool "${a.toolName}"`)
+      itemAssertions.push({ ...a, toolName: canonical })
+    } else {
+      itemAssertions.push(a)
     }
   }
 
   // 3. Mock outputs against each tool's declared outputSchema (warning is fine).
-  for (const mock of item.mocks) {
+  for (const mock of mocks) {
     const tool = toolMap.get(mock.toolName)!
     const validation = validateMockOutput(tool, mock.output)
     if (!validation.ok)
@@ -650,7 +680,7 @@ function mapAndValidateItem(
   // 4. Dedupe mocks by toolName (first wins — drawer's one-mock-per-tool model).
   const seenTools = new Set<string>()
   const connectorMocks: SimulationToolMock[] = []
-  for (const mock of item.mocks) {
+  for (const mock of mocks) {
     if (seenTools.has(mock.toolName)) continue
     seenTools.add(mock.toolName)
     connectorMocks.push({
@@ -673,7 +703,7 @@ function mapAndValidateItem(
         }
       : undefined
 
-  const assertions: AgentEvalAssertion[] = item.assertions.map((a) => mapAssertion(a))
+  const assertions: AgentEvalAssertion[] = itemAssertions.map((a) => mapAssertion(a))
   const config: SimulationConfig = {
     openingMessage: item.openingMessage,
     customerContext: item.customerContext,

--- a/packages/types/evals/index.ts
+++ b/packages/types/evals/index.ts
@@ -123,6 +123,13 @@ export type SimulationConfig = {
     recordIds: RecordId[]
     identityVerified: boolean
     claimed?: { name?: string; email?: string }
+    /**
+     * Per-field override of the auto-from-contact resolution. A field is auto
+     * (resolved from the subject contact into `claimed`) unless flagged manual
+     * here. Only meaningful when a contact is selected; without one every field
+     * is plain manual.
+     */
+    claimedManual?: { name?: boolean; email?: boolean }
   }
   startingFields: { ref: FieldReference; value: unknown }[]
   /** `passthrough_readonly` is opt-in and makes the run non-offline. Default `error`. */

--- a/packages/types/evals/schema.ts
+++ b/packages/types/evals/schema.ts
@@ -136,6 +136,9 @@ export const simulationConfigSchema = z.object({
     recordIds: z.array(recordIdSchema),
     identityVerified: z.boolean(),
     claimed: z.object({ name: z.string().optional(), email: z.string().optional() }).optional(),
+    claimedManual: z
+      .object({ name: z.boolean().optional(), email: z.boolean().optional() })
+      .optional(),
   }),
   startingFields: z.array(z.object({ ref: fieldReferenceSchema, value: z.unknown() })),
   unmatchedToolPolicy: z.enum(['error', 'passthrough_readonly']),


### PR DESCRIPTION
## Summary

- **Live tool-default mocks** — tools that declare an `exampleOutput` now serve it automatically when no literal mock matches (`tool_example` resolution). The default deliberately wins over `passthrough_readonly` so runs stay offline and deterministic; `captureMint` mirrors the same fallback. See `plans/evals/live-tool-default-mocks-plan.md`.
- **Tool responses editor** — a tool on its live default shows a read-only preview of the example with an **Override** button (pins an editable literal) and **Reset to default** (drops it again). Group headers count defaults alongside mocks; trace UI gets a distinct blue `default` badge.
- **Persona identity sync** — the test customer's claimed name/email now resolve from the subject contact's real system fields (`full_name`/`primary_email` via `useSystemValues`) instead of `RecordBadge` display strings, persisted into `claimed` while auto. New `claimedManual` flags in `SimulationConfig` track per-field manual overrides; the auto/manual badge only renders when a contact is selected.
- **Suggester hardening** — model-emitted tool names that drop the app-slug prefix (`find_shopify_order` → `shopify_find_shopify_order`) are rescued via unique `_`-boundary suffix match; ambiguous names still drop. Prompt now leads tool headings with the exact backticked name, and a fully-dropped generation is no longer cached for an hour.
- **Agent docked chat** — new tab-bar `⋯` menu with **Start new chat** for the Build and Chat tabs: remounts `KopilotChat` with a null session so the stream route creates a fresh thread, which then wins the latest-first session lookup.

## Test plan

- [x] `packages/lib` eval tests pass (52 tests — new coverage for example-output fallback ordering, captureMint fallback, tool-name rescue, and the no-cache-on-full-drop path)
- [x] `pnpm lint:changed` clean
- [ ] Manual: override/reset flow in the tool responses editor, persona auto-fill from a picked contact, start-new-chat on both tabs