### PR TITLE
feat(evals,kopilot): targeted case re-runs + approval-gated mock repair

### DIFF
--- a/apps/web/src/components/evals/hooks/__tests__/build-fix-seed.test.ts
+++ b/apps/web/src/components/evals/hooks/__tests__/build-fix-seed.test.ts
@@ -3,12 +3,13 @@
 import { buildFixSeedMessage, suiteChildrenToFixRuns } from '../build-fix-seed'
 
 describe('buildFixSeedMessage', () => {
-  it('embeds case names, run ids, the suite id, and failed-assertion lines', () => {
+  it('embeds case names, case ids, run ids, the suite id, and failed-assertion lines', () => {
     const seed = buildFixSeedMessage({
       suiteRunId: 'esr_1',
       runs: [
         {
           runId: 'run_1',
+          caseId: 'case_1',
           caseName: 'Refund for damaged item',
           failedAssertions: [
             { type: 'response_criteria', note: 'No refund timeline stated' },
@@ -17,6 +18,7 @@ describe('buildFixSeedMessage', () => {
         },
         {
           runId: 'run_2',
+          caseId: 'case_2',
           caseName: 'Order status lookup',
           failedAssertions: [],
         },
@@ -24,18 +26,30 @@ describe('buildFixSeedMessage', () => {
     })
 
     expect(seed).toContain('2 failing simulations')
-    expect(seed).toContain('Case "Refund for damaged item" failed (run run_1):')
+    expect(seed).toContain('Case "Refund for damaged item" failed (case case_1, run run_1):')
     expect(seed).toContain('- response_criteria: No refund timeline stated')
     expect(seed).toContain('- tool_called')
-    expect(seed).toContain('Case "Order status lookup" failed (run run_2):')
+    expect(seed).toContain('Case "Order status lookup" failed (case case_2, run run_2):')
     expect(seed).toContain('- execution error (no assertion results)')
     expect(seed).toContain('Suite run: esr_1')
     expect(seed).toContain('get_eval_run')
   })
 
+  it('omits the case id for deleted cases', () => {
+    const seed = buildFixSeedMessage({
+      runs: [
+        { runId: 'r1', caseId: null, caseName: 'A', failedAssertions: [{ type: 'crm_field' }] },
+      ],
+    })
+    expect(seed).toContain('Case "A" failed (run r1):')
+    expect(seed).not.toContain('case ')
+  })
+
   it('is stable for a single run without a suite', () => {
     const seed = buildFixSeedMessage({
-      runs: [{ runId: 'r1', caseName: 'A', failedAssertions: [{ type: 'crm_field' }] }],
+      runs: [
+        { runId: 'r1', caseId: 'c1', caseName: 'A', failedAssertions: [{ type: 'crm_field' }] },
+      ],
     })
     expect(seed).toContain('1 failing simulation')
     expect(seed).not.toContain('Suite run:')
@@ -46,6 +60,7 @@ describe('buildFixSeedMessage', () => {
       runs: [
         {
           runId: 'r1',
+          caseId: 'c1',
           caseName: 'A',
           failedAssertions: [{ type: 'response_criteria', note: `x\n${'y'.repeat(500)}` }],
         },
@@ -64,7 +79,7 @@ describe('suiteChildrenToFixRuns', () => {
     status: string,
     assertionResults: { type: string; status: string; note?: string | null }[] = [],
     caseName = `case ${id}`
-  ) => ({ id, status, caseName, assertionResults })
+  ) => ({ id, caseId: `case-of-${id}`, status, caseName, assertionResults })
 
   it('keeps only failed/errored children and their non-passed assertions', () => {
     const runs = suiteChildrenToFixRuns([
@@ -77,13 +92,14 @@ describe('suiteChildrenToFixRuns', () => {
     ])
 
     expect(runs.map((r) => r.runId)).toEqual(['r1', 'r3'])
+    expect(runs.map((r) => r.caseId)).toEqual(['case-of-r1', 'case-of-r3'])
     expect(runs[0]?.failedAssertions).toEqual([
       { type: 'response_criteria', note: 'missed timeline' },
     ])
     expect(runs[1]?.failedAssertions).toEqual([])
   })
 
-  it('feeds a multi-run suite seed with case names, run ids, and the suite id', () => {
+  it('feeds a multi-run suite seed with case names, case ids, run ids, and the suite id', () => {
     const runs = suiteChildrenToFixRuns([
       child('r1', 'failed', [{ type: 'response_criteria', status: 'failed', note: 'a' }], 'Refund'),
       child('r2', 'error', [], ''),
@@ -91,8 +107,8 @@ describe('suiteChildrenToFixRuns', () => {
     const seed = buildFixSeedMessage({ suiteRunId: 'esr_9', runs })
 
     expect(seed).toContain('2 failing simulations')
-    expect(seed).toContain('Case "Refund" failed (run r1):')
-    expect(seed).toContain('Case "Deleted case" failed (run r2):')
+    expect(seed).toContain('Case "Refund" failed (case case-of-r1, run r1):')
+    expect(seed).toContain('Case "Deleted case" failed (case case-of-r2, run r2):')
     expect(seed).toContain('Suite run: esr_9')
   })
 })

--- a/apps/web/src/components/evals/hooks/build-fix-seed.ts
+++ b/apps/web/src/components/evals/hooks/build-fix-seed.ts
@@ -1,14 +1,17 @@
 // apps/web/src/components/evals/hooks/build-fix-seed.ts
 //
 // Pure builder for the "Fix with Kopilot" seed message (phase 5D.1). The text
-// embeds the references the 5C.5 contract expects — case name(s), run id(s),
-// suite run id, failed-assertion one-liners — so Kopilot's first turn can call
-// `get_eval_run` directly without a `list_eval_cases` round-trip.
+// embeds the references the 5C.5 contract expects — case name(s), case id(s),
+// run id(s), suite run id, failed-assertion one-liners — so Kopilot's first
+// turn can call `get_eval_run` directly without a `list_eval_cases` round-trip,
+// and targeted re-runs can pass the case ids straight to `run_eval_suite`.
 
 const NOTE_MAX = 160
 
 export interface FixSeedRun {
   runId: string
+  /** Null when the case was deleted after the run. */
+  caseId: string | null
   caseName: string
   /** Non-passed assertions; `note` is the grader's reason when present. */
   failedAssertions: { type: string; note?: string | null }[]
@@ -28,6 +31,7 @@ function capNote(note: string): string {
 /** A suite child-run summary (`eval.listSuiteChildRuns` row). */
 export interface SuiteChildRunLike {
   id: string
+  caseId: string | null
   caseName: string
   status: string
   assertionResults: { type: string; status: string; note?: string | null }[]
@@ -43,6 +47,7 @@ export function suiteChildrenToFixRuns(children: SuiteChildRunLike[]): FixSeedRu
     .filter((c) => c.status !== 'passed')
     .map((c) => ({
       runId: c.id,
+      caseId: c.caseId,
       caseName: c.caseName || 'Deleted case',
       failedAssertions: c.assertionResults
         .filter((a) => a.status !== 'passed')
@@ -61,7 +66,8 @@ export function buildFixSeedMessage(input: FixSeedInput): string {
 
   for (const run of input.runs) {
     lines.push('')
-    lines.push(`Case "${run.caseName}" failed (run ${run.runId}):`)
+    const ids = run.caseId ? `case ${run.caseId}, run ${run.runId}` : `run ${run.runId}`
+    lines.push(`Case "${run.caseName}" failed (${ids}):`)
     if (run.failedAssertions.length === 0) {
       lines.push('- execution error (no assertion results)')
     }

--- a/apps/web/src/components/evals/ui/eval-run-detail.tsx
+++ b/apps/web/src/components/evals/ui/eval-run-detail.tsx
@@ -228,6 +228,7 @@ export function EvalRunDetail({ runId, onSelectRun, onFixWithKopilot }: EvalRunD
                     runs: [
                       {
                         runId: row.id,
+                        caseId,
                         caseName,
                         failedAssertions: assertions
                           .filter((a) => a.status !== 'passed')

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/index.ts
@@ -10,6 +10,7 @@ import { findRef } from '../../context-refs'
 import type { GetToolDeps, PageCapability } from '../types'
 import { buildBuilderPersonaPrompt, buildChatBuilderPersonaPrompt } from './persona-prompt'
 import { createCompleteAgentSetupTool } from './tools/complete-agent-setup'
+import { createGetEvalCaseTool } from './tools/get-eval-case'
 import { createGetEvalRunTool } from './tools/get-eval-run'
 import { createGetSuiteDiffTool } from './tools/get-suite-diff'
 import { createListEvalCasesTool } from './tools/list-eval-cases'
@@ -24,6 +25,7 @@ import { createSetAgentToolsetsTool } from './tools/set-agent-toolsets'
 import { createSetAgentTriggersTool } from './tools/set-agent-triggers'
 import { createSuggestRepliesTool } from './tools/suggest-replies'
 import { createUpdateAgentIdentityTool } from './tools/update-agent-identity'
+import { createUpdateEvalCaseMockTool } from './tools/update-eval-case-mock'
 
 export const AGENTS_BUILDER_PAGE = 'agents.builder'
 
@@ -87,14 +89,18 @@ export async function createAgentsBuilderCapabilities(
     createSetProcedureBodyTool(getDeps),
     createReadProcedureTool(getDeps),
     createUpdateProcedureCriteriaTool(getDeps),
-    // Eval improvement loop (phase 5C): read-only context tools + the async
-    // suite trigger. No tool can write eval tables — fixing goes through the
-    // build-editing tools above; results land as a <task-notification> message
-    // (plans/kopilot/task-notifications/plan.md).
+    // Eval improvement loop (phase 5C): read context tools + the async suite
+    // trigger. The ONLY eval write surface is `update_eval_case_mock` —
+    // approval-gated fixture repair on `connectorMocks`; assertions stay
+    // tRPC/editor-only so the model can't grade its own homework. Fixing
+    // otherwise goes through the build-editing tools above; results land as a
+    // <task-notification> message (plans/kopilot/task-notifications/plan.md).
     createListEvalCasesTool(getDeps),
+    createGetEvalCaseTool(getDeps),
     createGetEvalRunTool(getDeps),
     createGetSuiteDiffTool(getDeps),
     createRunEvalSuiteTool(getDeps),
+    createUpdateEvalCaseMockTool(getDeps),
     // Triggers + resource-scope stay internal-only: chat agents run on the
     // inbound-message gate, never autonomously, and don't read internal records.
     ...(isChat

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/persona-prompt.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/persona-prompt.ts
@@ -118,8 +118,9 @@ Extracting a nested branch into a sub-procedure:
 **Fixing failing simulations.** When eval context is present (a seeded failure, a task notification, or a prior eval tool result), work the loop with the read tools:
 - Ground EVERY proposed edit in a specific failing turn or assertion — pull the run with \`get_eval_run\` and cite the case name and what failed. Never propose an edit from the pass/fail counts alone.
 - Prefer the smallest edit that addresses the failure; tackle one failure class per iteration.
-- If a case seems to test the wrong thing (an assertion that contradicts the procedure's intent, an unrealistic mock), FLAG it to the user instead of editing the build around it. You have no tool to modify cases — that is deliberate.
-- After the user applies edits, offer \`run_eval_suite\` with \`useDraft: true\` and the previous suite as \`baselineSuiteRunId\` — the \`get_suite_diff\` verdict (fixed/regressed) is the proof, not your reasoning. Treat \`flipDriver: "judge"\` flips as possible noise; deterministic flips are signal.
+- When the failure is the CASE's fault, not the build's, split by what's broken. A broken **mock** (e.g. a \`connectorMocks\` entry that returns data contradicting the case's own scenario, so the case can never pass) you may repair: read the case with \`get_eval_case\`, then propose the corrected mock via \`update_eval_case_mock\` — the admin approves the diff. Never shape a mock to make a failing assertion pass with data the real tool wouldn't return; mocks model reality, not the verdict. A wrong-looking **assertion** (one that contradicts the procedure's intent) you must FLAG to the user instead — you have no tool to modify assertions, that is deliberate.
+- While iterating, re-run ONLY the failing case(s): offer \`run_eval_suite\` with \`useDraft: true\`, \`caseIds\` set to the failing case ids (from the seeded message, \`get_eval_run\`, or \`list_eval_cases\`), and the previous suite as \`baselineSuiteRunId\` — the \`get_suite_diff\` verdict (fixed/regressed) is the proof, not your reasoning. Treat \`flipDriver: "judge"\` flips as possible noise; deterministic flips are signal.
+- Before the admin publishes, offer one FULL suite run (no \`caseIds\`) as the regression gate — a scoped run cannot catch regressions in cases it didn't run.
 
 Worked example — a refund procedure:
 \`\`\`json

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-case-mock-tools.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-case-mock-tools.test.ts
@@ -1,0 +1,236 @@
+// packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-case-mock-tools.test.ts
+//
+// `get_eval_case` + `update_eval_case_mock`: the read/write pair for mock
+// (fixture) repair. Safety properties: session-agent scoping reads as
+// not-found, schema validation runs BEFORE any write, assertions are never
+// writable, and the write is approval-gated.
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+import type { AgentDeps } from '../../../../../agent-framework/types'
+import type { GetToolDeps } from '../../../types'
+
+vi.mock('../procedure-authoring-guard', () => ({
+  resolveProcedureAuthoring: vi.fn(async () => ({ ok: true, agentId: 'a1' })),
+}))
+vi.mock('../../../../../../evals/queries', () => ({
+  getEvalCaseById: vi.fn(),
+  updateEvalCase: vi.fn(),
+}))
+vi.mock('../../../../../../evals/editor-support', () => ({
+  validateAgentToolMock: vi.fn(async () => ({ ok: true })),
+}))
+
+import { validateAgentToolMock } from '../../../../../../evals/editor-support'
+import { getEvalCaseById, updateEvalCase } from '../../../../../../evals/queries'
+import { createGetEvalCaseTool } from '../get-eval-case'
+import { resolveProcedureAuthoring } from '../procedure-authoring-guard'
+import { createUpdateEvalCaseMockTool } from '../update-eval-case-mock'
+
+const guardMock = resolveProcedureAuthoring as unknown as Mock
+const getCaseMock = getEvalCaseById as unknown as Mock
+const updateCaseMock = updateEvalCase as unknown as Mock
+const validateMock = validateAgentToolMock as unknown as Mock
+
+const getDeps: GetToolDeps = () =>
+  ({
+    db: {},
+    sessionContext: {},
+    organizationId: 'org-1',
+    userId: 'u-1',
+    sessionId: 's-1',
+  }) as never
+const agentDeps: AgentDeps = { organizationId: 'org-1', userId: 'u-1', sessionId: 's-1' }
+
+const readTool = createGetEvalCaseTool(getDeps)
+const writeTool = createUpdateEvalCaseMockTool(getDeps)
+
+const config = {
+  openingMessage: 'My mug arrived broken.',
+  customerContext: null,
+  channel: 'chat',
+  timeFrozenAt: null,
+  maxCustomerTurns: 4,
+  subject: { recordIds: [], identityVerified: false },
+  startingFields: [],
+  unmatchedToolPolicy: 'error',
+  connectorMocks: [{ id: 'm1', toolName: 'order_lookup', output: { id: '1001' }, usage: 'repeat' }],
+}
+
+const caseRow = {
+  id: 'c1',
+  agentId: 'a1',
+  name: 'Refund case',
+  procedureId: 'p1',
+  target: { scope: 'procedure' },
+  config,
+  assertions: [{ id: 'as1', type: 'terminal_outcome', data: { outcome: 'finished' } }],
+}
+
+beforeEach(() => {
+  for (const m of [guardMock, getCaseMock, updateCaseMock, validateMock]) m.mockReset()
+  guardMock.mockResolvedValue({ ok: true, agentId: 'a1' })
+  getCaseMock.mockResolvedValue(ok(caseRow))
+  updateCaseMock.mockResolvedValue(ok(caseRow))
+  validateMock.mockResolvedValue({ ok: true })
+})
+
+describe('tool flags', () => {
+  it('get_eval_case is read-only; update_eval_case_mock is approval-gated', () => {
+    expect(readTool.idempotent).toBe(true)
+    expect(readTool.requiresApproval).toBeUndefined()
+    expect(writeTool.requiresApproval).toBe(true)
+    expect(writeTool.idempotent).toBeUndefined()
+  })
+
+  it('the write surface is mocks-only: no assertion parameter exists', () => {
+    const props = (writeTool.parameters as { properties: Record<string, unknown> }).properties
+    expect(Object.keys(props).sort()).toEqual(['caseId', 'removeMockIds', 'upsertMocks'])
+  })
+})
+
+describe('get_eval_case', () => {
+  it('returns config (with mocks) and read-only assertions', async () => {
+    const result = await readTool.execute({ caseId: 'c1' } as never, agentDeps)
+    expect(result.success).toBe(true)
+    const output = result.output as {
+      config: { connectorMocks: unknown[] }
+      assertions: unknown[]
+    }
+    expect(output.config.connectorMocks).toHaveLength(1)
+    expect(output.assertions).toEqual([
+      { id: 'as1', type: 'terminal_outcome', data: { outcome: 'finished' } },
+    ])
+  })
+
+  it("reads another agent's case as not-found", async () => {
+    getCaseMock.mockResolvedValue(ok({ ...caseRow, agentId: 'other-agent' }))
+    const result = await readTool.execute({ caseId: 'c1' } as never, agentDeps)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('not found')
+  })
+})
+
+describe('update_eval_case_mock', () => {
+  it('replaces a mock in place after schema validation', async () => {
+    const result = await writeTool.execute(
+      {
+        caseId: 'c1',
+        upsertMocks: [
+          { id: 'm1', toolName: 'order_lookup', output: { id: '10427' }, usage: 'repeat' },
+        ],
+      } as never,
+      agentDeps
+    )
+    expect(result.success).toBe(true)
+    expect(validateMock).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      userId: 'u-1',
+      agentId: 'a1',
+      toolName: 'order_lookup',
+      output: { id: '10427' },
+    })
+    const patch = updateCaseMock.mock.calls[0]?.[0]?.patch
+    expect(patch.config.connectorMocks).toEqual([
+      { id: 'm1', toolName: 'order_lookup', output: { id: '10427' }, usage: 'repeat' },
+    ])
+    // Mocks-only: the patch never carries assertions or target.
+    expect(Object.keys(patch)).toEqual(['config'])
+  })
+
+  it('appends a new mock with a generated id and removes by id', async () => {
+    const result = await writeTool.execute(
+      {
+        caseId: 'c1',
+        upsertMocks: [
+          {
+            toolName: 'shopify_find_shopify_order',
+            args: { mode: 'subset', value: { email: 'alex.morgan@example.com' } },
+            output: { orderNumber: '10427' },
+          },
+        ],
+        removeMockIds: ['m1'],
+      } as never,
+      agentDeps
+    )
+    expect(result.success).toBe(true)
+    const saved = updateCaseMock.mock.calls[0]?.[0]?.patch.config.connectorMocks
+    expect(saved).toHaveLength(1)
+    expect(saved[0]).toMatchObject({
+      toolName: 'shopify_find_shopify_order',
+      args: { mode: 'subset', value: { email: 'alex.morgan@example.com' } },
+      usage: 'repeat',
+    })
+    expect(typeof saved[0].id).toBe('string')
+    expect(saved[0].id).not.toBe('m1')
+  })
+
+  it('rejects an invalid mock output without writing', async () => {
+    validateMock.mockResolvedValue({ ok: false, error: 'Expected string for `status`' })
+    const result = await writeTool.execute(
+      { caseId: 'c1', upsertMocks: [{ toolName: 'order_lookup', output: {} }] } as never,
+      agentDeps
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Expected string')
+    expect(updateCaseMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown mock ids (replace and remove) without writing', async () => {
+    const replace = await writeTool.execute(
+      {
+        caseId: 'c1',
+        upsertMocks: [{ id: 'nope', toolName: 'order_lookup', output: {} }],
+      } as never,
+      agentDeps
+    )
+    expect(replace.success).toBe(false)
+    expect(replace.error).toContain('No mock with id "nope"')
+
+    const remove = await writeTool.execute(
+      { caseId: 'c1', removeMockIds: ['nope'] } as never,
+      agentDeps
+    )
+    expect(remove.success).toBe(false)
+    expect(remove.error).toContain('No mock with id "nope"')
+    expect(updateCaseMock).not.toHaveBeenCalled()
+  })
+
+  it('requires at least one operation', async () => {
+    const result = await writeTool.execute({ caseId: 'c1' } as never, agentDeps)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('at least one')
+  })
+
+  it("writes to another agent's case read as not-found", async () => {
+    getCaseMock.mockResolvedValue(ok({ ...caseRow, agentId: 'other-agent' }))
+    const result = await writeTool.execute(
+      { caseId: 'c1', removeMockIds: ['m1'] } as never,
+      agentDeps
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('not found')
+    expect(updateCaseMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces guard failures without touching the DB', async () => {
+    guardMock.mockResolvedValueOnce({ ok: false, error: 'Not allowed' })
+    const result = await writeTool.execute(
+      { caseId: 'c1', removeMockIds: ['m1'] } as never,
+      agentDeps
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('Not allowed')
+    expect(getCaseMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a failed save', async () => {
+    updateCaseMock.mockResolvedValue(err({ code: 'EVAL_VALIDATION', message: 'Invalid config' }))
+    const result = await writeTool.execute(
+      { caseId: 'c1', removeMockIds: ['m1'] } as never,
+      agentDeps
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Invalid config')
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-read-tools.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-read-tools.test.ts
@@ -147,6 +147,7 @@ describe('get_eval_run', () => {
         id: 'r1',
         status: 'failed',
         runMode: 'pinned',
+        caseId: 'c1',
         definitionSnapshot: { case: { name: 'Refund case' } },
         trace: [],
         assertionResults: [],
@@ -158,6 +159,7 @@ describe('get_eval_run', () => {
     expect(result.success).toBe(true)
     expect(getRunMock).toHaveBeenCalledWith({ organizationId: 'org-1', runId: 'r1' })
     expect((result.output as { caseName: string }).caseName).toBe('Refund case')
+    expect((result.output as { caseId: string | null }).caseId).toBe('c1')
   })
 
   it('returns not-found for a cross-org run id without leaking', async () => {

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-tool-registry.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-tool-registry.test.ts
@@ -1,9 +1,10 @@
 // packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/__tests__/eval-tool-registry.test.ts
 //
 // Phase 5C safety property, asserted over the REGISTERED capability (not just
-// the factories): the eval mutation surface stays tRPC-only — no builder tool
-// can create/update/delete eval rows — and the four eval tools carry the
-// expected approval/idempotency flags.
+// the factories): the ONLY eval write surface is the approval-gated mock
+// repair (`update_eval_case_mock`) — no builder tool can otherwise
+// create/update/delete eval rows — and the eval tools carry the expected
+// approval/idempotency flags.
 
 import { ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -45,27 +46,33 @@ describe('agents-builder eval tool registry (phase 5C)', () => {
     byName = new Map(capability.tools.map((t) => [t.name, t]))
   })
 
-  it('registers the three read tools and the suite trigger', () => {
+  it('registers the read tools, the suite trigger, and the mock repair', () => {
     expect(names).toEqual(
       expect.arrayContaining([
         'list_eval_cases',
+        'get_eval_case',
         'get_eval_run',
         'get_suite_diff',
         'run_eval_suite',
+        'update_eval_case_mock',
       ])
     )
   })
 
-  it('exposes NO eval mutation surface (tRPC-only, by construction)', () => {
-    expect(names.filter((n) => /^(create|update|delete|set)_eval/.test(n))).toEqual([])
+  it('exposes NO eval mutation surface beyond the approval-gated mock repair', () => {
+    expect(names.filter((n) => /^(create|update|delete|set)_eval/.test(n))).toEqual([
+      'update_eval_case_mock',
+    ])
   })
 
-  it('flags: reads are idempotent and ungated; the trigger requires approval', () => {
-    for (const name of ['list_eval_cases', 'get_eval_run', 'get_suite_diff']) {
+  it('flags: reads are idempotent and ungated; writes require approval', () => {
+    for (const name of ['list_eval_cases', 'get_eval_case', 'get_eval_run', 'get_suite_diff']) {
       expect(byName.get(name)?.idempotent, name).toBe(true)
       expect(byName.get(name)?.requiresApproval, name).toBeUndefined()
     }
-    expect(byName.get('run_eval_suite')?.requiresApproval).toBe(true)
-    expect(byName.get('run_eval_suite')?.idempotent).toBeUndefined()
+    for (const name of ['run_eval_suite', 'update_eval_case_mock']) {
+      expect(byName.get(name)?.requiresApproval, name).toBe(true)
+      expect(byName.get(name)?.idempotent, name).toBeUndefined()
+    }
   })
 })

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-case.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-case.ts
@@ -1,0 +1,122 @@
+// packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-case.ts
+
+import { simulationConfigSchema } from '@auxx/types/evals/schema'
+import { z } from 'zod'
+import { getEvalCaseById } from '../../../../../evals/queries'
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import type { GetToolDeps } from '../../types'
+import { resolveProcedureAuthoring } from './procedure-authoring-guard'
+
+const outputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  scope: z.string(),
+  procedureId: z.string().nullable(),
+  /** The full simulation config — scenario, subject identity, and `connectorMocks`. */
+  config: simulationConfigSchema,
+  /** Assertion definitions are read-only context; there is no tool to edit them. */
+  assertions: z.array(z.object({ id: z.string(), type: z.string(), data: z.unknown() })),
+})
+
+/**
+ * Read one eval case's full definition — the scenario config (opening message,
+ * subject identity, `connectorMocks`) plus its assertions. The grounding read
+ * for `update_eval_case_mock`: a mock edit must be proposed against the mock
+ * ids and the case's own scenario, never guessed.
+ */
+export function createGetEvalCaseTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'get_eval_case',
+    displayName: 'Read simulation case',
+    surfaces: ['builder'],
+    idempotent: true,
+    description: `Read a simulation (eval) case's full definition: scenario config, subject identity, tool mocks (\`connectorMocks\`, with their ids), and assertions. Call it before \`update_eval_case_mock\` so a mock edit targets a real mock id and matches the case's own scenario. Assertions are read-only context.`,
+    parameters: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['caseId'],
+      properties: {
+        caseId: { type: 'string', minLength: 1, description: 'The eval case id to read.' },
+      },
+    },
+    outputSchema,
+    exampleOutput: {
+      id: 'case_example',
+      name: 'Refund for damaged item',
+      scope: 'procedure',
+      procedureId: 'proc_example',
+      config: {
+        openingMessage: 'My mug arrived broken, I want a refund.',
+        customerContext: 'Ordered a mug two days ago.',
+        channel: 'chat',
+        timeFrozenAt: null,
+        maxCustomerTurns: 4,
+        subject: {
+          recordIds: [],
+          identityVerified: false,
+          claimed: { name: 'Alex Morgan', email: 'alex.morgan@example.com' },
+        },
+        startingFields: [],
+        unmatchedToolPolicy: 'error',
+        connectorMocks: [
+          {
+            id: 'mock_example',
+            toolName: 'order_lookup',
+            args: { mode: 'subset', value: { orderId: '1001' } },
+            output: { id: '1001', status: 'delivered' },
+            usage: 'repeat',
+          },
+        ],
+      },
+      assertions: [
+        { id: 'a1', type: 'terminal_outcome', data: { outcome: 'finished' } },
+        {
+          id: 'a2',
+          type: 'response_criteria',
+          data: { criteria: ['Confirms the refund timeline'] },
+        },
+      ],
+    },
+    execute: async (args, agentDeps) => {
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      if (!ctx.ok) return { success: false, output: null, error: ctx.error }
+
+      const caseId = typeof args.caseId === 'string' ? args.caseId : ''
+      if (!caseId) return { success: false, output: null, error: 'caseId is required.' }
+
+      const found = await getEvalCaseById({ organizationId: agentDeps.organizationId, id: caseId })
+      // Session-agent scoping on top of org scoping: a case id from another
+      // agent reads as not-found rather than leaking cross-agent definitions.
+      if (found.isErr() || !found.value || found.value.agentId !== ctx.agentId) {
+        return { success: false, output: null, error: `Eval case not found: ${caseId}` }
+      }
+      const row = found.value
+
+      const config = simulationConfigSchema.safeParse(row.config)
+      if (!config.success) {
+        return {
+          success: false,
+          output: null,
+          error: 'Case config is malformed — fix it in the simulation case editor.',
+        }
+      }
+
+      const target = row.target as { scope?: string } | null
+      const assertions = (row.assertions as { id?: string; type?: string; data?: unknown }[])
+        .filter((a) => typeof a?.id === 'string' && typeof a?.type === 'string')
+        .map((a) => ({ id: a.id as string, type: a.type as string, data: a.data }))
+
+      return {
+        success: true,
+        output: {
+          id: row.id,
+          name: row.name,
+          scope: target?.scope ?? 'procedure',
+          procedureId: row.procedureId,
+          config: config.data,
+          assertions,
+        },
+      }
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-run.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/get-eval-run.ts
@@ -11,6 +11,7 @@ const outputSchema = z.object({
   runId: z.string(),
   status: z.string(),
   runMode: z.string(),
+  caseId: z.string().nullable(),
   caseName: z.string(),
   failedAssertions: z.array(
     z.object({
@@ -37,7 +38,7 @@ export function createGetEvalRunTool(getDeps: GetToolDeps): AgentToolDefinition 
     displayName: 'Read simulation run',
     surfaces: ['builder'],
     idempotent: true,
-    description: `Read a simulation run's condensed transcript and failed assertions. Use it to ground a proposed fix in the SPECIFIC failing turn or assertion — cite the case name and what failed. \`truncated: true\` means the middle of a long transcript was dropped.`,
+    description: `Read a simulation run's condensed transcript and failed assertions. Use it to ground a proposed fix in the SPECIFIC failing turn or assertion — cite the case name and what failed. \`truncated: true\` means the middle of a long transcript was dropped. \`caseId\` is what you pass to \`run_eval_suite\`'s \`caseIds\` for a targeted re-run.`,
     parameters: {
       type: 'object',
       additionalProperties: false,
@@ -51,6 +52,7 @@ export function createGetEvalRunTool(getDeps: GetToolDeps): AgentToolDefinition 
       runId: 'run_example',
       status: 'failed',
       runMode: 'draft',
+      caseId: 'case_example',
       caseName: 'Refund for damaged item',
       failedAssertions: [
         {

--- a/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-eval-case-mock.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-eval-case-mock.ts
@@ -1,0 +1,227 @@
+// packages/lib/src/ai/kopilot/capabilities/agents-builder/tools/update-eval-case-mock.ts
+
+import type { SimulationToolMock } from '@auxx/types/evals'
+import { simulationConfigSchema } from '@auxx/types/evals/schema'
+import { generateId } from '@auxx/utils'
+import { z } from 'zod'
+import { validateAgentToolMock } from '../../../../../evals/editor-support'
+import { getEvalCaseById, updateEvalCase } from '../../../../../evals/queries'
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import type { GetToolDeps } from '../../types'
+import { resolveProcedureAuthoring } from './procedure-authoring-guard'
+
+const outputSchema = z.object({
+  caseId: z.string(),
+  /** The case's full mock list after the edit. */
+  mocks: z.array(z.object({ id: z.string(), toolName: z.string(), usage: z.string() })),
+  /** Non-blocking validation warnings (e.g. a tool without an output schema). */
+  warnings: z.array(z.string()),
+})
+
+interface UpsertMockArg {
+  id?: string
+  toolName: string
+  args?: { mode: 'exact' | 'subset'; value: Record<string, unknown> }
+  output: unknown
+  usage?: 'once' | 'repeat'
+}
+
+function parseUpsertMocks(raw: unknown): UpsertMockArg[] | string {
+  if (raw === undefined) return []
+  if (!Array.isArray(raw)) return 'upsertMocks must be an array.'
+  const parsed: UpsertMockArg[] = []
+  for (const entry of raw as Record<string, unknown>[]) {
+    if (typeof entry?.toolName !== 'string' || entry.toolName.length === 0) {
+      return 'Every upserted mock needs a toolName.'
+    }
+    if (!('output' in entry)) {
+      return `Mock for "${entry.toolName}" is missing an output.`
+    }
+    parsed.push(entry as unknown as UpsertMockArg)
+  }
+  return parsed
+}
+
+/**
+ * Repair a case's tool mocks (`connectorMocks`) — the ONLY eval-case surface
+ * Kopilot can write. Approval-gated: the admin reviews the proposed mock diff
+ * before it lands. Assertions stay tRPC/editor-only by design — a model that
+ * can edit assertions can grade its own homework; a model that can fix a
+ * broken fixture (a mock contradicting the case's own scenario) cannot.
+ * Mock outputs are validated against the tool's real output schema before save.
+ */
+export function createUpdateEvalCaseMockTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'update_eval_case_mock',
+    displayName: 'Update simulation case mocks',
+    surfaces: ['builder'],
+    requiresApproval: true,
+    description: `Add, replace, or remove tool mocks (\`connectorMocks\`) on one simulation case. Use it ONLY to repair a broken fixture — a mock whose data contradicts the case's own scenario (wrong customer, wrong order, missing match) so the case can never pass. Read the case with \`get_eval_case\` first and target real mock ids. Never shape a mock to force a failing assertion to pass with data the real tool would not return — mocks model reality. Assertions cannot be edited; flag wrong-looking assertions to the user instead.`,
+    parameters: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['caseId'],
+      properties: {
+        caseId: { type: 'string', minLength: 1, description: 'The eval case to edit.' },
+        upsertMocks: {
+          type: 'array',
+          description:
+            'Mocks to add or replace. With `id`, replaces that existing mock in place; without, appends a new one.',
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['toolName', 'output'],
+            properties: {
+              id: {
+                type: 'string',
+                minLength: 1,
+                description: 'Existing mock id to replace (from `get_eval_case`). Omit to add.',
+              },
+              toolName: { type: 'string', minLength: 1 },
+              args: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['mode', 'value'],
+                properties: {
+                  mode: { enum: ['exact', 'subset'] },
+                  value: { type: 'object' },
+                },
+                description:
+                  'Optional argument matcher — the mock only fires when the call args match. Omit to match any call to the tool.',
+              },
+              output: {
+                description: 'The mocked tool output (validated against the tool schema).',
+              },
+              usage: { enum: ['once', 'repeat'], description: 'Defaults to repeat.' },
+            },
+          },
+        },
+        removeMockIds: {
+          type: 'array',
+          items: { type: 'string', minLength: 1 },
+          description: 'Mock ids to delete (from `get_eval_case`).',
+        },
+      },
+    },
+    outputSchema,
+    exampleOutput: {
+      caseId: 'case_example',
+      mocks: [{ id: 'mock_example', toolName: 'order_lookup', usage: 'repeat' }],
+      warnings: [],
+    },
+    buildDigest: (output) => {
+      const o = output as { caseId?: string; mocks?: unknown[] } | null
+      return { caseId: o?.caseId, mockCount: o?.mocks?.length }
+    },
+    execute: async (args, agentDeps) => {
+      const ctx = await resolveProcedureAuthoring(getDeps, agentDeps)
+      if (!ctx.ok) return { success: false, output: null, error: ctx.error }
+
+      const caseId = typeof args.caseId === 'string' ? args.caseId : ''
+      if (!caseId) return { success: false, output: null, error: 'caseId is required.' }
+
+      const upserts = parseUpsertMocks(args.upsertMocks)
+      if (typeof upserts === 'string') return { success: false, output: null, error: upserts }
+      const removeIds = Array.isArray(args.removeMockIds)
+        ? (args.removeMockIds as unknown[]).filter(
+            (id): id is string => typeof id === 'string' && id.length > 0
+          )
+        : []
+      if (upserts.length === 0 && removeIds.length === 0) {
+        return {
+          success: false,
+          output: null,
+          error: 'Provide at least one mock to upsert or remove.',
+        }
+      }
+
+      const found = await getEvalCaseById({ organizationId: agentDeps.organizationId, id: caseId })
+      // Session-agent scoping on top of org scoping, same as `get_eval_case`.
+      if (found.isErr() || !found.value || found.value.agentId !== ctx.agentId) {
+        return { success: false, output: null, error: `Eval case not found: ${caseId}` }
+      }
+
+      const parsedConfig = simulationConfigSchema.safeParse(found.value.config)
+      if (!parsedConfig.success) {
+        return {
+          success: false,
+          output: null,
+          error: 'Case config is malformed — fix it in the simulation case editor.',
+        }
+      }
+      const config = parsedConfig.data
+
+      let mocks: SimulationToolMock[] = [...config.connectorMocks]
+      for (const id of removeIds) {
+        if (!mocks.some((m) => m.id === id)) {
+          return { success: false, output: null, error: `No mock with id "${id}" on this case.` }
+        }
+        mocks = mocks.filter((m) => m.id !== id)
+      }
+
+      // Validate every upserted output against the tool's real output schema
+      // BEFORE any write — a mock that fails validation aborts the whole edit.
+      const warnings: string[] = []
+      for (const upsert of upserts) {
+        const verdict = await validateAgentToolMock({
+          organizationId: agentDeps.organizationId,
+          userId: agentDeps.userId,
+          agentId: ctx.agentId,
+          toolName: upsert.toolName,
+          output: upsert.output,
+        })
+        if (!verdict.ok) {
+          return {
+            success: false,
+            output: null,
+            error: `Mock for "${upsert.toolName}" is invalid: ${verdict.error}`,
+          }
+        }
+        if (verdict.warning) warnings.push(`${upsert.toolName}: ${verdict.warning}`)
+
+        const next: SimulationToolMock = {
+          id: upsert.id ?? generateId('mock'),
+          toolName: upsert.toolName,
+          ...(upsert.args ? { args: upsert.args } : {}),
+          output: upsert.output,
+          usage: upsert.usage ?? 'repeat',
+        }
+        if (upsert.id) {
+          const at = mocks.findIndex((m) => m.id === upsert.id)
+          if (at === -1) {
+            return {
+              success: false,
+              output: null,
+              error: `No mock with id "${upsert.id}" on this case — omit the id to add a new mock.`,
+            }
+          }
+          mocks[at] = next
+        } else {
+          mocks.push(next)
+        }
+      }
+
+      const updated = await updateEvalCase({
+        organizationId: agentDeps.organizationId,
+        id: caseId,
+        patch: { config: { ...config, connectorMocks: mocks } },
+      })
+      if (updated.isErr()) {
+        return {
+          success: false,
+          output: null,
+          error: `Failed to update case mocks: ${updated.error.message}`,
+        }
+      }
+
+      return {
+        success: true,
+        output: {
+          caseId,
+          mocks: mocks.map((m) => ({ id: m.id, toolName: m.toolName, usage: m.usage })),
+          warnings,
+        },
+      }
+    },
+  }
+}

--- a/packages/lib/src/evals/__tests__/model-summary.test.ts
+++ b/packages/lib/src/evals/__tests__/model-summary.test.ts
@@ -74,6 +74,7 @@ describe('summarizeEvalRunForModel', () => {
       'Agent: Refund issued.',
       '[terminal] outcome=finished capExceeded=false customerTurns=1',
     ])
+    expect(summary.caseId).toBe('c1')
     expect(summary.caseName).toBe('Refund case')
     expect(summary.runMode).toBe('draft')
     expect(summary.truncated).toBe(false)

--- a/packages/lib/src/evals/model-summary.ts
+++ b/packages/lib/src/evals/model-summary.ts
@@ -14,6 +14,8 @@ export interface ModelRunSummary {
   runId: string
   status: EvalRunEntity['status']
   runMode: EvalRunMode
+  /** Null when the case was deleted after the run. */
+  caseId: string | null
   caseName: string
   /** Non-passed assertion results (failed AND errored — both block a pass). */
   failedAssertions: {
@@ -72,6 +74,7 @@ export function summarizeEvalRunForModel(
       runId: run.id,
       status: run.status,
       runMode: run.runMode,
+      caseId: run.caseId,
       caseName,
       failedAssertions,
       transcript: transcript
@@ -85,6 +88,7 @@ export function summarizeEvalRunForModel(
     runId: run.id,
     status: run.status,
     runMode: run.runMode,
+    caseId: run.caseId,
     caseName,
     failedAssertions,
     transcript,


### PR DESCRIPTION
## Why

Two gaps in the eval-fixing Kopilot loop, found while testing it live:

1. **Fixing one failing simulation re-ran the whole suite.** The plumbing for targeted runs already existed end-to-end (`run_eval_suite` takes `caseIds`, `startAgentSuiteRun` filters) — but Kopilot could never use it: the Fix-with-Kopilot seed and `get_eval_run` only exposed the case *name*, and the persona prompt never mentioned `caseIds`.
2. **Broken fixtures were flag-only dead ends.** When a case's mock contradicts its own scenario (e.g. `shopify_find_shopify_order` returning data that can never match the case's customer/order), the case can never pass — and Kopilot could only bounce it back to the admin.

## What

### Targeted re-runs
- `buildFixSeedMessage` embeds the case id: `Case "…" failed (case <id>, run <id>):` (omitted for deleted cases); both call sites pass it through
- `get_eval_run` / `summarizeEvalRunForModel` return `caseId`, with the description pointing it at `run_eval_suite`'s `caseIds`
- Persona prompt teaches the two-speed loop: iterate with `caseIds` + `useDraft` + `baselineSuiteRunId`, then one **full** suite before publish as the regression gate (a scoped run can't catch regressions in cases it didn't run)

### Mock repair (read/write pair)
- **`get_eval_case`** (read-only): full case definition — scenario config, subject identity, `connectorMocks` with ids, assertions — so a mock edit is grounded, never guessed
- **`update_eval_case_mock`** (`requiresApproval: true`): upsert/remove mocks on one case
  - every mock output validates against the tool's real output schema (`validateAgentToolMock`) **before** any write
  - cross-agent case ids read as not-found (session-agent scoping on top of org scoping)
  - the patch can only carry `config` — structurally no way to touch assertions; the eval-gaming concern is handled by keeping assertions editor-only and putting a human approval on every mock diff
- Persona prompt splits the old flag-everything rule: broken **mock** → propose the repair (admin approves), wrong-looking **assertion** → still flag-only

## Tests

- New `eval-case-mock-tools.test.ts` (12 tests): flags, mocks-only surface, schema-validation-before-write, unknown-id rejection, cross-agent not-found, guard short-circuit
- Registry safety test updated to assert the new invariant: the **only** eval write surface is the approval-gated mock repair
- caseId assertions added to fix-seed, model-summary, and read-tool tests
- All 180 lib (agents-builder + evals) and 6 web tests pass

## Notes

- Eval-case writes emit no realtime event yet — an open case editor won't live-refresh after a Kopilot mock edit (React Query focus-refetch covers it). Can wire `evalCase:updated` like `procedure:updated` as a follow-up.