### PR TITLE
fix(mcp): make MCP server connect retry-safe and simplify apps section

### DIFF
--- a/apps/web/src/components/apps/hooks/use-connect-flow.tsx
+++ b/apps/web/src/components/apps/hooks/use-connect-flow.tsx
@@ -168,7 +168,9 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
       }
 
       const onMessage = (e: MessageEvent) => {
-        if (e.origin !== window.location.origin) return
+        // The callback page may live on a different origin in dev (NGROK_URL tunnel), so also
+        // trust messages coming from the popup window we opened ourselves.
+        if (e.source !== popup && e.origin !== window.location.origin) return
         if (!e.data || e.data.type !== 'oauth_done') return
         handleDone(e.data as OAuthDonePayload)
       }

--- a/apps/web/src/components/mcp/hooks/use-mcp-oauth-popup.ts
+++ b/apps/web/src/components/mcp/hooks/use-mcp-oauth-popup.ts
@@ -61,7 +61,9 @@ export function useMcpOAuthPopup() {
       }
 
       const onMessage = (e: MessageEvent) => {
-        if (e.origin !== window.location.origin) return
+        // The callback page may live on a different origin in dev (NGROK_URL tunnel), so also
+        // trust messages coming from the popup window we opened ourselves.
+        if (e.source !== popup && e.origin !== window.location.origin) return
         if (!e.data || e.data.type !== 'oauth_done') return
         handleDone(e.data as OAuthDonePayload)
       }

--- a/apps/web/src/components/mcp/ui/mcp-apps-section.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-apps-section.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/mcp/ui/mcp-apps-section.tsx
 'use client'
 
+import { Button } from '@auxx/ui/components/button'
 import { Plug } from 'lucide-react'
 import { useState } from 'react'
 import { useMcpServers } from '../hooks/use-mcp-servers'
@@ -8,16 +9,16 @@ import { AddMcpServerDialog } from './add-mcp-server-dialog'
 import { McpAppCard } from './mcp-app-card'
 
 interface McpAppsSectionProps {
-  /** Marketplace browse (curated + add custom) is admin-only, matching the apps page. */
+  /** Connecting a new server is admin-only, matching the apps page. */
   isAdminOrOwner: boolean
   /** Search query from the apps page — filters by server name/description. */
   searchQuery?: string
 }
 
 /**
- * MCP block for Settings → Apps. Renders connected servers (alongside installed apps) and, for
- * admins, a browse strip of curated servers plus an "Add custom MCP server" card. Kept as one
- * self-contained component so the apps page only needs a single insertion point.
+ * MCP block for Settings → Apps. Renders connected servers (alongside installed apps) with a
+ * header button for admins to connect a new server. Kept as one self-contained component so the
+ * apps page only needs a single insertion point.
  */
 export function McpAppsSection({ isAdminOrOwner, searchQuery = '' }: McpAppsSectionProps) {
   const { servers, refresh } = useMcpServers()
@@ -27,55 +28,40 @@ export function McpAppsSection({ isAdminOrOwner, searchQuery = '' }: McpAppsSect
   const matches = (s: (typeof servers)[number]) =>
     !q || s.name.toLowerCase().includes(q) || (s.description?.toLowerCase().includes(q) ?? false)
 
-  // Connected (or org-owned custom) servers show in the installed strip; unconnected curated
-  // servers are the browse catalog.
+  // Connected (or org-owned custom) servers; unconnected curated servers are reachable through
+  // the connect dialog's paste step, which pivots to the curated flow on a recognized URL.
   const installed = servers.filter((s) => (s.connectionPresent || s.isCustom) && matches(s))
-  const browse = servers.filter((s) => !s.connectionPresent && !s.isCustom && matches(s))
 
   if (!isAdminOrOwner && installed.length === 0) return null
 
   return (
-    <div className='space-y-6'>
+    <div className='space-y-2'>
+      <div className='flex items-center justify-between gap-2'>
+        <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
+          <Plug className='size-4' />
+          MCP servers
+        </div>
+        {isAdminOrOwner && (
+          <Button variant='ghost' size='sm' onClick={() => setAddOpen(true)}>
+            Connect server
+          </Button>
+        )}
+      </div>
       {installed.length > 0 && (
-        <div className='space-y-2'>
-          <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-            <Plug className='size-4' />
-            MCP servers
-          </div>
-          <div className='w-full @container'>
-            <div className='grid w-full gap-2 @sm:grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3'>
-              {installed.map((server) => (
-                <McpAppCard key={server.serverId} server={server} />
-              ))}
-            </div>
+        <div className='w-full @container'>
+          <div className='grid w-full gap-2 @sm:grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3'>
+            {installed.map((server) => (
+              <McpAppCard key={server.serverId} server={server} />
+            ))}
           </div>
         </div>
       )}
-
       {isAdminOrOwner && (
-        <div className='space-y-2'>
-          <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-            <Plug className='size-4' />
-            Connect an MCP server
-          </div>
-          <div className='grid w-full gap-2 sm:grid-cols-2'>
-            {browse.map((server) => (
-              <McpAppCard key={server.serverId} server={server} />
-            ))}
-            <button
-              type='button'
-              onClick={() => setAddOpen(true)}
-              className='rounded-2xl border border-dashed bg-primary-50 hover:bg-primary-50/50 flex flex-col items-center justify-center gap-1 p-3 text-sm text-muted-foreground'>
-              <Plug className='size-4' />
-              Add custom MCP server
-            </button>
-          </div>
-          <AddMcpServerDialog
-            open={addOpen}
-            onOpenChange={setAddOpen}
-            onConnected={() => void refresh()}
-          />
-        </div>
+        <AddMcpServerDialog
+          open={addOpen}
+          onOpenChange={setAddOpen}
+          onConnected={() => void refresh()}
+        />
       )}
     </div>
   )

--- a/packages/lib/src/ai/mcp/connections/save-mcp-connection.ts
+++ b/packages/lib/src/ai/mcp/connections/save-mcp-connection.ts
@@ -1,6 +1,11 @@
 // packages/lib/src/ai/mcp/connections/save-mcp-connection.ts
 
-import { insertCredential, rotateSecrets, updateCredential } from '@auxx/credentials/store'
+import {
+  findCredential,
+  insertCredential,
+  rotateSecrets,
+  updateCredential,
+} from '@auxx/credentials/store'
 import { createScopedLogger } from '@auxx/logger'
 import { err, ok, type Result } from 'neverthrow'
 import type { McpConnectionError } from './types'
@@ -42,12 +47,24 @@ export async function saveMcpConnection(input: {
   /** When provided, update that credential row in place (reconnect flow). */
   connectionId?: string
 }): Promise<Result<string, McpConnectionError>> {
-  const { mcpServerId, serverName, organizationId, createdById, connectionData, connectionId } =
-    input
+  const { mcpServerId, serverName, organizationId, createdById, connectionData } = input
+  let { connectionId } = input
 
   const secrets = pickSecrets(connectionData)
   const metadata = (connectionData.metadata ?? {}) as Record<string, unknown>
   const expiresAt = connectionData.expiresAt ? new Date(connectionData.expiresAt) : null
+
+  // MCP connections are org-wide singletons per server — a repeat connect (e.g. retried OAuth)
+  // rotates the existing credential instead of stacking a second row.
+  if (!connectionId) {
+    const existing = await findCredential({
+      organizationId,
+      kind: 'mcp',
+      mcpServerId,
+      userId: null,
+    })
+    if (existing.isOk() && existing.value) connectionId = existing.value.id
+  }
 
   if (connectionId) {
     const rotated = await rotateSecrets(connectionId, organizationId, secrets, { expiresAt })

--- a/packages/lib/src/ai/mcp/manage.ts
+++ b/packages/lib/src/ai/mcp/manage.ts
@@ -75,8 +75,6 @@ export async function createCustomMcpServer(input: {
   clientSecret?: string
   returnTo?: string
 }): Promise<McpConnectOutcome & { serverId: string; slug: string }> {
-  const slug = await uniqueSlug(input.organizationId, slugify(input.name))
-
   let mode: 'none' | 'bearer' | 'oauth' = input.auth === 'auto' ? 'none' : input.auth
   let discovered: Awaited<ReturnType<typeof discoverMcpAuth>> | null = null
   if (input.auth === 'auto') {
@@ -86,53 +84,88 @@ export async function createCustomMcpServer(input: {
 
   const oauth = discovered?.isOk() && discovered.value.kind === 'oauth' ? discovered.value : null
 
-  const [server] = await db
-    .insert(schema.McpServer)
-    .values({
-      organizationId: input.organizationId,
-      slug,
-      name: input.name,
-      endpoint: input.endpoint,
-      description: input.description ?? null,
-      icon: input.icon ?? null,
-      createdById: input.createdById,
-      authDiscovery: oauth
-        ? {
-            authorizationServer: oauth.authorizationServer,
-            registrationEndpoint: oauth.registrationEndpoint,
-            discoveredAt: new Date().toISOString(),
-          }
-        : null,
-    })
-    .returning({ id: schema.McpServer.id })
-  if (!server) throw new Error('Failed to create McpServer')
+  // Retry-safe: an org server already pointing at this endpoint is reused (e.g. clicking Connect
+  // again after a missed OAuth popup result) instead of inserting a duplicate.
+  const existing = await db.query.McpServer.findFirst({
+    where: and(
+      eq(schema.McpServer.organizationId, input.organizationId),
+      eq(schema.McpServer.endpoint, input.endpoint)
+    ),
+    columns: { id: true, slug: true },
+  })
 
-  const connectionType = mode === 'oauth' ? 'oauth2-code' : mode === 'bearer' ? 'secret' : 'none'
-  await db.insert(schema.ConnectionDefinition).values({
-    mcpServerId: server.id,
-    major: 1,
-    connectionType,
-    label: `${input.name} Connection`,
-    global: true,
-    createdById: input.createdById,
-    oauth2AuthorizeUrl: oauth?.authorizeUrl ?? null,
-    oauth2AccessTokenUrl: oauth?.tokenUrl ?? null,
-    oauth2Scopes: oauth?.scopesSupported ?? [],
-    oauth2ClientId: input.clientId ?? null,
-    oauth2ClientSecret: input.clientSecret ?? null,
-    oauth2Features: { pkce: true },
-  })
-  await db.insert(schema.McpInstallation).values({
-    organizationId: input.organizationId,
-    mcpServerId: server.id,
-  })
+  let serverId: string
+  let slug: string
+  let existingClientId: string | null = null
+  if (existing) {
+    serverId = existing.id
+    slug = existing.slug
+    if (input.clientId) {
+      await db
+        .update(schema.ConnectionDefinition)
+        .set({
+          oauth2ClientId: input.clientId,
+          oauth2ClientSecret: input.clientSecret ?? null,
+        })
+        .where(eq(schema.ConnectionDefinition.mcpServerId, serverId))
+    } else {
+      const def = await db.query.ConnectionDefinition.findFirst({
+        where: eq(schema.ConnectionDefinition.mcpServerId, serverId),
+        columns: { oauth2ClientId: true },
+      })
+      existingClientId = def?.oauth2ClientId ?? null
+    }
+  } else {
+    slug = await uniqueSlug(input.organizationId, slugify(input.name))
+    const [server] = await db
+      .insert(schema.McpServer)
+      .values({
+        organizationId: input.organizationId,
+        slug,
+        name: input.name,
+        endpoint: input.endpoint,
+        description: input.description ?? null,
+        icon: input.icon ?? null,
+        createdById: input.createdById,
+        authDiscovery: oauth
+          ? {
+              authorizationServer: oauth.authorizationServer,
+              registrationEndpoint: oauth.registrationEndpoint,
+              discoveredAt: new Date().toISOString(),
+            }
+          : null,
+      })
+      .returning({ id: schema.McpServer.id })
+    if (!server) throw new Error('Failed to create McpServer')
+    serverId = server.id
+
+    const connectionType = mode === 'oauth' ? 'oauth2-code' : mode === 'bearer' ? 'secret' : 'none'
+    await db.insert(schema.ConnectionDefinition).values({
+      mcpServerId: serverId,
+      major: 1,
+      connectionType,
+      label: `${input.name} Connection`,
+      global: true,
+      createdById: input.createdById,
+      oauth2AuthorizeUrl: oauth?.authorizeUrl ?? null,
+      oauth2AccessTokenUrl: oauth?.tokenUrl ?? null,
+      oauth2Scopes: oauth?.scopesSupported ?? [],
+      oauth2ClientId: input.clientId ?? null,
+      oauth2ClientSecret: input.clientSecret ?? null,
+      oauth2Features: { pkce: true },
+    })
+    await db.insert(schema.McpInstallation).values({
+      organizationId: input.organizationId,
+      mcpServerId: serverId,
+    })
+  }
 
   await onCacheEvent('mcp.server.changed', { orgId: input.organizationId })
 
   if (mode === 'none' || mode === 'bearer') {
     if (mode === 'bearer' && input.token) {
       const saved = await saveMcpConnection({
-        mcpServerId: server.id,
+        mcpServerId: serverId,
         serverName: input.name,
         organizationId: input.organizationId,
         createdById: input.createdById,
@@ -145,21 +178,22 @@ export async function createCustomMcpServer(input: {
       })
       if (saved.isErr()) throw new Error(saved.error.message)
     }
-    await syncMcpTools({ mcpServerId: server.id, organizationId: input.organizationId })
+    await syncMcpTools({ mcpServerId: serverId, organizationId: input.organizationId })
     await onCacheEvent('mcp.connection.changed', { orgId: input.organizationId })
-    return { connected: true, serverId: server.id, slug }
+    return { connected: true, serverId, slug }
   }
 
-  // OAuth: ensure client creds (pasted or DCR).
+  // OAuth: ensure client creds (pasted, kept from a prior attempt, or DCR).
   const outcome = await ensureOAuthClient({
-    serverId: server.id,
+    serverId,
     organizationId: input.organizationId,
     serverName: input.name,
     registrationEndpoint: oauth?.registrationEndpoint,
     pastedClientId: input.clientId,
+    existingClientId,
     returnTo: input.returnTo,
   })
-  return { ...outcome, serverId: server.id, slug }
+  return { ...outcome, serverId, slug }
 }
 
 /**


### PR DESCRIPTION
## Summary

Makes the MCP server connect flow idempotent so retries don't create duplicates, fixes the OAuth callback in the dev tunnel, and simplifies the Settings → Apps MCP block.

## Changes

- **Retry-safe server create** (`manage.ts`): an org server already pointing at the same endpoint is reused instead of inserting a duplicate `McpServer` (e.g. clicking Connect again after a missed OAuth popup). Pasted client creds update the existing `ConnectionDefinition`; otherwise the previously discovered/registered `oauth2ClientId` is carried forward via `existingClientId`.
- **Singleton credential** (`save-mcp-connection.ts`): a repeat connect rotates the existing org-wide MCP credential rather than stacking a second credential row.
- **Dev tunnel OAuth callback** (`use-connect-flow.tsx`, `use-mcp-oauth-popup.ts`): also trust `postMessage` from the popup window we opened (`e.source === popup`), since the callback page may live on a different origin (NGROK_URL tunnel) in dev.
- **UI simplification** (`mcp-apps-section.tsx`): replaced the curated browse strip + "Add custom MCP server" card with a single "Connect server" header button that opens the connect dialog.

## Test plan

- [ ] Connect a new custom MCP server (none / bearer / OAuth)
- [ ] Retry Connect after dismissing the OAuth popup — no duplicate server/credential
- [ ] OAuth completes through the NGROK_URL dev tunnel