### PR TITLE
feat(agents,evals): procedure-doc mention reconciliation + eval trace tooling

### DIFF
--- a/apps/web/src/components/agents/ui/detail/agent-hero.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-hero.tsx
@@ -16,6 +16,7 @@ import { AvatarUpload } from '../../../file-upload/ui/avatar-upload'
 import { useAgentMutations } from '../../hooks/use-agent-mutations'
 import type { AgentDetail } from '../../store/agent-store'
 import { toSlug } from '../../utils/agent-slug'
+import { AgentModelBadge } from './agent-model-badge'
 
 interface AgentHeroProps {
   agent: AgentDetail
@@ -81,6 +82,7 @@ export function AgentHero({ agent }: AgentHeroProps) {
               </Badge>
             </Tooltip>
           ) : null}
+          <AgentModelBadge agent={agent} />
         </div>
         <div className='flex items-center text-xs text-neutral-500 min-w-0 gap-1'>
           <InlineSlugField

--- a/apps/web/src/components/agents/ui/detail/agent-model-badge.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-model-badge.tsx
@@ -1,0 +1,105 @@
+// apps/web/src/components/agents/ui/detail/agent-model-badge.tsx
+'use client'
+
+import { ModelType } from '@auxx/lib/ai/providers/types'
+import { badgeVariants } from '@auxx/ui/components/badge'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { cn } from '@auxx/ui/lib/utils'
+import { Bot, X } from 'lucide-react'
+import { useMemo } from 'react'
+import { Tooltip } from '~/components/global/tooltip'
+import { AiModelPicker } from '~/components/pickers/ai-model-picker'
+import ModelIcon from '~/components/workflow/ui/model-parameter/model-icon'
+import { api } from '~/trpc/react'
+import { useAgentMutations } from '../../hooks/use-agent-mutations'
+import type { AgentDetail } from '../../store/agent-store'
+
+interface AgentModelBadgeProps {
+  agent: AgentDetail
+}
+
+/**
+ * Hero badge that pins the agent's main LLM. Stores the picker's
+ * `provider:model` id on `Agent.modelId`; `null` means "use the system
+ * default" (resolved per turn by `resolveAgentConfig`). Mirrors the master
+ * Kopilot `ModelSection` — a separate ✕ clears back to the system default.
+ */
+export function AgentModelBadge({ agent }: AgentModelBadgeProps) {
+  const { updateAgent, isUpdating } = useAgentMutations()
+  const modelId = agent.modelId
+
+  // Resolve `provider:model` → display name/icon for the pinned label. Same
+  // query params as `AiModelPicker` so the result is shared from cache; only
+  // fetched once a model is actually pinned.
+  const { data, isLoading } = api.aiIntegration.getUnifiedModelData.useQuery(
+    { includeDefaults: true, modelTypes: [ModelType.LLM], includeUnconfigured: false },
+    { staleTime: 5 * 60 * 1000, enabled: !!modelId }
+  )
+
+  const pinned = useMemo(() => {
+    if (!modelId || !data) return null
+    for (const provider of data.providers) {
+      const model = provider.models.find((m) => `${provider.provider}:${m.modelId}` === modelId)
+      if (model) return { provider: provider.provider, model }
+    }
+    return null
+  }, [modelId, data])
+
+  return (
+    <div className='flex items-center gap-1 shrink-0'>
+      <AiModelPicker
+        value={modelId}
+        onChange={(model) => updateAgent(agent.id, { modelId: model?.id ?? null })}
+        modelTypes={[ModelType.LLM]}
+        skipDeprecated>
+        <button
+          type='button'
+          disabled={isUpdating}
+          className={cn(
+            badgeVariants({ variant: 'outline', size: 'sm' }),
+            'cursor-pointer gap-1 hover:bg-muted/40 transition-colors disabled:opacity-50'
+          )}>
+          {modelId ? (
+            isLoading && !pinned ? (
+              <Skeleton className='h-3 w-16' />
+            ) : pinned ? (
+              <>
+                <ModelIcon
+                  provider={pinned.provider}
+                  modelName={pinned.model.modelId}
+                  modelData={pinned.model}
+                  size='sm'
+                />
+                <span className='truncate max-w-[12rem]'>{pinned.model.displayName}</span>
+              </>
+            ) : (
+              // Pinned to a model that's no longer in the catalog (provider removed
+              // / model retired). Show the raw id so it's at least diagnosable.
+              <>
+                <Bot />
+                <span className='truncate max-w-[12rem]'>{modelId}</span>
+              </>
+            )
+          ) : (
+            <>
+              <Bot />
+              System default
+            </>
+          )}
+        </button>
+      </AiModelPicker>
+      {modelId ? (
+        <Tooltip content='Reset to system default'>
+          <button
+            type='button'
+            disabled={isUpdating}
+            onClick={() => updateAgent(agent.id, { modelId: null })}
+            aria-label='Reset to system default'
+            className='flex items-center justify-center rounded p-0.5 text-neutral-500 hover:bg-muted/40 hover:text-foreground transition-colors disabled:opacity-50'>
+            <X className='size-3' />
+          </button>
+        </Tooltip>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/components/evals/ui/eval-run-detail.tsx
+++ b/apps/web/src/components/evals/ui/eval-run-detail.tsx
@@ -10,9 +10,10 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { EmptySection, Section } from '@auxx/ui/components/section'
 import { Spinner } from '@auxx/ui/components/spinner'
 import { toastError } from '@auxx/ui/components/toast'
+import { useCopy } from '@auxx/ui/hooks/use-copy'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatRelativeTime } from '@auxx/utils'
-import { CircleDot, FileJson, History, ListChecks, Trash2 } from 'lucide-react'
+import { Check, CircleDot, Copy, FileJson, History, ListChecks, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
@@ -21,6 +22,7 @@ import { EvalAssertionResultRow } from './eval-assertion-result-row'
 import { EvalDrillBar } from './eval-drill-bar'
 import { EvalStatusDot, EvalStatusPill } from './eval-status-pill'
 import { EvalTraceView } from './eval-trace-view'
+import { type TraceMarkdownMeta, traceToMarkdown } from './messages/eval-trace-markdown'
 
 /**
  * Level 3 of the Simulations drill: one run's verdict, trace, and snapshot.
@@ -171,6 +173,13 @@ export function EvalRunDetail({ runId, onSelectRun }: EvalRunDetailProps) {
   const isLive = !TERMINAL.has(status)
   const banner = BANNER[status]
   const assertions = live.assertionResults.length ? live.assertionResults : []
+  const assertionTally = assertions.reduce(
+    (acc, r) => {
+      acc[r.status] += 1
+      return acc
+    },
+    { passed: 0, failed: 0, error: 0 }
+  )
 
   return (
     <>
@@ -213,6 +222,16 @@ export function EvalRunDetail({ runId, onSelectRun }: EvalRunDetailProps) {
           icon={<History className='size-4' />}
           description='The conversation and tool calls, in order.'
           className={SECTION_BLEED}
+          actions={
+            <CopyTraceButton
+              trace={live.trace}
+              meta={{
+                status,
+                summary: row.error ? `${banner.sentence} ${row.error}` : banner.sentence,
+                assertions: assertionTally,
+              }}
+            />
+          }
           collapsible>
           <div className='flex flex-col ps-2 pe-4'>
             <EvalTraceView trace={live.trace} isLive={isLive} />
@@ -232,6 +251,35 @@ export function EvalRunDetail({ runId, onSelectRun }: EvalRunDetailProps) {
         </Section>
       </ScrollArea>
     </>
+  )
+}
+
+// ── Copy-trace action ────────────────────────────────────────────────────────
+
+/**
+ * Header action for the Trace section — copies the full trace as Markdown
+ * (metadata header + conversation + tool args/output/badge + notices). Sits in
+ * the section `actions` slot, outside the collapse trigger, so it never toggles
+ * the section. Disabled until there are events to copy.
+ */
+function CopyTraceButton({
+  trace,
+  meta,
+}: {
+  trace: React.ComponentProps<typeof EvalTraceView>['trace']
+  meta: TraceMarkdownMeta
+}) {
+  const copy = useCopy({ toastMessage: 'Trace copied as Markdown' })
+  return (
+    <Button
+      variant='ghost'
+      size='icon-xs'
+      className='text-muted-foreground'
+      disabled={trace.length === 0}
+      onClick={() => copy.copy(traceToMarkdown(trace, meta))}
+      aria-label='Copy trace as Markdown'>
+      {copy.copied ? <Check /> : <Copy />}
+    </Button>
   )
 }
 

--- a/apps/web/src/components/evals/ui/messages/eval-trace-markdown.ts
+++ b/apps/web/src/components/evals/ui/messages/eval-trace-markdown.ts
@@ -1,0 +1,120 @@
+// apps/web/src/components/evals/ui/messages/eval-trace-markdown.ts
+
+import type { EvalTraceEvent } from '@auxx/types/evals'
+import type { ToolCallView } from './eval-trace-grouping'
+import { groupTrace } from './eval-trace-grouping'
+
+/**
+ * Pure serialization of an agent-simulation trace into copy-paste Markdown —
+ * the same conversation `EvalTraceView` renders, flattened for an LLM or a bug
+ * report. Reuses {@link groupTrace} so the markdown and the on-screen trace
+ * never drift (same turns, same tool-call args/output/resolution badge).
+ *
+ * A brief metadata header (status, verdict sentence, assertion tally, time
+ * span) precedes the trace; tool calls carry fenced JSON args, their output
+ * summary, and the resolution badge; non-message notices (terminal, errors,
+ * config/snapshot warnings) fold in as italic blockquotes in sequence.
+ */
+
+export interface TraceMarkdownMeta {
+  /** Terminal/in-flight run status, e.g. `passed`. */
+  status?: string
+  /** The verdict sentence shown in the banner (with any error appended). */
+  summary?: string
+  /** Per-status assertion tally for the header. */
+  assertions?: { passed: number; failed: number; error: number }
+}
+
+/** Prefix every line of a (possibly multi-line) block with `> ` for a blockquote. */
+function blockquote(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => `> ${line}`.trimEnd())
+    .join('\n')
+}
+
+function fencedJson(value: unknown): string {
+  let body: string
+  try {
+    body = JSON.stringify(value, null, 2)
+  } catch {
+    body = String(value)
+  }
+  return ['```json', body, '```'].join('\n')
+}
+
+function toolCallMarkdown(call: ToolCallView): string {
+  const parts = [`**Tool call — \`${call.name}\`** _(${call.badge.label})_`]
+  if (Object.keys(call.args).length > 0) {
+    parts.push('', 'Args:', fencedJson(call.args))
+  }
+  parts.push('', `Result: ${call.summary ? call.summary : '_(no output)_'}`)
+  return parts.join('\n')
+}
+
+/** Mirror of the notice card's `present()` — a one-line label + optional detail. */
+function noticeMarkdown(event: EvalTraceEvent): string {
+  const data = event.data
+  const message = typeof data.message === 'string' ? data.message : undefined
+
+  switch (event.type) {
+    case 'terminal': {
+      const outcome = typeof data.terminalOutcome === 'string' ? data.terminalOutcome : 'none'
+      const detail = data.capExceeded === true ? 'Customer-turn cap reached' : `Outcome: ${outcome}`
+      return blockquote(`_Terminal_ — ${detail}`)
+    }
+    case 'execution_error':
+      return blockquote(`_Execution error_${message ? ` — ${message}` : ''}`)
+    default: {
+      const title = event.type.replace(/_/g, ' ')
+      return blockquote(`_${title}_${message ? ` — ${message}` : ''}`)
+    }
+  }
+}
+
+function header(trace: EvalTraceEvent[], meta?: TraceMarkdownMeta): string {
+  const lines = ['# Eval run trace', '']
+  if (meta?.status) lines.push(`- **Status:** ${meta.status}`)
+  if (meta?.summary) lines.push(`- **Verdict:** ${meta.summary}`)
+  if (meta?.assertions) {
+    const { passed, failed, error } = meta.assertions
+    if (passed + failed + error > 0) {
+      lines.push(`- **Assertions:** ${passed} passed · ${failed} failed · ${error} error`)
+    }
+  }
+  const stamps = trace
+    .map((e) => e.timestamp)
+    .filter(Boolean)
+    .sort()
+  const first = stamps[0]
+  const last = stamps[stamps.length - 1]
+  if (first) lines.push(`- **Time:** ${first}${last && last !== first ? ` → ${last}` : ''}`)
+  lines.push(`- **Events:** ${trace.length}`)
+  return lines.join('\n')
+}
+
+/** Serialize a trace (already-grouped via {@link groupTrace}) into Markdown. */
+export function traceToMarkdown(trace: EvalTraceEvent[], meta?: TraceMarkdownMeta): string {
+  const sections = [header(trace, meta), '---']
+
+  for (const turn of groupTrace(trace)) {
+    if (turn.kind === 'customer') {
+      sections.push(['**Customer**', '', blockquote(turn.text || '_(empty message)_')].join('\n'))
+      continue
+    }
+
+    const body: string[] = ['**Agent**', '']
+    for (const run of turn.runs) {
+      if (run.kind === 'agent_text') {
+        body.push(run.text || '_(empty message)_', '')
+      } else if (run.kind === 'tool_calls') {
+        for (const call of run.calls) body.push(toolCallMarkdown(call), '')
+      } else {
+        body.push(noticeMarkdown(run.event), '')
+      }
+    }
+    sections.push(body.join('\n').trimEnd())
+  }
+
+  return `${sections.join('\n\n')}\n`
+}

--- a/apps/web/src/server/api/routers/agent-procedure.ts
+++ b/apps/web/src/server/api/routers/agent-procedure.ts
@@ -7,6 +7,7 @@ import {
   detachProcedure,
   listAgentProcedures,
   listProcedures,
+  reconcileAgentProcedureMentions,
   updateAgentProcedure,
 } from '@auxx/lib/agents/procedures'
 import { FeaturePermissionService } from '@auxx/lib/permissions'
@@ -86,6 +87,9 @@ export const agentProcedureRouter = createTRPCRouter({
         }),
         'attach procedure'
       )
+      // A fresh procedure has an empty doc, but reconcile anyway so the agent's
+      // `'procedure'` tag is initialized (and stays correct if the create seeds a body).
+      await reconcileAgentProcedureMentions(organizationId, input.agentId)
       return { linkId: link.id, procedureId: procedure.id }
     }),
 
@@ -103,6 +107,9 @@ export const agentProcedureRouter = createTRPCRouter({
         }),
         'attach procedure'
       )
+      // Attaching an existing (possibly published) procedure can lock new
+      // toolsets/knowledge on the agent — reconcile its `'procedure'` tag.
+      await reconcileAgentProcedureMentions(organizationId, input.agentId)
       return { linkId: link.id }
     }),
 
@@ -120,7 +127,16 @@ export const agentProcedureRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
       const { id, ...patch } = input
-      unwrap(await updateAgentProcedure({ organizationId, id, patch }), 'update agent procedure')
+      const row = unwrap(
+        await updateAgentProcedure({ organizationId, id, patch }),
+        'update agent procedure'
+      )
+      // Only an enabled flip changes the agent's effective procedure set;
+      // priority/override edits don't. Reconcile is idempotent, so re-running on a
+      // no-op enabled patch is harmless — gate on the field being present.
+      if (input.enabled !== undefined) {
+        await reconcileAgentProcedureMentions(organizationId, row.agentId)
+      }
       return { ok: true as const }
     }),
 
@@ -128,7 +144,13 @@ export const agentProcedureRouter = createTRPCRouter({
     .input(z.object({ id: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      unwrap(await detachProcedure({ organizationId, id: input.id }), 'detach procedure')
+      // detach returns the removed link's agentId so we can reconcile its
+      // `'procedure'` tag AFTER the delete (the link is now excluded).
+      const agentId = unwrap(
+        await detachProcedure({ organizationId, id: input.id }),
+        'detach procedure'
+      )
+      if (agentId) await reconcileAgentProcedureMentions(organizationId, agentId)
       return { ok: true as const }
     }),
 })

--- a/apps/web/src/server/api/routers/procedure.ts
+++ b/apps/web/src/server/api/routers/procedure.ts
@@ -8,9 +8,12 @@ import {
   discardProcedureDraft,
   getProcedureById,
   getProcedureVersionById,
+  listAgentIdsForProcedure,
   listProcedures,
   listProcedureVersions,
   publishProcedure,
+  reconcileProcedureMentionsForAgents,
+  reconcileProcedureMentionsForAllAgents,
   revertProcedure,
   type TiptapDoc,
   updateDraftDoc,
@@ -148,6 +151,9 @@ export const procedureRouter = createTRPCRouter({
           await updateDraftDoc({ organizationId, procedureId: id, doc: doc as TiptapDoc }),
           'update draft doc'
         )
+        // A draft doc edit can add/remove `tool:`/record chips — fan the
+        // `'procedure'` tag out to every agent this procedure is attached to.
+        await reconcileProcedureMentionsForAllAgents(organizationId, id)
       }
       // Re-read and return the authoritative meta (same projection as getById
       // minus draftDoc) so the client's optimistic store settles on truth —
@@ -172,7 +178,11 @@ export const procedureRouter = createTRPCRouter({
     .input(z.object({ id: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
+      // Capture the attached agents BEFORE the delete cascade-detaches the links,
+      // then reconcile each AFTER so the gone procedure drops out of their tag.
+      const agentIds = await listAgentIdsForProcedure(organizationId, input.id)
       unwrap(await deleteProcedure({ organizationId, procedureId: input.id }), 'delete procedure')
+      await reconcileProcedureMentionsForAgents(organizationId, agentIds)
       return { ok: true as const }
     }),
 
@@ -202,6 +212,9 @@ export const procedureRouter = createTRPCRouter({
         await discardProcedureDraft({ organizationId, procedureId: input.id }),
         'discard procedure draft'
       )
+      // Draft doc was rewritten back to the active version — the draft+active
+      // union may have changed, so re-fan the `'procedure'` tag.
+      await reconcileProcedureMentionsForAllAgents(organizationId, input.id)
       return {
         id: procedure.id,
         name: procedure.name,
@@ -282,6 +295,9 @@ export const procedureRouter = createTRPCRouter({
         'publish procedure'
       )
       await onCacheEvent('procedure.updated', { orgId: organizationId })
+      // Publish moves the active version — fan the `'procedure'` tag out so the
+      // runtime toolsets of every attached agent track the new active doc.
+      await reconcileProcedureMentionsForAllAgents(organizationId, input.id)
       logger.info('Procedure published', {
         organizationId,
         procedureId: input.id,
@@ -303,6 +319,8 @@ export const procedureRouter = createTRPCRouter({
         'revert procedure'
       )
       await onCacheEvent('procedure.updated', { orgId: organizationId })
+      // Revert repoints the active version + rewrites the draft — re-fan the tag.
+      await reconcileProcedureMentionsForAllAgents(organizationId, input.id)
       return { ok: true as const }
     }),
 })

--- a/apps/worker/scripts/backfill-procedure-mention-tags.ts
+++ b/apps/worker/scripts/backfill-procedure-mention-tags.ts
@@ -1,0 +1,98 @@
+// apps/worker/scripts/backfill-procedure-mention-tags.ts
+/**
+ * One-time backfill for the procedure-doc → toolset reconciliation feature.
+ *
+ * Step 1 (pure jsonb): tag every existing `source:'mention'` toolset/knowledge
+ *   row with `mentionedBy:['prompt']` — today all mentions originate from the
+ *   agent prompt. Idempotent: only rows missing `mentionedBy` are touched.
+ *
+ * Step 2 (lib reconcile): for every agent with an enabled attached procedure,
+ *   run `reconcileAgentProcedureMentions` to add the `'procedure'` tag from the
+ *   procedure docs (draft + active). This also fixes agents whose prompt-only
+ *   reconcile previously dropped a procedure-referenced toolset.
+ *
+ * Run (from repo root) under the worker runtime so the @auxx/lib import chain
+ * resolves its native ESM deps:
+ *   node --conditions source --env-file .env --import tsx/esm \
+ *     apps/worker/scripts/backfill-procedure-mention-tags.ts
+ */
+
+import { database, schema } from '@auxx/database'
+import { reconcileAgentProcedureMentions } from '@auxx/lib/agents/procedures'
+import { eq, sql } from 'drizzle-orm'
+
+async function backfillPromptTags() {
+  console.log('Step 1: tagging existing mention rows with ["prompt"]...')
+
+  // jsonb_set per element: add mentionedBy:['prompt'] to mention rows that lack
+  // it; leave manual/auto_default rows and already-tagged rows untouched.
+  const toolsets = await database.execute(sql`
+    UPDATE "Agent"
+    SET toolsets = COALESCE((
+      SELECT jsonb_agg(
+        CASE
+          WHEN elem->>'source' = 'mention' AND NOT jsonb_exists(elem, 'mentionedBy')
+          THEN elem || '{"mentionedBy":["prompt"]}'::jsonb
+          ELSE elem
+        END
+      )
+      FROM jsonb_array_elements(toolsets) AS elem
+    ), toolsets)
+    WHERE toolsets @> '[{"source":"mention"}]'::jsonb
+  `)
+  console.log('  toolsets rows updated:', toolsets.rowCount)
+
+  const knowledge = await database.execute(sql`
+    UPDATE "Agent"
+    SET knowledge = COALESCE((
+      SELECT jsonb_agg(
+        CASE
+          WHEN elem->>'source' = 'mention' AND NOT jsonb_exists(elem, 'mentionedBy')
+          THEN elem || '{"mentionedBy":["prompt"]}'::jsonb
+          ELSE elem
+        END
+      )
+      FROM jsonb_array_elements(knowledge) AS elem
+    ), knowledge)
+    WHERE knowledge @> '[{"source":"mention"}]'::jsonb
+  `)
+  console.log('  knowledge rows updated:', knowledge.rowCount)
+}
+
+async function backfillProcedureTags() {
+  console.log('Step 2: reconciling the "procedure" tag for agents with enabled procedures...')
+
+  const links = await database
+    .selectDistinct({
+      organizationId: schema.AgentProcedure.organizationId,
+      agentId: schema.AgentProcedure.agentId,
+    })
+    .from(schema.AgentProcedure)
+    .where(eq(schema.AgentProcedure.enabled, true))
+
+  console.log(`  ${links.length} agent(s) with enabled procedures`)
+  let ok = 0
+  for (const { organizationId, agentId } of links) {
+    try {
+      await reconcileAgentProcedureMentions(organizationId, agentId)
+      ok++
+    } catch (err) {
+      console.error(`  reconcile failed for agent ${agentId}:`, err)
+    }
+  }
+  console.log(`  reconciled ${ok}/${links.length} agents`)
+}
+
+async function main() {
+  try {
+    await backfillPromptTags()
+    await backfillProcedureTags()
+    console.log('Backfill complete.')
+    process.exit(0)
+  } catch (err) {
+    console.error('Backfill failed:', err)
+    process.exit(1)
+  }
+}
+
+main()

--- a/packages/database/src/db/schema/agent.ts
+++ b/packages/database/src/db/schema/agent.ts
@@ -16,6 +16,14 @@ import { Organization } from './organization'
 import { User } from './user'
 
 /**
+ * Which input locks a mention-sourced toolset/knowledge entry. A `tool:`/record
+ * chip enables its target from the agent **prompt** or from any enabled attached
+ * **procedure** doc; the two reconcile independently so the hot prompt-autosave
+ * path never reads procedures. See plans/evals/procedure-mention-toolset-reconciliation-plan.md.
+ */
+export type MentionSource = 'prompt' | 'procedure'
+
+/**
  * One entry inside `Agent.toolsets`. Replaces the old `AgentToolset` join
  * table. See plans/kopilot/agents/ui/single-row-agent.md §1.
  */
@@ -27,6 +35,12 @@ export interface ToolsetEntry {
   config: Record<string, unknown>
   enabled: boolean
   source: 'manual' | 'mention' | 'auto_default'
+  /**
+   * When `source === 'mention'`, the inputs that lock this toolset. Non-empty ⇒
+   * mention-locked + enabled. Cleared per-source by the matching reconciler; the
+   * row drops when it empties. Absent on manual/auto_default rows.
+   */
+  mentionedBy?: MentionSource[]
 }
 
 /**
@@ -41,6 +55,12 @@ export interface KnowledgeEntry {
   recordId: string
   mode: 'include_descendants' | 'include_one' | 'exclude'
   source: 'manual' | 'mention'
+  /**
+   * When `source === 'mention'`, the inputs that lock this record (prompt and/or
+   * an enabled attached procedure doc). Same semantics as
+   * {@link ToolsetEntry.mentionedBy}. Absent on manual rows.
+   */
+  mentionedBy?: MentionSource[]
 }
 
 /**

--- a/packages/lib/src/agents/__tests__/prompt-mention-reconciler.test.ts
+++ b/packages/lib/src/agents/__tests__/prompt-mention-reconciler.test.ts
@@ -3,11 +3,12 @@
 import { describe, expect, it } from 'vitest'
 import {
   type KnowledgeEntry,
-  reconcileKnowledge,
+  reconcileKnowledgeMentions,
   reconcilePromptMentions,
-  reconcileToolsets,
+  reconcileToolsetMentions,
   type ToolsetEntry,
   walkPromptDoc,
+  walkPromptDocs,
 } from '../prompt-mention-reconciler'
 import type { FlatToolCatalogEntry } from '../toolset-catalog'
 
@@ -134,114 +135,216 @@ describe('walkPromptDoc', () => {
   })
 })
 
-describe('reconcileToolsets', () => {
-  function ts(slug: string, source: ToolsetEntry['source']): ToolsetEntry {
-    return { slug, config: {}, enabled: true, source }
-  }
-
-  it('inserts a new mention row when slug is not covered', () => {
-    const next = reconcileToolsets([], new Set(['auxx:mail:threads']))
-    expect(next).toEqual([ts('auxx:mail:threads', 'mention')])
-  })
-
-  it('drops stale mention rows', () => {
-    const next = reconcileToolsets([ts('auxx:mail:threads', 'mention')], new Set())
-    expect(next).toEqual([])
-  })
-
-  it('promotes a manual row to mention when its slug is mentioned', () => {
-    const next = reconcileToolsets(
-      [ts('auxx:mail:threads', 'manual')],
-      new Set(['auxx:mail:threads'])
+describe('walkPromptDocs', () => {
+  it('unions slugs and recordIds across many docs', () => {
+    const result = walkPromptDocs(
+      [
+        doc(paragraph(reference('tool:list_threads'), reference('article:abc'))),
+        doc(paragraph(reference('tool:search_articles'), reference('article:abc'))),
+      ],
+      TOOL_CATALOG
     )
-    expect(next).toEqual([ts('auxx:mail:threads', 'mention')])
+    expect([...result.toolsetSlugs].sort()).toEqual(['auxx:knowledge', 'auxx:mail:threads'])
+    expect([...result.recordIds]).toEqual(['article:abc'])
   })
 
-  it('promotes an auto_default row to mention when its slug is mentioned', () => {
-    const next = reconcileToolsets(
-      [ts('auxx:mail:threads', 'auto_default')],
-      new Set(['auxx:mail:threads'])
+  it('resolves a same-id collision across docs by registered name', () => {
+    const result = walkPromptDocs(
+      [
+        doc(paragraph(reference('tool:slack_send_message'))),
+        doc(paragraph(reference('tool:teams_send_message'))),
+      ],
+      TOOL_CATALOG
     )
-    expect(next).toEqual([ts('auxx:mail:threads', 'mention')])
+    expect([...result.toolsetSlugs].sort()).toEqual(['app:slack:messages', 'app:teams:messages'])
   })
 
-  it('re-enables a disabled manual row when its slug is mentioned', () => {
-    const next = reconcileToolsets(
-      [{ slug: 'auxx:mail:threads', config: {}, enabled: false, source: 'manual' }],
-      new Set(['auxx:mail:threads'])
-    )
-    expect(next).toEqual([ts('auxx:mail:threads', 'mention')])
-  })
-
-  it('handles a mention→remove cycle', () => {
-    const first = reconcileToolsets([], new Set(['auxx:knowledge']))
-    const second = reconcileToolsets(first, new Set())
-    expect(second).toEqual([])
+  it('returns empty for no docs', () => {
+    const result = walkPromptDocs([], TOOL_CATALOG)
+    expect(result.toolsetSlugs.size).toBe(0)
+    expect(result.recordIds.size).toBe(0)
   })
 })
 
-describe('reconcileKnowledge', () => {
+describe('reconcileToolsetMentions', () => {
+  function ts(
+    slug: string,
+    source: ToolsetEntry['source'],
+    mentionedBy?: ToolsetEntry['mentionedBy']
+  ): ToolsetEntry {
+    return { slug, config: {}, enabled: true, source, ...(mentionedBy ? { mentionedBy } : {}) }
+  }
+
+  it('inserts a new prompt-tagged mention row when slug is not covered', () => {
+    const next = reconcileToolsetMentions([], new Set(['auxx:mail:threads']), 'prompt')
+    expect(next).toEqual([ts('auxx:mail:threads', 'mention', ['prompt'])])
+  })
+
+  it('drops a prompt-only mention row when no longer mentioned', () => {
+    const next = reconcileToolsetMentions(
+      [ts('auxx:mail:threads', 'mention', ['prompt'])],
+      new Set(),
+      'prompt'
+    )
+    expect(next).toEqual([])
+  })
+
+  it('promotes a manual row to a tagged mention when mentioned', () => {
+    const next = reconcileToolsetMentions(
+      [ts('auxx:mail:threads', 'manual')],
+      new Set(['auxx:mail:threads']),
+      'procedure'
+    )
+    expect(next).toEqual([ts('auxx:mail:threads', 'mention', ['procedure'])])
+  })
+
+  it('re-enables a disabled manual row when mentioned', () => {
+    const next = reconcileToolsetMentions(
+      [{ slug: 'auxx:mail:threads', config: {}, enabled: false, source: 'manual' }],
+      new Set(['auxx:mail:threads']),
+      'prompt'
+    )
+    expect(next).toEqual([ts('auxx:mail:threads', 'mention', ['prompt'])])
+  })
+
+  it('a prompt-only call leaves a procedure-tagged row intact', () => {
+    const next = reconcileToolsetMentions(
+      [ts('app:shopify:orders.read', 'mention', ['procedure'])],
+      new Set(),
+      'prompt'
+    )
+    expect(next).toEqual([ts('app:shopify:orders.read', 'mention', ['procedure'])])
+  })
+
+  it('a procedure-only call leaves a prompt-tagged row intact', () => {
+    const next = reconcileToolsetMentions(
+      [ts('auxx:mail:threads', 'mention', ['prompt'])],
+      new Set(),
+      'procedure'
+    )
+    expect(next).toEqual([ts('auxx:mail:threads', 'mention', ['prompt'])])
+  })
+
+  it('a slug locked by both tags survives clearing one tag', () => {
+    const both = ts('app:shopify:orders.read', 'mention', ['prompt', 'procedure'])
+    const afterPrompt = reconcileToolsetMentions([both], new Set(), 'prompt')
+    expect(afterPrompt).toEqual([ts('app:shopify:orders.read', 'mention', ['procedure'])])
+    // ...and drops only when the other tag is cleared too.
+    const afterBoth = reconcileToolsetMentions(afterPrompt, new Set(), 'procedure')
+    expect(afterBoth).toEqual([])
+  })
+
+  it('adds the second tag when both inputs mention the same slug', () => {
+    const promptOnly = reconcileToolsetMentions([], new Set(['auxx:knowledge']), 'prompt')
+    const both = reconcileToolsetMentions(promptOnly, new Set(['auxx:knowledge']), 'procedure')
+    expect(both).toEqual([ts('auxx:knowledge', 'mention', ['prompt', 'procedure'])])
+  })
+})
+
+describe('reconcileKnowledgeMentions', () => {
   function k(
     recordId: string,
     mode: KnowledgeEntry['mode'],
-    source: KnowledgeEntry['source']
+    source: KnowledgeEntry['source'],
+    mentionedBy?: KnowledgeEntry['mentionedBy']
   ): KnowledgeEntry {
-    return { recordId, mode, source }
+    return { recordId, mode, source, ...(mentionedBy ? { mentionedBy } : {}) }
   }
 
-  it('inserts a new mention entry when recordId is not covered', () => {
-    const next = reconcileKnowledge([], new Set(['article:abc']))
-    expect(next).toEqual([k('article:abc', 'include_one', 'mention')])
+  it('inserts a new prompt-tagged mention entry when not covered', () => {
+    const next = reconcileKnowledgeMentions([], new Set(['article:abc']), 'prompt')
+    expect(next).toEqual([k('article:abc', 'include_one', 'mention', ['prompt'])])
   })
 
-  it('drops stale mention entries', () => {
-    const next = reconcileKnowledge([k('article:abc', 'include_one', 'mention')], new Set())
+  it('drops a prompt-only mention entry when no longer mentioned', () => {
+    const next = reconcileKnowledgeMentions(
+      [k('article:abc', 'include_one', 'mention', ['prompt'])],
+      new Set(),
+      'prompt'
+    )
     expect(next).toEqual([])
   })
 
   it('keeps manual include entries and skips the duplicate mention', () => {
-    const next = reconcileKnowledge(
+    const next = reconcileKnowledgeMentions(
       [k('article:abc', 'include_descendants', 'manual')],
-      new Set(['article:abc'])
+      new Set(['article:abc']),
+      'procedure'
     )
     expect(next).toEqual([k('article:abc', 'include_descendants', 'manual')])
   })
 
-  it('drops a manual exclude when conflicting with a mention (mention wins)', () => {
-    const next = reconcileKnowledge(
+  it('drops a manual exclude colliding with a mention (mention wins)', () => {
+    const next = reconcileKnowledgeMentions(
       [k('article:abc', 'exclude', 'manual')],
-      new Set(['article:abc'])
+      new Set(['article:abc']),
+      'procedure'
     )
-    expect(next).toEqual([k('article:abc', 'include_one', 'mention')])
+    expect(next).toEqual([k('article:abc', 'include_one', 'mention', ['procedure'])])
   })
 
-  it('preserves manual entries on unrelated keys when reconciling mentions', () => {
-    const next = reconcileKnowledge(
-      [
-        k('article:keep', 'include_descendants', 'manual'),
-        k('article:stale', 'include_one', 'mention'),
-      ],
-      new Set(['article:new'])
+  it('a prompt-only call leaves a procedure-tagged record intact', () => {
+    const next = reconcileKnowledgeMentions(
+      [k('article:abc', 'include_one', 'mention', ['procedure'])],
+      new Set(),
+      'prompt'
     )
-    expect(next.sort((a, b) => a.recordId.localeCompare(b.recordId))).toEqual([
-      k('article:keep', 'include_descendants', 'manual'),
-      k('article:new', 'include_one', 'mention'),
-    ])
+    expect(next).toEqual([k('article:abc', 'include_one', 'mention', ['procedure'])])
+  })
+
+  it('a record locked by both tags survives clearing one tag', () => {
+    const both = k('article:abc', 'include_one', 'mention', ['prompt', 'procedure'])
+    const afterProcedure = reconcileKnowledgeMentions([both], new Set(), 'procedure')
+    expect(afterProcedure).toEqual([k('article:abc', 'include_one', 'mention', ['prompt'])])
   })
 })
 
 describe('reconcilePromptMentions', () => {
-  it('returns combined next state', () => {
+  it('returns combined next state tagged prompt', () => {
     const result = reconcilePromptMentions({
       prompt: doc(paragraph(reference('tool:list_threads'), reference('article:abc'))),
       current: { toolsets: [], knowledge: [] },
       toolCatalog: TOOL_CATALOG,
     })
     expect(result.toolsets).toEqual([
-      { slug: 'auxx:mail:threads', config: {}, enabled: true, source: 'mention' },
+      {
+        slug: 'auxx:mail:threads',
+        config: {},
+        enabled: true,
+        source: 'mention',
+        mentionedBy: ['prompt'],
+      },
     ])
     expect(result.knowledge).toEqual([
-      { recordId: 'article:abc', mode: 'include_one', source: 'mention' },
+      { recordId: 'article:abc', mode: 'include_one', source: 'mention', mentionedBy: ['prompt'] },
+    ])
+  })
+
+  it('does not clear a procedure-tagged toolset (regression guard)', () => {
+    const result = reconcilePromptMentions({
+      prompt: doc(), // empty prompt — no mentions
+      current: {
+        toolsets: [
+          {
+            slug: 'app:shopify:orders.read',
+            config: {},
+            enabled: true,
+            source: 'mention',
+            mentionedBy: ['procedure'],
+          },
+        ],
+        knowledge: [],
+      },
+      toolCatalog: TOOL_CATALOG,
+    })
+    expect(result.toolsets).toEqual([
+      {
+        slug: 'app:shopify:orders.read',
+        config: {},
+        enabled: true,
+        source: 'mention',
+        mentionedBy: ['procedure'],
+      },
     ])
   })
 })

--- a/packages/lib/src/agents/client.ts
+++ b/packages/lib/src/agents/client.ts
@@ -440,10 +440,12 @@ export type {
  * same functions on flush, so client and server agree by construction.
  */
 export {
-  reconcileKnowledge,
+  type MentionSource,
+  reconcileKnowledgeMentions,
   reconcilePromptMentions,
-  reconcileToolsets,
+  reconcileToolsetMentions,
   walkPromptDoc,
+  walkPromptDocs,
 } from './prompt-mention-reconciler'
 export { AGENT_SLUG_MAX, AGENT_SLUG_REGEX, agentSlugSchema } from './slug-schema'
 export {

--- a/packages/lib/src/agents/index.ts
+++ b/packages/lib/src/agents/index.ts
@@ -66,12 +66,14 @@ export {
   type KnowledgeEntry,
   type KnowledgeMode,
   type KnowledgeSource,
-  reconcileKnowledge,
+  type MentionSource,
+  reconcileKnowledgeMentions,
   reconcilePromptMentions,
-  reconcileToolsets,
+  reconcileToolsetMentions,
   type ToolsetEntry,
   type ToolsetSource,
   walkPromptDoc,
+  walkPromptDocs,
 } from './prompt-mention-reconciler'
 export { type ResolvedAgentConfig, resolveAgentConfig } from './resolve-agent-config'
 export {

--- a/packages/lib/src/agents/procedures/index.ts
+++ b/packages/lib/src/agents/procedures/index.ts
@@ -34,6 +34,12 @@ export {
 } from './control-tools'
 export { sessionMessagesToConversation } from './conversation'
 export {
+  listAgentIdsForProcedure,
+  reconcileAgentProcedureMentions,
+  reconcileProcedureMentionsForAgents,
+  reconcileProcedureMentionsForAllAgents,
+} from './mention-reconcile'
+export {
   type CodeBlockMapEntry,
   type ConditionBlockAttrs,
   type ConditionCaseAttrs,

--- a/packages/lib/src/agents/procedures/mention-reconcile.ts
+++ b/packages/lib/src/agents/procedures/mention-reconcile.ts
@@ -1,0 +1,150 @@
+// packages/lib/src/agents/procedures/mention-reconcile.ts
+
+import { database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, or } from 'drizzle-orm'
+import { onCacheEvent } from '../../cache'
+import { getRealtimeService, publishAgentUpdated } from '../../realtime'
+import {
+  reconcileKnowledgeMentions,
+  reconcileToolsetMentions,
+  walkPromptDocs,
+} from '../prompt-mention-reconciler'
+import { getOrgToolCatalog } from '../toolset-catalog'
+
+const logger = createScopedLogger('procedure-mention-reconcile')
+
+/**
+ * Recompute the **`'procedure'`** mention tag on one agent's `Agent.toolsets` /
+ * `Agent.knowledge` from its enabled attached procedures' docs.
+ *
+ * A `tool:`/record chip in a procedure doc enables its target on every agent the
+ * procedure is attached to — symmetric to the prompt path, but provenance-tagged
+ * `'procedure'` so the prompt-autosave reconciler never touches (or has to read)
+ * it. The procedure tag spans BOTH the draft and active version docs (D1): the
+ * eval suggester + editor read the draft pre-publish; the runtime reads the
+ * active. Over-enabling a draft-only tool is intentional — the capability is
+ * present but only *instructed* by the version that references it.
+ *
+ * Runs post-commit relative to the procedure write that triggered it; the per-tag
+ * reconciler is an idempotent full recompute, so a separate transaction is safe.
+ */
+export async function reconcileAgentProcedureMentions(
+  organizationId: string,
+  agentId: string
+): Promise<void> {
+  // Draft + active docs of every ENABLED attached procedure, in one query.
+  const rows = await database
+    .select({ doc: schema.ProcedureVersion.doc })
+    .from(schema.AgentProcedure)
+    .innerJoin(schema.Procedure, eq(schema.Procedure.id, schema.AgentProcedure.procedureId))
+    .innerJoin(
+      schema.ProcedureVersion,
+      or(
+        eq(schema.ProcedureVersion.id, schema.Procedure.draftVersionId),
+        eq(schema.ProcedureVersion.id, schema.Procedure.activeVersionId)
+      )
+    )
+    .where(
+      and(
+        eq(schema.AgentProcedure.agentId, agentId),
+        eq(schema.AgentProcedure.organizationId, organizationId),
+        eq(schema.AgentProcedure.enabled, true)
+      )
+    )
+
+  const docs = rows.map((r) => (r.doc ?? {}) as Record<string, unknown>)
+  const catalog = await getOrgToolCatalog(organizationId)
+  const { toolsetSlugs, recordIds } = walkPromptDocs(docs, catalog)
+
+  await database.transaction(async (tx) => {
+    const [agent] = await tx
+      .select({ toolsets: schema.Agent.toolsets, knowledge: schema.Agent.knowledge })
+      .from(schema.Agent)
+      .where(and(eq(schema.Agent.id, agentId), eq(schema.Agent.organizationId, organizationId)))
+      .for('update')
+      .limit(1)
+    if (!agent) return
+
+    const toolsets = reconcileToolsetMentions(agent.toolsets ?? [], toolsetSlugs, 'procedure')
+    const knowledge = reconcileKnowledgeMentions(agent.knowledge ?? [], recordIds, 'procedure')
+    await tx
+      .update(schema.Agent)
+      .set({ toolsets, knowledge, updatedAt: new Date() })
+      .where(eq(schema.Agent.id, agentId))
+  })
+
+  try {
+    await onCacheEvent('agent.updated', { orgId: organizationId })
+  } catch (err) {
+    logger.warn('Failed to invalidate caches after procedure mention reconcile', {
+      organizationId,
+      agentId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+  await publishAgentUpdated(getRealtimeService(), organizationId, { agentId })
+}
+
+/**
+ * Enabled-link agent ids for a procedure — the fan-out set for a procedure-side
+ * edit (draft save, publish, revert, discard). Reverse of `listAgentProcedures`.
+ * De-duped.
+ */
+export async function listAgentIdsForProcedure(
+  organizationId: string,
+  procedureId: string
+): Promise<string[]> {
+  const rows = await database
+    .select({ agentId: schema.AgentProcedure.agentId })
+    .from(schema.AgentProcedure)
+    .where(
+      and(
+        eq(schema.AgentProcedure.procedureId, procedureId),
+        eq(schema.AgentProcedure.organizationId, organizationId),
+        eq(schema.AgentProcedure.enabled, true)
+      )
+    )
+  return [...new Set(rows.map((r) => r.agentId))]
+}
+
+/**
+ * Reconcile the `'procedure'` tag on a list of agents. One failure is logged and
+ * skipped so the rest still settle. Used by procedure-delete (ids captured before
+ * the cascade) and any explicit fan-out.
+ */
+export async function reconcileProcedureMentionsForAgents(
+  organizationId: string,
+  agentIds: string[]
+): Promise<void> {
+  for (const agentId of agentIds) {
+    try {
+      await reconcileAgentProcedureMentions(organizationId, agentId)
+    } catch (err) {
+      logger.warn('Failed to reconcile procedure mentions for agent', {
+        organizationId,
+        agentId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+}
+
+/**
+ * Fan a procedure-side edit out to every agent the procedure is attached to
+ * (enabled links). Triggers: draft-doc save, publish, revert, discard.
+ */
+export async function reconcileProcedureMentionsForAllAgents(
+  organizationId: string,
+  procedureId: string
+): Promise<void> {
+  const agentIds = await listAgentIdsForProcedure(organizationId, procedureId)
+  if (agentIds.length > 8) {
+    logger.info('Large procedure mention fan-out', {
+      organizationId,
+      procedureId,
+      agentCount: agentIds.length,
+    })
+  }
+  await reconcileProcedureMentionsForAgents(organizationId, agentIds)
+}

--- a/packages/lib/src/agents/procedures/queries.ts
+++ b/packages/lib/src/agents/procedures/queries.ts
@@ -635,11 +635,15 @@ export async function detachProcedure(input: { organizationId: string; id: strin
           eq(schema.AgentProcedure.id, input.id),
           eq(schema.AgentProcedure.organizationId, input.organizationId)
         )
-      ),
+      )
+      .returning({ agentId: schema.AgentProcedure.agentId }),
     'detach-procedure'
   )
   if (result.isErr()) return err(result.error)
-  return ok(undefined)
+  // The deleted link's agentId — the caller reconciles its `'procedure'` tag
+  // AFTER the delete commits (so the now-removed link is excluded). Null if the
+  // link was already gone.
+  return ok(result.value[0]?.agentId ?? null)
 }
 
 export type { AgentProcedureEntity, ProcedureEntity, ProcedureVersionEntity }

--- a/packages/lib/src/agents/prompt-mention-reconciler.ts
+++ b/packages/lib/src/agents/prompt-mention-reconciler.ts
@@ -1,9 +1,9 @@
 // packages/lib/src/agents/prompt-mention-reconciler.ts
 
-import type { KnowledgeEntry, ToolsetEntry } from '@auxx/database'
+import type { KnowledgeEntry, MentionSource, ToolsetEntry } from '@auxx/database'
 import type { FlatToolCatalogEntry } from './toolset-catalog'
 
-export type { KnowledgeEntry, ToolsetEntry }
+export type { KnowledgeEntry, MentionSource, ToolsetEntry }
 export type ToolsetSource = ToolsetEntry['source']
 export type KnowledgeMode = KnowledgeEntry['mode']
 export type KnowledgeSource = KnowledgeEntry['source']
@@ -83,69 +83,119 @@ export function walkPromptDoc(
 }
 
 /**
- * Reconcile `Agent.toolsets` against the set of mentioned toolset slugs.
- *
- * - Stale `mention` rows (slug no longer mentioned) are dropped.
- * - When a slug is mentioned, the row is promoted to `source: 'mention'` and
- *   `enabled: true`, regardless of whether a prior manual / auto_default row
- *   existed (including one left at `enabled: false` from a previous trash).
- *   This makes "mentioned in prompt = locked" hold unconditionally.
- * - New mention rows are inserted when no row covers the slug.
+ * Walk several Tiptap docs and return the union of their mentioned toolset slugs
+ * and record ids. Used by the procedure side, where an agent's enabled attached
+ * procedures contribute many docs (each procedure's draft + active version) that
+ * collectively lock toolsets/knowledge. Pure.
  */
-export function reconcileToolsets(
+export function walkPromptDocs(
+  docs: Record<string, unknown>[],
+  toolCatalog: FlatToolCatalogEntry[]
+): WalkedPrompt {
+  const toolsetSlugs = new Set<string>()
+  const recordIds = new Set<string>()
+  for (const doc of docs) {
+    const walk = walkPromptDoc(doc, toolCatalog)
+    for (const slug of walk.toolsetSlugs) toolsetSlugs.add(slug)
+    for (const id of walk.recordIds) recordIds.add(id)
+  }
+  return { toolsetSlugs, recordIds }
+}
+
+/** De-dupe + drop a tag from a `mentionedBy` set; returns a fresh minimal array. */
+function withTag(mentionedBy: MentionSource[] | undefined, tag: MentionSource): MentionSource[] {
+  return mentionedBy?.includes(tag) ? mentionedBy : [...(mentionedBy ?? []), tag]
+}
+function withoutTag(mentionedBy: MentionSource[] | undefined, tag: MentionSource): MentionSource[] {
+  return (mentionedBy ?? []).filter((t) => t !== tag)
+}
+
+/**
+ * Reconcile `Agent.toolsets` against the slugs mentioned by a **single input**
+ * (`tag` = `'prompt'` or `'procedure'`). Touches only that tag's provenance and
+ * leaves the other input's lock intact, so the two sources reconcile
+ * independently — the prompt-autosave path can never drop a procedure-locked
+ * toolset and vice-versa.
+ *
+ * - A mentioned slug ensures `tag ∈ mentionedBy`, promotes any manual/auto_default
+ *   row to `source:'mention'`, and forces `enabled:true` (mentioned = locked).
+ * - An un-mentioned `mention` row loses `tag`; it drops only when `mentionedBy`
+ *   empties (the other tag may still hold it). Manual/auto_default rows are
+ *   never touched when not mentioned.
+ * - New mention rows are inserted for any slug not already covered.
+ */
+export function reconcileToolsetMentions(
   current: ToolsetEntry[],
-  mentionedSlugs: Set<string>
+  mentionedSlugs: Set<string>,
+  tag: MentionSource
 ): ToolsetEntry[] {
-  const kept = current
-    .filter((t) => t.source !== 'mention' || mentionedSlugs.has(t.slug))
-    .map((t) =>
-      mentionedSlugs.has(t.slug) ? { ...t, source: 'mention' as const, enabled: true } : t
-    )
+  const next = current.map((t): ToolsetEntry => {
+    const mentioned = mentionedSlugs.has(t.slug)
+    if (t.source === 'mention') {
+      return mentioned
+        ? { ...t, enabled: true, mentionedBy: withTag(t.mentionedBy, tag) }
+        : { ...t, mentionedBy: withoutTag(t.mentionedBy, tag) }
+    }
+    // manual / auto_default — promote to a mention lock while mentioned, else leave.
+    return mentioned ? { ...t, source: 'mention', enabled: true, mentionedBy: [tag] } : t
+  })
+  const kept = next.filter((t) => t.source !== 'mention' || (t.mentionedBy?.length ?? 0) > 0)
   const known = new Set(kept.map((t) => t.slug))
   const added: ToolsetEntry[] = []
   for (const slug of mentionedSlugs) {
     if (known.has(slug)) continue
-    added.push({ slug, config: {}, enabled: true, source: 'mention' })
+    added.push({ slug, config: {}, enabled: true, source: 'mention', mentionedBy: [tag] })
   }
   return [...kept, ...added]
 }
 
 /**
- * Reconcile `Agent.knowledge` against the set of mentioned recordIds.
+ * Reconcile `Agent.knowledge` against the recordIds mentioned by a **single
+ * input** (`tag`). Symmetric to {@link reconcileToolsetMentions}: per-tag, the
+ * other source's lock survives.
  *
- * - Existing `mention` entries are dropped — the walked set is authoritative.
- * - Manual `exclude` entries that collide with a mention are dropped (mention
- *   wins, per locked-from-prompt §3.3).
- * - Surviving manual entries suppress the duplicate mention insert.
+ * - A mentioned `mention` row keeps/gains `tag`; an un-mentioned one loses `tag`
+ *   and drops when `mentionedBy` empties.
+ * - A manual `exclude` colliding with a mention is dropped (mention wins). Other
+ *   manual entries survive and suppress the duplicate mention insert.
  * - New mention entries land with `mode='include_one'`, `source='mention'`.
  */
-export function reconcileKnowledge(
+export function reconcileKnowledgeMentions(
   current: KnowledgeEntry[],
-  mentionedRecordIds: Set<string>
+  mentionedRecordIds: Set<string>,
+  tag: MentionSource
 ): KnowledgeEntry[] {
-  const manualOrDefault = current.filter((k) => k.source !== 'mention')
-  const mentionEntries: KnowledgeEntry[] = [...mentionedRecordIds].map((recordId) => ({
-    recordId,
-    mode: 'include_one',
-    source: 'mention',
-  }))
-  const mentionKeys = new Set(mentionEntries.map((m) => m.recordId))
-  const survivors = manualOrDefault.filter(
-    (k) => !(k.mode === 'exclude' && mentionKeys.has(k.recordId))
-  )
-  const survivorKeys = new Set(survivors.map((k) => k.recordId))
-  const newMentionEntries = mentionEntries.filter((m) => !survivorKeys.has(m.recordId))
-  return [...survivors, ...newMentionEntries]
+  const kept: KnowledgeEntry[] = []
+  for (const k of current) {
+    const mentioned = mentionedRecordIds.has(k.recordId)
+    if (k.source === 'mention') {
+      const mentionedBy = mentioned ? withTag(k.mentionedBy, tag) : withoutTag(k.mentionedBy, tag)
+      if (mentionedBy.length > 0) kept.push({ ...k, mentionedBy })
+      continue
+    }
+    // manual: an exclude colliding with a mention is dropped (mention wins).
+    if (mentioned && k.mode === 'exclude') continue
+    kept.push(k)
+  }
+  const known = new Set(kept.map((k) => k.recordId))
+  const added: KnowledgeEntry[] = []
+  for (const recordId of mentionedRecordIds) {
+    if (known.has(recordId)) continue
+    added.push({ recordId, mode: 'include_one', source: 'mention', mentionedBy: [tag] })
+  }
+  return [...kept, ...added]
 }
 
 /**
- * Reconcile both toolsets and knowledge against a prompt doc. Returns the next
- * state for the agent row; caller writes one UPDATE.
+ * Reconcile both toolsets and knowledge against the **agent prompt** doc (the
+ * `'prompt'` tag). Returns the next state for the agent row; caller writes one
+ * UPDATE. The procedure side runs the same per-tag reconcilers under the
+ * `'procedure'` tag — see `reconcileAgentProcedureMentions`.
  */
 export function reconcilePromptMentions(input: ReconcileMentionsInput): ReconcileMentionsOutput {
   const walk = walkPromptDoc(input.prompt, input.toolCatalog)
   return {
-    toolsets: reconcileToolsets(input.current.toolsets, walk.toolsetSlugs),
-    knowledge: reconcileKnowledge(input.current.knowledge, walk.recordIds),
+    toolsets: reconcileToolsetMentions(input.current.toolsets, walk.toolsetSlugs, 'prompt'),
+    knowledge: reconcileKnowledgeMentions(input.current.knowledge, walk.recordIds, 'prompt'),
   }
 }

--- a/packages/lib/src/evals/worker/process-eval-run.ts
+++ b/packages/lib/src/evals/worker/process-eval-run.ts
@@ -17,12 +17,27 @@ import { runAgentSimulation } from '../simulation/executor'
 import type { AgentDefinitionSnapshotV1 } from '../snapshots'
 import type { EvalRunJobData } from './enqueue-eval-run'
 import { createEvalRunPublisher } from './publisher'
+import { withEvalRunLog } from './run-log'
 
 const logger = createScopedLogger('worker:eval-run')
 
 const CHECKPOINT_BATCH = 10
 
 export async function processEvalRun(ctx: JobContext<EvalRunJobData>): Promise<void> {
+  const { runId } = ctx.data
+  const run = () => processEvalRunInternal(ctx)
+
+  // Dev only: tee eval-relevant logs (orchestration + the inner agent engine)
+  // to a per-run file under `.logs/eval-runs`, alongside agent-session traces.
+  // Gated on `!== 'production'` so the worker dev script (which doesn't set
+  // NODE_ENV) still gets traces — same convention as `processAgentMessage`.
+  if (process.env.NODE_ENV !== 'production') {
+    return withEvalRunLog(runId, run)
+  }
+  return run()
+}
+
+async function processEvalRunInternal(ctx: JobContext<EvalRunJobData>): Promise<void> {
   const { organizationId, userId, runId } = ctx.data
 
   // 1. Atomically claim `queued|running → running` (bumps attempt). A terminal

--- a/packages/lib/src/evals/worker/run-log.ts
+++ b/packages/lib/src/evals/worker/run-log.ts
@@ -1,0 +1,56 @@
+// packages/lib/src/evals/worker/run-log.ts
+
+import path from 'node:path'
+import { type RunLogFilter, withRunLog } from '@auxx/logger/run-log'
+
+/**
+ * Scope prefixes considered relevant to an eval-run trace. We keep both the eval
+ * orchestration scopes (`eval-`, `worker:eval-`) AND the agent-engine scopes
+ * (`agent-`, `kopilot-`) because an eval run drives the real agent engine — the
+ * agent's turn-by-turn reasoning is precisely what you want to inspect when
+ * developing and debugging a simulation. Everything else (provider clients,
+ * registry plumbing, unrelated cross-cutting work) is dropped.
+ *
+ * Add a prefix here when introducing a new eval or agent-domain module that
+ * should appear in eval-run traces.
+ */
+const EVAL_SCOPE_PREFIXES = ['eval-', 'worker:eval-', 'agent-', 'kopilot-']
+
+/**
+ * Levels excluded from the eval-run trace. Debug/trace are useful for targeted
+ * local debugging via console but produce too much noise in the per-run file
+ * (full message dumps, internal state snapshots, etc.).
+ */
+const EXCLUDED_LEVELS = new Set(['debug', 'trace'])
+
+const evalRunLogFilter: RunLogFilter = ({ scope, level }) => {
+  if (EXCLUDED_LEVELS.has(level)) return false
+  return EVAL_SCOPE_PREFIXES.some((prefix) => scope.startsWith(prefix))
+}
+
+/**
+ * Tee eval-relevant logs from `fn`'s async context to a per-run file.
+ * Dev only — callers should gate on NODE_ENV before invoking.
+ *
+ * The path, scope allowlist, and level threshold are all decided here so the
+ * logger package stays domain-blind. Mirrors `withAgentRunLog` so eval traces
+ * sit alongside agent-session traces under `.logs`.
+ *
+ * File layout: `eval-runs/<YYYY-MM-DD>/<HH-mm-ss-SSSZ>__<runId>.log`.
+ * Date-bucketed so a day's runs sort lexically; run id stays in the filename for
+ * grep + cross-reference with the persisted run row. Colons replaced with
+ * hyphens so the names work on every filesystem.
+ */
+export function withEvalRunLog<T>(runId: string, fn: () => T): T {
+  const now = new Date()
+  const datePart = now.toISOString().slice(0, 10) // YYYY-MM-DD
+  const timePart = now.toISOString().slice(11, 23).replace(/[:.]/g, '-') // HH-mm-ss-SSS
+  const logFile = path.join(
+    process.cwd(),
+    '.logs',
+    'eval-runs',
+    datePart,
+    `${timePart}Z__${runId}.log`
+  )
+  return withRunLog(runId, logFile, fn, { filter: evalRunLogFilter })
+}


### PR DESCRIPTION
## Summary

Mention reconciliation now tracks **provenance per source**. A `tool:`/record chip locks its target from the agent **prompt** *or* from any enabled attached **procedure** doc. The two reconcile independently via a `mentionedBy: MentionSource[]` tag, so the hot prompt-autosave path never reads procedures and can't drop a procedure-locked toolset/knowledge entry — and vice-versa. An entry's row drops only once its `mentionedBy` set empties.

## Changes

**Schema** (`packages/database/src/db/schema/agent.ts`)
- `MentionSource = 'prompt' | 'procedure'`
- `mentionedBy?: MentionSource[]` on `ToolsetEntry` and `KnowledgeEntry`

**Lib** (`packages/lib/src/agents`)
- `reconcileToolsetMentions` / `reconcileKnowledgeMentions` — per-tag reconcilers replacing the old single-source `reconcileToolsets`/`reconcileKnowledge`
- `walkPromptDocs` — unions slugs/recordIds across many docs (a procedure contributes draft + active version docs)
- `procedures/mention-reconcile.ts` — `reconcileAgentProcedureMentions` + fan-out helpers (`reconcileProcedureMentionsForAgents`/`ForAllAgents`, `listAgentIdsForProcedure`)
- `detachProcedure` now returns the removed link's `agentId` so the caller can reconcile post-delete

**Routers**
- `agent-procedure`: reconcile the `procedure` tag on attach / attach-existing / enable-flip / detach
- `procedure`: reconcile on draft-save, publish, revert, discard, and delete (ids captured before the cascade)

**Backfill** (`apps/worker/scripts/backfill-procedure-mention-tags.ts`)
- Step 1: tag existing `mention` rows `['prompt']` (pure jsonb, idempotent)
- Step 2: reconcile the `procedure` tag for every agent with an enabled attached procedure

**Evals / agent UI**
- Copy-trace-as-Markdown action on the run-detail Trace section (`eval-trace-markdown.ts`, reuses `groupTrace` so markdown never drifts from the on-screen trace)
- Dev-only per-run log tee to `.logs/eval-runs/<date>/…` (`run-log.ts`), mirroring agent-session traces
- `AgentModelBadge` in the agent hero — pins `Agent.modelId`; ✕ clears back to the system default

## Testing
- `prompt-mention-reconciler.test.ts` rewritten for per-tag semantics — 27 tests pass, including both-tags-survive-clearing-one and the empty-prompt-doesn't-clear-a-procedure-tag regression guard
- Biome clean on all changed files

## Migration
No schema migration needed (`mentionedBy` is an optional jsonb field). Run the backfill script once after deploy to tag existing rows.