### PR TITLE
feat: developer API keys for headless publishing + per-tool MCP selection

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -6,6 +6,7 @@ import { createMiddleware } from 'hono/factory'
 import { extractBearerToken, validateBetterAuthToken } from '../lib/jwt-validator'
 import { errorResponse } from '../lib/response'
 import type { AppContext } from '../types/context'
+import { developerKeyAuth } from './developer-key-auth'
 import { internalAuthMiddleware } from './internal-auth'
 
 /**
@@ -28,6 +29,12 @@ export const authMiddleware = createMiddleware<AppContext>(async (c, next) => {
 
   if (!token) {
     return c.json(errorResponse('UNAUTHORIZED', 'Missing authentication token'), 401)
+  }
+
+  // Developer API keys (headless CI publishing) — resolved by hash lookup, no
+  // better-auth round-trip. Recognized by the `auxx_dev_` prefix.
+  if (token.startsWith('auxx_dev_')) {
+    return developerKeyAuth(c, next, token)
   }
 
   // Validate token with better-auth

--- a/apps/api/src/middleware/developer-key-auth.ts
+++ b/apps/api/src/middleware/developer-key-auth.ts
@@ -1,0 +1,63 @@
+// apps/api/src/middleware/developer-key-auth.ts
+
+import { hashApiKey } from '@auxx/credentials/api-key'
+import { database, schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import type { Context, Next } from 'hono'
+import { errorResponse } from '../lib/response'
+import type { AppContext } from '../types/context'
+
+/**
+ * Fixed scope set granted to any `type: 'developer'` API key. Developer keys
+ * exist solely for headless CLI publishing (CI); per-app authorization is still
+ * enforced downstream by `verifyAppAccess` against `DeveloperAccountMember`.
+ */
+const DEVELOPER_KEY_SCOPES = ['developer', 'apps:write', 'apps:read']
+
+/**
+ * Resolve a developer API key (bearer token with the `auxx_dev_` prefix) and set
+ * the request context, mirroring the better-auth bearer path. Validation is a
+ * single indexed lookup: `hashApiKey` is deterministic (fixed env salt), so we
+ * hash the incoming token and query the unique `hashedKey` index — no per-row
+ * scrypt loop and no better-auth round-trip.
+ *
+ * Only `type: 'developer'` keys are accepted here; product keys
+ * ('app'/'workflow'/'chat') are rejected so they stay non-publish-capable.
+ */
+export async function developerKeyAuth(c: Context<AppContext>, next: Next, token: string) {
+  const hashedKey = hashApiKey(token)
+
+  const apiKey = await database.query.ApiKey.findFirst({
+    where: eq(schema.ApiKey.hashedKey, hashedKey),
+  })
+
+  if (!apiKey || !apiKey.isActive || apiKey.type !== 'developer') {
+    return c.json(errorResponse('UNAUTHORIZED', 'Invalid API key'), 401)
+  }
+
+  // ApiKey.userId is a real User.id. Membership of the target app's developer
+  // account is checked per-app by verifyAppAccess, not here.
+  const users = await database
+    .select()
+    .from(schema.User)
+    .where(eq(schema.User.id, apiKey.userId))
+    .limit(1)
+
+  const user = users[0]
+
+  if (!user) {
+    return c.json(errorResponse('UNAUTHORIZED', 'User not found'), 401)
+  }
+
+  c.set('userId', apiKey.userId)
+  c.set('user', user)
+  c.set('scopes', DEVELOPER_KEY_SCOPES)
+  c.set('token', {
+    userId: apiKey.userId,
+    email: user.email,
+    scopes: DEVELOPER_KEY_SCOPES,
+    expiresAt: Date.now() + 365 * 24 * 60 * 60 * 1000,
+  })
+
+  await next()
+}

--- a/apps/build/src/app/(portal)/[slug]/settings/api-keys/_components/api-key-list.tsx
+++ b/apps/build/src/app/(portal)/[slug]/settings/api-keys/_components/api-key-list.tsx
@@ -1,0 +1,82 @@
+// apps/build/src/app/(portal)/[slug]/settings/api-keys/_components/api-key-list.tsx
+
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { formatDistanceToNow } from 'date-fns'
+import { KeyRound, Trash2 } from 'lucide-react'
+import { toastError } from '~/components/global/toast'
+import { useConfirm } from '~/hooks/use-confirm'
+import { api } from '~/trpc/react'
+
+type Key = {
+  id: string
+  name: string | null
+  createdAt: Date
+}
+
+interface Props {
+  developerSlug: string
+  keys: Key[]
+}
+
+export function ApiKeyList({ developerSlug, keys }: Props) {
+  const utils = api.useUtils()
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  const revoke = api.apiKeys.revoke.useMutation({
+    onSuccess: () => utils.apiKeys.list.invalidate({ developerSlug }),
+    onError: (error) => toastError({ title: 'Failed to revoke key', description: error.message }),
+  })
+
+  async function handleRevoke(key: Key) {
+    const confirmed = await confirm({
+      title: 'Revoke API key?',
+      description: `${key.name || 'This key'} will stop working immediately. This cannot be undone.`,
+      confirmText: 'Revoke',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) {
+      revoke.mutate({ developerSlug, id: key.id })
+    }
+  }
+
+  if (keys.length === 0) {
+    return (
+      <div className='text-center text-sm text-muted-foreground py-8'>
+        No API keys yet. Create one to publish apps from CI.
+      </div>
+    )
+  }
+
+  return (
+    <div className='space-y-1'>
+      {keys.map((key) => (
+        <div
+          key={key.id}
+          className='group flex items-center justify-between rounded-2xl border py-2 px-3 hover:bg-muted transition-colors duration-200'>
+          <div className='flex items-center gap-3'>
+            <div className='size-8 border bg-muted rounded-lg flex items-center justify-center shrink-0'>
+              <KeyRound className='size-4' />
+            </div>
+            <div className='flex flex-col'>
+              <div className='text-sm font-medium'>{key.name || 'Untitled key'}</div>
+              <div className='text-muted-foreground text-xs'>
+                Created {formatDistanceToNow(new Date(key.createdAt), { addSuffix: true })}
+              </div>
+            </div>
+          </div>
+          <Button
+            variant='ghost'
+            size='icon-sm'
+            onClick={() => handleRevoke(key)}
+            disabled={revoke.isPending}>
+            <Trash2 />
+          </Button>
+        </div>
+      ))}
+      <ConfirmDialog />
+    </div>
+  )
+}

--- a/apps/build/src/app/(portal)/[slug]/settings/api-keys/_components/create-api-key-dialog.tsx
+++ b/apps/build/src/app/(portal)/[slug]/settings/api-keys/_components/create-api-key-dialog.tsx
@@ -1,0 +1,106 @@
+// apps/build/src/app/(portal)/[slug]/settings/api-keys/_components/create-api-key-dialog.tsx
+
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { CopyButton } from '@auxx/ui/components/button-copy'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@auxx/ui/components/dialog'
+import { Input } from '@auxx/ui/components/input'
+import { Plus } from 'lucide-react'
+import { useState } from 'react'
+import { toastError } from '~/components/global/toast'
+import { api } from '~/trpc/react'
+
+interface Props {
+  developerSlug: string
+}
+
+/**
+ * Dialog to mint a developer API key. The plaintext is shown once on creation.
+ */
+export function CreateApiKeyDialog({ developerSlug }: Props) {
+  const utils = api.useUtils()
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [secret, setSecret] = useState('')
+
+  const create = api.apiKeys.create.useMutation({
+    onSuccess: (data) => {
+      setSecret(data.secretKey)
+      utils.apiKeys.list.invalidate({ developerSlug })
+    },
+    onError: (error) => toastError({ title: 'Failed to create key', description: error.message }),
+  })
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next)
+    if (!next) {
+      setName('')
+      setSecret('')
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant='outline' size='sm'>
+          <Plus />
+          Create key
+        </Button>
+      </DialogTrigger>
+      <DialogContent
+        onEscapeKeyDown={(e) => secret && e.preventDefault()}
+        onPointerDownOutside={(e) => secret && e.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>Create developer API key</DialogTitle>
+          <DialogDescription>
+            Use this key as <code>AUXX_API_KEY</code> in CI to publish apps headlessly.
+          </DialogDescription>
+        </DialogHeader>
+
+        {secret ? (
+          <div className='space-y-2'>
+            <DialogDescription>
+              This will only be shown once. Copy it and store it securely.
+            </DialogDescription>
+            <div className='flex items-center gap-2 rounded-md border px-3 py-2'>
+              <code className='flex-1 truncate text-xs'>{secret}</code>
+              <CopyButton text={secret} />
+            </div>
+          </div>
+        ) : (
+          <div className='space-y-4'>
+            <div className='space-y-1'>
+              <label className='text-sm font-medium' htmlFor='key-name'>
+                Name (optional)
+              </label>
+              <Input
+                id='key-name'
+                placeholder='CI deploy key'
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+            <div className='flex justify-end'>
+              <Button
+                variant='outline'
+                size='sm'
+                loading={create.isPending}
+                loadingText='Creating...'
+                onClick={() => create.mutate({ developerSlug, name: name || undefined })}>
+                Create
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/build/src/app/(portal)/[slug]/settings/api-keys/page.tsx
+++ b/apps/build/src/app/(portal)/[slug]/settings/api-keys/page.tsx
@@ -1,0 +1,50 @@
+// apps/build/src/app/(portal)/[slug]/settings/api-keys/page.tsx
+
+'use client'
+
+import { KeyRound } from 'lucide-react'
+import { useParams } from 'next/navigation'
+import { api } from '~/trpc/react'
+import SettingsHeader from '../_components/settings-header'
+import { ApiKeyList } from './_components/api-key-list'
+import { CreateApiKeyDialog } from './_components/create-api-key-dialog'
+
+function ApiKeysSettingsPage() {
+  const params = useParams<{ slug: string }>()
+
+  const { data, isLoading } = api.apiKeys.list.useQuery(
+    { developerSlug: params.slug },
+    { enabled: !!params.slug }
+  )
+
+  return (
+    <>
+      <SettingsHeader title='API Keys' icon={<KeyRound className='size-4' />} />
+      <div className='flex-1 overflow-y-auto min-h-0'>
+        <div className='p-6 lg:py-12 max-w-3xl mx-auto'>
+          <div className='flex flex-col space-y-6'>
+            <div className='space-y-0'>
+              <div className='text-xl font-semibold'>API Keys</div>
+              <div className='text-base'>
+                Create developer keys to publish apps from CI. Set the key as{' '}
+                <code>AUXX_API_KEY</code> in your workflow.
+              </div>
+            </div>
+
+            <div className='flex items-center justify-end'>
+              <CreateApiKeyDialog developerSlug={params.slug} />
+            </div>
+
+            {isLoading ? (
+              <div className='text-sm text-muted-foreground py-8 text-center'>Loading keys...</div>
+            ) : (
+              <ApiKeyList developerSlug={params.slug} keys={data ?? []} />
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default ApiKeysSettingsPage

--- a/apps/build/src/components/build-nav-main.tsx
+++ b/apps/build/src/components/build-nav-main.tsx
@@ -8,7 +8,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@auxx/ui/components/sidebar'
-import { Building2, NotebookText, Package, Plus, Users } from 'lucide-react'
+import { Building2, KeyRound, NotebookText, Package, Plus, Users } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { CreateAppDialog } from './apps/create-app-dialog'
@@ -95,6 +95,13 @@ export function BuildNavMain({ accountSlug }: Props) {
             <SidebarMenuButton className='text-muted-foreground' asChild>
               <Link href={`/${accountSlug}/settings/members`}>
                 <Users /> Members
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton className='text-muted-foreground' asChild>
+              <Link href={`/${accountSlug}/settings/api-keys`}>
+                <KeyRound /> API Keys
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/apps/build/src/server/api/root.ts
+++ b/apps/build/src/server/api/root.ts
@@ -1,6 +1,7 @@
 // apps/build/src/server/api/root.ts
 // Root tRPC router for developer portal
 
+import { apiKeysRouter } from './routers/api-keys'
 import { appsRouter } from './routers/apps'
 import { connectionsRouter } from './routers/connections'
 import { developerAccountsRouter } from './routers/developer-accounts'
@@ -20,6 +21,7 @@ export const appRouter = createTRPCRouter({
   connections: connectionsRouter,
   versions: versionsRouter,
   logs: logsRouter,
+  apiKeys: apiKeysRouter,
 })
 
 /** Export type for use in client */

--- a/apps/build/src/server/api/routers/api-keys.ts
+++ b/apps/build/src/server/api/routers/api-keys.ts
@@ -1,0 +1,129 @@
+// apps/build/src/server/api/routers/api-keys.ts
+// Developer API keys tRPC router (headless CLI publishing)
+
+import { generateApiKey, hashApiKey } from '@auxx/credentials/api-key'
+import { ApiKey, DeveloperAccount, DeveloperAccountMember } from '@auxx/database'
+import { TRPCError } from '@trpc/server'
+import { and, desc, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { createTRPCRouter, protectedProcedure } from '../trpc'
+
+/**
+ * Resolve a developer slug to an account ID and verify the caller is a member.
+ */
+async function resolveAccount(
+  db: Parameters<Parameters<typeof protectedProcedure.query>[0]>['ctx']['db'],
+  developerSlug: string,
+  userId: string
+) {
+  const [account] = await db
+    .select({ id: DeveloperAccount.id })
+    .from(DeveloperAccount)
+    .where(eq(DeveloperAccount.slug, developerSlug))
+    .limit(1)
+
+  if (!account) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Developer account not found' })
+  }
+
+  const [member] = await db
+    .select({ id: DeveloperAccountMember.id })
+    .from(DeveloperAccountMember)
+    .where(
+      and(
+        eq(DeveloperAccountMember.developerAccountId, account.id),
+        eq(DeveloperAccountMember.userId, userId)
+      )
+    )
+    .limit(1)
+
+  if (!member) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'You are not a member of this account' })
+  }
+
+  return account.id
+}
+
+/**
+ * Developer API keys router — manages `type: 'developer'` keys used by CI to
+ * publish apps headlessly. Keys are scoped to a developer account via
+ * `referenceId`; the plaintext is shown once on creation.
+ */
+export const apiKeysRouter = createTRPCRouter({
+  /**
+   * List active developer keys for an account (never returns plaintext/hash).
+   */
+  list: protectedProcedure
+    .input(z.object({ developerSlug: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const accountId = await resolveAccount(ctx.db, input.developerSlug, ctx.session.userId)
+
+      return ctx.db
+        .select({
+          id: ApiKey.id,
+          name: ApiKey.name,
+          createdAt: ApiKey.createdAt,
+        })
+        .from(ApiKey)
+        .where(
+          and(
+            eq(ApiKey.type, 'developer'),
+            eq(ApiKey.referenceId, accountId),
+            eq(ApiKey.isActive, true)
+          )
+        )
+        .orderBy(desc(ApiKey.createdAt))
+    }),
+
+  /**
+   * Mint a new developer key. Returns the plaintext `auxx_dev_...` once.
+   */
+  create: protectedProcedure
+    .input(z.object({ developerSlug: z.string(), name: z.string().optional() }))
+    .mutation(async ({ ctx, input }) => {
+      const accountId = await resolveAccount(ctx.db, input.developerSlug, ctx.session.userId)
+
+      const secretKey = generateApiKey('auxx_dev')
+      const hashedKey = hashApiKey(secretKey)
+      const keySuffix = secretKey.slice(-5).toUpperCase()
+
+      await ctx.db.insert(ApiKey).values({
+        userId: ctx.session.userId,
+        name: input.name || `Deploy key ...${keySuffix}`,
+        hashedKey,
+        isActive: true,
+        type: 'developer',
+        referenceId: accountId,
+        updatedAt: new Date(),
+      })
+
+      return { secretKey }
+    }),
+
+  /**
+   * Revoke (deactivate) a developer key.
+   */
+  revoke: protectedProcedure
+    .input(z.object({ developerSlug: z.string(), id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const accountId = await resolveAccount(ctx.db, input.developerSlug, ctx.session.userId)
+
+      const [updated] = await ctx.db
+        .update(ApiKey)
+        .set({ isActive: false, updatedAt: new Date() })
+        .where(
+          and(
+            eq(ApiKey.id, input.id),
+            eq(ApiKey.type, 'developer'),
+            eq(ApiKey.referenceId, accountId)
+          )
+        )
+        .returning({ id: ApiKey.id })
+
+      if (!updated) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'API key not found' })
+      }
+
+      return { success: true }
+    }),
+})

--- a/apps/web/src/components/agents/ui/detail/tools/catalog-node-row.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/catalog-node-row.tsx
@@ -27,6 +27,11 @@ interface CatalogNodeRowProps {
   inheritedColor: string | null
   stateBySlug: Map<string, ToolsetRowState>
   /**
+   * Per-toolset deny-list (registered tool names). MCP server rows use it to
+   * show an enabled-tool count (`N of M`) instead of a toolset count.
+   */
+  disabledToolsBySlug?: Map<string, Set<string>>
+  /**
    * Read-only restriction count per toolset slug. When a leaf has ≥1, a lock
    * badge renders; container rows roll up descendant counts into `secondary`.
    * Managing restrictions happens in the Restrictions section. See
@@ -86,6 +91,7 @@ export function CatalogNodeRow({
   inheritedIconId,
   inheritedColor,
   stateBySlug,
+  disabledToolsBySlug,
   restrictionCountBySlug,
   collapsed,
   onToggleCollapsed,
@@ -119,6 +125,7 @@ export function CatalogNodeRow({
 
   const isOpen = !collapsed.has(node.id)
   const stats = summarizeContainer(node, stateBySlug)
+  const mcpTools = node.origin === 'mcp' ? mcpToolStats(node, disabledToolsBySlug) : null
   const restrictionCount = countRestrictions(node, restrictionCountBySlug)
   const containerWarn = Boolean(warnNotExternalSafe) && hasUnverifiedTool(node)
   const isApp = node.kind === 'app'
@@ -154,7 +161,8 @@ export function CatalogNodeRow({
         isMcp ? (
           <span className='inline-flex items-center gap-2'>
             <span>
-              {stats.enabled} {pluralize(stats.enabled, 'tool')}
+              {mcpTools ? `${mcpTools.enabled} of ${mcpTools.total}` : stats.enabled}{' '}
+              {pluralize(mcpTools?.total ?? stats.enabled, 'tool')}
             </span>
             {restrictionCount > 0 ? <RestrictionLockBadge count={restrictionCount} /> : null}
             {containerWarn ? <ChatWarnBadge /> : null}
@@ -204,6 +212,7 @@ export function CatalogNodeRow({
           inheritedIconId={iconId}
           inheritedColor={color}
           stateBySlug={stateBySlug}
+          disabledToolsBySlug={disabledToolsBySlug}
           restrictionCountBySlug={restrictionCountBySlug}
           collapsed={collapsed}
           onToggleCollapsed={onToggleCollapsed}
@@ -293,6 +302,27 @@ function summarizeContainer(
     else removable++
   }
   return { total, enabled, removable, locked }
+}
+
+/**
+ * Enabled-vs-total tool count for an MCP server node. MCP servers hold a single
+ * toolset whose `tools[]` are gated per-agent by the `disabledTools` deny-list,
+ * so `enabled = total − disabled`.
+ */
+function mcpToolStats(
+  node: CatalogNode,
+  disabledToolsBySlug: Map<string, Set<string>> | undefined
+): { enabled: number; total: number } {
+  let total = 0
+  let disabled = 0
+  for (const leaf of collectLeaves(node)) {
+    total += leaf.tools.length
+    const denied = disabledToolsBySlug?.get(leaf.slug)
+    if (denied) {
+      for (const tool of leaf.tools) if (denied.has(tool.name)) disabled++
+    }
+  }
+  return { enabled: total - disabled, total }
 }
 
 /** Sum the restriction counts of every toolset leaf under a node. */

--- a/apps/web/src/components/agents/ui/detail/tools/tool-select-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tool-select-dialog.tsx
@@ -20,6 +20,8 @@ export interface InstalledToolsetEntry {
   slug: string
   enabled: boolean
   source: 'manual' | 'mention' | 'auto_default'
+  /** Toolset-shaped overrides — `{ disabledTools?: string[] }`. Drives per-tool MCP selection. */
+  config?: Record<string, unknown>
 }
 
 interface ToolSelectDialogProps {
@@ -31,6 +33,16 @@ interface ToolSelectDialogProps {
   onToggleToolset: (slug: string, enabled: boolean) => void | Promise<void>
   /** Bulk-toggle multiple toolsets ("Add all tools"). */
   onToggleToolsets: (changes: Array<{ slug: string; enabled: boolean }>) => void | Promise<void>
+  /**
+   * Patch a toolset's `enabled` flag and/or `disabledTools` deny-list. When
+   * supplied, MCP servers gain per-tool selection in their detail view; when
+   * omitted, MCP servers fall back to a single whole-server toggle (used by
+   * surfaces whose storage doesn't honor `disabledTools`).
+   */
+  onUpdateToolset?: (
+    slug: string,
+    patch: { enabled?: boolean; disabledTools?: string[] }
+  ) => void | Promise<void>
   open: boolean
   onOpenChange: (open: boolean) => void
   /**
@@ -48,7 +60,12 @@ interface ToolSelectDialogProps {
 type ViewMode = 'list' | 'app-detail'
 type ListTab = 'all' | 'apps' | 'mcps'
 
-type InstalledState = Pick<InstalledToolsetEntry, 'enabled' | 'source'>
+interface InstalledState {
+  enabled: boolean
+  source: InstalledToolsetEntry['source']
+  /** Registered tool names disabled inside this toolset. */
+  disabledTools: string[]
+}
 
 /**
  * Multi-view dialog used to add toolsets to an agent. Three surfaces:
@@ -65,6 +82,7 @@ export function ToolSelectDialog({
   boundAppIds,
   onToggleToolset,
   onToggleToolsets,
+  onUpdateToolset,
   open,
   onOpenChange,
   initialAppId,
@@ -104,7 +122,8 @@ export function ToolSelectDialog({
   const installedState = useMemo<Map<string, InstalledState>>(() => {
     const map = new Map<string, InstalledState>()
     for (const row of installedToolsets) {
-      map.set(row.slug, { enabled: row.enabled, source: row.source })
+      const disabledTools = (row.config?.disabledTools as string[] | undefined) ?? []
+      map.set(row.slug, { enabled: row.enabled, source: row.source, disabledTools })
     }
     return map
   }, [installedToolsets])
@@ -125,6 +144,54 @@ export function ToolSelectDialog({
 
   function sourceOf(slug: string): InstalledState['source'] | undefined {
     return installedState.get(slug)?.source
+  }
+
+  function disabledToolsOf(slug: string): string[] {
+    return installedState.get(slug)?.disabledTools ?? []
+  }
+
+  // A tool is enabled when its toolset is installed AND the tool's registered
+  // name is not in the toolset's deny-list.
+  function isToolEnabled(slug: string, toolName: string): boolean {
+    if (!isInstalled(slug)) return false
+    return !disabledToolsOf(slug).includes(toolName)
+  }
+
+  /**
+   * Toggle one tool inside an MCP toolset. Edits the `disabledTools` deny-list,
+   * enabling/disabling the parent toolset at the edges:
+   *  - first tool checked on a not-yet-enabled toolset installs it, denying the rest;
+   *  - unchecking the last enabled tool disables the toolset and clears the deny-list.
+   */
+  const handleToolClick = (slug: string, toolName: string, allToolNames: string[]) => {
+    if (!onUpdateToolset) return
+    const source = sourceOf(slug)
+    // Locked toolset (mention/auto_default): per-tool edits are no-ops, mirroring `handleToolsetClick`.
+    if (isInstalled(slug) && source && source !== 'manual') return
+
+    if (isToolEnabled(slug, toolName)) {
+      const nextDisabled = [...disabledToolsOf(slug), toolName]
+      const allDisabled = allToolNames.every((n) => nextDisabled.includes(n))
+      if (allDisabled) {
+        void onUpdateToolset(slug, { enabled: false, disabledTools: [] })
+      } else {
+        void onUpdateToolset(slug, { disabledTools: nextDisabled })
+      }
+      return
+    }
+
+    if (installedState.get(slug)?.enabled) {
+      // Toolset already on — just lift this tool out of the deny-list.
+      void onUpdateToolset(slug, {
+        disabledTools: disabledToolsOf(slug).filter((n) => n !== toolName),
+      })
+    } else {
+      // Toolset off/absent — install it with only this tool enabled.
+      void onUpdateToolset(slug, {
+        enabled: true,
+        disabledTools: allToolNames.filter((n) => n !== toolName),
+      })
+    }
   }
 
   const handleToolsetClick = (slug: string) => {
@@ -211,8 +278,11 @@ export function ToolSelectDialog({
                   app={selectedApp}
                   isInstalled={isInstalled}
                   sourceOf={sourceOf}
+                  isToolEnabled={isToolEnabled}
                   onToggle={handleToolsetClick}
+                  onToolClick={handleToolClick}
                   onRemove={handleRemove}
+                  onUpdateToolset={onUpdateToolset}
                   onAddAll={(slugs) => {
                     if (slugs.length === 0) return
                     void onToggleToolsets(slugs.map((slug) => ({ slug, enabled: true })))
@@ -423,21 +493,38 @@ interface AppDetailViewProps {
   app: CatalogContainerNode
   isInstalled: (slug: string) => boolean
   sourceOf: (slug: string) => InstalledState['source'] | undefined
+  isToolEnabled: (slug: string, toolName: string) => boolean
   onToggle: (slug: string) => void
+  onToolClick: (slug: string, toolName: string, allToolNames: string[]) => void
   onRemove: (slug: string) => void
+  onUpdateToolset?: (
+    slug: string,
+    patch: { enabled?: boolean; disabledTools?: string[] }
+  ) => void | Promise<void>
   onAddAll: (slugs: string[]) => void
   /** When false, an inline hint appears prompting the admin to pick a credential. */
   hasBoundAccount: boolean
 }
 
-function AppDetailView({
+function AppDetailView(props: AppDetailViewProps) {
+  // MCP servers carry a single toolset whose tools have no further grouping —
+  // drill into the individual tools instead of the one toolset row. Falls back
+  // to the toolset view when the surface can't persist per-tool deny-lists.
+  return props.app.origin === 'mcp' && props.onUpdateToolset ? (
+    <McpToolDetailView {...props} />
+  ) : (
+    <AppToolsetDetailView {...props} />
+  )
+}
+
+/** Native-app detail — one selectable row per toolset (unchanged behavior). */
+function AppToolsetDetailView({
   app,
   isInstalled,
   sourceOf,
   onToggle,
   onRemove,
   onAddAll,
-  hasBoundAccount,
 }: AppDetailViewProps) {
   const leaves = useMemo(() => flattenCatalogToToolsets([app]), [app])
   const installedCount = leaves.reduce((n, l) => (isInstalled(l.slug) ? n + 1 : n), 0)
@@ -475,6 +562,76 @@ function AppDetailView({
               source={sourceOf(entry.slug)}
               onSelect={() => onToggle(entry.slug)}
               onRemove={() => onRemove(entry.slug)}
+            />
+          ))}
+        </div>
+      </ScrollArea>
+    </>
+  )
+}
+
+/** MCP detail — one selectable `ToolSelectRow` per individual tool. */
+function McpToolDetailView({
+  app,
+  sourceOf,
+  isToolEnabled,
+  onToolClick,
+  onUpdateToolset,
+}: AppDetailViewProps) {
+  const leaves = useMemo(() => flattenCatalogToToolsets([app]), [app])
+  // MCP apps hold exactly one toolset; flatten its tools, tagging each with its slug.
+  const tools = useMemo(
+    () =>
+      leaves.flatMap((leaf) =>
+        leaf.tools.map((tool) => ({
+          tool,
+          slug: leaf.slug,
+          iconId: leaf.iconId,
+          color: leaf.color || null,
+          allNames: leaf.tools.map((t) => t.name),
+        }))
+      ),
+    [leaves]
+  )
+
+  const enabledCount = tools.reduce((n, t) => (isToolEnabled(t.slug, t.tool.name) ? n + 1 : n), 0)
+  const total = tools.length
+  const allEnabled = enabledCount === total && total > 0
+
+  return (
+    <>
+      <div className='flex items-center justify-between border-b ps-3 pe-2 py-1'>
+        <span className='text-xs text-muted-foreground'>
+          {enabledCount}/{total} {pluralize(total, 'tool')} enabled
+        </span>
+        <Button
+          size='sm'
+          variant='ghost'
+          disabled={allEnabled}
+          onClick={() => {
+            if (!onUpdateToolset) return
+            for (const slug of new Set(leaves.map((l) => l.slug))) {
+              void onUpdateToolset(slug, { enabled: true, disabledTools: [] })
+            }
+          }}>
+          {allEnabled ? 'All enabled' : 'Add all tools'}
+        </Button>
+      </div>
+
+      <ScrollArea viewportClassName='max-h-[32rem]' scrollbarClassName='w-1!'>
+        <div className='p-3'>
+          {tools.map(({ tool, slug, iconId, color, allNames }) => (
+            <ToolSelectRow
+              key={tool.name}
+              id={tool.name}
+              iconId={iconId}
+              color={color}
+              label={tool.displayName}
+              description={tool.description || undefined}
+              installed={isToolEnabled(slug, tool.name)}
+              source={sourceOf(slug)}
+              onSelect={() => onToolClick(slug, tool.name, allNames)}
+              onRemove={() => onToolClick(slug, tool.name, allNames)}
             />
           ))}
         </div>

--- a/apps/web/src/components/agents/ui/detail/tools/tools-section.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tools-section.tsx
@@ -47,7 +47,7 @@ export function ToolsSection({ agent, onAutosaveChange }: ToolsSectionProps) {
     [onAutosaveChange]
   )
 
-  const { toggleToolset, toggleToolsets } = useToolsetMutations(
+  const { toggleToolset, toggleToolsets, updateToolset } = useToolsetMutations(
     agent.id,
     agent.slug,
     handleSavingChange
@@ -66,6 +66,17 @@ export function ToolsSection({ agent, onAutosaveChange }: ToolsSectionProps) {
     const map = new Map<string, ToolsetRowState>()
     for (const row of agent.toolsets) {
       map.set(row.slug, { enabled: row.enabled, source: row.source })
+    }
+    return map
+  }, [agent.toolsets])
+
+  // Per-toolset disabled-tool deny-lists, so MCP server rows can show an
+  // enabled-tool count (`N of M`) instead of a toolset count.
+  const disabledToolsBySlug = useMemo<Map<string, Set<string>>>(() => {
+    const map = new Map<string, Set<string>>()
+    for (const row of agent.toolsets) {
+      const disabled = (row.config as { disabledTools?: string[] })?.disabledTools
+      if (disabled && disabled.length > 0) map.set(row.slug, new Set(disabled))
     }
     return map
   }, [agent.toolsets])
@@ -236,6 +247,7 @@ export function ToolsSection({ agent, onAutosaveChange }: ToolsSectionProps) {
                 inheritedIconId={root.iconId ?? 'package'}
                 inheritedColor={root.color}
                 stateBySlug={stateBySlug}
+                disabledToolsBySlug={disabledToolsBySlug}
                 restrictionCountBySlug={restrictionCountBySlug}
                 collapsed={collapsed}
                 onToggleCollapsed={toggleCollapsed}
@@ -272,6 +284,7 @@ export function ToolsSection({ agent, onAutosaveChange }: ToolsSectionProps) {
         surface={agent.kind === 'chat' ? 'chat' : undefined}
         onToggleToolset={toggleToolset}
         onToggleToolsets={toggleToolsets}
+        onUpdateToolset={updateToolset}
         open={dialogOpen}
         onOpenChange={(next) => {
           setDialogOpen(next)

--- a/apps/web/src/components/agents/ui/detail/tools/use-toolset-mutations.ts
+++ b/apps/web/src/components/agents/ui/detail/tools/use-toolset-mutations.ts
@@ -6,9 +6,22 @@ import { useCallback, useRef } from 'react'
 import { api } from '~/trpc/react'
 import type { AgentDetail } from '../../../store/agent-store'
 
+/** Patch shape mirroring the server's `AgentToolsetPatch` — both fields optional. */
+export interface ToolsetPatch {
+  enabled?: boolean
+  /** Registered tool names disabled inside this toolset (full replace). */
+  disabledTools?: string[]
+}
+
 interface UseToolsetMutationsReturn {
   toggleToolset: (slug: string, enabled: boolean) => Promise<void>
   toggleToolsets: (changes: Array<{ slug: string; enabled: boolean }>) => Promise<void>
+  /**
+   * Patch a single toolset's `enabled` flag and/or its `config.disabledTools`
+   * deny-list in one optimistic mutation. Backs per-tool MCP selection — the
+   * caller computes the next deny-list from the tool checkboxes.
+   */
+  updateToolset: (slug: string, patch: ToolsetPatch) => Promise<void>
   isPending: boolean
 }
 
@@ -31,10 +44,10 @@ export function useToolsetMutations(
   const update = api.agentToolset.update.useMutation()
   const savingTimerRef = useRef<ReturnType<typeof setTimeout>>()
 
-  const applyOptimisticChange = (
+  const applyOptimisticPatch = (
     toolsets: AgentDetail['toolsets'],
     slug: string,
-    enabled: boolean
+    patch: ToolsetPatch
   ): AgentDetail['toolsets'] => {
     const idx = toolsets.findIndex((t) => t.slug === slug)
     if (idx >= 0) {
@@ -43,8 +56,12 @@ export function useToolsetMutations(
       const next = [...toolsets]
       next[idx] = {
         ...current,
-        enabled,
+        enabled: patch.enabled ?? current.enabled,
         source: current.source === 'auto_default' ? 'manual' : current.source,
+        config:
+          patch.disabledTools !== undefined
+            ? { ...current.config, disabledTools: patch.disabledTools }
+            : current.config,
       }
       return next
     }
@@ -52,9 +69,9 @@ export function useToolsetMutations(
       ...toolsets,
       {
         slug,
-        enabled,
+        enabled: patch.enabled ?? true,
         source: 'manual',
-        config: {},
+        config: patch.disabledTools !== undefined ? { disabledTools: patch.disabledTools } : {},
       },
     ]
   }
@@ -68,11 +85,43 @@ export function useToolsetMutations(
 
       utils.agent.getById.setData({ agentId: agentSlug }, (old) => {
         if (!old) return old
-        return { ...old, toolsets: applyOptimisticChange(old.toolsets, slug, enabled) }
+        return { ...old, toolsets: applyOptimisticPatch(old.toolsets, slug, { enabled }) }
       })
 
       try {
         await update.mutateAsync({ agentId, slug, enabled })
+      } catch (err) {
+        utils.agent.getById.setData({ agentId: agentSlug }, previous)
+        toastError({
+          title: 'Failed to update toolset',
+          description: err instanceof Error ? err.message : 'Unknown error',
+        })
+      } finally {
+        clearTimeout(savingTimerRef.current)
+        onSavingChange?.(false)
+      }
+    },
+    [agentId, agentSlug, onSavingChange, update, utils.agent.getById]
+  )
+
+  /**
+   * Patch one toolset's `enabled` flag and/or `disabledTools` deny-list. One
+   * optimistic write mirroring the server's `applyToolsetPatch`, then a single
+   * mutation — no invalidate on success.
+   */
+  const updateToolset = useCallback(
+    async (slug: string, patch: ToolsetPatch) => {
+      savingTimerRef.current = setTimeout(() => onSavingChange?.(true), 400)
+
+      const previous = utils.agent.getById.getData({ agentId: agentSlug })
+
+      utils.agent.getById.setData({ agentId: agentSlug }, (old) => {
+        if (!old) return old
+        return { ...old, toolsets: applyOptimisticPatch(old.toolsets, slug, patch) }
+      })
+
+      try {
+        await update.mutateAsync({ agentId, slug, ...patch })
       } catch (err) {
         utils.agent.getById.setData({ agentId: agentSlug }, previous)
         toastError({
@@ -103,7 +152,7 @@ export function useToolsetMutations(
         if (!old) return old
         let toolsets = old.toolsets
         for (const { slug, enabled } of changes) {
-          toolsets = applyOptimisticChange(toolsets, slug, enabled)
+          toolsets = applyOptimisticPatch(toolsets, slug, { enabled })
         }
         return { ...old, toolsets }
       })
@@ -126,5 +175,5 @@ export function useToolsetMutations(
     [agentId, agentSlug, onSavingChange, update, utils.agent.getById]
   )
 
-  return { toggleToolset, toggleToolsets, isPending: update.isPending }
+  return { toggleToolset, toggleToolsets, updateToolset, isPending: update.isPending }
 }

--- a/packages/database/src/db/schema/api-key.ts
+++ b/packages/database/src/db/schema/api-key.ts
@@ -27,9 +27,9 @@ export const ApiKey = pgTable(
       onUpdate: 'cascade',
       onDelete: 'cascade',
     }),
-    /** Type of API key: 'app' for traditional org-level, 'workflow' for workflow-scoped, 'chat' for chat-widget JWT signing */
+    /** Type of API key: 'app' for traditional org-level, 'workflow' for workflow-scoped, 'chat' for chat-widget JWT signing, 'developer' for headless CLI publishing (CI) */
     type: text().default('app').notNull(),
-    /** Reference ID (workflowAppId when type='workflow', channelId/integrationId when type='chat', null for 'app') */
+    /** Reference ID (workflowAppId when type='workflow', channelId/integrationId when type='chat', developerAccountId when type='developer', null for 'app') */
     referenceId: text(),
     /**
      * AES-256-GCM encrypted plaintext secret (via `@auxx/credentials/crypto`).

--- a/packages/sdk/src/auth/auth.ts
+++ b/packages/sdk/src/auth/auth.ts
@@ -42,6 +42,13 @@ class Authenticator {
    * Ensure user is authenticated, prompting for login if needed
    */
   async ensureAuthed(): Promise<Result<string, AuthError | any>> {
+    // Headless auth for CI: when AUXX_API_KEY is set, send it directly as the
+    // bearer token and skip the keychain + OAuth refresh entirely. The
+    // `auxx_dev_` prefix routes it to the developer-key path on the API.
+    if (process.env.AUXX_API_KEY) {
+      return { success: true, value: process.env.AUXX_API_KEY }
+    }
+
     const existingTokenResult = await getKeychain().load()
 
     if (isError(existingTokenResult)) {

--- a/packages/sdk/src/env.ts
+++ b/packages/sdk/src/env.ts
@@ -42,3 +42,10 @@ export const USE_SETTINGS = process.env.USE_SETTINGS !== 'false'
 
 /** SDK OAuth Client ID - this will be registered in better-auth */
 export const SDK_CLIENT_ID = process.env.AUXX_SDK_CLIENT_ID || 'auxx-sdk-cli'
+
+/**
+ * Developer API key for headless authentication (CI). When set, the CLI sends
+ * this as the bearer token and skips the interactive OAuth/keychain flow.
+ * Mint one in the build portal under settings/api-keys.
+ */
+export const AUXX_API_KEY = process.env.AUXX_API_KEY


### PR DESCRIPTION
## Summary

Two features:

### Developer API keys (headless SDK publishing)
- New `developer` API key type with `auxx_dev_` prefix, scoped to a developer account
- Dedicated API middleware (`developer-key-auth.ts`) resolves keys by hash lookup — no better-auth round-trip
- Build portal gets a **Settings → API Keys** page to mint, list, and revoke keys
- SDK honors `AUXX_API_KEY`: when set, it's sent directly as the bearer token, skipping the interactive OAuth/keychain flow — enables one-shot `auxx publish` in CI

### Per-tool MCP selection in the agent tool dialog
- Opening an MCP server in the tool select dialog now lists its individual tools as selectable rows instead of a single whole-server toggle
- Selections persist via the toolset's `config.disabledTools` deny-list, with edge handling: first tool checked installs the toolset (denying the rest), unchecking the last tool disables it and clears the list
- Catalog rows show an enabled-of-total count (`3 of 12 tools`) for MCP servers
- New `updateToolset` optimistic mutation patches `enabled` + `disabledTools` in one call

## Test plan
- [ ] Mint a developer key in the build portal, run `AUXX_API_KEY=auxx_dev_... auxx publish` headlessly
- [ ] Toggle individual MCP tools in an agent's tool dialog; verify counts and persistence after reload