### PR TITLE
refactor(ui): polish credential dialog and MCP tool list

### DIFF
--- a/apps/web/src/components/ai/ui/credential-configuration-dialog.tsx
+++ b/apps/web/src/components/ai/ui/credential-configuration-dialog.tsx
@@ -8,6 +8,7 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -28,6 +29,7 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from '@auxx/ui/components/input-group'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { Label } from '@auxx/ui/components/label'
 import { RadioGroup, RadioGroupItem } from '@auxx/ui/components/radio-group'
 import {
@@ -41,7 +43,7 @@ import { Separator } from '@auxx/ui/components/separator'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-import { Eye, EyeOff, PlusIcon } from 'lucide-react'
+import { Eye, EyeOff, PlusIcon, Trash2 } from 'lucide-react'
 import type React from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -676,23 +678,21 @@ export function CredentialConfigurationDialog({
                             <RadioGroup
                               value={field.value}
                               onValueChange={field.onChange}
-                              className='flex flex-wrap gap-3 grid-cols-4'>
+                              className='flex flex-wrap gap-2'>
                               {availableModelTypes.map((option) => (
                                 <div
                                   key={option.value}
-                                  className='relative flex flex-col flex-1 gap-3 rounded-md border border-input p-4 shadow-xs outline-none has-[&_[data-state=checked]]:border-info'>
-                                  <div className='flex items-center gap-2'>
-                                    <RadioGroupItem
-                                      id={`modelType-${option.value}`}
-                                      value={option.value}
-                                      className='peer after:absolute after:inset-0'
-                                    />
-                                    <Label
-                                      htmlFor={`modelType-${option.value}`}
-                                      className='font-medium cursor-pointer peer-data-[state=checked]:text-info'>
-                                      {option.label}
-                                    </Label>
-                                  </div>
+                                  className='relative flex items-center gap-2 rounded-md border border-input px-3 py-2 shadow-xs outline-none has-[&_[data-state=checked]]:border-info'>
+                                  <RadioGroupItem
+                                    id={`modelType-${option.value}`}
+                                    value={option.value}
+                                    className='peer after:absolute after:inset-0'
+                                  />
+                                  <Label
+                                    htmlFor={`modelType-${option.value}`}
+                                    className='font-medium whitespace-nowrap cursor-pointer peer-data-[state=checked]:text-info'>
+                                    {option.label}
+                                  </Label>
                                 </div>
                               ))}
                             </RadioGroup>
@@ -720,47 +720,45 @@ export function CredentialConfigurationDialog({
                   </>
                 )}
 
-                {/* Action Buttons */}
-                <div className='flex justify-between pt-4'>
-                  {/* Delete button (for provider edit mode OR custom-model edit mode) */}
+                <DialogFooter className='mt-0'>
                   {operation === 'edit' && (
                     <Button
                       type='button'
                       size='sm'
-                      variant='destructive'
+                      variant='destructive-hover'
                       onClick={mode === 'provider' ? handleDeleteProvider : handleDeleteCustomModel}
                       loading={deleteProvider.isPending || deleteCustomModel.isPending}
-                      loadingText='Removing...'>
+                      loadingText='Removing...'
+                      className='mr-auto'>
+                      <Trash2 />
                       {mode === 'provider' ? 'Remove API Key' : 'Remove Model'}
                     </Button>
                   )}
-
-                  <div className='flex gap-2 ml-auto'>
-                    <Button
-                      type='button'
-                      variant='ghost'
-                      size='sm'
-                      onClick={() => onOpenChange(false)}>
-                      Cancel
-                    </Button>
-                    <Button
-                      type='submit'
-                      size='sm'
-                      variant='outline'
-                      loading={saveProviderConfiguration.isPending || saveCustomModel.isPending}
-                      loadingText={
-                        mode === 'provider'
-                          ? 'Saving...'
-                          : operation === 'create'
-                            ? 'Creating...'
-                            : 'Updating...'
-                      }>
-                      {mode === 'provider'
-                        ? `${operation === 'create' ? 'Save' : 'Update'} Provider`
-                        : `${operation === 'create' ? 'Create' : 'Update'} Custom Model`}
-                    </Button>
-                  </div>
-                </div>
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    size='sm'
+                    onClick={() => onOpenChange(false)}>
+                    Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+                  </Button>
+                  <Button
+                    type='submit'
+                    size='sm'
+                    variant='outline'
+                    loading={saveProviderConfiguration.isPending || saveCustomModel.isPending}
+                    loadingText={
+                      mode === 'provider'
+                        ? 'Saving...'
+                        : operation === 'create'
+                          ? 'Creating...'
+                          : 'Updating...'
+                    }>
+                    {mode === 'provider'
+                      ? `${operation === 'create' ? 'Save' : 'Update'} Provider`
+                      : `${operation === 'create' ? 'Create' : 'Update'} Custom Model`}{' '}
+                    <KbdSubmit variant='outline' size='sm' />
+                  </Button>
+                </DialogFooter>
               </>
             )}
 

--- a/apps/web/src/components/mcp/ui/mcp-server-detail.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-server-detail.tsx
@@ -70,13 +70,18 @@ export function McpServerDetail({ initialServer }: { initialServer: McpDetailSer
   return (
     <SettingsPage
       icon={
-        <div className='size-10 rounded-xl border flex items-center justify-center overflow-hidden'>
-          {current.icon?.iconId ? (
-            <AppIcon iconId={current.icon.iconId} color={current.icon.color} size='md' />
-          ) : (
+        current.icon?.iconId ? (
+          <AppIcon
+            iconId={current.icon.iconId}
+            color={current.icon.color}
+            size='xl'
+            className='rounded-xl border overflow-hidden [&_img]:size-6'
+          />
+        ) : (
+          <div className='size-10 rounded-xl border flex items-center justify-center'>
             <Plug className='size-5 text-muted-foreground' />
-          )}
-        </div>
+          </div>
+        )
       }
       title={
         <div className='flex items-center gap-2'>

--- a/apps/web/src/components/mcp/ui/mcp-server-tools-tab.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-server-tools-tab.tsx
@@ -1,10 +1,13 @@
 // apps/web/src/components/mcp/ui/mcp-server-tools-tab.tsx
 'use client'
 
+import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Switch } from '@auxx/ui/components/switch'
 import { toastError } from '@auxx/ui/components/toast'
-import { AlertTriangle, Pencil, RefreshCw, Wrench } from 'lucide-react'
+import { ToggleCard } from '@auxx/ui/components/toggle-card'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { AlertTriangle, Pencil, RefreshCw, ShieldCheck, Wrench } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { api } from '~/trpc/react'
 import type { McpDetailServer } from './mcp-server-detail'
@@ -112,52 +115,53 @@ export function McpServerToolsTab({ server, onChanged }: McpServerToolsTabProps)
         </div>
       )}
 
-      <div className='flex items-center justify-between rounded-lg border bg-primary-50 p-3'>
-        <div className='flex flex-col'>
-          <span className='text-sm font-medium'>Trust all tools</span>
-          <span className='text-xs text-muted-foreground'>
-            Trusted tools run without approval. Which agents get the tools is configured per agent.
-          </span>
-        </div>
-        <Switch
-          checked={allTrusted}
-          onCheckedChange={toggleAll}
-          disabled={update.isPending || server.tools.length === 0}
-        />
-      </div>
+      <ToggleCard
+        title='Trust all tools'
+        description='Trusted tools run without approval. Which agents get the tools is configured per agent.'
+        icon={<ShieldCheck className='size-3.5' />}
+        checked={allTrusted}
+        onCheckedChange={toggleAll}
+        disabled={update.isPending || server.tools.length === 0}
+        switchSize='sm'
+        className='bg-primary-50'
+      />
 
-      <div className='flex flex-col divide-y rounded-lg border'>
+      <div className='flex flex-col gap-0.5'>
         {server.tools.length === 0 ? (
           <div className='p-4 text-center text-sm text-muted-foreground'>
             No tools — connect and refresh to populate the list.
           </div>
         ) : (
           server.tools.map((tool) => (
-            <div key={tool.name} className='flex items-center justify-between gap-3 p-3'>
-              <div className='flex min-w-0 flex-col'>
-                <div className='flex items-center gap-2'>
-                  <span className='truncate text-sm font-medium'>{tool.title ?? tool.name}</span>
-                  <span
-                    className='inline-flex items-center gap-1 rounded border px-1 text-[10px] text-muted-foreground'
-                    title={
-                      tool.readOnlyHint
-                        ? 'Read-only tool'
-                        : 'Write tool — requires approval unless trusted'
-                    }>
-                    {tool.readOnlyHint ? 'Read' : <Pencil className='size-2.5' />}
-                    {tool.readOnlyHint ? '' : 'Write'}
-                  </span>
-                </div>
-                {tool.description && (
-                  <span className='truncate text-xs text-muted-foreground'>{tool.description}</span>
-                )}
-              </div>
-              <Switch
-                checked={trusted.has(tool.name)}
-                onCheckedChange={(on) => toggleTool(tool.name, on)}
-                disabled={update.isPending}
-              />
-            </div>
+            <TreeRow
+              rowClassName='bg-primary-100/50 hover:bg-primary-100'
+              key={tool.name}
+              icon={<Wrench className='size-4 text-muted-foreground' />}
+              title={tool.title ?? tool.name}
+              description={tool.description}
+              onToggleOpen={() => toggleTool(tool.name, !trusted.has(tool.name))}
+              secondary={
+                <Badge
+                  variant='outline'
+                  size='xs'
+                  title={
+                    tool.readOnlyHint
+                      ? 'Read-only tool'
+                      : 'Write tool — requires approval unless trusted'
+                  }>
+                  {tool.readOnlyHint ? 'Read' : <Pencil className='size-2.5' />}
+                  {tool.readOnlyHint ? '' : 'Write'}
+                </Badge>
+              }
+              actions={
+                <Switch
+                  size='xs'
+                  checked={trusted.has(tool.name)}
+                  onCheckedChange={(on) => toggleTool(tool.name, on)}
+                  disabled={update.isPending}
+                />
+              }
+            />
           ))
         )}
       </div>

--- a/packages/ui/src/components/tree-row.tsx
+++ b/packages/ui/src/components/tree-row.tsx
@@ -29,7 +29,10 @@ export interface TreeRowProps {
   expandable?: boolean
   /** Controlled expand state. */
   isOpen?: boolean
-  /** Click handler for the chevron. */
+  /**
+   * Fired by the chevron and by a click anywhere on the row. Supply it without
+   * `expandable` to make the whole row a toggle (e.g. flip a trailing switch).
+   */
   onToggleOpen?: () => void
 
   /** Click on the title text — useful for "click row to toggle checkbox" UX. */
@@ -78,6 +81,9 @@ export function TreeRow({
   // INDENT_REM - 1.125 — consistent at every depth.
   const connectorLeftRem = paddingLeftRem + 1.125
   const showChildren = expandable ? !!isOpen : (isOpen ?? children !== undefined)
+  // The whole row is clickable whenever a toggle handler is supplied — `expandable`
+  // only controls the chevron, not whether clicking the row does something.
+  const rowClickable = onToggleOpen !== undefined
 
   const titleNode = (
     <span
@@ -106,10 +112,10 @@ export function TreeRow({
           className={cn(
             'group/tree-row flex items-center justify-between rounded-md text-sm px-1',
             'text-muted-foreground hover:bg-background',
-            expandable && 'cursor-pointer',
+            rowClickable && 'cursor-pointer',
             rowClassName
           )}
-          onClick={expandable ? onToggleOpen : undefined}>
+          onClick={rowClickable ? onToggleOpen : undefined}>
           <div className='flex items-center flex-1 min-w-0'>
             {icon !== undefined && (
               <span className='flex items-center justify-center px-1 size-7 text-muted-foreground shrink-0'>


### PR DESCRIPTION
## Summary
UI polish across the credential configuration dialog and the MCP server detail/tools views.

- **Credential dialog**: actions now live in a `DialogFooter` with keyboard hints (`esc` / submit), the delete action uses `destructive-hover`, and model-type options are compact inline radios instead of a 4-col card grid.
- **MCP server detail**: the app icon renders as a bordered rounded tile (falls back to the `Plug` glyph when no icon is set).
- **MCP tools tab**: replaced the bespoke list with `ToggleCard` for "Trust all tools" and `TreeRow` rows per tool (Badge for read/write hint, compact Switch for trust).
- **tree-row**: the whole row is now clickable whenever `onToggleOpen` is supplied — `expandable` only governs the chevron.

## Test plan
- [ ] Open the credential configuration dialog (provider + custom-model, create + edit) and verify footer layout, kbd hints, and delete styling.
- [ ] Visit an MCP server detail page with and without a configured icon.
- [ ] Toggle individual tool trust and "Trust all tools" on the MCP tools tab.