### PR TITLE
feat(kopilot): render GFM prose tables in BlockCard + prose polish

### DIFF
--- a/apps/web/src/components/evals/ui/messages/eval-agent-message.tsx
+++ b/apps/web/src/components/evals/ui/messages/eval-agent-message.tsx
@@ -5,6 +5,7 @@
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { useToolAppResolver } from '~/components/kopilot/hooks/use-tool-app-resolver'
+import { proseTableComponents } from '~/components/kopilot/ui/messages/prose-table'
 import { ToolStatusPill } from '~/components/kopilot/ui/messages/tool-status-pill'
 import { SparkleIcon } from '~/components/kopilot/ui/sparkle-icon'
 import type { Run } from './eval-trace-grouping'
@@ -35,7 +36,9 @@ export function EvalAgentMessage({ runs }: { runs: Run[] }) {
               <div
                 key={run.id}
                 className='kopilot-prose w-fit max-w-[90%] rounded-r-xl rounded-bl rounded-tl-xl border bg-card px-3 py-2 text-sm/5 shadow-sm'>
-                <Markdown remarkPlugins={[remarkGfm]}>{run.text}</Markdown>
+                <Markdown remarkPlugins={[remarkGfm]} components={proseTableComponents}>
+                  {run.text}
+                </Markdown>
               </div>
             )
           }

--- a/apps/web/src/components/kopilot/hooks/__tests__/use-smooth-stream.test.ts
+++ b/apps/web/src/components/kopilot/hooks/__tests__/use-smooth-stream.test.ts
@@ -1,0 +1,70 @@
+// apps/web/src/components/kopilot/hooks/__tests__/use-smooth-stream.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { splitAtHorizon } from '../use-smooth-stream'
+
+const WORDS = (n: number) => Array.from({ length: n }, (_, i) => `word${i}`).join(' ')
+
+const TABLE = [
+  '| Name | Status |',
+  '| --- | --- |',
+  '| Acme | active |',
+  '| Globex | churned |',
+].join('\n')
+
+describe('splitAtHorizon', () => {
+  it('splits plain prose into prefix + 12-word tail', () => {
+    const text = WORDS(30)
+    const { prefix, tail, prefixWordCount } = splitAtHorizon(text)
+    expect(prefixWordCount).toBe(18)
+    expect(prefix + tail).toBe(text)
+    expect(tail.trim().split(/\s+/)).toHaveLength(12)
+  })
+
+  it('puts everything in the tail for short prose', () => {
+    const text = WORDS(5)
+    expect(splitAtHorizon(text)).toEqual({ prefix: '', tail: text, prefixWordCount: 0 })
+  })
+
+  it('holds the tail empty inside an open auxx fence', () => {
+    const text = `${WORDS(20)}\n\`\`\`auxx:table\n{"columns": [`
+    const split = splitAtHorizon(text)
+    expect(split.tail).toBe('')
+    expect(split.prefix).toBe(text)
+  })
+
+  it('holds the tail empty while streaming inside a table (mid-row)', () => {
+    const text = `${WORDS(20)}\n\n| Name | Status |\n| --- | --- |\n| Acme | act`
+    const split = splitAtHorizon(text)
+    expect(split.tail).toBe('')
+    expect(split.prefix).toBe(text)
+  })
+
+  it('keeps holding across the newline gap between table rows', () => {
+    const text = `${WORDS(20)}\n\n${TABLE}\n`
+    const split = splitAtHorizon(text)
+    expect(split.tail).toBe('')
+  })
+
+  it('keeps holding while fewer than tailWords words follow the table', () => {
+    const text = `${WORDS(20)}\n\n${TABLE}\n\nDone. Five more words here.`
+    const split = splitAtHorizon(text)
+    expect(split.tail).toBe('')
+    expect(split.prefix).toBe(text)
+  })
+
+  it('resumes the tail once the table is more than tailWords words back', () => {
+    const text = `${WORDS(5)}\n\n${TABLE}\n\n${WORDS(20)}`
+    const { prefix, tail } = splitAtHorizon(text)
+    expect(tail).not.toBe('')
+    expect(tail).not.toContain('|')
+    expect(prefix + tail).toBe(text)
+  })
+
+  it('holds when a table appears within the first tailWords words', () => {
+    const text = `Accounts:\n\n| Name |\n| --- |\n| Acme |`
+    const split = splitAtHorizon(text)
+    expect(split.tail).toBe('')
+    expect(split.prefix).toBe(text)
+  })
+})

--- a/apps/web/src/components/kopilot/hooks/use-smooth-stream.ts
+++ b/apps/web/src/components/kopilot/hooks/use-smooth-stream.ts
@@ -124,13 +124,22 @@ interface SplitOpts {
  * Split the currently-displayed string into a stable markdown prefix and a
  * trailing window of up to `tailWords` words for per-word animation. Holds the
  * tail empty while inside an unclosed ```auxx:` fence so partial JSON stays in
- * the prefix where the code-block renderer can show a partial card.
+ * the prefix where the code-block renderer can show a partial card, and
+ * whenever the tail would contain a GFM table row — the tail renders as raw
+ * spans outside the markdown tree, so table text in it would show as literal
+ * pipe characters below the styled table.
  */
 export function splitAtHorizon(displayed: string, opts?: SplitOpts): StreamSplit {
   const tailWords = opts?.tailWords ?? 12
 
-  if (hasOpenAuxxFence(displayed)) {
-    return { prefix: displayed, tail: '', prefixWordCount: countWords(displayed) }
+  const allPrefix: StreamSplit = {
+    prefix: displayed,
+    tail: '',
+    prefixWordCount: countWords(displayed),
+  }
+
+  if (hasOpenAuxxFence(displayed) || endsInsideGfmTable(displayed)) {
+    return allPrefix
   }
 
   const wordPositions: number[] = []
@@ -142,16 +151,35 @@ export function splitAtHorizon(displayed: string, opts?: SplitOpts): StreamSplit
 
   const total = wordPositions.length
   if (total <= tailWords) {
+    if (TABLE_LINE_RE.test(displayed)) return allPrefix
     return { prefix: '', tail: displayed, prefixWordCount: 0 }
   }
 
   const splitIdx = total - tailWords
   const splitAt = wordPositions[splitIdx]!
+  const tail = displayed.slice(splitAt)
+  // A table ended fewer than `tailWords` words ago — keep its rows out of the
+  // raw tail until enough prose has accumulated after it.
+  if (TABLE_LINE_RE.test(tail)) return allPrefix
   return {
     prefix: displayed.slice(0, splitAt),
-    tail: displayed.slice(splitAt),
+    tail,
     prefixWordCount: splitIdx,
   }
+}
+
+/** Matches a line that begins a GFM table row (start-of-string or after \n). */
+const TABLE_LINE_RE = /(^|\n)\s*\|/
+
+/**
+ * Whether the displayed string currently ends inside a GFM table: its last
+ * non-empty line is a table row. Trailing whitespace is ignored so the hold
+ * survives the newline gap between one row's closing `|` and the next row.
+ */
+function endsInsideGfmTable(s: string): boolean {
+  const trimmed = s.trimEnd()
+  const lastLine = trimmed.slice(trimmed.lastIndexOf('\n') + 1)
+  return lastLine.trimStart().startsWith('|')
 }
 
 /**

--- a/apps/web/src/components/kopilot/styles/kopilot-prose.css
+++ b/apps/web/src/components/kopilot/styles/kopilot-prose.css
@@ -50,6 +50,21 @@
     padding-left: 0.125rem;
   }
 
+  & li::marker {
+    color: var(--color-muted-foreground);
+  }
+
+  /* GFM task lists — suppress the bullet, align and tint the checkbox */
+  & li:has(> input[type='checkbox']) {
+    list-style: none;
+  }
+
+  & li > input[type='checkbox'] {
+    margin-right: 0.375rem;
+    vertical-align: -0.125em;
+    accent-color: var(--color-primary);
+  }
+
   & li > p {
     margin-top: 0;
     margin-bottom: 0;
@@ -62,12 +77,14 @@
     margin-bottom: 0.125rem;
   }
 
-  /* Inline code */
+  /* Inline code — token pill: hairline ring over a softened background,
+     em-relative so it scales inside headings and lists */
   & :not(pre) > code {
-    background-color: var(--color-muted);
-    border-radius: 0.25rem;
-    padding: 0.125rem 0.375rem;
-    font-size: 0.8125rem;
+    background-color: color-mix(in oklab, var(--color-muted) 60%, transparent);
+    border: 1px solid color-mix(in oklab, var(--color-border) 70%, transparent);
+    border-radius: 0.3rem;
+    padding: 0.1em 0.35em;
+    font-size: 0.85em;
     font-weight: 500;
     word-break: break-word;
   }
@@ -86,6 +103,7 @@
 
   & pre code {
     background: none;
+    border: none;
     padding: 0;
     font-size: inherit;
     font-weight: normal;
@@ -142,14 +160,23 @@
   & h3 { font-size: 0.9375rem; }
   & h4 { font-size: 0.875rem; }
 
-  /* Blockquote */
+  /* Blockquote — quoted source material gets a soft panel, not a pinstripe */
   & blockquote {
-    border-left: 3px solid var(--color-border);
-    padding-left: 0.75rem;
-    margin-top: 0.375rem;
-    margin-bottom: 0.375rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-left: 2px solid color-mix(in oklab, var(--color-primary) 35%, transparent);
+    background-color: color-mix(in oklab, var(--color-muted) 40%, transparent);
+    border-radius: 0 0.5rem 0.5rem 0;
     color: var(--color-muted-foreground);
-    font-style: italic;
+  }
+
+  & blockquote > p:first-child {
+    margin-top: 0;
+  }
+
+  & blockquote > p:last-child {
+    margin-bottom: 0;
   }
 
   /* Horizontal rule */
@@ -160,24 +187,9 @@
     border-top: 1px solid var(--color-border);
   }
 
-  /* Tables */
-  & table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
-    font-size: 0.8125rem;
-  }
-
-  & th,
-  & td {
-    border: 1px solid var(--color-border);
-    padding: 0.375rem 0.625rem;
-    text-align: left;
-  }
-
-  & th {
-    font-weight: 600;
-    background-color: var(--color-muted);
+  /* Images — keep model-emitted images inside the panel */
+  & img {
+    max-width: 100%;
+    border-radius: 0.5rem;
   }
 }

--- a/apps/web/src/components/kopilot/ui/blocks/table-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/table-block.tsx
@@ -19,6 +19,7 @@ import { ActionButton } from '~/components/workflow/ui/action-button'
 import { BlockCard } from './block-card'
 import type { BlockRendererProps } from './block-registry'
 import type { TableBlockData, TableCellData, TableColumnData } from './block-schemas'
+import { tableBodyCellClass, tableClass, tableHeaderCellClass, tableRowClass } from './table-styles'
 
 function CellContent({ cell }: { cell: TableCellData }) {
   // Entity record link
@@ -146,14 +147,14 @@ function getColumnAlign(
 
 function TableContent({ columns, rows }: { columns: TableColumnData[]; rows: TableCellData[][] }) {
   return (
-    <table className='w-full text-sm' style={{ borderCollapse: 'separate', borderSpacing: 0 }}>
+    <table className={tableClass} style={{ borderCollapse: 'separate', borderSpacing: 0 }}>
       <thead>
         <tr>
           {columns.map((col, i) => (
             <th
               key={i}
               className={cn(
-                'text-muted-foreground whitespace-nowrap border-b bg-muted px-3 py-2 font-medium',
+                tableHeaderCellClass,
                 'sticky top-0 z-10',
                 i === 0 && 'left-0 z-20 rounded-tl-2xl shadow-[2px_0_4px_-2px_rgba(0,0,0,0.06)]',
                 i === columns.length - 1 && 'rounded-tr-2xl'
@@ -166,12 +167,12 @@ function TableContent({ columns, rows }: { columns: TableColumnData[]; rows: Tab
       </thead>
       <tbody>
         {rows.map((row, rowIdx) => (
-          <tr key={rowIdx} className='hover:bg-muted/30 transition-colors'>
+          <tr key={rowIdx} className={tableRowClass}>
             {row.map((cell, colIdx) => (
               <td
                 key={colIdx}
                 className={cn(
-                  'max-w-[280px] break-words px-3 py-2 align-top',
+                  tableBodyCellClass,
                   rowIdx < rows.length - 1 && 'border-b',
                   colIdx === 0 &&
                     'sticky left-0 z-10 bg-card shadow-[2px_0_4px_-2px_rgba(0,0,0,0.06)]',
@@ -189,7 +190,7 @@ function TableContent({ columns, rows }: { columns: TableColumnData[]; rows: Tab
   )
 }
 
-function ExpandButton({
+export function ExpandButton({
   isExpanded,
   onExpandChange,
   insetHeader,

--- a/apps/web/src/components/kopilot/ui/blocks/table-styles.ts
+++ b/apps/web/src/components/kopilot/ui/blocks/table-styles.ts
@@ -1,0 +1,20 @@
+// apps/web/src/components/kopilot/ui/blocks/table-styles.ts
+
+/**
+ * Shared table styling vocabulary, consumed by both the `auxx:table` block
+ * (`table-block.tsx`) and plain GFM markdown tables in assistant prose
+ * (`../messages/prose-table.tsx`) so the two render with the same visual
+ * language. Block-only extras (sticky header/first column, corner rounding,
+ * edge shadows) stay in `table-block.tsx`.
+ */
+
+export const tableClass = 'w-full text-sm'
+
+// text-left overrides the UA default `th { text-align: center }`; explicit
+// alignment (block getColumnAlign, GFM `:---:`) arrives as inline style and wins.
+export const tableHeaderCellClass =
+  'text-left text-muted-foreground whitespace-nowrap border-b bg-muted px-3 py-2 font-medium'
+
+export const tableBodyCellClass = 'max-w-[280px] break-words px-3 py-2 align-top'
+
+export const tableRowClass = 'hover:bg-muted/30 transition-colors'

--- a/apps/web/src/components/kopilot/ui/messages/assistant-message.tsx
+++ b/apps/web/src/components/kopilot/ui/messages/assistant-message.tsx
@@ -15,6 +15,7 @@ import { SparkleIcon } from '../sparkle-icon'
 import { AssistantThinkingStatus } from './assistant-thinking-status'
 import { AuxxInlineLink } from './auxx-inline-link'
 import { MessageActions } from './message-actions'
+import { proseTableComponents } from './prose-table'
 import { StreamingText } from './streaming-text'
 import { type ThinkingPillStep, ThinkingSteps } from './thinking-steps'
 
@@ -87,6 +88,7 @@ function buildMarkdownComponents(
       }
       return <pre {...props} />
     },
+    ...proseTableComponents,
     a({ href, children }) {
       if (typeof href === 'string' && href.startsWith('auxx://')) {
         const label =

--- a/apps/web/src/components/kopilot/ui/messages/prose-table.tsx
+++ b/apps/web/src/components/kopilot/ui/messages/prose-table.tsx
@@ -1,0 +1,139 @@
+// apps/web/src/components/kopilot/ui/messages/prose-table.tsx
+
+'use client'
+
+import { Dialog, DialogContent, DialogTitle } from '@auxx/ui/components/dialog'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { VisuallyHidden } from '@auxx/ui/components/visually-hidden'
+import { cn } from '@auxx/ui/lib/utils'
+import { type ReactNode, useState } from 'react'
+import type { Components } from 'react-markdown'
+import { BlockCard } from '../blocks/block-card'
+import { ExpandButton } from '../blocks/table-block'
+import {
+  tableBodyCellClass,
+  tableClass,
+  tableHeaderCellClass,
+  tableRowClass,
+} from '../blocks/table-styles'
+
+/**
+ * Table-level chrome replicating `table-block.tsx`'s per-cell extras (sticky
+ * header, sticky first column with edge shadow, 2xl corner rounding, last-row
+ * border removal) via arbitrary variants — the GFM cell components don't know
+ * their row/column position, so position-dependent styling lives here.
+ */
+const proseTableChrome = cn(
+  '[&_thead_th]:sticky [&_thead_th]:top-0 [&_thead_th]:z-10',
+  '[&_thead_th:first-child]:left-0 [&_thead_th:first-child]:z-20',
+  '[&_thead_th:first-child]:rounded-tl-2xl [&_thead_th:last-child]:rounded-tr-2xl',
+  '[&_thead_th:first-child]:shadow-[2px_0_4px_-2px_rgba(0,0,0,0.06)]',
+  '[&_tbody_td:first-child]:sticky [&_tbody_td:first-child]:left-0',
+  '[&_tbody_td:first-child]:z-10 [&_tbody_td:first-child]:bg-card',
+  '[&_tbody_td:first-child]:shadow-[2px_0_4px_-2px_rgba(0,0,0,0.06)]',
+  '[&_tbody_tr:last-child>td]:border-b-0',
+  '[&_tbody_tr:last-child>td:first-child]:rounded-bl-2xl',
+  '[&_tbody_tr:last-child>td:last-child]:rounded-br-2xl'
+)
+
+/** Minimal hast shape — avoids a direct dependency on the `hast` package. */
+interface HastNode {
+  tagName?: string
+  children?: HastNode[]
+}
+
+/** Count body rows from the markdown AST node (cells are opaque React children). */
+function countTableRows(node: unknown): number | undefined {
+  const tbody = (node as HastNode | undefined)?.children?.find((c) => c.tagName === 'tbody')
+  if (!tbody?.children) return undefined
+  return tbody.children.filter((c) => c.tagName === 'tr').length
+}
+
+/**
+ * Plain GFM markdown tables in assistant prose, rendered with the same
+ * `BlockCard` chrome as the `auxx:table` block so both table paths look
+ * identical. Cell *content* still comes from the markdown tree (no typed
+ * cells), which is the remaining difference from `auxx:table`.
+ */
+export function ProseTable({ rowCount, children }: { rowCount?: number; children: ReactNode }) {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const table = (
+    <table
+      className={cn(tableClass, proseTableChrome)}
+      style={{ borderCollapse: 'separate', borderSpacing: 0 }}>
+      {children}
+    </table>
+  )
+
+  const rowLabel =
+    rowCount !== undefined ? `${rowCount} ${rowCount === 1 ? 'row' : 'rows'}` : undefined
+
+  return (
+    // No `not-prose`: cell content is markdown (links, inline code) and should
+    // keep prose styling — unlike auxx:table, whose cells are typed components.
+    <div className='my-2'>
+      <BlockCard
+        data-slot='prose-table-block'
+        className='**:data-[slot=block-card-body]:p-0'
+        primaryText='Table'
+        hasFooter={false}
+        hasHeader
+        secondaryText={
+          rowLabel && <span className='text-xs text-muted-foreground'>{rowLabel}</span>
+        }
+        headerActions={
+          <ExpandButton isExpanded={false} onExpandChange={setIsExpanded} insetHeader />
+        }>
+        <ScrollArea
+          orientation='horizontal'
+          allowScrollChaining
+          className='overflow-hidden rounded-xl'>
+          <div className='pb-2'>{table}</div>
+        </ScrollArea>
+      </BlockCard>
+
+      <Dialog open={isExpanded} onOpenChange={setIsExpanded}>
+        <DialogContent size='3xl' innerClassName='h-[80vh] flex flex-col p-0' showClose={false}>
+          <VisuallyHidden>
+            <DialogTitle>Table</DialogTitle>
+          </VisuallyHidden>
+          <div className='flex shrink-0 items-center justify-between border-b px-4 py-3'>
+            <span className='text-xs font-semibold text-foreground/90'>Table</span>
+            <span className='flex items-center gap-1.5'>
+              {rowLabel && <span className='text-xs text-muted-foreground'>{rowLabel}</span>}
+              <ExpandButton isExpanded onExpandChange={setIsExpanded} />
+            </span>
+          </div>
+          <div className='min-h-0 flex-1 overflow-hidden'>
+            <ScrollArea orientation='both' className='h-full'>
+              <div className='pb-2'>{table}</div>
+            </ScrollArea>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+/**
+ * react-markdown component overrides that route GFM tables through
+ * {@link ProseTable}. Spread into any components map that renders assistant
+ * prose (kopilot chat, eval traces) so tables look the same everywhere.
+ * `className` merges so remark-gfm's `:---:` alignment (passed as style/align
+ * props) survives the spread.
+ */
+export const proseTableComponents: Components = {
+  table({ node, children }) {
+    return <ProseTable rowCount={countTableRows(node)}>{children}</ProseTable>
+  },
+  th({ node: _node, className, ...props }) {
+    return <th {...props} className={cn(tableHeaderCellClass, className)} />
+  },
+  td({ node: _node, className, ...props }) {
+    return <td {...props} className={cn(tableBodyCellClass, 'border-b', className)} />
+  },
+  tr({ node: _node, className, ...props }) {
+    return <tr {...props} className={cn(tableRowClass, className)} />
+  },
+}


### PR DESCRIPTION
## Summary

Makes Kopilot's markdown prose match the auxx-block design language. Until now, when the model emitted a plain GFM markdown table (the natural fallback when it doesn't use the `auxx:table` fence), it rendered with bare bordered-cell wiki styling next to the rich block version.

### Tables
- Plain GFM tables now render inside the same `BlockCard` as `auxx:table`: "Table" header with live row count (derived from the markdown AST node — cells stay opaque React children), expand-to-dialog, sticky header + sticky first column with edge shadows, corner rounding.
- Shared cell styling extracted to `table-styles.ts`, consumed by both `table-block.tsx` (no visual change) and the new GFM path.
- Overrides ship as a shared `proseTableComponents` map in `prose-table.tsx`, wired into both kopilot chat (`buildMarkdownComponents`) and eval traces (`eval-agent-message.tsx` renders its own bare `Markdown` and would have lost all table styling once the prose table CSS was deleted).
- GFM `:---:` alignment survives (arrives as inline style, wins over classes). Header cells get explicit `text-left` since removing the old CSS exposed the UA `th { text-align: center }` default.

### Streaming
- `splitAtHorizon()` holds the raw animated word-tail empty while inside a GFM table or while a table sits within the would-be 12-word tail — partial tables always render through the markdown prefix, never as literal pipe text below the styled table. Same pattern as the existing auxx-fence hold.
- New test file covers mid-row holds, the newline gap between rows, the just-after-table window, and resume (8 tests).

### Prose polish (`kopilot-prose.css`)
- Inline code: em-scaled ringed pill (scales inside headings/lists), `color-mix` ring + softened background.
- Blockquote: soft panel with primary-tinted accent border and rounded right corners, italic dropped.
- GFM task lists: bullet suppressed, checkbox gets primary `accent-color`.
- List markers tinted `muted-foreground`; images clamped to container width with rounded corners.

## Test plan
- [x] `splitAtHorizon` unit tests (8/8 passing)
- [x] Biome clean on all changed files
- [ ] Manual: ask Kopilot for a markdown table comparison and watch it stream — rows fill inside the card, no raw pipe text below; row count ticks up live
- [ ] Manual: `auxx:table` block unchanged; eval trace tables styled
- [ ] Manual: blockquote / task list / inline code in headings, dark mode