### PR TITLE
feat(mcp): add templates, custom-header auth, and manual OAuth config

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/apps/installed/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/installed/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 import { Input } from '@auxx/ui/components/input'
 // apps/web/src/app/(protected)/app/settings/apps/installed/page.tsx
-import { Code } from 'lucide-react'
+import { Code, Trash } from 'lucide-react'
 import { useState } from 'react'
 import { dedupeInstallationsByApp } from '~/components/apps/dedupe-installations'
+import { useUninstallApp } from '~/components/apps/hooks/use-uninstall-app'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { AppListCard } from '~/components/apps/ui/app-list-card'
 import SettingsPage from '~/components/global/settings-page'
@@ -18,6 +19,7 @@ export default function AppsInstalledListPage() {
     // type filter is optional - omitting it returns all installations (both dev and production)
   })
   const { data: results } = api.apps.list.useQuery({})
+  const { uninstallApp, ConfirmDialog } = useUninstallApp()
 
   // Collapse dev+production installs of the same app to one entry (see helper).
   const installed = dedupeInstallationsByApp(installedResult?.installations ?? [])
@@ -60,6 +62,7 @@ export default function AppsInstalledListPage() {
         { title: 'Installed' },
       ]}
       button={<></>}>
+      <ConfirmDialog />
       <div className='flex flex-col flex-1 p-3 sm:p-6 space-y-6 @container'>
         <Input
           placeholder='Search installed apps'
@@ -80,7 +83,7 @@ export default function AppsInstalledListPage() {
           </div>
         ) : (
           <div className='grid w-full gap-2 @sm:grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3'>
-            {filteredInstalledApps.map(({ app }) => (
+            {filteredInstalledApps.map(({ app, installation }) => (
               <AppListCard
                 key={app.id}
                 title={app.title}
@@ -92,6 +95,14 @@ export default function AppsInstalledListPage() {
                 badges={[
                   ...(app.isDevelopment ? [{ icon: <Code className='size-3' /> }] : []),
                   ...(app.isInstalled ? [{ label: 'Installed' }] : []),
+                ]}
+                menuItems={[
+                  {
+                    label: 'Uninstall',
+                    icon: <Trash />,
+                    destructive: true,
+                    onClick: () => void uninstallApp(app.slug, installation.installationType),
+                  },
                 ]}
               />
             ))}

--- a/apps/web/src/app/(protected)/app/settings/apps/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/page.tsx
@@ -14,11 +14,13 @@ import {
   MessageSquare,
   Package,
   Phone,
+  Trash,
 } from 'lucide-react'
 import Link from 'next/link'
 // ~/app/(protected)/app/settings/integrations/_components/integration-list.tsx
 import { useLayoutEffect, useRef, useState } from 'react'
 import { dedupeInstallationsByApp } from '~/components/apps/dedupe-installations'
+import { useUninstallApp } from '~/components/apps/hooks/use-uninstall-app'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { AppListCard } from '~/components/apps/ui/app-list-card'
 import SettingsPage from '~/components/global/settings-page'
@@ -50,6 +52,7 @@ export default function IntegrationList() {
   const { isAdminOrOwner } = useUser()
   const { hasAccess } = useFeatureFlags()
   const hasMcpAccess = hasAccess(FeatureKey.mcp)
+  const { uninstallApp, ConfirmDialog } = useUninstallApp()
   const { data: results } = api.apps.list.useQuery({}, { enabled: isAdminOrOwner })
   const { data: installedResult } = api.apps.listInstalled.useQuery({
     // type filter is optional - omitting it returns all installations (both dev and production)
@@ -236,6 +239,7 @@ export default function IntegrationList() {
       }
       breadcrumbs={[{ title: 'Settings', href: '/app/settings' }, { title: 'Apps' }]}
       button={<></>}>
+      <ConfirmDialog />
       <div className='flex flex-col flex-1 p-3 sm:p-6 space-y-8'>
         <div className='space-y-2'>
           <div className='flex items-center justify-between gap-2'>
@@ -255,7 +259,7 @@ export default function IntegrationList() {
             {isAdminOrOwner ? (
               installedAppsToShow.length > 0 ? (
                 <div className='grid w-full gap-2 @sm:grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3'>
-                  {installedAppsToShow.map(({ app }) => (
+                  {installedAppsToShow.map(({ app, installation }) => (
                     <AppListCard
                       key={app.id}
                       title={app.title}
@@ -269,6 +273,14 @@ export default function IntegrationList() {
                       badges={[
                         ...(app.isDevelopment ? [{ icon: <Code className='size-3' /> }] : []),
                         ...(app.isInstalled ? [{ label: 'Installed' }] : []),
+                      ]}
+                      menuItems={[
+                        {
+                          label: 'Uninstall',
+                          icon: <Trash />,
+                          destructive: true,
+                          onClick: () => void uninstallApp(app.slug, installation.installationType),
+                        },
                       ]}
                     />
                   ))}
@@ -390,6 +402,18 @@ export default function IntegrationList() {
                                       : []),
                                     ...(app.isInstalled ? [{ label: 'Installed' }] : []),
                                   ]}
+                                  menuItems={
+                                    app.isInstalled
+                                      ? [
+                                          {
+                                            label: 'Uninstall',
+                                            icon: <Trash />,
+                                            destructive: true,
+                                            onClick: () => void uninstallApp(app.slug),
+                                          },
+                                        ]
+                                      : undefined
+                                  }
                                 />
                               ))}
                             </div>

--- a/apps/web/src/components/apps/hooks/use-uninstall-app.ts
+++ b/apps/web/src/components/apps/hooks/use-uninstall-app.ts
@@ -1,0 +1,54 @@
+// apps/web/src/components/apps/hooks/use-uninstall-app.ts
+'use client'
+
+import { toastError } from '@auxx/ui/components/toast'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useExtensionsContext } from '~/providers/extensions/extensions-context'
+import { api } from '~/trpc/react'
+
+/**
+ * Confirm-and-uninstall flow for an installed app, shared by the apps list pages.
+ * Invalidates `apps.list` / `apps.listInstalled` and refreshes the ExtensionsContext
+ * projection so every card grid updates without a reload. Render `<ConfirmDialog />`
+ * once in the calling page.
+ */
+export function useUninstallApp() {
+  const utils = api.useUtils()
+  const { refreshInstallations } = useExtensionsContext()
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  const uninstall = api.apps.uninstall.useMutation({
+    onError: (error) => {
+      toastError({ title: 'Failed to uninstall app', description: error.message })
+    },
+  })
+
+  // `type` is the installation's installationType (a plain text column, so typed `string`);
+  // values outside the dev/prod union fall back to "first active installation".
+  const uninstallApp = async (appSlug: string, type?: string) => {
+    const confirmed = await confirm({
+      title: 'Uninstall app?',
+      description: 'Workflows and agents using this app will stop working.',
+      confirmText: 'Uninstall',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!confirmed) return
+
+    try {
+      await uninstall.mutateAsync({
+        appSlug,
+        type: type === 'development' || type === 'production' ? type : undefined,
+      })
+    } catch {
+      return // toast shown by onError
+    }
+    await Promise.all([
+      utils.apps.list.invalidate(),
+      utils.apps.listInstalled.invalidate(),
+      refreshInstallations(),
+    ])
+  }
+
+  return { uninstallApp, isPending: uninstall.isPending, ConfirmDialog }
+}

--- a/apps/web/src/components/apps/ui/app-list-card.tsx
+++ b/apps/web/src/components/apps/ui/app-list-card.tsx
@@ -2,10 +2,26 @@
 
 'use client'
 
-import { BadgeCheck, Mail } from 'lucide-react'
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { BadgeCheck, Mail, MoreVertical } from 'lucide-react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import type React from 'react'
 import { Tooltip } from '~/components/global/tooltip'
+
+export interface AppListCardMenuItem {
+  label: string
+  icon?: React.ReactNode
+  onClick: () => void
+  destructive?: boolean
+  disabled?: boolean
+}
 
 interface AppListCardProps {
   title: string
@@ -17,12 +33,16 @@ interface AppListCardProps {
   subtitle?: string
   verified?: boolean
   badges?: { label?: string; icon?: React.ReactNode }[]
+  /** Optional actions shown in a hover-revealed three-dot dropdown in the top-right. */
+  menuItems?: AppListCardMenuItem[]
 }
 
 /**
  * AppListCard component
  * Displays a card with icon, title, description, and optional badges. Pass
  * either `href` (renders as a link) or `onClick` (renders as a button).
+ * Pass `menuItems` to add a three-dot dropdown; the card then renders as a
+ * clickable div so the trigger isn't nested inside a link/button.
  */
 export function AppListCard({
   title,
@@ -34,7 +54,11 @@ export function AppListCard({
   subtitle,
   verified,
   badges,
+  menuItems,
 }: AppListCardProps) {
+  const router = useRouter()
+  const hasMenu = !!menuItems?.length
+
   const cardClass =
     'rounded-2xl bg-primary-50 hover:bg-primary-50/50 hover:outline-5 hover:outline-primary-50 flex flex-col p-3 gap-2 border text-left disabled:opacity-60 disabled:cursor-not-allowed'
 
@@ -75,6 +99,45 @@ export function AppListCard({
       <div className='text-sm text-muted-foreground line-clamp-2'>{description}</div>
     </>
   )
+
+  if (hasMenu) {
+    return (
+      <div
+        className={`${cardClass} cursor-pointer group/app-card relative`}
+        onClick={() => {
+          if (disabled) return
+          if (onClick) onClick()
+          else if (href) router.push(href)
+        }}>
+        {body}
+        <div className='absolute bottom-2 right-2'>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                className='opacity-0 group-hover/app-card:opacity-100 duration-300 data-[state=open]:opacity-100! data-[state=open]:bg-muted! transition-opacity rounded-lg'
+                variant='ghost'
+                size='icon-xs'
+                onClick={(e) => e.stopPropagation()}>
+                <MoreVertical />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end' onClick={(e) => e.stopPropagation()}>
+              {menuItems?.map((item) => (
+                <DropdownMenuItem
+                  key={item.label}
+                  onClick={item.onClick}
+                  disabled={item.disabled}
+                  variant={item.destructive ? 'destructive' : undefined}>
+                  {item.icon}
+                  {item.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    )
+  }
 
   if (onClick) {
     return (

--- a/apps/web/src/components/mcp/hooks/use-mcp-oauth-popup.ts
+++ b/apps/web/src/components/mcp/hooks/use-mcp-oauth-popup.ts
@@ -49,15 +49,22 @@ export function useMcpOAuthPopup() {
       teardown()
       setPending(true)
 
-      const handleDone = (payload: OAuthDonePayload) => {
+      let settled = false
+      let cancelTimer: ReturnType<typeof setTimeout> | null = null
+
+      /** Settle exactly once: a toast only on explicit failure (not on user cancel). */
+      const finish = (ok: boolean, error?: string | null) => {
+        if (settled) return
+        settled = true
         teardown()
-        if (!payload.ok) {
-          toastError({
-            title: 'Failed to connect',
-            description: payload.error || 'Connection failed',
-          })
+        if (!ok && error) {
+          toastError({ title: 'Failed to connect', description: error })
         }
-        onDone(payload.ok)
+        onDone(ok)
+      }
+
+      const handleDone = (payload: OAuthDonePayload) => {
+        finish(payload.ok, payload.ok ? undefined : payload.error || 'Connection failed')
       }
 
       const onMessage = (e: MessageEvent) => {
@@ -81,13 +88,19 @@ export function useMcpOAuthPopup() {
       }
 
       const closedInterval = setInterval(() => {
-        if (popup.closed) teardown()
+        if (!popup.closed) return
+        clearInterval(closedInterval)
+        // The callback page posts its result right before closing itself — give that message a
+        // beat to arrive before treating the close as a user cancel. Without this, cancelling
+        // never fires `onDone` and callers' per-row pending state sticks.
+        cancelTimer = setTimeout(() => finish(false), 750)
       }, 500)
 
       teardownRef.current = () => {
         window.removeEventListener('message', onMessage)
         bc?.close()
         clearInterval(closedInterval)
+        if (cancelTimer) clearTimeout(cancelTimer)
         try {
           if (!popup.closed) popup.close()
         } catch {

--- a/apps/web/src/components/mcp/ui/add-mcp-server-dialog.tsx
+++ b/apps/web/src/components/mcp/ui/add-mcp-server-dialog.tsx
@@ -10,7 +10,7 @@ import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { Label } from '@auxx/ui/components/label'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
-import { ClipboardPaste, Plug } from 'lucide-react'
+import { ChevronDown, ChevronRight, ClipboardPaste, Plug, Plus, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { AppIcon } from '~/components/apps/ui/app-icon'
@@ -21,13 +21,16 @@ import type { RouterOutputs } from '~/trpc/react'
 import { api } from '~/trpc/react'
 import { useMcpOAuthPopup } from '../hooks/use-mcp-oauth-popup'
 
-type AuthMode = 'auto' | 'bearer' | 'none'
+type AuthMode = 'auto' | 'oauth' | 'bearer' | 'headers' | 'none'
 type ResolveResult = RouterOutputs['mcp']['resolveSnippet'][number]
 type RemoteResult = Extract<ResolveResult, { kind: 'remote' }>
+type HeaderRow = { name: string; value: string }
 
 const AUTH_OPTIONS = [
   { label: 'Auto-detect', value: 'auto' },
+  { label: 'OAuth', value: 'oauth' },
   { label: 'Bearer token', value: 'bearer' },
+  { label: 'Custom headers', value: 'headers' },
   { label: 'No authentication', value: 'none' },
 ]
 
@@ -37,6 +40,19 @@ export interface McpServerEditTarget {
   name: string
   endpoint: string
   connectionType: 'oauth2-code' | 'secret' | 'none' | null
+  /** Derived server-side — distinguishes bearer from custom headers (both `'secret'`). */
+  authPosture: 'oauth' | 'bearer' | 'headers' | 'none' | null
+  /** Custom bearer header name (e.g. `X-API-Key`), from the credential metadata. */
+  authHeaderName: string | null
+  /** Header names of a headers-auth connection — prefills rows (values stay blank = keep). */
+  headerNames: string[]
+  /** OAuth config prefill from the ConnectionDefinition (client secret never leaves the server). */
+  oauth: {
+    clientId: string | null
+    authorizeUrl: string | null
+    tokenUrl: string | null
+    scopes: string[]
+  } | null
 }
 
 interface AddMcpServerDialogProps {
@@ -54,8 +70,9 @@ interface AddMcpServerDialogProps {
  * Two-step dialog for adding (and editing) a custom MCP server.
  *  - **paste** — drop any URL / config snippet / install command; Resolve runs `mcp.resolveSnippet`
  *    and prefills the fields step (or pivots to the curated connect flow / shows an inline error).
- *  - **fields** — Name / Endpoint / Auth rows; submit forks connected → close, `needsOAuth` → popup,
- *    `needsClientCredentials` → reveal client-cred rows.
+ *  - **fields** — Name / Endpoint / Auth rows (auto / OAuth with client creds + endpoint
+ *    overrides / bearer / custom headers / none); submit forks connected → close, `needsOAuth` →
+ *    popup, `needsClientCredentials` → flip to OAuth mode for a retry with pasted creds.
  * In `update` mode the paste step is skipped: the dialog opens on **fields**, prefilled from the
  * passed server, and submits `mcp.update`.
  */
@@ -69,13 +86,12 @@ export function AddMcpServerDialog({
   const router = useRouter()
   const isUpdate = mode === 'update'
 
-  // In update mode, seed the auth selector from the server's current connection type.
-  const initialAuth: AuthMode =
-    isUpdate && server?.connectionType === 'secret'
-      ? 'bearer'
-      : isUpdate && server?.connectionType === 'none'
-        ? 'none'
-        : 'auto'
+  // In update mode, seed the auth selector from the server's derived auth posture.
+  const initialAuth: AuthMode = isUpdate ? (server?.authPosture ?? 'auto') : 'auto'
+  const initialHeaderRows = (): HeaderRow[] =>
+    isUpdate && server?.headerNames?.length
+      ? server.headerNames.map((n) => ({ name: n, value: '' }))
+      : [{ name: '', value: '' }]
 
   const [step, setStep] = useState<'paste' | 'fields' | 'multi'>(isUpdate ? 'fields' : 'paste')
   const [snippet, setSnippet] = useState('')
@@ -88,10 +104,14 @@ export function AddMcpServerDialog({
   const [endpoint, setEndpoint] = useState(server?.endpoint ?? '')
   const [auth, setAuth] = useState<AuthMode>(initialAuth)
   const [token, setToken] = useState('')
-  const [headerName, setHeaderName] = useState('')
-  const [clientId, setClientId] = useState('')
+  const [headerName, setHeaderName] = useState(server?.authHeaderName ?? '')
+  const [headerRows, setHeaderRows] = useState<HeaderRow[]>(initialHeaderRows)
+  const [clientId, setClientId] = useState(server?.oauth?.clientId ?? '')
   const [clientSecret, setClientSecret] = useState('')
-  const [needsClientCreds, setNeedsClientCreds] = useState(false)
+  const [authorizeUrl, setAuthorizeUrl] = useState(server?.oauth?.authorizeUrl ?? '')
+  const [tokenUrl, setTokenUrl] = useState(server?.oauth?.tokenUrl ?? '')
+  const [scopes, setScopes] = useState((server?.oauth?.scopes ?? []).join(' '))
+  const [showOAuthAdvanced, setShowOAuthAdvanced] = useState(false)
   const [errors, setErrors] = useState<Record<string, string>>({})
   const [placeholders, setPlaceholders] = useState<string[]>([])
   const [placeholderValues, setPlaceholderValues] = useState<Record<string, string>>({})
@@ -117,10 +137,14 @@ export function AddMcpServerDialog({
     setEndpoint(server?.endpoint ?? '')
     setAuth(initialAuth)
     setToken('')
-    setHeaderName('')
-    setClientId('')
+    setHeaderName(server?.authHeaderName ?? '')
+    setHeaderRows(initialHeaderRows())
+    setClientId(server?.oauth?.clientId ?? '')
     setClientSecret('')
-    setNeedsClientCreds(false)
+    setAuthorizeUrl(server?.oauth?.authorizeUrl ?? '')
+    setTokenUrl(server?.oauth?.tokenUrl ?? '')
+    setScopes((server?.oauth?.scopes ?? []).join(' '))
+    setShowOAuthAdvanced(false)
     setErrors({})
     setPlaceholders([])
     setPlaceholderValues({})
@@ -197,12 +221,62 @@ export function AddMcpServerDialog({
     if (!name.trim()) next.name = 'Name is required'
     if (!endpoint.trim()) next.endpoint = 'Endpoint URL is required'
     if (auth === 'bearer' && !token.trim() && !isUpdate) next.token = 'Token is required'
-    if (needsClientCreds && !clientId.trim()) next.clientId = 'Client ID is required'
+    if (auth === 'oauth') {
+      if (clientSecret.trim() && !clientId.trim()) {
+        next.clientId = 'Client ID is required when a secret is set'
+      }
+      if (authorizeUrl.trim() && !isValidUrl(authorizeUrl)) {
+        next.authorizeUrl = 'Must be a valid https URL'
+      }
+      if (tokenUrl.trim() && !isValidUrl(tokenUrl)) next.tokenUrl = 'Must be a valid https URL'
+      // The overrides only work as a pair — discovery is skipped when both are set.
+      if (authorizeUrl.trim() && !tokenUrl.trim()) next.tokenUrl = 'Token URL is required too'
+      if (tokenUrl.trim() && !authorizeUrl.trim()) {
+        next.authorizeUrl = 'Authorize URL is required too'
+      }
+    }
+    if (auth === 'headers') {
+      const touched = headerRows.filter((r) => r.name.trim() || r.value.trim())
+      const complete = touched.filter((r) => r.name.trim() && r.value.trim())
+      if (!isUpdate && complete.length === 0) {
+        next.headers = 'Add at least one header (name and value)'
+      } else if (touched.some((r) => r.value.trim() && !r.name.trim())) {
+        next.headers = 'Every header value needs a name'
+      } else if (complete.length > 0 && touched.length !== complete.length) {
+        // Full-replace semantics: a partial set would silently drop the blank ones.
+        next.headers = 'Fill in all header values, or leave all blank to keep the current ones'
+      }
+    }
     for (const p of placeholders) {
       if (!placeholderValues[p]?.trim()) next[`ph_${p}`] = `${p} is required`
     }
     setErrors(next)
     return Object.keys(next).length === 0
+  }
+
+  /** OAuth payload — blank fields are omitted so the server keeps existing values. */
+  function oauthInput() {
+    if (auth !== 'oauth') return undefined
+    const scopeList = scopes
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+    return {
+      clientId: clientId.trim() || undefined,
+      clientSecret: clientSecret.trim() || undefined,
+      authorizeUrl: authorizeUrl.trim() || undefined,
+      tokenUrl: tokenUrl.trim() || undefined,
+      scopes: scopeList.length > 0 ? scopeList : undefined,
+    }
+  }
+
+  /** Complete header rows — `undefined` (keep existing) when none are filled in. */
+  function headersInput() {
+    if (auth !== 'headers') return undefined
+    const complete = headerRows
+      .filter((r) => r.name.trim() && r.value.trim())
+      .map((r) => ({ name: r.name.trim(), value: r.value.trim() }))
+    return complete.length > 0 ? complete : undefined
   }
 
   function resolvedEndpoint(): string {
@@ -225,6 +299,8 @@ export function AddMcpServerDialog({
           auth,
           token: auth === 'bearer' && token.trim() ? token.trim() : undefined,
           authHeaderName: customHeaderName(),
+          headers: headersInput(),
+          oauth: oauthInput(),
         })
         onConnected()
         close()
@@ -248,10 +324,10 @@ export function AddMcpServerDialog({
       auth,
       token: auth === 'bearer' ? token.trim() : undefined,
       authHeaderName: customHeaderName(),
+      headers: headersInput(),
+      oauth: oauthInput(),
       description: enrichment.description,
       icon: enrichment.iconId ? { iconId: enrichment.iconId } : undefined,
-      clientId: needsClientCreds ? clientId : undefined,
-      clientSecret: needsClientCreds ? clientSecret || undefined : undefined,
       returnTo: `/app/settings/apps/mcp/${slugifyName(name)}`,
     }
   }
@@ -275,7 +351,8 @@ export function AddMcpServerDialog({
       return
     }
     if ('needsClientCredentials' in result && result.needsClientCredentials) {
-      setNeedsClientCreds(true)
+      // Flip to OAuth mode so the client-cred fields are visible for the retry.
+      setAuth('oauth')
       toastError({
         title: 'Automatic registration unavailable',
         description: 'Paste an OAuth Client ID (and Secret) from the provider to continue.',
@@ -438,8 +515,7 @@ export function AddMcpServerDialog({
                 loading={isSubmitting}
                 loadingText={isUpdate ? 'Saving...' : 'Connecting...'}
                 data-dialog-submit>
-                {isUpdate ? 'Save' : needsClientCreds ? 'Retry' : 'Connect'}{' '}
-                <KbdSubmit variant='outline' size='sm' />
+                {isUpdate ? 'Save' : 'Connect'} <KbdSubmit variant='outline' size='sm' />
               </Button>
             )}
             {step === 'multi' && (
@@ -462,129 +538,256 @@ export function AddMcpServerDialog({
 
   function renderFields() {
     return (
-      <VarEditorField
-        orientation='responsive'
-        className='p-0 sm:[&_[data-slot=field-row-label]]:w-40'>
-        <VarEditorFieldRow
-          title='Name'
-          type={BaseType.STRING}
-          showIcon
-          isRequired
-          validationError={errors.name}>
-          <div className='flex items-center gap-2'>
-            {enrichment.iconId && <AppIcon iconId={enrichment.iconId} size='sm' />}
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={name}
-              onChange={(v) => setName((v as string) ?? '')}
-              placeholder='e.g. Acme Tools'
-              disabled={isSubmitting}
-            />
-          </div>
-        </VarEditorFieldRow>
-
-        <VarEditorFieldRow
-          title='Endpoint URL'
-          type={BaseType.STRING}
-          showIcon
-          isRequired
-          validationError={errors.endpoint}>
-          <FieldInputAdapter
-            fieldType={FieldType.URL}
-            value={endpoint}
-            onChange={(v) => setEndpoint((v as string) ?? '')}
-            placeholder='https://example.com/mcp'
-            disabled={isSubmitting}
-          />
-        </VarEditorFieldRow>
-
-        <VarEditorFieldRow title='Authentication' type={BaseType.STRING} showIcon>
-          <FieldInputAdapter
-            fieldType={FieldType.SINGLE_SELECT}
-            fieldOptions={{ options: AUTH_OPTIONS }}
-            value={[auth]}
-            onChange={(v) => setAuth(((v as string[])[0] as AuthMode) ?? 'auto')}
-            disabled={isSubmitting}
-          />
-        </VarEditorFieldRow>
-
-        {auth === 'bearer' && (
-          <>
-            <VarEditorFieldRow
-              title='Token'
-              type={BaseType.STRING}
-              showIcon
-              isRequired={!isUpdate}
-              validationError={errors.token}>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={token}
-                onChange={(v) => setToken((v as string) ?? '')}
-                placeholder={isUpdate ? 'Leave blank to keep current token' : 'Secret token'}
-                disabled={isSubmitting}
-              />
-            </VarEditorFieldRow>
-            <VarEditorFieldRow title='Header name' type={BaseType.STRING} showIcon>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={headerName}
-                onChange={(v) => setHeaderName((v as string) ?? '')}
-                placeholder='Authorization'
-                disabled={isSubmitting}
-              />
-            </VarEditorFieldRow>
-          </>
-        )}
-
-        {placeholders.map((p) => (
+      <>
+        <VarEditorField
+          orientation='responsive'
+          className='p-0 sm:[&_[data-slot=field-row-label]]:w-40'>
           <VarEditorFieldRow
-            key={p}
-            title={p}
+            title='Name'
             type={BaseType.STRING}
             showIcon
             isRequired
-            validationError={errors[`ph_${p}`]}>
+            validationError={errors.name}>
+            <div className='flex items-center gap-2'>
+              {enrichment.iconId && <AppIcon iconId={enrichment.iconId} size='sm' />}
+              <FieldInputAdapter
+                fieldType={FieldType.TEXT}
+                value={name}
+                onChange={(v) => setName((v as string) ?? '')}
+                placeholder='e.g. Acme Tools'
+                disabled={isSubmitting}
+              />
+            </div>
+          </VarEditorFieldRow>
+
+          <VarEditorFieldRow
+            title='Endpoint URL'
+            type={BaseType.STRING}
+            showIcon
+            isRequired
+            validationError={errors.endpoint}>
             <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={placeholderValues[p] ?? ''}
-              onChange={(v) =>
-                setPlaceholderValues((prev) => ({ ...prev, [p]: (v as string) ?? '' }))
-              }
-              placeholder={`Value for ${p}`}
+              fieldType={FieldType.URL}
+              value={endpoint}
+              onChange={(v) => setEndpoint((v as string) ?? '')}
+              placeholder='https://example.com/mcp'
               disabled={isSubmitting}
             />
           </VarEditorFieldRow>
-        ))}
 
-        {needsClientCreds && (
-          <>
+          <VarEditorFieldRow title='Authentication' type={BaseType.STRING} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.SINGLE_SELECT}
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              fieldOptions={{ options: AUTH_OPTIONS }}
+              value={[auth]}
+              onChange={(v) => setAuth(((v as string[])[0] as AuthMode) ?? 'auto')}
+              disabled={isSubmitting}
+            />
+          </VarEditorFieldRow>
+
+          {auth === 'bearer' && (
+            <>
+              <VarEditorFieldRow
+                title='Token'
+                type={BaseType.STRING}
+                showIcon
+                isRequired={!isUpdate}
+                validationError={errors.token}>
+                <FieldInputAdapter
+                  fieldType={FieldType.TEXT}
+                  value={token}
+                  onChange={(v) => setToken((v as string) ?? '')}
+                  placeholder={isUpdate ? 'Leave blank to keep current token' : 'Secret token'}
+                  disabled={isSubmitting}
+                />
+              </VarEditorFieldRow>
+              <VarEditorFieldRow title='Header name' type={BaseType.STRING} showIcon>
+                <FieldInputAdapter
+                  fieldType={FieldType.TEXT}
+                  value={headerName}
+                  onChange={(v) => setHeaderName((v as string) ?? '')}
+                  placeholder='Authorization'
+                  disabled={isSubmitting}
+                />
+              </VarEditorFieldRow>
+            </>
+          )}
+
+          {auth === 'headers' && (
             <VarEditorFieldRow
-              title='Client ID'
+              title='Headers'
+              type={BaseType.STRING}
+              showIcon
+              isRequired={!isUpdate}
+              validationError={errors.headers}>
+              <div className='flex flex-col gap-2'>
+                {headerRows.map((row, i) => (
+                  <div key={i} className='flex items-center gap-2'>
+                    <FieldInputAdapter
+                      fieldType={FieldType.TEXT}
+                      value={row.name}
+                      onChange={(v) => updateHeaderRow(i, { name: (v as string) ?? '' })}
+                      placeholder='X-API-Key'
+                      disabled={isSubmitting}
+                    />
+                    <FieldInputAdapter
+                      fieldType={FieldType.TEXT}
+                      value={row.value}
+                      onChange={(v) => updateHeaderRow(i, { value: (v as string) ?? '' })}
+                      placeholder={
+                        isUpdate && row.name && !row.value ? 'Blank keeps current value' : 'Value'
+                      }
+                      disabled={isSubmitting}
+                    />
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      onClick={() => removeHeaderRow(i)}
+                      disabled={isSubmitting || headerRows.length === 1}>
+                      <Trash2 />
+                    </Button>
+                  </div>
+                ))}
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  className='self-start'
+                  onClick={() => setHeaderRows((prev) => [...prev, { name: '', value: '' }])}
+                  disabled={isSubmitting}>
+                  <Plus />
+                  Add header
+                </Button>
+              </div>
+            </VarEditorFieldRow>
+          )}
+
+          {auth === 'oauth' && (
+            <>
+              <VarEditorFieldRow
+                title='Client ID'
+                type={BaseType.STRING}
+                showIcon
+                validationError={errors.clientId}>
+                <FieldInputAdapter
+                  fieldType={FieldType.TEXT}
+                  value={clientId}
+                  onChange={(v) => setClientId((v as string) ?? '')}
+                  placeholder='Blank tries automatic registration (DCR)'
+                  disabled={isSubmitting}
+                />
+              </VarEditorFieldRow>
+              <VarEditorFieldRow title='Client Secret' type={BaseType.STRING} showIcon>
+                <FieldInputAdapter
+                  fieldType={FieldType.TEXT}
+                  value={clientSecret}
+                  onChange={(v) => setClientSecret((v as string) ?? '')}
+                  placeholder={
+                    isUpdate ? 'Leave blank to keep current secret' : 'Optional for public clients'
+                  }
+                  disabled={isSubmitting}
+                />
+              </VarEditorFieldRow>
+            </>
+          )}
+
+          {placeholders.map((p) => (
+            <VarEditorFieldRow
+              key={p}
+              title={p}
               type={BaseType.STRING}
               showIcon
               isRequired
-              validationError={errors.clientId}>
+              validationError={errors[`ph_${p}`]}>
               <FieldInputAdapter
                 fieldType={FieldType.TEXT}
-                value={clientId}
-                onChange={(v) => setClientId((v as string) ?? '')}
-                placeholder='OAuth client ID'
+                value={placeholderValues[p] ?? ''}
+                onChange={(v) =>
+                  setPlaceholderValues((prev) => ({ ...prev, [p]: (v as string) ?? '' }))
+                }
+                placeholder={`Value for ${p}`}
                 disabled={isSubmitting}
               />
             </VarEditorFieldRow>
-            <VarEditorFieldRow title='Client Secret' type={BaseType.STRING} showIcon>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={clientSecret}
-                onChange={(v) => setClientSecret((v as string) ?? '')}
-                placeholder='OAuth client secret (optional for public clients)'
-                disabled={isSubmitting}
-              />
-            </VarEditorFieldRow>
-          </>
+          ))}
+        </VarEditorField>
+
+        {auth === 'oauth' && (
+          <div className='mt-4'>
+            <button
+              type='button'
+              onClick={() => setShowOAuthAdvanced((v) => !v)}
+              className='flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors'>
+              {showOAuthAdvanced ? (
+                <ChevronDown className='h-4 w-4' />
+              ) : (
+                <ChevronRight className='h-4 w-4' />
+              )}
+              Advanced OAuth settings
+            </button>
+            {showOAuthAdvanced && (
+              <VarEditorField
+                orientation='responsive'
+                className='p-0 mt-4 sm:[&_[data-slot=field-row-label]]:w-40'>
+                <VarEditorFieldRow
+                  title='Authorize URL'
+                  type={BaseType.STRING}
+                  showIcon
+                  validationError={errors.authorizeUrl}>
+                  <FieldInputAdapter
+                    fieldType={FieldType.URL}
+                    value={authorizeUrl}
+                    onChange={(v) => setAuthorizeUrl((v as string) ?? '')}
+                    placeholder='Blank uses OAuth discovery'
+                    disabled={isSubmitting}
+                  />
+                </VarEditorFieldRow>
+                <VarEditorFieldRow
+                  title='Token URL'
+                  type={BaseType.STRING}
+                  showIcon
+                  validationError={errors.tokenUrl}>
+                  <FieldInputAdapter
+                    fieldType={FieldType.URL}
+                    value={tokenUrl}
+                    onChange={(v) => setTokenUrl((v as string) ?? '')}
+                    placeholder='Blank uses OAuth discovery'
+                    disabled={isSubmitting}
+                  />
+                </VarEditorFieldRow>
+                <VarEditorFieldRow title='Scopes' type={BaseType.STRING} showIcon>
+                  <FieldInputAdapter
+                    fieldType={FieldType.TEXT}
+                    value={scopes}
+                    onChange={(v) => setScopes((v as string) ?? '')}
+                    placeholder='Space-separated, e.g. read write'
+                    disabled={isSubmitting}
+                  />
+                </VarEditorFieldRow>
+              </VarEditorField>
+            )}
+          </div>
         )}
-      </VarEditorField>
+      </>
     )
+  }
+
+  function updateHeaderRow(index: number, patch: Partial<HeaderRow>) {
+    setHeaderRows((prev) => prev.map((row, i) => (i === index ? { ...row, ...patch } : row)))
+  }
+
+  function removeHeaderRow(index: number) {
+    setHeaderRows((prev) =>
+      prev.length === 1 ? [{ name: '', value: '' }] : prev.filter((_, i) => i !== index)
+    )
+  }
+}
+
+function isValidUrl(value: string): boolean {
+  try {
+    return new URL(value.trim()).protocol === 'https:'
+  } catch {
+    return false
   }
 }
 

--- a/apps/web/src/components/mcp/ui/connect-curated-dialog.tsx
+++ b/apps/web/src/components/mcp/ui/connect-curated-dialog.tsx
@@ -2,7 +2,6 @@
 'use client'
 
 import type { ConnectionVariable } from '@auxx/database'
-import { FieldType } from '@auxx/database/enums'
 import { Button } from '@auxx/ui/components/button'
 import {
   Dialog,
@@ -14,11 +13,10 @@ import {
 } from '@auxx/ui/components/dialog'
 import { toastError } from '@auxx/ui/components/toast'
 import { useState } from 'react'
-import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
-import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
+import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 import { useMcpOAuthPopup } from '../hooks/use-mcp-oauth-popup'
+import { ConnectionVariableFields } from './connection-variable-fields'
 
 interface ConnectCuratedDialogProps {
   open: boolean
@@ -130,43 +128,16 @@ export function ConnectCuratedDialog({
         <VarEditorField
           orientation='responsive'
           className='p-0 sm:[&_[data-slot=field-row-label]]:w-40'>
-          {connectionVariables.map((variable) => (
-            <VarEditorFieldRow
-              key={variable.key}
-              title={variable.label}
-              description={variable.description}
-              type={BaseType.STRING}
-              showIcon
-              isRequired={variable.required !== false}
-              validationError={errors[variable.key]}>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={values[variable.key] ?? ''}
-                onChange={(v) =>
-                  setValues((prev) => ({ ...prev, [variable.key]: (v as string) ?? '' }))
-                }
-                placeholder={variable.placeholder}
-                disabled={isPending}
-              />
-            </VarEditorFieldRow>
-          ))}
-
-          {isSecret && (
-            <VarEditorFieldRow
-              title='Token'
-              type={BaseType.STRING}
-              showIcon
-              isRequired
-              validationError={errors.__token}>
-              <FieldInputAdapter
-                fieldType={FieldType.TEXT}
-                value={token}
-                onChange={(v) => setToken((v as string) ?? '')}
-                placeholder='Bearer token'
-                disabled={isPending}
-              />
-            </VarEditorFieldRow>
-          )}
+          <ConnectionVariableFields
+            variables={connectionVariables}
+            values={values}
+            onValueChange={(key, value) => setValues((prev) => ({ ...prev, [key]: value }))}
+            showToken={isSecret}
+            token={token}
+            onTokenChange={setToken}
+            errors={errors}
+            disabled={isPending}
+          />
         </VarEditorField>
 
         <DialogFooter>

--- a/apps/web/src/components/mcp/ui/connection-variable-fields.tsx
+++ b/apps/web/src/components/mcp/ui/connection-variable-fields.tsx
@@ -1,0 +1,76 @@
+// apps/web/src/components/mcp/ui/connection-variable-fields.tsx
+'use client'
+
+import type { ConnectionVariable } from '@auxx/database'
+import { FieldType } from '@auxx/database/enums'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { BaseType } from '~/components/workflow/types'
+import { VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
+
+interface ConnectionVariableFieldsProps {
+  /** Connection-variable defs from the server's ConnectionDefinition (or template). */
+  variables: ConnectionVariable[]
+  values: Record<string, string>
+  onValueChange: (key: string, value: string) => void
+  /** Render a bearer-token row (secret-auth servers). Its error key is `__token`. */
+  showToken?: boolean
+  token?: string
+  onTokenChange?: (token: string) => void
+  errors: Record<string, string>
+  disabled?: boolean
+}
+
+/**
+ * Connection-variable rows + optional bearer-token row, shared by the curated connect dialog
+ * and the template dialog's fields step. Render inside a `VarEditorField`.
+ */
+export function ConnectionVariableFields({
+  variables,
+  values,
+  onValueChange,
+  showToken = false,
+  token = '',
+  onTokenChange,
+  errors,
+  disabled = false,
+}: ConnectionVariableFieldsProps) {
+  return (
+    <>
+      {variables.map((variable) => (
+        <VarEditorFieldRow
+          key={variable.key}
+          title={variable.label}
+          description={variable.description}
+          type={BaseType.STRING}
+          showIcon
+          isRequired={variable.required !== false}
+          validationError={errors[variable.key]}>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={values[variable.key] ?? ''}
+            onChange={(v) => onValueChange(variable.key, (v as string) ?? '')}
+            placeholder={variable.placeholder}
+            disabled={disabled}
+          />
+        </VarEditorFieldRow>
+      ))}
+
+      {showToken && (
+        <VarEditorFieldRow
+          title='Token'
+          type={BaseType.STRING}
+          showIcon
+          isRequired
+          validationError={errors.__token}>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={token}
+            onChange={(v) => onTokenChange?.((v as string) ?? '')}
+            placeholder='Bearer token'
+            disabled={disabled}
+          />
+        </VarEditorFieldRow>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/components/mcp/ui/mcp-app-card.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-app-card.tsx
@@ -1,9 +1,12 @@
 // apps/web/src/components/mcp/ui/mcp-app-card.tsx
 'use client'
 
-import { Plug } from 'lucide-react'
+import { toastError } from '@auxx/ui/components/toast'
+import { Plug, Trash } from 'lucide-react'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { AppListCard } from '~/components/apps/ui/app-list-card'
+import { useConfirm } from '~/hooks/use-confirm'
+import { api } from '~/trpc/react'
 import type { McpServerListEntry } from '../hooks/use-mcp-servers'
 import { mcpStatus } from './mcp-status-pill'
 
@@ -14,27 +17,75 @@ const STATUS_LABEL: Record<ReturnType<typeof mcpStatus>, string> = {
   not_connected: '',
 }
 
+interface McpAppCardProps {
+  server: McpServerListEntry
+  /** Show an uninstall action in the card dropdown (admin-only mutation). */
+  canUninstall?: boolean
+  /** Called after the server was removed, to refresh the list. */
+  onRemoved?: () => void
+}
+
 /**
  * `AppListCard`-shaped card for an MCP server, used in both the browse (curated) and installed
  * sections of Settings → Apps. Carries an "MCP" badge; connected servers also show a status badge.
  * Links to the server's detail page.
  */
-export function McpAppCard({ server }: { server: McpServerListEntry }) {
+export function McpAppCard({ server, canUninstall, onRemoved }: McpAppCardProps) {
   const statusLabel = STATUS_LABEL[mcpStatus(server)]
+  const [confirm, ConfirmDialog] = useConfirm()
+  const remove = api.mcp.delete.useMutation()
+
+  const showUninstall = canUninstall && (server.connectionPresent || server.isCustom)
+
+  async function handleUninstall() {
+    const ok = await confirm({
+      title: 'Uninstall MCP server?',
+      description: 'Agents using its tools will lose them.',
+      confirmText: 'Uninstall',
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await remove.mutateAsync({ serverId: server.serverId })
+      onRemoved?.()
+    } catch (err) {
+      toastError({
+        title: 'Failed to uninstall MCP server',
+        description: err instanceof Error ? err.message : 'Unknown error',
+      })
+    }
+  }
+
   return (
-    <AppListCard
-      title={server.name}
-      description={server.description}
-      href={`/app/settings/apps/mcp/${server.slug}`}
-      icon={
-        server.icon?.iconId ? (
-          <AppIcon iconId={server.icon.iconId} color={server.icon.color} size='sm' />
-        ) : (
-          <Plug className='size-4 text-muted-foreground' />
-        )
-      }
-      subtitle={server.isCustom ? 'Custom server' : 'Curated'}
-      badges={[{ label: 'MCP' }, ...(statusLabel ? [{ label: statusLabel }] : [])]}
-    />
+    <>
+      <ConfirmDialog />
+      <AppListCard
+        title={server.name}
+        description={server.description}
+        href={`/app/settings/apps/mcp/${server.slug}`}
+        icon={
+          server.icon?.iconId ? (
+            <AppIcon iconId={server.icon.iconId} color={server.icon.color} size='sm' />
+          ) : (
+            <Plug className='size-4 text-muted-foreground' />
+          )
+        }
+        subtitle={server.isCustom ? 'Custom server' : 'Curated'}
+        badges={[{ label: 'MCP' }, ...(statusLabel ? [{ label: statusLabel }] : [])]}
+        menuItems={
+          showUninstall
+            ? [
+                {
+                  label: 'Uninstall',
+                  icon: <Trash />,
+                  destructive: true,
+                  disabled: remove.isPending,
+                  onClick: () => void handleUninstall(),
+                },
+              ]
+            : undefined
+        }
+      />
+    </>
   )
 }

--- a/apps/web/src/components/mcp/ui/mcp-apps-section.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-apps-section.tsx
@@ -1,12 +1,82 @@
 // apps/web/src/components/mcp/ui/mcp-apps-section.tsx
 'use client'
 
+import { AnimatedGradientText } from '@auxx/ui/components/animated-gradient-text'
 import { Button } from '@auxx/ui/components/button'
-import { Plug } from 'lucide-react'
-import { useState } from 'react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { LayoutTemplate, Plug } from 'lucide-react'
+import { type ReactNode, useState } from 'react'
 import { useMcpServers } from '../hooks/use-mcp-servers'
 import { AddMcpServerDialog } from './add-mcp-server-dialog'
 import { McpAppCard } from './mcp-app-card'
+import { McpTemplateDialog } from './mcp-template-dialog'
+
+/** Empty-state card matching the `AppListCard` shape, dashed to read as a placeholder. */
+function ConnectPlaceholderCard({
+  icon,
+  title,
+  subtitle,
+  description,
+  onClick,
+}: {
+  icon: ReactNode
+  title: ReactNode
+  subtitle: string
+  description: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      className='rounded-2xl border border-dashed bg-primary-50 hover:bg-primary-50/50 hover:outline-5 hover:outline-primary-50 flex flex-col p-3 gap-2 text-left'>
+      <div className='flex flex-row items-start gap-2'>
+        <div className='size-8 rounded-xl border border-dashed flex items-center justify-center'>
+          {icon}
+        </div>
+        <div className='flex flex-col'>
+          <div className='text-sm font-semibold'>{title}</div>
+          <div className='text-xs text-muted-foreground'>{subtitle}</div>
+        </div>
+      </div>
+      <div className='text-sm text-muted-foreground line-clamp-2'>{description}</div>
+    </button>
+  )
+}
+
+/** Connect menu behind the section-header button. */
+function ConnectServerDropdown({
+  align,
+  onCustom,
+  onTemplate,
+  children,
+}: {
+  align: 'start' | 'end'
+  onCustom: () => void
+  onTemplate: () => void
+  children: ReactNode
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
+      <DropdownMenuContent align={align} className='w-56'>
+        <DropdownMenuItem onClick={onCustom}>
+          <Plug />
+          Connect custom server
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={onTemplate} className='data-highlighted:bg-[#ffaa40]/10'>
+          <LayoutTemplate className='text-[#ffaa40]' />
+          <AnimatedGradientText>Connect from template</AnimatedGradientText>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
 
 interface McpAppsSectionProps {
   /** Connecting a new server is admin-only, matching the apps page. */
@@ -17,19 +87,21 @@ interface McpAppsSectionProps {
 
 /**
  * MCP block for Settings → Apps. Renders connected servers (alongside installed apps) with a
- * header button for admins to connect a new server. Kept as one self-contained component so the
- * apps page only needs a single insertion point.
+ * header dropdown for admins to connect a new server — custom (paste dialog) or from the
+ * template catalog. Kept as one self-contained component so the apps page only needs a single
+ * insertion point.
  */
 export function McpAppsSection({ isAdminOrOwner, searchQuery = '' }: McpAppsSectionProps) {
   const { servers, refresh } = useMcpServers()
   const [addOpen, setAddOpen] = useState(false)
+  const [templateOpen, setTemplateOpen] = useState(false)
 
   const q = searchQuery.trim().toLowerCase()
   const matches = (s: (typeof servers)[number]) =>
     !q || s.name.toLowerCase().includes(q) || (s.description?.toLowerCase().includes(q) ?? false)
 
   // Connected (or org-owned custom) servers; unconnected curated servers are reachable through
-  // the connect dialog's paste step, which pivots to the curated flow on a recognized URL.
+  // the template dialog or the connect dialog's paste step.
   const installed = servers.filter((s) => (s.connectionPresent || s.isCustom) && matches(s))
 
   if (!isAdminOrOwner && installed.length === 0) return null
@@ -42,26 +114,61 @@ export function McpAppsSection({ isAdminOrOwner, searchQuery = '' }: McpAppsSect
           MCP servers
         </div>
         {isAdminOrOwner && (
-          <Button variant='ghost' size='sm' onClick={() => setAddOpen(true)}>
-            Connect server
-          </Button>
+          <ConnectServerDropdown
+            align='end'
+            onCustom={() => setAddOpen(true)}
+            onTemplate={() => setTemplateOpen(true)}>
+            <Button variant='ghost' size='sm'>
+              Connect server
+            </Button>
+          </ConnectServerDropdown>
         )}
       </div>
-      {installed.length > 0 && (
+      {(installed.length > 0 || isAdminOrOwner) && (
         <div className='w-full @container'>
           <div className='grid w-full gap-2 @sm:grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3'>
             {installed.map((server) => (
-              <McpAppCard key={server.serverId} server={server} />
+              <McpAppCard
+                key={server.serverId}
+                server={server}
+                canUninstall={isAdminOrOwner}
+                onRemoved={() => void refresh()}
+              />
             ))}
+            {installed.length === 0 && isAdminOrOwner && (
+              <>
+                <ConnectPlaceholderCard
+                  icon={<Plug className='size-4 text-muted-foreground' />}
+                  title='Connect custom server'
+                  subtitle='Custom server'
+                  description='Paste a URL, config snippet, or install command.'
+                  onClick={() => setAddOpen(true)}
+                />
+                <ConnectPlaceholderCard
+                  icon={<LayoutTemplate className='size-4 text-[#ffaa40]' />}
+                  title={<AnimatedGradientText>Connect from template</AnimatedGradientText>}
+                  subtitle='Curated'
+                  description='Pick a server from the curated template catalog.'
+                  onClick={() => setTemplateOpen(true)}
+                />
+              </>
+            )}
           </div>
         </div>
       )}
       {isAdminOrOwner && (
-        <AddMcpServerDialog
-          open={addOpen}
-          onOpenChange={setAddOpen}
-          onConnected={() => void refresh()}
-        />
+        <>
+          <AddMcpServerDialog
+            open={addOpen}
+            onOpenChange={setAddOpen}
+            onConnected={() => void refresh()}
+          />
+          <McpTemplateDialog
+            open={templateOpen}
+            onOpenChange={setTemplateOpen}
+            onConnected={() => void refresh()}
+          />
+        </>
       )}
     </div>
   )

--- a/apps/web/src/components/mcp/ui/mcp-server-detail.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-server-detail.tsx
@@ -127,6 +127,10 @@ export function McpServerDetail({ initialServer }: { initialServer: McpDetailSer
             name: current.name,
             endpoint: current.endpoint ?? '',
             connectionType: current.connectionType,
+            authPosture: current.authPosture,
+            authHeaderName: current.authHeaderName,
+            headerNames: current.headerNames,
+            oauth: current.oauth,
           }}
           onConnected={onChanged}
         />

--- a/apps/web/src/components/mcp/ui/mcp-template-dialog.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-template-dialog.tsx
@@ -1,0 +1,414 @@
+// apps/web/src/components/mcp/ui/mcp-template-dialog.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { Dialog, DialogContent, DialogFooter } from '@auxx/ui/components/dialog'
+import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@auxx/ui/components/empty'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { RadioGroup } from '@auxx/ui/components/radio-group'
+import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { toastError } from '@auxx/ui/components/toast'
+import { cn } from '@auxx/ui/lib/utils'
+import {
+  Code,
+  LayoutGrid,
+  ListTodo,
+  type LucideIcon,
+  Plug,
+  Search,
+  ShoppingCart,
+  Zap,
+} from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useMemo, useRef, useState } from 'react'
+import { AppIcon } from '~/components/apps/ui/app-icon'
+import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
+import type { RouterOutputs } from '~/trpc/react'
+import { api } from '~/trpc/react'
+import { useMcpOAuthPopup } from '../hooks/use-mcp-oauth-popup'
+import { useMcpServers } from '../hooks/use-mcp-servers'
+import { ConnectionVariableFields } from './connection-variable-fields'
+
+type McpTemplate = RouterOutputs['mcp']['listTemplates']['templates'][number]
+
+/** Sidebar category icons — keep in sync with `mcpTemplateCategories` in @auxx/lib. */
+const CATEGORY_ICONS: Record<string, LucideIcon> = {
+  LayoutGrid,
+  Code,
+  ListTodo,
+  ShoppingCart,
+  Search,
+  Zap,
+}
+
+interface McpTemplateDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Called after a successful connect (or OAuth popup completion). */
+  onConnected: () => void
+}
+
+/**
+ * "Connect from template" dialog for Settings → Apps. Mirrors the agent-template dialog's
+ * list view (category sidebar + search); the catalog comes from `mcp.listTemplates` (never
+ * bundled client-side). Clicking a template connects one-click: OAuth goes straight to the
+ * popup; templates needing connection variables or a token get an inline fields step.
+ * Already-connected templates show a badge and route to the server's detail page instead.
+ */
+export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTemplateDialogProps) {
+  const router = useRouter()
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedCategory, setSelectedCategory] = useState('all')
+  const [step, setStep] = useState<'list' | 'fields'>('list')
+  const [active, setActive] = useState<McpTemplate | null>(null)
+  const [connectingId, setConnectingId] = useState<string | null>(null)
+  const [values, setValues] = useState<Record<string, string>>({})
+  const [token, setToken] = useState('')
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const catalog = api.mcp.listTemplates.useQuery(undefined, { enabled: open })
+  const connectTemplate = api.mcp.connectTemplate.useMutation()
+  const oauth = useMcpOAuthPopup()
+  const { servers } = useMcpServers()
+
+  const templates = useMemo(() => catalog.data?.templates ?? [], [catalog.data])
+  const categories = catalog.data?.categories ?? []
+  const isSubmitting = connectTemplate.isPending || oauth.pending
+
+  /** Connected (or browsable) server matching a template, by slug. */
+  const serverFor = (template: McpTemplate) => servers.find((s) => s.slug === template.id)
+
+  const filteredTemplates = useMemo(() => {
+    let list = templates
+    if (selectedCategory !== 'all') {
+      list = list.filter((t) => (t.categories as string[]).includes(selectedCategory))
+    }
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase()
+      list = list.filter(
+        (t) => t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q)
+      )
+    }
+    return list
+  }, [templates, searchQuery, selectedCategory])
+
+  function reset() {
+    setSearchQuery('')
+    setSelectedCategory('all')
+    setStep('list')
+    setActive(null)
+    setConnectingId(null)
+    setValues({})
+    setToken('')
+    setErrors({})
+  }
+
+  function close() {
+    reset()
+    onOpenChange(false)
+  }
+
+  function handleConnected(slug: string) {
+    onConnected()
+    close()
+    router.push(`/app/settings/apps/mcp/${slug}`)
+  }
+
+  async function connect(template: McpTemplate, vars?: Record<string, string>, secret?: string) {
+    try {
+      const result = await connectTemplate.mutateAsync({
+        templateId: template.id,
+        connectionVariables: vars && Object.keys(vars).length > 0 ? vars : undefined,
+        token: secret || undefined,
+        returnTo: `/app/settings/apps/mcp/${template.id}`,
+      })
+      if ('connected' in result && result.connected) {
+        handleConnected(result.slug)
+        return
+      }
+      if ('needsOAuth' in result && result.needsOAuth) {
+        oauth.open({
+          authorizeUrl: result.authorizeUrl,
+          onDone: (ok) => {
+            if (ok) handleConnected(result.slug)
+            else setConnectingId(null)
+          },
+        })
+        return
+      }
+      if ('needsClientCredentials' in result && result.needsClientCredentials) {
+        setConnectingId(null)
+        toastError({
+          title: 'Connection not available',
+          description:
+            'This server needs OAuth client credentials that could not be registered automatically. Add it as a custom server instead.',
+        })
+      }
+    } catch (err) {
+      setConnectingId(null)
+      toastError({
+        title: 'Failed to connect',
+        description: err instanceof Error ? err.message : 'Unknown error',
+      })
+    }
+  }
+
+  async function handleSelectTemplate(template: McpTemplate) {
+    if (isSubmitting || connectingId) return
+
+    const existing = serverFor(template)
+    if (existing?.connectionPresent) {
+      close()
+      router.push(`/app/settings/apps/mcp/${existing.slug}`)
+      return
+    }
+
+    const needsFields =
+      (template.connectionVariables?.length ?? 0) > 0 || template.connectionType === 'secret'
+    if (needsFields) {
+      setActive(template)
+      setValues({})
+      setToken('')
+      setErrors({})
+      setStep('fields')
+      return
+    }
+
+    setConnectingId(template.id)
+    await connect(template)
+  }
+
+  function validateFields(template: McpTemplate): boolean {
+    const next: Record<string, string> = {}
+    for (const v of template.connectionVariables ?? []) {
+      if (v.required !== false && !values[v.key]?.trim()) next[v.key] = `${v.label} is required`
+    }
+    if (template.connectionType === 'secret' && !token.trim()) next.__token = 'Token is required'
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  async function handleSubmitFields() {
+    if (!active || !validateFields(active)) return
+    setConnectingId(active.id)
+    await connect(active, values, token)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? onOpenChange(true) : close())}>
+      <DialogContent
+        innerClassName='p-0'
+        position='tc'
+        size='content'
+        onOpenAutoFocus={(e) => {
+          e.preventDefault()
+          searchInputRef.current?.focus()
+        }}>
+        <div className='flex flex-col'>
+          <DialogNav
+            title='Connect from template'
+            description='Select an MCP server template to connect'
+            onBack={step === 'fields' ? () => setStep('list') : undefined}
+            backDisabled={isSubmitting}
+            crumbs={[
+              step === 'fields' && active
+                ? { label: `Connect ${active.name}`, icon: <Plug /> }
+                : { label: 'MCP templates', icon: <Plug /> },
+            ]}
+          />
+
+          <DialogNavPages value={step}>
+            <DialogNavPage value='list' size='3xl'>
+              {renderList()}
+            </DialogNavPage>
+            <DialogNavPage value='fields' size='sm'>
+              <div className='p-3'>{active && renderFields(active)}</div>
+            </DialogNavPage>
+          </DialogNavPages>
+
+          <DialogFooter className='mt-0 border-t p-3'>
+            <Button size='sm' variant='ghost' onClick={close} disabled={isSubmitting}>
+              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+            </Button>
+            {step === 'fields' && (
+              <Button
+                size='sm'
+                variant='outline'
+                onClick={handleSubmitFields}
+                loading={isSubmitting}
+                loadingText='Connecting...'
+                data-dialog-submit>
+                Connect <KbdSubmit variant='outline' size='sm' />
+              </Button>
+            )}
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+
+  function renderList() {
+    return (
+      <div className='flex flex-col sm:flex-row justify-start w-full min-h-0'>
+        {/* Category sidebar */}
+        <div className='hidden sm:flex w-56 border-r bg-muted/30 flex-col'>
+          <ScrollArea className='max-h-[440px]'>
+            <h3 className='p-3 pb-0 text-sm font-semibold text-muted-foreground sticky top-0'>
+              Categories
+            </h3>
+            <div className='p-3'>
+              <RadioGroup value={selectedCategory} onValueChange={setSelectedCategory}>
+                {categories.map((category) => {
+                  const count =
+                    category.value === 'all'
+                      ? templates.length
+                      : templates.filter((t) => (t.categories as string[]).includes(category.value))
+                          .length
+                  const Icon = CATEGORY_ICONS[category.icon]
+                  return (
+                    <RadioGroupItemCard
+                      key={category.value}
+                      label={category.label}
+                      value={category.value}
+                      description={`${count} template${count !== 1 ? 's' : ''}`}
+                      icon={Icon ? <Icon /> : undefined}
+                    />
+                  )
+                })}
+              </RadioGroup>
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* Template list */}
+        <div className='flex-1 overflow-hidden flex flex-col min-w-0'>
+          <div className='py-3 px-3'>
+            <InputSearch
+              ref={searchInputRef}
+              placeholder='Search templates...'
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onClear={() => setSearchQuery('')}
+            />
+          </div>
+
+          {catalog.isLoading ? (
+            <div className='p-3 pt-0 space-y-2'>
+              {[0, 1, 2, 3].map((i) => (
+                <div key={i} className='h-14 rounded-2xl border bg-muted/40 animate-pulse' />
+              ))}
+            </div>
+          ) : filteredTemplates.length > 0 ? (
+            <ScrollArea className='max-h-[400px]'>
+              <div className='p-3 pt-0 space-y-2'>
+                {filteredTemplates.map((template) => renderRow(template))}
+              </div>
+            </ScrollArea>
+          ) : (
+            <Empty className='py-10'>
+              <EmptyHeader>
+                <EmptyMedia variant='icon'>
+                  <Search />
+                </EmptyMedia>
+                <EmptyTitle>No templates found</EmptyTitle>
+                <EmptyDescription>
+                  {searchQuery
+                    ? 'No templates match your search. Try adjusting your query.'
+                    : 'No templates available in this category.'}
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  function renderRow(template: McpTemplate) {
+    const isConnected = !!serverFor(template)?.connectionPresent
+    const isConnecting = connectingId === template.id
+    const isAnyConnecting = connectingId !== null
+    return (
+      <button
+        type='button'
+        key={template.id}
+        onClick={() => handleSelectTemplate(template)}
+        disabled={isAnyConnecting && !isConnected}
+        className={cn(
+          'group flex items-center justify-between gap-3 rounded-2xl border py-2 px-3 hover:bg-muted transition-colors duration-200 cursor-pointer text-left w-full',
+          isAnyConnecting && !isConnecting && 'opacity-50 cursor-default',
+          isConnecting && 'bg-muted'
+        )}>
+        <div className='flex items-start gap-3 flex-1 min-w-0'>
+          <div className='size-8 rounded-lg border bg-background flex items-center justify-center shrink-0'>
+            {template.icon?.iconId ? (
+              <AppIcon iconId={template.icon.iconId} size='sm' />
+            ) : (
+              <Plug className='size-4 text-muted-foreground' />
+            )}
+          </div>
+          <div className='flex flex-col flex-1 min-w-0'>
+            <span className='text-sm font-medium truncate'>{template.name}</span>
+            <span className='text-xs text-muted-foreground line-clamp-1 mt-0.5'>
+              {template.description}
+            </span>
+          </div>
+        </div>
+        <div className='flex gap-1 shrink-0'>
+          {isConnected ? (
+            <Badge variant='secondary' className='text-xs'>
+              Connected
+            </Badge>
+          ) : (
+            template.categories.map((cat) => (
+              <Badge key={cat} variant='outline' className='text-xs'>
+                {categories.find((c) => c.value === cat)?.label ?? cat}
+              </Badge>
+            ))
+          )}
+        </div>
+      </button>
+    )
+  }
+
+  function renderFields(template: McpTemplate) {
+    return (
+      <div className='flex flex-col gap-2'>
+        <VarEditorField
+          orientation='responsive'
+          className='p-0 sm:[&_[data-slot=field-row-label]]:w-40'>
+          <ConnectionVariableFields
+            variables={template.connectionVariables ?? []}
+            values={values}
+            onValueChange={(key, value) => setValues((prev) => ({ ...prev, [key]: value }))}
+            showToken={template.connectionType === 'secret'}
+            token={token}
+            onTokenChange={setToken}
+            errors={errors}
+            disabled={isSubmitting}
+          />
+        </VarEditorField>
+        {template.docsUrl && (
+          <a
+            href={template.docsUrl}
+            target='_blank'
+            rel='noreferrer'
+            className='self-start text-muted-foreground text-xs underline-offset-2 hover:underline'>
+            Where do I find this? View the {template.name} docs
+          </a>
+        )}
+      </div>
+    )
+  }
+}

--- a/apps/web/src/server/api/routers/mcp.ts
+++ b/apps/web/src/server/api/routers/mcp.ts
@@ -1,12 +1,16 @@
 // apps/web/src/server/api/routers/mcp.ts
 
+import { findCredential } from '@auxx/credentials/store'
 import type { ConnectionVariable } from '@auxx/database'
 import { database as db, schema } from '@auxx/database'
 import {
   checkMcpResolveRateLimit,
   connectCuratedMcpServer,
+  connectMcpTemplate,
   createCustomMcpServer,
   deleteMcpServer,
+  mcpTemplateCategories,
+  mcpTemplates,
   resolveMcpSnippet,
   syncMcpTools,
   updateMcpServer,
@@ -28,13 +32,41 @@ const mcpAdminProcedure = adminProcedure.use(async ({ ctx, next }) => {
   return next()
 })
 
-/** Fetch the connection-variable defs (for the curated connect dialog) for a server. */
-async function getConnectionVariables(serverId: string): Promise<ConnectionVariable[]> {
+/**
+ * Fetch the connection-definition data the detail page + edit dialog need: connection-variable
+ * defs (curated connect dialog) and the OAuth config prefill (client SECRET intentionally
+ * excluded — it never leaves the server).
+ */
+async function getConnectionDefinitionInfo(serverId: string): Promise<{
+  connectionVariables: ConnectionVariable[]
+  oauth: {
+    clientId: string | null
+    authorizeUrl: string | null
+    tokenUrl: string | null
+    scopes: string[]
+  } | null
+}> {
   const def = await db.query.ConnectionDefinition.findFirst({
     where: eq(schema.ConnectionDefinition.mcpServerId, serverId),
-    columns: { oauth2Features: true },
+    columns: {
+      oauth2Features: true,
+      oauth2ClientId: true,
+      oauth2AuthorizeUrl: true,
+      oauth2AccessTokenUrl: true,
+      oauth2Scopes: true,
+    },
   })
-  return def?.oauth2Features?.connectionVariables ?? []
+  return {
+    connectionVariables: def?.oauth2Features?.connectionVariables ?? [],
+    oauth: def
+      ? {
+          clientId: def.oauth2ClientId,
+          authorizeUrl: def.oauth2AuthorizeUrl,
+          tokenUrl: def.oauth2AccessTokenUrl,
+          scopes: def.oauth2Scopes ?? [],
+        }
+      : null,
+  }
 }
 
 /** Fetch the raw endpoint (shown on the detail page's About tab for custom servers). */
@@ -44,6 +76,45 @@ async function getServerEndpoint(serverId: string): Promise<string | null> {
     columns: { endpoint: true },
   })
   return server?.endpoint ?? null
+}
+
+/**
+ * Derive the edit dialog's auth posture + prefill data from the credential's plaintext metadata
+ * (no decryption). `connectionType` alone can't distinguish bearer from custom headers — both
+ * store as `'secret'`; headers-auth connections carry their header NAMES in metadata.
+ */
+async function getAuthPosture(
+  serverId: string,
+  organizationId: string,
+  connectionType: 'oauth2-code' | 'secret' | 'none' | null
+): Promise<{
+  authPosture: 'oauth' | 'bearer' | 'headers' | 'none' | null
+  authHeaderName: string | null
+  headerNames: string[]
+}> {
+  if (connectionType === 'oauth2-code') {
+    return { authPosture: 'oauth', authHeaderName: null, headerNames: [] }
+  }
+  if (connectionType === 'none') {
+    return { authPosture: 'none', authHeaderName: null, headerNames: [] }
+  }
+  if (connectionType !== 'secret') {
+    return { authPosture: null, authHeaderName: null, headerNames: [] }
+  }
+  const credential = await findCredential({
+    organizationId,
+    kind: 'mcp',
+    mcpServerId: serverId,
+    userId: null,
+  })
+  const metadata = credential.isOk() ? (credential.value?.metadata ?? {}) : {}
+  const headerNames = Array.isArray(metadata.headerNames) ? (metadata.headerNames as string[]) : []
+  const authHeaderName = (metadata.authHeader as { name?: string } | undefined)?.name ?? null
+  return {
+    authPosture: headerNames.length > 0 ? 'headers' : 'bearer',
+    authHeaderName,
+    headerNames,
+  }
 }
 
 /**
@@ -78,11 +149,46 @@ export const mcpRouter = createTRPCRouter({
       const servers = await getOrgCache().get(ctx.session.organizationId, 'mcpServers')
       const server = servers.find((s) => s.slug === input.slug)
       if (!server) return null
-      const [connectionVariables, endpoint] = await Promise.all([
-        getConnectionVariables(server.serverId),
+      const [defInfo, endpoint, posture] = await Promise.all([
+        getConnectionDefinitionInfo(server.serverId),
         getServerEndpoint(server.serverId),
+        getAuthPosture(server.serverId, ctx.session.organizationId, server.connectionType),
       ])
-      return { ...server, connectionVariables, endpoint }
+      return { ...server, ...defInfo, endpoint, ...posture }
+    }),
+
+  /**
+   * Static template catalog from `@auxx/lib/ai/mcp` — the "Connect from template" dialog's data
+   * source (the catalog never ships in the client bundle). Mirrors `list`'s gate-to-empty shape.
+   */
+  listTemplates: protectedProcedure.query(async ({ ctx }) => {
+    const hasAccess = await new FeaturePermissionService().hasAccess(
+      ctx.session.organizationId,
+      FeatureKey.mcp
+    )
+    if (!hasAccess) return { templates: [], categories: [] }
+    return { templates: mcpTemplates, categories: mcpTemplateCategories }
+  }),
+
+  /**
+   * Connect a catalog template: upserts the curated/global row from the lib definition, then
+   * runs the curated connect flow.
+   */
+  connectTemplate: mcpAdminProcedure
+    .input(
+      z.object({
+        templateId: z.string(),
+        connectionVariables: z.record(z.string(), z.string()).optional(),
+        token: z.string().optional(),
+        returnTo: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      return connectMcpTemplate({
+        organizationId: ctx.session.organizationId,
+        createdById: ctx.session.user.id,
+        ...input,
+      })
     }),
 
   /**
@@ -106,9 +212,21 @@ export const mcpRouter = createTRPCRouter({
       z.object({
         name: z.string().min(1).max(120),
         endpoint: z.string().url(),
-        auth: z.enum(['auto', 'bearer', 'none']),
+        auth: z.enum(['auto', 'oauth', 'bearer', 'headers', 'none']),
         token: z.string().optional(),
         authHeaderName: z.string().optional(),
+        headers: z
+          .array(z.object({ name: z.string().min(1), value: z.string().min(1) }))
+          .optional(),
+        oauth: z
+          .object({
+            clientId: z.string().optional(),
+            clientSecret: z.string().optional(),
+            authorizeUrl: z.string().url().optional(),
+            tokenUrl: z.string().url().optional(),
+            scopes: z.array(z.string()).optional(),
+          })
+          .optional(),
         description: z.string().optional(),
         icon: z
           .object({
@@ -117,8 +235,6 @@ export const mcpRouter = createTRPCRouter({
             iconId: z.string().optional(),
           })
           .optional(),
-        clientId: z.string().optional(),
-        clientSecret: z.string().optional(),
         returnTo: z.string().optional(),
       })
     )
@@ -162,16 +278,28 @@ export const mcpRouter = createTRPCRouter({
       return result
     }),
 
-  /** Edit a custom server (name / endpoint / bearer auth) and/or update trust config. */
+  /** Edit a custom server (name / endpoint / auth) and/or update trust config. */
   update: mcpAdminProcedure
     .input(
       z.object({
         serverId: z.string(),
         name: z.string().min(1).max(120).optional(),
         endpoint: z.string().url().optional(),
-        auth: z.enum(['auto', 'bearer', 'none']).optional(),
+        auth: z.enum(['auto', 'oauth', 'bearer', 'headers', 'none']).optional(),
         token: z.string().optional(),
         authHeaderName: z.string().optional(),
+        headers: z
+          .array(z.object({ name: z.string().min(1), value: z.string().min(1) }))
+          .optional(),
+        oauth: z
+          .object({
+            clientId: z.string().optional(),
+            clientSecret: z.string().optional(),
+            authorizeUrl: z.string().url().optional(),
+            tokenUrl: z.string().url().optional(),
+            scopes: z.array(z.string()).optional(),
+          })
+          .optional(),
         trust: z
           .object({ allTools: z.boolean().optional(), tools: z.array(z.string()).optional() })
           .optional(),

--- a/packages/lib/src/ai/mcp/__tests__/manage.test.ts
+++ b/packages/lib/src/ai/mcp/__tests__/manage.test.ts
@@ -80,6 +80,11 @@ vi.mock('../connections', () => ({
 const syncMcpTools = vi.fn(async () => ({ ok: true, toolCount: 1 }))
 vi.mock('../sync', () => ({ syncMcpTools: (...a: unknown[]) => syncMcpTools(...a) }))
 
+const ensureCuratedMcpServer = vi.fn(async () => ({ serverId: 'srv-curated' }))
+vi.mock('../templates/ensure', () => ({
+  ensureCuratedMcpServer: (...a: unknown[]) => ensureCuratedMcpServer(...a),
+}))
+
 vi.mock('../../../cache/invalidate', () => ({ onCacheEvent: async () => undefined }))
 
 vi.mock('@auxx/credentials/store', async () => {
@@ -88,7 +93,7 @@ vi.mock('@auxx/credentials/store', async () => {
 })
 
 import { ok } from 'neverthrow'
-import { connectCuratedMcpServer, createCustomMcpServer } from '../manage'
+import { connectCuratedMcpServer, connectMcpTemplate, createCustomMcpServer } from '../manage'
 
 const OAUTH_DISCOVERY = ok({
   kind: 'oauth' as const,
@@ -110,6 +115,7 @@ beforeEach(() => {
   registerDcrClient.mockReset()
   saveMcpConnection.mockClear()
   syncMcpTools.mockClear()
+  ensureCuratedMcpServer.mockClear()
 })
 
 describe('createCustomMcpServer (auth: auto → oauth)', () => {
@@ -149,6 +155,121 @@ describe('createCustomMcpServer (auth: auto → oauth)', () => {
       auth: 'auto',
     })
     expect(result).toMatchObject({ needsClientCredentials: true })
+  })
+})
+
+describe('createCustomMcpServer (explicit auth modes)', () => {
+  it('oauth with manual authorize/token URLs skips discovery entirely', async () => {
+    const result = await createCustomMcpServer({
+      organizationId: 'org-1',
+      createdById: 'user-1',
+      name: 'Manual OAuth',
+      endpoint: 'https://server.example.com/mcp',
+      auth: 'oauth',
+      oauth: {
+        clientId: 'pasted-cid',
+        clientSecret: 'pasted-secret',
+        authorizeUrl: 'https://as.example.com/authorize',
+        tokenUrl: 'https://as.example.com/token',
+        scopes: ['read', 'write'],
+      },
+    })
+
+    expect(discoverMcpAuth).not.toHaveBeenCalled()
+    expect(result).toMatchObject({ needsOAuth: true })
+    const defInsert = state.inserts.find((i) => i.table === 'ConnectionDefinition')
+    expect(defInsert?.values).toMatchObject({
+      connectionType: 'oauth2-code',
+      oauth2AuthorizeUrl: 'https://as.example.com/authorize',
+      oauth2AccessTokenUrl: 'https://as.example.com/token',
+      oauth2Scopes: ['read', 'write'],
+      oauth2ClientId: 'pasted-cid',
+      oauth2ClientSecret: 'pasted-secret',
+    })
+  })
+
+  it('oauth without overrides throws when discovery finds no OAuth metadata', async () => {
+    discoverMcpAuth.mockResolvedValue(
+      (await import('neverthrow')).err({ code: 'DISCOVERY_FAILED', message: 'no metadata' })
+    )
+
+    await expect(
+      createCustomMcpServer({
+        organizationId: 'org-1',
+        createdById: 'user-1',
+        name: 'Broken OAuth',
+        endpoint: 'https://server.example.com/mcp',
+        auth: 'oauth',
+        oauth: { clientId: 'cid' },
+      })
+    ).rejects.toThrow(/OAuth discovery failed/)
+  })
+
+  it('headers mode stores the header map as secrets and the names in metadata', async () => {
+    const result = await createCustomMcpServer({
+      organizationId: 'org-1',
+      createdById: 'user-1',
+      name: 'Header Server',
+      endpoint: 'https://server.example.com/mcp',
+      auth: 'headers',
+      headers: [
+        { name: 'X-API-Key', value: 'secret-1' },
+        { name: 'X-Api-Version', value: '2026-01' },
+      ],
+    })
+
+    expect(result).toMatchObject({ connected: true })
+    const defInsert = state.inserts.find((i) => i.table === 'ConnectionDefinition')
+    expect(defInsert?.values).toMatchObject({ connectionType: 'secret' })
+    expect(saveMcpConnection).toHaveBeenCalledTimes(1)
+    const arg = saveMcpConnection.mock.calls[0]![0] as {
+      connectionData: { headers?: Record<string, string>; metadata?: { headerNames?: string[] } }
+    }
+    expect(arg.connectionData.headers).toEqual({
+      'X-API-Key': 'secret-1',
+      'X-Api-Version': '2026-01',
+    })
+    expect(arg.connectionData.metadata?.headerNames).toEqual(['X-API-Key', 'X-Api-Version'])
+    expect(syncMcpTools).toHaveBeenCalled()
+  })
+})
+
+describe('connectMcpTemplate', () => {
+  it('throws on an unknown template id', async () => {
+    await expect(
+      connectMcpTemplate({
+        organizationId: 'org-1',
+        createdById: 'user-1',
+        templateId: 'not-a-template',
+      })
+    ).rejects.toThrow(/Unknown MCP template/)
+    expect(ensureCuratedMcpServer).not.toHaveBeenCalled()
+  })
+
+  it('upserts the curated row from the catalog, then runs the curated connect flow', async () => {
+    // `shopify` is a none-auth template; the curated row + def come from the upsert.
+    ensureCuratedMcpServer.mockResolvedValue({ serverId: 'srv-curated' })
+    state.servers = [
+      {
+        id: 'srv-curated',
+        name: 'Shopify Storefront',
+        endpoint: 'https://{shop}.myshopify.com/api/mcp',
+        authDiscovery: null,
+      },
+    ]
+    state.connectionDef = { connectionType: 'none', oauth2ClientId: null }
+
+    const result = await connectMcpTemplate({
+      organizationId: 'org-1',
+      createdById: 'user-1',
+      templateId: 'shopify',
+      connectionVariables: { shop: 'my-store' },
+    })
+
+    expect(result).toMatchObject({ connected: true, serverId: 'srv-curated', slug: 'shopify' })
+    const ensureArg = ensureCuratedMcpServer.mock.calls[0]![0] as { id: string }
+    expect(ensureArg.id).toBe('shopify')
+    expect(saveMcpConnection).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/lib/src/ai/mcp/auth.ts
+++ b/packages/lib/src/ai/mcp/auth.ts
@@ -65,7 +65,10 @@ export async function buildMcpRequestContext(opts: {
   const endpoint = interpolateEndpoint(server.endpoint, variables)
 
   const headers: Record<string, string> = {}
-  if (connection.type !== 'none' && connection.value) {
+  if (connection.headers && Object.keys(connection.headers).length > 0) {
+    // Custom-header auth: the connection carries a full name → value map.
+    Object.assign(headers, connection.headers)
+  } else if (connection.type !== 'none' && connection.value) {
     // Custom-header escape hatch: pasted remotes are often `X-API-Key: <secret>` rather than
     // `Authorization: Bearer`. `metadata.authHeader` overrides the default header name/prefix.
     const authHeader = connection.metadata?.authHeader as

--- a/packages/lib/src/ai/mcp/connections/resolve-mcp-connection-for-runtime.ts
+++ b/packages/lib/src/ai/mcp/connections/resolve-mcp-connection-for-runtime.ts
@@ -13,6 +13,7 @@ interface McpSecrets {
   accessToken?: string
   refreshToken?: string
   secret?: string
+  headers?: Record<string, string>
 }
 
 /**
@@ -76,6 +77,7 @@ export async function resolveMcpConnectionForRuntime(input: {
     id: record.id,
     type: connectionType,
     value: secrets.accessToken || secrets.secret || '',
+    headers: secrets.headers,
     metadata: record.metadata,
     expiresAt: record.expiresAt ? record.expiresAt.toISOString() : undefined,
   })

--- a/packages/lib/src/ai/mcp/connections/save-mcp-connection.ts
+++ b/packages/lib/src/ai/mcp/connections/save-mcp-connection.ts
@@ -17,11 +17,13 @@ function pickSecrets(data: {
   accessToken?: string
   refreshToken?: string
   secret?: string
+  headers?: Record<string, string>
 }): Record<string, unknown> {
   const secrets: Record<string, unknown> = {}
   if (data.accessToken !== undefined) secrets.accessToken = data.accessToken
   if (data.refreshToken !== undefined) secrets.refreshToken = data.refreshToken
   if (data.secret !== undefined) secrets.secret = data.secret
+  if (data.headers !== undefined) secrets.headers = data.headers
   return secrets
 }
 
@@ -42,6 +44,7 @@ export async function saveMcpConnection(input: {
     refreshToken?: string
     expiresAt?: string
     secret?: string
+    headers?: Record<string, string>
     metadata?: Record<string, unknown>
   }
   /** When provided, update that credential row in place (reconnect flow). */

--- a/packages/lib/src/ai/mcp/connections/types.ts
+++ b/packages/lib/src/ai/mcp/connections/types.ts
@@ -8,6 +8,8 @@ export interface DecryptedConnectionData {
   accessToken?: string
   refreshToken?: string
   secret?: string
+  /** Custom-header auth: full header name → value map (values are secrets). */
+  headers?: Record<string, string>
   metadata?: Record<string, unknown>
   expiresAt?: string
 }
@@ -19,6 +21,8 @@ export interface McpRuntimeConnection {
   id: string
   type: 'oauth2-code' | 'secret' | 'none'
   value: string
+  /** Custom-header auth — wins over the single-value Authorization path when present. */
+  headers?: Record<string, string>
   metadata?: Record<string, unknown>
   expiresAt?: string
 }

--- a/packages/lib/src/ai/mcp/index.ts
+++ b/packages/lib/src/ai/mcp/index.ts
@@ -21,9 +21,10 @@ export type { McpAuthDiscoveryResult, McpDiscoveryError } from './discovery'
 export { discoverMcpAuth, registerDcrClient } from './discovery'
 export type { MappedMcpError } from './errors'
 export { McpAuthError, mapMcpError } from './errors'
-export type { McpConnectOutcome } from './manage'
+export type { McpConnectOutcome, McpOAuthConfigInput } from './manage'
 export {
   connectCuratedMcpServer,
+  connectMcpTemplate,
   createCustomMcpServer,
   deleteMcpServer,
   updateMcpServer,
@@ -44,5 +45,7 @@ export type {
 export { parseMcpSnippet, resolveMcpSnippet } from './snippet'
 export type { SyncMcpToolsResult } from './sync'
 export { syncMcpTools } from './sync'
+export type { McpTemplate, McpTemplateCategory, McpTemplateCategoryDef } from './templates'
+export { ensureCuratedMcpServer, mcpTemplateCategories, mcpTemplates } from './templates'
 export { buildMcpAgentTools, mcpToolName, wrapMcpOutput } from './tool-adapter'
 export type { CachedMcpServer, McpCallResult, McpToolDescriptor, McpTrustConfig } from './types'

--- a/packages/lib/src/ai/mcp/manage.ts
+++ b/packages/lib/src/ai/mcp/manage.ts
@@ -12,6 +12,8 @@ import { onCacheEvent } from '../../cache/invalidate'
 import { deleteMcpConnection, saveMcpConnection } from './connections'
 import { discoverMcpAuth, registerDcrClient } from './discovery'
 import { syncMcpTools } from './sync'
+import { mcpTemplates } from './templates/catalog'
+import { ensureCuratedMcpServer } from './templates/ensure'
 
 const logger = createScopedLogger('mcp-manage')
 const CALLBACK_BASE = process.env.NGROK_URL || WEBAPP_URL
@@ -53,36 +55,65 @@ function authorizeUrlFor(serverId: string, returnTo?: string): string {
   return `/api/mcp/${serverId}/oauth2/authorize${qs}`
 }
 
+/** Manual OAuth client config + endpoint overrides pasted in the create/edit dialog. */
+export interface McpOAuthConfigInput {
+  clientId?: string
+  clientSecret?: string
+  /** With `tokenUrl`, skips RFC 9728/8414 discovery entirely. */
+  authorizeUrl?: string
+  tokenUrl?: string
+  scopes?: string[]
+}
+
+/** name → value map from repeatable header rows. */
+function headerMap(headers: Array<{ name: string; value: string }>): Record<string, string> {
+  return Object.fromEntries(headers.map((h) => [h.name, h.value]))
+}
+
 /**
  * Create an org-owned custom MCP server from a pasted URL.
- *  - `auto` → discover auth posture.
- *  - bearer/none → save connection (bearer) + sync → `{ connected: true }`.
- *  - oauth → DCR (or pasted client creds) → `{ needsOAuth }`; DCR failure → `{ needsClientCredentials }`.
+ *  - `auto` → discover auth posture (none or oauth).
+ *  - bearer/headers/none → save connection + sync → `{ connected: true }`.
+ *  - oauth → pasted client creds / DCR → `{ needsOAuth }`; DCR failure → `{ needsClientCredentials }`.
+ *    Manual authorize/token URL overrides skip discovery for servers without OAuth metadata.
  */
 export async function createCustomMcpServer(input: {
   organizationId: string
   createdById: string
   name: string
   endpoint: string
-  auth: 'auto' | 'bearer' | 'none'
+  auth: 'auto' | 'oauth' | 'bearer' | 'headers' | 'none'
   token?: string
   /** Non-`Authorization` header name for the bearer token (e.g. `X-API-Key`). */
   authHeaderName?: string
+  /** Custom-header auth rows (`auth: 'headers'`). */
+  headers?: Array<{ name: string; value: string }>
+  /** OAuth client creds + endpoint overrides (`auth: 'oauth'`, or auto-discovered OAuth). */
+  oauth?: McpOAuthConfigInput
   /** Enrichment lifted from the resolved snippet (registry / favicon). */
   description?: string
   icon?: McpServerIcon
-  clientId?: string
-  clientSecret?: string
   returnTo?: string
 }): Promise<McpConnectOutcome & { serverId: string; slug: string }> {
-  let mode: 'none' | 'bearer' | 'oauth' = input.auth === 'auto' ? 'none' : input.auth
-  let discovered: Awaited<ReturnType<typeof discoverMcpAuth>> | null = null
-  if (input.auth === 'auto') {
-    discovered = await discoverMcpAuth(input.endpoint)
-    if (discovered.isOk()) mode = discovered.value.kind === 'oauth' ? 'oauth' : 'none'
-  }
+  let mode: 'none' | 'bearer' | 'headers' | 'oauth' = input.auth === 'auto' ? 'none' : input.auth
+  const hasOAuthOverrides = !!(input.oauth?.authorizeUrl && input.oauth?.tokenUrl)
 
-  const oauth = discovered?.isOk() && discovered.value.kind === 'oauth' ? discovered.value : null
+  // Discovery runs for auto (to learn the posture) and for explicit OAuth without manual URLs.
+  let discovered: Awaited<ReturnType<typeof discoverMcpAuth>> | null = null
+  if (input.auth === 'auto' || (input.auth === 'oauth' && !hasOAuthOverrides)) {
+    discovered = await discoverMcpAuth(input.endpoint)
+    if (input.auth === 'auto' && discovered.isOk()) {
+      mode = discovered.value.kind === 'oauth' ? 'oauth' : 'none'
+    }
+  }
+  const oauthMeta =
+    discovered?.isOk() && discovered.value.kind === 'oauth' ? discovered.value : null
+
+  if (input.auth === 'oauth' && !hasOAuthOverrides && !oauthMeta) {
+    throw new Error(
+      'OAuth discovery failed for this endpoint — provide the authorize and token URLs under Advanced OAuth settings.'
+    )
+  }
 
   // Retry-safe: an org server already pointing at this endpoint is reused (e.g. clicking Connect
   // again after a missed OAuth popup result) instead of inserting a duplicate.
@@ -100,15 +131,26 @@ export async function createCustomMcpServer(input: {
   if (existing) {
     serverId = existing.id
     slug = existing.slug
-    if (input.clientId) {
+    if (input.oauth && Object.values(input.oauth).some((v) => v !== undefined)) {
       await db
         .update(schema.ConnectionDefinition)
         .set({
-          oauth2ClientId: input.clientId,
-          oauth2ClientSecret: input.clientSecret ?? null,
+          ...(input.oauth.clientId !== undefined && { oauth2ClientId: input.oauth.clientId }),
+          // Blank/omitted secret keeps the stored (possibly DCR-minted) one.
+          ...(input.oauth.clientSecret !== undefined && {
+            oauth2ClientSecret: input.oauth.clientSecret,
+          }),
+          ...(input.oauth.authorizeUrl !== undefined && {
+            oauth2AuthorizeUrl: input.oauth.authorizeUrl,
+          }),
+          ...(input.oauth.tokenUrl !== undefined && {
+            oauth2AccessTokenUrl: input.oauth.tokenUrl,
+          }),
+          ...(input.oauth.scopes !== undefined && { oauth2Scopes: input.oauth.scopes }),
         })
         .where(eq(schema.ConnectionDefinition.mcpServerId, serverId))
-    } else {
+    }
+    if (!input.oauth?.clientId) {
       const def = await db.query.ConnectionDefinition.findFirst({
         where: eq(schema.ConnectionDefinition.mcpServerId, serverId),
         columns: { oauth2ClientId: true },
@@ -127,10 +169,10 @@ export async function createCustomMcpServer(input: {
         description: input.description ?? null,
         icon: input.icon ?? null,
         createdById: input.createdById,
-        authDiscovery: oauth
+        authDiscovery: oauthMeta
           ? {
-              authorizationServer: oauth.authorizationServer,
-              registrationEndpoint: oauth.registrationEndpoint,
+              authorizationServer: oauthMeta.authorizationServer,
+              registrationEndpoint: oauthMeta.registrationEndpoint,
               discoveredAt: new Date().toISOString(),
             }
           : null,
@@ -139,7 +181,8 @@ export async function createCustomMcpServer(input: {
     if (!server) throw new Error('Failed to create McpServer')
     serverId = server.id
 
-    const connectionType = mode === 'oauth' ? 'oauth2-code' : mode === 'bearer' ? 'secret' : 'none'
+    const connectionType =
+      mode === 'oauth' ? 'oauth2-code' : mode === 'bearer' || mode === 'headers' ? 'secret' : 'none'
     await db.insert(schema.ConnectionDefinition).values({
       mcpServerId: serverId,
       major: 1,
@@ -147,11 +190,11 @@ export async function createCustomMcpServer(input: {
       label: `${input.name} Connection`,
       global: true,
       createdById: input.createdById,
-      oauth2AuthorizeUrl: oauth?.authorizeUrl ?? null,
-      oauth2AccessTokenUrl: oauth?.tokenUrl ?? null,
-      oauth2Scopes: oauth?.scopesSupported ?? [],
-      oauth2ClientId: input.clientId ?? null,
-      oauth2ClientSecret: input.clientSecret ?? null,
+      oauth2AuthorizeUrl: input.oauth?.authorizeUrl ?? oauthMeta?.authorizeUrl ?? null,
+      oauth2AccessTokenUrl: input.oauth?.tokenUrl ?? oauthMeta?.tokenUrl ?? null,
+      oauth2Scopes: input.oauth?.scopes ?? oauthMeta?.scopesSupported ?? [],
+      oauth2ClientId: input.oauth?.clientId ?? null,
+      oauth2ClientSecret: input.oauth?.clientSecret ?? null,
       oauth2Features: { pkce: true },
     })
     await db.insert(schema.McpInstallation).values({
@@ -162,7 +205,7 @@ export async function createCustomMcpServer(input: {
 
   await onCacheEvent('mcp.server.changed', { orgId: input.organizationId })
 
-  if (mode === 'none' || mode === 'bearer') {
+  if (mode === 'none' || mode === 'bearer' || mode === 'headers') {
     if (mode === 'bearer' && input.token) {
       const saved = await saveMcpConnection({
         mcpServerId: serverId,
@@ -178,6 +221,22 @@ export async function createCustomMcpServer(input: {
       })
       if (saved.isErr()) throw new Error(saved.error.message)
     }
+    if (mode === 'headers' && input.headers?.length) {
+      const saved = await saveMcpConnection({
+        mcpServerId: serverId,
+        serverName: input.name,
+        organizationId: input.organizationId,
+        createdById: input.createdById,
+        connectionData: {
+          headers: headerMap(input.headers),
+          // Header NAMES are not secrets — kept in plaintext metadata so the edit
+          // dialog can prefill rows (and getBySlug can derive the auth posture)
+          // without decrypting.
+          metadata: { headerNames: input.headers.map((h) => h.name) },
+        },
+      })
+      if (saved.isErr()) throw new Error(saved.error.message)
+    }
     await syncMcpTools({ mcpServerId: serverId, organizationId: input.organizationId })
     await onCacheEvent('mcp.connection.changed', { orgId: input.organizationId })
     return { connected: true, serverId, slug }
@@ -188,12 +247,42 @@ export async function createCustomMcpServer(input: {
     serverId,
     organizationId: input.organizationId,
     serverName: input.name,
-    registrationEndpoint: oauth?.registrationEndpoint,
-    pastedClientId: input.clientId,
+    registrationEndpoint: oauthMeta?.registrationEndpoint,
+    pastedClientId: input.oauth?.clientId,
     existingClientId,
     returnTo: input.returnTo,
   })
   return { ...outcome, serverId, slug }
+}
+
+/**
+ * Connect a catalog template for an org: upsert the curated/global row from the template
+ * definition (so new templates work in every environment without a re-seed), then run the
+ * normal curated connect flow.
+ */
+export async function connectMcpTemplate(input: {
+  organizationId: string
+  createdById: string
+  templateId: string
+  connectionVariables?: Record<string, string>
+  token?: string
+  returnTo?: string
+}): Promise<McpConnectOutcome & { serverId: string; slug: string }> {
+  const template = mcpTemplates.find((t) => t.id === input.templateId)
+  if (!template) throw new Error(`Unknown MCP template '${input.templateId}'`)
+
+  const { serverId } = await ensureCuratedMcpServer(template)
+  await onCacheEvent('mcp.server.changed', { orgId: input.organizationId })
+
+  const outcome = await connectCuratedMcpServer({
+    organizationId: input.organizationId,
+    createdById: input.createdById,
+    serverId,
+    connectionVariables: input.connectionVariables,
+    token: input.token,
+    returnTo: input.returnTo,
+  })
+  return { ...outcome, serverId, slug: template.id }
 }
 
 /**
@@ -365,10 +454,10 @@ async function ensureOAuthClient(input: {
 }
 
 /**
- * Update an org-owned custom server (rename, endpoint, bearer/none auth) and/or its trust config;
- * busts the cache. OAuth (re)connection stays on the detail page's reconnect button — switching a
- * server *into* OAuth here is out of scope (the endpoint/name still update). `auth: 'auto'` leaves
- * the existing connection untouched.
+ * Update an org-owned custom server (rename, endpoint, auth) and/or its trust config; busts the
+ * cache. OAuth (re)connection stays on the detail page's reconnect button — `auth: 'oauth'` only
+ * updates the definition's client creds / endpoint overrides. `auth: 'auto'` leaves the existing
+ * connection untouched.
  */
 export async function updateMcpServer(input: {
   organizationId: string
@@ -377,9 +466,12 @@ export async function updateMcpServer(input: {
   updatedById?: string
   name?: string
   endpoint?: string
-  auth?: 'auto' | 'bearer' | 'none'
+  auth?: 'auto' | 'oauth' | 'bearer' | 'headers' | 'none'
   token?: string
   authHeaderName?: string
+  /** Custom-header rows — full replace when provided; omit to keep the existing headers. */
+  headers?: Array<{ name: string; value: string }>
+  oauth?: McpOAuthConfigInput
   trust?: { allTools?: boolean; tools?: string[] }
 }): Promise<void> {
   const serverPatch: { name?: string; endpoint?: string } = {}
@@ -399,7 +491,12 @@ export async function updateMcpServer(input: {
 
   await applyAuthUpdate(input)
 
-  if (input.endpoint || input.auth === 'bearer' || input.auth === 'none') {
+  if (
+    input.endpoint ||
+    input.auth === 'bearer' ||
+    input.auth === 'headers' ||
+    input.auth === 'none'
+  ) {
     // Endpoint or credential changed → re-probe tools (best-effort; ignore failures).
     await syncMcpTools({ mcpServerId: input.serverId, organizationId: input.organizationId })
   }
@@ -418,16 +515,42 @@ export async function updateMcpServer(input: {
   await onCacheEvent('mcp.tools.synced', { orgId: input.organizationId })
 }
 
-/** Apply a bearer/none auth change on update: re-save (or clear) the org secret + header metadata. */
+/** Apply an auth change on update: re-save (or clear) the org secret + definition type. */
 async function applyAuthUpdate(input: {
   organizationId: string
   serverId: string
   updatedById?: string
-  auth?: 'auto' | 'bearer' | 'none'
+  auth?: 'auto' | 'oauth' | 'bearer' | 'headers' | 'none'
   token?: string
   authHeaderName?: string
+  headers?: Array<{ name: string; value: string }>
+  oauth?: McpOAuthConfigInput
 }): Promise<void> {
-  if (input.auth !== 'bearer' && input.auth !== 'none') return
+  if (!input.auth || input.auth === 'auto') return
+
+  if (input.auth === 'oauth') {
+    // Definition-only: client creds / endpoint overrides. Reconnecting (the popup) stays on the
+    // detail page — provided fields update, omitted fields keep their (possibly DCR-minted) values.
+    await db
+      .update(schema.ConnectionDefinition)
+      .set({
+        connectionType: 'oauth2-code',
+        ...(input.oauth?.clientId !== undefined && { oauth2ClientId: input.oauth.clientId }),
+        // Blank/omitted secret keeps the stored (possibly DCR-minted) one.
+        ...(input.oauth?.clientSecret !== undefined && {
+          oauth2ClientSecret: input.oauth.clientSecret,
+        }),
+        ...(input.oauth?.authorizeUrl !== undefined && {
+          oauth2AuthorizeUrl: input.oauth.authorizeUrl,
+        }),
+        ...(input.oauth?.tokenUrl !== undefined && {
+          oauth2AccessTokenUrl: input.oauth.tokenUrl,
+        }),
+        ...(input.oauth?.scopes !== undefined && { oauth2Scopes: input.oauth.scopes }),
+      })
+      .where(eq(schema.ConnectionDefinition.mcpServerId, input.serverId))
+    return
+  }
 
   if (input.auth === 'none') {
     await db
@@ -439,12 +562,28 @@ async function applyAuthUpdate(input: {
     return
   }
 
-  // bearer — only re-save when a token was supplied (an empty token keeps the existing secret).
+  // bearer/headers — only re-save when new secret material was supplied (blank keeps existing).
   await db
     .update(schema.ConnectionDefinition)
     .set({ connectionType: 'secret' })
     .where(eq(schema.ConnectionDefinition.mcpServerId, input.serverId))
-  if (!input.token) return
+  const connectionData =
+    input.auth === 'bearer'
+      ? input.token
+        ? {
+            secret: input.token,
+            metadata: input.authHeaderName
+              ? { authHeader: { name: input.authHeaderName } }
+              : undefined,
+          }
+        : null
+      : input.headers?.length
+        ? {
+            headers: headerMap(input.headers),
+            metadata: { headerNames: input.headers.map((h) => h.name) },
+          }
+        : null
+  if (!connectionData) return
 
   const existing = await findCredential({
     kind: 'mcp',
@@ -462,10 +601,7 @@ async function applyAuthUpdate(input: {
     serverName: server?.name ?? 'MCP',
     organizationId: input.organizationId,
     createdById: input.updatedById ?? server?.createdById ?? '',
-    connectionData: {
-      secret: input.token,
-      metadata: input.authHeaderName ? { authHeader: { name: input.authHeaderName } } : undefined,
-    },
+    connectionData,
     connectionId: existingId,
   })
   if (saved.isErr()) throw new Error(saved.error.message)

--- a/packages/lib/src/ai/mcp/templates/__tests__/catalog.test.ts
+++ b/packages/lib/src/ai/mcp/templates/__tests__/catalog.test.ts
@@ -1,0 +1,46 @@
+// packages/lib/src/ai/mcp/templates/__tests__/catalog.test.ts
+//
+// Sanity checks over the static catalog — pure data, no mocks.
+
+import { describe, expect, it } from 'vitest'
+import { mcpTemplateCategories, mcpTemplates } from '../catalog'
+
+describe('mcpTemplates catalog', () => {
+  it('has unique, slug-shaped ids', () => {
+    const ids = mcpTemplates.map((t) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    for (const id of ids) expect(id).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/)
+  })
+
+  it('keeps the originally-seeded slugs stable', () => {
+    // These predate the catalog (seeded rows exist in prod) — the upsert must match them in place.
+    const ids = new Set(mcpTemplates.map((t) => t.id))
+    expect(ids.has('linear')).toBe(true)
+    expect(ids.has('notion')).toBe(true)
+    expect(ids.has('shopify')).toBe(true)
+  })
+
+  it('only uses declared categories', () => {
+    const known = new Set(mcpTemplateCategories.map((c) => c.value))
+    for (const t of mcpTemplates) {
+      expect(t.categories.length).toBeGreaterThan(0)
+      for (const c of t.categories) expect(known.has(c)).toBe(true)
+    }
+  })
+
+  it('has https endpoints that parse as URLs (placeholders substituted)', () => {
+    for (const t of mcpTemplates) {
+      const resolved = t.endpoint.replace(/\{[^}]+\}/g, 'placeholder')
+      const url = new URL(resolved)
+      expect(url.protocol).toBe('https:')
+    }
+  })
+
+  it('declares a connection variable for every endpoint placeholder', () => {
+    for (const t of mcpTemplates) {
+      const placeholders = t.endpoint.match(/\{([^}]+)\}/g)?.map((m) => m.slice(1, -1)) ?? []
+      const declared = new Set((t.connectionVariables ?? []).map((v) => v.key))
+      for (const p of placeholders) expect(declared.has(p)).toBe(true)
+    }
+  })
+})

--- a/packages/lib/src/ai/mcp/templates/__tests__/ensure.test.ts
+++ b/packages/lib/src/ai/mcp/templates/__tests__/ensure.test.ts
@@ -1,0 +1,144 @@
+// packages/lib/src/ai/mcp/templates/__tests__/ensure.test.ts
+//
+// The upsert contract: insert-new, update-in-place keeping the row id (McpInstallation FKs),
+// and definition updates that never touch lazily-discovered OAuth URLs / DCR client creds.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('drizzle-orm', () => ({
+  and: (...a: unknown[]) => ({ and: a }),
+  eq: (...a: unknown[]) => ({ eq: a }),
+  isNull: (...a: unknown[]) => ({ isNull: a }),
+}))
+
+vi.mock('@auxx/database', () => ({
+  schema: {
+    McpServer: { _name: 'McpServer' },
+    ConnectionDefinition: { _name: 'ConnectionDefinition' },
+  },
+  database: {},
+}))
+
+import type { McpTemplate } from '../catalog'
+import { ensureCuratedMcpServer } from '../ensure'
+
+const state = {
+  serverRows: [] as Array<{ id: string }>,
+  defRows: [] as Array<{ id: string }>,
+  inserts: [] as Array<{ table: string; values: Record<string, unknown> }>,
+  updates: [] as Array<{ table: string; values: Record<string, unknown> }>,
+}
+
+const tableName = (t: unknown) => (t as { _name?: string })?._name ?? 'unknown'
+
+/** Minimal select/insert/update chain matching exactly what ensure.ts calls. */
+const fakeDb = {
+  select: () => ({
+    from: (table: unknown) => ({
+      where: () => ({
+        limit: async () => (tableName(table) === 'McpServer' ? state.serverRows : state.defRows),
+      }),
+    }),
+  }),
+  insert: (table: unknown) => ({
+    values: (values: Record<string, unknown>) => {
+      state.inserts.push({ table: tableName(table), values })
+      const promise = Promise.resolve(undefined) as Promise<undefined> & {
+        returning: () => Promise<Array<{ id: string }>>
+      }
+      promise.returning = async () => [{ id: 'srv-new' }]
+      return promise
+    },
+  }),
+  update: (table: unknown) => ({
+    set: (values: Record<string, unknown>) => {
+      state.updates.push({ table: tableName(table), values })
+      return { where: async () => undefined }
+    },
+  }),
+  // biome-ignore lint/suspicious/noExplicitAny: structural stand-in for the Drizzle Database type
+} as any
+
+const TEMPLATE: McpTemplate = {
+  id: 'linear',
+  name: 'Linear',
+  description: 'Linear issues.',
+  icon: { iconId: 'https://linear.app/favicon.ico' },
+  categories: ['project-management'],
+  endpoint: 'https://mcp.linear.app/mcp',
+  connectionType: 'oauth2-code',
+}
+
+beforeEach(() => {
+  state.serverRows = []
+  state.defRows = []
+  state.inserts = []
+  state.updates = []
+})
+
+describe('ensureCuratedMcpServer', () => {
+  it('inserts a new global server + connection definition when none exist', async () => {
+    const { serverId } = await ensureCuratedMcpServer(TEMPLATE, fakeDb)
+
+    expect(serverId).toBe('srv-new')
+    const serverInsert = state.inserts.find((i) => i.table === 'McpServer')
+    expect(serverInsert?.values).toMatchObject({
+      organizationId: null,
+      slug: 'linear',
+      name: 'Linear',
+      endpoint: 'https://mcp.linear.app/mcp',
+      createdById: null,
+    })
+    const defInsert = state.inserts.find((i) => i.table === 'ConnectionDefinition')
+    expect(defInsert?.values).toMatchObject({
+      mcpServerId: 'srv-new',
+      connectionType: 'oauth2-code',
+      global: true,
+      oauth2Features: { pkce: true, connectionVariables: [] },
+    })
+    expect(state.updates).toHaveLength(0)
+  })
+
+  it('updates an existing server in place, keeping the row id stable', async () => {
+    state.serverRows = [{ id: 'srv-existing' }]
+    state.defRows = [{ id: 'def-existing' }]
+
+    const { serverId } = await ensureCuratedMcpServer(TEMPLATE, fakeDb)
+
+    expect(serverId).toBe('srv-existing')
+    expect(state.inserts).toHaveLength(0)
+    expect(state.updates.map((u) => u.table)).toEqual(['McpServer', 'ConnectionDefinition'])
+  })
+
+  it('never overwrites lazily-discovered OAuth URLs or client creds on the definition', async () => {
+    state.serverRows = [{ id: 'srv-existing' }]
+    state.defRows = [{ id: 'def-existing' }]
+
+    await ensureCuratedMcpServer(TEMPLATE, fakeDb)
+
+    const defUpdate = state.updates.find((u) => u.table === 'ConnectionDefinition')
+    expect(Object.keys(defUpdate?.values ?? {}).sort()).toEqual([
+      'connectionType',
+      'label',
+      'oauth2Features',
+    ])
+  })
+
+  it('carries connection variables into oauth2Features', async () => {
+    await ensureCuratedMcpServer(
+      {
+        ...TEMPLATE,
+        id: 'shopify',
+        connectionType: 'none',
+        connectionVariables: [{ key: 'shop', label: 'Shop subdomain', required: true }],
+      },
+      fakeDb
+    )
+
+    const defInsert = state.inserts.find((i) => i.table === 'ConnectionDefinition')
+    expect(defInsert?.values.oauth2Features).toEqual({
+      pkce: false,
+      connectionVariables: [{ key: 'shop', label: 'Shop subdomain', required: true }],
+    })
+  })
+})

--- a/packages/lib/src/ai/mcp/templates/catalog.ts
+++ b/packages/lib/src/ai/mcp/templates/catalog.ts
@@ -1,0 +1,187 @@
+// packages/lib/src/ai/mcp/templates/catalog.ts
+//
+// Ship-with-the-code MCP server templates surfaced in the "Connect from template" dialog
+// (Settings → Apps). Pure data — no DB, no tRPC. The catalog is served to the client via
+// `mcp.listTemplates` (it never ships in the client bundle) and is the source of truth for
+// curated/global McpServer rows: `ensureCuratedMcpServer` upserts a row at connect time, and
+// `@auxx/seed`'s McpDomain loops the same catalog for fresh installs.
+
+import type { ConnectionVariable, McpServerIcon } from '@auxx/database'
+
+export type McpTemplateCategory =
+  | 'dev-tools'
+  | 'project-management'
+  | 'commerce'
+  | 'data-search'
+  | 'productivity'
+
+export interface McpTemplateCategoryDef {
+  value: McpTemplateCategory | 'all'
+  label: string
+  /** Lucide icon name, resolved via the dialog's icon registry (agent-template-dialog pattern). */
+  icon: string
+}
+
+export interface McpTemplate {
+  /** Stable kebab-case slug — becomes the global McpServer.slug (tool namespace mcp__<slug>__). */
+  id: string
+  name: string
+  description: string
+  /** `iconId` is a logo/favicon URL rendered by AppIcon. */
+  icon?: McpServerIcon
+  categories: McpTemplateCategory[]
+  /** Streamable HTTP endpoint; may contain `{connectionVariable}` placeholders. */
+  endpoint: string
+  /** oauth2-code → OAuth 2.1 (client creds minted lazily via DCR on first connect). */
+  connectionType: 'oauth2-code' | 'secret' | 'none'
+  /** Variables the org must supply at connect time (interpolated into the endpoint). */
+  connectionVariables?: ConnectionVariable[]
+  /** Provider docs for the connect step (e.g. where to find the API key). */
+  docsUrl?: string
+}
+
+export const mcpTemplateCategories: McpTemplateCategoryDef[] = [
+  { value: 'all', label: 'All templates', icon: 'LayoutGrid' },
+  { value: 'dev-tools', label: 'Developer tools', icon: 'Code' },
+  { value: 'project-management', label: 'Project management', icon: 'ListTodo' },
+  { value: 'commerce', label: 'Commerce', icon: 'ShoppingCart' },
+  { value: 'data-search', label: 'Data & search', icon: 'Search' },
+  { value: 'productivity', label: 'Productivity', icon: 'Zap' },
+]
+
+/**
+ * Endpoints + auth posture verified against live provider docs (2026-06). All endpoints are
+ * Streamable HTTP. The `linear`/`notion`/`shopify` slugs predate this catalog (originally seeded
+ * by @auxx/seed) — keep them stable so the upsert matches existing rows in place.
+ */
+export const mcpTemplates: McpTemplate[] = [
+  {
+    id: 'linear',
+    name: 'Linear',
+    description: 'Find, create, and update Linear issues, projects, and comments.',
+    icon: { iconId: 'https://linear.app/favicon.ico' },
+    categories: ['project-management'],
+    endpoint: 'https://mcp.linear.app/mcp',
+    connectionType: 'oauth2-code',
+    docsUrl: 'https://linear.app/docs/mcp',
+  },
+  {
+    id: 'notion',
+    name: 'Notion',
+    description: 'Search, read, and update pages and databases in your Notion workspace.',
+    icon: { iconId: 'https://www.notion.so/favicon.ico' },
+    categories: ['productivity', 'project-management'],
+    endpoint: 'https://mcp.notion.com/mcp',
+    connectionType: 'oauth2-code',
+    docsUrl: 'https://developers.notion.com/docs/mcp',
+  },
+  {
+    id: 'shopify',
+    name: 'Shopify Storefront',
+    description: 'Search products, manage carts, and read store policies on a Shopify storefront.',
+    icon: { iconId: 'https://www.shopify.com/favicon.ico' },
+    categories: ['commerce'],
+    endpoint: 'https://{shop}.myshopify.com/api/mcp',
+    connectionType: 'none',
+    connectionVariables: [
+      {
+        key: 'shop',
+        label: 'Shop subdomain',
+        description: 'Only the subdomain, e.g. my-store from my-store.myshopify.com',
+        placeholder: 'my-store',
+        required: true,
+      },
+    ],
+    docsUrl: 'https://shopify.dev/docs/apps/build/storefront-mcp',
+  },
+  {
+    id: 'github',
+    name: 'GitHub',
+    description: 'Read repositories, issues, and pull requests; create and update issues.',
+    icon: { iconId: 'https://github.com/favicon.ico' },
+    categories: ['dev-tools'],
+    endpoint: 'https://api.githubcopilot.com/mcp/',
+    connectionType: 'oauth2-code',
+    docsUrl: 'https://github.com/github/github-mcp-server',
+  },
+  {
+    id: 'sentry',
+    name: 'Sentry',
+    description: 'Query Sentry issues, events, and projects to debug production errors.',
+    icon: { iconId: 'https://sentry.io/favicon.ico' },
+    categories: ['dev-tools'],
+    endpoint: 'https://mcp.sentry.dev/mcp',
+    connectionType: 'oauth2-code',
+    docsUrl: 'https://docs.sentry.io/product/sentry-mcp/',
+  },
+  {
+    id: 'stripe',
+    name: 'Stripe',
+    description: 'Look up customers, payments, subscriptions, and invoices in Stripe.',
+    icon: { iconId: 'https://stripe.com/favicon.ico' },
+    categories: ['commerce'],
+    endpoint: 'https://mcp.stripe.com',
+    connectionType: 'oauth2-code',
+    docsUrl: 'https://docs.stripe.com/mcp',
+  },
+  {
+    id: 'paypal',
+    name: 'PayPal',
+    description: 'Manage PayPal invoices, orders, and transactions.',
+    icon: { iconId: 'https://www.paypal.com/favicon.ico' },
+    categories: ['commerce'],
+    endpoint: 'https://mcp.paypal.com/mcp',
+    connectionType: 'oauth2-code',
+    docsUrl: 'https://developer.paypal.com/tools/mcp-server/',
+  },
+  {
+    id: 'context7',
+    name: 'Context7',
+    description: 'Fetch up-to-date documentation and code examples for any library.',
+    icon: { iconId: 'https://context7.com/favicon.ico' },
+    categories: ['dev-tools', 'data-search'],
+    endpoint: 'https://mcp.context7.com/mcp',
+    connectionType: 'none',
+    docsUrl: 'https://context7.com',
+  },
+  {
+    id: 'huggingface',
+    name: 'Hugging Face',
+    description: 'Search models, datasets, papers, and Spaces on the Hugging Face Hub.',
+    icon: { iconId: 'https://huggingface.co/favicon.ico' },
+    categories: ['data-search'],
+    endpoint: 'https://huggingface.co/mcp',
+    connectionType: 'secret',
+    docsUrl: 'https://huggingface.co/settings/mcp',
+  },
+  {
+    id: 'zapier',
+    name: 'Zapier',
+    description: 'Trigger Zapier actions across thousands of connected apps.',
+    icon: { iconId: 'https://zapier.com/favicon.ico' },
+    categories: ['productivity'],
+    endpoint: 'https://mcp.zapier.com/api/mcp/mcp',
+    connectionType: 'secret',
+    docsUrl: 'https://zapier.com/mcp',
+  },
+  {
+    id: 'deepwiki',
+    name: 'DeepWiki',
+    description: 'Ask questions about any public GitHub repository, answered from its docs.',
+    icon: { iconId: 'https://deepwiki.com/favicon.ico' },
+    categories: ['dev-tools', 'data-search'],
+    endpoint: 'https://mcp.deepwiki.com/mcp',
+    connectionType: 'none',
+    docsUrl: 'https://docs.devin.ai/work-with-devin/deepwiki-mcp',
+  },
+  {
+    id: 'exa',
+    name: 'Exa Search',
+    description: 'Web search and content crawling built for AI agents.',
+    icon: { iconId: 'https://exa.ai/favicon.ico' },
+    categories: ['data-search'],
+    endpoint: 'https://mcp.exa.ai/mcp',
+    connectionType: 'secret',
+    docsUrl: 'https://docs.exa.ai/reference/exa-mcp',
+  },
+]

--- a/packages/lib/src/ai/mcp/templates/ensure.ts
+++ b/packages/lib/src/ai/mcp/templates/ensure.ts
@@ -1,0 +1,87 @@
+// packages/lib/src/ai/mcp/templates/ensure.ts
+
+import { type Database, database as defaultDb, schema } from '@auxx/database'
+import { and, eq, isNull } from 'drizzle-orm'
+import type { McpTemplate } from './catalog'
+
+/**
+ * Upsert the curated/global (`organizationId: null`) McpServer + ConnectionDefinition for a
+ * template. Called at connect time (so new templates work without a re-seed) and from
+ * `@auxx/seed`'s McpDomain for fresh installs.
+ *
+ * Idempotency is manual: the `McpServer_org_slug_idx` unique index is on
+ * `(organizationId, slug)` and Postgres treats NULL organizationIds as DISTINCT, so
+ * `onConflictDoNothing` would not dedupe global rows. We SELECT by slug and update in place,
+ * keeping the row id stable so existing McpInstallations keep their FK.
+ *
+ * On update, only template-owned fields are written — authorize/token URLs and DCR-minted
+ * client creds on the definition are filled lazily on first connect and must survive re-upserts.
+ */
+export async function ensureCuratedMcpServer(
+  template: McpTemplate,
+  db: Database = defaultDb
+): Promise<{ serverId: string }> {
+  const existing = await db
+    .select({ id: schema.McpServer.id })
+    .from(schema.McpServer)
+    .where(and(isNull(schema.McpServer.organizationId), eq(schema.McpServer.slug, template.id)))
+    .limit(1)
+
+  const serverValues = {
+    organizationId: null,
+    slug: template.id,
+    name: template.name,
+    description: template.description,
+    icon: template.icon ?? null,
+    endpoint: template.endpoint,
+    // Curated rows are catalog-authored, not user-authored — `createdById` FKs to User.
+    createdById: null,
+  }
+
+  let serverId: string
+  if (existing.length > 0) {
+    serverId = existing[0]!.id
+    await db.update(schema.McpServer).set(serverValues).where(eq(schema.McpServer.id, serverId))
+  } else {
+    const [created] = await db
+      .insert(schema.McpServer)
+      .values(serverValues)
+      .returning({ id: schema.McpServer.id })
+    if (!created) throw new Error(`Failed to insert curated MCP server '${template.id}'`)
+    serverId = created.id
+  }
+
+  const oauth2Features = {
+    pkce: template.connectionType === 'oauth2-code',
+    connectionVariables: template.connectionVariables ?? [],
+  }
+
+  const existingDef = await db
+    .select({ id: schema.ConnectionDefinition.id })
+    .from(schema.ConnectionDefinition)
+    .where(eq(schema.ConnectionDefinition.mcpServerId, serverId))
+    .limit(1)
+
+  if (existingDef.length > 0) {
+    await db
+      .update(schema.ConnectionDefinition)
+      .set({
+        connectionType: template.connectionType,
+        label: `${template.name} Connection`,
+        oauth2Features,
+      })
+      .where(eq(schema.ConnectionDefinition.id, existingDef[0]!.id))
+  } else {
+    await db.insert(schema.ConnectionDefinition).values({
+      mcpServerId: serverId,
+      major: 1,
+      connectionType: template.connectionType,
+      label: `${template.name} Connection`,
+      global: true,
+      createdById: 'system',
+      oauth2Features,
+    })
+  }
+
+  return { serverId }
+}

--- a/packages/lib/src/ai/mcp/templates/index.ts
+++ b/packages/lib/src/ai/mcp/templates/index.ts
@@ -1,0 +1,5 @@
+// packages/lib/src/ai/mcp/templates/index.ts
+
+export type { McpTemplate, McpTemplateCategory, McpTemplateCategoryDef } from './catalog'
+export { mcpTemplateCategories, mcpTemplates } from './catalog'
+export { ensureCuratedMcpServer } from './ensure'

--- a/packages/seed/src/domains/mcp.domain.ts
+++ b/packages/seed/src/domains/mcp.domain.ts
@@ -1,150 +1,28 @@
 // packages/seed/src/domains/mcp.domain.ts
 // Idempotent seeder for curated (global) MCP servers available to every organization.
 
-import type { ConnectionVariable, Database, McpServerIcon } from '@auxx/database'
+import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 
 const logger = createScopedLogger('mcp-domain')
 
-/** A curated MCP server + its connection posture, seeded as a global (org-less) row. */
-interface CuratedMcpServer {
-  slug: string
-  name: string
-  description: string
-  icon?: McpServerIcon
-  /** Streamable HTTP endpoint; may contain `{connectionVariable}` placeholders. */
-  endpoint: string
-  /** oauth2-code → OAuth 2.1 (client creds minted lazily via DCR on first connect). */
-  connectionType: 'oauth2-code' | 'secret' | 'none'
-  /** Variables the org must supply at connect time (interpolated into the endpoint). */
-  connectionVariables?: ConnectionVariable[]
-}
-
-/**
- * Curated servers. Endpoints + auth posture verified against live provider docs (2026-06):
- *  - Linear/Notion: hosted, OAuth 2.1 + Dynamic Client Registration (no static client creds).
- *  - Shopify storefront: public per-store endpoint, no auth; needs the shop subdomain.
- */
-const CURATED_SERVERS: CuratedMcpServer[] = [
-  {
-    slug: 'linear',
-    name: 'Linear',
-    description: 'Find, create, and update Linear issues, projects, and comments.',
-    endpoint: 'https://mcp.linear.app/mcp',
-    connectionType: 'oauth2-code',
-  },
-  {
-    slug: 'notion',
-    name: 'Notion',
-    description: 'Search, read, and update pages and databases in your Notion workspace.',
-    endpoint: 'https://mcp.notion.com/mcp',
-    connectionType: 'oauth2-code',
-  },
-  {
-    slug: 'shopify',
-    name: 'Shopify Storefront',
-    description: 'Search products, manage carts, and read store policies on a Shopify storefront.',
-    endpoint: 'https://{shop}.myshopify.com/api/mcp',
-    connectionType: 'none',
-    connectionVariables: [
-      {
-        key: 'shop',
-        label: 'Shop subdomain',
-        description: 'Only the subdomain, e.g. my-store from my-store.myshopify.com',
-        placeholder: 'my-store',
-        required: true,
-      },
-    ],
-  },
-]
-
 /**
  * McpDomain upserts the curated/global MCP servers (`organizationId: null`) that every
- * organization can browse and connect from Settings → Apps.
- *
- * Idempotency is manual: the `McpServer_org_slug_idx` unique index is on
- * `(organizationId, slug)` and Postgres treats NULL organizationIds as DISTINCT, so
- * `onConflictDoNothing` would not dedupe global rows. We therefore SELECT by slug
- * (organizationId IS NULL) and update in place, keeping the row id stable so existing
- * McpInstallations keep their FK.
+ * organization can browse and connect from Settings → Apps. The catalog lives in
+ * `@auxx/lib/ai/mcp` (templates module) — it is also upserted lazily at connect time, so this
+ * seeder only matters for fresh installs and keeping long-lived environments tidy.
  */
 export class McpDomain {
   /**
-   * Upserts all curated servers + their connection definitions. Safe to re-run.
+   * Upserts all catalog templates + their connection definitions. Safe to re-run.
    * @param db - Drizzle database instance.
    */
   async insertDirectly(db: Database): Promise<void> {
-    const { schema } = await import('@auxx/database')
-    const { and, eq, isNull } = await import('drizzle-orm')
+    const { ensureCuratedMcpServer, mcpTemplates } = await import('@auxx/lib/ai/mcp')
 
-    for (const curated of CURATED_SERVERS) {
-      const existing = await db
-        .select({ id: schema.McpServer.id })
-        .from(schema.McpServer)
-        .where(
-          and(isNull(schema.McpServer.organizationId), eq(schema.McpServer.slug, curated.slug))
-        )
-        .limit(1)
-
-      const serverValues = {
-        organizationId: null,
-        slug: curated.slug,
-        name: curated.name,
-        description: curated.description,
-        icon: curated.icon ?? null,
-        endpoint: curated.endpoint,
-        // Curated rows are seeded, not user-authored — `createdById` FKs to User (set null).
-        createdById: null,
-      }
-
-      let serverId: string
-      if (existing.length > 0) {
-        serverId = existing[0]!.id
-        await db.update(schema.McpServer).set(serverValues).where(eq(schema.McpServer.id, serverId))
-        logger.info('Updated curated MCP server', { slug: curated.slug })
-      } else {
-        const [created] = await db
-          .insert(schema.McpServer)
-          .values(serverValues)
-          .returning({ id: schema.McpServer.id })
-        serverId = created!.id
-        logger.info('Inserted curated MCP server', { slug: curated.slug })
-      }
-
-      // Connection definition (one per server). OAuth servers carry only `pkce: true` +
-      // connectionVariables; authorize/token URLs and DCR-minted client creds are filled
-      // lazily by `connectCuratedMcpServer` on first org connect.
-      const defValues = {
-        mcpServerId: serverId,
-        major: 1,
-        connectionType: curated.connectionType,
-        label: `${curated.name} Connection`,
-        global: true,
-        createdById: 'system',
-        oauth2Features: {
-          pkce: curated.connectionType === 'oauth2-code',
-          connectionVariables: curated.connectionVariables ?? [],
-        },
-      }
-
-      const existingDef = await db
-        .select({ id: schema.ConnectionDefinition.id })
-        .from(schema.ConnectionDefinition)
-        .where(eq(schema.ConnectionDefinition.mcpServerId, serverId))
-        .limit(1)
-
-      if (existingDef.length > 0) {
-        await db
-          .update(schema.ConnectionDefinition)
-          .set({
-            connectionType: defValues.connectionType,
-            label: defValues.label,
-            oauth2Features: defValues.oauth2Features,
-          })
-          .where(eq(schema.ConnectionDefinition.id, existingDef[0]!.id))
-      } else {
-        await db.insert(schema.ConnectionDefinition).values(defValues)
-      }
+    for (const template of mcpTemplates) {
+      await ensureCuratedMcpServer(template, db)
+      logger.info('Upserted curated MCP server', { slug: template.id })
     }
   }
 }


### PR DESCRIPTION
## Summary

Expands MCP server connection support with three capabilities and tightens the apps UI around them.

- **Templates** — adds an MCP template catalog (`templates/catalog.ts`) and an `ensureCuratedMcpServer` helper, exposed through `@auxx/lib/ai/mcp`, a `listTemplates` tRPC query, and a new template-picker dialog.
- **Custom-header auth** — new `'headers'` auth posture wired end-to-end: connection `types`, `save-mcp-connection`/`resolve-mcp-connection-for-runtime`, `manage` create/update, and repeatable header form fields (`connection-variable-fields.tsx`).
- **Manual OAuth config** — `McpOAuthConfigInput` (clientId/secret + authorizeUrl/tokenUrl/scopes) lets servers without discoverable RFC 9728/8414 metadata connect by pasting endpoints under Advanced OAuth settings; discovery is skipped when both URLs are provided.
- **Apps UI** — adds `use-uninstall-app` hook and refreshes the installed/apps pages, app list card, and MCP apps section/cards.

## Test plan

- [x] Unit tests added for template catalog + ensure (`templates/__tests__/`)
- [x] Extended `manage.test.ts` for the new auth/OAuth paths
- [ ] Manual: connect a custom-header server and a manual-OAuth server from the dialog
- [ ] Manual: install/uninstall a template from the apps section