### PR TITLE
feat(mcp): manual OAuth setup flow for non-DCR providers

### DIFF
--- a/apps/web/src/components/mcp/ui/add-mcp-server-dialog.tsx
+++ b/apps/web/src/components/mcp/ui/add-mcp-server-dialog.tsx
@@ -66,6 +66,8 @@ interface AddMcpServerDialogProps {
   mode?: 'create' | 'update'
   /** Required for `update` — the server being edited. */
   server?: McpServerEditTarget
+  /** Provider requires a client secret on token exchange (no public-client PKCE), e.g. GitHub. */
+  secretRequired?: boolean
 }
 
 /**
@@ -84,6 +86,7 @@ export function AddMcpServerDialog({
   onConnected,
   mode = 'create',
   server,
+  secretRequired = false,
 }: AddMcpServerDialogProps) {
   const router = useRouter()
   const isUpdate = mode === 'update'
@@ -229,6 +232,10 @@ export function AddMcpServerDialog({
     if (auth === 'oauth') {
       if (clientSecret.trim() && !clientId.trim()) {
         next.clientId = 'Client ID is required when a secret is set'
+      }
+      // Only enforced once creds are being entered — a credless save (rename etc.) stays valid.
+      if (secretRequired && clientId.trim() && !clientSecret.trim()) {
+        next.clientSecret = 'This provider requires a client secret'
       }
       if (authorizeUrl.trim() && !isValidUrl(authorizeUrl)) {
         next.authorizeUrl = 'Must be a valid https URL'
@@ -685,13 +692,22 @@ export function AddMcpServerDialog({
                   disabled={isSubmitting}
                 />
               </VarEditorFieldRow>
-              <VarEditorFieldRow title='Client Secret' type={BaseType.STRING} showIcon>
+              <VarEditorFieldRow
+                title='Client Secret'
+                type={BaseType.STRING}
+                showIcon
+                isRequired={secretRequired}
+                validationError={errors.clientSecret}>
                 <FieldInputAdapter
                   fieldType={FieldType.TEXT}
                   value={clientSecret}
                   onChange={(v) => setClientSecret((v as string) ?? '')}
                   placeholder={
-                    isUpdate ? 'Leave blank to keep current secret' : 'Optional for public clients'
+                    secretRequired && !secretPrefill
+                      ? 'Required by this provider'
+                      : isUpdate
+                        ? 'Leave blank to keep current secret'
+                        : 'Optional for public clients'
                   }
                   disabled={isSubmitting}
                 />

--- a/apps/web/src/components/mcp/ui/mcp-server-connection-tab.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-server-connection-tab.tsx
@@ -2,8 +2,9 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
+import { CopyButton } from '@auxx/ui/components/button-copy'
 import { toastError } from '@auxx/ui/components/toast'
-import { Plug } from 'lucide-react'
+import { KeyRound, Plug } from 'lucide-react'
 import { useState } from 'react'
 import { ConnectionList } from '~/components/apps/ui/connection-list'
 import { ConnectionRow, type ConnectionStatus } from '~/components/apps/ui/connection-row'
@@ -31,6 +32,8 @@ const MCP_ROW_STATUS: Record<keyof typeof MCP_STATUS_LABEL, ConnectionStatus> = 
 interface McpServerConnectionTabProps {
   server: McpDetailServer
   onChanged: () => void
+  /** Opens the edit dialog hosted by the detail page (the one creds-entry surface). */
+  onRequestEdit?: () => void
 }
 
 /**
@@ -39,7 +42,11 @@ interface McpServerConnectionTabProps {
  * (variables/secret/OAuth); zero-variable OAuth servers connect + open the popup directly. Custom
  * OAuth servers reconnect via the authorize popup. Uninstall lives in the page header.
  */
-export function McpServerConnectionTab({ server, onChanged }: McpServerConnectionTabProps) {
+export function McpServerConnectionTab({
+  server,
+  onChanged,
+  onRequestEdit,
+}: McpServerConnectionTabProps) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const oauth = useMcpOAuthPopup()
 
@@ -48,6 +55,11 @@ export function McpServerConnectionTab({ server, onChanged }: McpServerConnectio
   const isOAuth = server.connectionType === 'oauth2-code'
   const hasVariables = server.connectionVariables.length > 0
   const isSecret = server.connectionType === 'secret'
+
+  // Custom OAuth server with no client creds (the provider has no DCR, e.g. GitHub) — the
+  // authorize popup can only fail, so a setup walkthrough replaces the Connect row.
+  const needsManualSetup =
+    server.isCustom && isOAuth && !server.oauth?.clientId && !server.connectionPresent
 
   async function handleConnect() {
     // Curated OAuth with no variables, or any reconnect of an OAuth server → straight to the popup.
@@ -77,6 +89,8 @@ export function McpServerConnectionTab({ server, onChanged }: McpServerConnectio
     }
     // Custom OAuth reconnect → authorize popup directly (no curated connect endpoint for custom).
     if (server.isCustom && isOAuth) {
+      // No stored client creds — the authorize route can only fail; the setup block handles this.
+      if (needsManualSetup) return
       oauth.open({
         authorizeUrl: `/api/mcp/${server.serverId}/oauth2/authorize?returnTo=${encodeURIComponent(
           `/app/settings/apps/mcp/${server.slug}`
@@ -120,30 +134,74 @@ export function McpServerConnectionTab({ server, onChanged }: McpServerConnectio
           <Plug className='size-4' />
           Connection
         </div>
-        <ConnectionList>
-          <ConnectionRow
-            status={MCP_ROW_STATUS[status]}
-            title={server.name}
-            subtitle={
-              <>
-                {MCP_STATUS_LABEL[status]}
-                {server.connectionExpiresAt &&
-                  ` · Token expires ${new Date(server.connectionExpiresAt).toLocaleString()}`}
-              </>
-            }
-            actions={() => (
-              <Button
-                variant='outline'
-                size='sm'
-                onClick={handleConnect}
-                loading={connect.isPending || oauth.pending}
-                loadingText='Connecting...'>
-                <Plug />
-                {connectLabel}
-              </Button>
+        {needsManualSetup ? (
+          <div className='flex flex-col gap-3 rounded-lg border p-4 text-sm'>
+            <div className='font-medium'>Finish OAuth setup</div>
+            {server.templateSetup?.setupHint && (
+              <p className='text-muted-foreground'>{server.templateSetup.setupHint}</p>
             )}
-          />
-        </ConnectionList>
+            <ol className='list-decimal space-y-1 ps-4 text-muted-foreground'>
+              <li>
+                {server.templateSetup?.createOAuthAppUrl || server.templateSetup?.docsUrl ? (
+                  <a
+                    href={
+                      server.templateSetup.createOAuthAppUrl ?? server.templateSetup.docsUrl ?? '#'
+                    }
+                    target='_blank'
+                    rel='noreferrer'
+                    className='underline underline-offset-2 hover:text-foreground'>
+                    Create an OAuth app with the provider
+                  </a>
+                ) : (
+                  'Create an OAuth app with the provider'
+                )}
+              </li>
+              <li>Set its authorization callback URL to the one below</li>
+              <li>
+                Paste the app's Client ID
+                {server.templateSetup?.clientSecretRequired ? ' and Client Secret' : ''} here and
+                connect
+              </li>
+            </ol>
+            {server.redirectUri && (
+              <div className='flex items-center gap-1'>
+                <code className='break-all rounded-md border bg-muted px-2 py-1 font-mono text-xs'>
+                  {server.redirectUri}
+                </code>
+                <CopyButton text={server.redirectUri} />
+              </div>
+            )}
+            <Button variant='outline' size='sm' className='self-start' onClick={onRequestEdit}>
+              <KeyRound />
+              Add credentials
+            </Button>
+          </div>
+        ) : (
+          <ConnectionList>
+            <ConnectionRow
+              status={MCP_ROW_STATUS[status]}
+              title={server.name}
+              subtitle={
+                <>
+                  {MCP_STATUS_LABEL[status]}
+                  {server.connectionExpiresAt &&
+                    ` · Token expires ${new Date(server.connectionExpiresAt).toLocaleString()}`}
+                </>
+              }
+              actions={() => (
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={handleConnect}
+                  loading={connect.isPending || oauth.pending}
+                  loadingText='Connecting...'>
+                  <Plug />
+                  {connectLabel}
+                </Button>
+              )}
+            />
+          </ConnectionList>
+        )}
       </div>
 
       <ConnectCuratedDialog

--- a/apps/web/src/components/mcp/ui/mcp-server-detail.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-server-detail.tsx
@@ -119,7 +119,11 @@ export function McpServerDetail({ initialServer }: { initialServer: McpDetailSer
         </div>
       }>
       <div className='flex flex-col flex-1 gap-8 p-6'>
-        <McpServerConnectionTab server={current} onChanged={onChanged} />
+        <McpServerConnectionTab
+          server={current}
+          onChanged={onChanged}
+          onRequestEdit={() => setEditOpen(true)}
+        />
         <McpServerToolsTab server={current} onChanged={onChanged} />
       </div>
       {current.isCustom && (
@@ -137,6 +141,7 @@ export function McpServerDetail({ initialServer }: { initialServer: McpDetailSer
             headerNames: current.headerNames,
             oauth: current.oauth,
           }}
+          secretRequired={current.templateSetup?.clientSecretRequired}
           onConnected={onChanged}
         />
       )}

--- a/apps/web/src/components/mcp/ui/mcp-template-dialog.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-template-dialog.tsx
@@ -43,15 +43,17 @@ export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTempla
 
   const catalog = api.mcp.listTemplates.useQuery(undefined, { enabled: open })
   const connectTemplate = api.mcp.connectTemplate.useMutation()
+  const createServer = api.mcp.create.useMutation()
   const oauth = useMcpOAuthPopup()
   const { servers } = useMcpServers()
 
   const templates = useMemo(() => catalog.data?.templates ?? [], [catalog.data])
   const categories = catalog.data?.categories ?? []
-  const isSubmitting = connectTemplate.isPending || oauth.pending
+  const isSubmitting = connectTemplate.isPending || createServer.isPending || oauth.pending
 
-  /** Connected (or browsable) server matching a template, by slug. */
-  const serverFor = (template: McpTemplate) => servers.find((s) => s.slug === template.id)
+  /** Server matching a template — by slug, or by endpoint when the slug was deduped. */
+  const serverFor = (template: McpTemplate) =>
+    servers.find((s) => s.slug === template.id || s.endpoint === template.endpoint)
 
   function resetFields() {
     setConnectingId(null)
@@ -122,6 +124,18 @@ export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTempla
       return 'handled'
     }
 
+    if (template.clientRegistration === 'manual') {
+      // Saved-but-unconnected manual server → back to its pending setup page instead of a
+      // second create; otherwise fall through to the gallery's manual setup step. Only org-owned
+      // servers count — a stray curated row at the same slug must not swallow the manual flow.
+      if (existing?.isCustom) {
+        close()
+        router.push(`/app/settings/apps/mcp/${existing.slug}`)
+        return 'handled'
+      }
+      return
+    }
+
     const needsFields =
       (template.connectionVariables?.length ?? 0) > 0 || template.connectionType === 'secret'
     if (needsFields) {
@@ -150,6 +164,44 @@ export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTempla
     if (!validateFields(template)) return
     setConnectingId(template.id)
     await connect(template, values, token)
+  }
+
+  /**
+   * Manual (non-DCR) templates: save an org-owned custom server prefilled from the template —
+   * `needsClientCredentials` is the expected success-pending outcome (the callback URL the user
+   * must register at the provider contains the new serverId), so route to the server page where
+   * the setup steps + credential entry live.
+   */
+  async function handleSaveManual(template: McpTemplate) {
+    setConnectingId(template.id)
+    try {
+      const result = await createServer.mutateAsync({
+        name: template.name,
+        endpoint: template.endpoint,
+        auth: 'oauth',
+        description: template.description,
+        icon: template.icon ?? undefined,
+        returnTo: `/app/settings/apps/mcp/${template.id}`,
+      })
+      if ('needsOAuth' in result && result.needsOAuth) {
+        // Re-save of a server that already has client creds → straight to the popup.
+        oauth.open({
+          authorizeUrl: result.authorizeUrl,
+          onDone: (ok) => {
+            if (ok) handleConnected(result.slug)
+            else setConnectingId(null)
+          },
+        })
+        return
+      }
+      handleConnected(result.slug)
+    } catch (err) {
+      setConnectingId(null)
+      toastError({
+        title: 'Failed to save server',
+        description: err instanceof Error ? err.message : 'Unknown error',
+      })
+    }
   }
 
   return (
@@ -192,44 +244,81 @@ export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTempla
       detailCrumb={(template) => `Connect ${template.name}`}
       detailBusy={isSubmitting}
       onDetailExit={resetFields}
-      renderDetail={(template) => (
-        <div className='flex flex-col gap-2 p-3'>
-          <VarEditorField
-            orientation='responsive'
-            className='p-0 sm:[&_[data-slot=field-row-label]]:w-40'>
-            <ConnectionVariableFields
-              variables={template.connectionVariables ?? []}
-              values={values}
-              onValueChange={(key, value) => setValues((prev) => ({ ...prev, [key]: value }))}
-              showToken={template.connectionType === 'secret'}
-              token={token}
-              onTokenChange={setToken}
-              errors={errors}
-              disabled={isSubmitting}
-            />
-          </VarEditorField>
-          {template.docsUrl && (
-            <a
-              href={template.docsUrl}
-              target='_blank'
-              rel='noreferrer'
-              className='self-start text-xs text-muted-foreground underline-offset-2 hover:underline'>
-              Where do I find this? View the {template.name} docs
-            </a>
-          )}
-        </div>
-      )}
-      renderDetailFooter={(template) => (
-        <Button
-          size='sm'
-          variant='outline'
-          onClick={() => handleSubmitFields(template)}
-          loading={isSubmitting}
-          loadingText='Connecting...'
-          data-dialog-submit>
-          Connect <KbdSubmit variant='outline' size='sm' />
-        </Button>
-      )}
+      renderDetail={(template) =>
+        template.clientRegistration === 'manual' ? (
+          <div className='flex flex-col gap-2 p-3 text-sm'>
+            {template.setupHint && <p>{template.setupHint}</p>}
+            <p className='text-muted-foreground'>
+              Save first — the callback URL you'll need for the OAuth app is shown on the next
+              screen.
+            </p>
+            {template.docsUrl && (
+              <a
+                href={template.docsUrl}
+                target='_blank'
+                rel='noreferrer'
+                className='self-start text-xs text-muted-foreground underline-offset-2 hover:underline'>
+                View the {template.name} docs
+              </a>
+            )}
+          </div>
+        ) : (
+          renderVariableFields(template)
+        )
+      }
+      renderDetailFooter={(template) =>
+        template.clientRegistration === 'manual' ? (
+          <Button
+            size='sm'
+            variant='outline'
+            onClick={() => handleSaveManual(template)}
+            loading={isSubmitting}
+            loadingText='Saving...'
+            data-dialog-submit>
+            Save <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        ) : (
+          <Button
+            size='sm'
+            variant='outline'
+            onClick={() => handleSubmitFields(template)}
+            loading={isSubmitting}
+            loadingText='Connecting...'
+            data-dialog-submit>
+            Connect <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        )
+      }
     />
   )
+
+  function renderVariableFields(template: McpTemplate) {
+    return (
+      <div className='flex flex-col gap-2 p-3'>
+        <VarEditorField
+          orientation='responsive'
+          className='p-0 sm:[&_[data-slot=field-row-label]]:w-40'>
+          <ConnectionVariableFields
+            variables={template.connectionVariables ?? []}
+            values={values}
+            onValueChange={(key, value) => setValues((prev) => ({ ...prev, [key]: value }))}
+            showToken={template.connectionType === 'secret'}
+            token={token}
+            onTokenChange={setToken}
+            errors={errors}
+            disabled={isSubmitting}
+          />
+        </VarEditorField>
+        {template.docsUrl && (
+          <a
+            href={template.docsUrl}
+            target='_blank'
+            rel='noreferrer'
+            className='self-start text-xs text-muted-foreground underline-offset-2 hover:underline'>
+            Where do I find this? View the {template.name} docs
+          </a>
+        )}
+      </div>
+    )
+  }
 }

--- a/apps/web/src/server/api/routers/mcp.ts
+++ b/apps/web/src/server/api/routers/mcp.ts
@@ -10,6 +10,7 @@ import {
   connectMcpTemplate,
   createCustomMcpServer,
   deleteMcpServer,
+  mcpRedirectUri,
   mcpTemplateCategories,
   mcpTemplates,
   resolveMcpSnippet,
@@ -76,6 +77,33 @@ async function getConnectionDefinitionInfo(
           scopes: def.oauth2Scopes ?? [],
         }
       : null,
+  }
+}
+
+/**
+ * Setup guidance for custom servers created from a `clientRegistration: 'manual'` template,
+ * matched by endpoint (custom servers carry no template FK). When the provider's "create OAuth
+ * app" form supports prefill query params (GitHub), the callback URL is baked into the link.
+ */
+function getTemplateSetup(endpoint: string | null, redirectUri: string | null) {
+  if (!endpoint) return null
+  const template = mcpTemplates.find(
+    (t) => t.clientRegistration === 'manual' && t.endpoint === endpoint
+  )
+  if (!template) return null
+  let createOAuthAppUrl = template.createOAuthAppUrl ?? null
+  if (createOAuthAppUrl && redirectUri && new URL(createOAuthAppUrl).hostname === 'github.com') {
+    const url = new URL(createOAuthAppUrl)
+    url.searchParams.set('oauth_application[name]', `Auxx — ${template.name}`)
+    url.searchParams.set('oauth_application[url]', new URL(redirectUri).origin)
+    url.searchParams.set('oauth_application[callback_url]', redirectUri)
+    createOAuthAppUrl = url.toString()
+  }
+  return {
+    setupHint: template.setupHint ?? null,
+    createOAuthAppUrl,
+    docsUrl: template.docsUrl ?? null,
+    clientSecretRequired: template.clientSecretRequired ?? false,
   }
 }
 
@@ -166,7 +194,13 @@ export const mcpRouter = createTRPCRouter({
         getServerEndpoint(server.serverId),
         getAuthPosture(server.serverId, ctx.session.organizationId, server.connectionType),
       ])
-      return { ...server, ...defInfo, endpoint, ...posture }
+      // Computed server-side: CALLBACK_BASE can be an ngrok URL the browser can't derive.
+      const redirectUri =
+        server.isCustom && server.connectionType === 'oauth2-code'
+          ? mcpRedirectUri(server.serverId)
+          : null
+      const templateSetup = getTemplateSetup(endpoint, redirectUri)
+      return { ...server, ...defInfo, endpoint, ...posture, redirectUri, templateSetup }
     }),
 
   /**

--- a/packages/lib/src/ai/mcp/__tests__/capabilities.test.ts
+++ b/packages/lib/src/ai/mcp/__tests__/capabilities.test.ts
@@ -26,6 +26,7 @@ function server(overrides: Partial<CachedMcpServer> = {}): CachedMcpServer {
     name: 'Demo',
     description: null,
     icon: null,
+    endpoint: 'https://demo.example.com/mcp',
     isCustom: true,
     toolsetSlug: 'mcp:srv-1',
     connectionType: 'secret',

--- a/packages/lib/src/ai/mcp/__tests__/tool-adapter.test.ts
+++ b/packages/lib/src/ai/mcp/__tests__/tool-adapter.test.ts
@@ -24,6 +24,7 @@ function makeServer(overrides: Partial<CachedMcpServer> = {}): CachedMcpServer {
     name: 'Demo',
     description: null,
     icon: null,
+    endpoint: 'https://demo.example.com/mcp',
     isCustom: true,
     toolsetSlug: 'mcp:srv-1',
     connectionType: 'secret',

--- a/packages/lib/src/ai/mcp/index.ts
+++ b/packages/lib/src/ai/mcp/index.ts
@@ -27,6 +27,7 @@ export {
   connectMcpTemplate,
   createCustomMcpServer,
   deleteMcpServer,
+  mcpRedirectUri,
   updateMcpServer,
 } from './manage'
 export type { McpRateLimitResult } from './rate-limiter'

--- a/packages/lib/src/ai/mcp/manage.ts
+++ b/packages/lib/src/ai/mcp/manage.ts
@@ -61,6 +61,15 @@ function authorizeUrlFor(serverId: string, returnTo?: string): string {
   return `/api/mcp/${serverId}/oauth2/authorize${qs}`
 }
 
+/**
+ * The OAuth redirect URI for a server — what the user registers at the provider when DCR
+ * isn't available. Server-side only: `CALLBACK_BASE` can be an ngrok URL in dev, which the
+ * browser can't derive.
+ */
+export function mcpRedirectUri(serverId: string): string {
+  return `${CALLBACK_BASE}/api/mcp/${serverId}/oauth2/callback`
+}
+
 /** Manual OAuth client config + endpoint overrides pasted in the create/edit dialog. */
 export interface McpOAuthConfigInput {
   clientId?: string
@@ -284,6 +293,13 @@ export async function connectMcpTemplate(input: {
 }): Promise<McpConnectOutcome & { serverId: string; slug: string }> {
   const template = mcpTemplates.find((t) => t.id === input.templateId)
   if (!template) throw new Error(`Unknown MCP template '${input.templateId}'`)
+  // Non-DCR providers must go through the custom-server flow (org-owned server + pasted
+  // OAuth app creds) — running the curated upsert here would only strand a global row.
+  if (template.clientRegistration === 'manual') {
+    throw new Error(
+      `The ${template.name} template requires manual OAuth setup — save it from the template gallery and finish setup on its server page.`
+    )
+  }
 
   const { serverId } = await ensureCuratedMcpServer(template)
   await onCacheEvent('mcp.server.changed', { orgId: input.organizationId })
@@ -447,7 +463,7 @@ async function ensureOAuthClient(input: {
   if (!input.registrationEndpoint) {
     return { needsClientCredentials: true }
   }
-  const redirectUri = `${CALLBACK_BASE}/api/mcp/${input.serverId}/oauth2/callback`
+  const redirectUri = mcpRedirectUri(input.serverId)
   const dcr = await registerDcrClient({
     registrationEndpoint: input.registrationEndpoint,
     redirectUri,

--- a/packages/lib/src/ai/mcp/templates/catalog.ts
+++ b/packages/lib/src/ai/mcp/templates/catalog.ts
@@ -38,6 +38,18 @@ export interface McpTemplate {
   connectionVariables?: ConnectionVariable[]
   /** Provider docs for the connect step (e.g. where to find the API key). */
   docsUrl?: string
+  /**
+   * How the OAuth client is obtained (absent = `'dcr'`). `'manual'` = the provider has no
+   * Dynamic Client Registration; the template routes through the custom-server flow and the
+   * user registers an OAuth app themselves.
+   */
+  clientRegistration?: 'dcr' | 'manual'
+  /** Shown in the manual setup step (e.g. "GitHub does not support automatic registration…"). */
+  setupHint?: string
+  /** Deep link to the provider's "create OAuth app" form. */
+  createOAuthAppUrl?: string
+  /** Provider requires a client secret on token exchange (no public-client PKCE). */
+  clientSecretRequired?: boolean
 }
 
 export const mcpTemplateCategories: McpTemplateCategoryDef[] = [
@@ -102,7 +114,13 @@ export const mcpTemplates: McpTemplate[] = [
     categories: ['dev-tools'],
     endpoint: 'https://api.githubcopilot.com/mcp/',
     connectionType: 'oauth2-code',
-    docsUrl: 'https://github.com/github/github-mcp-server',
+    // github.com/login/oauth publishes no registration_endpoint — DCR can never work.
+    clientRegistration: 'manual',
+    clientSecretRequired: true,
+    setupHint:
+      'GitHub does not support automatic client registration. Create an OAuth app on GitHub and paste its Client ID and Client Secret.',
+    createOAuthAppUrl: 'https://github.com/settings/applications/new',
+    docsUrl: 'https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app',
   },
   {
     id: 'sentry',

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -393,6 +393,8 @@ export interface CachedMcpServer {
   name: string
   description: string | null
   icon: McpServerIcon | null
+  /** Lets the template gallery match an org server back to its template when slugs dedupe. */
+  endpoint: string
   isCustom: boolean // organizationId != null
   toolsetSlug: string // `mcp:<serverId>`
   connectionType: 'oauth2-code' | 'secret' | 'none' | null // null = no definition yet

--- a/packages/lib/src/cache/providers/mcp-servers-provider.ts
+++ b/packages/lib/src/cache/providers/mcp-servers-provider.ts
@@ -93,6 +93,7 @@ export const mcpServersProvider: CacheProvider<CachedMcpServer[]> = {
         name: server.name,
         description: server.description ?? null,
         icon: server.icon ?? null,
+        endpoint: server.endpoint,
         isCustom: server.organizationId != null,
         toolsetSlug: `mcp:${server.id}`,
         connectionType: connType,

--- a/packages/ui/src/components/icon-data.ts
+++ b/packages/ui/src/components/icon-data.ts
@@ -380,6 +380,7 @@ export const ICON_DATA: IconItem[] = [
   { id: 'columns', label: 'Columns', icon: Columns3 },
   { id: 'layout', label: 'Layout', icon: Layout },
   { id: 'layout-dashboard', label: 'Layout Dashboard', icon: LayoutDashboard },
+  { id: 'layout-grid', label: 'Layout Grid', icon: LayoutGrid },
   { id: 'book-open', label: 'Book Open', icon: BookOpen },
   { id: 'code', label: 'Code', icon: Code },
   { id: 'terminal', label: 'Terminal', icon: Terminal },


### PR DESCRIPTION
## What

Adds a manual OAuth setup flow for MCP providers that don't support Dynamic Client Registration (DCR) — GitHub being the motivating case. `github.com/login/oauth` publishes no `registration_endpoint`, so DCR can never work; the curated connect flow previously only stranded a global row.

Templates marked `clientRegistration: 'manual'` now route through the custom-server flow: the user saves an org-owned server, registers their own OAuth app at the provider, and pastes the Client ID + Secret.

## Changes

- **Template catalog**: add `clientRegistration`, `setupHint`, `createOAuthAppUrl`, and `clientSecretRequired` fields. Mark the GitHub template `manual` with a prefilled "create OAuth app" link.
- **Template gallery dialog**: manual templates render a setup-first detail + "Save" action that creates the org server and routes to its page; re-saves with existing creds go straight to the authorize popup.
- **Connection tab**: manual server with no client creds shows a setup walkthrough (numbered steps + copyable callback URL + "Add credentials") instead of a Connect row that could only fail.
- **Edit dialog**: enforces a required client secret when the provider needs one (`secretRequired`).
- **Router/lib**: expose `mcpRedirectUri` and compute the redirect URI server-side (`CALLBACK_BASE` may be an ngrok URL the browser can't derive); surface `templateSetup` + `redirectUri` on the server detail query. `connectMcpTemplate` now rejects manual templates with a clear error.
- **Cache**: add `endpoint` to `CachedMcpServer` so the gallery can match an org server back to its template when slugs dedupe.
- **Icons**: register `layout-grid`.

## Testing

- Updated `capabilities.test.ts` and `tool-adapter.test.ts` fixtures with the new `endpoint` field.