### PR TITLE
feat(agents,resources): rebuild field badge on record-badge variants + binding picker badges

### DIFF
--- a/apps/web/src/components/agents/ui/detail/bindings/binding-var-picker.tsx
+++ b/apps/web/src/components/agents/ui/detail/bindings/binding-var-picker.tsx
@@ -27,14 +27,17 @@ import {
 } from '@auxx/ui/components/command'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { cn } from '@auxx/ui/lib/utils'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import type { FieldPickerNavigationItem } from '~/components/pickers/field-picker'
 import { FieldPickerInnerContent } from '~/components/pickers/field-picker'
 import { useResourceProperty } from '~/components/resources'
+import { FieldBadge } from '~/components/resources/ui/field-badge'
+import { recordBadgeVariants } from '~/components/resources/ui/record-badge'
 import { isVarFieldTypeCompatible } from '~/lib/agents/bindings/arg-to-field-type'
 import { api } from '~/trpc/react'
-import { useBindingRefLabel } from './hooks/use-binding-ref-label'
+import { useBindingRefBadgeKey, useBindingRefLabel } from './hooks/use-binding-ref-label'
 
 interface BindingVarPickerProps {
   /** Currently-bound field ref (`{ kind:'var' }.ref` — single segment or FieldPath). */
@@ -77,7 +80,12 @@ export function BindingVarPicker({
 }: BindingVarPickerProps) {
   const [open, setOpen] = useState(false)
   const refLabel = useBindingRefLabel()
-  const label = value ? refLabel(value) : undefined
+  const toBadgeKey = useBindingRefBadgeKey()
+  const badgeKey = value ? toBadgeKey(value) : null
+  const rootEntity = value
+    ? parseResourceFieldId((Array.isArray(value) ? value[0]! : value) as ResourceFieldId)
+        .entityDefinitionId
+    : ''
 
   const handleSelect = (ref: VarRef) => {
     onChange(ref)
@@ -93,8 +101,13 @@ export function BindingVarPicker({
           size='sm'
           disabled={disabled}
           className='h-8 w-full justify-between px-2 font-normal'>
-          {label ? (
-            <span className='truncate'>{label}</span>
+          {value ? (
+            badgeKey ? (
+              <FieldBadge id={badgeKey} entityDefinitionId={rootEntity} />
+            ) : (
+              // `self` refs aren't real fields — same badge shell, entity icon + label.
+              <SelfRefBadge rootEntity={rootEntity} label={refLabel(value)} />
+            )
           ) : (
             <span className='text-muted-foreground'>Select a dynamic value…</span>
           )}
@@ -296,6 +309,20 @@ function AnchorItem({
       </div>
       <ChevronRight className='size-4 opacity-50' />
     </CommandItem>
+  )
+}
+
+/**
+ * Trigger badge for a bound `self` ref — not a real field, so `FieldBadge`
+ * can't resolve it. Same `recordBadgeVariants` shell, entity icon + label.
+ */
+function SelfRefBadge({ rootEntity, label }: { rootEntity: string; label: string }) {
+  const entityProps = useResourceProperty(rootEntity, ['icon', 'color'])
+  return (
+    <span data-slot='field-badge' className={cn(recordBadgeVariants({}), 'font-normal')}>
+      <EntityIcon iconId={entityProps?.icon ?? 'circle'} color={entityProps?.color} size='xs' />
+      <span className='truncate'>{label}</span>
+    </span>
   )
 }
 

--- a/apps/web/src/components/agents/ui/detail/bindings/hooks/use-binding-ref-label.ts
+++ b/apps/web/src/components/agents/ui/detail/bindings/hooks/use-binding-ref-label.ts
@@ -1,7 +1,13 @@
 // apps/web/src/components/agents/ui/detail/bindings/hooks/use-binding-ref-label.ts
 'use client'
 
-import { parseResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
+import type { Resource, ResourceField } from '@auxx/lib/resources/client'
+import {
+  fieldRefToKey,
+  parseResourceFieldId,
+  type ResourceFieldId,
+  toFieldPath,
+} from '@auxx/types/field'
 import { useCallback, useMemo } from 'react'
 import { useResourceStore } from '~/components/resources'
 import { api } from '~/trpc/react'
@@ -12,6 +18,42 @@ const APP_SEGMENT_PREFIX = '@app:'
 /** Capitalize an entity-type slug for display ("participant" → "Participant"). */
 function capitalize(slug: string): string {
   return slug.charAt(0).toUpperCase() + slug.slice(1)
+}
+
+/** Parse an `@app:<slug>:<key>` field part. Returns null for non-app parts. */
+function parseAppFieldPart(fieldId: string): { slug: string; key: string } | null {
+  if (!fieldId.startsWith(APP_SEGMENT_PREFIX)) return null
+  const rest = fieldId.slice(APP_SEGMENT_PREFIX.length)
+  const sep = rest.indexOf(':')
+  if (sep <= 0) return null
+  return { slug: rest.slice(0, sep), key: rest.slice(sep + 1) }
+}
+
+/** Find the concrete app-owned field an `@app:<slug>:<key>` segment names. */
+function findAppField(
+  resource: Resource | undefined,
+  slug: string,
+  key: string,
+  slugByInstallationId: Map<string, string>
+): ResourceField | undefined {
+  return resource?.fields.find(
+    (f) =>
+      f.appFieldKey === key &&
+      f.appInstallationId &&
+      slugByInstallationId.get(f.appInstallationId) === slug
+  )
+}
+
+/** Map installationId → app slug from the cached installed-apps query. */
+function useAppSlugMap(): Map<string, string> {
+  const installed = api.apps.listInstalled.useQuery({})
+  return useMemo(() => {
+    const map = new Map<string, string>()
+    for (const i of installed.data?.installations ?? []) {
+      map.set(i.installationId, i.app.slug)
+    }
+    return map
+  }, [installed.data])
 }
 
 /**
@@ -28,15 +70,7 @@ function capitalize(slug: string): string {
 export function useBindingRefLabel(): (ref: string | string[] | undefined) => string {
   const resourceMap = useResourceStore((s) => s.resourceMap)
   const fieldMap = useResourceStore((s) => s.fieldMap)
-  const installed = api.apps.listInstalled.useQuery({})
-
-  const slugByInstallationId = useMemo(() => {
-    const map = new Map<string, string>()
-    for (const i of installed.data?.installations ?? []) {
-      map.set(i.installationId, i.app.slug)
-    }
-    return map
-  }, [installed.data])
+  const slugByInstallationId = useAppSlugMap()
 
   return useCallback(
     (ref) => {
@@ -51,18 +85,9 @@ export function useBindingRefLabel(): (ref: string | string[] | undefined) => st
             return `${resource?.label ?? capitalize(entityDefinitionId)} ID`
           }
 
-          if (fieldId.startsWith(APP_SEGMENT_PREFIX)) {
-            const rest = fieldId.slice(APP_SEGMENT_PREFIX.length)
-            const sep = rest.indexOf(':')
-            if (sep <= 0) return segment
-            const slug = rest.slice(0, sep)
-            const key = rest.slice(sep + 1)
-            const field = resource?.fields.find(
-              (f) =>
-                f.appFieldKey === key &&
-                f.appInstallationId &&
-                slugByInstallationId.get(f.appInstallationId) === slug
-            )
+          const app = parseAppFieldPart(fieldId)
+          if (app) {
+            const field = findAppField(resource, app.slug, app.key, slugByInstallationId)
             return field?.label ?? segment
           }
 
@@ -71,5 +96,46 @@ export function useBindingRefLabel(): (ref: string | string[] | undefined) => st
         .join(' → ')
     },
     [resourceMap, fieldMap, slugByInstallationId]
+  )
+}
+
+/**
+ * Resolve a stored binding var ref to a `FieldBadge`-compatible key
+ * (`fieldRefToKey` format), rewriting `@app:` segments to the concrete
+ * app-owned field's `resourceFieldId` so `useField`/`useFields` can look it
+ * up. Returns null when the ref isn't a real field (`self` refs) or an app
+ * segment can't be resolved — callers fall back to the plain label.
+ */
+export function useBindingRefBadgeKey(): (ref: string | string[] | undefined) => string | null {
+  const resourceMap = useResourceStore((s) => s.resourceMap)
+  const slugByInstallationId = useAppSlugMap()
+
+  return useCallback(
+    (ref) => {
+      if (!ref) return null
+      const segments = Array.isArray(ref) ? ref : [ref]
+      const resolved: ResourceFieldId[] = []
+      for (const segment of segments) {
+        const { entityDefinitionId, fieldId } = parseResourceFieldId(segment as ResourceFieldId)
+        if (fieldId === 'self') return null
+
+        const app = parseAppFieldPart(fieldId)
+        if (app) {
+          const field = findAppField(
+            resourceMap.get(entityDefinitionId),
+            app.slug,
+            app.key,
+            slugByInstallationId
+          )
+          if (!field?.resourceFieldId) return null
+          resolved.push(field.resourceFieldId)
+          continue
+        }
+
+        resolved.push(segment as ResourceFieldId)
+      }
+      return fieldRefToKey(resolved.length === 1 ? resolved[0]! : toFieldPath(resolved))
+    },
+    [resourceMap, slugByInstallationId]
   )
 }

--- a/apps/web/src/components/resources/ui/field-badge.tsx
+++ b/apps/web/src/components/resources/ui/field-badge.tsx
@@ -1,6 +1,10 @@
 // apps/web/src/components/resources/ui/field-badge.tsx
 'use client'
 
+import { getEffectiveFieldType } from '@auxx/lib/custom-fields/client'
+import { fieldTypeOptions } from '@auxx/lib/custom-fields/types'
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { getRelatedEntityDefinitionId, type RelationshipConfig } from '@auxx/types/custom-field'
 import {
   type FieldPath,
   isFieldPath,
@@ -11,13 +15,18 @@ import {
   toResourceFieldId,
 } from '@auxx/types/field'
 import { Badge } from '@auxx/ui/components/badge'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { Skeleton } from '@auxx/ui/components/skeleton'
 import { type BreadcrumbSegment, SmartBreadcrumb } from '@auxx/ui/components/smart-breadcrumb'
 import { cn } from '@auxx/ui/lib/utils'
-import { AlertTriangle } from 'lucide-react'
+import type { VariantProps } from 'class-variance-authority'
+import { AlertTriangle, X } from 'lucide-react'
 import { useMemo } from 'react'
-import { useField, useFields } from '~/components/resources/hooks/use-field'
+import { useField, useFields, useResourceProperty } from '~/components/resources/hooks/use-field'
+import { useResourceStore } from '~/components/resources/store/resource-store'
+import { recordBadgeVariants } from './record-badge'
 
-interface FieldBadgeProps {
+interface FieldBadgeProps extends Pick<VariantProps<typeof recordBadgeVariants>, 'size'> {
   /**
    * Encoded `FieldReference` key produced by `fieldRefToKey`. Three
    * accepted shapes (decoded via `keyToFieldRef`):
@@ -29,16 +38,29 @@ interface FieldBadgeProps {
   /** Entity context for plain-`FieldId` resolution. */
   entityDefinitionId: string
   selected?: boolean
+  /** Whether to show the field-type icon (default: true). */
+  showIcon?: boolean
+  /** When set, renders a trailing X button that fires this handler on click. */
+  onRemove?: () => void
   className?: string
 }
 
 /**
  * Display badge for a field reference inside an editor (CALC formulas, AI
- * prompts, future filter chips). Self-fetches its labels from the
- * resource store via `useField`/`useFields` — callers don't hand
- * `availableFields` arrays anymore.
+ * prompts, binding pickers, filter chips). Self-fetches its labels from the
+ * resource store via `useField`/`useFields`. Shares `recordBadgeVariants` and
+ * the `skeleton`/`record-remove` data-slot structure with `RecordBadge`, so
+ * field and record chips render identically side by side.
  */
-export function FieldBadge({ id, entityDefinitionId, selected, className }: FieldBadgeProps) {
+export function FieldBadge({
+  id,
+  entityDefinitionId,
+  selected,
+  showIcon = true,
+  onRemove,
+  size,
+  className,
+}: FieldBadgeProps) {
   const ref: ResourceFieldId | FieldPath = useMemo(() => {
     if (isPlainFieldId(id)) {
       return toResourceFieldId(entityDefinitionId, toFieldId(id))
@@ -50,19 +72,52 @@ export function FieldBadge({ id, entityDefinitionId, selected, className }: Fiel
   // branch and useField/useFields handle it.
   const singleField = useField(isFieldPath(ref) ? null : ref)
   const pathFields = useFields(isFieldPath(ref) ? ref : [])
+  const hasLoadedOnce = useResourceStore((s) => s.hasLoadedOnce)
+
+  const terminalField = isFieldPath(ref) ? pathFields[pathFields.length - 1] : singleField
+
+  const badgeClasses = cn(
+    recordBadgeVariants({ size }),
+    'font-normal',
+    selected && 'ring-2 ring-primary ring-offset-1',
+    className
+  )
+
+  // Store not hydrated yet — skeleton instead of flashing the unknown badge.
+  if (!hasLoadedOnce && !terminalField) {
+    return (
+      <span data-slot='field-badge' aria-busy className={badgeClasses}>
+        {showIcon && <Skeleton />}
+        <Skeleton />
+      </span>
+    )
+  }
+
+  if (!isFieldPath(ref) && !singleField) {
+    return <UnknownBadge id={id} selected={selected} className={className} />
+  }
+
+  const remove = onRemove && (
+    <button
+      type='button'
+      data-slot='record-remove'
+      aria-label='Remove'
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        onRemove()
+      }}>
+      <X />
+    </button>
+  )
 
   if (!isFieldPath(ref)) {
-    if (!singleField) return <UnknownBadge id={id} selected={selected} className={className} />
     return (
-      <Badge
-        variant='secondary'
-        className={cn(
-          fieldBadgeBaseClasses,
-          selected && 'ring-2 ring-primary ring-offset-1',
-          className
-        )}>
-        {singleField.label}
-      </Badge>
+      <span data-slot='field-badge' className={badgeClasses}>
+        {showIcon && <FieldBadgeIcon field={singleField} />}
+        <span className='truncate'>{singleField!.label}</span>
+        {remove}
+      </span>
     )
   }
 
@@ -74,35 +129,41 @@ export function FieldBadge({ id, entityDefinitionId, selected, className }: Fiel
   }))
 
   return (
-    <Badge
-      variant='secondary'
-      className={cn(
-        fieldBadgeBaseClasses,
-        'max-w-[280px]',
-        selected && 'ring-2 ring-primary ring-offset-1',
-        className
-      )}>
+    <span data-slot='field-badge' className={cn(badgeClasses, 'max-w-[280px]')}>
+      {showIcon && <FieldBadgeIcon field={terminalField} />}
       <SmartBreadcrumb
         segments={segments}
         mode='display'
         size='sm'
         className='[&_[data-slot=breadcrumb-list]]:m-0! [&_[data-slot=breadcrumb-list]]:p-0!'
       />
-    </Badge>
+      {remove}
+    </span>
   )
 }
 
 /**
- * Shared base classes mirroring `RecordBadge`'s default variant + default
- * size, so field badges sit visually next to record badges in editors and
- * filter chips without drift.
+ * Leading icon for the (terminal) field — the field-type icon from
+ * `fieldTypeOptions`, or the target entity's icon for relationship terminals,
+ * mirroring how `FieldItem` rows render in the pickers.
  */
-const fieldBadgeBaseClasses = cn(
-  'flex items-center rounded-[5px] ring-1 py-0',
-  'cursor-default ring-neutral-300 bg-neutral-100 text-neutral-600',
-  'dark:text-neutral-100 dark:bg-muted dark:ring-neutral-800',
-  'h-5 gap-1.5 ps-0.5 pe-1.5 text-sm font-normal'
-)
+function FieldBadgeIcon({ field }: { field: ResourceField | undefined }) {
+  const relatedEntityDefinitionId = field?.relationship
+    ? getRelatedEntityDefinitionId(field.relationship as RelationshipConfig)
+    : null
+  const targetProps = useResourceProperty(relatedEntityDefinitionId, ['icon', 'color'])
+
+  if (field?.relationship && targetProps) {
+    return <EntityIcon iconId={targetProps.icon} color={targetProps.color} size='xs' />
+  }
+
+  const effectiveFieldType = field ? getEffectiveFieldType(field) : undefined
+  const iconId =
+    (effectiveFieldType &&
+      fieldTypeOptions[effectiveFieldType as keyof typeof fieldTypeOptions]?.iconId) ||
+    'circle'
+  return <EntityIcon iconId={iconId} size='xs' className='text-muted-foreground' />
+}
 
 function UnknownBadge({
   id,

--- a/apps/web/src/lib/agents/bindings/arg-to-field-type.ts
+++ b/apps/web/src/lib/agents/bindings/arg-to-field-type.ts
@@ -2,6 +2,7 @@
 
 import { FieldType } from '@auxx/database/enums'
 import type { FieldOptions } from '@auxx/lib/field-values/client'
+import { isTypeCompatible, mapFieldTypeToBaseType } from '@auxx/lib/workflow-engine/client'
 
 /**
  * A single top-level property of a tool's `inputsJsonSchema`, in the minimal
@@ -91,24 +92,14 @@ export function argToFieldType(arg: ToolArgSchema): ArgFieldTypeResult {
 
 /**
  * True when a var's `fieldType` is compatible with an arg's mapped FieldType.
- * Lenient by design: any TEXT-ish var (TEXT/EMAIL/URL/PHONE/…) may bind a
- * string arg, since the value is a scalar the tool ultimately coerces. Exact
- * match otherwise. See plans/chat/v6 phase-4 var-picker type-match.
+ * Delegates to the workflow engine's coercion-aware `TYPE_COMPATIBILITY_MAP`
+ * (`isTypeCompatible`) over `BaseType`s — the same matrix the workflow variable
+ * picker uses — so binding and workflow type-matching never diverge. The arg's
+ * FieldType is the destination; the field's FieldType is the source.
  */
 export function isVarFieldTypeCompatible(argFieldType: string, varFieldType: string): boolean {
   if (argFieldType === varFieldType) return true
-  if (argFieldType === FieldType.TEXT) {
-    return TEXT_LIKE_FIELD_TYPES.has(varFieldType)
-  }
-  return false
+  return isTypeCompatible(mapFieldTypeToBaseType(varFieldType), [
+    mapFieldTypeToBaseType(argFieldType),
+  ])
 }
-
-/** FieldTypes whose stored scalar is a plain string — interchangeable with TEXT. */
-const TEXT_LIKE_FIELD_TYPES: ReadonlySet<string> = new Set([
-  FieldType.TEXT,
-  FieldType.EMAIL,
-  FieldType.URL,
-  FieldType.PHONE_INTL,
-  FieldType.RICH_TEXT,
-  FieldType.SINGLE_SELECT,
-])


### PR DESCRIPTION
## Summary

Follow-up to #791 (binding var picker on the resource-store infrastructure) — three changes:

### FieldBadge rebuilt on the RecordBadge pattern
- Imports `recordBadgeVariants` instead of hand-copying its classes; root is `data-slot='field-badge'` with the `size` variant (`default` | `sm`).
- Inner slots match RecordBadge's selectors so the variant CSS applies for free: `Skeleton` (`data-slot='skeleton'`) loading pair while the resource store hydrates (previously flashed the destructive unknown badge), and an optional `onRemove` X button (`data-slot='record-remove'`).
- New `showIcon` prop (default true): field-type icon from `fieldTypeOptions` via `getEffectiveFieldType` (CALC shows its result type), target entity icon for relationship terminals — mirrors `FieldItem` rows. `SmartBreadcrumb` still renders `FieldPath` keys.
- Existing consumers (calc formula editor, AI prompt editor, rich-text `field:` references) gain the type icon by default.

### Binding picker trigger renders a FieldBadge
- New `useBindingRefBadgeKey` hook translates stored binding refs into keys `useField` can resolve: `@app:<slug>:<key>` segments are rewritten to the concrete app field's `resourceFieldId` **for display only** (the stored binding stays late-bound); `self` refs return null and render the same badge shell with the anchor entity's icon instead.
- Shared `@app:` parsing/lookup helpers between the label hook and the badge-key hook.

### Type-compat filter delegates to the workflow matrix
- `isVarFieldTypeCompatible` now maps both sides through `mapFieldTypeToBaseType` and uses the workflow engine's coercion-aware `TYPE_COMPATIBILITY_MAP` (`isTypeCompatible`) — the same matrix the workflow variable picker uses.
- Fixes the picker showing **only relationship fields** for non-TEXT args: the old rule was exact-match-unless-TEXT, so enum/number/boolean inputs filtered out every scalar field. Now enum args accept string fields, number args accept numeric/string fields, etc.

## Test plan
- `biome check` clean on all touched + consumer files.
- Manual: agent detail → Bindings → add override → bind an input; trigger shows the field badge (breadcrumb for drilled paths, entity-icon badge for Contact ID, resolved label for the Shopify customer ID app field); enum/number args now list scalar fields.