### PR TITLE
feat(agents,evals): registered-name tool chips + eval run deletion

### DIFF
--- a/apps/web/src/components/agents/ui/detail/bindings/add-binding-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/bindings/add-binding-dialog.tsx
@@ -105,10 +105,10 @@ export function AddBindingDialog({
   }, [open, editing])
 
   const handleSelectTool = (chipId: string) => {
-    // ToolReferenceList emits `tool:<catalogName>`; map to the registered name.
-    const catalogName = chipId.replace(/^tool:/, '')
-    const resolved = toolMeta.registeredNameByCatalogName.get(catalogName)
-    if (!resolved) return
+    // ToolReferenceList emits `tool:<registeredName>` — the chip tail IS the
+    // binding-map key, no catalog→registered translation needed.
+    const resolved = chipId.replace(/^tool:/, '')
+    if (!toolMeta.byRegisteredName.has(resolved)) return
     setRegisteredName(resolved)
     setDraft({ ...(agent.toolRestrictions?.[resolved] ?? {}) })
     setStep('args')
@@ -154,7 +154,7 @@ export function AddBindingDialog({
             <DialogNavPage value='tool' size='md'>
               <div className='p-3'>
                 <ToolReferenceList
-                  filterNames={toolMeta.enabledCatalogNames}
+                  filterNames={toolMeta.enabledToolNames}
                   onSelectSingle={handleSelectTool}
                   className='border'
                 />

--- a/apps/web/src/components/agents/ui/detail/bindings/hooks/use-tool-meta.ts
+++ b/apps/web/src/components/agents/ui/detail/bindings/hooks/use-tool-meta.ts
@@ -12,10 +12,8 @@ import type { AgentDetail } from '../../../../store/agent-store'
  * UI can read a tool's parameter schema without a server round-trip.
  */
 export interface ToolMeta {
-  /** Binding-map key (`<appSlug>_<toolId>`). */
+  /** Binding-map key (`<appSlug>_<toolId>`) — also the catalog `name` and chip tail. */
   registeredName: string
-  /** Catalog `name` for selection — what `ToolReferenceList` emits as `tool:<name>`. */
-  catalogName: string
   /** Human-friendly tool label. */
   displayName: string
   /** Resolved icon id (toolset iconKey → app avatar → 'package'). */
@@ -31,10 +29,8 @@ export interface ToolMeta {
 export interface UseToolMetaResult {
   /** Lookup keyed by registered name. */
   byRegisteredName: Map<string, ToolMeta>
-  /** Lookup keyed by catalog name (`tool.id`) → registered name, for the dialog. */
-  registeredNameByCatalogName: Map<string, string>
-  /** Catalog names of tools in an enabled toolset — feeds the picker `filterNames`. */
-  enabledCatalogNames: ReadonlySet<string>
+  /** Registered names of tools in an enabled toolset — feeds the picker `filterNames`. */
+  enabledToolNames: ReadonlySet<string>
   isLoading: boolean
 }
 
@@ -42,9 +38,10 @@ export interface UseToolMetaResult {
  * Build the tool-metadata lookups the Bindings UI needs from the installed-apps
  * cache + the agent's toolset state.
  *
- * `ToolReferenceList` emits `tool:<catalogName>` where `catalogName` is the raw
- * tool id; bindings are keyed by the registered name. This hook bridges the two
- * and exposes each tool's parameter schema. See plans/chat/v8 phase-5.
+ * Catalog chips, bindings, and the runtime toolset all key on the registered
+ * name now, so `ToolReferenceList` emits `tool:<registeredName>` and the binding
+ * map keys match without translation. This hook exposes each tool's parameter
+ * schema keyed by that one name. See plans/kopilot/agents/tool-chip-registered-name.md.
  */
 export function useToolMeta(agent: AgentDetail): UseToolMetaResult {
   const { appInstallations, isLoading } = useExtensionsContext()
@@ -55,15 +52,13 @@ export function useToolMeta(agent: AgentDetail): UseToolMetaResult {
     )
 
     const byRegisteredName = new Map<string, ToolMeta>()
-    const registeredNameByCatalogName = new Map<string, string>()
-    const enabledCatalogNames = new Set<string>()
+    const enabledToolNames = new Set<string>()
 
     for (const inst of appInstallations) {
       for (const tool of inst.agentTools ?? []) {
         const enabled = enabledToolsetSlugs.has(tool.toolsetSlug)
         const meta: ToolMeta = {
           registeredName: tool.registeredName,
-          catalogName: tool.id,
           displayName: tool.name,
           iconId: tool.iconId,
           toolsetSlug: tool.toolsetSlug,
@@ -71,11 +66,10 @@ export function useToolMeta(agent: AgentDetail): UseToolMetaResult {
           enabled,
         }
         byRegisteredName.set(tool.registeredName, meta)
-        registeredNameByCatalogName.set(tool.id, tool.registeredName)
-        if (enabled) enabledCatalogNames.add(tool.id)
+        if (enabled) enabledToolNames.add(tool.registeredName)
       }
     }
 
-    return { byRegisteredName, registeredNameByCatalogName, enabledCatalogNames, isLoading }
+    return { byRegisteredName, enabledToolNames, isLoading }
   }, [appInstallations, agent.toolsets, isLoading])
 }

--- a/apps/web/src/components/evals/ui/eval-case-row.tsx
+++ b/apps/web/src/components/evals/ui/eval-case-row.tsx
@@ -1,10 +1,12 @@
 // apps/web/src/components/evals/ui/eval-case-row.tsx
 'use client'
 
+import { toastError } from '@auxx/ui/components/toast'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { formatRelativeTime } from '@auxx/utils'
 import { ChevronRight, Cog, FlaskConical, Play, Trash2 } from 'lucide-react'
 import { useState } from 'react'
+import { useConfirm } from '~/hooks/use-confirm'
 import { api, type RouterOutputs } from '~/trpc/react'
 import { EvalStatusDot, EvalStatusPill, evalStatusVisual } from './eval-status-pill'
 
@@ -46,82 +48,116 @@ export function EvalCaseRow({
   const runsQuery = api.eval.listRuns.useQuery({ caseId: item.id }, { enabled: isOpen })
   const lastRun = item.latestRun
 
+  const utils = api.useUtils()
+  const [confirm, ConfirmDialog] = useConfirm()
+  const deleteRun = api.eval.deleteRun.useMutation({
+    onSuccess: () => {
+      void utils.eval.listRuns.invalidate({ caseId: item.id })
+      void utils.eval.list.invalidate()
+    },
+    onError: (err) => toastError({ title: 'Failed to delete run', description: err.message }),
+  })
+
+  const handleDeleteRun = async (runId: string) => {
+    const confirmed = await confirm({
+      title: 'Delete run?',
+      description: 'This run and its trace will be removed. This cannot be undone.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) deleteRun.mutate({ runId })
+  }
+
   return (
-    <TreeRow
-      icon={<FlaskConical className='size-4 text-muted-foreground' />}
-      title={item.name}
-      depth={depth}
-      rowClassName='hover:bg-primary-100'
-      expandable
-      isOpen={isOpen}
-      onToggleOpen={() => setIsOpen((o) => !o)}
-      secondary={
-        <span className='flex items-center gap-1.5'>
-          <EvalStatusPill status={lastRun?.status ?? null} />
-          {lastRun ? (
-            <span className='text-xs text-muted-foreground'>
-              {formatRelativeTime(lastRun.at, true)}
-            </span>
-          ) : null}
-        </span>
-      }
-      actions={
-        <div className='flex items-center gap-0'>
-          <TreeRowButton tooltipText='Edit' onClick={onEdit} aria-label='Edit simulation'>
-            <Cog />
-          </TreeRowButton>
-          <TreeRowButton
-            tooltipText='Run'
-            onClick={onRun}
-            disabled={isRunning}
-            aria-label='Run simulation'>
-            <Play />
-          </TreeRowButton>
-          <TreeRowButton
-            variant='destructive'
-            tooltipText='Delete'
-            onClick={onDelete}
-            disabled={isDeleting}
-            aria-label='Delete simulation'>
-            <Trash2 />
-          </TreeRowButton>
-        </div>
-      }>
-      {runsQuery.isLoading ? (
-        <TreeRow
-          depth={depth + 1}
-          title={<span className='text-xs text-muted-foreground'>Loading runs…</span>}
-        />
-      ) : runsQuery.data?.runs.length ? (
-        runsQuery.data.runs.map((run) => (
-          <TreeRow
-            key={run.id}
-            depth={depth + 1}
-            rowClassName='hover:bg-primary-100'
-            icon={<EvalStatusDot status={run.status} />}
-            title={evalStatusVisual(run.status).label}
-            secondary={
+    <>
+      <ConfirmDialog />
+      <TreeRow
+        icon={<FlaskConical className='size-4 text-muted-foreground' />}
+        title={item.name}
+        depth={depth}
+        rowClassName='hover:bg-primary-100'
+        expandable
+        isOpen={isOpen}
+        onToggleOpen={() => setIsOpen((o) => !o)}
+        secondary={
+          <span className='flex items-center gap-1.5'>
+            <EvalStatusPill status={lastRun?.status ?? null} />
+            {lastRun ? (
               <span className='text-xs text-muted-foreground'>
-                {formatRelativeTime(run.createdAt, true)}
+                {formatRelativeTime(lastRun.at, true)}
               </span>
-            }
-            onTitleClick={() => onOpenRun(run.id)}
-            actions={
-              <TreeRowButton
-                tooltipText='View run'
-                onClick={() => onOpenRun(run.id)}
-                aria-label='View run detail'>
-                <ChevronRight />
-              </TreeRowButton>
-            }
+            ) : null}
+          </span>
+        }
+        actions={
+          <div className='flex items-center gap-0'>
+            <TreeRowButton tooltipText='Edit' onClick={onEdit} aria-label='Edit simulation'>
+              <Cog />
+            </TreeRowButton>
+            <TreeRowButton
+              tooltipText='Run'
+              onClick={onRun}
+              disabled={isRunning}
+              aria-label='Run simulation'>
+              <Play />
+            </TreeRowButton>
+            <TreeRowButton
+              variant='destructive'
+              tooltipText='Delete'
+              onClick={onDelete}
+              disabled={isDeleting}
+              aria-label='Delete simulation'>
+              <Trash2 />
+            </TreeRowButton>
+          </div>
+        }>
+        {runsQuery.isLoading ? (
+          <TreeRow
+            depth={depth + 1}
+            title={<span className='text-xs text-muted-foreground'>Loading runs…</span>}
           />
-        ))
-      ) : (
-        <TreeRow
-          depth={depth + 1}
-          title={<span className='text-xs text-muted-foreground'>No runs yet.</span>}
-        />
-      )}
-    </TreeRow>
+        ) : runsQuery.data?.runs.length ? (
+          runsQuery.data.runs.map((run) => (
+            <TreeRow
+              key={run.id}
+              depth={depth + 1}
+              rowClassName='hover:bg-primary-100'
+              icon={<EvalStatusDot status={run.status} />}
+              title={evalStatusVisual(run.status).label}
+              secondary={
+                <span className='text-xs text-muted-foreground'>
+                  {formatRelativeTime(run.createdAt, true)}
+                </span>
+              }
+              onTitleClick={() => onOpenRun(run.id)}
+              actions={
+                <div className='flex items-center gap-0'>
+                  <TreeRowButton
+                    variant='destructive'
+                    tooltipText='Delete run'
+                    onClick={() => handleDeleteRun(run.id)}
+                    disabled={deleteRun.isPending && deleteRun.variables?.runId === run.id}
+                    aria-label='Delete run'>
+                    <Trash2 />
+                  </TreeRowButton>
+                  <TreeRowButton
+                    tooltipText='View run'
+                    onClick={() => onOpenRun(run.id)}
+                    aria-label='View run detail'>
+                    <ChevronRight />
+                  </TreeRowButton>
+                </div>
+              }
+            />
+          ))
+        ) : (
+          <TreeRow
+            depth={depth + 1}
+            title={<span className='text-xs text-muted-foreground'>No runs yet.</span>}
+          />
+        )}
+      </TreeRow>
+    </>
   )
 }

--- a/apps/web/src/components/evals/ui/eval-run-detail.tsx
+++ b/apps/web/src/components/evals/ui/eval-run-detail.tsx
@@ -4,14 +4,17 @@
 import type { EvalRunStatus } from '@auxx/types/evals'
 import { Alert, AlertDescription } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
+import { useNavStack } from '@auxx/ui/components/nav-stack'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { EmptySection, Section } from '@auxx/ui/components/section'
 import { Spinner } from '@auxx/ui/components/spinner'
+import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatRelativeTime } from '@auxx/utils'
-import { CircleDot, FileJson, History, ListChecks } from 'lucide-react'
+import { CircleDot, FileJson, History, ListChecks, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { useEvalRunActions, useEvalRunState } from '../stores/use-eval-run-store'
 import { EvalAssertionResultRow } from './eval-assertion-result-row'
@@ -65,9 +68,34 @@ export function EvalRunDetail({ runId, onSelectRun }: EvalRunDetailProps) {
   const runQuery = api.eval.getRun.useQuery({ runId })
   const live = useEvalRunState(runId)
   const { connect, hydrateFromRun } = useEvalRunActions()
+  const utils = api.useUtils()
+  const { pop } = useNavStack()
+  const [confirm, ConfirmDialog] = useConfirm()
 
   const row = runQuery.data
   const caseId = row?.caseId ?? null
+
+  // Deleting the run pops back to the previous panel (the run no longer exists)
+  // and refreshes the case's run list + latest-run pill.
+  const deleteRun = api.eval.deleteRun.useMutation({
+    onSuccess: () => {
+      if (caseId) void utils.eval.listRuns.invalidate({ caseId })
+      void utils.eval.list.invalidate()
+      pop()
+    },
+    onError: (err) => toastError({ title: 'Failed to delete run', description: err.message }),
+  })
+
+  const handleDelete = async () => {
+    const confirmed = await confirm({
+      title: 'Delete run?',
+      description: 'This run and its trace will be removed. This cannot be undone.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) deleteRun.mutate({ runId })
+  }
 
   // Seed the store from the authoritative row whenever it (re)loads.
   useEffect(() => {
@@ -92,14 +120,28 @@ export function EvalRunDetail({ runId, onSelectRun }: EvalRunDetailProps) {
   // The back bar carries the run-history switcher on its right; it stays mounted
   // across loading / not-found so navigation never disappears.
   const bar = (
-    <EvalDrillBar
-      title='Run detail'
-      actions={
-        caseId ? (
-          <RunHistoryPopover caseId={caseId} activeRunId={runId} onSelectRun={onSelectRun} />
-        ) : null
-      }
-    />
+    <>
+      <ConfirmDialog />
+      <EvalDrillBar
+        title='Run detail'
+        actions={
+          <>
+            {caseId ? (
+              <RunHistoryPopover caseId={caseId} activeRunId={runId} onSelectRun={onSelectRun} />
+            ) : null}
+            <Button
+              variant='ghost'
+              size='icon-xs'
+              className='text-muted-foreground hover:text-destructive'
+              loading={deleteRun.isPending}
+              onClick={handleDelete}
+              aria-label='Delete run'>
+              <Trash2 />
+            </Button>
+          </>
+        }
+      />
+    </>
   )
 
   if (runQuery.isLoading) {

--- a/apps/web/src/server/api/routers/eval.ts
+++ b/apps/web/src/server/api/routers/eval.ts
@@ -7,6 +7,7 @@ import {
   createQueuedEvalRun,
   createSuiteRunWithChildren,
   deleteEvalCase,
+  deleteEvalRun,
   failQueuedEvalRun,
   getEvalCaseById,
   getEvalRun,
@@ -401,6 +402,16 @@ export const evalRouter = createTRPCRouter({
       )
       if (!cancelled) throw new TRPCError({ code: 'NOT_FOUND', message: 'Eval run not found' })
       return { status: cancelled.status }
+    }),
+
+  deleteRun: evalAdminProcedure
+    .input(z.object({ runId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      unwrap(
+        await deleteEvalRun({ organizationId: ctx.session.organizationId, runId: input.runId }),
+        'delete eval run'
+      )
+      return { ok: true as const }
     }),
 
   // ── Suggestions ───────────────────────────────────────────────────────────

--- a/packages/lib/src/agents/__tests__/client.test.ts
+++ b/packages/lib/src/agents/__tests__/client.test.ts
@@ -1,7 +1,14 @@
 // packages/lib/src/agents/__tests__/client.test.ts
 
 import { describe, expect, it } from 'vitest'
-import { type FlatToolsetCatalogEntry, matchesToolsetSearch } from '../client'
+import {
+  buildCatalogTreeFromInstallations,
+  type CachedInstalledAppLike,
+  type CatalogContainerNode,
+  type CatalogToolsetNode,
+  type FlatToolsetCatalogEntry,
+  matchesToolsetSearch,
+} from '../client'
 
 const entry = (over: Partial<FlatToolsetCatalogEntry>): FlatToolsetCatalogEntry => ({
   slug: 'auxx:entities:search',
@@ -40,5 +47,39 @@ describe('matchesToolsetSearch', () => {
   it('is case-insensitive and returns false on no match', () => {
     expect(matchesToolsetSearch(e, 'ENTITIES')).toBe(true)
     expect(matchesToolsetSearch(e, 'nonsense')).toBe(false)
+  })
+})
+
+describe('buildCatalogTreeFromInstallations', () => {
+  const installation = (over?: Partial<CachedInstalledAppLike>): CachedInstalledAppLike => ({
+    app: { id: 'shopify', title: 'Shopify', avatarUrl: null },
+    agentToolsets: [
+      {
+        slug: 'app:shopify:orders.read',
+        name: 'Orders',
+        description: '',
+        iconKey: null,
+        subGroup: null,
+      },
+    ],
+    agentTools: [
+      {
+        id: 'find_shopify_order',
+        name: 'Find Shopify order',
+        registeredName: 'shopify_find_shopify_order',
+        description: 'Look up an order.',
+        toolsetSlug: 'app:shopify:orders.read',
+      },
+    ],
+    ...over,
+  })
+
+  it('surfaces the registered name as the catalog `name`, manifest id as the displayName label', () => {
+    const tree = buildCatalogTreeFromInstallations([installation()])
+    const app = tree.find((n) => n.id === 'app:shopify') as CatalogContainerNode
+    const toolset = app.children[0] as CatalogToolsetNode
+    const [entry] = toolset.tools
+    expect(entry.name).toBe('shopify_find_shopify_order')
+    expect(entry.displayName).toBe('Find Shopify order')
   })
 })

--- a/packages/lib/src/agents/__tests__/filter-tools.test.ts
+++ b/packages/lib/src/agents/__tests__/filter-tools.test.ts
@@ -83,6 +83,19 @@ describe('filterToolsByToolsets', () => {
     expect(result.map((t) => t.name)).toEqual(['get_thread_detail'])
   })
 
+  it('disables an app tool by its registered name', () => {
+    // Runtime app tools are named by the registered name (`<slug>_<id>`); now
+    // that the catalog/builder persist that same name into `disabledTools`,
+    // per-tool disable lands instead of silently no-op'ing on the manifest id.
+    const findOrder = tool('shopify_find_shopify_order', 'app:shopify:orders.read')
+    const cancelOrder = tool('shopify_cancel_shopify_order', 'app:shopify:orders.read')
+    const result = filterToolsByToolsets(
+      [findOrder, cancelOrder],
+      agent([{ slug: 'app:shopify:orders.read', disabledTools: ['shopify_find_shopify_order'] }])
+    )
+    expect(result.map((t) => t.name)).toEqual(['shopify_cancel_shopify_order'])
+  })
+
   it('silently ignores unknown slugs in config', () => {
     const result = filterToolsByToolsets(
       [findThreads],

--- a/packages/lib/src/agents/__tests__/prompt-mention-reconciler.test.ts
+++ b/packages/lib/src/agents/__tests__/prompt-mention-reconciler.test.ts
@@ -32,6 +32,28 @@ const TOOL_CATALOG: FlatToolCatalogEntry[] = [
     toolsetColor: '',
     path: [],
   },
+  // App-tool entries carry the registered name (`<slug>_<id>`), so two apps
+  // publishing the same manifest id (`send_message`) stay distinguishable.
+  {
+    name: 'slack_send_message',
+    displayName: 'Send message',
+    description: '',
+    toolsetSlug: 'app:slack:messages',
+    toolsetLabel: '',
+    toolsetIconId: '',
+    toolsetColor: '',
+    path: [],
+  },
+  {
+    name: 'teams_send_message',
+    displayName: 'Send message',
+    description: '',
+    toolsetSlug: 'app:teams:messages',
+    toolsetLabel: '',
+    toolsetIconId: '',
+    toolsetColor: '',
+    path: [],
+  },
 ]
 
 function doc(...children: unknown[]): Record<string, unknown> {
@@ -57,6 +79,19 @@ describe('walkPromptDoc', () => {
     const result = walkPromptDoc(doc(paragraph(reference('tool:list_threads'))), TOOL_CATALOG)
     expect([...result.toolsetSlugs]).toEqual(['auxx:mail:threads'])
     expect(result.recordIds.size).toBe(0)
+  })
+
+  it('maps an app-tool registered-name chip to its toolset slug', () => {
+    const result = walkPromptDoc(doc(paragraph(reference('tool:slack_send_message'))), TOOL_CATALOG)
+    expect([...result.toolsetSlugs]).toEqual(['app:slack:messages'])
+  })
+
+  it('resolves a same-id collision unambiguously by registered name', () => {
+    const result = walkPromptDoc(
+      doc(paragraph(reference('tool:slack_send_message'), reference('tool:teams_send_message'))),
+      TOOL_CATALOG
+    )
+    expect([...result.toolsetSlugs].sort()).toEqual(['app:slack:messages', 'app:teams:messages'])
   })
 
   it('accepts direct toolset: references', () => {

--- a/packages/lib/src/agents/client.ts
+++ b/packages/lib/src/agents/client.ts
@@ -218,6 +218,15 @@ export interface CachedInstalledAppLike {
   agentTools?: ReadonlyArray<{
     id: string
     name: string
+    /**
+     * LLM-facing name the bridge registers this tool under
+     * (`getRegisteredToolName(appSlug, id)` for app tools, the bare name for
+     * built-ins). This — not the raw manifest `id` — is the catalog entry's
+     * `name`, so `tool:<name>` chips, system-prompt references, eval mocks, and
+     * the runtime toolset all speak one name. See
+     * plans/kopilot/agents/tool-chip-registered-name.md.
+     */
+    registeredName: string
     description: string
     toolsetSlug: string
     /** Mirrors `AgentToolDefinition.surfaces` — where the tool is offered. Absent ⇒ all. */
@@ -368,7 +377,7 @@ export function buildCatalogTreeFromInstallations(
     for (const tool of agentTools) {
       const arr = toolsBySlug.get(tool.toolsetSlug) ?? []
       arr.push({
-        name: tool.id,
+        name: tool.registeredName,
         displayName: tool.name,
         description: shortDescription(tool.description),
         surfaces: tool.surfaces,

--- a/packages/lib/src/evals/index.ts
+++ b/packages/lib/src/evals/index.ts
@@ -48,6 +48,7 @@ export {
   createQueuedEvalRun,
   createSuiteRunWithChildren,
   deleteEvalCase,
+  deleteEvalRun,
   getEvalCaseById,
   getEvalRun,
   getEvalSuiteRun,

--- a/packages/lib/src/evals/queries.ts
+++ b/packages/lib/src/evals/queries.ts
@@ -146,6 +146,29 @@ export async function deleteEvalCase(input: { organizationId: string; id: string
   return ok(undefined)
 }
 
+/** Delete one run. Trace and assertion results are inline jsonb, so this is a single row delete. */
+export async function deleteEvalRun(input: { organizationId: string; runId: string }) {
+  const result = await fromDatabase(
+    database
+      .delete(schema.EvalRun)
+      .where(
+        and(
+          eq(schema.EvalRun.id, input.runId),
+          eq(schema.EvalRun.organizationId, input.organizationId)
+        )
+      )
+      .returning({ id: schema.EvalRun.id }),
+    'delete-eval-run'
+  )
+  if (result.isErr()) return err(result.error)
+  if (!result.value[0])
+    return err({
+      code: 'EVAL_RUN_NOT_FOUND' as const,
+      message: `Eval run not found: ${input.runId}`,
+    })
+  return ok(undefined)
+}
+
 /**
  * Cases for an agent. Omit `procedureId` for the agent-root view (every case,
  * for grouping); pass it to scope to one procedure's procedure-scoped cases.

--- a/packages/lib/src/evals/suggestions.ts
+++ b/packages/lib/src/evals/suggestions.ts
@@ -620,12 +620,14 @@ type AuthoringSuggestion = z.infer<typeof authoringSuggestionSchema>
 // ── Per-item mapping + validation (the drop pipeline) ──────────────────────
 
 /**
- * Resolve a model-emitted tool name to a canonical registered name. App tools
- * register as `<appSlug>_<toolId>` and the toolId often already contains the app
- * name (`shopify_find_shopify_order`) — small utility models reliably "simplify"
- * those to the natural tail (`find_shopify_order`) despite the exactly-as-written
- * prompt rule. An exact hit wins; otherwise a UNIQUE `_`-boundary suffix match
- * rescues the name. Ambiguity (or no match) stays `null` → the item is dropped.
+ * Resolve a model-emitted tool name to a canonical registered name. The
+ * procedure text now renders `tool:` chips as their registered names
+ * (`shopify_find_shopify_order`), so the exact-match path is the norm. The
+ * suffix rescue stays as a belt: small utility models still sometimes "simplify"
+ * an app tool to its natural tail (`find_shopify_order`) despite the
+ * exactly-as-written prompt rule. An exact hit wins; otherwise a UNIQUE
+ * `_`-boundary suffix match rescues the name. Ambiguity (or no match) stays
+ * `null` → the item is dropped.
  */
 function resolveToolName(name: string, toolMap: Map<string, AgentToolDefinition>): string | null {
   if (toolMap.has(name)) return name


### PR DESCRIPTION
## Summary

Two related changes pulled from the bindings/evals work:

**Registered-name tool chips.** Tool chips, bindings, system-prompt references, eval mocks, and the runtime toolset now all key on the registered name (`<appSlug>_<toolId>`) instead of the raw manifest `id`.
- The catalog entry's `name` is now `tool.registeredName`, so `tool:<name>` chips, prompt references, and the runtime toolset speak one name — the bindings dialog no longer needs a catalog→registered translation map.
- Disambiguates apps that publish the same manifest id (e.g. slack/teams `send_message`).
- Per-tool disable lands on the runtime tool name instead of silently no-op'ing on the manifest id.
- `useToolMeta` drops `catalogName` / `registeredNameByCatalogName` / `enabledCatalogNames` in favor of a single `enabledToolNames` keyed by registered name.
- Suggestion resolver: exact-match is now the norm; the `_`-boundary suffix rescue stays as a belt for small models that simplify to the natural tail.

**Eval run deletion.** New `deleteEvalRun` query + `deleteRun` admin procedure. Delete actions added to the case's run rows and the run-detail bar (pops back to the previous panel on success, refreshes the run list + latest-run pill).

## Test plan

- [x] New unit tests: catalog tree surfaces registered name as `name`; `filterToolsByToolsets` disables by registered name; prompt reconciler maps registered-name chips and resolves same-id collisions.
- [ ] Manually delete a run from both the case row and the run-detail bar.