### PR TITLE
fix(mcp): reliable OAuth popup completion + shared utils

### DIFF
--- a/apps/web/src/app/api/mcp/[serverId]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/mcp/[serverId]/oauth2/callback/route.ts
@@ -22,32 +22,30 @@ function isValidReturnTo(value: string | undefined | null): value is string {
   return !!value && value.startsWith('/') && !value.startsWith('//')
 }
 
-/** Popup termination page — postMessage to opener + BroadcastChannel('oauth-mcp-connect'), close. */
-function renderPopupTerminationPage(payload: {
+/** Origins allowed to host the popup termination page (the app window's own origin). */
+const TERMINATION_ORIGINS = [WEBAPP_URL, process.env.NGROK_URL].filter(Boolean) as string[]
+
+/**
+ * Redirect the popup to the termination page on the *opener's* origin.
+ *
+ * The callback runs on the public tunnel origin (NGROK_URL) so providers like Stripe can reach
+ * it, but a cross-origin popup can't notify the app window — `BroadcastChannel` is origin-scoped
+ * and `window.opener` is often severed by the provider's COOP header. Bouncing the popup back to
+ * the app origin (`/api/mcp/oauth-complete`) lets both channels deliver the result. `originOfOpener`
+ * is validated against an allowlist to avoid an open redirect.
+ */
+function popupTerminationRedirect(payload: {
   ok: boolean
   error?: string | null
   originOfOpener: string
 }): NextResponse {
-  const message = { type: 'oauth_done', ok: payload.ok, error: payload.error ?? null }
-  const serializedMessage = JSON.stringify(message).replace(/</g, '\\u003c')
-  const serializedOrigin = JSON.stringify(payload.originOfOpener).replace(/</g, '\\u003c')
-  const heading = payload.ok ? 'Connected' : 'Connection failed'
-  const body = payload.ok
-    ? 'You can close this window.'
-    : `Something went wrong: ${payload.error ?? 'Unknown error'}. You can close this window.`
-  const html = `<!doctype html>
-<html><head><title>${heading}</title></head>
-<body style="font-family: -apple-system, sans-serif; padding: 2rem; text-align: center;">
-<h1>${heading}</h1><p>${body}</p>
-<script>(function(){var p=${serializedMessage};var o=${serializedOrigin};
-try{if(window.opener){window.opener.postMessage(p,o);}}catch(_){}
-try{var bc=new BroadcastChannel('oauth-mcp-connect');bc.postMessage(p);bc.close();}catch(_){}
-try{window.close();}catch(_){}})();</script>
-</body></html>`
-  return new NextResponse(html, {
-    status: payload.ok ? 200 : 400,
-    headers: { 'Content-Type': 'text/html' },
-  })
+  const origin = TERMINATION_ORIGINS.includes(payload.originOfOpener)
+    ? payload.originOfOpener
+    : WEBAPP_URL
+  const url = new URL('/api/mcp/oauth-complete', origin)
+  url.searchParams.set('ok', String(payload.ok))
+  if (!payload.ok && payload.error) url.searchParams.set('error', payload.error)
+  return NextResponse.redirect(url.toString())
 }
 
 export async function GET(
@@ -58,6 +56,7 @@ export async function GET(
   const code = searchParams.get('code')
   const state = searchParams.get('state')
   const providerError = searchParams.get('error')
+  const providerErrorDescription = searchParams.get('error_description')
   const { serverId } = await params
 
   let metadata: Record<string, unknown> | null = null
@@ -74,7 +73,11 @@ export async function GET(
   const originOfOpener = (metadata?.originOfOpener as string) || WEBAPP_URL
 
   if (providerError) {
-    logger.error('MCP OAuth provider error', { providerError, serverId })
+    logger.error('MCP OAuth provider error', {
+      providerError,
+      providerErrorDescription,
+      serverId,
+    })
     if (state) {
       try {
         const redis = await getRedisClient()
@@ -82,7 +85,7 @@ export async function GET(
       } catch {}
     }
     if (isPopup)
-      return renderPopupTerminationPage({ ok: false, error: providerError, originOfOpener })
+      return popupTerminationRedirect({ ok: false, error: providerError, originOfOpener })
     return new NextResponse(`OAuth error: ${providerError}`, { status: 400 })
   }
 
@@ -172,9 +175,13 @@ export async function GET(
       })
     }
     await onCacheEvent('mcp.connection.changed', { orgId: metadata.organizationId as string })
+    logger.info('MCP connect complete', {
+      serverId,
+      organizationId: metadata.organizationId as string,
+    })
 
     if (isPopup) {
-      const res = renderPopupTerminationPage({ ok: true, originOfOpener })
+      const res = popupTerminationRedirect({ ok: true, originOfOpener })
       res.cookies.delete('oauth_return_to')
       return res
     }
@@ -189,7 +196,7 @@ export async function GET(
       error: error instanceof Error ? error.message : String(error),
     })
     if (isPopup) {
-      return renderPopupTerminationPage({
+      return popupTerminationRedirect({
         ok: false,
         error: error instanceof Error ? error.message : 'Unknown error',
         originOfOpener,

--- a/apps/web/src/app/api/mcp/oauth-complete/route.ts
+++ b/apps/web/src/app/api/mcp/oauth-complete/route.ts
@@ -1,0 +1,41 @@
+// apps/web/src/app/api/mcp/oauth-complete/route.ts
+
+import { type NextRequest, NextResponse } from 'next/server'
+
+/**
+ * Popup termination page, rendered on the *opener's* origin so the OAuth result reliably reaches
+ * the app window.
+ *
+ * The MCP OAuth callback necessarily runs on the public tunnel origin (NGROK_URL) so external
+ * providers (Stripe, etc.) can reach it. A popup that ends on that cross-origin page can't notify
+ * the localhost app window: `BroadcastChannel` is origin-scoped, and `window.opener` is commonly
+ * severed by the provider's `Cross-Origin-Opener-Policy: same-origin` header during the redirect
+ * chain. The callback therefore redirects the popup *here* — same origin as the opener — where both
+ * the `oauth-mcp-connect` BroadcastChannel and `postMessage` reach the app window.
+ */
+export function GET(request: NextRequest): NextResponse {
+  const ok = request.nextUrl.searchParams.get('ok') === 'true'
+  const error = request.nextUrl.searchParams.get('error')
+  const message = { type: 'oauth_done', ok, error: ok ? null : error || 'Connection failed' }
+  const serializedMessage = JSON.stringify(message).replace(/</g, '\\u003c')
+  const heading = ok ? 'Connected' : 'Connection failed'
+  const body = ok
+    ? 'You can close this window.'
+    : `Something went wrong: ${error || 'Unknown error'}. You can close this window.`
+  // Post the result, THEN close after a beat. After the provider's COOP header severs
+  // `window.opener`, BroadcastChannel is the only channel left — and closing the window in the
+  // same tick can drop the not-yet-dispatched message, so the close is deferred to let it flush.
+  const html = `<!doctype html>
+<html><head><title>${heading}</title></head>
+<body style="font-family: -apple-system, sans-serif; padding: 2rem; text-align: center;">
+<h1>${heading}</h1><p>${body}</p>
+<script>(function(){var p=${serializedMessage};var bc=null;
+try{if(window.opener){window.opener.postMessage(p,window.location.origin);}}catch(_){}
+try{bc=new BroadcastChannel('oauth-mcp-connect');bc.postMessage(p);}catch(_){}
+setTimeout(function(){try{if(bc)bc.close();}catch(_){}try{window.close();}catch(_){}},400);})();</script>
+</body></html>`
+  return new NextResponse(html, {
+    status: ok ? 200 : 400,
+    headers: { 'Content-Type': 'text/html' },
+  })
+}

--- a/apps/web/src/components/dynamic-table/components/header-cell.tsx
+++ b/apps/web/src/components/dynamic-table/components/header-cell.tsx
@@ -29,6 +29,7 @@ import { type BreadcrumbSegment, SmartBreadcrumb } from '@auxx/ui/components/sma
 import { toastInfo } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
 import { generateId } from '@auxx/utils/generateId'
+import { isEmpty } from '@auxx/utils/objects'
 import type { Header, Row, Table } from '@tanstack/react-table'
 import {
   ArrowUpDown,
@@ -88,12 +89,7 @@ interface HeaderCellProps<TData> {
  * previous AI error counts as missing — retrying is the expected behavior.
  */
 function isMissingCell(value: unknown, aiStatus: string | undefined): boolean {
-  const isEmpty =
-    value === undefined ||
-    value === null ||
-    value === '' ||
-    (Array.isArray(value) && value.length === 0)
-  return isEmpty && aiStatus !== 'generating' && aiStatus !== 'result'
+  return isEmpty(value) && aiStatus !== 'generating' && aiStatus !== 'result'
 }
 
 /**
@@ -121,17 +117,11 @@ function collectAiTargetRowIds<TData>(
     // server would dedupe but this saves a wasted quota attempt.
     if (status === 'generating') continue
 
-    const isEmpty =
-      value === undefined ||
-      value === null ||
-      value === '' ||
-      (Array.isArray(value) && value.length === 0)
-
     if (mode === 'fill-missing') {
       if (isMissingCell(value, status)) rowIds.push(row.id)
     } else {
       rowIds.push(row.id)
-      if (!isEmpty) nonEmptyCount++
+      if (!isEmpty(value)) nonEmptyCount++
     }
   }
 

--- a/apps/web/src/components/mail/searchbar/advanced-filter-mode.tsx
+++ b/apps/web/src/components/mail/searchbar/advanced-filter-mode.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from '@auxx/ui/components/button'
 import { Label } from '@auxx/ui/components/label'
 import { cn } from '@auxx/ui/lib/utils'
+import { isEmpty } from '@auxx/utils/objects'
 import { useMemo, useState } from 'react'
 import { v4 as generateId } from 'uuid'
 import ConditionOperator from '~/components/conditions/components/condition-operator'
@@ -64,14 +65,8 @@ function setConditionValue(
   operator: Operator,
   value: any
 ): SearchCondition[] {
-  const isEmpty =
-    value === undefined ||
-    value === null ||
-    value === '' ||
-    (Array.isArray(value) && value.length === 0)
-
   // For no-value operators, keep the condition even without a value
-  if (isEmpty && operatorRequiresValue(operator)) {
+  if (isEmpty(value) && operatorRequiresValue(operator)) {
     return conditions.filter((c) => c.fieldId !== fieldId)
   }
 

--- a/apps/web/src/components/mcp/hooks/use-mcp-oauth-popup.ts
+++ b/apps/web/src/components/mcp/hooks/use-mcp-oauth-popup.ts
@@ -3,6 +3,10 @@
 
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import type { RouterOutputs } from '~/trpc/react'
+import { api } from '~/trpc/react'
+
+type McpListEntry = RouterOutputs['mcp']['list'][number]
 
 interface OAuthDonePayload {
   type: 'oauth_done'
@@ -11,21 +15,42 @@ interface OAuthDonePayload {
   error?: string | null
 }
 
+/** Identifies the server whose connection the hook polls for while the popup is open. */
+export interface VerifyServerMatch {
+  serverId?: string
+  slug?: string
+  endpoint?: string
+}
+
 export interface OpenMcpOAuthOptions {
   /** Server-built authorize URL (`/api/mcp/<serverId>/oauth2/authorize?...`). */
   authorizeUrl: string
-  /** Fired once the popup reports completion (success or failure). */
+  /** Fired once the connect is confirmed, failed, or timed out. */
   onDone: (ok: boolean) => void
+  /**
+   * The server being connected — drives the authoritative success signal: poll `mcp.list` until
+   * the server's credential snapshot changes (connect: `connectionPresent` flips on; reconnect:
+   * the expiry/sync stamps move). Always pass this for OAuth connects.
+   */
+  verifyServer?: VerifyServerMatch
+  /** Custom poll override; wins over `verifyServer`. Returns true once the connect landed. */
+  verify?: () => Promise<boolean>
 }
 
 /**
- * Opens the MCP OAuth popup and resolves when the server-rendered callback page posts
- * `{ type: 'oauth_done' }` (via `postMessage` and the `oauth-mcp-connect` BroadcastChannel).
- * Falls back to a full-page redirect if the popup is blocked. Mirrors `useConnectFlow`'s popup
- * machinery, scoped to MCP.
+ * Opens the MCP OAuth popup and resolves when the connect is confirmed — instantly via the
+ * termination page's `postMessage`/`oauth-mcp-connect` BroadcastChannel (`/api/mcp/oauth-complete`
+ * runs on this window's origin, so both channels reach it), with server-side polling as the
+ * authoritative backstop. The popup lifecycle never settles the flow: providers that send
+ * `Cross-Origin-Opener-Policy: same-origin` (e.g. Stripe) sever the browsing-context group,
+ * after which `popup.closed` is wrong in both directions (reads `true` while the popup is still
+ * on the consent screen, and can stay `false` after a real close). A genuine user-cancel
+ * therefore spins until the hard timeout. Falls back to a full-page redirect if the popup is
+ * blocked.
  */
 export function useMcpOAuthPopup() {
   const [pending, setPending] = useState(false)
+  const utils = api.useUtils()
 
   const teardownRef = useRef<(() => void) | null>(null)
   const teardown = useCallback(() => {
@@ -35,7 +60,7 @@ export function useMcpOAuthPopup() {
   useEffect(() => () => teardown(), [teardown])
 
   const open = useCallback(
-    ({ authorizeUrl, onDone }: OpenMcpOAuthOptions) => {
+    ({ authorizeUrl, onDone, verifyServer, verify }: OpenMcpOAuthOptions) => {
       const popupUrl = authorizeUrl.includes('?')
         ? `${authorizeUrl}&mode=popup`
         : `${authorizeUrl}?mode=popup`
@@ -50,9 +75,8 @@ export function useMcpOAuthPopup() {
       setPending(true)
 
       let settled = false
-      let cancelTimer: ReturnType<typeof setTimeout> | null = null
 
-      /** Settle exactly once: a toast only on explicit failure (not on user cancel). */
+      /** Settle exactly once: a toast only on explicit failure (not on cancel/timeout). */
       const finish = (ok: boolean, error?: string | null) => {
         if (settled) return
         settled = true
@@ -87,20 +111,28 @@ export function useMcpOAuthPopup() {
         // BroadcastChannel unavailable — postMessage path still works.
       }
 
-      const closedInterval = setInterval(() => {
-        if (!popup.closed) return
-        clearInterval(closedInterval)
-        // The callback page posts its result right before closing itself — give that message a
-        // beat to arrive before treating the close as a user cancel. Without this, cancelling
-        // never fires `onDone` and callers' per-row pending state sticks.
-        cancelTimer = setTimeout(() => finish(false), 750)
-      }, 500)
+      const verifyFn = verify ?? (verifyServer ? buildSnapshotVerify(utils, verifyServer) : null)
+      const verifyInterval = verifyFn
+        ? setInterval(() => {
+            void (async () => {
+              if (settled) return
+              try {
+                if (await verifyFn()) finish(true)
+              } catch {
+                // Transient fetch error — the next tick retries.
+              }
+            })()
+          }, 1500)
+        : null
+
+      // Hard ceiling so an undetectable user-cancel doesn't spin forever.
+      const giveUpTimer = setTimeout(() => finish(false), 180_000)
 
       teardownRef.current = () => {
         window.removeEventListener('message', onMessage)
         bc?.close()
-        clearInterval(closedInterval)
-        if (cancelTimer) clearTimeout(cancelTimer)
+        if (verifyInterval) clearInterval(verifyInterval)
+        clearTimeout(giveUpTimer)
         try {
           if (!popup.closed) popup.close()
         } catch {
@@ -109,8 +141,51 @@ export function useMcpOAuthPopup() {
         setPending(false)
       }
     },
-    [teardown]
+    [teardown, utils]
   )
 
   return { open, pending }
+}
+
+/**
+ * Default verify: re-fetch `mcp.list` each tick and report success once the matched server's
+ * credential snapshot differs from its pre-popup baseline. The baseline makes reconnects work —
+ * `connectionPresent` is already true before the popup, so success is a *changed* expiry/sync
+ * stamp, not presence. (A reconnect against a provider that returns no token expiry AND whose
+ * inline tool-sync fails yields no change to observe; the message fast-path still covers it.)
+ */
+function buildSnapshotVerify(
+  utils: ReturnType<typeof api.useUtils>,
+  match: VerifyServerMatch
+): () => Promise<boolean> {
+  const find = (list: McpListEntry[]) =>
+    list.find(
+      (s) =>
+        (!!match.serverId && s.serverId === match.serverId) ||
+        (!!match.slug && s.slug === match.slug) ||
+        (!!match.endpoint && s.endpoint === match.endpoint)
+    )
+  const snapshot = (s: McpListEntry) => `${s.connectionExpiresAt ?? ''}|${s.lastSyncedAt ?? ''}`
+
+  // Baseline from the cached list when available; otherwise the first tick records it.
+  let baseline: string | null = null
+  let baselineKnown = false
+  const cached = utils.mcp.list.getData()
+  if (cached) {
+    const server = find(cached)
+    baseline = server?.connectionPresent ? snapshot(server) : null
+    baselineKnown = true
+  }
+
+  return async () => {
+    const list = await utils.mcp.list.fetch(undefined, { staleTime: 0 })
+    const server = find(list)
+    if (!baselineKnown) {
+      baseline = server?.connectionPresent ? snapshot(server) : null
+      baselineKnown = true
+      return false
+    }
+    if (!server?.connectionPresent) return false
+    return baseline === null || snapshot(server) !== baseline
+  }
 }

--- a/apps/web/src/components/mcp/hooks/use-mcp-servers.ts
+++ b/apps/web/src/components/mcp/hooks/use-mcp-servers.ts
@@ -10,17 +10,17 @@ export type McpServerListEntry = RouterOutputs['mcp']['list'][number]
 
 /**
  * Loads the org's MCP servers (curated + custom, connected + browsable) and exposes a
- * `refresh` that re-fetches `mcp.list` AND the ExtensionsContext projection so the builder
- * catalog updates the same beat the settings UI does.
+ * `refresh` that re-fetches `mcp.list` — one invalidation covers both this query and the
+ * ExtensionsContext projection (the builder catalog derives from the same query), so the
+ * builder updates the same beat the settings UI does.
  */
 export function useMcpServers() {
   const query = api.mcp.list.useQuery()
-  const utils = api.useUtils()
   const { refreshMcpServers } = useExtensionsContext()
 
   const refresh = useCallback(async () => {
-    await Promise.all([utils.mcp.list.invalidate(), refreshMcpServers()])
-  }, [utils, refreshMcpServers])
+    await refreshMcpServers()
+  }, [refreshMcpServers])
 
   return {
     servers: query.data ?? [],

--- a/apps/web/src/components/mcp/ui/add-mcp-server-dialog.tsx
+++ b/apps/web/src/components/mcp/ui/add-mcp-server-dialog.tsx
@@ -372,6 +372,7 @@ export function AddMcpServerDialog({
     if ('needsOAuth' in result && result.needsOAuth) {
       oauth.open({
         authorizeUrl: result.authorizeUrl,
+        verifyServer: { serverId: result.serverId },
         onDone: (ok) => {
           if (ok) {
             onConnected()
@@ -442,7 +443,11 @@ export function AddMcpServerDialog({
         })
         if ('needsOAuth' in result && result.needsOAuth) {
           await new Promise<void>((resolve) =>
-            oauth.open({ authorizeUrl: result.authorizeUrl, onDone: () => resolve() })
+            oauth.open({
+              authorizeUrl: result.authorizeUrl,
+              verifyServer: { serverId: result.serverId },
+              onDone: () => resolve(),
+            })
           )
         }
       }

--- a/apps/web/src/components/mcp/ui/connect-curated-dialog.tsx
+++ b/apps/web/src/components/mcp/ui/connect-curated-dialog.tsx
@@ -90,6 +90,7 @@ export function ConnectCuratedDialog({
       if ('needsOAuth' in result && result.needsOAuth) {
         oauth.open({
           authorizeUrl: result.authorizeUrl,
+          verifyServer: { serverId },
           onDone: (ok) => {
             if (ok) {
               onConnected()

--- a/apps/web/src/components/mcp/ui/mcp-server-connection-tab.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-server-connection-tab.tsx
@@ -72,7 +72,11 @@ export function McpServerConnectionTab({
           return
         }
         if ('needsOAuth' in result && result.needsOAuth) {
-          oauth.open({ authorizeUrl: result.authorizeUrl, onDone: (ok) => ok && onChanged() })
+          oauth.open({
+            authorizeUrl: result.authorizeUrl,
+            verifyServer: { serverId: server.serverId },
+            onDone: (ok) => ok && onChanged(),
+          })
           return
         }
         toastError({
@@ -95,6 +99,7 @@ export function McpServerConnectionTab({
         authorizeUrl: `/api/mcp/${server.serverId}/oauth2/authorize?returnTo=${encodeURIComponent(
           `/app/settings/apps/mcp/${server.slug}`
         )}`,
+        verifyServer: { serverId: server.serverId },
         onDone: (ok) => ok && onChanged(),
       })
       return

--- a/apps/web/src/components/mcp/ui/mcp-server-detail.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-server-detail.tsx
@@ -40,11 +40,9 @@ export function McpServerDetail({ initialServer }: { initialServer: McpDetailSer
   const remove = api.mcp.delete.useMutation()
 
   const onChanged = useCallback(async () => {
-    await Promise.all([
-      utils.mcp.getBySlug.invalidate({ slug: current.slug }),
-      utils.mcp.list.invalidate(),
-      refreshMcpServers(),
-    ])
+    // refreshMcpServers() already invalidates `mcp.list` (the ExtensionsContext catalog derives
+    // from the same query) — invalidating it here too would double-fetch.
+    await Promise.all([utils.mcp.getBySlug.invalidate({ slug: current.slug }), refreshMcpServers()])
   }, [utils, current.slug, refreshMcpServers])
 
   async function handleRemove() {

--- a/apps/web/src/components/mcp/ui/mcp-server-tools-tab.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-server-tools-tab.tsx
@@ -174,7 +174,7 @@ export function McpServerToolsTab({ server, onChanged }: McpServerToolsTabProps)
             ))}
           </div>
 
-          <div className='sticky top-0 self-start rounded-lg border bg-background p-3 text-sm'>
+          <div className='sticky top-0 self-start rounded-lg border bg-background p-3 text-sm mb-[300px]'>
             {selected ? (
               <McpToolDetailPanel
                 key={selected.name}

--- a/apps/web/src/components/mcp/ui/mcp-template-dialog.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-template-dialog.tsx
@@ -100,6 +100,7 @@ export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTempla
       if ('needsOAuth' in result && result.needsOAuth) {
         oauth.open({
           authorizeUrl: result.authorizeUrl,
+          verifyServer: { serverId: result.serverId, endpoint: template.endpoint },
           onDone: (ok) => {
             if (ok) handleConnected(result.slug)
             else setConnectingId(null)
@@ -204,6 +205,7 @@ export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTempla
         // The reused server already has client creds → straight to the popup.
         oauth.open({
           authorizeUrl: result.authorizeUrl,
+          verifyServer: { serverId: result.serverId, endpoint: template.endpoint },
           onDone: (ok) => {
             if (ok) handleConnected(result.slug)
             else setConnectingId(null)
@@ -243,6 +245,7 @@ export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTempla
       if ('needsOAuth' in result && result.needsOAuth) {
         oauth.open({
           authorizeUrl: result.authorizeUrl,
+          verifyServer: { serverId: result.serverId, endpoint: template.endpoint },
           onDone: (ok) => {
             if (ok) handleConnected(result.slug)
             else setConnectingId(null)

--- a/apps/web/src/components/mcp/ui/mcp-tool-run-panel.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-tool-run-panel.tsx
@@ -6,10 +6,13 @@ import { Button } from '@auxx/ui/components/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
+import { safeJsonParse, safeJsonStringify } from '@auxx/utils/json'
+import { isEmpty } from '@auxx/utils/objects'
 import { AlertTriangle, Braces, Play } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { type ReactNode, useMemo, useState } from 'react'
 import { topLevelArgs } from '~/components/agents/ui/detail/bindings/tool-args'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { CodeEditor, CodeLanguage } from '~/components/workflow/ui/code-editor'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { argToFieldType } from '~/lib/agents/bindings/arg-to-field-type'
 import type { RouterOutputs } from '~/trpc/react'
@@ -27,16 +30,6 @@ interface McpToolRunPanelProps {
   onResult?: (result: McpToolRunSuccess | null) => void
 }
 
-/** Pull a top-level arg's JSON-Schema `default`, if it declares one. */
-function argDefault(schema: { default?: unknown }): unknown {
-  return schema.default
-}
-
-/** Is a value "empty" for the purpose of omitting an optional arg from the call? */
-function isEmpty(v: unknown): boolean {
-  return v === undefined || v === null || v === ''
-}
-
 /**
  * Test-run UI for a single MCP tool: a typed args form (reusing the bindings stack's
  * `topLevelArgs` + `argToFieldType` + `FieldInputAdapter`, minus the const/var toggle), a raw-JSON
@@ -50,8 +43,7 @@ export function McpToolRunPanel({ serverId, tool, onResult }: McpToolRunPanelPro
   const initialValues = useMemo(() => {
     const out: Record<string, unknown> = {}
     for (const arg of toolArgs) {
-      const d = argDefault(arg.schema)
-      if (d !== undefined) out[arg.name] = d
+      if (arg.schema.default !== undefined) out[arg.name] = arg.schema.default
     }
     return out
   }, [toolArgs])
@@ -59,12 +51,12 @@ export function McpToolRunPanel({ serverId, tool, onResult }: McpToolRunPanelPro
   const [values, setValues] = useState<Record<string, unknown>>(initialValues)
   const [mode, setMode] = useState<'form' | 'json'>('form')
   const [rawJson, setRawJson] = useState('{}')
-  const [result, setResult] = useState<TestResult | null>(null)
+  const [result, setResult] = useState<McpToolRunSuccess | null>(null)
 
   const testTool = api.mcp.testTool.useMutation()
 
   const requiredMissing = toolArgs.some((a) => a.required && isEmpty(values[a.name]))
-  const rawParsed = mode === 'json' ? safeParseObject(rawJson) : null
+  const rawParsed = useMemo(() => safeParseObject(rawJson), [rawJson])
   const canRun = mode === 'form' ? !requiredMissing : rawParsed.ok
 
   const setArg = (name: string, value: unknown) => setValues((prev) => ({ ...prev, [name]: value }))
@@ -75,7 +67,10 @@ export function McpToolRunPanel({ serverId, tool, onResult }: McpToolRunPanelPro
     const out: Record<string, unknown> = {}
     for (const arg of toolArgs) {
       const v = values[arg.name]
-      if (!isEmpty(v)) out[arg.name] = v
+      if (isEmpty(v)) continue
+      // Select widgets (string-enum args) emit `string[]`; tool args are scalar
+      // (v6 scalar-only) → unwrap the single selection back to its scalar value.
+      out[arg.name] = Array.isArray(v) ? v[0] : v
     }
     return out
   }
@@ -107,14 +102,11 @@ export function McpToolRunPanel({ serverId, tool, onResult }: McpToolRunPanelPro
   /** Switch modes, carrying the current args across so neither view loses work. */
   function toggleMode() {
     if (mode === 'form') {
-      setRawJson(JSON.stringify(buildArgs() ?? {}, null, 2))
-      setMode('json')
+      setRawJson(safeJsonStringify(buildArgs() ?? {}, 2))
     } else if (rawParsed.ok) {
       setValues(rawParsed.value)
-      setMode('form')
-    } else {
-      setMode('form')
     }
+    setMode(mode === 'form' ? 'json' : 'form')
   }
 
   return (
@@ -143,6 +135,7 @@ export function McpToolRunPanel({ serverId, tool, onResult }: McpToolRunPanelPro
                   {mapped.supported ? (
                     <FieldInputAdapter
                       fieldType={mapped.fieldType}
+                      triggerProps={{ className: 'ps-0 w-full pe-1' }}
                       fieldOptions={mapped.options}
                       value={values[arg.name]}
                       onChange={(v) => setArg(arg.name, v)}
@@ -162,11 +155,11 @@ export function McpToolRunPanel({ serverId, tool, onResult }: McpToolRunPanelPro
           </VarEditorField>
         )
       ) : (
-        <Textarea
-          className='min-h-40 font-mono text-xs'
+        <CodeEditor
+          language={CodeLanguage.json}
           value={rawJson}
-          onChange={(e) => setRawJson(e.target.value)}
-          spellCheck={false}
+          onChange={setRawJson}
+          minHeight={160}
         />
       )}
 
@@ -190,14 +183,47 @@ export function McpToolRunPanel({ serverId, tool, onResult }: McpToolRunPanelPro
         )}
       </div>
 
-      {result?.ok && <McpToolResultView result={result} />}
+      {result && <McpToolResultView result={result} />}
     </div>
   )
 }
 
-/** Result viewer: Result/JSON tabs, duration badge, isError banner. */
-function McpToolResultView({ result }: { result: Extract<TestResult, { ok: true }> }) {
-  const hasJson = result.structuredContent !== undefined
+/**
+ * Result viewer: duration badge, isError banner, and a content area that adapts to what the tool
+ * returned. A tool can carry plain `text`, a stringified-JSON `text`, and/or `structuredContent` —
+ * we render a JSON view when there's JSON and a Text view when there's plain text, and only split
+ * into tabs when both genuinely exist (so a JSON-only result isn't shown twice under two labels).
+ */
+function McpToolResultView({ result }: { result: McpToolRunSuccess }) {
+  // `structuredContent` is already JSON; `text` is JSON only when it parses as one. When `text` is
+  // JSON we treat it as the JSON view (and drop the redundant text view), else it's the plain view.
+  const textAsJson = useMemo(() => formatJson(result.text), [result.text])
+  const json =
+    result.structuredContent !== undefined
+      ? safeJsonStringify(result.structuredContent, 2)
+      : textAsJson
+  const plainText = textAsJson ? null : result.text
+
+  const views: { value: string; label: string; node: ReactNode }[] = []
+  if (json) {
+    views.push({
+      value: 'json',
+      label: 'JSON',
+      node: <CodeEditor language={CodeLanguage.json} value={json} readOnly minHeight={120} />,
+    })
+  }
+  if (plainText || views.length === 0) {
+    views.push({
+      value: 'text',
+      label: 'Text',
+      node: (
+        <pre className='max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background p-2 font-mono text-xs'>
+          {plainText || '(empty)'}
+        </pre>
+      ),
+    })
+  }
+
   return (
     <div className='mt-1 flex flex-col gap-2 rounded-lg border bg-primary-50/40 p-2'>
       <div className='flex items-center justify-between'>
@@ -214,24 +240,24 @@ function McpToolResultView({ result }: { result: Extract<TestResult, { ok: true 
         </div>
       )}
 
-      <Tabs defaultValue={hasJson ? 'json' : 'text'}>
-        <TabsList size='sm'>
-          <TabsTrigger value='text'>Result</TabsTrigger>
-          {hasJson && <TabsTrigger value='json'>JSON</TabsTrigger>}
-        </TabsList>
-        <TabsContent value='text'>
-          <pre className='max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background p-2 font-mono text-xs'>
-            {result.text || '(empty)'}
-          </pre>
-        </TabsContent>
-        {hasJson && (
-          <TabsContent value='json'>
-            <pre className='max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background p-2 font-mono text-xs'>
-              {JSON.stringify(result.structuredContent, null, 2)}
-            </pre>
-          </TabsContent>
-        )}
-      </Tabs>
+      {views.length === 1 ? (
+        views[0].node
+      ) : (
+        <Tabs defaultValue={views[0].value}>
+          <TabsList>
+            {views.map((v) => (
+              <TabsTrigger key={v.value} value={v.value} size='sm'>
+                {v.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          {views.map((v) => (
+            <TabsContent key={v.value} value={v.value}>
+              {v.node}
+            </TabsContent>
+          ))}
+        </Tabs>
+      )}
     </div>
   )
 }
@@ -239,29 +265,31 @@ function McpToolResultView({ result }: { result: Extract<TestResult, { ok: true 
 function safeParseObject(
   text: string
 ): { ok: true; value: Record<string, unknown> } | { ok: false } {
-  try {
-    const parsed = JSON.parse(text)
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
-      return { ok: true, value: parsed }
-    return { ok: false }
-  } catch {
-    return { ok: false }
-  }
+  const parsed = safeJsonParse(text)
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
+    return { ok: true, value: parsed as Record<string, unknown> }
+  return { ok: false }
+}
+
+/**
+ * Pretty-print `text` if it's a JSON object/array string, else null. Used to render
+ * tool results that ship their payload as a stringified JSON blob with proper formatting.
+ */
+function formatJson(text: string | undefined): string | null {
+  if (!text || (text[0] !== '{' && text[0] !== '[')) return null
+  const parsed = safeJsonParse(text)
+  return parsed && typeof parsed === 'object' ? safeJsonStringify(parsed, 2) : null
 }
 
 /** Render an arbitrary value as editable text for the per-arg JSON fallback. */
 function asText(v: unknown): string {
   if (v === undefined) return ''
   if (typeof v === 'string') return v
-  return JSON.stringify(v, null, 2)
+  return safeJsonStringify(v, 2)
 }
 
 /** Parse a per-arg JSON value, falling back to the raw string when it isn't valid JSON. */
 function parseLooseJson(text: string): unknown {
   if (text.trim() === '') return undefined
-  try {
-    return JSON.parse(text)
-  } catch {
-    return text
-  }
+  return safeJsonParse<unknown>(text, text)
 }

--- a/packages/lib/src/conditions/evaluate.ts
+++ b/packages/lib/src/conditions/evaluate.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/conditions/evaluate.ts
 
+import { isEmpty } from '@auxx/utils/objects'
 import type { Operator } from './operator-definitions'
 import type { ConditionContext } from './resolve-context'
 import type { Condition, ConditionGroup } from './types'
@@ -362,16 +363,6 @@ function isEqual(a: unknown, b: unknown): boolean {
   }
 
   return aStr === bStr
-}
-
-/**
- * Check if value is empty (null, undefined, empty string, empty array).
- */
-function isEmpty(value: unknown): boolean {
-  if (value == null) return true
-  if (value === '') return true
-  if (Array.isArray(value) && value.length === 0) return true
-  return false
 }
 
 /**

--- a/packages/utils/src/__tests__/json.test.ts
+++ b/packages/utils/src/__tests__/json.test.ts
@@ -1,0 +1,39 @@
+// packages/utils/src/__tests__/json.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { bigIntReplacer, safeJsonParse, safeJsonStringify } from '../json'
+
+describe('safeJsonParse', () => {
+  it('parses valid JSON', () => {
+    expect(safeJsonParse('{"a":1}')).toEqual({ a: 1 })
+    expect(safeJsonParse('[1,2,3]')).toEqual([1, 2, 3])
+  })
+
+  it('returns undefined on invalid JSON', () => {
+    expect(safeJsonParse('{ not json')).toBeUndefined()
+    expect(safeJsonParse('')).toBeUndefined()
+  })
+
+  it('returns the provided fallback on invalid JSON', () => {
+    expect(safeJsonParse('nope', null)).toBeNull()
+    expect(safeJsonParse('nope', { ok: false })).toEqual({ ok: false })
+  })
+})
+
+describe('safeJsonStringify', () => {
+  it('renders BigInt as a string instead of throwing', () => {
+    expect(safeJsonStringify({ id: 9007199254740993n })).toBe('{"id":"9007199254740993"}')
+  })
+
+  it('honors the space arg for pretty-printing', () => {
+    expect(safeJsonStringify({ a: 1 }, 2)).toBe('{\n  "a": 1\n}')
+  })
+})
+
+describe('bigIntReplacer', () => {
+  it('stringifies bigint and passes everything else through', () => {
+    expect(bigIntReplacer('k', 5n)).toBe('5')
+    expect(bigIntReplacer('k', 'x')).toBe('x')
+    expect(bigIntReplacer('k', 42)).toBe(42)
+  })
+})

--- a/packages/utils/src/__tests__/objects.test.ts
+++ b/packages/utils/src/__tests__/objects.test.ts
@@ -1,7 +1,29 @@
 // packages/utils/src/__tests__/objects.test.ts
 
 import { describe, expect, it } from 'vitest'
-import { deepEqual } from '../objects'
+import { deepEqual, isEmpty } from '../objects'
+
+describe('isEmpty', () => {
+  it('is true for undefined, null, empty string, and empty array', () => {
+    expect(isEmpty(undefined)).toBe(true)
+    expect(isEmpty(null)).toBe(true)
+    expect(isEmpty('')).toBe(true)
+    expect(isEmpty([])).toBe(true)
+  })
+
+  it('is false for falsy-but-present values', () => {
+    expect(isEmpty(0)).toBe(false)
+    expect(isEmpty(false)).toBe(false)
+    expect(isEmpty(Number.NaN)).toBe(false)
+  })
+
+  it('is false for whitespace strings, empty objects, and populated values', () => {
+    expect(isEmpty(' ')).toBe(false)
+    expect(isEmpty({})).toBe(false)
+    expect(isEmpty([0])).toBe(false)
+    expect(isEmpty('a')).toBe(false)
+  })
+})
 
 describe('deepEqual', () => {
   it('compares object keys order-independently', () => {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -127,7 +127,7 @@ export {
 // OAuth utilities
 export { validateRedirectPath } from './oauth'
 // Object utilities
-export { cloneDeep, deepMerge, getByPath } from './objects'
+export { cloneDeep, deepMerge, getByPath, isEmpty } from './objects'
 // Parse utilities
 export { parseBoolean, toNumeric } from './parse'
 // Relationship utilities

--- a/packages/utils/src/json.ts
+++ b/packages/utils/src/json.ts
@@ -1,6 +1,39 @@
 // packages/utils/src/json.ts
 
 /**
+ * `JSON.parse` that returns `fallback` (default `undefined`) instead of throwing
+ * on invalid input. Generic over the expected shape — the caller asserts the
+ * type; no runtime validation is performed, so pair it with a schema when the
+ * input is untrusted. PURE.
+ */
+export function safeJsonParse<T = unknown>(value: string, fallback?: T): T | undefined {
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * `JSON.stringify` replacer that renders `BigInt` as a (lossless) string, so
+ * payloads carrying bigint — e.g. Postgres `bigserial` ids — don't throw
+ * "Do not know how to serialize a BigInt". Strings, not numbers: `Number`
+ * conversion silently loses precision past `2^53`. PURE.
+ */
+export function bigIntReplacer(_key: string, value: unknown): unknown {
+  return typeof value === 'bigint' ? value.toString() : value
+}
+
+/**
+ * `JSON.stringify` that tolerates `BigInt` (rendered as a string via
+ * {@link bigIntReplacer}). `space` pretty-prints exactly like the native arg.
+ * PURE.
+ */
+export function safeJsonStringify(value: unknown, space?: number | string): string {
+  return JSON.stringify(value, bigIntReplacer, space)
+}
+
+/**
  * Deterministic, key-order-independent JSON serialization. Recursively sorts
  * object keys (bytewise) and drops `undefined` object values, so two
  * structurally-equal values serialize to the identical string regardless of key

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -108,6 +108,23 @@ export function deepMerge<T extends Record<string, unknown>>(target: T, source: 
 }
 
 /**
+ * Is a value "empty": `undefined`, `null`, the empty string, or an empty array.
+ *
+ * The canonical predicate for omitting optional args/fields and "has the user
+ * provided a value" checks. Deliberately NOT empty: `{}`, whitespace-only
+ * strings, `0`, and `false` — callers that need those have different semantics
+ * and should say so locally. PURE.
+ */
+export function isEmpty(value: unknown): boolean {
+  return (
+    value === undefined ||
+    value === null ||
+    value === '' ||
+    (Array.isArray(value) && value.length === 0)
+  )
+}
+
+/**
  * Shallow equality check for objects.
  * Compares top-level properties only (reference equality for nested objects).
  */

--- a/packages/utils/vitest.config.ts
+++ b/packages/utils/vitest.config.ts
@@ -1,0 +1,14 @@
+// packages/utils/vitest.config.ts
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'utils',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.ts', 'src/**/__tests__/**/*.ts'],
+    exclude: ['node_modules/**', 'dist/**', '**/*.config.*'],
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       './packages/workflow-nodes/vitest.config.ts',
       './packages/database/vitest.config.ts',
       './packages/credentials/vitest.config.ts',
+      './packages/utils/vitest.config.ts',
       './packages/test-utils/vitest.config.ts',
     ],
   },


### PR DESCRIPTION
## Summary

Fixes MCP OAuth connects that never settled when a provider's popup couldn't notify the app window, plus a small shared-utils refactor.

### OAuth popup completion
The MCP OAuth callback runs on the public tunnel origin (`NGROK_URL`) so external providers (Stripe, etc.) can reach it. A popup ending on that cross-origin page can't notify the localhost app window: `BroadcastChannel` is origin-scoped and `window.opener` is commonly severed by the provider's `Cross-Origin-Opener-Policy: same-origin` header.

- New `/api/mcp/oauth-complete` termination page on the **opener's** origin. The callback redirects the popup there (origin allowlisted against open-redirect), so both `postMessage` and the `oauth-mcp-connect` BroadcastChannel reach the app window.
- `useMcpOAuthPopup` now polls `mcp.list` for a changed credential snapshot as the authoritative success signal, with a hard timeout — the popup lifecycle never settles the flow (`popup.closed` is unreliable once COOP severs the context). All OAuth connect call sites pass `verifyServer`.
- Log the provider's `error_description` and a connect-complete line.

### Shared utils refactor
- Extract `isEmpty` into `@auxx/utils/objects` and `safeJsonParse` / `safeJsonStringify` / `bigIntReplacer` into `@auxx/utils/json`; dedupe the inline copies across `header-cell`, `advanced-filter-mode`, `conditions/evaluate`, and the MCP tool-run panel.
- MCP tool-run panel: `CodeEditor` for the raw-JSON view, adaptive result views (only split into tabs when both JSON and text genuinely exist), scalar unwrap for string-enum args.
- Drop redundant `mcp.list` invalidations (the ExtensionsContext catalog derives from the same query).

## Test plan
- [x] `vitest run --project utils` — 79 passing (new tests for `isEmpty`, `safeJsonParse`, `safeJsonStringify`, `bigIntReplacer`)
- [ ] Manual: connect an OAuth MCP server (e.g. Stripe) via popup → completes; cancel → settles at timeout; reconnect → detected via snapshot change