### PR TITLE
feat(kopilot,evals): async task-notifications + run_eval_suite tool

### DIFF
--- a/apps/web/src/app/api/kopilot/stream/__tests__/task-notification.test.ts
+++ b/apps/web/src/app/api/kopilot/stream/__tests__/task-notification.test.ts
@@ -1,0 +1,142 @@
+// apps/web/src/app/api/kopilot/stream/__tests__/task-notification.test.ts
+
+import type { TaskNotificationKindHandler } from '@auxx/lib/ai/kopilot/task-notifications'
+import { describe, expect, it } from 'vitest'
+import { isNotificationForTask, resolveTaskNotification } from '../task-notification'
+
+const TASK = { kind: 'eval-suite', ref: 'esr_1' }
+
+function makeHandler(overrides: Partial<TaskNotificationKindHandler> = {}) {
+  const handler: TaskNotificationKindHandler = {
+    kind: 'eval-suite',
+    load: async () => ({ id: 'esr_1', status: 'completed' }),
+    isTerminal: () => true,
+    summarize: () => ({
+      status: 'completed',
+      summary: '5 runs: 4 passed · 1 failed',
+      instruction: 'Report the outcome.',
+    }),
+    ...overrides,
+  }
+  return handler
+}
+
+function makeDeps(input: {
+  handler?: TaskNotificationKindHandler | undefined
+  messages?: Record<string, unknown>[] | null
+}) {
+  return {
+    getHandler: () => input.handler,
+    loadSessionMessages: async () => (input.messages === undefined ? [] : input.messages),
+  }
+}
+
+describe('resolveTaskNotification', () => {
+  it('rejects when sessionId is missing (notifications never create sessions)', async () => {
+    const result = await resolveTaskNotification(
+      { task: TASK, organizationId: 'org_1' },
+      makeDeps({ handler: makeHandler() })
+    )
+    expect(result).toMatchObject({ ok: false, status: 400 })
+  })
+
+  it('rejects a missing or partial task ref', async () => {
+    const result = await resolveTaskNotification(
+      { sessionId: 's_1', task: { kind: 'eval-suite' }, organizationId: 'org_1' },
+      makeDeps({ handler: makeHandler() })
+    )
+    expect(result).toMatchObject({ ok: false, status: 400 })
+  })
+
+  it('rejects an unknown kind', async () => {
+    const result = await resolveTaskNotification(
+      { sessionId: 's_1', task: TASK, organizationId: 'org_1' },
+      makeDeps({ handler: undefined })
+    )
+    expect(result).toMatchObject({ ok: false, status: 400 })
+  })
+
+  it('404s when the task does not exist or belongs to another org', async () => {
+    const result = await resolveTaskNotification(
+      { sessionId: 's_1', task: TASK, organizationId: 'org_1' },
+      makeDeps({ handler: makeHandler({ load: async () => null }) })
+    )
+    expect(result).toMatchObject({ ok: false, status: 404 })
+  })
+
+  it('422s when the task is not terminal yet', async () => {
+    const result = await resolveTaskNotification(
+      { sessionId: 's_1', task: TASK, organizationId: 'org_1' },
+      makeDeps({ handler: makeHandler({ isTerminal: () => false }) })
+    )
+    expect(result).toMatchObject({ ok: false, status: 422 })
+  })
+
+  it('404s when the session cannot be loaded', async () => {
+    const result = await resolveTaskNotification(
+      { sessionId: 's_1', task: TASK, organizationId: 'org_1' },
+      makeDeps({ handler: makeHandler(), messages: null })
+    )
+    expect(result).toMatchObject({ ok: false, status: 404 })
+  })
+
+  it('no-ops when the session already carries a notification for this task', async () => {
+    const result = await resolveTaskNotification(
+      { sessionId: 's_1', task: TASK, organizationId: 'org_1' },
+      makeDeps({
+        handler: makeHandler(),
+        messages: [
+          { role: 'user', content: 'hi' },
+          {
+            role: 'user',
+            content: '<task-notification>…</task-notification>',
+            metadata: { origin: 'task-notification', kind: 'eval-suite', ref: 'esr_1' },
+          },
+        ],
+      })
+    )
+    expect(result).toEqual({ ok: true, deduped: true })
+  })
+
+  it('rewrites the body from the handler summary, ignoring client text', async () => {
+    const result = await resolveTaskNotification(
+      { sessionId: 's_1', task: TASK, organizationId: 'org_1' },
+      makeDeps({ handler: makeHandler() })
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok || result.deduped) throw new Error('expected a rewritten notification')
+    expect(result.message).toContain('<summary>5 runs: 4 passed · 1 failed</summary>')
+    expect(result.message).toContain('<ref>esr_1</ref>')
+    expect(result.metadata).toEqual({
+      origin: 'task-notification',
+      kind: 'eval-suite',
+      ref: 'esr_1',
+    })
+  })
+
+  it('500s when the handler load throws', async () => {
+    const result = await resolveTaskNotification(
+      { sessionId: 's_1', task: TASK, organizationId: 'org_1' },
+      makeDeps({
+        handler: makeHandler({
+          load: async () => {
+            throw new Error('db down')
+          },
+        }),
+      })
+    )
+    expect(result).toMatchObject({ ok: false, status: 500, error: 'db down' })
+  })
+})
+
+describe('isNotificationForTask', () => {
+  it('matches only on origin + kind + ref', () => {
+    const msg = {
+      metadata: { origin: 'task-notification', kind: 'eval-suite', ref: 'esr_1' },
+    }
+    expect(isNotificationForTask(msg, TASK)).toBe(true)
+    expect(isNotificationForTask(msg, { kind: 'eval-suite', ref: 'esr_2' })).toBe(false)
+    expect(isNotificationForTask({ metadata: { origin: 'other' } }, TASK)).toBe(false)
+    expect(isNotificationForTask({}, TASK)).toBe(false)
+  })
+})

--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -49,6 +49,7 @@ import {
 import { headers } from 'next/headers'
 import type { NextRequest } from 'next/server'
 import { auth } from '~/auth/server'
+import { resolveTaskNotification } from './task-notification'
 
 const logger = createScopedLogger('kopilot-stream')
 
@@ -103,6 +104,15 @@ interface KopilotStreamRequest {
    * and layers the DM trigger-instructions slot into the system prompt.
    */
   triggerKind?: 'dm'
+  /**
+   * Async-task continuation (plans/kopilot/task-notifications/plan.md). When
+   * set, `task` is required, the session must exist, and the route rewrites
+   * `message` from DB truth via the kind handler — the client is a trigger,
+   * never the source of result data.
+   */
+  origin?: 'task-notification'
+  /** The watched task this notification is for. Required with `origin`. */
+  task?: { kind: string; ref: string }
 }
 
 /**
@@ -152,6 +162,33 @@ export async function POST(request: NextRequest) {
 
   if (!body.message || typeof body.message !== 'string') {
     return new Response('Message is required', { status: 400 })
+  }
+
+  // Async-task continuation: validate, dedupe, and rewrite the body from DB
+  // truth BEFORE the stream opens, so failures are plain HTTP, not SSE.
+  let taskNotificationMetadata: Record<string, unknown> | undefined
+  if (body.origin === 'task-notification') {
+    if ((body.type ?? 'message') !== 'message') {
+      return new Response('Task notifications must use type "message"', { status: 400 })
+    }
+    const resolved = await resolveTaskNotification({
+      sessionId: body.sessionId,
+      task: body.task,
+      organizationId,
+    })
+    if (!resolved.ok) {
+      return new Response(resolved.error, { status: resolved.status })
+    }
+    if (resolved.deduped) {
+      // Another tab already delivered this notification — idempotent no-op.
+      // Shaped as a one-event SSE stream so the client's normal turn pipeline
+      // (which POSTed expecting an event stream) completes cleanly.
+      return new Response('event: done\ndata: {"type":"done","deduped":true}\n\n', {
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+      })
+    }
+    body.message = resolved.message
+    taskNotificationMetadata = resolved.metadata
   }
 
   const { message, type = 'message', page, context } = body
@@ -336,7 +373,12 @@ export async function POST(request: NextRequest) {
           ),
         })
 
-        const runPath = shouldUseWorker()
+        // Task-notification turns always run in-process: the worker job path
+        // doesn't carry the user-message metadata stamp yet, and without it
+        // the server-side dedupe (metadata scan) breaks. Revisit with §E
+        // (worker-side delivery).
+        const useWorkerPath = shouldUseWorker() && body.origin !== 'task-notification'
+        const runPath = useWorkerPath
           ? () =>
               runWorkerPath({
                 sessionId,
@@ -374,6 +416,7 @@ export async function POST(request: NextRequest) {
                 savedMessages,
                 savedDomainState,
                 storedModelId,
+                userMessageMetadata: taskNotificationMetadata,
                 send,
                 request,
                 isNewSession,
@@ -441,6 +484,8 @@ async function runInProcessPath(params: {
   savedMessages: Record<string, unknown>[]
   savedDomainState: Record<string, unknown>
   storedModelId: string | null
+  /** Stamped onto the persisted user message (task-notification origin markers). */
+  userMessageMetadata?: Record<string, unknown>
   send: (event: AgentEvent | { type: string; [key: string]: unknown }) => void
   request: NextRequest
   isNewSession: boolean
@@ -462,6 +507,7 @@ async function runInProcessPath(params: {
     savedMessages,
     savedDomainState,
     storedModelId,
+    userMessageMetadata,
     send,
     request,
     isNewSession,
@@ -660,7 +706,11 @@ async function runInProcessPath(params: {
           inputAmendment,
           context: sessionContext,
         })
-      : engine.submitMessage(message, sessionContext)
+      : engine.submitMessage(
+          message,
+          sessionContext,
+          userMessageMetadata ? { metadata: userMessageMetadata } : undefined
+        )
 
   const usageEntries: UsageTrackingRequest[] = []
 

--- a/apps/web/src/app/api/kopilot/stream/task-notification.ts
+++ b/apps/web/src/app/api/kopilot/stream/task-notification.ts
@@ -1,0 +1,118 @@
+// apps/web/src/app/api/kopilot/stream/task-notification.ts
+//
+// Server-side validation + body rewrite for task-notification messages
+// (plans/kopilot/task-notifications/plan.md §C). The client is only a trigger:
+// the message body is rebuilt here from DB truth via the kind handler, and a
+// session that already carries a notification for the same (kind, ref) no-ops.
+
+import {
+  buildTaskNotificationBody,
+  getTaskNotificationHandler,
+  type TaskNotificationKindHandler,
+} from '@auxx/lib/ai/kopilot/task-notifications'
+import { getSessionById } from '@auxx/services'
+
+export const TASK_NOTIFICATION_ORIGIN = 'task-notification'
+
+export interface TaskNotificationMetadata {
+  origin: typeof TASK_NOTIFICATION_ORIGIN
+  kind: string
+  ref: string
+  [key: string]: unknown
+}
+
+export type TaskNotificationResolution =
+  | { ok: true; deduped: false; message: string; metadata: TaskNotificationMetadata }
+  | { ok: true; deduped: true }
+  | { ok: false; status: 400 | 404 | 422 | 500; error: string }
+
+interface ResolveDeps {
+  getHandler: (kind: string) => TaskNotificationKindHandler | undefined
+  loadSessionMessages: (input: {
+    sessionId: string
+    organizationId: string
+  }) => Promise<Record<string, unknown>[] | null>
+}
+
+const defaultDeps: ResolveDeps = {
+  getHandler: getTaskNotificationHandler,
+  loadSessionMessages: async ({ sessionId, organizationId }) => {
+    const result = await getSessionById({ sessionId, organizationId })
+    if (result.isErr()) return null
+    return (result.value.messages ?? []) as Record<string, unknown>[]
+  },
+}
+
+/** True when `message` is a persisted notification for the same task. */
+export function isNotificationForTask(
+  message: Record<string, unknown>,
+  task: { kind: string; ref: string }
+): boolean {
+  const metadata = message.metadata as Record<string, unknown> | undefined
+  if (!metadata) return false
+  return (
+    metadata.origin === TASK_NOTIFICATION_ORIGIN &&
+    metadata.kind === task.kind &&
+    metadata.ref === task.ref
+  )
+}
+
+export async function resolveTaskNotification(
+  input: {
+    sessionId?: string
+    task?: { kind?: string; ref?: string }
+    organizationId: string
+  },
+  deps: ResolveDeps = defaultDeps
+): Promise<TaskNotificationResolution> {
+  const { sessionId, task, organizationId } = input
+
+  // Notifications continue an existing conversation; they never create sessions.
+  if (!sessionId) {
+    return { ok: false, status: 400, error: 'Task notifications require a sessionId' }
+  }
+  if (!task?.kind || !task.ref) {
+    return { ok: false, status: 400, error: 'Task notifications require task.kind and task.ref' }
+  }
+  const { kind, ref } = task
+
+  const handler = deps.getHandler(kind)
+  if (!handler) {
+    return { ok: false, status: 400, error: `Unknown task-notification kind: ${kind}` }
+  }
+
+  let snapshot: Record<string, unknown> | null
+  try {
+    snapshot = await handler.load(ref, organizationId)
+  } catch (error) {
+    return {
+      ok: false,
+      status: 500,
+      error: error instanceof Error ? error.message : 'Failed to load task',
+    }
+  }
+  if (!snapshot) {
+    return { ok: false, status: 404, error: `Task not found: ${kind}/${ref}` }
+  }
+  // Client retries on its next status tick once the task is actually terminal.
+  if (!handler.isTerminal(snapshot)) {
+    return { ok: false, status: 422, error: `Task is not terminal yet: ${kind}/${ref}` }
+  }
+
+  const messages = await deps.loadSessionMessages({ sessionId, organizationId })
+  if (!messages) {
+    return { ok: false, status: 404, error: 'Session not found' }
+  }
+  // Authoritative idempotency check — one notification per task per session.
+  if (messages.some((m) => isNotificationForTask(m, { kind, ref }))) {
+    return { ok: true, deduped: true }
+  }
+
+  const summary = handler.summarize(snapshot)
+  return {
+    ok: true,
+    deduped: false,
+    message: buildTaskNotificationBody({ kind, ref, ...summary }),
+    metadata: { origin: TASK_NOTIFICATION_ORIGIN, kind, ref },
+  }
+}

--- a/apps/web/src/components/global/dashboard.tsx
+++ b/apps/web/src/components/global/dashboard.tsx
@@ -26,6 +26,7 @@ import { useFavoriteDragEnd } from '~/components/favorites/hooks/use-favorite-dr
 import { FavoriteDragOverlay } from '~/components/favorites/ui/favorite-drag-overlay'
 import AppSidebar from '~/components/global/sidebar'
 import { KopilotDock } from '~/components/kopilot/ui/kopilot-dock'
+import { KopilotRuntime } from '~/components/kopilot/ui/kopilot-runtime'
 import MailThreadItemDragOverlay from '~/components/mail/mail-thread-item-drag-overlay'
 import { useThreadMutation } from '~/components/threads/hooks'
 import { useOverages } from '~/hooks/use-overages'
@@ -135,6 +136,10 @@ export const Dashboard = ({
               {children}
             </SidebarInset>
             <KopilotDock />
+            {/* Headless turn runner + task-notification watches. Sibling of the
+                dock — it must stay alive when the dock renders null (kopilot
+                page, panel closed). */}
+            <KopilotRuntime />
           </div>
         </DndStateProvider>
         {portalContainer &&

--- a/apps/web/src/components/global/sidebar/nav-user.tsx
+++ b/apps/web/src/components/global/sidebar/nav-user.tsx
@@ -80,6 +80,7 @@ export function NavUser({ user }: Prop) {
   const { hasAccess } = useFeatureFlags()
   const kopilotEnabled = hasAccess('kopilot')
   const toggleKopilot = useKopilotStore((s) => s.togglePanel)
+  const hasUnreadNotification = useKopilotStore((s) => s.hasUnreadNotification)
 
   // const session = await auth();
   const {
@@ -346,9 +347,15 @@ export function NavUser({ user }: Prop) {
             <Tooltip content='Kopilot' shortcut={['⌘', '⇧', 'K']}>
               <button
                 type='button'
-                className='shrink-0 flex items-center justify-center size-8 rounded-2xl text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors group-data-[collapsible=icon]:hidden'
+                className='relative shrink-0 flex items-center justify-center size-8 rounded-2xl text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors group-data-[collapsible=icon]:hidden'
                 onClick={toggleKopilot}>
                 <Sparkles className='size-4' />
+                {hasUnreadNotification && (
+                  <span
+                    aria-label='Unread Kopilot notification'
+                    className='absolute right-1 top-1 size-2 rounded-full bg-primary'
+                  />
+                )}
               </button>
             </Tooltip>
           )}

--- a/apps/web/src/components/kopilot/hooks/use-kopilot-sse.ts
+++ b/apps/web/src/components/kopilot/hooks/use-kopilot-sse.ts
@@ -4,32 +4,13 @@ import { generateId } from '@auxx/utils/generateId'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { type SSEConfig, useSSE } from '~/hooks/use-sse'
 import { api } from '~/trpc/react'
+import type { KopilotRequest } from '../stores/kopilot-store'
 import { useKopilotStore } from '../stores/kopilot-store'
 import { patchSessionTitleInListCache, upsertSessionInListCache } from './kopilot-session-cache'
 
-export interface KopilotRequest {
-  sessionId?: string
-  message: string
-  type?: 'message' | 'approval'
-  page?: string
-  context?: Record<string, unknown>
-  /** Approval action — required when type is 'approval' */
-  approvalAction?: 'approve' | 'reject'
-  /** Input amendment for approval actions (e.g. { mode: 'draft' }) */
-  inputAmendment?: Record<string, unknown>
-  /** Model override in "provider:model" format — omit to use system default */
-  modelId?: string
-  /** Target a user-authored agent on session create; ignored on existing sessions. */
-  agentId?: string | null
-  /** Session-domain discriminator on session create. Defaults to 'kopilot' server-side. */
-  sessionType?: 'kopilot' | 'builder'
-  /**
-   * Trigger discriminator. 'dm' means the request originated from the agent
-   * Chat tab or the composer sender picker; the SSE route gates the agent's
-   * `dm` AgentTrigger and layers DM trigger-instructions into the prompt.
-   */
-  triggerKind?: 'dm'
-}
+// The request shape lives in the store (the single app-level KopilotRuntime
+// consumes `pendingRequest` from there). Re-exported for existing importers.
+export type { KopilotRequest } from '../stores/kopilot-store'
 
 interface UseKopilotSSEOptions {
   /** Request to send (triggers SSE connection when non-null) */

--- a/apps/web/src/components/kopilot/hooks/use-task-watchers.tsx
+++ b/apps/web/src/components/kopilot/hooks/use-task-watchers.tsx
@@ -1,0 +1,53 @@
+// apps/web/src/components/kopilot/hooks/use-task-watchers.tsx
+//
+// Per-kind terminal detection for task watches. Each kind contributes a
+// headless watcher component; `KopilotRuntime` mounts one per active watch.
+// The browser-side poll is only a *detector* — the completion event of record
+// stays the worker's DB write (plans/kopilot/task-notifications/plan.md §D).
+
+'use client'
+
+import type { ComponentType } from 'react'
+import { useEffect } from 'react'
+import { api } from '~/trpc/react'
+import { type TaskWatch, taskWatchKey, useTaskWatchStore } from '../stores/task-watch-store'
+
+export interface TaskWatcherProps {
+  watch: TaskWatch
+}
+
+/** Suite orchestration statuses that mean "stop watching". */
+const EVAL_SUITE_TERMINAL = new Set(['completed', 'cancelled', 'error'])
+
+/**
+ * Poll the suite-run status (~4s) while the watch is live and flip it to
+ * terminal-queued on the first terminal tick. A few seconds of latency on a
+ * minutes-long task is invisible; no dedicated suite SSE channel needed in v1.
+ */
+function EvalSuiteWatcher({ watch }: TaskWatcherProps) {
+  const markTerminal = useTaskWatchStore((s) => s.markTerminal)
+  const watching = watch.state === 'watching'
+
+  const suite = api.eval.getSuiteRun.useQuery(
+    { suiteRunId: watch.ref },
+    { enabled: watching, refetchInterval: watching ? 4000 : false }
+  )
+
+  const status = suite.data?.status
+  useEffect(() => {
+    if (watching && status && EVAL_SUITE_TERMINAL.has(status)) {
+      markTerminal(taskWatchKey(watch))
+    }
+  }, [watching, status, markTerminal, watch])
+
+  return null
+}
+
+/**
+ * kind → watcher component. Adding a task-notification consumer client-side =
+ * one watcher entry here (the server side is a kind handler in
+ * `@auxx/lib/ai/kopilot/task-notifications`).
+ */
+export const TASK_WATCHERS: Record<string, ComponentType<TaskWatcherProps>> = {
+  'eval-suite': EvalSuiteWatcher,
+}

--- a/apps/web/src/components/kopilot/stores/__tests__/task-watch-store.test.ts
+++ b/apps/web/src/components/kopilot/stores/__tests__/task-watch-store.test.ts
@@ -1,0 +1,55 @@
+// apps/web/src/components/kopilot/stores/__tests__/task-watch-store.test.ts
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { taskWatchKey, useTaskWatchStore } from '../task-watch-store'
+
+const WATCH = { sessionId: 's1', kind: 'eval-suite', ref: 'esr_1' }
+const KEY = taskWatchKey(WATCH)
+
+beforeEach(() => {
+  useTaskWatchStore.setState({ watches: {} })
+})
+
+describe('task-watch store', () => {
+  it('registers a watch once — re-registration never resets state', () => {
+    const store = useTaskWatchStore.getState()
+    store.registerWatch(WATCH)
+    expect(useTaskWatchStore.getState().watches[KEY]?.state).toBe('watching')
+
+    store.markTerminal(KEY)
+    store.registerWatch(WATCH)
+    expect(useTaskWatchStore.getState().watches[KEY]?.state).toBe('terminal-queued')
+
+    store.markDone(KEY)
+    store.registerWatch(WATCH)
+    // A done watch stays done — this is what prevents notify loops after the
+    // replay scan re-sees the same tool output.
+    expect(useTaskWatchStore.getState().watches[KEY]?.state).toBe('done')
+  })
+
+  it('markTerminal transitions only from watching', () => {
+    const store = useTaskWatchStore.getState()
+    store.registerWatch(WATCH)
+    store.markDone(KEY)
+    store.markTerminal(KEY)
+    expect(useTaskWatchStore.getState().watches[KEY]?.state).toBe('done')
+  })
+
+  it('resumeWatching reopens a queued watch (422 race) but never a done one', () => {
+    const store = useTaskWatchStore.getState()
+    store.registerWatch(WATCH)
+    store.markTerminal(KEY)
+    store.resumeWatching(KEY)
+    expect(useTaskWatchStore.getState().watches[KEY]?.state).toBe('watching')
+
+    store.markTerminal(KEY)
+    store.markDone(KEY)
+    store.resumeWatching(KEY)
+    expect(useTaskWatchStore.getState().watches[KEY]?.state).toBe('done')
+  })
+
+  it('keys are scoped by session, kind, and ref', () => {
+    expect(taskWatchKey(WATCH)).toBe('s1:eval-suite:esr_1')
+    expect(taskWatchKey({ ...WATCH, sessionId: 's2' })).not.toBe(KEY)
+  })
+})

--- a/apps/web/src/components/kopilot/stores/kopilot-store.ts
+++ b/apps/web/src/components/kopilot/stores/kopilot-store.ts
@@ -69,8 +69,12 @@ export interface KopilotMessage {
   timestamp: number
   /** Parent message ID — null for root messages */
   parentId: string | null
-  /** Agent metadata — last agent that contributed to this turn. */
-  metadata?: { agent?: string; modelId?: string }
+  /**
+   * Agent metadata — last agent that contributed to this turn. Task-notification
+   * user messages additionally carry `origin: 'task-notification'` + kind/ref
+   * (server-stamped; rendered as a system chip, never a user bubble).
+   */
+  metadata?: { agent?: string; modelId?: string; origin?: string; kind?: string; ref?: string }
   /** Approval state — present when this message represents a tool approval request */
   approval?: {
     toolName: string
@@ -98,6 +102,42 @@ export interface KopilotStreamState {
   currentRoute: string | null
   /** Tools currently executing */
   activeTools: Array<{ tool: string; agent: string }>
+}
+
+/**
+ * Outgoing request for the Kopilot stream route. Lives in the store (not the
+ * SSE hook) so any surface can submit while the single app-level
+ * `KopilotRuntime` owns the connection — turns keep running with the panel
+ * closed (task notifications).
+ */
+export interface KopilotRequest {
+  sessionId?: string
+  message: string
+  type?: 'message' | 'approval'
+  page?: string
+  context?: Record<string, unknown>
+  /** Approval action — required when type is 'approval' */
+  approvalAction?: 'approve' | 'reject'
+  /** Input amendment for approval actions (e.g. { mode: 'draft' }) */
+  inputAmendment?: Record<string, unknown>
+  /** Model override in "provider:model" format — omit to use system default */
+  modelId?: string
+  /** Target a user-authored agent on session create; ignored on existing sessions. */
+  agentId?: string | null
+  /** Session-domain discriminator on session create. Defaults to 'kopilot' server-side. */
+  sessionType?: 'kopilot' | 'builder'
+  /**
+   * Trigger discriminator. 'dm' means the request originated from the agent
+   * Chat tab or the composer sender picker; the SSE route gates the agent's
+   * `dm` AgentTrigger and layers DM trigger-instructions into the prompt.
+   */
+  triggerKind?: 'dm'
+  /**
+   * Async-task continuation: the route rewrites `message` from DB truth and
+   * stamps the persisted user message. Requires `task`.
+   */
+  origin?: 'task-notification'
+  task?: { kind: string; ref: string }
 }
 
 /** Compute the visible message path by walking the tree from root to leaf */
@@ -290,6 +330,21 @@ interface KopilotState {
   // Status
   isStreaming: boolean
   setIsStreaming: (streaming: boolean) => void
+
+  /**
+   * The request the app-level `KopilotRuntime` should send next. Set by any
+   * chat surface (composer, approval card, task-notification drain); cleared
+   * by the runtime once the SSE connection starts.
+   */
+  pendingRequest: KopilotRequest | null
+  setPendingRequest: (request: KopilotRequest | null) => void
+
+  /**
+   * A task-notification turn ran while the panel was closed. Cleared when the
+   * panel opens. Rendered as a dot on the Kopilot launcher.
+   */
+  hasUnreadNotification: boolean
+  setHasUnreadNotification: (unread: boolean) => void
 
   // Lifecycle
   reset: () => void
@@ -571,6 +626,14 @@ export const useKopilotStore = create<KopilotState>()(
       // Status
       isStreaming: false,
       setIsStreaming: (isStreaming) => set({ isStreaming }),
+
+      // Outgoing request (consumed by KopilotRuntime)
+      pendingRequest: null,
+      setPendingRequest: (pendingRequest) => set({ pendingRequest }),
+
+      // Unread task-notification indicator
+      hasUnreadNotification: false,
+      setHasUnreadNotification: (hasUnreadNotification) => set({ hasUnreadNotification }),
 
       // Lifecycle
       reset: () =>

--- a/apps/web/src/components/kopilot/stores/task-watch-store.ts
+++ b/apps/web/src/components/kopilot/stores/task-watch-store.ts
@@ -1,0 +1,70 @@
+// apps/web/src/components/kopilot/stores/task-watch-store.ts
+//
+// Watches for async tasks started by Kopilot tools (output carried a
+// `taskNotification: { kind, ref }`). One generic store keyed
+// (sessionId, kind, ref); per-kind terminal detection plugs in via watcher
+// components in `hooks/use-task-watchers`. Not persisted — replay-on-load
+// rebuilds watches from session history. See plans/kopilot/task-notifications.
+
+import { create } from 'zustand'
+
+export type TaskWatchState =
+  /** Task still running — a kind watcher is polling its status. */
+  | 'watching'
+  /** Terminal — a notification intent is queued, waiting for an idle session. */
+  | 'terminal-queued'
+  /** Notification POSTed (or found already delivered). Nothing left to do. */
+  | 'done'
+
+export interface TaskWatch {
+  sessionId: string
+  kind: string
+  ref: string
+  state: TaskWatchState
+}
+
+export function taskWatchKey(watch: Pick<TaskWatch, 'sessionId' | 'kind' | 'ref'>): string {
+  return `${watch.sessionId}:${watch.kind}:${watch.ref}`
+}
+
+interface TaskWatchStore {
+  watches: Record<string, TaskWatch>
+  /** Idempotent — an existing watch (any state) is left untouched. */
+  registerWatch: (watch: Pick<TaskWatch, 'sessionId' | 'kind' | 'ref'>) => void
+  markTerminal: (key: string) => void
+  markDone: (key: string) => void
+  /** Drain hit a not-terminal-yet race (422) — resume polling. */
+  resumeWatching: (key: string) => void
+}
+
+export const useTaskWatchStore = create<TaskWatchStore>()((set) => ({
+  watches: {},
+
+  registerWatch: (watch) =>
+    set((s) => {
+      const key = taskWatchKey(watch)
+      if (s.watches[key]) return s
+      return { watches: { ...s.watches, [key]: { ...watch, state: 'watching' } } }
+    }),
+
+  markTerminal: (key) =>
+    set((s) => {
+      const existing = s.watches[key]
+      if (!existing || existing.state !== 'watching') return s
+      return { watches: { ...s.watches, [key]: { ...existing, state: 'terminal-queued' } } }
+    }),
+
+  markDone: (key) =>
+    set((s) => {
+      const existing = s.watches[key]
+      if (!existing || existing.state === 'done') return s
+      return { watches: { ...s.watches, [key]: { ...existing, state: 'done' } } }
+    }),
+
+  resumeWatching: (key) =>
+    set((s) => {
+      const existing = s.watches[key]
+      if (!existing || existing.state === 'done') return s
+      return { watches: { ...s.watches, [key]: { ...existing, state: 'watching' } } }
+    }),
+}))

--- a/apps/web/src/components/kopilot/ui/kopilot-chat.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-chat.tsx
@@ -3,10 +3,9 @@
 'use client'
 
 import { generateId } from '@auxx/utils/generateId'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useLoadSession } from '../hooks/use-kopilot-sessions'
-import { type KopilotRequest, useKopilotSSE } from '../hooks/use-kopilot-sse'
-import { useKopilotStore } from '../stores/kopilot-store'
+import { type KopilotRequest, useKopilotStore } from '../stores/kopilot-store'
 import { applyChipDismissals, selectMergedContext } from '../stores/select-context'
 import './blocks/register-blocks'
 import { api } from '~/trpc/react'
@@ -73,13 +72,9 @@ export function KopilotChat({
 
   const composerRef = useRef<KopilotComposerHandle>(null)
   const messageListRef = useRef<KopilotMessageListHandle>(null)
-  const [pendingRequest, setPendingRequest] = useState<KopilotRequest | null>(null)
-
-  // SSE hook
-  useKopilotSSE({
-    pendingRequest,
-    onRequestSent: () => setPendingRequest(null),
-  })
+  // Submissions go through the store; the app-level KopilotRuntime owns the
+  // SSE connection so turns keep streaming when this surface unmounts.
+  const setPendingRequest = useKopilotStore((s) => s.setPendingRequest)
 
   // Session loading
   const loadSession = useLoadSession()
@@ -156,7 +151,7 @@ export function KopilotChat({
     (request: KopilotRequest) => {
       setPendingRequest(augmentRequest(request))
     },
-    [augmentRequest]
+    [augmentRequest, setPendingRequest]
   )
 
   const handleSuggestionClick = useCallback(
@@ -194,7 +189,7 @@ export function KopilotChat({
         })
       )
     },
-    [addMessage, page, augmentRequest]
+    [addMessage, page, augmentRequest, setPendingRequest]
   )
 
   // Auto-submit `initialMessage` once on mount when no existing session.
@@ -214,7 +209,7 @@ export function KopilotChat({
     (request: KopilotRequest) => {
       setPendingRequest(augmentRequest(request))
     },
-    [augmentRequest]
+    [augmentRequest, setPendingRequest]
   )
 
   const handleEditMessage = useCallback(
@@ -247,7 +242,7 @@ export function KopilotChat({
         })
       )
     },
-    [messageMap, activeSessionId, page, augmentRequest]
+    [messageMap, activeSessionId, page, augmentRequest, setPendingRequest]
   )
 
   return (

--- a/apps/web/src/components/kopilot/ui/kopilot-message-list.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-message-list.tsx
@@ -18,10 +18,12 @@ import {
 import type { KopilotRequest } from '../hooks/use-kopilot-sse'
 import { useKopilotChatOptions } from '../options'
 import { type KopilotMessage, useKopilotStore } from '../stores/kopilot-store'
+import { isTaskNotificationMessage } from '../utils/task-notifications'
 import { KopilotEmptyState } from './kopilot-empty-state'
 import { AssistantMessage, type InlineApprovalLookup } from './messages/assistant-message'
 import { AssistantThinkingStatus } from './messages/assistant-thinking-status'
 import { BranchNavigator } from './messages/branch-navigator'
+import { TaskNotificationChip } from './messages/task-notification-chip'
 import { UserMessage } from './messages/user-message'
 import { SparkleIcon } from './sparkle-icon'
 
@@ -341,6 +343,13 @@ export function KopilotMessageList({
 
     switch (message.role) {
       case 'user':
+        // Task notifications are machine-injected continuations stamped with
+        // an origin marker — render a muted system chip, never a user bubble,
+        // and exclude them from edit/retry affordances.
+        if (isTaskNotificationMessage(message)) {
+          messageEl = <TaskNotificationChip message={message} />
+          break
+        }
         messageEl = (
           <UserMessage
             message={message}

--- a/apps/web/src/components/kopilot/ui/kopilot-runtime.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-runtime.tsx
@@ -1,0 +1,132 @@
+// apps/web/src/components/kopilot/ui/kopilot-runtime.tsx
+
+'use client'
+
+import { generateId } from '@auxx/utils/generateId'
+import { useEffect } from 'react'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { useKopilotSSE } from '../hooks/use-kopilot-sse'
+import { TASK_WATCHERS } from '../hooks/use-task-watchers'
+import { useKopilotStore } from '../stores/kopilot-store'
+import { taskWatchKey, useTaskWatchStore } from '../stores/task-watch-store'
+import {
+  canDrainNotification,
+  findUnnotifiedTaskRefs,
+  isTaskNotificationMessage,
+  TASK_NOTIFICATION_ORIGIN,
+} from '../utils/task-notifications'
+
+/**
+ * App-level, headless Kopilot turn runner. Owns the single SSE connection
+ * keyed off the store's `pendingRequest` so turns stream into the store even
+ * when no chat surface is mounted (panel closed, user navigated away) — the
+ * prerequisite for task-notification delivery + the unread badge.
+ *
+ * Also hosts the task-notification loop: watch registration from session
+ * history, per-kind status watchers, and the between-turns drain.
+ * See plans/kopilot/task-notifications/plan.md §D.
+ */
+export function KopilotRuntime() {
+  const { hasAccess } = useFeatureFlags()
+  if (!hasAccess('kopilot')) return null
+  return <KopilotRuntimeInner />
+}
+
+function KopilotRuntimeInner() {
+  const pendingRequest = useKopilotStore((s) => s.pendingRequest)
+  const setPendingRequest = useKopilotStore((s) => s.setPendingRequest)
+
+  // The one SSE runner for every Kopilot surface.
+  useKopilotSSE({
+    pendingRequest,
+    onRequestSent: () => setPendingRequest(null),
+  })
+
+  // ── Watch registration (live + replay-on-load in one scan) ──
+  // Whenever the visible messages change, register a watch for every tool
+  // output carrying `taskNotification` that has no delivered notification yet.
+  // Registration is idempotent; terminal-vs-running is the watcher's job.
+  const messages = useKopilotStore((s) => s.messages)
+  const activeSessionId = useKopilotStore((s) => s.activeSessionId)
+  const registerWatch = useTaskWatchStore((s) => s.registerWatch)
+
+  useEffect(() => {
+    if (!activeSessionId) return
+    for (const task of findUnnotifiedTaskRefs(messages)) {
+      registerWatch({ sessionId: activeSessionId, ...task })
+    }
+  }, [messages, activeSessionId, registerWatch])
+
+  // ── Drain: terminal watch + idle session → notification turn ──
+  const watches = useTaskWatchStore((s) => s.watches)
+  const isStreaming = useKopilotStore((s) => s.isStreaming)
+
+  useEffect(() => {
+    const store = useKopilotStore.getState()
+    const watchStore = useTaskWatchStore.getState()
+
+    // Only the active session drains — its messages are what the store
+    // renders. Watches for other sessions deliver via replay when reopened.
+    const next = Object.values(watchStore.watches).find(
+      (w) => w.state === 'terminal-queued' && w.sessionId === store.activeSessionId
+    )
+    if (!next) return
+    if (!canDrainNotification(store)) return
+
+    const key = taskWatchKey(next)
+
+    // Client-side dedupe (the server check is authoritative — this just avoids
+    // an obviously redundant POST after replay).
+    if (store.messages.some((m) => isTaskNotificationMessage(m, next))) {
+      watchStore.markDone(key)
+      return
+    }
+    watchStore.markDone(key)
+
+    // Local chip renders immediately; the server persists the canonical
+    // (rewritten) message, so a reload shows the same chip from history.
+    const leaf = store.messages[store.messages.length - 1]
+    store.addMessage({
+      id: generateId(),
+      role: 'user',
+      content: '',
+      timestamp: Date.now(),
+      parentId: leaf?.id ?? null,
+      metadata: { origin: TASK_NOTIFICATION_ORIGIN, kind: next.kind, ref: next.ref },
+    })
+
+    if (!store.panelOpen) store.setHasUnreadNotification(true)
+
+    store.setPendingRequest({
+      sessionId: next.sessionId,
+      // Placeholder — the route rebuilds the body from DB truth (§C.4).
+      message: '<task-notification pending>',
+      type: 'message',
+      origin: 'task-notification',
+      task: { kind: next.kind, ref: next.ref },
+    })
+  }, [watches, isStreaming, pendingRequest, messages, activeSessionId])
+
+  // ── Unread badge lifecycle ──
+  const panelOpen = useKopilotStore((s) => s.panelOpen)
+  const hasUnreadNotification = useKopilotStore((s) => s.hasUnreadNotification)
+  const setHasUnreadNotification = useKopilotStore((s) => s.setHasUnreadNotification)
+  useEffect(() => {
+    if (panelOpen && hasUnreadNotification) setHasUnreadNotification(false)
+  }, [panelOpen, hasUnreadNotification, setHasUnreadNotification])
+
+  // ── Per-kind status watchers (headless) ──
+  const liveWatches = Object.values(watches).filter(
+    (w) => w.state === 'watching' && w.sessionId === activeSessionId
+  )
+
+  return (
+    <>
+      {liveWatches.map((watch) => {
+        const Watcher = TASK_WATCHERS[watch.kind]
+        if (!Watcher) return null
+        return <Watcher key={taskWatchKey(watch)} watch={watch} />
+      })}
+    </>
+  )
+}

--- a/apps/web/src/components/kopilot/ui/messages/task-notification-chip.tsx
+++ b/apps/web/src/components/kopilot/ui/messages/task-notification-chip.tsx
@@ -1,0 +1,30 @@
+// apps/web/src/components/kopilot/ui/messages/task-notification-chip.tsx
+
+'use client'
+
+import { BellRing } from 'lucide-react'
+import type { KopilotMessage } from '../../stores/kopilot-store'
+
+/** Human label per task kind; falls back to a generic line for new kinds. */
+const KIND_LABELS: Record<string, string> = {
+  'eval-suite': 'Simulation suite finished',
+}
+
+/**
+ * Muted, centered chip for task-notification messages — these are
+ * machine-injected continuations, not something the user said, so they must
+ * not render as a user bubble (and carry no edit/retry affordances).
+ */
+export function TaskNotificationChip({ message }: { message: KopilotMessage }) {
+  const kind = message.metadata?.kind ?? ''
+  const label = KIND_LABELS[kind] ?? 'Background task finished'
+
+  return (
+    <div className='flex justify-center py-1'>
+      <div className='inline-flex items-center gap-1.5 rounded-full border bg-muted/50 px-3 py-1 text-xs text-muted-foreground'>
+        <BellRing className='size-3' />
+        <span>{label}</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/kopilot/ui/messages/tool-status-pill-config.ts
+++ b/apps/web/src/components/kopilot/ui/messages/tool-status-pill-config.ts
@@ -213,6 +213,19 @@ const configs: Record<string, ToolPillConfig> = {
       error: () => ({ label: 'Failed to update records' }),
     },
   },
+  run_eval_suite: {
+    icon: 'FlaskConical',
+    labels: {
+      running: () => ({ label: 'Starting simulation suite' }),
+      // "Completed" here means the batch was FIRED — results arrive later as a
+      // task-notification chip in the conversation.
+      completed: () => ({
+        label: 'Simulation suite running',
+        secondary: 'results will arrive here',
+      }),
+      error: () => ({ label: 'Failed to start simulation suite' }),
+    },
+  },
 }
 
 /** Convert snake_case tool name to a readable label */

--- a/apps/web/src/components/kopilot/utils/__tests__/task-notifications.test.ts
+++ b/apps/web/src/components/kopilot/utils/__tests__/task-notifications.test.ts
@@ -1,0 +1,110 @@
+// apps/web/src/components/kopilot/utils/__tests__/task-notifications.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { KopilotMessage } from '../../stores/kopilot-store'
+import {
+  canDrainNotification,
+  extractTaskRefs,
+  findUnnotifiedTaskRefs,
+  hasPendingApproval,
+  isTaskNotificationMessage,
+} from '../task-notifications'
+
+let nextId = 0
+function msg(partial: Partial<KopilotMessage>): KopilotMessage {
+  nextId += 1
+  return { id: `m${nextId}`, role: 'user', timestamp: 0, parentId: null, ...partial }
+}
+
+function toolMsg(output: unknown, status: 'completed' | 'running' = 'completed'): KopilotMessage {
+  return msg({
+    role: 'assistant',
+    parts: [
+      { type: 'text', text: 'hi' },
+      { type: 'tool_call', toolCallId: 't1', name: 'run_eval_suite', args: {}, status, output },
+    ],
+  })
+}
+
+function notificationMsg(kind: string, ref: string): KopilotMessage {
+  return msg({
+    role: 'user',
+    content: '<task-notification>…</task-notification>',
+    metadata: { origin: 'task-notification', kind, ref },
+  })
+}
+
+const SUITE_OUTPUT = {
+  suiteRunId: 'esr_1',
+  taskNotification: { kind: 'eval-suite', ref: 'esr_1' },
+}
+
+describe('extractTaskRefs', () => {
+  it('finds refs on completed tool outputs and dedupes', () => {
+    const messages = [toolMsg(SUITE_OUTPUT), toolMsg(SUITE_OUTPUT)]
+    expect(extractTaskRefs(messages)).toEqual([{ kind: 'eval-suite', ref: 'esr_1' }])
+  })
+
+  it('ignores running tools, outputs without the marker, and malformed refs', () => {
+    const messages = [
+      toolMsg(SUITE_OUTPUT, 'running'),
+      toolMsg({ anything: true }),
+      toolMsg({ taskNotification: { kind: 'eval-suite' } }),
+      msg({ role: 'user', content: 'hello' }),
+    ]
+    expect(extractTaskRefs(messages)).toEqual([])
+  })
+})
+
+describe('findUnnotifiedTaskRefs (replay classification)', () => {
+  it('returns refs lacking a notification message', () => {
+    expect(findUnnotifiedTaskRefs([toolMsg(SUITE_OUTPUT)])).toEqual([
+      { kind: 'eval-suite', ref: 'esr_1' },
+    ])
+  })
+
+  it('skips refs already notified', () => {
+    const messages = [toolMsg(SUITE_OUTPUT), notificationMsg('eval-suite', 'esr_1')]
+    expect(findUnnotifiedTaskRefs(messages)).toEqual([])
+  })
+
+  it('does not match a notification for a different ref', () => {
+    const messages = [toolMsg(SUITE_OUTPUT), notificationMsg('eval-suite', 'esr_OTHER')]
+    expect(findUnnotifiedTaskRefs(messages)).toEqual([{ kind: 'eval-suite', ref: 'esr_1' }])
+  })
+})
+
+describe('isTaskNotificationMessage', () => {
+  it('requires user role + origin marker', () => {
+    expect(isTaskNotificationMessage(notificationMsg('eval-suite', 'esr_1'))).toBe(true)
+    expect(isTaskNotificationMessage(msg({ role: 'user', content: 'hi' }))).toBe(false)
+    expect(
+      isTaskNotificationMessage(msg({ role: 'system', metadata: { origin: 'task-notification' } }))
+    ).toBe(false)
+  })
+})
+
+describe('canDrainNotification (the gate)', () => {
+  const idle = { isStreaming: false, pendingRequest: null, messages: [] as KopilotMessage[] }
+
+  it('drains only when fully idle', () => {
+    expect(canDrainNotification(idle)).toBe(true)
+    expect(canDrainNotification({ ...idle, isStreaming: true })).toBe(false)
+    expect(canDrainNotification({ ...idle, pendingRequest: { message: 'x' } })).toBe(false)
+  })
+
+  it('a pending approval counts as an active turn', () => {
+    const approvalPending = msg({
+      role: 'system',
+      approval: { toolName: 'x', toolCallId: 't', args: {}, status: 'pending' },
+    })
+    expect(canDrainNotification({ ...idle, messages: [approvalPending] })).toBe(false)
+    expect(hasPendingApproval([approvalPending])).toBe(true)
+
+    const approvalDecided = msg({
+      role: 'system',
+      approval: { toolName: 'x', toolCallId: 't', args: {}, status: 'approved' },
+    })
+    expect(canDrainNotification({ ...idle, messages: [approvalDecided] })).toBe(true)
+  })
+})

--- a/apps/web/src/components/kopilot/utils/task-notifications.ts
+++ b/apps/web/src/components/kopilot/utils/task-notifications.ts
@@ -1,0 +1,73 @@
+// apps/web/src/components/kopilot/utils/task-notifications.ts
+//
+// Pure helpers for the task-notification client loop (registration scan,
+// history dedupe, drain gate). Kept free of store/React imports so they are
+// trivially unit-testable. See plans/kopilot/task-notifications/plan.md §D.
+
+import type { KopilotMessage } from '../stores/kopilot-store'
+
+export const TASK_NOTIFICATION_ORIGIN = 'task-notification'
+
+export interface TaskRef {
+  kind: string
+  ref: string
+}
+
+/** True when `message` is the (server-stamped) notification for this task. */
+export function isTaskNotificationMessage(message: KopilotMessage, task?: TaskRef): boolean {
+  if (message.role !== 'user') return false
+  if (message.metadata?.origin !== TASK_NOTIFICATION_ORIGIN) return false
+  if (!task) return true
+  return message.metadata.kind === task.kind && message.metadata.ref === task.ref
+}
+
+/** Every `taskNotification` ref carried by tool outputs in these messages. */
+export function extractTaskRefs(messages: KopilotMessage[]): TaskRef[] {
+  const refs: TaskRef[] = []
+  const seen = new Set<string>()
+  for (const message of messages) {
+    for (const part of message.parts ?? []) {
+      if (part.type !== 'tool_call' || part.status !== 'completed') continue
+      const ref = (part.output as { taskNotification?: { kind?: string; ref?: string } } | null)
+        ?.taskNotification
+      if (!ref?.kind || !ref.ref) continue
+      const key = `${ref.kind}:${ref.ref}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      refs.push({ kind: ref.kind, ref: ref.ref })
+    }
+  }
+  return refs
+}
+
+/**
+ * Replay-on-load + live registration in one scan: refs whose notification has
+ * not been delivered yet. Whether the task is still running is the watcher's
+ * job (status poll) — terminal tasks simply mark terminal on the first tick
+ * and drain immediately.
+ */
+export function findUnnotifiedTaskRefs(messages: KopilotMessage[]): TaskRef[] {
+  return extractTaskRefs(messages).filter(
+    (task) => !messages.some((m) => isTaskNotificationMessage(m, task))
+  )
+}
+
+/** Any approval card still waiting on the human? Counts as an active turn. */
+export function hasPendingApproval(messages: KopilotMessage[]): boolean {
+  return messages.some((m) => m.approval?.status === 'pending')
+}
+
+/**
+ * The drain gate: notifications are a queue, never an interrupt. User input
+ * always outranks them — anything in flight or awaiting a human wins.
+ */
+export function canDrainNotification(input: {
+  isStreaming: boolean
+  pendingRequest: unknown
+  messages: KopilotMessage[]
+}): boolean {
+  if (input.isStreaming) return false
+  if (input.pendingRequest) return false
+  if (hasPendingApproval(input.messages)) return false
+  return true
+}

--- a/apps/web/src/server/api/routers/eval.ts
+++ b/apps/web/src/server/api/routers/eval.ts
@@ -5,7 +5,6 @@ import {
   cancelEvalRun,
   createEvalCase,
   createQueuedEvalRun,
-  createSuiteRunWithChildren,
   deleteEvalCase,
   deleteEvalRun,
   failQueuedEvalRun,
@@ -16,13 +15,13 @@ import {
   listAgentEffectiveTools,
   listEvalCasesByAgent,
   listEvalRuns,
-  type PreparedRunSnapshots,
   prepareRunSnapshots,
   suggestAgentSimulations,
   updateEvalCase,
   validateAgentToolMock,
   validateEvalCase,
 } from '@auxx/lib/evals'
+import { startAgentSuiteRun } from '@auxx/lib/evals/start-suite-run'
 import { enqueueEvalRun } from '@auxx/lib/evals/worker'
 import { FeaturePermissionService } from '@auxx/lib/permissions'
 import { FeatureKey } from '@auxx/lib/permissions/client'
@@ -332,65 +331,23 @@ export const evalRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
 
-      // Resolve the selected cases (explicit ids, else every case under the scope).
-      const all = unwrap(
-        await listEvalCasesByAgent({
-          organizationId,
-          agentId: input.agentId,
-          procedureId: input.procedureId,
-        }),
-        'list eval cases'
-      )
-      const selected = input.caseIds ? all.filter((c) => input.caseIds?.includes(c.id)) : all
-      if (selected.length === 0) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No eval cases selected' })
-      }
-
-      // Build snapshots for every case BEFORE the transaction.
-      const children: { caseId: string; definitionSnapshot: unknown; runtimeSnapshot: unknown }[] =
-        []
-      for (const row of selected) {
-        const prepared: PreparedRunSnapshots = unwrap(
-          await prepareRunSnapshots({
-            organizationId,
-            userId,
-            case: parseCase(row),
-            mode: input.useDraft ? 'draft' : 'pinned',
-          }),
-          `prepare eval run for case ${row.id}`
-        )
-        children.push({
-          caseId: row.id,
-          definitionSnapshot: prepared.definitionSnapshot,
-          runtimeSnapshot: prepared.runtimeSnapshot,
+      // Shared with the Kopilot `run_eval_suite` tool — selection, snapshots,
+      // atomic suite creation, and per-child enqueue all live in the lib recipe.
+      const result = await startAgentSuiteRun({
+        organizationId,
+        userId,
+        agentId: input.agentId,
+        procedureId: input.procedureId,
+        caseIds: input.caseIds,
+        useDraft: input.useDraft,
+      })
+      if (result.isErr()) {
+        throw new TRPCError({
+          code: result.error.code === 'EVAL_VALIDATION' ? 'BAD_REQUEST' : 'INTERNAL_SERVER_ERROR',
+          message: result.error.message,
         })
       }
-
-      const created = unwrap(
-        await createSuiteRunWithChildren({
-          organizationId,
-          kind: 'agent_simulation',
-          createdById: userId,
-          selectionSnapshot: { caseIds: selected.map((c) => c.id) },
-          children,
-        }),
-        'create eval suite run'
-      )
-
-      // Enqueue each child; a per-child enqueue failure fails that child only.
-      for (const run of created.runs) {
-        try {
-          await enqueueEvalRun({ organizationId, userId, runId: run.id })
-        } catch (error) {
-          await failQueuedEvalRun({
-            runId: run.id,
-            errorCode: 'ENQUEUE_FAILED',
-            error: error instanceof Error ? error.message : String(error),
-          })
-        }
-      }
-
-      return { suiteRunId: created.suiteRun.id, runIds: created.runs.map((r) => r.id) }
+      return { suiteRunId: result.value.suiteRun.id, runIds: result.value.runIds }
     }),
 
   cancelRun: evalAdminProcedure

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -112,6 +112,12 @@
       "import": "./dist/ai/kopilot/capabilities/kb/tools/write-helpers.mjs",
       "default": "./src/ai/kopilot/capabilities/kb/tools/write-helpers.ts"
     },
+    "./ai/kopilot/task-notifications": {
+      "types": "./src/ai/kopilot/task-notifications/index.ts",
+      "source": "./src/ai/kopilot/task-notifications/index.ts",
+      "import": "./dist/ai/kopilot/task-notifications/index.mjs",
+      "default": "./src/ai/kopilot/task-notifications/index.ts"
+    },
     "./ai/providers/types": {
       "types": "./src/ai/providers/types.ts",
       "source": "./src/ai/providers/types.ts",
@@ -315,6 +321,12 @@
       "source": "./src/evals/index.ts",
       "import": "./dist/evals/index.mjs",
       "default": "./src/evals/index.ts"
+    },
+    "./evals/start-suite-run": {
+      "types": "./src/evals/start-suite-run.ts",
+      "source": "./src/evals/start-suite-run.ts",
+      "import": "./dist/evals/start-suite-run.mjs",
+      "default": "./src/evals/start-suite-run.ts"
     },
     "./evals/worker": {
       "types": "./src/evals/worker/index.ts",

--- a/packages/lib/src/ai/agent-framework/engine.ts
+++ b/packages/lib/src/ai/agent-framework/engine.ts
@@ -65,7 +65,11 @@ export class AgentEngine {
    */
   async *submitMessage(
     userMessage: string,
-    context?: Record<string, unknown>
+    context?: Record<string, unknown>,
+    opts?: {
+      /** Stamped onto the user message record (e.g. task-notification origin markers). */
+      metadata?: Record<string, unknown>
+    }
   ): AsyncGenerator<AgentEvent> {
     this.turnId = generateId('turn')
     this.resetTurnUsage()
@@ -82,6 +86,7 @@ export class AgentEngine {
       role: 'user',
       content: userMessage,
       timestamp: Date.now(),
+      ...(opts?.metadata ? { metadata: opts.metadata } : {}),
     }
     // A fresh user message means the user is abandoning whatever was paused.
     // Drop pendingToolCall (the paused message already lives in state.messages

--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -394,7 +394,18 @@ export interface AgentToolDefinition {
   summary?: (args: Record<string, unknown>) => string
 }
 
-/** Result from executing a tool */
+/**
+ * Result from executing a tool.
+ *
+ * Async-task convention: a tool that fires background work (BullMQ job,
+ * minutes-long batch) returns immediately and includes
+ * `taskNotification: { kind, ref }` in its success `output`, plus a sentence
+ * telling the model results arrive later so it ends its turn. The client
+ * watches the ref and injects a `<task-notification>` message when the task
+ * completes. The `kind` must have a registered handler in
+ * `@auxx/lib/ai/kopilot/task-notifications`. See
+ * plans/kopilot/task-notifications/convention.md.
+ */
 export interface AgentToolResult {
   success: boolean
   output: unknown

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/index.ts
@@ -14,6 +14,7 @@ import { createCreateProcedureTool } from './tools/procedure-create'
 import { createReadProcedureTool } from './tools/procedure-read'
 import { createSetProcedureBodyTool } from './tools/procedure-set-body'
 import { createUpdateProcedureCriteriaTool } from './tools/procedure-update-criteria'
+import { createRunEvalSuiteTool } from './tools/run-eval-suite'
 import { createSetAgentPromptTool } from './tools/set-agent-prompt'
 import { createSetAgentResourceScopeTool } from './tools/set-agent-resource-scope'
 import { createSetAgentToolsetsTool } from './tools/set-agent-toolsets'
@@ -83,6 +84,9 @@ export async function createAgentsBuilderCapabilities(
     createSetProcedureBodyTool(getDeps),
     createReadProcedureTool(getDeps),
     createUpdateProcedureCriteriaTool(getDeps),
+    // Async eval batch — returns a taskNotification ref; results land as a
+    // <task-notification> message (plans/kopilot/task-notifications/plan.md).
+    createRunEvalSuiteTool(getDeps),
     // Triggers + resource-scope stay internal-only: chat agents run on the
     // inbound-message gate, never autonomously, and don't read internal records.
     ...(isChat

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/persona-prompt.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/persona-prompt.ts
@@ -113,6 +113,8 @@ Extracting a nested branch into a sub-procedure:
 
 **Publish.** You write a **draft**. After the body compiles clean, tell the admin to review it in the procedure editor and hit **Publish** to make it live — you do not publish.
 
+**Verify with simulations — \`run_eval_suite\`.** After editing a procedure (or when the admin asks to test the agent), offer to run the simulation suite. The tool starts a background batch and returns immediately: summarize what is running and END YOUR TURN — never poll. The results arrive automatically as a \`<task-notification>\` message that starts a new turn; ground your report in that notification's summary before claiming success, and propose the next edit when cases failed. Pass \`useDraft: true\` to test an unpublished draft. Never re-run the suite unprompted.
+
 Worked example — a refund procedure:
 \`\`\`json
 {

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/run-eval-suite.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/run-eval-suite.test.ts
@@ -1,0 +1,104 @@
+// packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/run-eval-suite.test.ts
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+import type { AgentDeps } from '../../../../../agent-framework/types'
+import type { GetToolDeps } from '../../../types'
+
+// Force the auth guard to pass so we can exercise the tool's own logic.
+vi.mock('../procedure-authoring-guard', () => ({
+  resolveProcedureAuthoring: vi.fn(async () => ({ ok: true, agentId: 'a1' })),
+}))
+// Stub the suite-start recipe (DB + enqueue).
+vi.mock('../../../../../../evals/start-suite-run', () => ({
+  startAgentSuiteRun: vi.fn(),
+}))
+
+import { startAgentSuiteRun } from '../../../../../../evals/start-suite-run'
+import { resolveProcedureAuthoring } from '../procedure-authoring-guard'
+import { createRunEvalSuiteTool } from '../run-eval-suite'
+
+const startMock = startAgentSuiteRun as unknown as Mock
+const guardMock = resolveProcedureAuthoring as unknown as Mock
+
+const getDeps: GetToolDeps = () =>
+  ({
+    db: {},
+    sessionContext: {},
+    organizationId: 'org-1',
+    userId: 'u-1',
+    sessionId: 's-1',
+  }) as never
+const agentDeps: AgentDeps = { organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' }
+const tool = createRunEvalSuiteTool(getDeps)
+
+beforeEach(() => {
+  guardMock.mockClear()
+  guardMock.mockResolvedValue({ ok: true, agentId: 'a1' })
+  startMock.mockReset()
+  startMock.mockResolvedValue(
+    ok({ suiteRun: { id: 'esr_1' }, runIds: ['er_1', 'er_2'], requestedCount: 2 })
+  )
+})
+
+describe('run_eval_suite', () => {
+  it('requires human approval (the spend gate / burn-loop cap)', () => {
+    expect(tool.requiresApproval).toBe(true)
+  })
+
+  it('starts the suite for the session agent and returns a taskNotification ref', async () => {
+    const result = await tool.execute({ useDraft: true } as never, agentDeps)
+    expect(result.success).toBe(true)
+    expect(startMock).toHaveBeenCalledOnce()
+    expect(startMock.mock.calls[0]![0]).toMatchObject({
+      organizationId: 'org-1',
+      userId: 'u-1',
+      agentId: 'a1',
+      useDraft: true,
+    })
+    const output = result.output as {
+      suiteRunId: string
+      requestedCount: number
+      status: string
+      taskNotification: { kind: string; ref: string }
+      note: string
+    }
+    expect(output.suiteRunId).toBe('esr_1')
+    expect(output.requestedCount).toBe(2)
+    expect(output.status).toBe('running')
+    expect(output.taskNotification).toEqual({ kind: 'eval-suite', ref: 'esr_1' })
+    expect(output.note).toContain('end your turn')
+  })
+
+  it('passes procedureId and filters caseIds to strings', async () => {
+    await tool.execute({ procedureId: 'p1', caseIds: ['c1', 42, '', 'c2'] } as never, agentDeps)
+    expect(startMock.mock.calls[0]![0]).toMatchObject({
+      procedureId: 'p1',
+      caseIds: ['c1', 'c2'],
+    })
+  })
+
+  it('surfaces the guard failure without starting anything', async () => {
+    guardMock.mockResolvedValueOnce({ ok: false, error: 'Not allowed' })
+    const result = await tool.execute({} as never, agentDeps)
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('Not allowed')
+    expect(startMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a start failure (e.g. no cases selected)', async () => {
+    startMock.mockResolvedValueOnce(
+      err({ code: 'EVAL_VALIDATION', message: 'No eval cases selected' })
+    )
+    const result = await tool.execute({} as never, agentDeps)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('No eval cases selected')
+  })
+
+  it('digest projects the suite ref + count', () => {
+    expect(tool.buildDigest?.({ suiteRunId: 'esr_1', requestedCount: 2, note: 'x' })).toEqual({
+      suiteRunId: 'esr_1',
+      requestedCount: 2,
+    })
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/run-eval-suite.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/run-eval-suite.ts
@@ -1,0 +1,114 @@
+// packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/run-eval-suite.ts
+
+import { z } from 'zod'
+import { startAgentSuiteRun } from '../../../../../evals/start-suite-run'
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import { EVAL_SUITE_TASK_KIND, type TaskNotificationRef } from '../../../task-notifications'
+import type { GetToolDeps } from '../../types'
+import { resolveProcedureAuthoring } from './procedure-authoring-guard'
+
+const outputSchema = z.object({
+  suiteRunId: z.string(),
+  requestedCount: z.number(),
+  status: z.literal('running'),
+  taskNotification: z.object({ kind: z.string(), ref: z.string() }),
+  note: z.string(),
+})
+
+/**
+ * Fire a simulation suite for the session agent and return immediately with a
+ * `taskNotification` ref — the async-task continuation contract
+ * (plans/kopilot/task-notifications/plan.md §A). Results arrive as a
+ * `<task-notification>` message in a later turn; the model must end its turn
+ * after informing the user. `requiresApproval` is the human spend gate AND the
+ * burn-loop cap: every edit→rerun cycle has a human click in it.
+ */
+export function createRunEvalSuiteTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'run_eval_suite',
+    displayName: 'Run simulation suite',
+    surfaces: ['builder'],
+    requiresApproval: true,
+    description: `Run this agent's simulation (eval) suite as a background batch. Returns immediately with a suite-run reference — the suite takes minutes.
+
+The results arrive automatically as a \`<task-notification>\` message in a later turn. After calling this tool: tell the user what is running and END YOUR TURN. Never poll for results and never re-run the suite unprompted.`,
+    parameters: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        procedureId: {
+          type: 'string',
+          description: "Restrict the suite to one procedure's cases. Omit to run every case.",
+        },
+        caseIds: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description: 'Explicit case ids to run. Omit to run every case under the scope.',
+        },
+        useDraft: {
+          type: 'boolean',
+          description:
+            'Run against the attached procedure DRAFT instead of the pinned (published) version. Use after editing a procedure to verify the draft before the user publishes.',
+        },
+      },
+    },
+    outputSchema,
+    exampleOutput: {
+      suiteRunId: 'esr_example',
+      requestedCount: 5,
+      status: 'running',
+      taskNotification: { kind: EVAL_SUITE_TASK_KIND, ref: 'esr_example' },
+      note: 'Suite is running; results arrive as a task notification.',
+    },
+    buildDigest: (output) => {
+      const o = output as { suiteRunId?: string; requestedCount?: number } | null
+      return { suiteRunId: o?.suiteRunId, requestedCount: o?.requestedCount }
+    },
+    execute: async (args, agentDeps) => {
+      // Same contract as the eval tRPC router: agentProcedures feature + admin,
+      // and the session agent verified org-scoped. One guard, shared with the
+      // procedure-authoring tools.
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      if (!ctx.ok) return { success: false, output: null, error: ctx.error }
+
+      const procedureId = typeof args.procedureId === 'string' ? args.procedureId : undefined
+      const caseIds = Array.isArray(args.caseIds)
+        ? args.caseIds.filter((id): id is string => typeof id === 'string' && id.length > 0)
+        : undefined
+      const useDraft = args.useDraft === true
+
+      const started = await startAgentSuiteRun({
+        organizationId: agentDeps.organizationId,
+        userId: agentDeps.userId,
+        agentId: ctx.agentId,
+        procedureId,
+        caseIds,
+        useDraft,
+      })
+      if (started.isErr()) {
+        return {
+          success: false,
+          output: null,
+          error: `Failed to start eval suite: ${started.error.message}`,
+        }
+      }
+
+      const taskNotification: TaskNotificationRef = {
+        kind: EVAL_SUITE_TASK_KIND,
+        ref: started.value.suiteRun.id,
+      }
+      return {
+        success: true,
+        output: {
+          suiteRunId: started.value.suiteRun.id,
+          requestedCount: started.value.requestedCount,
+          status: 'running' as const,
+          taskNotification,
+          note:
+            `The suite is running (${started.value.requestedCount} case${started.value.requestedCount === 1 ? '' : 's'}). ` +
+            'Results will arrive automatically as a task-notification message — summarize what is running for the user and end your turn.',
+        },
+      }
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/index.ts
+++ b/packages/lib/src/ai/kopilot/index.ts
@@ -39,6 +39,17 @@ export {
   type ToolCallSummary,
 } from './runners'
 export { generateSessionTitle } from './session-title'
+export {
+  buildTaskNotificationBody,
+  EVAL_SUITE_TASK_KIND,
+  getTaskNotificationHandler,
+  listTaskNotificationKinds,
+  type TaskNotificationBodyInput,
+  type TaskNotificationKindHandler,
+  type TaskNotificationRef,
+  type TaskNotificationSummary,
+  type TaskSnapshot,
+} from './task-notifications'
 export type {
   KopilotDomainState,
   PlanState,

--- a/packages/lib/src/ai/kopilot/task-notifications/__tests__/task-notifications.test.ts
+++ b/packages/lib/src/ai/kopilot/task-notifications/__tests__/task-notifications.test.ts
@@ -1,0 +1,104 @@
+// packages/lib/src/ai/kopilot/task-notifications/__tests__/task-notifications.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { buildTaskNotificationBody } from '../body'
+import { EVAL_SUITE_TASK_KIND, evalSuiteTaskNotificationHandler } from '../kinds/eval-suite'
+import { getTaskNotificationHandler, listTaskNotificationKinds } from '../registry'
+
+/** Minimal suite-run snapshot; only the fields the handler reads. */
+function suite(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'esr_1',
+    status: 'completed',
+    requestedCount: 5,
+    completedCount: 5,
+    passedCount: 4,
+    failedCount: 1,
+    errorCount: 0,
+    cancelledCount: 0,
+    timedOutCount: 0,
+    ...overrides,
+  }
+}
+
+describe('task-notification registry', () => {
+  it('resolves registered kinds', () => {
+    expect(getTaskNotificationHandler(EVAL_SUITE_TASK_KIND)).toBe(evalSuiteTaskNotificationHandler)
+    expect(listTaskNotificationKinds()).toContain(EVAL_SUITE_TASK_KIND)
+  })
+
+  it('returns undefined for unknown kinds', () => {
+    expect(getTaskNotificationHandler('nope')).toBeUndefined()
+  })
+})
+
+describe('eval-suite handler — isTerminal', () => {
+  it.each([
+    ['queued', false],
+    ['running', false],
+    ['completed', true],
+    ['cancelled', true],
+    ['error', true],
+  ])('%s → %s', (status, expected) => {
+    expect(evalSuiteTaskNotificationHandler.isTerminal(suite({ status }))).toBe(expected)
+  })
+})
+
+describe('eval-suite handler — summarize', () => {
+  it('builds the headline from counters', () => {
+    const result = evalSuiteTaskNotificationHandler.summarize(suite())
+    expect(result.status).toBe('completed')
+    expect(result.summary).toBe('5 runs: 4 passed · 1 failed')
+    expect(result.instruction).toContain('Do not re-run the suite')
+  })
+
+  it('includes error/cancelled/timed-out counts only when nonzero', () => {
+    const result = evalSuiteTaskNotificationHandler.summarize(
+      suite({ errorCount: 2, cancelledCount: 1, timedOutCount: 3 })
+    )
+    expect(result.summary).toBe(
+      '5 runs: 4 passed · 1 failed · 2 errored · 1 cancelled · 3 timed out'
+    )
+  })
+
+  it('singularizes a one-run suite', () => {
+    const result = evalSuiteTaskNotificationHandler.summarize(
+      suite({ requestedCount: 1, passedCount: 1, failedCount: 0 })
+    )
+    expect(result.summary).toBe('1 run: 1 passed · 0 failed')
+  })
+})
+
+describe('buildTaskNotificationBody', () => {
+  it('emits the canonical XML shape', () => {
+    const body = buildTaskNotificationBody({
+      kind: 'eval-suite',
+      ref: 'esr_1',
+      status: 'completed',
+      summary: '5 runs: 4 passed · 1 failed',
+      instruction: 'Report the outcome.',
+    })
+    expect(body).toBe(
+      [
+        '<task-notification>',
+        '  <kind>eval-suite</kind>',
+        '  <ref>esr_1</ref>',
+        '  <status>completed</status>',
+        '  <summary>5 runs: 4 passed · 1 failed</summary>',
+        '  <instruction>Report the outcome.</instruction>',
+        '</task-notification>',
+      ].join('\n')
+    )
+  })
+
+  it('escapes XML-significant characters', () => {
+    const body = buildTaskNotificationBody({
+      kind: 'eval-suite',
+      ref: 'esr_1',
+      status: 'error',
+      summary: 'failed on <case> & friends',
+      instruction: 'x',
+    })
+    expect(body).toContain('<summary>failed on &lt;case&gt; &amp; friends</summary>')
+  })
+})

--- a/packages/lib/src/ai/kopilot/task-notifications/body.ts
+++ b/packages/lib/src/ai/kopilot/task-notifications/body.ts
@@ -1,0 +1,29 @@
+// packages/lib/src/ai/kopilot/task-notifications/body.ts
+
+import type { TaskNotificationSummary } from './types'
+
+export interface TaskNotificationBodyInput extends TaskNotificationSummary {
+  kind: string
+  ref: string
+}
+
+function escapeXml(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+}
+
+/**
+ * The model-facing message body for a completed async task. One builder so
+ * every kind emits the same shape; content comes from the kind handler's
+ * `summarize()` (DB truth), never from the client.
+ */
+export function buildTaskNotificationBody(input: TaskNotificationBodyInput): string {
+  return [
+    '<task-notification>',
+    `  <kind>${escapeXml(input.kind)}</kind>`,
+    `  <ref>${escapeXml(input.ref)}</ref>`,
+    `  <status>${escapeXml(input.status)}</status>`,
+    `  <summary>${escapeXml(input.summary)}</summary>`,
+    `  <instruction>${escapeXml(input.instruction)}</instruction>`,
+    '</task-notification>',
+  ].join('\n')
+}

--- a/packages/lib/src/ai/kopilot/task-notifications/index.ts
+++ b/packages/lib/src/ai/kopilot/task-notifications/index.ts
@@ -1,0 +1,11 @@
+// packages/lib/src/ai/kopilot/task-notifications/index.ts
+
+export { buildTaskNotificationBody, type TaskNotificationBodyInput } from './body'
+export { EVAL_SUITE_TASK_KIND, evalSuiteTaskNotificationHandler } from './kinds/eval-suite'
+export { getTaskNotificationHandler, listTaskNotificationKinds } from './registry'
+export type {
+  TaskNotificationKindHandler,
+  TaskNotificationRef,
+  TaskNotificationSummary,
+  TaskSnapshot,
+} from './types'

--- a/packages/lib/src/ai/kopilot/task-notifications/kinds/eval-suite.ts
+++ b/packages/lib/src/ai/kopilot/task-notifications/kinds/eval-suite.ts
@@ -1,0 +1,55 @@
+// packages/lib/src/ai/kopilot/task-notifications/kinds/eval-suite.ts
+
+import type { EvalSuiteRunEntity } from '@auxx/database'
+import { getEvalSuiteRun } from '../../../../evals/queries'
+import type { TaskNotificationKindHandler, TaskSnapshot } from '../types'
+
+export const EVAL_SUITE_TASK_KIND = 'eval-suite'
+
+/** Suite `status` describes orchestration; any of these means "stop watching". */
+const TERMINAL_STATUSES: ReadonlySet<EvalSuiteRunEntity['status']> = new Set([
+  'completed',
+  'cancelled',
+  'error',
+])
+
+function asSuite(task: TaskSnapshot): EvalSuiteRunEntity {
+  return task as unknown as EvalSuiteRunEntity
+}
+
+/**
+ * Task-notification handler for eval suite runs (`run_eval_suite`).
+ * Summaries come from the suite counters; detail stays behind the eval read
+ * tools (pointer, not payload).
+ */
+export const evalSuiteTaskNotificationHandler: TaskNotificationKindHandler = {
+  kind: EVAL_SUITE_TASK_KIND,
+
+  async load(ref, organizationId) {
+    const result = await getEvalSuiteRun({ organizationId, suiteRunId: ref })
+    if (result.isErr()) {
+      throw new Error(`Failed to load eval suite run ${ref}: ${result.error.message}`)
+    }
+    return (result.value as TaskSnapshot | null) ?? null
+  },
+
+  isTerminal(task) {
+    return TERMINAL_STATUSES.has(asSuite(task).status)
+  },
+
+  summarize(task) {
+    const suite = asSuite(task)
+    const counts = [`${suite.passedCount} passed`, `${suite.failedCount} failed`]
+    if (suite.errorCount > 0) counts.push(`${suite.errorCount} errored`)
+    if (suite.cancelledCount > 0) counts.push(`${suite.cancelledCount} cancelled`)
+    if (suite.timedOutCount > 0) counts.push(`${suite.timedOutCount} timed out`)
+
+    return {
+      status: suite.status,
+      summary: `${suite.requestedCount} run${suite.requestedCount === 1 ? '' : 's'}: ${counts.join(' · ')}`,
+      instruction:
+        'The eval suite has finished. Report the outcome to the user and propose next steps. ' +
+        'Do not re-run the suite unless the user asks.',
+    }
+  },
+}

--- a/packages/lib/src/ai/kopilot/task-notifications/registry.ts
+++ b/packages/lib/src/ai/kopilot/task-notifications/registry.ts
@@ -1,0 +1,17 @@
+// packages/lib/src/ai/kopilot/task-notifications/registry.ts
+
+import { evalSuiteTaskNotificationHandler } from './kinds/eval-suite'
+import type { TaskNotificationKindHandler } from './types'
+
+/** Adding a consumer = one handler file under ./kinds/ + an entry here. */
+const handlers: Record<string, TaskNotificationKindHandler> = {
+  [evalSuiteTaskNotificationHandler.kind]: evalSuiteTaskNotificationHandler,
+}
+
+export function getTaskNotificationHandler(kind: string): TaskNotificationKindHandler | undefined {
+  return handlers[kind]
+}
+
+export function listTaskNotificationKinds(): string[] {
+  return Object.keys(handlers)
+}

--- a/packages/lib/src/ai/kopilot/task-notifications/types.ts
+++ b/packages/lib/src/ai/kopilot/task-notifications/types.ts
@@ -1,0 +1,43 @@
+// packages/lib/src/ai/kopilot/task-notifications/types.ts
+//
+// Generic async-task continuation for Kopilot tools: a tool fires background
+// work, returns a `TaskNotificationRef`, and when the work reaches a terminal
+// state the client injects a server-built `<task-notification>` message that
+// starts a new turn. See plans/kopilot/task-notifications/plan.md.
+
+/**
+ * Marker a tool includes in its output to opt into async-task continuation.
+ * The client registers a watch for `(kind, ref)` when this field streams in.
+ */
+export interface TaskNotificationRef {
+  /** Registered kind, e.g. 'eval-suite'. Must have a server-side handler. */
+  kind: string
+  /** Kind-scoped task id, e.g. an EvalSuiteRun id. */
+  ref: string
+}
+
+/** Opaque task state loaded by a kind handler; narrowed inside the handler. */
+export type TaskSnapshot = Record<string, unknown>
+
+/** Server-built, model-facing notification content. Never client-supplied. */
+export interface TaskNotificationSummary {
+  /** Terminal status word, e.g. 'completed' | 'cancelled' | 'error'. */
+  status: string
+  /** One-line outcome headline, e.g. "5 runs: 4 passed · 1 failed". */
+  summary: string
+  /** What the model should do next — and what it must not do (no self-restart). */
+  instruction: string
+}
+
+/**
+ * Per-kind handler resolved by the stream route when a task-notification
+ * message arrives. Functional module shape, one handler file per kind under
+ * `./kinds/`.
+ */
+export interface TaskNotificationKindHandler {
+  kind: string
+  /** Org-scoped load of the task's current state; null → unknown/foreign ref. */
+  load(ref: string, organizationId: string): Promise<TaskSnapshot | null>
+  isTerminal(task: TaskSnapshot): boolean
+  summarize(task: TaskSnapshot): TaskNotificationSummary
+}

--- a/packages/lib/src/evals/start-suite-run.ts
+++ b/packages/lib/src/evals/start-suite-run.ts
@@ -1,0 +1,126 @@
+// packages/lib/src/evals/start-suite-run.ts
+//
+// The suite-start recipe shared by the `eval.runAll` tRPC mutation and the
+// Kopilot `run_eval_suite` tool: resolve the selected cases, build snapshots,
+// atomically create the suite + queued children, then enqueue each child.
+// Permission/feature gating stays in the callers. Deliberately NOT exported
+// from ./index — it pulls the BullMQ enqueue path (same split as ./worker).
+
+import type { EvalSuiteRunEntity } from '@auxx/database'
+import {
+  agentEvalAssertionsSchema,
+  agentEvalTargetSchema,
+  simulationConfigSchema,
+} from '@auxx/types/evals/schema'
+import { err, ok, type Result } from 'neverthrow'
+import { failQueuedEvalRun } from './lifecycle'
+import { prepareRunSnapshots } from './prepare-run'
+import { createSuiteRunWithChildren, listEvalCasesByAgent } from './queries'
+import type { EvalServiceError } from './types'
+import { enqueueEvalRun } from './worker/enqueue-eval-run'
+
+export interface StartAgentSuiteRunInput {
+  organizationId: string
+  userId: string
+  agentId: string
+  /** Restrict the selection to one procedure's cases. */
+  procedureId?: string
+  /** Explicit case ids; omit to run every case under the scope. */
+  caseIds?: string[]
+  /** Run the attached draft instead of the pinned version (regression gate). */
+  useDraft?: boolean
+}
+
+export interface StartAgentSuiteRunResult {
+  suiteRun: EvalSuiteRunEntity
+  runIds: string[]
+  requestedCount: number
+}
+
+/**
+ * Start a suite run for an agent. Mirrors the original `eval.runAll` body:
+ * a per-child enqueue failure fails that child only (`failQueuedEvalRun`
+ * drives it terminal so suite counters still converge).
+ */
+export async function startAgentSuiteRun(
+  input: StartAgentSuiteRunInput
+): Promise<Result<StartAgentSuiteRunResult, EvalServiceError>> {
+  const { organizationId, userId } = input
+
+  const listed = await listEvalCasesByAgent({
+    organizationId,
+    agentId: input.agentId,
+    procedureId: input.procedureId,
+  })
+  if (listed.isErr()) return err(listed.error)
+
+  const selected = input.caseIds
+    ? listed.value.filter((c) => input.caseIds?.includes(c.id))
+    : listed.value
+  if (selected.length === 0) {
+    return err({ code: 'EVAL_VALIDATION', message: 'No eval cases selected' })
+  }
+
+  // Build snapshots for every case BEFORE the transaction.
+  const children: { caseId: string; definitionSnapshot: unknown; runtimeSnapshot: unknown }[] = []
+  for (const row of selected) {
+    let parsedCase: Parameters<typeof prepareRunSnapshots>[0]['case']
+    try {
+      parsedCase = {
+        id: row.id,
+        name: row.name,
+        createdAt: row.createdAt.toISOString(),
+        target: agentEvalTargetSchema.parse(row.target),
+        config: simulationConfigSchema.parse(row.config),
+        assertions: agentEvalAssertionsSchema.parse(row.assertions),
+      }
+    } catch (cause) {
+      return err({
+        code: 'EVAL_VALIDATION',
+        message: `Eval case ${row.id} has an invalid payload`,
+        cause,
+      })
+    }
+
+    const prepared = await prepareRunSnapshots({
+      organizationId,
+      userId,
+      case: parsedCase,
+      mode: input.useDraft ? 'draft' : 'pinned',
+    })
+    if (prepared.isErr()) return err(prepared.error)
+    children.push({
+      caseId: row.id,
+      definitionSnapshot: prepared.value.definitionSnapshot,
+      runtimeSnapshot: prepared.value.runtimeSnapshot,
+    })
+  }
+
+  const created = await createSuiteRunWithChildren({
+    organizationId,
+    kind: 'agent_simulation',
+    createdById: userId,
+    selectionSnapshot: { caseIds: selected.map((c) => c.id) },
+    children,
+  })
+  if (created.isErr()) return err(created.error)
+
+  // Enqueue each child; a per-child enqueue failure fails that child only.
+  for (const run of created.value.runs) {
+    try {
+      await enqueueEvalRun({ organizationId, userId, runId: run.id })
+    } catch (error) {
+      await failQueuedEvalRun({
+        runId: run.id,
+        errorCode: 'ENQUEUE_FAILED',
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  return ok({
+    suiteRun: created.value.suiteRun,
+    runIds: created.value.runs.map((r) => r.id),
+    requestedCount: created.value.runs.length,
+  })
+}


### PR DESCRIPTION
## Summary

Introduces an **async-task continuation** path for Kopilot: a tool can fire long-running background work, end its turn immediately, and have the results injected later as a `<task-notification>` message that kicks off a fresh turn. The first consumer is a `run_eval_suite` builder tool that starts a simulation batch and reports back when it finishes.

## What's included

**Task-notification framework (`@auxx/lib/ai/kopilot/task-notifications`)**
- Kind registry + body builder, with an `eval-suite` kind handler
- New `AgentToolResult` convention: tools returning `taskNotification: { kind, ref }` signal fire-and-end; the client watches the ref and injects the notification on completion
- `AgentEngine.submitMessage` accepts optional `metadata` stamped onto the persisted user message

**`run_eval_suite` tool + persona**
- New builder tool returns a `taskNotification` ref instead of blocking
- `startAgentSuiteRun` lib recipe (selection → snapshots → atomic suite creation → per-child enqueue) shared by the tool and the tRPC `eval` router, replacing the inlined router logic
- Persona prompt instructs the model to summarize what's running and **end its turn** — never poll

**Web runtime**
- App-level `KopilotRuntime` (sibling of the dock in `Dashboard`) owns the SSE connection so turns keep streaming when the panel is closed; submissions now flow through the store's `pendingRequest`
- `KopilotRequest` shape moved into the store (re-exported for existing importers)
- Stream route validates + dedupes `origin: 'task-notification'` requests and rewrites `message` from DB truth before opening the stream (failures are plain HTTP, not SSE); task-notification turns always run in-process
- Task-notification chip rendering (muted system chip, excluded from edit/retry), unread launcher dot, and a `run_eval_suite` tool status pill

## Tests
- Unit tests for the task-notification registry/body, stream-route resolution, task-watch store, and client-side task-notification utils

## Notes
- Task-notification turns run in-process for now; worker-side delivery is deferred (noted inline as §E).