### PR TITLE
feat(ai): add Anthropic Fable 5 / Opus 4.8 / 4.7 and Kimi K2.6 models

### DIFF
--- a/packages/lib/src/ai/providers/anthropic/__tests__/anthropic-llm-client.test.ts
+++ b/packages/lib/src/ai/providers/anthropic/__tests__/anthropic-llm-client.test.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/ai/providers/anthropic/__tests__/anthropic-llm-client.test.ts
 
 import Anthropic from '@anthropic-ai/sdk'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { DEFAULT_CLIENT_CONFIG } from '../../../clients/base/types'
 import { AnthropicLLMClient } from '../anthropic-llm-client'
 
@@ -126,4 +126,74 @@ describe.skipIf(!apiKey)('AnthropicLLMClient integration', () => {
     expect(response.content).toBeTruthy()
     expect(response.content.length).toBeGreaterThan(5)
   }, 15_000)
+})
+
+/**
+ * Unit tests for sampling-parameter handling. No API key required — the
+ * Anthropic SDK is mocked so we can inspect the exact request payload.
+ *
+ * Fable 5 / Opus 4.8 / Opus 4.7 reject temperature/top_p/top_k with a 400.
+ * The client must strip them; unrestricted models must keep them.
+ */
+describe('AnthropicLLMClient sampling-parameter stripping', () => {
+  function createClientWithSpy() {
+    const create = vi.fn(async (params: any) => ({
+      id: 'msg_test',
+      model: params.model,
+      content: [{ type: 'text', text: 'ok' }],
+      usage: { input_tokens: 10, output_tokens: 2 },
+      stop_reason: 'end_turn',
+    }))
+
+    const mockAnthropic = { messages: { create } } as unknown as Anthropic
+    const client = new AnthropicLLMClient(mockAnthropic, {
+      ...DEFAULT_CLIENT_CONFIG,
+      retries: { ...DEFAULT_CLIENT_CONFIG.retries, maxAttempts: 1 },
+    })
+    return { client, create }
+  }
+
+  it('strips temperature/top_p for sampling-restricted models (Opus 4.8)', async () => {
+    const { client, create } = createClientWithSpy()
+
+    await client.invoke({
+      model: 'claude-opus-4-8',
+      messages: [{ role: 'user', content: 'Hi' }],
+      parameters: { max_tokens: 32, temperature: 0, top_p: 0.9 },
+    })
+
+    const sent = create.mock.calls[0][0]
+    expect(sent.temperature).toBeUndefined()
+    expect(sent.top_p).toBeUndefined()
+  })
+
+  it('strips sampling params for Fable 5 and Opus 4.7', async () => {
+    for (const model of ['claude-fable-5', 'claude-opus-4-7']) {
+      const { client, create } = createClientWithSpy()
+
+      await client.invoke({
+        model,
+        messages: [{ role: 'user', content: 'Hi' }],
+        parameters: { max_tokens: 32, temperature: 0.7, top_p: 0.95 },
+      })
+
+      const sent = create.mock.calls[0][0]
+      expect(sent.temperature, model).toBeUndefined()
+      expect(sent.top_p, model).toBeUndefined()
+    }
+  })
+
+  it('keeps temperature/top_p for unrestricted models (Sonnet 4.6)', async () => {
+    const { client, create } = createClientWithSpy()
+
+    await client.invoke({
+      model: 'claude-sonnet-4-6',
+      messages: [{ role: 'user', content: 'Hi' }],
+      parameters: { max_tokens: 32, temperature: 0.5, top_p: 0.9 },
+    })
+
+    const sent = create.mock.calls[0][0]
+    expect(sent.temperature).toBe(0.5)
+    expect(sent.top_p).toBe(0.9)
+  })
 })

--- a/packages/lib/src/ai/providers/anthropic/anthropic-defaults.ts
+++ b/packages/lib/src/ai/providers/anthropic/anthropic-defaults.ts
@@ -42,7 +42,110 @@ export const ANTHROPIC_CAPABILITIES: ProviderCapabilities = {
     'Get your API key from the Anthropic console at https://console.anthropic.com/',
 }
 
+/**
+ * Fable 5 / Opus 4.8 / Opus 4.7 remove sampling parameters — sending
+ * `temperature`, `top_p`, or `top_k` returns a 400 (`invalid_request_error`).
+ * Sampling is steered by prompting + effort on these models. The Anthropic
+ * client reads `unsupportedParams` and strips these at the wire boundary.
+ */
+const CLAUDE_NO_SAMPLING_PARAMS: ModelCapabilities['parameterRestrictions'] = {
+  isReasoningModel: false, // thinking is off-by-default; we don't send a thinking block
+  supportedParams: ['max_tokens'],
+  unsupportedParams: ['temperature', 'top_p', 'top_k'],
+}
+
+/** Max-tokens-only rules for sampling-restricted Claude models (hides temp/top_p in the UI). */
+const CLAUDE_MAXTOKENS_ONLY_RULES = [
+  {
+    name: 'max_tokens',
+    type: 'int' as const,
+    label: 'Max Tokens',
+    help: 'Maximum number of tokens to generate in the response.',
+    default: 16384,
+    min: 1,
+    max: 128000,
+    precision: 0,
+    required: false,
+    template: 'max_tokens',
+  },
+]
+
 export const ANTHROPIC_MODELS: Record<string, ModelCapabilities> = {
+  'claude-fable-5': {
+    provider: 'anthropic',
+    modelId: 'claude-fable-5',
+    fetchFrom: FetchFrom.PREDEFINED_MODEL,
+    displayName: 'Claude Fable 5',
+    icon: 'anthropic',
+    color: '#D97706',
+    contextLength: 200000,
+    maxTokens: 128000,
+    modelType: ModelType.LLM,
+    features: ['chat', 'tools', 'computer_use'],
+    supports: {
+      streaming: true,
+      structured: true,
+      vision: true,
+      toolCalling: true,
+      systemMessages: true,
+      fileInput: true,
+    },
+    costPer1kTokens: { input: 0.01, output: 0.05, cachedInput: 0.001, cacheWrite: 0.0125 },
+    description:
+      'Claude Fable 5 — most powerful Anthropic model, tier above Opus. Sampling parameters (temperature, top_p) are fixed by the model.',
+    parameterRestrictions: CLAUDE_NO_SAMPLING_PARAMS,
+    parameterRules: CLAUDE_MAXTOKENS_ONLY_RULES,
+  },
+  'claude-opus-4-8': {
+    provider: 'anthropic',
+    modelId: 'claude-opus-4-8',
+    fetchFrom: FetchFrom.PREDEFINED_MODEL,
+    displayName: 'Claude Opus 4.8',
+    icon: 'anthropic',
+    color: '#D97706',
+    contextLength: 200000,
+    maxTokens: 128000,
+    modelType: ModelType.LLM,
+    features: ['chat', 'tools', 'computer_use'],
+    supports: {
+      streaming: true,
+      structured: true,
+      vision: true,
+      toolCalling: true,
+      systemMessages: true,
+      fileInput: true,
+    },
+    costPer1kTokens: { input: 0.005, output: 0.025, cachedInput: 0.0005, cacheWrite: 0.00625 },
+    description:
+      'Claude Opus 4.8 — most capable Opus: autonomous long-horizon agentic work. Sampling parameters (temperature, top_p) are fixed by the model.',
+    parameterRestrictions: CLAUDE_NO_SAMPLING_PARAMS,
+    parameterRules: CLAUDE_MAXTOKENS_ONLY_RULES,
+  },
+  'claude-opus-4-7': {
+    provider: 'anthropic',
+    modelId: 'claude-opus-4-7',
+    fetchFrom: FetchFrom.PREDEFINED_MODEL,
+    displayName: 'Claude Opus 4.7',
+    icon: 'anthropic',
+    color: '#D97706',
+    contextLength: 200000,
+    maxTokens: 128000,
+    modelType: ModelType.LLM,
+    features: ['chat', 'tools', 'computer_use'],
+    supports: {
+      streaming: true,
+      structured: true,
+      vision: true,
+      toolCalling: true,
+      systemMessages: true,
+      fileInput: true,
+    },
+    costPer1kTokens: { input: 0.005, output: 0.025, cachedInput: 0.0005, cacheWrite: 0.00625 },
+    description:
+      'Claude Opus 4.7 — previous-generation Opus; strong long-horizon agentic and vision work. Sampling parameters (temperature, top_p) are fixed by the model.',
+    parameterRestrictions: CLAUDE_NO_SAMPLING_PARAMS,
+    parameterRules: CLAUDE_MAXTOKENS_ONLY_RULES,
+  },
   'claude-opus-4-6': {
     provider: 'anthropic',
     modelId: 'claude-opus-4-6',

--- a/packages/lib/src/ai/providers/anthropic/anthropic-llm-client.ts
+++ b/packages/lib/src/ai/providers/anthropic/anthropic-llm-client.ts
@@ -581,12 +581,19 @@ export class AnthropicLLMClient extends LLMClient {
       anthropicParams.system = buildSystemBlocks(systemMessage)
     }
 
-    // Add optional parameters
-    if (parameters?.temperature !== undefined) {
+    // Add optional sampling parameters, but only when the model accepts them.
+    // Fable 5 / Opus 4.8 / Opus 4.7 remove temperature/top_p/top_k and 400 if
+    // they're sent — strip anything the model lists in `unsupportedParams`.
+    // This gate covers every caller (including the agent-framework summarizer's
+    // hardcoded temperature: 0) since both invoke paths funnel through here.
+    const modelConfig = ANTHROPIC_MODELS[params.model]
+    const unsupportedParams = new Set(modelConfig?.parameterRestrictions?.unsupportedParams ?? [])
+
+    if (parameters?.temperature !== undefined && !unsupportedParams.has('temperature')) {
       anthropicParams.temperature = parameters.temperature
     }
 
-    if (parameters?.top_p !== undefined) {
+    if (parameters?.top_p !== undefined && !unsupportedParams.has('top_p')) {
       anthropicParams.top_p = parameters.top_p
     }
 

--- a/packages/lib/src/ai/providers/kimi/kimi-client.ts
+++ b/packages/lib/src/ai/providers/kimi/kimi-client.ts
@@ -76,7 +76,7 @@ export class KimiClient extends ProviderClient {
     try {
       const extractedCreds = this.extractCredentials(credentials)
       const client = this.getApiClient(extractedCreds)
-      const testModel = model || 'kimi-k2.5'
+      const testModel = model || 'kimi-k2.6'
 
       await client.chat.completions.create({
         model: testModel,

--- a/packages/lib/src/ai/providers/kimi/kimi-defaults.ts
+++ b/packages/lib/src/ai/providers/kimi/kimi-defaults.ts
@@ -8,7 +8,7 @@ export const KIMI_CAPABILITIES: ProviderCapabilities = {
   icon: 'kimi',
   color: '#027AFF',
   supportedModelTypes: [ModelType.LLM],
-  defaultModel: 'kimi-k2.5',
+  defaultModel: 'kimi-k2.6',
   requiresApiKey: true,
   toolFormat: 'openai',
   configurateMethods: ['predefined-model', 'customizable-model'],
@@ -129,6 +129,31 @@ const KIMI_RESTRICTED_PARAMS = {
 }
 
 export const KIMI_MODELS: Record<string, ModelCapabilities> = {
+  'kimi-k2.6': {
+    provider: 'kimi',
+    modelId: 'kimi-k2.6',
+    fetchFrom: FetchFrom.PREDEFINED_MODEL,
+    displayName: 'Kimi K2.6',
+    icon: 'kimi',
+    color: '#027AFF',
+    contextLength: 262144,
+    maxTokens: 262144,
+    modelType: ModelType.LLM,
+    features: ['chat', 'code', 'vision'],
+    supports: {
+      streaming: true,
+      structured: true,
+      vision: true,
+      toolCalling: true,
+      systemMessages: true,
+      fileInput: false,
+    },
+    costPer1kTokens: { input: 0.00095, output: 0.004, cachedInput: 0.00016 },
+    description:
+      'Moonshot AI flagship multimodal model: 262K context, image + video input, tool calling, structured output, and built-in thinking. Sampling parameters (temperature, top_p) are fixed by the model.',
+    parameterRestrictions: KIMI_RESTRICTED_PARAMS,
+    parameterRules: KIMI_K25_PARAMETER_RULES,
+  },
   'kimi-k2.5': {
     provider: 'kimi',
     modelId: 'kimi-k2.5',

--- a/packages/lib/src/ai/providers/kimi/kimi-llm-client.ts
+++ b/packages/lib/src/ai/providers/kimi/kimi-llm-client.ts
@@ -6,10 +6,10 @@ import { OpenAILLMClient } from '../openai/openai-llm-client'
 /**
  * Kimi LLM client that extends OpenAI's client.
  *
- * Kimi's API is OpenAI-compatible. For kimi-k2.5, the OpenAI-compatible
+ * Kimi's API is OpenAI-compatible. For kimi-k2.5 / kimi-k2.6, the OpenAI-compatible
  * client handles everything (chat, tools, structured output, vision).
  *
- * kimi-k2.5 has thinking/reasoning enabled by default. The API returns
+ * kimi-k2.5 / kimi-k2.6 have thinking/reasoning enabled by default. The API returns
  * `reasoning_content` in responses and requires it in subsequent assistant
  * messages — Kimi requires reasoning_content on ALL assistant messages
  * in multi-turn conversations.


### PR DESCRIPTION
## What

Adds the latest Anthropic and Kimi models to the provider registry.

### Anthropic
- New models: `claude-fable-5` ($10/$50), `claude-opus-4-8` ($5/$25), `claude-opus-4-7` ($5/$25) — added at the top of `ANTHROPIC_MODELS` so they lead the picker. 128K max output, vision + file input, computer-use, with cached-read/cache-write multipliers wired for COGS.
- **Load-bearing fix:** these models remove sampling params (`temperature`/`top_p`/`top_k`) and **400 if any are sent**. The Anthropic client previously sent them unconditionally, and `agent-framework/context-manager.ts` injects a hardcoded `temperature: 0` — so without this, the conversation summarizer would 400 on the new models. `buildAnthropicParams` now strips any param listed in the model's `parameterRestrictions.unsupportedParams`. No-op for Sonnet/Haiku/older Opus.
- New unit tests assert sampling params are stripped for the restricted models and kept for unrestricted ones.

### Kimi
- Adds `kimi-k2.6` and promotes it to the provider default.

## Notes / open items
- Anthropic provider default left as `claude-sonnet-4-6` (cost/speed default for the helpdesk path); Opus/Fable are opt-in.
- `contextLength` shipped at 200K to match siblings (1M available — deferred).
- Adaptive thinking + `effort` intentionally out of scope (needs stream-event plumbing) — follow-up.
- **Confirm list pricing** against the Anthropic/Moonshot consoles before merge — it feeds billing.

## Test
- `pnpm vitest run` on the Anthropic client + model-lifecycle suites: all green (3 new unit tests + existing integration + lifecycle invariants).
- Biome clean on changed files.