### PR TITLE
feat(credentials): encrypt connection client credentials at rest

### DIFF
--- a/apps/api/src/routes/deployments.ts
+++ b/apps/api/src/routes/deployments.ts
@@ -2,7 +2,7 @@
 // Deployment management routes
 
 import { database, schema } from '@auxx/database'
-import { invalidateAppCatalog, invalidateOrgsByDeploymentId, onCacheEvent } from '@auxx/lib/cache'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { calculateNextVersion } from '@auxx/services/app-versions'
 import { verifyAppAccess } from '@auxx/services/developer-accounts'
 import { and, eq } from 'drizzle-orm'
@@ -249,60 +249,66 @@ deployments.get('/:appId/deployments', requireScope(['developer', 'apps:read']),
 /**
  * PATCH /api/v1/apps/:appId/deployments/:id/status
  * Update deployment status (prod only).
+ *
+ * Disabled: no callers (SDK and apps/build both go through the
+ * updateDeploymentStatus service), and this raw write bypasses autoApprove,
+ * the single-review guard, and reconcileAppReviewState. If a CLI-facing
+ * status endpoint is needed, reimplement it on top of
+ * @auxx/services/app-versions updateDeploymentStatus.
  */
-deployments.patch(
-  '/:appId/deployments/:id/status',
-  requireScope(['developer', 'apps:write']),
-  async (c) => {
-    const appId = c.req.param('appId')
-    const deploymentId = c.req.param('id')
-    const userId = c.get('userId')
-    const body = await c.req.json()
-    const { status } = body
-
-    const accessResult = await verifyAppAccess({ appId, userId })
-    if (accessResult.isErr()) {
-      const error = accessResult.error
-      const statusCode = ERROR_STATUS_MAP[error.code] ?? 500
-      return c.json(errorResponse('INTERNAL_ERROR', error.message), statusCode)
-    }
-
-    const deployment = await database.query.AppDeployment.findFirst({
-      where: and(eq(schema.AppDeployment.id, deploymentId), eq(schema.AppDeployment.appId, appId)),
-    })
-
-    if (!deployment) {
-      return c.json(errorResponse('DEPLOYMENT_NOT_FOUND', 'Deployment not found'), 404)
-    }
-
-    // Validate status transition (developer actions only)
-    const validTransitions: Record<string, string[]> = {
-      active: ['pending-review'],
-      'pending-review': ['withdrawn'],
-    }
-
-    const allowed = validTransitions[deployment.status]
-    if (!allowed || !allowed.includes(status)) {
-      return c.json(
-        errorResponse(
-          'INVALID_STATUS_TRANSITION',
-          `Cannot transition from '${deployment.status}' to '${status}'`
-        ),
-        400
-      )
-    }
-
-    const [updated] = await database
-      .update(schema.AppDeployment)
-      .set({ status })
-      .where(eq(schema.AppDeployment.id, deploymentId))
-      .returning()
-
-    await invalidateOrgsByDeploymentId(deploymentId, database)
-    await invalidateAppCatalog()
-
-    return c.json({ deployment: updated })
-  }
-)
+// deployments.patch(
+//   '/:appId/deployments/:id/status',
+//   requireScope(['developer', 'apps:write']),
+//   async (c) => {
+//     const appId = c.req.param('appId')
+//     const deploymentId = c.req.param('id')
+//     const userId = c.get('userId')
+//     const body = await c.req.json()
+//     const { status } = body
+//
+//     const accessResult = await verifyAppAccess({ appId, userId })
+//     if (accessResult.isErr()) {
+//       const error = accessResult.error
+//       const statusCode = ERROR_STATUS_MAP[error.code] ?? 500
+//       return c.json(errorResponse('INTERNAL_ERROR', error.message), statusCode)
+//     }
+//
+//     const deployment = await database.query.AppDeployment.findFirst({
+//       where: and(eq(schema.AppDeployment.id, deploymentId), eq(schema.AppDeployment.appId, appId)),
+//     })
+//
+//     if (!deployment) {
+//       return c.json(errorResponse('DEPLOYMENT_NOT_FOUND', 'Deployment not found'), 404)
+//     }
+//
+//     // Validate status transition (developer actions only)
+//     const validTransitions: Record<string, string[]> = {
+//       active: ['pending-review'],
+//       'pending-review': ['withdrawn'],
+//     }
+//
+//     const allowed = validTransitions[deployment.status]
+//     if (!allowed || !allowed.includes(status)) {
+//       return c.json(
+//         errorResponse(
+//           'INVALID_STATUS_TRANSITION',
+//           `Cannot transition from '${deployment.status}' to '${status}'`
+//         ),
+//         400
+//       )
+//     }
+//
+//     const [updated] = await database
+//       .update(schema.AppDeployment)
+//       .set({ status })
+//       .where(eq(schema.AppDeployment.id, deploymentId))
+//       .returning()
+//
+//     await invalidateOrgsByDeploymentId(deploymentId, database)
+//     await invalidateAppCatalog()
+//
+//     return c.json({ deployment: updated })
+//   }
+// )
 
 export default deployments

--- a/apps/build/.env.example
+++ b/apps/build/.env.example
@@ -23,6 +23,9 @@ REDIS_PASSWORD=
 
 # ─── Auth (env-only secrets) ──────────────────────────────
 API_KEY_SALT=
+# Same value as web/worker/api — ConnectionDefinition client creds are encrypted with it
+# (openssl rand -hex 32)
+CREDENTIAL_ENCRYPTION_KEY=
 
 # ─── Infra ────────────────────────────────────────────────
 AWS_REGION=us-west-1

--- a/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/page.tsx
+++ b/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/page.tsx
@@ -1,6 +1,7 @@
 // apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/page.tsx
 'use client'
 
+import { HIDDEN_VALUE } from '@auxx/credentials/crypto/client'
 import type { ConnectionVariable } from '@auxx/database'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
@@ -20,7 +21,12 @@ import {
   FieldSet,
 } from '@auxx/ui/components/field'
 import { Input } from '@auxx/ui/components/input'
-import { InputGroup, InputGroupAddon, InputGroupInput } from '@auxx/ui/components/input-group'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@auxx/ui/components/input-group'
 import {
   Select,
   SelectContent,
@@ -33,7 +39,7 @@ import { Switch } from '@auxx/ui/components/switch'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { TooltipError, TooltipExplanation } from '@auxx/ui/components/tooltip'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-import { AlertTriangle, Loader2, Settings2, X } from 'lucide-react'
+import { AlertTriangle, Eye, EyeOff, Loader2, Settings2, X } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
@@ -190,6 +196,9 @@ export default function ConnectionsPage() {
   const { app_slug } = useParams<{ app_slug: string }>()
   const utils = api.useUtils()
   const hasLoadedConnection = useRef(false)
+  // The server prefills a *masked* secret — if it's submitted unchanged, send the sentinel so
+  // the stored value is kept (the mask itself must never be persisted).
+  const maskedSecretPrefill = useRef('')
 
   // Get app data
   const { data: app, isLoading: isLoadingApp } = api.apps.get.useQuery({
@@ -238,12 +247,17 @@ export default function ConnectionsPage() {
     reset,
     control,
     watch,
+    setValue,
   } = form
 
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [connectionVariables, setConnectionVariables] = useState<ConnectionVariable[]>([])
   const [variableDialogOpen, setVariableDialogOpen] = useState(false)
   const [variablesDirty, setVariablesDirty] = useState(false)
+  // Eye toggle flips the input type; it only ever exposes the mask (or what the user typed).
+  // The real secret comes back exclusively via the audited reveal mutation below.
+  const [secretVisible, setSecretVisible] = useState(false)
+  const revealedSecret = useRef<string | null>(null)
 
   // Watch form fields - using watch instead of useWatch to avoid timing issues with reset
   const connectionType = watch('connectionType') || 'none'
@@ -254,6 +268,8 @@ export default function ConnectionsPage() {
       const scheduleValue = convertSecondsToSchedule(connection.oauth2RefreshTokenIntervalSeconds)
       const connectionTypeValue = connection.connectionType as 'none' | 'secret' | 'oauth2-code'
       const features = (connection.oauth2Features as Record<string, unknown>) ?? {}
+
+      maskedSecretPrefill.current = connection.oauth2ClientSecret || ''
 
       reset({
         connectionType: connectionTypeValue,
@@ -319,6 +335,22 @@ export default function ConnectionsPage() {
     },
   })
 
+  // Reveal-on-demand ("dev lost the secret" recovery) — server audits every reveal.
+  const revealClientSecret = api.connections.revealClientSecret.useMutation({
+    onSuccess: ({ clientSecret: revealed }) => {
+      if (!revealed) return
+      revealedSecret.current = revealed
+      setValue('oauth2ClientSecret', revealed)
+      setSecretVisible(true)
+    },
+    onError: (error) => {
+      toastError({
+        title: 'Failed to reveal client secret',
+        description: error.message,
+      })
+    },
+  })
+
   // Computed value for conditional rendering
   const isOAuth2 = connectionType === 'oauth2-code'
 
@@ -327,6 +359,11 @@ export default function ConnectionsPage() {
   const tokenUrl = watch('oauth2AccessTokenUrl') || ''
   const clientId = watch('oauth2ClientId') || ''
   const clientSecret = watch('oauth2ClientSecret') || ''
+
+  // Reveal only applies while the field still shows the untouched masked prefill.
+  const canReveal = !!maskedSecretPrefill.current && clientSecret === maskedSecretPrefill.current
+
+  const secretRegister = register('oauth2ClientSecret')
 
   const detectedPlaceholders = useMemo(() => {
     const allFields = [authorizeUrl, tokenUrl, clientId, clientSecret].join(' ')
@@ -365,7 +402,10 @@ export default function ConnectionsPage() {
         oauth2AuthorizeUrl: data.oauth2AuthorizeUrl,
         oauth2AccessTokenUrl: data.oauth2AccessTokenUrl,
         oauth2ClientId: data.oauth2ClientId,
-        oauth2ClientSecret: data.oauth2ClientSecret,
+        oauth2ClientSecret:
+          maskedSecretPrefill.current && data.oauth2ClientSecret === maskedSecretPrefill.current
+            ? HIDDEN_VALUE
+            : data.oauth2ClientSecret,
         oauth2Scopes: scopesArray,
         oauth2TokenRequestAuthMethod: data.oauth2TokenRequestAuthMethod,
         oauth2RefreshTokenIntervalSeconds: refreshSeconds,
@@ -591,12 +631,43 @@ export default function ConnectionsPage() {
                   </Field>
                   <Field>
                     <FieldLabel htmlFor='app-organization-client-secret'>Client secret</FieldLabel>
-                    <Input
-                      id='app-organization-client-secret'
-                      placeholder=''
-                      type='password'
-                      {...register('oauth2ClientSecret')}
-                    />
+                    <InputGroup>
+                      <InputGroupInput
+                        id='app-organization-client-secret'
+                        placeholder=''
+                        type={secretVisible ? 'text' : 'password'}
+                        {...secretRegister}
+                        onBlur={(e) => {
+                          // Re-mask after a reveal unless the user edited the value.
+                          if (revealedSecret.current && e.target.value === revealedSecret.current) {
+                            setValue('oauth2ClientSecret', maskedSecretPrefill.current)
+                            revealedSecret.current = null
+                            setSecretVisible(false)
+                          }
+                          return secretRegister.onBlur(e)
+                        }}
+                      />
+                      <InputGroupAddon align='inline-end'>
+                        {canReveal && (
+                          <InputGroupButton
+                            onClick={() =>
+                              app &&
+                              revealClientSecret.mutate({ appId: app.id, version: 1, global: true })
+                            }
+                            disabled={revealClientSecret.isPending}>
+                            {revealClientSecret.isPending ? 'Revealing...' : 'Reveal'}
+                          </InputGroupButton>
+                        )}
+                        <InputGroupButton
+                          className='mr-1'
+                          aria-label={secretVisible ? 'Hide secret' : 'Show secret'}
+                          aria-pressed={secretVisible}
+                          size='icon-xs'
+                          onClick={() => setSecretVisible((v) => !v)}>
+                          {secretVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
                     {errors.oauth2ClientSecret && (
                       <p className='text-sm text-red-600 mt-1'>
                         {errors.oauth2ClientSecret.message}

--- a/apps/build/src/components/apps/publish-app-dialog.tsx
+++ b/apps/build/src/components/apps/publish-app-dialog.tsx
@@ -279,8 +279,8 @@ export function PublishAppDialog({
     label: c.label,
     oauth2AuthorizeUrl: c.oauth2AuthorizeUrl,
     oauth2AccessTokenUrl: c.oauth2AccessTokenUrl,
-    oauth2ClientId: c.oauth2ClientId,
-    oauth2ClientSecret: c.oauth2ClientSecret,
+    hasClientId: c.hasClientId,
+    hasClientSecret: c.hasClientSecret,
     oauth2Scopes: c.oauth2Scopes,
   }))
 

--- a/apps/build/src/lib/publish-checks.ts
+++ b/apps/build/src/lib/publish-checks.ts
@@ -78,8 +78,9 @@ export interface ConnectionForPublishCheck {
   label: string
   oauth2AuthorizeUrl: string | null
   oauth2AccessTokenUrl: string | null
-  oauth2ClientId: string | null
-  oauth2ClientSecret: string | null
+  // Presence-only — credential values never ship on the list path
+  hasClientId: boolean
+  hasClientSecret: boolean
   oauth2Scopes: string[] | null
 }
 
@@ -96,8 +97,8 @@ export function isConnectionsConfigComplete(connections: ConnectionForPublishChe
     const checks = {
       oauth2AuthorizeUrl: isValidStringField(c.oauth2AuthorizeUrl),
       oauth2AccessTokenUrl: isValidStringField(c.oauth2AccessTokenUrl),
-      oauth2ClientId: isValidStringField(c.oauth2ClientId),
-      oauth2ClientSecret: isValidStringField(c.oauth2ClientSecret),
+      oauth2ClientId: c.hasClientId,
+      oauth2ClientSecret: c.hasClientSecret,
       oauth2Scopes: (c.oauth2Scopes ?? []).length > 0,
     }
     return Object.values(checks).every((check) => check)

--- a/apps/build/src/server/api/routers/connections.ts
+++ b/apps/build/src/server/api/routers/connections.ts
@@ -1,12 +1,57 @@
 // apps/build/src/server/api/routers/connections.ts
 // Connections tRPC router
 
-import { App, ConnectionDefinition, DeveloperAccountMember } from '@auxx/database'
+import { decryptValue, encryptValue, isMaskEcho, maskValue } from '@auxx/credentials/crypto'
+import { App, ConnectionDefinition, DeveloperAccountMember, type database } from '@auxx/database'
+import { AUDIT_ACTIONS, recordAudit } from '@auxx/lib/audit-log'
 import { invalidateOrgsByAppId } from '@auxx/lib/cache'
 import { TRPCError } from '@trpc/server'
 import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '../trpc'
+
+/** Pure `{var}` templates are config, not secret material — shown unmasked in the form. */
+const TEMPLATE_ONLY = /^\{[^}]+\}$/
+
+/** Fetch the app and assert the caller is a member of its developer account. */
+async function getAppForMember(db: typeof database, appId: string, userId: string) {
+  const [app] = await db.select().from(App).where(eq(App.id, appId)).limit(1)
+  if (!app) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'App not found' })
+  }
+
+  const [member] = await db
+    .select()
+    .from(DeveloperAccountMember)
+    .where(
+      and(
+        eq(DeveloperAccountMember.developerAccountId, app.developerAccountId),
+        eq(DeveloperAccountMember.userId, userId)
+      )
+    )
+    .limit(1)
+
+  if (!member) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this app' })
+  }
+
+  return app
+}
+
+/**
+ * Redact a row before it leaves the server: client id decrypted (public by protocol),
+ * client secret decrypted then masked — the real value never reaches the browser.
+ */
+function redactConnection<
+  T extends { oauth2ClientId: string | null; oauth2ClientSecret: string | null },
+>(connection: T): T {
+  const secret = decryptValue(connection.oauth2ClientSecret)
+  return {
+    ...connection,
+    oauth2ClientId: decryptValue(connection.oauth2ClientId),
+    oauth2ClientSecret: secret && !TEMPLATE_ONLY.test(secret) ? maskValue(secret) : secret,
+  }
+}
 
 /**
  * Connections router
@@ -16,30 +61,20 @@ export const connectionsRouter = createTRPCRouter({
    * List all connection definitions for an app
    */
   list: protectedProcedure.input(z.object({ appId: z.string() })).query(async ({ ctx, input }) => {
-    const [app] = await ctx.db.select().from(App).where(eq(App.id, input.appId)).limit(1)
-    if (!app) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'App not found' })
-    }
+    await getAppForMember(ctx.db, input.appId, ctx.session.userId)
 
-    const [member] = await ctx.db
-      .select()
-      .from(DeveloperAccountMember)
-      .where(
-        and(
-          eq(DeveloperAccountMember.developerAccountId, app.developerAccountId),
-          eq(DeveloperAccountMember.userId, ctx.session.userId)
-        )
-      )
-      .limit(1)
-
-    if (!member) {
-      throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this app' })
-    }
-
-    return ctx.db
+    // Publish checks only need presence — booleans from the in-hand ciphertext, zero decrypts,
+    // and credential material never ships on the list path.
+    const connections = await ctx.db
       .select()
       .from(ConnectionDefinition)
       .where(eq(ConnectionDefinition.appId, input.appId))
+
+    return connections.map(({ oauth2ClientId, oauth2ClientSecret, ...rest }) => ({
+      ...rest,
+      hasClientId: Boolean(oauth2ClientId),
+      hasClientSecret: Boolean(oauth2ClientSecret),
+    }))
   }),
 
   /**
@@ -54,34 +89,7 @@ export const connectionsRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
-      // Verify user has access to the app
-      const [app] = await ctx.db.select().from(App).where(eq(App.id, input.appId)).limit(1)
-
-      if (!app) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'App not found',
-        })
-      }
-
-      // Verify membership
-      const [member] = await ctx.db
-        .select()
-        .from(DeveloperAccountMember)
-        .where(
-          and(
-            eq(DeveloperAccountMember.developerAccountId, app.developerAccountId),
-            eq(DeveloperAccountMember.userId, ctx.session.userId)
-          )
-        )
-        .limit(1)
-
-      if (!member) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'You do not have access to this app',
-        })
-      }
+      await getAppForMember(ctx.db, input.appId, ctx.session.userId)
 
       // Get connection definition
       const [connection] = await ctx.db
@@ -96,7 +104,7 @@ export const connectionsRouter = createTRPCRouter({
         )
         .limit(1)
 
-      return connection || null
+      return connection ? redactConnection(connection) : null
     }),
 
   /**
@@ -153,34 +161,7 @@ export const connectionsRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      // Verify user has access to the app
-      const [app] = await ctx.db.select().from(App).where(eq(App.id, input.appId)).limit(1)
-
-      if (!app) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'App not found',
-        })
-      }
-
-      // Verify membership
-      const [member] = await ctx.db
-        .select()
-        .from(DeveloperAccountMember)
-        .where(
-          and(
-            eq(DeveloperAccountMember.developerAccountId, app.developerAccountId),
-            eq(DeveloperAccountMember.userId, ctx.session.userId)
-          )
-        )
-        .limit(1)
-
-      if (!member) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'You do not have access to this app',
-        })
-      }
+      const app = await getAppForMember(ctx.db, input.appId, ctx.session.userId)
 
       // Check if connection exists
       const [existing] = await ctx.db
@@ -195,6 +176,26 @@ export const connectionsRouter = createTRPCRouter({
         )
         .limit(1)
 
+      // Write-only secret contract: the form prefills a mask, so an unchanged field comes back
+      // as HIDDEN_VALUE (or, from a buggy client, the mask itself) — both keep the stored
+      // ciphertext instead of corrupting the credential. Blank on an existing row also keeps it.
+      const storedSecret = existing?.oauth2ClientSecret ?? null
+      const submittedSecret = input.oauth2ClientSecret
+      const secretIsMaskEcho = submittedSecret !== undefined && isMaskEcho(submittedSecret)
+      if (secretIsMaskEcho && !storedSecret) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Client secret looks like a masked placeholder — paste the real secret.',
+        })
+      }
+      const oauth2ClientSecret =
+        storedSecret &&
+        (submittedSecret === undefined || submittedSecret === '' || secretIsMaskEcho)
+          ? storedSecret
+          : submittedSecret
+            ? encryptValue(submittedSecret)
+            : submittedSecret
+
       // Prepare data
       const data = {
         developerAccountId: app.developerAccountId,
@@ -206,8 +207,10 @@ export const connectionsRouter = createTRPCRouter({
         description: input.description,
         oauth2AuthorizeUrl: input.oauth2AuthorizeUrl,
         oauth2AccessTokenUrl: input.oauth2AccessTokenUrl,
-        oauth2ClientId: input.oauth2ClientId,
-        oauth2ClientSecret: input.oauth2ClientSecret,
+        oauth2ClientId: input.oauth2ClientId
+          ? encryptValue(input.oauth2ClientId)
+          : input.oauth2ClientId,
+        oauth2ClientSecret,
         oauth2Scopes: input.oauth2Scopes || [],
         oauth2TokenRequestAuthMethod: input.oauth2TokenRequestAuthMethod || 'request-body',
         oauth2RefreshTokenIntervalSeconds: input.oauth2RefreshTokenIntervalSeconds,
@@ -237,6 +240,59 @@ export const connectionsRouter = createTRPCRouter({
 
       await invalidateOrgsByAppId(input.appId, ctx.db)
 
-      return result
+      return result ? redactConnection(result) : result
+    }),
+
+  /**
+   * Return the decrypted client secret — plaintext, once, on explicit user action
+   * ("dev lost the secret" recovery). Platform-level audit row (connection definitions
+   * belong to developer accounts, not orgs); the reveal fails if the audit write fails.
+   */
+  revealClientSecret: protectedProcedure
+    .input(
+      z.object({
+        appId: z.string(),
+        version: z.number(),
+        global: z.boolean(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const app = await getAppForMember(ctx.db, input.appId, ctx.session.userId)
+
+      const [connection] = await ctx.db
+        .select()
+        .from(ConnectionDefinition)
+        .where(
+          and(
+            eq(ConnectionDefinition.appId, input.appId),
+            eq(ConnectionDefinition.major, input.version),
+            eq(ConnectionDefinition.global, input.global)
+          )
+        )
+        .limit(1)
+
+      if (!connection?.oauth2ClientSecret) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'No client secret is stored' })
+      }
+
+      const audit = await recordAudit({
+        organizationId: null,
+        category: 'security',
+        action: AUDIT_ACTIONS.connectionClientSecretRevealed,
+        actorType: 'user',
+        actorId: ctx.session.userId,
+        targetType: 'connectionDefinition',
+        targetId: connection.id,
+        metadata: { appId: input.appId, developerAccountId: app.developerAccountId },
+      })
+      // An unauditable reveal is the thing this mutation exists to prevent.
+      if (audit.isErr()) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Could not record the audit entry — secret not revealed.',
+        })
+      }
+
+      return { clientSecret: decryptValue(connection.oauth2ClientSecret) }
     }),
 })

--- a/apps/web/src/components/mcp/ui/add-mcp-server-dialog.tsx
+++ b/apps/web/src/components/mcp/ui/add-mcp-server-dialog.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/mcp/ui/add-mcp-server-dialog.tsx
 'use client'
 
+import { HIDDEN_VALUE } from '@auxx/credentials/crypto/client'
 import { FieldType } from '@auxx/database/enums'
 import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
@@ -46,9 +47,10 @@ export interface McpServerEditTarget {
   authHeaderName: string | null
   /** Header names of a headers-auth connection — prefills rows (values stay blank = keep). */
   headerNames: string[]
-  /** OAuth config prefill from the ConnectionDefinition (client secret never leaves the server). */
+  /** OAuth config prefill from the ConnectionDefinition (only the MASK of the secret leaves the server). */
   oauth: {
     clientId: string | null
+    clientSecret: string | null
     authorizeUrl: string | null
     tokenUrl: string | null
     scopes: string[]
@@ -106,8 +108,11 @@ export function AddMcpServerDialog({
   const [token, setToken] = useState('')
   const [headerName, setHeaderName] = useState(server?.authHeaderName ?? '')
   const [headerRows, setHeaderRows] = useState<HeaderRow[]>(initialHeaderRows)
+  // The secret prefill is a MASK — submitting it unchanged sends the HIDDEN_VALUE sentinel
+  // so the server keeps the stored ciphertext.
+  const secretPrefill = server?.oauth?.clientSecret ?? ''
   const [clientId, setClientId] = useState(server?.oauth?.clientId ?? '')
-  const [clientSecret, setClientSecret] = useState('')
+  const [clientSecret, setClientSecret] = useState(secretPrefill)
   const [authorizeUrl, setAuthorizeUrl] = useState(server?.oauth?.authorizeUrl ?? '')
   const [tokenUrl, setTokenUrl] = useState(server?.oauth?.tokenUrl ?? '')
   const [scopes, setScopes] = useState((server?.oauth?.scopes ?? []).join(' '))
@@ -140,7 +145,7 @@ export function AddMcpServerDialog({
     setHeaderName(server?.authHeaderName ?? '')
     setHeaderRows(initialHeaderRows())
     setClientId(server?.oauth?.clientId ?? '')
-    setClientSecret('')
+    setClientSecret(secretPrefill)
     setAuthorizeUrl(server?.oauth?.authorizeUrl ?? '')
     setTokenUrl(server?.oauth?.tokenUrl ?? '')
     setScopes((server?.oauth?.scopes ?? []).join(' '))
@@ -263,7 +268,10 @@ export function AddMcpServerDialog({
       .filter(Boolean)
     return {
       clientId: clientId.trim() || undefined,
-      clientSecret: clientSecret.trim() || undefined,
+      clientSecret:
+        secretPrefill && clientSecret === secretPrefill
+          ? HIDDEN_VALUE
+          : clientSecret.trim() || undefined,
       authorizeUrl: authorizeUrl.trim() || undefined,
       tokenUrl: tokenUrl.trim() || undefined,
       scopes: scopeList.length > 0 ? scopeList : undefined,

--- a/apps/web/src/server/api/routers/mcp.ts
+++ b/apps/web/src/server/api/routers/mcp.ts
@@ -1,5 +1,6 @@
 // apps/web/src/server/api/routers/mcp.ts
 
+import { decryptValue, maskValue } from '@auxx/credentials/crypto'
 import { findCredential } from '@auxx/credentials/store'
 import type { ConnectionVariable } from '@auxx/database'
 import { database as db, schema } from '@auxx/database'
@@ -17,6 +18,7 @@ import {
 } from '@auxx/lib/ai/mcp'
 import { getOrgCache } from '@auxx/lib/cache'
 import { RateLimitError } from '@auxx/lib/errors'
+import { isAdminOrOwner } from '@auxx/lib/members'
 import { FeaturePermissionService } from '@auxx/lib/permissions'
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { createScopedLogger } from '@auxx/logger'
@@ -34,13 +36,18 @@ const mcpAdminProcedure = adminProcedure.use(async ({ ctx, next }) => {
 
 /**
  * Fetch the connection-definition data the detail page + edit dialog need: connection-variable
- * defs (curated connect dialog) and the OAuth config prefill (client SECRET intentionally
- * excluded — it never leaves the server).
+ * defs (curated connect dialog) and the OAuth config prefill. Only the MASK of the client
+ * secret leaves the server, and only for admins — the edit dialog is admin-only, so members
+ * (read-only viewers) get null.
  */
-async function getConnectionDefinitionInfo(serverId: string): Promise<{
+async function getConnectionDefinitionInfo(
+  serverId: string,
+  includeSecretMask: boolean
+): Promise<{
   connectionVariables: ConnectionVariable[]
   oauth: {
     clientId: string | null
+    clientSecret: string | null
     authorizeUrl: string | null
     tokenUrl: string | null
     scopes: string[]
@@ -51,16 +58,19 @@ async function getConnectionDefinitionInfo(serverId: string): Promise<{
     columns: {
       oauth2Features: true,
       oauth2ClientId: true,
+      oauth2ClientSecret: true,
       oauth2AuthorizeUrl: true,
       oauth2AccessTokenUrl: true,
       oauth2Scopes: true,
     },
   })
+  const secret = includeSecretMask ? decryptValue(def?.oauth2ClientSecret ?? null) : null
   return {
     connectionVariables: def?.oauth2Features?.connectionVariables ?? [],
     oauth: def
       ? {
-          clientId: def.oauth2ClientId,
+          clientId: decryptValue(def.oauth2ClientId),
+          clientSecret: secret ? maskValue(secret) : null,
           authorizeUrl: def.oauth2AuthorizeUrl,
           tokenUrl: def.oauth2AccessTokenUrl,
           scopes: def.oauth2Scopes ?? [],
@@ -150,7 +160,9 @@ export const mcpRouter = createTRPCRouter({
       const server = servers.find((s) => s.slug === input.slug)
       if (!server) return null
       const [defInfo, endpoint, posture] = await Promise.all([
-        getConnectionDefinitionInfo(server.serverId),
+        isAdminOrOwner(ctx.session.organizationId, ctx.session.userId).then((isAdmin) =>
+          getConnectionDefinitionInfo(server.serverId, isAdmin)
+        ),
         getServerEndpoint(server.serverId),
         getAuthPosture(server.serverId, ctx.session.organizationId, server.connectionType),
       ])

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -70,6 +70,12 @@
       "import": "./dist/crypto/index.mjs",
       "default": "./src/crypto/index.ts"
     },
+    "./crypto/client": {
+      "types": "./src/crypto/client.ts",
+      "source": "./src/crypto/client.ts",
+      "import": "./dist/crypto/client.mjs",
+      "default": "./src/crypto/client.ts"
+    },
     "./store": {
       "types": "./src/store/index.ts",
       "source": "./src/store/index.ts",

--- a/packages/credentials/scripts/backfill-conndef-creds.ts
+++ b/packages/credentials/scripts/backfill-conndef-creds.ts
@@ -1,0 +1,54 @@
+// packages/credentials/scripts/backfill-conndef-creds.ts
+// Phase 7 backfill: encrypt plaintext ConnectionDefinition.oauth2ClientId/oauth2ClientSecret
+// with the v2 secret box. Idempotent — already-encrypted columns are skipped.
+//
+// Run from packages/credentials (dry run by default, prints the plan):
+//   npx dotenv -e ../../.env -- npx tsx scripts/backfill-conndef-creds.ts
+//   npx dotenv -e ../../.env -- npx tsx scripts/backfill-conndef-creds.ts --execute
+
+import { database as db, schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import { encryptValue, isV2Payload } from '../src/crypto'
+
+const execute = process.argv.includes('--execute')
+
+async function main() {
+  const defs = await db.select().from(schema.ConnectionDefinition)
+
+  let updated = 0
+  for (const def of defs) {
+    const clientIdPlain = def.oauth2ClientId !== null && !isV2Payload(def.oauth2ClientId)
+    const clientSecretPlain =
+      def.oauth2ClientSecret !== null && !isV2Payload(def.oauth2ClientSecret)
+    if (!clientIdPlain && !clientSecretPlain) continue
+
+    updated++
+    console.log(
+      `  id=${def.id} label=${JSON.stringify(def.label)} ` +
+        `clientId=${clientIdPlain ? 'ENCRYPT' : 'ok'} ` +
+        `clientSecret=${clientSecretPlain ? 'ENCRYPT' : 'ok'}`
+    )
+
+    if (!execute) continue
+    await db
+      .update(schema.ConnectionDefinition)
+      .set({
+        ...(clientIdPlain && { oauth2ClientId: encryptValue(def.oauth2ClientId as string) }),
+        ...(clientSecretPlain && {
+          oauth2ClientSecret: encryptValue(def.oauth2ClientSecret as string),
+        }),
+      })
+      .where(eq(schema.ConnectionDefinition.id, def.id))
+  }
+
+  console.log(
+    `\n${defs.length} definitions scanned, ${updated} with plaintext creds ` +
+      (execute ? 'encrypted.' : 'to encrypt (dry run — pass --execute to apply).')
+  )
+  process.exit(0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/credentials/scripts/inspect-credential-blobs.ts
+++ b/packages/credentials/scripts/inspect-credential-blobs.ts
@@ -2,7 +2,7 @@
 // Throwaway: report credential blob shapes + ConnectionDefinition secret-var flags. Keys only, no values.
 
 import { database as db, schema } from '@auxx/database'
-import { decryptSecrets } from '../src/crypto'
+import { decryptSecrets, isV2Payload } from '../src/crypto'
 
 function keys(o: unknown): string[] {
   return o && typeof o === 'object' ? Object.keys(o as object) : []
@@ -53,6 +53,31 @@ async function main() {
   console.log('\n=== ConnectionDefinitions with secret-flagged connectionVariables ===')
   for (const [appId, set] of secretVarsByApp) {
     if (set.size) console.log(`  appId=${appId} secretVars=[${[...set].join(',')}]`)
+  }
+
+  // Phase 7 post-backfill verification: every non-null cred column should be v2 ciphertext.
+  console.log('\n=== ConnectionDefinition cred columns (v2 vs plaintext) ===')
+  const tally = { clientId: { v2: 0, plaintext: 0 }, clientSecret: { v2: 0, plaintext: 0 } }
+  for (const d of defs) {
+    if (d.oauth2ClientId !== null)
+      tally.clientId[isV2Payload(d.oauth2ClientId) ? 'v2' : 'plaintext']++
+    if (d.oauth2ClientSecret !== null)
+      tally.clientSecret[isV2Payload(d.oauth2ClientSecret) ? 'v2' : 'plaintext']++
+  }
+  console.log(`  oauth2ClientId:     v2=${tally.clientId.v2} plaintext=${tally.clientId.plaintext}`)
+  console.log(
+    `  oauth2ClientSecret: v2=${tally.clientSecret.v2} plaintext=${tally.clientSecret.plaintext}`
+  )
+  for (const d of defs) {
+    const plainCols = [
+      d.oauth2ClientId !== null && !isV2Payload(d.oauth2ClientId) && 'clientId',
+      d.oauth2ClientSecret !== null && !isV2Payload(d.oauth2ClientSecret) && 'clientSecret',
+    ].filter(Boolean)
+    if (plainCols.length) {
+      console.log(
+        `  ⚠ PLAINTEXT id=${d.id} label=${JSON.stringify(d.label)} cols=[${plainCols.join(',')}]`
+      )
+    }
   }
   console.log('(end)')
   process.exit(0)

--- a/packages/credentials/src/crypto/__tests__/secret-box.test.ts
+++ b/packages/credentials/src/crypto/__tests__/secret-box.test.ts
@@ -1,7 +1,16 @@
 // packages/credentials/src/crypto/__tests__/secret-box.test.ts
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { decryptSecrets, encryptSecrets, isV2Payload } from '../secret-box'
+import { HIDDEN_VALUE } from '../client'
+import {
+  decryptSecrets,
+  decryptValue,
+  encryptSecrets,
+  encryptValue,
+  isMaskEcho,
+  isV2Payload,
+  maskValue,
+} from '../secret-box'
 
 const V2_KEY = 'a'.repeat(64) // 64 hex chars → 32 bytes
 
@@ -71,6 +80,88 @@ describe('tamper detection', () => {
     raw[12] ^= 0x01 // first auth-tag byte (after 12-byte IV)
     const tampered = `v2:${raw.toString('base64')}`
     expect(() => decryptSecrets(tampered)).toThrow('Failed to decrypt credential secrets')
+  })
+})
+
+describe('encryptValue / decryptValue', () => {
+  it('round-trips a string value', () => {
+    expect(decryptValue(encryptValue('shpss_abc123'))).toBe('shpss_abc123')
+  })
+
+  it('produces a v2 payload', () => {
+    expect(isV2Payload(encryptValue('x'))).toBe(true)
+  })
+
+  it('passes through plaintext unchanged (lenient policy)', () => {
+    expect(decryptValue('plain-client-secret')).toBe('plain-client-secret')
+    expect(decryptValue('{client_secret}')).toBe('{client_secret}')
+    expect(decryptValue('')).toBe('')
+  })
+
+  it('handles null', () => {
+    expect(decryptValue(null)).toBeNull()
+  })
+})
+
+describe('maskValue', () => {
+  it('reveals 4+4 for 16+ char secrets', () => {
+    expect(maskValue('abcdefghijklmnop')).toBe('abcd********mnop')
+  })
+
+  it('reveals 3+3 at 12 chars and 2+2 at 10 chars', () => {
+    expect(maskValue('abcdefghijkl')).toBe('abc******jkl')
+    expect(maskValue('abcdefghij')).toBe('ab******ij')
+  })
+
+  it('returns the fixed full mask under 10 chars', () => {
+    for (const len of [0, 1, 5, 8, 9]) {
+      expect(maskValue('x'.repeat(len))).toBe('********')
+    }
+  })
+
+  it('caps the star run at 20', () => {
+    const masked = maskValue('a'.repeat(100))
+    expect(masked).toBe(`aaaa${'*'.repeat(20)}aaaa`)
+  })
+
+  it('always hides at least 6 chars (property)', () => {
+    for (let len = 0; len <= 64; len++) {
+      const value = Array.from({ length: len }, (_, i) => String.fromCharCode(97 + (i % 26))).join(
+        ''
+      )
+      const masked = maskValue(value)
+      // Count revealed original chars: prefix + suffix that match the source value
+      let prefix = 0
+      while (prefix < masked.length && masked[prefix] !== '*') prefix++
+      let suffix = 0
+      while (suffix < masked.length && masked[masked.length - 1 - suffix] !== '*') suffix++
+      if (masked === '********') {
+        expect(value.length).toBeLessThan(10)
+      } else {
+        expect(value.length - prefix - suffix).toBeGreaterThanOrEqual(6)
+        expect(value.startsWith(masked.slice(0, prefix))).toBe(true)
+        expect(value.endsWith(masked.slice(masked.length - suffix))).toBe(true)
+      }
+    }
+  })
+})
+
+describe('isMaskEcho', () => {
+  it('catches the HIDDEN_VALUE sentinel', () => {
+    expect(isMaskEcho(HIDDEN_VALUE)).toBe(true)
+  })
+
+  it('catches maskValue output across lengths (full mask included)', () => {
+    for (const len of [0, 5, 9, 10, 12, 16, 40, 100]) {
+      expect(isMaskEcho(maskValue('x'.repeat(len)))).toBe(true)
+    }
+    expect(isMaskEcho('ab****yz')).toBe(true)
+  })
+
+  it('passes real values through', () => {
+    expect(isMaskEcho('{client_secret}')).toBe(false)
+    expect(isMaskEcho('shpss_real_secret_no_star_runs')).toBe(false)
+    expect(isMaskEcho('')).toBe(false)
   })
 })
 

--- a/packages/credentials/src/crypto/client.ts
+++ b/packages/credentials/src/crypto/client.ts
@@ -1,0 +1,8 @@
+// packages/credentials/src/crypto/client.ts
+// Client-safe exports — pure constants only, no server dependencies
+
+/**
+ * Sentinel a form submits in place of an unchanged masked secret.
+ * The server swaps it back for the stored ciphertext instead of persisting it.
+ */
+export const HIDDEN_VALUE = '__HIDDEN__'

--- a/packages/credentials/src/crypto/index.ts
+++ b/packages/credentials/src/crypto/index.ts
@@ -1,7 +1,12 @@
 // packages/credentials/src/crypto/index.ts
 
+export { HIDDEN_VALUE } from './client'
 export {
   decryptSecrets,
+  decryptValue,
   encryptSecrets,
+  encryptValue,
+  isMaskEcho,
   isV2Payload,
+  maskValue,
 } from './secret-box'

--- a/packages/credentials/src/crypto/secret-box.ts
+++ b/packages/credentials/src/crypto/secret-box.ts
@@ -3,6 +3,7 @@
 import { createScopedLogger } from '@auxx/logger'
 import crypto from 'crypto'
 import { configService } from '../config/config-service'
+import { HIDDEN_VALUE } from './client'
 
 const logger = createScopedLogger('credential-secret-box')
 
@@ -56,6 +57,50 @@ export function encryptSecrets(secrets: Record<string, unknown>): string {
     logger.error('Failed to encrypt credential secrets')
     throw new Error('Failed to encrypt credential secrets')
   }
+}
+
+/** Fixed mask for short secrets — constant length so it never leaks that the secret is short. */
+const FULL_MASK = '********'
+
+/** Encrypt a single string value to the v2 format (wraps the object box). */
+export function encryptValue(value: string): string {
+  return encryptSecrets({ v: value })
+}
+
+/**
+ * Decrypt a single string value produced by encryptValue.
+ *
+ * Lenient policy (ConnectionDefinition columns): non-`v2:` payloads are returned
+ * unchanged so deploy-then-backfill ordering is safe and plaintext dev rows keep
+ * working. Distinct from the strict `decryptSecrets`, which rejects them.
+ */
+export function decryptValue(payload: string | null): string | null {
+  if (payload === null) return null
+  if (!isV2Payload(payload)) return payload
+  return decryptSecrets<{ v: string }>(payload).v
+}
+
+/**
+ * Mask a secret for display: up to 4 chars revealed per side, with at least
+ * 6 chars always hidden (`revealPerSide = min(4, floor((length - 6) / 2))`).
+ * Secrets shorter than 10 chars return a fixed-length full mask.
+ */
+export function maskValue(value: string): string {
+  const revealPerSide = Math.min(4, Math.floor((value.length - 6) / 2))
+  if (revealPerSide < 2) return FULL_MASK
+  const stars = '*'.repeat(Math.min(value.length - 2 * revealPerSide, 20))
+  return value.slice(0, revealPerSide) + stars + value.slice(-revealPerSide)
+}
+
+/** Mask-shaped values, as produced by `maskValue` (the full mask included). */
+const MASK_SHAPE = /^.{2,4}\*+.{2,4}$/
+
+/**
+ * True when a submitted value is a client echoing a masked prefill back — the
+ * `HIDDEN_VALUE` sentinel or a `maskValue`-shaped string. Never persist it.
+ */
+export function isMaskEcho(value: string): boolean {
+  return value === HIDDEN_VALUE || MASK_SHAPE.test(value)
 }
 
 /** Decrypt a payload produced by encryptSecrets. */

--- a/packages/credentials/tsdown.config.ts
+++ b/packages/credentials/tsdown.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     'src/config/index.ts',
     'src/config/client.ts',
     'src/crypto/index.ts',
+    'src/crypto/client.ts',
     'src/store/index.ts',
     'src/lambda-auth/index.ts',
   ],

--- a/packages/database/src/db/schema/connection-definition.ts
+++ b/packages/database/src/db/schema/connection-definition.ts
@@ -86,8 +86,8 @@ export const ConnectionDefinition = pgTable(
     oauth2AuthorizeUrl: text(),
     oauth2AccessTokenUrl: text(),
     oauth2Scopes: jsonb().$type<string[]>().default([]),
-    oauth2ClientId: text(),
-    oauth2ClientSecret: text(), // Encrypted
+    oauth2ClientId: text(), // v2 secret-box ciphertext (see @auxx/credentials/crypto decryptValue policy)
+    oauth2ClientSecret: text(), // v2 secret-box ciphertext (see @auxx/credentials/crypto decryptValue policy)
     oauth2TokenRequestAuthMethod: text().default('request-body'), // request-body, basic-auth
     oauth2RefreshTokenIntervalSeconds: integer(),
     oauth2Features: jsonb().$type<OAuth2Features>().default({}),

--- a/packages/lib/scripts/check-credential-refresh-roundtrip.ts
+++ b/packages/lib/scripts/check-credential-refresh-roundtrip.ts
@@ -22,6 +22,7 @@ loadEnv({ path: path.resolve(here, '../../../.env') })
 const { database, schema } = await import('@auxx/database')
 const { eq } = await import('drizzle-orm')
 const { getCredential, revealSecrets, updateCredential } = await import('@auxx/credentials/store')
+const { encryptValue } = await import('@auxx/credentials/crypto')
 const { saveMcpConnection, resolveMcpConnectionForRuntime } = await import('../src/ai/mcp')
 const { refreshCredentialTokens } = await import('../src/workflows/oauth2-workflow')
 
@@ -97,8 +98,8 @@ async function main() {
     global: true,
     createdById,
     oauth2AccessTokenUrl: mock.tokenUrl,
-    oauth2ClientId: 'client-id',
-    oauth2ClientSecret: 'client-secret',
+    oauth2ClientId: encryptValue('client-id'),
+    oauth2ClientSecret: encryptValue('client-secret'),
     oauth2TokenRequestAuthMethod: 'request-body',
   })
 

--- a/packages/lib/src/admin/export-apps.ts
+++ b/packages/lib/src/admin/export-apps.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/admin/export-apps.ts
 
+import { decryptValue } from '@auxx/credentials/crypto'
 import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 
@@ -81,7 +82,7 @@ export async function exportByDeveloperAccount(db: Database, developerAccountId:
           major: cd.major,
           oauth2AuthorizeUrl: cd.oauth2AuthorizeUrl,
           oauth2AccessTokenUrl: cd.oauth2AccessTokenUrl,
-          oauth2ClientId: cd.oauth2ClientId,
+          oauth2ClientId: decryptValue(cd.oauth2ClientId),
           // oauth2ClientSecret intentionally excluded
           oauth2Scopes: cd.oauth2Scopes,
           oauth2TokenRequestAuthMethod: cd.oauth2TokenRequestAuthMethod,

--- a/packages/lib/src/admin/import-apps.ts
+++ b/packages/lib/src/admin/import-apps.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/admin/import-apps.ts
 
+import { encryptValue } from '@auxx/credentials/crypto'
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
@@ -298,7 +299,7 @@ export async function importApps(
           global: cd.global,
           oauth2AuthorizeUrl: cd.oauth2AuthorizeUrl,
           oauth2AccessTokenUrl: cd.oauth2AccessTokenUrl,
-          oauth2ClientId: cd.oauth2ClientId,
+          oauth2ClientId: cd.oauth2ClientId ? encryptValue(cd.oauth2ClientId) : cd.oauth2ClientId,
           oauth2Scopes: cd.oauth2Scopes,
           oauth2TokenRequestAuthMethod: cd.oauth2TokenRequestAuthMethod,
           oauth2RefreshTokenIntervalSeconds: cd.oauth2RefreshTokenIntervalSeconds,

--- a/packages/lib/src/ai/mcp/__tests__/manage.test.ts
+++ b/packages/lib/src/ai/mcp/__tests__/manage.test.ts
@@ -92,8 +92,19 @@ vi.mock('@auxx/credentials/store', async () => {
   return { findCredential: async () => ok(null) }
 })
 
+import { decryptValue, HIDDEN_VALUE, isV2Payload } from '@auxx/credentials/crypto'
 import { ok } from 'neverthrow'
-import { connectCuratedMcpServer, connectMcpTemplate, createCustomMcpServer } from '../manage'
+import {
+  connectCuratedMcpServer,
+  connectMcpTemplate,
+  createCustomMcpServer,
+  updateMcpServer,
+} from '../manage'
+
+/** Decrypt a recorded write value (client creds are persisted as v2 ciphertext). */
+function decryptWrite(value: unknown): string | null {
+  return decryptValue((value as string | undefined) ?? null)
+}
 
 const OAUTH_DISCOVERY = ok({
   kind: 'oauth' as const,
@@ -106,6 +117,7 @@ const OAUTH_DISCOVERY = ok({
 })
 
 beforeEach(() => {
+  vi.stubEnv('CREDENTIAL_ENCRYPTION_KEY', 'a'.repeat(64))
   state.servers = []
   state.connectionDef = undefined
   state.installation = undefined
@@ -135,9 +147,12 @@ describe('createCustomMcpServer (auth: auto → oauth)', () => {
     if ('authorizeUrl' in result) {
       expect(result.authorizeUrl).toBe('/api/mcp/srv-new/oauth2/authorize')
     }
-    // DCR-minted client id persisted onto the connection definition.
-    const clientUpdate = state.updates.find((u) => u.values.oauth2ClientId === 'dcr-cid')
+    // DCR-minted client id persisted onto the connection definition (encrypted).
+    const clientUpdate = state.updates.find(
+      (u) => decryptWrite(u.values.oauth2ClientId) === 'dcr-cid'
+    )
     expect(clientUpdate).toBeDefined()
+    expect(isV2Payload(clientUpdate?.values.oauth2ClientId as string)).toBe(true)
     expect(syncMcpTools).not.toHaveBeenCalled()
   })
 
@@ -183,9 +198,12 @@ describe('createCustomMcpServer (explicit auth modes)', () => {
       oauth2AuthorizeUrl: 'https://as.example.com/authorize',
       oauth2AccessTokenUrl: 'https://as.example.com/token',
       oauth2Scopes: ['read', 'write'],
-      oauth2ClientId: 'pasted-cid',
-      oauth2ClientSecret: 'pasted-secret',
     })
+    // Pasted creds are persisted as v2 ciphertext, never plaintext.
+    expect(isV2Payload(defInsert?.values.oauth2ClientId as string)).toBe(true)
+    expect(isV2Payload(defInsert?.values.oauth2ClientSecret as string)).toBe(true)
+    expect(decryptWrite(defInsert?.values.oauth2ClientId)).toBe('pasted-cid')
+    expect(decryptWrite(defInsert?.values.oauth2ClientSecret)).toBe('pasted-secret')
   })
 
   it('oauth without overrides throws when discovery finds no OAuth metadata', async () => {
@@ -231,6 +249,80 @@ describe('createCustomMcpServer (explicit auth modes)', () => {
     })
     expect(arg.connectionData.metadata?.headerNames).toEqual(['X-API-Key', 'X-Api-Version'])
     expect(syncMcpTools).toHaveBeenCalled()
+  })
+})
+
+describe('masked-prefill echoes are never persisted', () => {
+  const oauthEcho = (clientSecret: string) => ({
+    clientId: 'cid-1',
+    clientSecret,
+    authorizeUrl: 'https://as.example.com/authorize',
+    tokenUrl: 'https://as.example.com/token',
+  })
+
+  it.each([
+    HIDDEN_VALUE,
+    'past****cret',
+    '********',
+  ])('createCustomMcpServer on an existing server drops %s from the definition update', async (echo) => {
+    state.servers = [{ id: 'srv-1', slug: 'my-server' }]
+
+    await createCustomMcpServer({
+      organizationId: 'org-1',
+      createdById: 'user-1',
+      name: 'My Server',
+      endpoint: 'https://server.example.com/mcp',
+      auth: 'oauth',
+      oauth: oauthEcho(echo),
+    })
+
+    const defUpdate = state.updates.find((u) => u.table === 'ConnectionDefinition')
+    expect(defUpdate).toBeDefined()
+    expect(decryptWrite(defUpdate?.values.oauth2ClientId)).toBe('cid-1')
+    expect(defUpdate?.values).not.toHaveProperty('oauth2ClientSecret')
+  })
+
+  it.each([
+    HIDDEN_VALUE,
+    'past****cret',
+  ])('updateMcpServer (oauth) drops %s from the definition update', async (echo) => {
+    await updateMcpServer({
+      organizationId: 'org-1',
+      serverId: 'srv-1',
+      auth: 'oauth',
+      oauth: { clientSecret: echo },
+    })
+
+    const defUpdate = state.updates.find((u) => u.table === 'ConnectionDefinition')
+    expect(defUpdate).toBeDefined()
+    expect(defUpdate?.values).toMatchObject({ connectionType: 'oauth2-code' })
+    expect(defUpdate?.values).not.toHaveProperty('oauth2ClientSecret')
+  })
+
+  it('updateMcpServer (oauth) still persists a real replacement secret', async () => {
+    await updateMcpServer({
+      organizationId: 'org-1',
+      serverId: 'srv-1',
+      auth: 'oauth',
+      oauth: { clientSecret: 'brand-new-real-secret' },
+    })
+
+    const defUpdate = state.updates.find((u) => u.table === 'ConnectionDefinition')
+    expect(decryptWrite(defUpdate?.values.oauth2ClientSecret)).toBe('brand-new-real-secret')
+  })
+
+  it('createCustomMcpServer rejects a mask echo for a brand-new server', async () => {
+    await expect(
+      createCustomMcpServer({
+        organizationId: 'org-1',
+        createdById: 'user-1',
+        name: 'New Server',
+        endpoint: 'https://server.example.com/mcp',
+        auth: 'oauth',
+        oauth: oauthEcho(HIDDEN_VALUE),
+      })
+    ).rejects.toThrow(/masked placeholder/)
+    expect(state.inserts).toHaveLength(0)
   })
 })
 
@@ -328,8 +420,10 @@ describe('connectCuratedMcpServer', () => {
       (u) => u.values.oauth2AuthorizeUrl === 'https://as.example.com/authorize'
     )
     expect(urlUpdate).toBeDefined()
-    // DCR client persisted too.
-    expect(state.updates.some((u) => u.values.oauth2ClientId === 'linear-cid')).toBe(true)
+    // DCR client persisted too (encrypted).
+    expect(state.updates.some((u) => decryptWrite(u.values.oauth2ClientId) === 'linear-cid')).toBe(
+      true
+    )
   })
 
   it('skips DCR when the curated OAuth def already has a client id', async () => {

--- a/packages/lib/src/ai/mcp/manage.ts
+++ b/packages/lib/src/ai/mcp/manage.ts
@@ -4,6 +4,7 @@
 // curated servers, refresh, rename, delete). Kept out of the router per the >20-line rule.
 
 import { WEBAPP_URL } from '@auxx/config/urls'
+import { encryptValue, isMaskEcho } from '@auxx/credentials/crypto'
 import { findCredential } from '@auxx/credentials/store'
 import { database as db, type McpServerIcon, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
@@ -48,6 +49,11 @@ async function uniqueSlug(organizationId: string, base: string): Promise<string>
   let n = 2
   while (taken.has(`${base}-${n}`)) n++
   return `${base}-${n}`
+}
+
+/** Encrypt non-empty client creds; empty/null pass through so presence semantics survive. */
+function encryptCred(value: string | null): string | null {
+  return value ? encryptValue(value) : value
 }
 
 function authorizeUrlFor(serverId: string, returnTo?: string): string {
@@ -135,11 +141,15 @@ export async function createCustomMcpServer(input: {
       await db
         .update(schema.ConnectionDefinition)
         .set({
-          ...(input.oauth.clientId !== undefined && { oauth2ClientId: input.oauth.clientId }),
-          // Blank/omitted secret keeps the stored (possibly DCR-minted) one.
-          ...(input.oauth.clientSecret !== undefined && {
-            oauth2ClientSecret: input.oauth.clientSecret,
+          ...(input.oauth.clientId !== undefined && {
+            oauth2ClientId: encryptCred(input.oauth.clientId),
           }),
+          // Blank/omitted secret keeps the stored (possibly DCR-minted) one; so does a
+          // masked-prefill echo (HIDDEN_VALUE or mask-shaped) — never persist the mask.
+          ...(input.oauth.clientSecret !== undefined &&
+            !isMaskEcho(input.oauth.clientSecret) && {
+              oauth2ClientSecret: encryptCred(input.oauth.clientSecret),
+            }),
           ...(input.oauth.authorizeUrl !== undefined && {
             oauth2AuthorizeUrl: input.oauth.authorizeUrl,
           }),
@@ -158,6 +168,10 @@ export async function createCustomMcpServer(input: {
       existingClientId = def?.oauth2ClientId ?? null
     }
   } else {
+    // New server — there is no stored secret a mask echo could "keep"; reject it outright.
+    if (input.oauth?.clientSecret && isMaskEcho(input.oauth.clientSecret)) {
+      throw new Error('Client secret looks like a masked placeholder — paste the real secret.')
+    }
     slug = await uniqueSlug(input.organizationId, slugify(input.name))
     const [server] = await db
       .insert(schema.McpServer)
@@ -193,8 +207,8 @@ export async function createCustomMcpServer(input: {
       oauth2AuthorizeUrl: input.oauth?.authorizeUrl ?? oauthMeta?.authorizeUrl ?? null,
       oauth2AccessTokenUrl: input.oauth?.tokenUrl ?? oauthMeta?.tokenUrl ?? null,
       oauth2Scopes: input.oauth?.scopes ?? oauthMeta?.scopesSupported ?? [],
-      oauth2ClientId: input.oauth?.clientId ?? null,
-      oauth2ClientSecret: input.oauth?.clientSecret ?? null,
+      oauth2ClientId: encryptCred(input.oauth?.clientId ?? null),
+      oauth2ClientSecret: encryptCred(input.oauth?.clientSecret ?? null),
       oauth2Features: { pkce: true },
     })
     await db.insert(schema.McpInstallation).values({
@@ -446,8 +460,8 @@ async function ensureOAuthClient(input: {
   await db
     .update(schema.ConnectionDefinition)
     .set({
-      oauth2ClientId: dcr.value.clientId,
-      oauth2ClientSecret: dcr.value.clientSecret ?? null,
+      oauth2ClientId: encryptCred(dcr.value.clientId),
+      oauth2ClientSecret: encryptCred(dcr.value.clientSecret ?? null),
     })
     .where(eq(schema.ConnectionDefinition.mcpServerId, input.serverId))
   return { needsOAuth: true, authorizeUrl: authorizeUrlFor(input.serverId, input.returnTo) }
@@ -535,11 +549,15 @@ async function applyAuthUpdate(input: {
       .update(schema.ConnectionDefinition)
       .set({
         connectionType: 'oauth2-code',
-        ...(input.oauth?.clientId !== undefined && { oauth2ClientId: input.oauth.clientId }),
-        // Blank/omitted secret keeps the stored (possibly DCR-minted) one.
-        ...(input.oauth?.clientSecret !== undefined && {
-          oauth2ClientSecret: input.oauth.clientSecret,
+        ...(input.oauth?.clientId !== undefined && {
+          oauth2ClientId: encryptCred(input.oauth.clientId),
         }),
+        // Blank/omitted secret keeps the stored (possibly DCR-minted) one; so does a
+        // masked-prefill echo (HIDDEN_VALUE or mask-shaped) — never persist the mask.
+        ...(input.oauth?.clientSecret !== undefined &&
+          !isMaskEcho(input.oauth.clientSecret) && {
+            oauth2ClientSecret: encryptCred(input.oauth.clientSecret),
+          }),
         ...(input.oauth?.authorizeUrl !== undefined && {
           oauth2AuthorizeUrl: input.oauth.authorizeUrl,
         }),

--- a/packages/lib/src/ai/providers/utils.ts
+++ b/packages/lib/src/ai/providers/utils.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/ai/providers/utils.ts
 
+import { maskValue } from '@auxx/credentials/crypto'
 import { createScopedLogger } from '../../logger'
 import { providerPositions } from './provider-registry'
 import {
@@ -180,18 +181,11 @@ export function obfuscateCredentials(
 }
 
 /**
- * Obfuscate a token/API key for display
+ * Obfuscate a token/API key for display. Delegates to the shared `maskValue` rule
+ * (at least 6 chars always hidden; short tokens get a fixed full mask).
  */
 export function obfuscateToken(token: string): string {
-  if (!token || token.length < 8) {
-    return HIDDEN_VALUE
-  }
-
-  const start = token.slice(0, 4)
-  const end = token.slice(-4)
-  const middle = '*'.repeat(Math.min(token.length - 8, 20))
-
-  return `${start}${middle}${end}`
+  return maskValue(token)
 }
 
 /**

--- a/packages/lib/src/audit-log/audit-actions.ts
+++ b/packages/lib/src/audit-log/audit-actions.ts
@@ -28,6 +28,7 @@ export const AUDIT_ACTIONS = {
   twoFactorDisabled: '2fa.disabled',
   passkeyAdded: 'passkey.added',
   passkeyRemoved: 'passkey.removed',
+  connectionClientSecretRevealed: 'connection.client_secret_revealed',
   // super-admin actions on a user (internal)
   userDeleted: 'user.deleted',
   userEmailVerifiedByAdmin: 'user.email_verified_by_admin',

--- a/packages/services/src/app-connections/interpolate-connection.ts
+++ b/packages/services/src/app-connections/interpolate-connection.ts
@@ -1,8 +1,11 @@
 // packages/services/src/app-connections/interpolate-connection.ts
 
+import { decryptValue } from '@auxx/credentials/crypto'
+
 /**
  * Resolve {key} placeholders across all OAuth connection fields.
  * URL values are URI-encoded; credential values are used as-is.
+ * Client id/secret are stored as v2 ciphertext — decrypted before interpolation.
  */
 export function interpolateConnectionFields(
   connDef: {
@@ -21,8 +24,8 @@ export function interpolateConnectionFields(
   return {
     authorizeUrl: interpolateUrl(connDef.oauth2AuthorizeUrl ?? '', variables),
     accessTokenUrl: interpolateUrl(connDef.oauth2AccessTokenUrl ?? '', variables),
-    clientId: interpolateValue(connDef.oauth2ClientId ?? '', variables),
-    clientSecret: interpolateValue(connDef.oauth2ClientSecret ?? '', variables),
+    clientId: interpolateValue(decryptValue(connDef.oauth2ClientId) ?? '', variables),
+    clientSecret: interpolateValue(decryptValue(connDef.oauth2ClientSecret) ?? '', variables),
   }
 }
 


### PR DESCRIPTION
## Summary

Encrypts `ConnectionDefinition.oauth2ClientId` / `oauth2ClientSecret` with the v2 secret box and keeps the plaintext secret off the wire. Previously these OAuth client credentials were stored as plaintext and the secret was shipped to the browser on the connection form.

## Crypto primitives (`@auxx/credentials/crypto`)

- `encryptValue` / `decryptValue` — single-value wrappers over the secret box. `decryptValue` is **lenient**: non-`v2:` payloads pass through unchanged, so deploy-then-backfill ordering is safe and plaintext dev rows keep working (distinct from the strict `decryptSecrets`).
- `maskValue` — display mask, always hides ≥6 chars; short secrets get a fixed full mask so length never leaks.
- `isMaskEcho` — detects a client echoing a masked prefill back, so the mask is never persisted.
- `HIDDEN_VALUE` sentinel exported from `@auxx/credentials/crypto/client` (pure constant, client-safe).

## Behavior

- **Encrypt on write / decrypt on read**: build connections router, MCP `manage` (including DCR-minted creds), app import; decrypt at the interpolation boundary and on export (client id only).
- **Write-only secret contract**: forms prefill a mask; an unchanged submit sends `HIDDEN_VALUE` (or the mask) and keeps the stored ciphertext. Submitting a mask echo with no stored secret is rejected.
- **List path** returns presence booleans (`hasClientId` / `hasClientSecret`) only — no credential material.
- **Audited reveal-on-demand** mutation (`connection.client_secret_revealed`) for "dev lost the secret" recovery; the reveal fails if the audit write fails.
- **UI**: Eye toggle + Reveal button on the build connections form; MCP secret mask is admin-only (members get null).
- `obfuscateToken` now delegates to the shared `maskValue` rule.

## Migration / ops

- Backfill script `packages/credentials/scripts/backfill-conndef-creds.ts` (idempotent, dry-run by default) encrypts existing plaintext rows.
- `inspect-credential-blobs.ts` gains a post-backfill v2-vs-plaintext verification pass.
- `CREDENTIAL_ENCRYPTION_KEY` added to `apps/build/.env.example` (same key as web/worker/api).

## Misc

- Disabled the unused raw deployment-status `PATCH` route — it bypassed `autoApprove`, the single-review guard, and `reconcileAppReviewState`; both real callers go through the `updateDeploymentStatus` service.

## Test plan

- [x] New unit tests for `encryptValue`/`decryptValue`, `maskValue`, `isMaskEcho` (`secret-box.test.ts`)
- [x] Updated MCP `manage` tests for encrypted creds + mask-echo handling
- [ ] Run backfill (dry-run, then `--execute`) against each environment before/after deploy