### PR TITLE
fix(agents): fix rapid per-tool MCP click race + suppress realtime self-echo on toolset writes

### DIFF
--- a/apps/web/src/components/agents/ui/detail/tools/tool-select-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tool-select-dialog.tsx
@@ -34,15 +34,22 @@ interface ToolSelectDialogProps {
   /** Bulk-toggle multiple toolsets ("Add all tools"). */
   onToggleToolsets: (changes: Array<{ slug: string; enabled: boolean }>) => void | Promise<void>
   /**
-   * Patch a toolset's `enabled` flag and/or `disabledTools` deny-list. When
-   * supplied, MCP servers gain per-tool selection in their detail view; when
-   * omitted, MCP servers fall back to a single whole-server toggle (used by
-   * surfaces whose storage doesn't honor `disabledTools`).
+   * Patch a toolset's `enabled` flag and/or `disabledTools` deny-list. In the
+   * MCP per-tool detail view this backs only the non-racy "Add all tools"
+   * button; per-tool clicks go through `onToggleTool`.
    */
   onUpdateToolset?: (
     slug: string,
     patch: { enabled?: boolean; disabledTools?: string[] }
   ) => void | Promise<void>
+  /**
+   * Toggle one tool inside an MCP toolset's deny-list. The handler owns the
+   * read-modify-write against fresh state (see `useToolsetMutations.toggleTool`)
+   * so rapid clicks chain correctly. When this or `onUpdateToolset` is omitted,
+   * MCP servers fall back to a single whole-server toggle (used by surfaces
+   * whose storage doesn't honor `disabledTools`).
+   */
+  onToggleTool?: (slug: string, toolName: string, allToolNames: string[]) => void | Promise<void>
   open: boolean
   onOpenChange: (open: boolean) => void
   /**
@@ -83,6 +90,7 @@ export function ToolSelectDialog({
   onToggleToolset,
   onToggleToolsets,
   onUpdateToolset,
+  onToggleTool,
   open,
   onOpenChange,
   initialAppId,
@@ -155,43 +163,6 @@ export function ToolSelectDialog({
   function isToolEnabled(slug: string, toolName: string): boolean {
     if (!isInstalled(slug)) return false
     return !disabledToolsOf(slug).includes(toolName)
-  }
-
-  /**
-   * Toggle one tool inside an MCP toolset. Edits the `disabledTools` deny-list,
-   * enabling/disabling the parent toolset at the edges:
-   *  - first tool checked on a not-yet-enabled toolset installs it, denying the rest;
-   *  - unchecking the last enabled tool disables the toolset and clears the deny-list.
-   */
-  const handleToolClick = (slug: string, toolName: string, allToolNames: string[]) => {
-    if (!onUpdateToolset) return
-    const source = sourceOf(slug)
-    // Locked toolset (mention/auto_default): per-tool edits are no-ops, mirroring `handleToolsetClick`.
-    if (isInstalled(slug) && source && source !== 'manual') return
-
-    if (isToolEnabled(slug, toolName)) {
-      const nextDisabled = [...disabledToolsOf(slug), toolName]
-      const allDisabled = allToolNames.every((n) => nextDisabled.includes(n))
-      if (allDisabled) {
-        void onUpdateToolset(slug, { enabled: false, disabledTools: [] })
-      } else {
-        void onUpdateToolset(slug, { disabledTools: nextDisabled })
-      }
-      return
-    }
-
-    if (installedState.get(slug)?.enabled) {
-      // Toolset already on — just lift this tool out of the deny-list.
-      void onUpdateToolset(slug, {
-        disabledTools: disabledToolsOf(slug).filter((n) => n !== toolName),
-      })
-    } else {
-      // Toolset off/absent — install it with only this tool enabled.
-      void onUpdateToolset(slug, {
-        enabled: true,
-        disabledTools: allToolNames.filter((n) => n !== toolName),
-      })
-    }
   }
 
   const handleToolsetClick = (slug: string) => {
@@ -280,7 +251,7 @@ export function ToolSelectDialog({
                   sourceOf={sourceOf}
                   isToolEnabled={isToolEnabled}
                   onToggle={handleToolsetClick}
-                  onToolClick={handleToolClick}
+                  onToggleTool={onToggleTool}
                   onRemove={handleRemove}
                   onUpdateToolset={onUpdateToolset}
                   onAddAll={(slugs) => {
@@ -495,7 +466,7 @@ interface AppDetailViewProps {
   sourceOf: (slug: string) => InstalledState['source'] | undefined
   isToolEnabled: (slug: string, toolName: string) => boolean
   onToggle: (slug: string) => void
-  onToolClick: (slug: string, toolName: string, allToolNames: string[]) => void
+  onToggleTool?: (slug: string, toolName: string, allToolNames: string[]) => void | Promise<void>
   onRemove: (slug: string) => void
   onUpdateToolset?: (
     slug: string,
@@ -510,7 +481,7 @@ function AppDetailView(props: AppDetailViewProps) {
   // MCP servers carry a single toolset whose tools have no further grouping —
   // drill into the individual tools instead of the one toolset row. Falls back
   // to the toolset view when the surface can't persist per-tool deny-lists.
-  return props.app.origin === 'mcp' && props.onUpdateToolset ? (
+  return props.app.origin === 'mcp' && props.onToggleTool && props.onUpdateToolset ? (
     <McpToolDetailView {...props} />
   ) : (
     <AppToolsetDetailView {...props} />
@@ -575,7 +546,7 @@ function McpToolDetailView({
   app,
   sourceOf,
   isToolEnabled,
-  onToolClick,
+  onToggleTool,
   onUpdateToolset,
 }: AppDetailViewProps) {
   const leaves = useMemo(() => flattenCatalogToToolsets([app]), [app])
@@ -630,8 +601,8 @@ function McpToolDetailView({
               description={tool.description || undefined}
               installed={isToolEnabled(slug, tool.name)}
               source={sourceOf(slug)}
-              onSelect={() => onToolClick(slug, tool.name, allNames)}
-              onRemove={() => onToolClick(slug, tool.name, allNames)}
+              onSelect={() => void onToggleTool?.(slug, tool.name, allNames)}
+              onRemove={() => void onToggleTool?.(slug, tool.name, allNames)}
             />
           ))}
         </div>

--- a/apps/web/src/components/agents/ui/detail/tools/tools-section.tsx
+++ b/apps/web/src/components/agents/ui/detail/tools/tools-section.tsx
@@ -47,7 +47,7 @@ export function ToolsSection({ agent, onAutosaveChange }: ToolsSectionProps) {
     [onAutosaveChange]
   )
 
-  const { toggleToolset, toggleToolsets, updateToolset } = useToolsetMutations(
+  const { toggleToolset, toggleToolsets, updateToolset, toggleTool } = useToolsetMutations(
     agent.id,
     agent.slug,
     handleSavingChange
@@ -285,6 +285,7 @@ export function ToolsSection({ agent, onAutosaveChange }: ToolsSectionProps) {
         onToggleToolset={toggleToolset}
         onToggleToolsets={toggleToolsets}
         onUpdateToolset={updateToolset}
+        onToggleTool={toggleTool}
         open={dialogOpen}
         onOpenChange={(next) => {
           setDialogOpen(next)

--- a/apps/web/src/components/agents/ui/detail/tools/use-toolset-mutations.ts
+++ b/apps/web/src/components/agents/ui/detail/tools/use-toolset-mutations.ts
@@ -22,6 +22,13 @@ interface UseToolsetMutationsReturn {
    * caller computes the next deny-list from the tool checkboxes.
    */
   updateToolset: (slug: string, patch: ToolsetPatch) => Promise<void>
+  /**
+   * Toggle one tool inside a toolset's deny-list. Reads the toolset's current
+   * state from the live `agent.getById` cache at click time — not from
+   * memoized props — so rapid clicks chain on each other instead of
+   * overwriting from the same stale base array.
+   */
+  toggleTool: (slug: string, toolName: string, allToolNames: string[]) => Promise<void>
   isPending: boolean
 }
 
@@ -137,6 +144,48 @@ export function useToolsetMutations(
   )
 
   /**
+   * Per-tool toggle with the deny-list read-modify-write done against the
+   * fresh cache. Edge rules match the MCP drill-in UX: checking the first
+   * tool of a disabled toolset installs it denying the rest; unchecking the
+   * last enabled tool disables the toolset and clears the deny-list. Locked
+   * toolsets (`mention` / `auto_default`) are no-ops.
+   */
+  const toggleTool = useCallback(
+    async (slug: string, toolName: string, allToolNames: string[]) => {
+      const agent = utils.agent.getById.getData({ agentId: agentSlug })
+      const entry = agent?.toolsets.find((t) => t.slug === slug)
+      const enabled = entry?.enabled ?? false
+      const installed = enabled || entry?.source === 'mention'
+      if (installed && entry && entry.source !== 'manual') return
+      const disabledTools =
+        (entry?.config as { disabledTools?: string[] } | undefined)?.disabledTools ?? []
+
+      if (installed && !disabledTools.includes(toolName)) {
+        // Tool currently enabled — add it to the deny-list.
+        const nextDisabled = [...disabledTools, toolName]
+        if (allToolNames.every((n) => nextDisabled.includes(n))) {
+          await updateToolset(slug, { enabled: false, disabledTools: [] })
+        } else {
+          await updateToolset(slug, { disabledTools: nextDisabled })
+        }
+        return
+      }
+
+      if (enabled) {
+        // Toolset already on — just lift this tool out of the deny-list.
+        await updateToolset(slug, { disabledTools: disabledTools.filter((n) => n !== toolName) })
+      } else {
+        // Toolset off/absent — install it with only this tool enabled.
+        await updateToolset(slug, {
+          enabled: true,
+          disabledTools: allToolNames.filter((n) => n !== toolName),
+        })
+      }
+    },
+    [agentSlug, updateToolset, utils.agent.getById]
+  )
+
+  /**
    * Bulk variant. Applies one combined optimistic write and fires all
    * mutations in parallel. No invalidate — the optimistic write already
    * mirrors the server response.
@@ -175,5 +224,5 @@ export function useToolsetMutations(
     [agentId, agentSlug, onSavingChange, update, utils.agent.getById]
   )
 
-  return { toggleToolset, toggleToolsets, updateToolset, isPending: update.isPending }
+  return { toggleToolset, toggleToolsets, updateToolset, toggleTool, isPending: update.isPending }
 }

--- a/apps/web/src/server/api/routers/agent-toolset.ts
+++ b/apps/web/src/server/api/routers/agent-toolset.ts
@@ -52,11 +52,19 @@ export const agentToolsetRouter = createTRPCRouter({
       const { organizationId } = ctx.session
       await ensureAgentInOrg(organizationId, input.agentId)
 
-      await updateAgentToolset(organizationId, input.agentId, {
-        slug: input.slug,
-        enabled: input.enabled,
-        disabledTools: input.disabledTools,
-      })
+      // Exclude the writer's own socket from the `agent:updated` broadcast so
+      // the realtime self-echo doesn't refetch over its optimistic cache.
+      const excludeSocketId = ctx.headers.get('x-realtime-socket-id') ?? undefined
+      await updateAgentToolset(
+        organizationId,
+        input.agentId,
+        {
+          slug: input.slug,
+          enabled: input.enabled,
+          disabledTools: input.disabledTools,
+        },
+        { excludeSocketId }
+      )
 
       logger.info('Agent toolset updated', {
         organizationId,
@@ -76,7 +84,10 @@ export const agentToolsetRouter = createTRPCRouter({
       const { organizationId } = ctx.session
       await ensureAgentInOrg(organizationId, input.agentId)
 
-      await batchUpdateAgentToolsets(organizationId, input.agentId, input.toolsets)
+      const excludeSocketId = ctx.headers.get('x-realtime-socket-id') ?? undefined
+      await batchUpdateAgentToolsets(organizationId, input.agentId, input.toolsets, {
+        excludeSocketId,
+      })
 
       logger.info('Agent toolsets batch-updated', {
         organizationId,

--- a/packages/lib/src/agents/agent-toolset-service.ts
+++ b/packages/lib/src/agents/agent-toolset-service.ts
@@ -173,11 +173,16 @@ async function clearOrphanedAppAccounts(
  * No restriction auto-create: v8 tool bindings are intrinsic to the tool
  * (author `inputBindings`), so enabling a toolset yields its scoped behavior
  * with zero extra writes. See plans/chat/v8 phase-6 §1.
+ *
+ * `options.excludeSocketId` keeps the `agent:updated` broadcast away from the
+ * originating browser so it doesn't clobber its own optimistic cache —
+ * server-originated writes (no socket) still broadcast to everyone.
  */
 export async function updateAgentToolset(
   organizationId: string,
   agentId: string,
   patch: AgentToolsetPatch,
+  options: { excludeSocketId?: string } = {},
   db: Database = defaultDb as Database
 ): Promise<void> {
   await db.transaction(async (tx) => {
@@ -210,18 +215,28 @@ export async function updateAgentToolset(
       error: err instanceof Error ? err.message : String(err),
     })
   }
-  await publishAgentUpdated(getRealtimeService(), organizationId, { agentId })
+  await publishAgentUpdated(
+    getRealtimeService(),
+    organizationId,
+    { agentId },
+    {
+      excludeSocketId: options.excludeSocketId,
+    }
+  )
 }
 
 /**
  * Apply many toolset patches for an agent in one transaction. Entries not in
  * the patch list are left untouched — callers send the full set they want to
  * enable, plus explicit `enabled: false` for ones they unchecked.
+ *
+ * `options.excludeSocketId`: see {@link updateAgentToolset}.
  */
 export async function batchUpdateAgentToolsets(
   organizationId: string,
   agentId: string,
   patches: AgentToolsetPatch[],
+  options: { excludeSocketId?: string } = {},
   db: Database = defaultDb as Database
 ): Promise<void> {
   await db.transaction(async (tx) => {
@@ -257,5 +272,12 @@ export async function batchUpdateAgentToolsets(
       error: err instanceof Error ? err.message : String(err),
     })
   }
-  await publishAgentUpdated(getRealtimeService(), organizationId, { agentId })
+  await publishAgentUpdated(
+    getRealtimeService(),
+    organizationId,
+    { agentId },
+    {
+      excludeSocketId: options.excludeSocketId,
+    }
+  )
 }


### PR DESCRIPTION
## Summary

- Move the per-tool deny-list read-modify-write into `useToolsetMutations.toggleTool` so each click reads fresh tRPC cache instead of stale memoized props — rapid clicks now chain correctly instead of overwriting from the same stale base array
- Thread `excludeSocketId` through `updateAgentToolset` / `batchUpdateAgentToolsets` so the originating socket's optimistic cache isn't clobbered by the realtime broadcast it triggered
- Wire new `onToggleTool` prop through `ToolSelectDialog` → `McpToolDetailView` so the dialog delegates to the mutation handler rather than computing state itself

## Test plan

- [ ] Open an agent's tools dialog, navigate into an MCP server's per-tool view
- [ ] Rapidly click several tool checkboxes — verify each click toggles the correct tool without reverting others
- [ ] Toggle a tool on/off and verify the optimistic UI state is not reset by a realtime echo after save
- [ ] Enable the first tool on a disabled MCP server — verify the server installs and only that tool is enabled
- [ ] Disable all tools on an enabled MCP server — verify the server is disabled and deny-list is cleared