### PR TITLE
refactor(settings): shared SettingsSection header component

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/apps/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/page.tsx
@@ -23,7 +23,7 @@ import { dedupeInstallationsByApp } from '~/components/apps/dedupe-installations
 import { useUninstallApp } from '~/components/apps/hooks/use-uninstall-app'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { AppListCard } from '~/components/apps/ui/app-list-card'
-import SettingsPage from '~/components/global/settings-page'
+import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import { McpAppsSection } from '~/components/mcp/ui/mcp-apps-section'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
@@ -241,20 +241,19 @@ export default function IntegrationList() {
       button={<></>}>
       <ConfirmDialog />
       <div className='flex flex-col flex-1 p-3 sm:p-6 space-y-8'>
-        <div className='space-y-2'>
-          <div className='flex items-center justify-between gap-2'>
-            <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-              <Globe className='size-4' />
-              Installed apps
-            </div>
-            {isAdminOrOwner && hasMoreInstalled && (
+        <SettingsSection
+          className='space-y-2'
+          icon={Globe}
+          title='Installed apps'
+          action={
+            isAdminOrOwner && hasMoreInstalled ? (
               <Link href='/app/settings/apps/installed'>
                 <Button variant='ghost' size='sm'>
                   View all
                 </Button>
               </Link>
-            )}
-          </div>
+            ) : undefined
+          }>
           <div className='w-full @container'>
             {isAdminOrOwner ? (
               installedAppsToShow.length > 0 ? (
@@ -309,23 +308,18 @@ export default function IntegrationList() {
               </div>
             )}
           </div>
-        </div>
+        </SettingsSection>
         {/* MCP servers — connected (installed) + curated browse + add custom. */}
         {hasMcpAccess && (
           <McpAppsSection isAdminOrOwner={isAdminOrOwner} searchQuery={searchQuery} />
         )}
 
         {isAdminOrOwner && (
-          <div className='space-y-6'>
-            <div className='space-y-1'>
-              <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-                <Globe className='size-4' />
-                Browse apps
-              </div>
-              <div className='text-sm text-muted-foreground'>
-                Discover new apps to help you work better
-              </div>
-            </div>
+          <SettingsSection
+            className='space-y-6'
+            icon={Globe}
+            title='Browse apps'
+            description='Discover new apps to help you work better'>
             <div className='flex flex-col gap-6 justify-start w-full'>
               <div className='sticky pt-20 -mt-20  top-0'>
                 <div className='grid sm:grid-cols-3 pb-4 sm:pb-0'>
@@ -429,7 +423,7 @@ export default function IntegrationList() {
                 </div>
               </div>
             </div>
-          </div>
+          </SettingsSection>
         )}
       </div>
     </SettingsPage>

--- a/apps/web/src/app/(protected)/app/settings/channels/_components/calendar-sync-toggle.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/calendar-sync-toggle.tsx
@@ -5,6 +5,7 @@ import { Button } from '@auxx/ui/components/button'
 import { Switch } from '@auxx/ui/components/switch'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { CalendarDays, RefreshCw } from 'lucide-react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { api } from '~/trpc/react'
 
 interface CalendarSyncToggleProps {
@@ -71,32 +72,24 @@ export function CalendarSyncToggle({ integrationId }: CalendarSyncToggleProps) {
   }
 
   return (
-    <div className='space-y-4'>
-      <div className='space-y-1'>
-        <div className='flex items-center justify-between'>
-          <div className='space-y-1'>
-            <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-              <CalendarDays className='size-4' /> Calendar Sync
-            </div>
-            <p className='text-sm text-muted-foreground'>
-              Sync Google Calendar events, meeting links, and CRM-ready Meeting records.
-            </p>
-          </div>
-          {isEnabled && (
-            <Button
-              variant='outline'
-              size='sm'
-              onClick={handleManualSync}
-              disabled={triggerSync.isPending}
-              loading={triggerSync.isPending}
-              loadingText='Syncing...'>
-              <RefreshCw />
-              Sync now
-            </Button>
-          )}
-        </div>
-      </div>
-
+    <SettingsSection
+      icon={CalendarDays}
+      title='Calendar Sync'
+      description='Sync Google Calendar events, meeting links, and CRM-ready Meeting records.'
+      action={
+        isEnabled ? (
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={handleManualSync}
+            disabled={triggerSync.isPending}
+            loading={triggerSync.isPending}
+            loadingText='Syncing...'>
+            <RefreshCw />
+            Sync now
+          </Button>
+        ) : undefined
+      }>
       <div className='group flex items-center justify-between rounded-2xl border py-2 px-3 hover:bg-muted transition-colors duration-200'>
         <div className='flex items-center gap-3'>
           <div className='size-8 border bg-muted rounded-lg flex items-center justify-center group-hover:bg-secondary transition-colors overflow-hidden shrink-0'>
@@ -122,6 +115,6 @@ export function CalendarSyncToggle({ integrationId }: CalendarSyncToggleProps) {
           disabled={enableSync.isPending || disableSync.isPending}
         />
       </div>
-    </div>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/app/(protected)/app/settings/channels/_components/email-list-dialog.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/email-list-dialog.tsx
@@ -23,6 +23,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { Edit, Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { client } from '~/auth/auth-client'
+import { SettingsSection } from '~/components/global/settings-page'
 
 /** Validates an email address or a bare domain. */
 function isValidEntry(value: string): boolean {
@@ -215,13 +216,13 @@ export function EmailFilterSection({
   const hiddenCount = entries.length - 4
 
   return (
-    <div className='space-y-4'>
-      <div className='space-y-1'>
-        <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
+    <SettingsSection
+      title={
+        <>
           {icon} {title}
-        </div>
-        <p className='text-sm text-muted-foreground'>{description}</p>
-      </div>
+        </>
+      }
+      description={description}>
       <div
         className={cn(
           'group flex items-start justify-between gap-3 rounded-2xl border px-3 py-2 transition-colors duration-200 hover:bg-muted',
@@ -281,6 +282,6 @@ export function EmailFilterSection({
           onClose={() => setDialogOpen(false)}
         />
       )}
-    </div>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-labels.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-labels.tsx
@@ -17,6 +17,7 @@ import { Switch } from '@auxx/ui/components/switch'
 import { toastError } from '@auxx/ui/components/toast'
 import { Edit, FolderSync, RefreshCw } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { api } from '~/trpc/react'
 
 interface IntegrationLabelsProps {
@@ -70,14 +71,10 @@ export default function IntegrationLabels({ integration }: IntegrationLabelsProp
   }, [labels, search])
 
   return (
-    <div className='space-y-4'>
-      <div className='space-y-1'>
-        <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-          <FolderSync className='size-4' /> Synced Folders
-        </div>
-        <p className='text-sm text-muted-foreground'>Choose which folders to sync messages from.</p>
-      </div>
-
+    <SettingsSection
+      icon={FolderSync}
+      title='Synced Folders'
+      description='Choose which folders to sync messages from.'>
       <div className='group flex items-center justify-between rounded-2xl border py-2 px-3 hover:bg-muted transition-colors duration-200'>
         <div className='flex items-center gap-3'>
           <div className='size-8 border bg-muted rounded-lg flex items-center justify-center group-hover:bg-secondary transition-colors overflow-hidden shrink-0'>
@@ -184,6 +181,6 @@ export default function IntegrationLabels({ integration }: IntegrationLabelsProp
           </DialogContent>
         </Dialog>
       ) : null}
-    </div>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-routing.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-routing.tsx
@@ -41,6 +41,7 @@ import {
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { toRecordId, useRecord, useRecordList, useResource } from '~/components/resources'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
@@ -185,16 +186,11 @@ export default function IntegrationRouting({ integration }: IntegrationRoutingPr
 
       {/* Data Sync — hidden for forwarding integrations */}
       {!isForwarding && (
-        <div className='space-y-1'>
-          <div className='flex items-center justify-between'>
-            <div className='space-y-1'>
-              <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-                <CloudDownload className='size-4' /> Data Sync
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Configure how data from this integration is synced to your inboxes.
-              </p>
-            </div>
+        <SettingsSection
+          icon={CloudDownload}
+          title='Data Sync'
+          description='Configure how data from this integration is synced to your inboxes.'
+          action={
             <Button
               variant='outline'
               size='sm'
@@ -205,30 +201,32 @@ export default function IntegrationRouting({ integration }: IntegrationRoutingPr
               <RefreshCw />
               Sync Messages
             </Button>
-          </div>
-          <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-start'>
-            <div className='text-sm text-muted-foreground'>Last synced</div>
-            <Badge variant='green' size='sm'>
-              {lastSynced}
-            </Badge>
-          </div>
-          {integration.syncStatus && (
+          }>
+          <div className='space-y-2'>
             <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-start'>
-              <div className='text-sm text-muted-foreground'>Sync status</div>
-              <SyncStatusBadge syncStatus={integration.syncStatus} />
+              <div className='text-sm text-muted-foreground'>Last synced</div>
+              <Badge variant='green' size='sm'>
+                {lastSynced}
+              </Badge>
             </div>
-          )}
-          {isThrottled && (
-            <Alert>
-              <Clock className='h-4 w-4' />
-              <AlertTitle>Rate limited</AlertTitle>
-              <AlertDescription>
-                This integration is temporarily throttled. Sync will resume after{' '}
-                {new Date(integration.throttleRetryAfter).toLocaleString()}.
-              </AlertDescription>
-            </Alert>
-          )}
-        </div>
+            {integration.syncStatus && (
+              <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-start'>
+                <div className='text-sm text-muted-foreground'>Sync status</div>
+                <SyncStatusBadge syncStatus={integration.syncStatus} />
+              </div>
+            )}
+            {isThrottled && (
+              <Alert>
+                <Clock className='h-4 w-4' />
+                <AlertTitle>Rate limited</AlertTitle>
+                <AlertDescription>
+                  This integration is temporarily throttled. Sync will resume after{' '}
+                  {new Date(integration.throttleRetryAfter).toLocaleString()}.
+                </AlertDescription>
+              </Alert>
+            )}
+          </div>
+        </SettingsSection>
       )}
 
       {/* Forwarding Address — only for forwarding integrations */}
@@ -245,15 +243,10 @@ export default function IntegrationRouting({ integration }: IntegrationRoutingPr
         <IntegrationLabels integration={integration} />
       )}
 
-      <div className='space-y-4'>
-        <div className='space-y-1'>
-          <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-            <MailPlus className='size-4' /> Message Routing
-          </div>
-          <p className='text-sm text-muted-foreground'>
-            Configure how messages from this integration are routed to your inboxes.
-          </p>
-        </div>
+      <SettingsSection
+        icon={MailPlus}
+        title='Message Routing'
+        description='Configure how messages from this integration are routed to your inboxes.'>
         <div>
           {connectedInbox || isLoadingConnectedInbox ? (
             <div className='space-y-4'>
@@ -355,13 +348,10 @@ export default function IntegrationRouting({ integration }: IntegrationRoutingPr
             </DialogContent>
           </Dialog>
         ) : null}
-      </div>
+      </SettingsSection>
 
       {!isForwarding && (
-        <div className='space-y-2'>
-          <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-            <AlertTriangle className='size-4' /> Danger Zone
-          </div>
+        <SettingsSection className='space-y-2' icon={AlertTriangle} title='Danger Zone'>
           <div className='group flex items-center border py-2 px-3 hover:bg-destructive/2 transition-colors duration-200 rounded-2xl border-destructive/50'>
             <div className='flex flex-col justify-between gap-4 w-full md:flex-row md:items-center'>
               <div className='flex items-center gap-3'>
@@ -387,7 +377,7 @@ export default function IntegrationRouting({ integration }: IntegrationRoutingPr
               <ConfirmDialog />
             </div>
           </div>
-        </div>
+        </SettingsSection>
       )}
     </div>
   )
@@ -405,15 +395,10 @@ function ForwardingAddressSection({
   const hasAllowedSenders = allowedSenders.length > 0
 
   return (
-    <div className='space-y-4'>
-      <div className='space-y-1'>
-        <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-          <Mail className='size-4' /> Forwarding Address
-        </div>
-        <p className='text-sm text-muted-foreground'>
-          Forward emails to this address to create tickets.
-        </p>
-      </div>
+    <SettingsSection
+      icon={Mail}
+      title='Forwarding Address'
+      description='Forward emails to this address to create tickets.'>
       <div
         className={`group flex items-center justify-between rounded-2xl border py-2 px-3 transition-colors duration-200 ${
           hasAllowedSenders ? 'hover:bg-muted' : 'border-destructive/50 hover:bg-destructive/2'
@@ -443,7 +428,7 @@ function ForwardingAddressSection({
           {copied ? 'Copied' : 'Copy'}
         </Button>
       </div>
-    </div>
+    </SettingsSection>
   )
 }
 
@@ -459,15 +444,10 @@ function AllowedSendersSection({
   const hasEntries = allowedSenders.length > 0
 
   return (
-    <div className='space-y-4'>
-      <div className='space-y-1'>
-        <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-          <Shield className='size-4' /> Allowed Senders
-        </div>
-        <p className='text-sm text-muted-foreground'>
-          Only emails from these addresses will be accepted.
-        </p>
-      </div>
+    <SettingsSection
+      icon={Shield}
+      title='Allowed Senders'
+      description='Only emails from these addresses will be accepted.'>
       <div
         className={`group flex items-center justify-between rounded-2xl border py-2 px-3 transition-colors duration-200 ${
           hasEntries ? 'hover:bg-muted' : 'border-destructive/50 hover:bg-destructive/2'
@@ -515,7 +495,7 @@ function AllowedSendersSection({
           onClose={() => setDialogOpen(false)}
         />
       )}
-    </div>
+    </SettingsSection>
   )
 }
 

--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-settings-advanced.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-settings-advanced.tsx
@@ -7,6 +7,7 @@ import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { Ban, MailMinus, MailPlus, ShieldCheck, UserCheck, Users, UserX } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { api } from '~/trpc/react'
 import { EmailFilterSection } from './email-list-dialog'
 
@@ -77,14 +78,10 @@ export default function IntegrationSettingsAdvanced({
   return (
     <div className='space-y-4 sm:space-y-10 p-3 sm:p-6'>
       {/* Record Creation */}
-      <div className='space-y-4'>
-        <div className='space-y-1'>
-          <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-            <MailPlus className='size-4' /> Record Creation
-          </div>
-          <p className='text-sm text-muted-foreground'>Manage how records will be created.</p>
-        </div>
-
+      <SettingsSection
+        icon={MailPlus}
+        title='Record Creation'
+        description='Manage how records will be created.'>
         <RadioGroup
           value={recordCreationMode}
           onValueChange={handleRecordCreationChange}
@@ -108,7 +105,7 @@ export default function IntegrationSettingsAdvanced({
             description='No records will automatically be created. Message events will still be associated with records created manually.'
           />
         </RadioGroup>
-      </div>
+      </SettingsSection>
 
       {/* Email Filtering Rules */}
       <EmailFilterSection

--- a/apps/web/src/app/(protected)/app/settings/kopilot/_components/model-section.tsx
+++ b/apps/web/src/app/(protected)/app/settings/kopilot/_components/model-section.tsx
@@ -4,6 +4,7 @@
 import { ModelType } from '@auxx/lib/ai/providers/types'
 import { Button } from '@auxx/ui/components/button'
 import { X } from 'lucide-react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { AiModelPicker } from '~/components/pickers/ai-model-picker'
 import { useSettings } from '~/hooks/use-settings'
 
@@ -20,14 +21,10 @@ export function ModelSection() {
   const modelId = getSetting('kopilot.modelId') as string | null
 
   return (
-    <section className='space-y-3'>
-      <div className='space-y-1'>
-        <h2 className='text-base font-semibold tracking-tight text-foreground'>Model</h2>
-        <p className='text-sm text-muted-foreground'>
-          Default model for Kopilot. Per-session and per-turn picks override this. Leave unset to
-          use the system default.
-        </p>
-      </div>
+    <SettingsSection
+      className='space-y-3'
+      title='Model'
+      description='Default model for Kopilot. Per-session and per-turn picks override this. Leave unset to use the system default.'>
       <div className='flex items-center gap-2'>
         <AiModelPicker
           value={modelId}
@@ -50,6 +47,6 @@ export function ModelSection() {
           </Button>
         )}
       </div>
-    </section>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/app/(protected)/app/settings/kopilot/_components/toolsets-section.tsx
+++ b/apps/web/src/app/(protected)/app/settings/kopilot/_components/toolsets-section.tsx
@@ -16,6 +16,7 @@ import {
 } from '~/components/agents/ui/detail/tools/catalog-node-row'
 import { ToolSelectDialog } from '~/components/agents/ui/detail/tools/tool-select-dialog'
 import { AppAccountDialog } from '~/components/apps/ui/app-account-dialog'
+import { SettingsSection } from '~/components/global/settings-page'
 import { useMasterKopilotToolsets } from './use-master-kopilot-toolsets'
 
 /**
@@ -108,9 +109,11 @@ export function ToolsetsSection() {
   )
 
   return (
-    <section className='space-y-3'>
-      <div className='flex items-start justify-between gap-3'>
-        <SectionHeading />
+    <SettingsSection
+      className='space-y-3'
+      title='Toolsets'
+      description='Native Auxx tools available to Kopilot. App-backed tools require a workspace credential pin.'
+      action={
         <Button
           size='sm'
           variant='ghost'
@@ -121,7 +124,7 @@ export function ToolsetsSection() {
           <Plus />
           Add tools
         </Button>
-      </div>
+      }>
       <div className='flex flex-col pe-4'>
         {catalogIsLoading ? (
           <div className='flex flex-col gap-1'>
@@ -183,17 +186,6 @@ export function ToolsetsSection() {
           if (!open) setAccountPickerAppId(null)
         }}
       />
-    </section>
-  )
-}
-
-function SectionHeading() {
-  return (
-    <div className='space-y-1'>
-      <h2 className='text-base font-semibold tracking-tight text-foreground'>Toolsets</h2>
-      <p className='text-sm text-muted-foreground'>
-        Native Auxx tools available to Kopilot. App-backed tools require a workspace credential pin.
-      </p>
-    </div>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/app/(protected)/app/settings/members/_components/member-list.tsx
+++ b/apps/web/src/app/(protected)/app/settings/members/_components/member-list.tsx
@@ -44,6 +44,7 @@ import {
 import { useRouter } from 'next/navigation'
 // src/app/(auth)/app/settings/members/_components/member-list.tsx
 import { useState } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
@@ -280,10 +281,7 @@ export function MemberList({
   }
   return (
     <div className='p-3 sm:p-6'>
-      <div className='space-y-4'>
-        <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-          <Users className='size-4' /> Members
-        </div>
+      <SettingsSection className='space-y-4' icon={Users} title='Members'>
         {displayList.map((item) => {
           const isCopyingThisLink =
             getAndCopyLinkMutation.isPending &&
@@ -453,7 +451,7 @@ export function MemberList({
             </div>
           )
         })}
-      </div>
+      </SettingsSection>
 
       {/* Remove member confirmation dialog */}
       <Dialog open={isRemoveDialogOpen} onOpenChange={setIsRemoveDialogOpen}>

--- a/apps/web/src/app/(protected)/app/settings/plans/_components/billing-details-section.tsx
+++ b/apps/web/src/app/(protected)/app/settings/plans/_components/billing-details-section.tsx
@@ -4,6 +4,7 @@
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Wallet } from 'lucide-react'
 import { Suspense } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { BillingAddressCard } from '~/components/subscriptions/billing-address-card'
 import { PaymentMethodsCard } from '~/components/subscriptions/payment-methods-card'
 import { api } from '~/trpc/react'
@@ -20,23 +21,21 @@ export function BillingDetailsSection() {
   if (subscription && !subscription.capabilities?.managedPaymentMethods) return null
 
   return (
-    <div id='billing-details' className='@container space-y-3'>
-      <div className='space-y-1'>
-        <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
-          <Wallet className='size-4' /> Billing Details
+    <div id='billing-details' className='@container'>
+      <SettingsSection
+        className='space-y-3'
+        icon={Wallet}
+        title='Billing Details'
+        description='Manage your payment methods and billing information'>
+        <div className='grid grid-cols-1 @lg:grid-cols-2 gap-6'>
+          <Suspense fallback={<BillingCardSkeleton />}>
+            <BillingAddressCard />
+          </Suspense>
+          <Suspense fallback={<BillingCardSkeleton />}>
+            <PaymentMethodsCard />
+          </Suspense>
         </div>
-        <div className='text-sm text-muted-foreground mb-4'>
-          Manage your payment methods and billing information
-        </div>
-      </div>
-      <div className='grid grid-cols-1 @lg:grid-cols-2 gap-6'>
-        <Suspense fallback={<BillingCardSkeleton />}>
-          <BillingAddressCard />
-        </Suspense>
-        <Suspense fallback={<BillingCardSkeleton />}>
-          <PaymentMethodsCard />
-        </Suspense>
-      </div>
+      </SettingsSection>
     </div>
   )
 }

--- a/apps/web/src/app/(protected)/app/settings/plans/_components/shopify-admin-billing-banner-wrapper.tsx
+++ b/apps/web/src/app/(protected)/app/settings/plans/_components/shopify-admin-billing-banner-wrapper.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { Wallet } from 'lucide-react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { ShopifyAdminBillingBanner } from '~/components/subscriptions/shopify-admin-billing-banner'
 import { api } from '~/trpc/react'
 
@@ -17,16 +18,14 @@ export function ShopifyAdminBillingBannerWrapper() {
   if (subscription?.billingProvider !== 'shopify') return null
 
   return (
-    <div id='billing-details' className='space-y-3'>
-      <div className='space-y-1'>
-        <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
-          <Wallet className='size-4' /> Billing Details
-        </div>
-        <div className='text-sm text-muted-foreground mb-4'>
-          Manage your payment methods and billing information
-        </div>
-      </div>
-      <ShopifyAdminBillingBanner shopDomain={subscription.shopifyShopDomain} />
+    <div id='billing-details'>
+      <SettingsSection
+        className='space-y-3'
+        icon={Wallet}
+        title='Billing Details'
+        description='Manage your payment methods and billing information'>
+        <ShopifyAdminBillingBanner shopDomain={subscription.shopifyShopDomain} />
+      </SettingsSection>
     </div>
   )
 }

--- a/apps/web/src/app/(protected)/app/settings/plans/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/plans/page.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Receipt } from 'lucide-react'
 import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
-import SettingsPage from '~/components/global/settings-page'
+import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import {
   BillingCycleAlert,
   BillingCycleAlertSkeleton,
@@ -45,21 +45,17 @@ export default function PlansPage() {
 
         <BillingDetailsSection />
 
-        <div className='space-y-3'>
-          <div className='space-y-1'>
-            <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
-              <Receipt className='size-4' /> History
-            </div>
-            <div className='text-sm text-muted-foreground mb-4'>
-              View and track your past invoices
-            </div>
-          </div>
+        <SettingsSection
+          className='space-y-3'
+          icon={<Receipt className='size-4' />}
+          title='History'
+          description='View and track your past invoices'>
           <div className='rounded-2xl border'>
             <Suspense fallback={<InvoiceListSkeleton />}>
               <InvoiceList />
             </Suspense>
           </div>
-        </div>
+        </SettingsSection>
         <div className='space-y-4'>
           <CancelSubscriptionDialog />
         </div>

--- a/apps/web/src/app/(protected)/app/tickets/_components/ticket-number-form.tsx
+++ b/apps/web/src/app/(protected)/app/tickets/_components/ticket-number-form.tsx
@@ -11,6 +11,7 @@ import { Hash } from 'lucide-react'
 import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { SettingsSection } from '~/components/global/settings-page'
 import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
@@ -170,164 +171,162 @@ export default function TicketNumberingSettings() {
 
   return (
     <div className='container mx-auto max-w-2xl overflow-y-auto pb-10 pt-4'>
-      {/* Title Header */}
-      <div className='mb-6 space-y-1'>
-        <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-          <Hash className='size-4' /> Ticket Numbering
-        </div>
-        <p className='text-sm text-muted-foreground'>Configure how ticket numbers are generated.</p>
-      </div>
+      <SettingsSection
+        className='mb-6'
+        icon={Hash}
+        title='Ticket Numbering'
+        description='Configure how ticket numbers are generated.'>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-60'>
+              {/* Prefix Settings */}
+              <VarEditorFieldRow
+                title='Use Prefix'
+                description='Enable to use a prefix for ticket numbers (e.g., SUP-0001)'
+                type={BaseType.BOOLEAN}
+                showIcon>
+                <ConstantInputAdapter
+                  value={form.watch('usePrefix')}
+                  onChange={(_, val) => form.setValue('usePrefix', val)}
+                  varType={BaseType.BOOLEAN}
+                  fieldOptions={{ variant: 'switch' }}
+                />
+              </VarEditorFieldRow>
 
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)}>
-          <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-60'>
-            {/* Prefix Settings */}
-            <VarEditorFieldRow
-              title='Use Prefix'
-              description='Enable to use a prefix for ticket numbers (e.g., SUP-0001)'
-              type={BaseType.BOOLEAN}
-              showIcon>
-              <ConstantInputAdapter
-                value={form.watch('usePrefix')}
-                onChange={(_, val) => form.setValue('usePrefix', val)}
-                varType={BaseType.BOOLEAN}
-                fieldOptions={{ variant: 'switch' }}
-              />
-            </VarEditorFieldRow>
+              {form.watch('usePrefix') && (
+                <>
+                  <VarEditorFieldRow
+                    title='Prefix Text'
+                    description='Short text to prefix the ticket number (e.g., SUP)'
+                    type={BaseType.STRING}
+                    showIcon>
+                    <ConstantInputAdapter
+                      value={form.watch('prefix') ?? ''}
+                      onChange={(_, val) => form.setValue('prefix', val)}
+                      varType={BaseType.STRING}
+                      placeholder='SUP'
+                    />
+                  </VarEditorFieldRow>
 
-            {form.watch('usePrefix') && (
-              <>
+                  <VarEditorFieldRow
+                    title='Include Date'
+                    description='Add date component to prefix (e.g., SUP2403-0001)'
+                    type={BaseType.BOOLEAN}
+                    showIcon>
+                    <ConstantInputAdapter
+                      value={form.watch('useDateInPrefix')}
+                      onChange={(_, val) => form.setValue('useDateInPrefix', val)}
+                      varType={BaseType.BOOLEAN}
+                      fieldOptions={{ variant: 'switch' }}
+                    />
+                  </VarEditorFieldRow>
+
+                  {form.watch('useDateInPrefix') && (
+                    <VarEditorFieldRow
+                      title='Date Format'
+                      description='Format of the date component in the prefix'
+                      type={BaseType.ENUM}
+                      showIcon>
+                      <ConstantInputAdapter
+                        value={form.watch('dateFormat')}
+                        onChange={(_, val) => form.setValue('dateFormat', val)}
+                        varType={BaseType.ENUM}
+                        fieldOptions={{ enum: DATE_FORMAT_OPTIONS }}
+                      />
+                    </VarEditorFieldRow>
+                  )}
+                </>
+              )}
+
+              {/* Suffix Settings */}
+              <VarEditorFieldRow
+                title='Use Suffix'
+                description='Enable to use a suffix for ticket numbers (e.g., 0001-SUP)'
+                type={BaseType.BOOLEAN}
+                showIcon>
+                <ConstantInputAdapter
+                  value={form.watch('useSuffix')}
+                  onChange={(_, val) => form.setValue('useSuffix', val)}
+                  varType={BaseType.BOOLEAN}
+                  fieldOptions={{ variant: 'switch' }}
+                />
+              </VarEditorFieldRow>
+
+              {form.watch('useSuffix') && (
                 <VarEditorFieldRow
-                  title='Prefix Text'
-                  description='Short text to prefix the ticket number (e.g., SUP)'
+                  title='Suffix Text'
+                  description='Text to append after the ticket number'
                   type={BaseType.STRING}
                   showIcon>
                   <ConstantInputAdapter
-                    value={form.watch('prefix') ?? ''}
-                    onChange={(_, val) => form.setValue('prefix', val)}
+                    value={form.watch('suffix') ?? ''}
+                    onChange={(_, val) => form.setValue('suffix', val)}
                     varType={BaseType.STRING}
                     placeholder='SUP'
                   />
                 </VarEditorFieldRow>
+              )}
 
-                <VarEditorFieldRow
-                  title='Include Date'
-                  description='Add date component to prefix (e.g., SUP2403-0001)'
-                  type={BaseType.BOOLEAN}
-                  showIcon>
-                  <ConstantInputAdapter
-                    value={form.watch('useDateInPrefix')}
-                    onChange={(_, val) => form.setValue('useDateInPrefix', val)}
-                    varType={BaseType.BOOLEAN}
-                    fieldOptions={{ variant: 'switch' }}
-                  />
-                </VarEditorFieldRow>
-
-                {form.watch('useDateInPrefix') && (
-                  <VarEditorFieldRow
-                    title='Date Format'
-                    description='Format of the date component in the prefix'
-                    type={BaseType.ENUM}
-                    showIcon>
-                    <ConstantInputAdapter
-                      value={form.watch('dateFormat')}
-                      onChange={(_, val) => form.setValue('dateFormat', val)}
-                      varType={BaseType.ENUM}
-                      fieldOptions={{ enum: DATE_FORMAT_OPTIONS }}
-                    />
-                  </VarEditorFieldRow>
-                )}
-              </>
-            )}
-
-            {/* Suffix Settings */}
-            <VarEditorFieldRow
-              title='Use Suffix'
-              description='Enable to use a suffix for ticket numbers (e.g., 0001-SUP)'
-              type={BaseType.BOOLEAN}
-              showIcon>
-              <ConstantInputAdapter
-                value={form.watch('useSuffix')}
-                onChange={(_, val) => form.setValue('useSuffix', val)}
-                varType={BaseType.BOOLEAN}
-                fieldOptions={{ variant: 'switch' }}
-              />
-            </VarEditorFieldRow>
-
-            {form.watch('useSuffix') && (
+              {/* Number Format */}
               <VarEditorFieldRow
-                title='Suffix Text'
-                description='Text to append after the ticket number'
+                title='Padding Length'
+                description='Number of digits to pad the numeric part (e.g., 4 for 0001)'
+                type={BaseType.NUMBER}
+                showIcon>
+                <ConstantInputAdapter
+                  value={form.watch('paddingLength')}
+                  onChange={(_, val) => form.setValue('paddingLength', val)}
+                  varType={BaseType.NUMBER}
+                  placeholder='4'
+                />
+              </VarEditorFieldRow>
+
+              <VarEditorFieldRow
+                title='Separator'
+                description='Character(s) to separate parts (e.g., -, ., _)'
                 type={BaseType.STRING}
                 showIcon>
                 <ConstantInputAdapter
-                  value={form.watch('suffix') ?? ''}
-                  onChange={(_, val) => form.setValue('suffix', val)}
+                  value={form.watch('separator')}
+                  onChange={(_, val) => form.setValue('separator', val)}
                   varType={BaseType.STRING}
-                  placeholder='SUP'
+                  placeholder='-'
                 />
               </VarEditorFieldRow>
-            )}
+            </VarEditorField>
 
-            {/* Number Format */}
-            <VarEditorFieldRow
-              title='Padding Length'
-              description='Number of digits to pad the numeric part (e.g., 4 for 0001)'
-              type={BaseType.NUMBER}
-              showIcon>
-              <ConstantInputAdapter
-                value={form.watch('paddingLength')}
-                onChange={(_, val) => form.setValue('paddingLength', val)}
-                varType={BaseType.NUMBER}
-                placeholder='4'
-              />
-            </VarEditorFieldRow>
-
-            <VarEditorFieldRow
-              title='Separator'
-              description='Character(s) to separate parts (e.g., -, ., _)'
-              type={BaseType.STRING}
-              showIcon>
-              <ConstantInputAdapter
-                value={form.watch('separator')}
-                onChange={(_, val) => form.setValue('separator', val)}
-                varType={BaseType.STRING}
-                placeholder='-'
-              />
-            </VarEditorFieldRow>
-          </VarEditorField>
-
-          {/* Preview Section */}
-          <div className='mt-6 rounded-xl border bg-primary-100/30 p-4'>
-            <div className='mb-2 text-sm font-medium'>Preview</div>
-            <div className='grid grid-cols-2 gap-4'>
-              <div>
-                <div className='text-xs text-muted-foreground'>Current sequence</div>
-                <div className='text-lg font-bold'>{currentNumber}</div>
-              </div>
-              <div>
-                <div className='text-xs text-muted-foreground'>Next ticket</div>
-                <div className='font-mono text-lg font-bold'>{sampleSequence}</div>
+            {/* Preview Section */}
+            <div className='mt-6 rounded-xl border bg-primary-100/30 p-4'>
+              <div className='mb-2 text-sm font-medium'>Preview</div>
+              <div className='grid grid-cols-2 gap-4'>
+                <div>
+                  <div className='text-xs text-muted-foreground'>Current sequence</div>
+                  <div className='text-lg font-bold'>{currentNumber}</div>
+                </div>
+                <div>
+                  <div className='text-xs text-muted-foreground'>Next ticket</div>
+                  <div className='font-mono text-lg font-bold'>{sampleSequence}</div>
+                </div>
               </div>
             </div>
-          </div>
 
-          {/* Action Buttons */}
-          <div className='mt-6 flex justify-end gap-2'>
-            <Button type='button' variant='ghost' size='sm' onClick={() => form.reset()}>
-              Reset
-            </Button>
-            <Button
-              type='submit'
-              size='sm'
-              variant='outline'
-              loading={updateSequence.isPending}
-              loadingText='Saving...'>
-              Save Settings
-            </Button>
-          </div>
-        </form>
-      </Form>
+            {/* Action Buttons */}
+            <div className='mt-6 flex justify-end gap-2'>
+              <Button type='button' variant='ghost' size='sm' onClick={() => form.reset()}>
+                Reset
+              </Button>
+              <Button
+                type='submit'
+                size='sm'
+                variant='outline'
+                loading={updateSequence.isPending}
+                loadingText='Saving...'>
+                Save Settings
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </SettingsSection>
     </div>
   )
 }

--- a/apps/web/src/app/(protected)/app/tickets/settings/domains/page.tsx
+++ b/apps/web/src/app/(protected)/app/tickets/settings/domains/page.tsx
@@ -40,7 +40,7 @@ import {
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
-import SettingsPage from '~/components/global/settings-page'
+import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import DomainTestingTab from '../../_components/domain-testing-tab'
@@ -388,17 +388,14 @@ function DomainsListView({
   }
 
   return (
-    <div className='space-y-4'>
-      {/* Header with Add Button */}
-      <div className='flex items-center justify-between'>
-        <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
-          <Globe className='size-4' /> Email Domains
-        </div>
+    <SettingsSection
+      icon={Globe}
+      title='Email Domains'
+      action={
         <Button size='sm' onClick={onAddDomain}>
           <Plus /> Add Domain
         </Button>
-      </div>
-
+      }>
       {/* Domain List */}
       <div className='space-y-2'>
         {domains.map((domain) => (
@@ -465,6 +462,6 @@ function DomainsListView({
       </div>
 
       <ConfirmDialog />
-    </div>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/apps/ui/app-connections.tsx
+++ b/apps/web/src/components/apps/ui/app-connections.tsx
@@ -9,9 +9,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
+import type { LucideIcon } from 'lucide-react'
 import { MoreHorizontal, Pencil, Plus, RefreshCw, Unplug, User, Users } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { useUser } from '~/hooks/use-user'
 import type { RouterOutputs } from '~/trpc/react'
 import { api } from '~/trpc/react'
@@ -111,7 +113,7 @@ function AppConnections({ app, returnTo, scope, onConnectionCreated }: Props) {
           rows={personalRows}
           returnTo={returnTo}
           canEdit
-          icon={<User className='size-4' />}
+          icon={User}
           title='Personal'
           isLoading={isLoadingConnections}
           onConnectionCreated={onConnectionCreated}
@@ -125,7 +127,7 @@ function AppConnections({ app, returnTo, scope, onConnectionCreated }: Props) {
           rows={workspaceRows}
           returnTo={returnTo}
           canEdit={isAdminOrOwner}
-          icon={<Users className='size-4' />}
+          icon={Users}
           title='Workspace'
           isLoading={isLoadingConnections}
           onConnectionCreated={onConnectionCreated}
@@ -144,7 +146,7 @@ type ConnectionSectionProps = {
   rows: ConnectionRowType[]
   returnTo?: string
   canEdit: boolean
-  icon: React.ReactNode
+  icon: LucideIcon
   title: string
   isLoading: boolean
   onConnectionCreated?: (credId: string, scope: Scope) => void
@@ -175,13 +177,12 @@ function ConnectionSection({
   const showAddButton = canEdit && (isOAuth || isSecret)
 
   return (
-    <div className='space-y-2'>
-      <div className='flex items-end justify-between'>
-        <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-          {icon}
-          {title}
-        </div>
-        {showAddButton && (
+    <SettingsSection
+      className='space-y-2'
+      icon={icon}
+      title={title}
+      action={
+        showAddButton ? (
           <Button
             variant='outline'
             size='sm'
@@ -189,8 +190,8 @@ function ConnectionSection({
             <Plus />
             Add Connection
           </Button>
-        )}
-      </div>
+        ) : undefined
+      }>
       <ConnectionList
         isLoading={isLoading}
         emptyMessage={
@@ -260,6 +261,6 @@ function ConnectionSection({
       </ConnectionList>
       {flow.Dialogs}
       <rowActions.ConfirmDialog />
-    </div>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/chat-widget/ui/settings/sections/ai-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/ai-section.tsx
@@ -18,6 +18,7 @@ import { BookOpen, Bot, Home, Sparkles } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { SettingsSection } from '~/components/global/settings-page'
 import { ActorPicker } from '~/components/pickers/actor-picker'
 import { MultiRelationInput } from '~/components/shared/multi-relation-input'
 import { BaseType } from '~/components/workflow/types'
@@ -113,47 +114,37 @@ export function AiSection({ widget, channelId }: AiSectionProps) {
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
         <div className='p-6'>
-          <div className='space-y-1 mb-4'>
-            <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-              <Bot className='size-4' /> Agent
-            </div>
-            <p className='text-sm text-muted-foreground'>
-              The AI agent that replies to incoming chat messages.
-            </p>
-          </div>
-
-          <VarEditorField orientation='responsive' className='p-0'>
-            <VarEditorFieldRow
-              title='AI Auto-Reply'
-              description='Pick an Agent that responds automatically to new chat messages. Leave unset to require a human reply.'
-              type={BaseType.ACTOR}
-              icon={<Sparkles className='size-3.5' />}
-              showIcon>
-              <ActorPicker
-                value={agentActorIds}
-                onChange={handleAgentChange}
-                multi={false}
-                target='agent'
-                agentFilter={agentFilter}
-                emptyLabel='Choose an agent…'
-                disabled={update.isPending}
-                triggerProps={{ className: 'w-full ps-0 pe-1' }}
-              />
-            </VarEditorFieldRow>
-          </VarEditorField>
+          <SettingsSection
+            icon={Bot}
+            title='Agent'
+            description='The AI agent that replies to incoming chat messages.'>
+            <VarEditorField orientation='responsive' className='p-0'>
+              <VarEditorFieldRow
+                title='AI Auto-Reply'
+                description='Pick an Agent that responds automatically to new chat messages. Leave unset to require a human reply.'
+                type={BaseType.ACTOR}
+                icon={<Sparkles className='size-3.5' />}
+                showIcon>
+                <ActorPicker
+                  value={agentActorIds}
+                  onChange={handleAgentChange}
+                  multi={false}
+                  target='agent'
+                  agentFilter={agentFilter}
+                  emptyLabel='Choose an agent…'
+                  disabled={update.isPending}
+                  triggerProps={{ className: 'w-full ps-0 pe-1' }}
+                />
+              </VarEditorFieldRow>
+            </VarEditorField>
+          </SettingsSection>
         </div>
 
         <div className='border-t p-6 space-y-4'>
-          <div>
-            <div className='space-y-1 mb-4'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <BookOpen className='size-4' /> Knowledge base
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Source articles for the widget's Home and Browse screens.
-              </p>
-            </div>
-
+          <SettingsSection
+            icon={BookOpen}
+            title='Knowledge base'
+            description="Source articles for the widget's Home and Browse screens.">
             <VarEditorField orientation='responsive' className='p-0'>
               <FormField
                 control={form.control}
@@ -191,7 +182,7 @@ export function AiSection({ widget, channelId }: AiSectionProps) {
                 }}
               />
             </VarEditorField>
-          </div>
+          </SettingsSection>
 
           <div>
             <FormField

--- a/apps/web/src/components/chat-widget/ui/settings/sections/appearance-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/appearance-section.tsx
@@ -11,6 +11,7 @@ import { LayoutGrid, MessageSquare, Moon, Palette, Smartphone, Sun, SunMoon } fr
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { SettingsSection } from '~/components/global/settings-page'
 import { ColorField } from '~/components/ui/color-field'
 import { BaseType } from '~/components/workflow/types'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
@@ -131,296 +132,282 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
       <form onSubmit={form.handleSubmit(onSubmit)}>
         <div className='p-6 space-y-8'>
           <div>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <Palette className='size-4' /> Branding
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                The color and logo shown on the widget header.
-              </p>
-            </div>
-
-            <VarEditorField
-              orientation='responsive'
-              className='p-0 **:data-[slot=field-row-label]:w-[12rem]! @sm:**:data-[slot=field-row-label]:w-[12rem]!'>
-              <FormField
-                control={form.control}
-                name='defaultTheme'
-                render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
-                    title='Theme'
-                    description='Default color scheme. The embed script can override this per-page via data-theme.'
-                    type={BaseType.ENUM}
-                    icon={<SunMoon className='size-3.5' />}
-                    showIcon
-                    validationError={fieldState.error?.message}>
-                    <FieldInputAdapter
-                      fieldType={FieldType.SINGLE_SELECT}
-                      fieldOptions={{ options: THEME_OPTIONS }}
-                      value={field.value}
-                      onChange={(v) => {
-                        const next = Array.isArray(v) ? v[0] : v
-                        if (typeof next === 'string') {
-                          field.onChange(next as AppearanceForm['defaultTheme'])
-                        }
-                      }}
-                      placeholder='Choose theme'
-                      triggerProps={{ className: 'w-full ps-0 pe-1' }}
-                    />
-                  </VarEditorFieldRow>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name='primaryColor'
-                render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
-                    title='Primary Color'
-                    description='Used for the launcher button, send buttons, and accent UI.'
-                    type={BaseType.STRING}
-                    icon={<Palette className='size-3.5' />}
-                    showIcon
-                    isRequired
-                    validationError={fieldState.error?.message}>
-                    <ColorField
-                      value={field.value || ''}
-                      onChange={field.onChange}
-                      placeholder='Pick a color'
-                    />
-                  </VarEditorFieldRow>
-                )}
-              />
-
-              {showDarkColors ? (
+            <SettingsSection
+              className='mb-6'
+              icon={Palette}
+              title='Branding'
+              description='The color and logo shown on the widget header.'>
+              <VarEditorField
+                orientation='responsive'
+                className='p-0 **:data-[slot=field-row-label]:w-[12rem]! @sm:**:data-[slot=field-row-label]:w-[12rem]!'>
                 <FormField
                   control={form.control}
-                  name='primaryColorDark'
+                  name='defaultTheme'
                   render={({ field, fieldState }) => (
                     <VarEditorFieldRow
-                      title='Primary Color (dark)'
-                      description='Primary color in dark mode. Optional — falls back to the light primary color.'
-                      type={BaseType.STRING}
-                      icon={<Moon className='size-3.5' />}
+                      title='Theme'
+                      description='Default color scheme. The embed script can override this per-page via data-theme.'
+                      type={BaseType.ENUM}
+                      icon={<SunMoon className='size-3.5' />}
                       showIcon
                       validationError={fieldState.error?.message}>
-                      <ColorField
-                        value={field.value || ''}
-                        onChange={field.onChange}
-                        placeholder='Same as light'
-                      />
-                    </VarEditorFieldRow>
-                  )}
-                />
-              ) : null}
-
-              <FormField
-                control={form.control}
-                name='headerColor'
-                render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
-                    title='Header Color'
-                    description='Background of the Home greeting band. Leave empty to derive from the brand color. Text color is auto-picked for contrast.'
-                    type={BaseType.STRING}
-                    icon={<Palette className='size-3.5' />}
-                    showIcon
-                    validationError={fieldState.error?.message}>
-                    <ColorField
-                      value={field.value || ''}
-                      onChange={field.onChange}
-                      placeholder='Auto (brand)'
-                      clearable
-                    />
-                  </VarEditorFieldRow>
-                )}
-              />
-
-              {showDarkColors ? (
-                <FormField
-                  control={form.control}
-                  name='headerColorDark'
-                  render={({ field, fieldState }) => (
-                    <VarEditorFieldRow
-                      title='Header Color (dark)'
-                      description='Home greeting band color in dark mode. Optional — falls back to the light header color.'
-                      type={BaseType.STRING}
-                      icon={<Moon className='size-3.5' />}
-                      showIcon
-                      validationError={fieldState.error?.message}>
-                      <ColorField
-                        value={field.value || ''}
-                        onChange={field.onChange}
-                        placeholder='Same as light'
-                      />
-                    </VarEditorFieldRow>
-                  )}
-                />
-              ) : null}
-
-              <FormField
-                control={form.control}
-                name='logoLight'
-                render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
-                    title='Light mode logo'
-                    description='Shown on the dark primary-colored header band.'
-                    icon={<Sun className='size-3.5' />}
-                    showIcon
-                    validationError={fieldState.error?.message}>
-                    <LogoUploadCell
-                      variant='light'
-                      value={field.value ?? ''}
-                      onChange={(v) => field.onChange(v)}
-                      chatWidgetId={chatWidgetId}
-                    />
-                  </VarEditorFieldRow>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name='logoDark'
-                render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
-                    title='Dark mode logo'
-                    description='Used when the resolved theme is dark. Falls back to the light logo if unset.'
-                    icon={<Moon className='size-3.5' />}
-                    showIcon
-                    validationError={fieldState.error?.message}>
-                    <LogoUploadCell
-                      variant='dark'
-                      value={field.value ?? ''}
-                      onChange={(v) => field.onChange(v)}
-                      chatWidgetId={chatWidgetId}
-                    />
-                  </VarEditorFieldRow>
-                )}
-              />
-            </VarEditorField>
-
-            <div className='space-y-1 mt-6 mb-4'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <LayoutGrid className='size-4' /> Layout
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Where and how the widget appears on the page.
-              </p>
-            </div>
-
-            <VarEditorField orientation='responsive' className='p-0'>
-              <FormField
-                control={form.control}
-                name='position'
-                render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
-                    title='Position'
-                    description='Corner of the page where the widget anchors.'
-                    type={BaseType.ENUM}
-                    icon={<LayoutGrid className='size-3.5' />}
-                    showIcon
-                    validationError={fieldState.error?.message}>
-                    <FieldInputAdapter
-                      fieldType={FieldType.SINGLE_SELECT}
-                      fieldOptions={{ options: POSITION_OPTIONS }}
-                      value={field.value}
-                      onChange={(v) => {
-                        const next = Array.isArray(v) ? v[0] : v
-                        if (typeof next === 'string') {
-                          field.onChange(next as AppearanceForm['position'])
-                        }
-                      }}
-                      placeholder='Choose position'
-                      triggerProps={{ className: 'w-full' }}
-                    />
-                  </VarEditorFieldRow>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name='mobileFullScreen'
-                render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
-                    title='Mobile Full Screen'
-                    description='Expand the widget to fill the screen on small devices.'
-                    type={BaseType.BOOLEAN}
-                    icon={<Smartphone className='size-3.5' />}
-                    showIcon
-                    validationError={fieldState.error?.message}>
-                    <div className='ps-3'>
                       <FieldInputAdapter
-                        fieldType={FieldType.CHECKBOX}
-                        fieldOptions={{ variant: 'switch' }}
+                        fieldType={FieldType.SINGLE_SELECT}
+                        fieldOptions={{ options: THEME_OPTIONS }}
                         value={field.value}
-                        onChange={(v) => field.onChange(Boolean(v))}
+                        onChange={(v) => {
+                          const next = Array.isArray(v) ? v[0] : v
+                          if (typeof next === 'string') {
+                            field.onChange(next as AppearanceForm['defaultTheme'])
+                          }
+                        }}
+                        placeholder='Choose theme'
+                        triggerProps={{ className: 'w-full ps-0 pe-1' }}
                       />
-                    </div>
-                  </VarEditorFieldRow>
-                )}
-              />
-            </VarEditorField>
+                    </VarEditorFieldRow>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name='primaryColor'
+                  render={({ field, fieldState }) => (
+                    <VarEditorFieldRow
+                      title='Primary Color'
+                      description='Used for the launcher button, send buttons, and accent UI.'
+                      type={BaseType.STRING}
+                      icon={<Palette className='size-3.5' />}
+                      showIcon
+                      isRequired
+                      validationError={fieldState.error?.message}>
+                      <ColorField
+                        value={field.value || ''}
+                        onChange={field.onChange}
+                        placeholder='Pick a color'
+                      />
+                    </VarEditorFieldRow>
+                  )}
+                />
+
+                {showDarkColors ? (
+                  <FormField
+                    control={form.control}
+                    name='primaryColorDark'
+                    render={({ field, fieldState }) => (
+                      <VarEditorFieldRow
+                        title='Primary Color (dark)'
+                        description='Primary color in dark mode. Optional — falls back to the light primary color.'
+                        type={BaseType.STRING}
+                        icon={<Moon className='size-3.5' />}
+                        showIcon
+                        validationError={fieldState.error?.message}>
+                        <ColorField
+                          value={field.value || ''}
+                          onChange={field.onChange}
+                          placeholder='Same as light'
+                        />
+                      </VarEditorFieldRow>
+                    )}
+                  />
+                ) : null}
+
+                <FormField
+                  control={form.control}
+                  name='headerColor'
+                  render={({ field, fieldState }) => (
+                    <VarEditorFieldRow
+                      title='Header Color'
+                      description='Background of the Home greeting band. Leave empty to derive from the brand color. Text color is auto-picked for contrast.'
+                      type={BaseType.STRING}
+                      icon={<Palette className='size-3.5' />}
+                      showIcon
+                      validationError={fieldState.error?.message}>
+                      <ColorField
+                        value={field.value || ''}
+                        onChange={field.onChange}
+                        placeholder='Auto (brand)'
+                        clearable
+                      />
+                    </VarEditorFieldRow>
+                  )}
+                />
+
+                {showDarkColors ? (
+                  <FormField
+                    control={form.control}
+                    name='headerColorDark'
+                    render={({ field, fieldState }) => (
+                      <VarEditorFieldRow
+                        title='Header Color (dark)'
+                        description='Home greeting band color in dark mode. Optional — falls back to the light header color.'
+                        type={BaseType.STRING}
+                        icon={<Moon className='size-3.5' />}
+                        showIcon
+                        validationError={fieldState.error?.message}>
+                        <ColorField
+                          value={field.value || ''}
+                          onChange={field.onChange}
+                          placeholder='Same as light'
+                        />
+                      </VarEditorFieldRow>
+                    )}
+                  />
+                ) : null}
+
+                <FormField
+                  control={form.control}
+                  name='logoLight'
+                  render={({ field, fieldState }) => (
+                    <VarEditorFieldRow
+                      title='Light mode logo'
+                      description='Shown on the dark primary-colored header band.'
+                      icon={<Sun className='size-3.5' />}
+                      showIcon
+                      validationError={fieldState.error?.message}>
+                      <LogoUploadCell
+                        variant='light'
+                        value={field.value ?? ''}
+                        onChange={(v) => field.onChange(v)}
+                        chatWidgetId={chatWidgetId}
+                      />
+                    </VarEditorFieldRow>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name='logoDark'
+                  render={({ field, fieldState }) => (
+                    <VarEditorFieldRow
+                      title='Dark mode logo'
+                      description='Used when the resolved theme is dark. Falls back to the light logo if unset.'
+                      icon={<Moon className='size-3.5' />}
+                      showIcon
+                      validationError={fieldState.error?.message}>
+                      <LogoUploadCell
+                        variant='dark'
+                        value={field.value ?? ''}
+                        onChange={(v) => field.onChange(v)}
+                        chatWidgetId={chatWidgetId}
+                      />
+                    </VarEditorFieldRow>
+                  )}
+                />
+              </VarEditorField>
+            </SettingsSection>
+
+            <SettingsSection
+              className='mt-6 mb-4'
+              icon={LayoutGrid}
+              title='Layout'
+              description='Where and how the widget appears on the page.'>
+              <VarEditorField orientation='responsive' className='p-0'>
+                <FormField
+                  control={form.control}
+                  name='position'
+                  render={({ field, fieldState }) => (
+                    <VarEditorFieldRow
+                      title='Position'
+                      description='Corner of the page where the widget anchors.'
+                      type={BaseType.ENUM}
+                      icon={<LayoutGrid className='size-3.5' />}
+                      showIcon
+                      validationError={fieldState.error?.message}>
+                      <FieldInputAdapter
+                        fieldType={FieldType.SINGLE_SELECT}
+                        fieldOptions={{ options: POSITION_OPTIONS }}
+                        value={field.value}
+                        onChange={(v) => {
+                          const next = Array.isArray(v) ? v[0] : v
+                          if (typeof next === 'string') {
+                            field.onChange(next as AppearanceForm['position'])
+                          }
+                        }}
+                        placeholder='Choose position'
+                        triggerProps={{ className: 'w-full' }}
+                      />
+                    </VarEditorFieldRow>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name='mobileFullScreen'
+                  render={({ field, fieldState }) => (
+                    <VarEditorFieldRow
+                      title='Mobile Full Screen'
+                      description='Expand the widget to fill the screen on small devices.'
+                      type={BaseType.BOOLEAN}
+                      icon={<Smartphone className='size-3.5' />}
+                      showIcon
+                      validationError={fieldState.error?.message}>
+                      <div className='ps-3'>
+                        <FieldInputAdapter
+                          fieldType={FieldType.CHECKBOX}
+                          fieldOptions={{ variant: 'switch' }}
+                          value={field.value}
+                          onChange={(v) => field.onChange(Boolean(v))}
+                        />
+                      </div>
+                    </VarEditorFieldRow>
+                  )}
+                />
+              </VarEditorField>
+            </SettingsSection>
           </div>
 
           <div>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <MessageSquare className='size-4' /> Greeting
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Personalised message shown on the widget's Home screen.
-              </p>
-            </div>
+            <SettingsSection
+              className='mb-6'
+              icon={MessageSquare}
+              title='Greeting'
+              description="Personalised message shown on the widget's Home screen.">
+              <FormField
+                control={form.control}
+                name='homeGreetingTemplate'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <GreetingEditor
+                        value={(field.value as JSONContent | null) ?? null}
+                        onChange={field.onChange}
+                        placeholder='Hi {visitor:name} 👋'
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Type <code className='rounded bg-muted px-1'>{'{'}</code> to insert a visitor
+                      field. Click the badge to set a fallback for when the value isn't available.
+                    </FormDescription>
+                  </FormItem>
+                )}
+              />
+            </SettingsSection>
 
-            <FormField
-              control={form.control}
-              name='homeGreetingTemplate'
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <GreetingEditor
-                      value={(field.value as JSONContent | null) ?? null}
-                      onChange={field.onChange}
-                      placeholder='Hi {visitor:name} 👋'
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Type <code className='rounded bg-muted px-1'>{'{'}</code> to insert a visitor
-                    field. Click the badge to set a fallback for when the value isn't available.
-                  </FormDescription>
-                </FormItem>
-              )}
-            />
-
-            <div className='space-y-1 mt-6 mb-4'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <MessageSquare className='size-4' /> Welcome message
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Synthetic first bubble shown inside a new conversation, before the visitor types
-                anything. Sender is the configured AI agent (or your org name when no agent is
-                bound).
-              </p>
-            </div>
-
-            <FormField
-              control={form.control}
-              name='welcomeMessageTemplate'
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <GreetingEditor
-                      value={(field.value as JSONContent | null) ?? null}
-                      onChange={field.onChange}
-                      placeholder='Hi {visitor:name}, how can I help today?'
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Type <code className='rounded bg-muted px-1'>{'{'}</code> to insert a visitor
-                    field. The bubble disappears the moment the visitor sends their first message.
-                  </FormDescription>
-                </FormItem>
-              )}
-            />
+            <SettingsSection
+              className='mt-6 mb-4'
+              icon={MessageSquare}
+              title='Welcome message'
+              description='Synthetic first bubble shown inside a new conversation, before the visitor types anything. Sender is the configured AI agent (or your org name when no agent is bound).'>
+              <FormField
+                control={form.control}
+                name='welcomeMessageTemplate'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <GreetingEditor
+                        value={(field.value as JSONContent | null) ?? null}
+                        onChange={field.onChange}
+                        placeholder='Hi {visitor:name}, how can I help today?'
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Type <code className='rounded bg-muted px-1'>{'{'}</code> to insert a visitor
+                      field. The bubble disappears the moment the visitor sends their first message.
+                    </FormDescription>
+                  </FormItem>
+                )}
+              />
+            </SettingsSection>
 
             <div className='mt-6 mb-2 text-sm font-medium text-foreground'>Suggested replies</div>
             <p className='mb-3 text-sm text-muted-foreground'>

--- a/apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
@@ -28,6 +28,7 @@ import {
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { SettingsSection } from '~/components/global/settings-page'
 import { BaseType } from '~/components/workflow/types'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
@@ -91,16 +92,10 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
         <div className='p-6 space-y-8'>
-          <div>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <SlidersHorizontal className='size-4' /> Engagement
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                How and when the widget engages visitors.
-              </p>
-            </div>
-
+          <SettingsSection
+            icon={SlidersHorizontal}
+            title='Engagement'
+            description='How and when the widget engages visitors.'>
             <VarEditorField
               orientation='responsive'
               className='p-0 **:data-[slot=field-row-label]:w-auto! @sm:**:data-[slot=field-row-label]:w-auto! **:data-[slot=field-row-content]:flex **:data-[slot=field-row-content]:justify-end **:data-[slot=field-row-content]:pe-3'>
@@ -232,18 +227,12 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                 )}
               />
             </VarEditorField>
-          </div>
+          </SettingsSection>
 
-          <div>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <MessageSquareOff className='size-4' /> Offline
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Message shown when chats start outside of operating hours.
-              </p>
-            </div>
-
+          <SettingsSection
+            icon={MessageSquareOff}
+            title='Offline'
+            description='Message shown when chats start outside of operating hours.'>
             <FormField
               control={form.control}
               name='offlineMessage'
@@ -260,7 +249,7 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                 </FormItem>
               )}
             />
-          </div>
+          </SettingsSection>
         </div>
 
         <div className='flex justify-end gap-2 border-t px-4 py-4'>

--- a/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
@@ -27,6 +27,7 @@ import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { SettingsSection } from '~/components/global/settings-page'
 import { InboxDialog } from '~/components/inbox/inbox-dialog'
 import { useResource } from '~/components/resources/hooks/use-resource'
 import { MultiRelationInput } from '~/components/shared/multi-relation-input'
@@ -126,213 +127,205 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
         <div className='p-6'>
-          <div className='space-y-1 mb-6'>
-            <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-              <Settings className='size-4' /> General
-            </div>
-            <p className='text-sm text-muted-foreground'>
-              Internal name, header text, and active status.
-            </p>
-          </div>
-
-          <VarEditorField orientation='responsive' className='p-0'>
-            <FormField
-              control={form.control}
-              name='name'
-              render={({ field, fieldState }) => (
-                <VarEditorFieldRow
-                  title='Widget Name'
-                  description='Shown only to your team.'
-                  type={BaseType.STRING}
-                  icon={<Tag className='size-3.5' />}
-                  showIcon
-                  isRequired
-                  validationError={fieldState.error?.message}>
-                  <FieldInputAdapter
-                    fieldType={FieldType.TEXT}
-                    value={field.value}
-                    onChange={(v) => field.onChange((v as string) ?? '')}
-                    placeholder='Internal name'
-                  />
-                </VarEditorFieldRow>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name='title'
-              render={({ field, fieldState }) => (
-                <VarEditorFieldRow
-                  title='Header Title'
-                  description='Appears at the top of the widget.'
-                  type={BaseType.STRING}
-                  icon={<TypeIcon className='size-3.5' />}
-                  showIcon
-                  isRequired
-                  validationError={fieldState.error?.message}>
-                  <FieldInputAdapter
-                    fieldType={FieldType.TEXT}
-                    value={field.value}
-                    onChange={(v) => field.onChange((v as string) ?? '')}
-                    placeholder='Chat'
-                  />
-                </VarEditorFieldRow>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name='subtitle'
-              render={({ field, fieldState }) => (
-                <VarEditorFieldRow
-                  title='Subtitle'
-                  description='Shown under the header title.'
-                  type={BaseType.STRING}
-                  icon={<TypeIcon className='size-3.5' />}
-                  showIcon
-                  validationError={fieldState.error?.message}>
-                  <FieldInputAdapter
-                    fieldType={FieldType.TEXT}
-                    value={field.value ?? ''}
-                    onChange={(v) => field.onChange((v as string) ?? '')}
-                    placeholder='We typically reply in minutes'
-                  />
-                </VarEditorFieldRow>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name='isActive'
-              render={({ field, fieldState }) => (
-                <VarEditorFieldRow
-                  title='Active'
-                  description='When off, the widget will not render or accept new chats.'
-                  type={BaseType.BOOLEAN}
-                  icon={<Power className='size-3.5' />}
-                  showIcon
-                  validationError={fieldState.error?.message}>
-                  <FieldInputAdapter
-                    fieldType={FieldType.CHECKBOX}
-                    fieldOptions={{ variant: 'switch' }}
-                    value={field.value}
-                    onChange={(v) => field.onChange(Boolean(v))}
-                  />
-                </VarEditorFieldRow>
-              )}
-            />
-
-            <VarEditorFieldRow
-              title='Inbox'
-              description='Where new chat conversations land.'
-              type={BaseType.RELATION}
-              icon={<InboxIcon className='size-3.5' />}
-              showIcon>
-              <MultiRelationInput
-                entityDefinitionId='inbox'
-                value={inboxRecordId ? [inboxRecordId] : []}
-                onChange={handleInboxChange}
-                multi={false}
-                placeholder='Pick an inbox'
-                disabled={update.isPending}
-                triggerProps={{ className: 'w-full ps-0 pe-1', badgeHoverCard: false }}
-                onCreate={() => setInboxDialogOpen(true)}
-                createLabel='Create inbox'
+          <SettingsSection
+            className='space-y-6'
+            icon={Settings}
+            title='General'
+            description='Internal name, header text, and active status.'>
+            <VarEditorField orientation='responsive' className='p-0'>
+              <FormField
+                control={form.control}
+                name='name'
+                render={({ field, fieldState }) => (
+                  <VarEditorFieldRow
+                    title='Widget Name'
+                    description='Shown only to your team.'
+                    type={BaseType.STRING}
+                    icon={<Tag className='size-3.5' />}
+                    showIcon
+                    isRequired
+                    validationError={fieldState.error?.message}>
+                    <FieldInputAdapter
+                      fieldType={FieldType.TEXT}
+                      value={field.value}
+                      onChange={(v) => field.onChange((v as string) ?? '')}
+                      placeholder='Internal name'
+                    />
+                  </VarEditorFieldRow>
+                )}
               />
-            </VarEditorFieldRow>
 
-            <VarEditorFieldRow
-              title='Privacy URL'
-              description='When set, the widget shows a consent banner under the composer linking to this URL. Leave blank to hide.'
-              type={BaseType.STRING}
-              icon={<LinkIcon className='size-3.5' />}
-              isRequired
-              showIcon>
-              <div
-                onBlur={() => {
-                  const next = privacyUrlDraft.trim()
-                  const current = widget.chatWidget?.privacyPolicyUrl ?? ''
-                  if (next === current) return
-                  update.mutate({
-                    integrationId: channelId,
-                    privacyPolicyUrl: next === '' ? null : next,
-                  })
-                }}>
-                <FieldInputAdapter
-                  fieldType={FieldType.URL}
-                  value={privacyUrlDraft}
-                  onChange={(v) => setPrivacyUrlDraft((v as string) ?? '')}
-                  placeholder='https://example.com/privacy'
+              <FormField
+                control={form.control}
+                name='title'
+                render={({ field, fieldState }) => (
+                  <VarEditorFieldRow
+                    title='Header Title'
+                    description='Appears at the top of the widget.'
+                    type={BaseType.STRING}
+                    icon={<TypeIcon className='size-3.5' />}
+                    showIcon
+                    isRequired
+                    validationError={fieldState.error?.message}>
+                    <FieldInputAdapter
+                      fieldType={FieldType.TEXT}
+                      value={field.value}
+                      onChange={(v) => field.onChange((v as string) ?? '')}
+                      placeholder='Chat'
+                    />
+                  </VarEditorFieldRow>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name='subtitle'
+                render={({ field, fieldState }) => (
+                  <VarEditorFieldRow
+                    title='Subtitle'
+                    description='Shown under the header title.'
+                    type={BaseType.STRING}
+                    icon={<TypeIcon className='size-3.5' />}
+                    showIcon
+                    validationError={fieldState.error?.message}>
+                    <FieldInputAdapter
+                      fieldType={FieldType.TEXT}
+                      value={field.value ?? ''}
+                      onChange={(v) => field.onChange((v as string) ?? '')}
+                      placeholder='We typically reply in minutes'
+                    />
+                  </VarEditorFieldRow>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name='isActive'
+                render={({ field, fieldState }) => (
+                  <VarEditorFieldRow
+                    title='Active'
+                    description='When off, the widget will not render or accept new chats.'
+                    type={BaseType.BOOLEAN}
+                    icon={<Power className='size-3.5' />}
+                    showIcon
+                    validationError={fieldState.error?.message}>
+                    <FieldInputAdapter
+                      fieldType={FieldType.CHECKBOX}
+                      fieldOptions={{ variant: 'switch' }}
+                      value={field.value}
+                      onChange={(v) => field.onChange(Boolean(v))}
+                    />
+                  </VarEditorFieldRow>
+                )}
+              />
+
+              <VarEditorFieldRow
+                title='Inbox'
+                description='Where new chat conversations land.'
+                type={BaseType.RELATION}
+                icon={<InboxIcon className='size-3.5' />}
+                showIcon>
+                <MultiRelationInput
+                  entityDefinitionId='inbox'
+                  value={inboxRecordId ? [inboxRecordId] : []}
+                  onChange={handleInboxChange}
+                  multi={false}
+                  placeholder='Pick an inbox'
                   disabled={update.isPending}
+                  triggerProps={{ className: 'w-full ps-0 pe-1', badgeHoverCard: false }}
+                  onCreate={() => setInboxDialogOpen(true)}
+                  createLabel='Create inbox'
                 />
-              </div>
-            </VarEditorFieldRow>
-          </VarEditorField>
+              </VarEditorFieldRow>
+
+              <VarEditorFieldRow
+                title='Privacy URL'
+                description='When set, the widget shows a consent banner under the composer linking to this URL. Leave blank to hide.'
+                type={BaseType.STRING}
+                icon={<LinkIcon className='size-3.5' />}
+                isRequired
+                showIcon>
+                <div
+                  onBlur={() => {
+                    const next = privacyUrlDraft.trim()
+                    const current = widget.chatWidget?.privacyPolicyUrl ?? ''
+                    if (next === current) return
+                    update.mutate({
+                      integrationId: channelId,
+                      privacyPolicyUrl: next === '' ? null : next,
+                    })
+                  }}>
+                  <FieldInputAdapter
+                    fieldType={FieldType.URL}
+                    value={privacyUrlDraft}
+                    onChange={(v) => setPrivacyUrlDraft((v as string) ?? '')}
+                    placeholder='https://example.com/privacy'
+                    disabled={update.isPending}
+                  />
+                </div>
+              </VarEditorFieldRow>
+            </VarEditorField>
+          </SettingsSection>
         </div>
 
         <div className='border-t p-6'>
-          <div className='space-y-1 mb-4'>
-            <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-              <Users className='size-4' /> Audience
-            </div>
-            <p className='text-sm text-muted-foreground'>Who is this widget for?</p>
-          </div>
+          <SettingsSection icon={Users} title='Audience' description='Who is this widget for?'>
+            <FormField
+              control={form.control}
+              name='chatAudience'
+              render={({ field }) => (
+                <>
+                  <RadioTab
+                    value={field.value}
+                    onValueChange={(v) => {
+                      const next = v as ChatAudience
+                      field.onChange(next)
+                      // Persist immediately (like inbox/privacy/domains) so the
+                      // Identity tab unlocks without a separate "Save Changes".
+                      update.mutate({ integrationId: channelId, chatAudience: next })
+                    }}
+                    size='sm'
+                    radioGroupClassName='grid w-full grid-cols-3'
+                    className='border border-primary-200 flex w-full mb-3'>
+                    <RadioTabItem value='visitors' size='sm'>
+                      <UserRound />
+                      Visitors only
+                    </RadioTabItem>
+                    <RadioTabItem value='both' size='sm'>
+                      <Users />
+                      Both
+                    </RadioTabItem>
+                    <RadioTabItem value='users' size='sm'>
+                      <ShieldCheck />
+                      Users only
+                    </RadioTabItem>
+                  </RadioTab>
 
-          <FormField
-            control={form.control}
-            name='chatAudience'
-            render={({ field }) => (
-              <>
-                <RadioTab
-                  value={field.value}
-                  onValueChange={(v) => {
-                    const next = v as ChatAudience
-                    field.onChange(next)
-                    // Persist immediately (like inbox/privacy/domains) so the
-                    // Identity tab unlocks without a separate "Save Changes".
-                    update.mutate({ integrationId: channelId, chatAudience: next })
-                  }}
-                  size='sm'
-                  radioGroupClassName='grid w-full grid-cols-3'
-                  className='border border-primary-200 flex w-full mb-3'>
-                  <RadioTabItem value='visitors' size='sm'>
-                    <UserRound />
-                    Visitors only
-                  </RadioTabItem>
-                  <RadioTabItem value='both' size='sm'>
-                    <Users />
-                    Both
-                  </RadioTabItem>
-                  <RadioTabItem value='users' size='sm'>
-                    <ShieldCheck />
-                    Users only
-                  </RadioTabItem>
-                </RadioTab>
+                  <p className='text-xs text-muted-foreground'>
+                    {AUDIENCE_DESCRIPTIONS[field.value]}
+                  </p>
 
-                <p className='text-xs text-muted-foreground'>
-                  {AUDIENCE_DESCRIPTIONS[field.value]}
-                </p>
-
-                {field.value === 'users' && identityVerification === 'off' && (
-                  <Alert variant='warning' className='mt-3'>
-                    <AlertTriangle />
-                    <div className='flex items-center gap-2'>
-                      <span className='flex-1'>
-                        Rollout is off. Anonymous visitors can still chat. Start rollout on the
-                        Identity tab to lock down.
-                      </span>
-                      <button
-                        type='button'
-                        onClick={() => setActiveSection('identity')}
-                        className='shrink-0 font-medium underline'>
-                        Open Identity
-                      </button>
-                    </div>
-                  </Alert>
-                )}
-              </>
-            )}
-          />
+                  {field.value === 'users' && identityVerification === 'off' && (
+                    <Alert variant='warning' className='mt-3'>
+                      <AlertTriangle />
+                      <div className='flex items-center gap-2'>
+                        <span className='flex-1'>
+                          Rollout is off. Anonymous visitors can still chat. Start rollout on the
+                          Identity tab to lock down.
+                        </span>
+                        <button
+                          type='button'
+                          onClick={() => setActiveSection('identity')}
+                          className='shrink-0 font-medium underline'>
+                          Open Identity
+                        </button>
+                      </div>
+                    </Alert>
+                  )}
+                </>
+              )}
+            />
+          </SettingsSection>
         </div>
 
         <div className='flex flex-wrap items-center justify-between gap-3 border-t p-6'>

--- a/apps/web/src/components/chat-widget/ui/settings/sections/identity-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/identity-section.tsx
@@ -33,6 +33,7 @@ import {
 import { useQueryState } from 'nuqs'
 import { useCallback, useState } from 'react'
 import { EmailFilterSection } from '~/app/(protected)/app/settings/channels/_components/email-list-dialog'
+import { SettingsSection } from '~/components/global/settings-page'
 import { Tooltip } from '~/components/global/tooltip'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
@@ -133,17 +134,10 @@ export function IdentitySection({ widget, channelId }: IdentitySectionProps) {
     <>
       <ConfirmDialog />
       <div className='p-6 space-y-8'>
-        <div>
-          <div className='space-y-1 mb-4'>
-            <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-              <ShieldCheck className='size-4' /> Identity verification
-            </div>
-            <p className='text-sm text-muted-foreground'>
-              Sign a short-lived JWT on your server with one of these per-channel secrets so the
-              widget can prove who the visitor is.
-            </p>
-          </div>
-
+        <SettingsSection
+          icon={ShieldCheck}
+          title='Identity verification'
+          description='Sign a short-lived JWT on your server with one of these per-channel secrets so the widget can prove who the visitor is.'>
           <EnforcementCard
             state={state}
             stateLabel={stateLabel}
@@ -233,7 +227,7 @@ export function IdentitySection({ widget, channelId }: IdentitySectionProps) {
               </div>
             )}
           </div>
-        </div>
+        </SettingsSection>
 
         <div>
           <EmailFilterSection

--- a/apps/web/src/components/chat-widget/ui/settings/sections/setup-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/setup-section.tsx
@@ -9,6 +9,7 @@ import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { ArrowUpRight, Code, ExternalLink } from 'lucide-react'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useMemo } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import CodeEditor from '~/components/workflow/ui/code-editor'
 import { CodeLanguage } from '~/components/workflow/ui/code-editor/types'
 import { useEnv } from '~/providers/dehydrated-state-provider'
@@ -77,16 +78,10 @@ export function SetupSection({ widget, channelId }: SetupSectionProps) {
 
   return (
     <div className='p-6 space-y-8'>
-      <div>
-        <div className='space-y-1 mb-4'>
-          <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-            <Code className='size-4' /> Install
-          </div>
-          <p className='text-sm text-muted-foreground'>
-            Choose your stack. The snippet below is ready to paste.
-          </p>
-        </div>
-
+      <SettingsSection
+        icon={Code}
+        title='Install'
+        description='Choose your stack. The snippet below is ready to paste.'>
         <p className='mb-3 text-xs text-muted-foreground'>
           {verified
             ? 'Your server signs a short-lived JWT so the widget knows exactly which logged-in user it’s talking to. Messages can’t be spoofed and chats link back to the real account.'
@@ -192,7 +187,7 @@ export function SetupSection({ widget, channelId }: SetupSectionProps) {
             <ExternalLink className='size-3.5' />
           </button>
         </div>
-      </div>
+      </SettingsSection>
     </div>
   )
 }

--- a/apps/web/src/components/custom-fields/ui/entity-appearance-editor.tsx
+++ b/apps/web/src/components/custom-fields/ui/entity-appearance-editor.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { AlertTriangle, Check, Palette } from 'lucide-react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { useEntityDefinitionMutations } from '~/components/resources/hooks'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 
@@ -91,142 +92,139 @@ export function EntityAppearanceEditor({
 
   return (
     <div className='p-4 border-b'>
-      <h3 className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base mb-4'>
-        <Palette className='size-4' />
-        Appearance
-      </h3>
+      <SettingsSection className='mb-4' icon={Palette} title='Appearance'>
+        {disabled && (
+          <div className='text-xs text-muted-foreground italic mb-4'>
+            System entities cannot be customized. Display fields are predefined.
+          </div>
+        )}
 
-      {disabled && (
-        <div className='text-xs text-muted-foreground italic mb-4'>
-          System entities cannot be customized. Display fields are predefined.
-        </div>
-      )}
-
-      <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
-        {/* Left column: Select fields */}
-        <div>
-          <VarEditorField className='p-0 dark:bg-primary-50'>
-            <VarEditorFieldRow
-              title='Display Field'
-              description='Shown as the main name in pickers'>
-              {disabled ? (
-                <span className='text-sm text-muted-foreground h-7.5 flex items-center'>
-                  {primaryField?.name ?? 'None'}
-                </span>
-              ) : (
-                <Select
-                  value={primaryDisplayFieldId ?? 'none'}
-                  onValueChange={(v) =>
-                    handleChange('primaryDisplayFieldId', v === 'none' ? null : v)
-                  }>
-                  <SelectTrigger variant='transparent' size='sm'>
-                    <SelectValue placeholder='Select field' />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value='none'>None</SelectItem>
-                    {selectableFields
-                      .filter(
-                        (f) =>
-                          f.fieldType &&
-                          PRIMARY_DISPLAY_ELIGIBLE_TYPES.includes(f.fieldType as FieldType)
-                      )
-                      .map((field) => (
-                        <SelectItem key={field.id} value={field.id}>
-                          {field.name ?? field.label}
-                        </SelectItem>
-                      ))}
-                  </SelectContent>
-                </Select>
-              )}
-            </VarEditorFieldRow>
-            <VarEditorFieldRow
-              title='Subtitle Field'
-              description='Optional subtitle below the name'>
-              {disabled ? (
-                <span className='text-sm text-muted-foreground h-7.5 flex items-center'>
-                  {secondaryField?.name ?? secondaryField?.label ?? 'None'}
-                </span>
-              ) : (
-                <Select
-                  value={secondaryDisplayFieldId ?? 'none'}
-                  onValueChange={(v) =>
-                    handleChange('secondaryDisplayFieldId', v === 'none' ? null : v)
-                  }>
-                  <SelectTrigger variant='transparent' size='sm'>
-                    <SelectValue placeholder='Select field' />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value='none'>None</SelectItem>
-                    {selectableFields.map((field) => (
-                      <SelectItem key={field.id} value={field.id}>
-                        {field.name ?? field.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
-            </VarEditorFieldRow>
-            <VarEditorFieldRow title='Avatar Field' description='Image field for avatar'>
-              {disabled ? (
-                <span className='text-sm text-muted-foreground h-7.5 flex items-center'>
-                  {avatarField?.name ?? avatarField?.label ?? 'None'}
-                </span>
-              ) : (
-                <Select
-                  value={avatarFieldId ?? 'none'}
-                  onValueChange={(v) => handleChange('avatarFieldId', v === 'none' ? null : v)}>
-                  <SelectTrigger variant='transparent' size='sm'>
-                    <SelectValue placeholder='Select field' />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value='none'>None</SelectItem>
-                    {selectableFields
-                      .filter((f) => f.fieldType === 'URL' || f.fieldType === 'FILE')
-                      .map((field) => (
-                        <SelectItem key={field.id} value={field.id}>
-                          {field.name ?? field.label}
-                        </SelectItem>
-                      ))}
-                  </SelectContent>
-                </Select>
-              )}
-            </VarEditorFieldRow>
-            {avatarWarnings.length > 0 && (
-              <div className='flex gap-2 px-3 py-2 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 rounded-md mx-2 mb-2'>
-                <AlertTriangle className='size-3.5 shrink-0 mt-0.5' />
-                <div className='space-y-0.5'>
-                  {avatarWarnings.map((w) => (
-                    <p key={w}>{w}</p>
-                  ))}
-                </div>
-              </div>
-            )}
-          </VarEditorField>
-        </div>
-
-        {/* Right column: Preview */}
-        <div className='flex items-center justify-center border rounded-2xl p-4 bg-muted dark:bg-primary-50 min-h-[120px]'>
-          <div className='max-w-[300px] w-full'>
-            <div className='flex items-center gap-2 rounded-2xl border bg-background py-2 ps-1 pe-2'>
-              <Avatar className='size-6'>
-                <AvatarFallback className='text-xs'>
-                  {(primaryField?.name || singular || 'D')[0]}
-                </AvatarFallback>
-              </Avatar>
-              <div className='flex flex-1 flex-col'>
-                <span className='truncate text-sm'>
-                  {primaryField?.name || singular || 'Display Name'}
-                </span>
-                {secondaryField && (
-                  <span className='text-xs text-muted-foreground'>{secondaryField.name}</span>
+        <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
+          {/* Left column: Select fields */}
+          <div>
+            <VarEditorField className='p-0 dark:bg-primary-50'>
+              <VarEditorFieldRow
+                title='Display Field'
+                description='Shown as the main name in pickers'>
+                {disabled ? (
+                  <span className='text-sm text-muted-foreground h-7.5 flex items-center'>
+                    {primaryField?.name ?? 'None'}
+                  </span>
+                ) : (
+                  <Select
+                    value={primaryDisplayFieldId ?? 'none'}
+                    onValueChange={(v) =>
+                      handleChange('primaryDisplayFieldId', v === 'none' ? null : v)
+                    }>
+                    <SelectTrigger variant='transparent' size='sm'>
+                      <SelectValue placeholder='Select field' />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value='none'>None</SelectItem>
+                      {selectableFields
+                        .filter(
+                          (f) =>
+                            f.fieldType &&
+                            PRIMARY_DISPLAY_ELIGIBLE_TYPES.includes(f.fieldType as FieldType)
+                        )
+                        .map((field) => (
+                          <SelectItem key={field.id} value={field.id}>
+                            {field.name ?? field.label}
+                          </SelectItem>
+                        ))}
+                    </SelectContent>
+                  </Select>
                 )}
+              </VarEditorFieldRow>
+              <VarEditorFieldRow
+                title='Subtitle Field'
+                description='Optional subtitle below the name'>
+                {disabled ? (
+                  <span className='text-sm text-muted-foreground h-7.5 flex items-center'>
+                    {secondaryField?.name ?? secondaryField?.label ?? 'None'}
+                  </span>
+                ) : (
+                  <Select
+                    value={secondaryDisplayFieldId ?? 'none'}
+                    onValueChange={(v) =>
+                      handleChange('secondaryDisplayFieldId', v === 'none' ? null : v)
+                    }>
+                    <SelectTrigger variant='transparent' size='sm'>
+                      <SelectValue placeholder='Select field' />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value='none'>None</SelectItem>
+                      {selectableFields.map((field) => (
+                        <SelectItem key={field.id} value={field.id}>
+                          {field.name ?? field.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </VarEditorFieldRow>
+              <VarEditorFieldRow title='Avatar Field' description='Image field for avatar'>
+                {disabled ? (
+                  <span className='text-sm text-muted-foreground h-7.5 flex items-center'>
+                    {avatarField?.name ?? avatarField?.label ?? 'None'}
+                  </span>
+                ) : (
+                  <Select
+                    value={avatarFieldId ?? 'none'}
+                    onValueChange={(v) => handleChange('avatarFieldId', v === 'none' ? null : v)}>
+                    <SelectTrigger variant='transparent' size='sm'>
+                      <SelectValue placeholder='Select field' />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value='none'>None</SelectItem>
+                      {selectableFields
+                        .filter((f) => f.fieldType === 'URL' || f.fieldType === 'FILE')
+                        .map((field) => (
+                          <SelectItem key={field.id} value={field.id}>
+                            {field.name ?? field.label}
+                          </SelectItem>
+                        ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </VarEditorFieldRow>
+              {avatarWarnings.length > 0 && (
+                <div className='flex gap-2 px-3 py-2 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 rounded-md mx-2 mb-2'>
+                  <AlertTriangle className='size-3.5 shrink-0 mt-0.5' />
+                  <div className='space-y-0.5'>
+                    {avatarWarnings.map((w) => (
+                      <p key={w}>{w}</p>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </VarEditorField>
+          </div>
+
+          {/* Right column: Preview */}
+          <div className='flex items-center justify-center border rounded-2xl p-4 bg-muted dark:bg-primary-50 min-h-[120px]'>
+            <div className='max-w-[300px] w-full'>
+              <div className='flex items-center gap-2 rounded-2xl border bg-background py-2 ps-1 pe-2'>
+                <Avatar className='size-6'>
+                  <AvatarFallback className='text-xs'>
+                    {(primaryField?.name || singular || 'D')[0]}
+                  </AvatarFallback>
+                </Avatar>
+                <div className='flex flex-1 flex-col'>
+                  <span className='truncate text-sm'>
+                    {primaryField?.name || singular || 'Display Name'}
+                  </span>
+                  {secondaryField && (
+                    <span className='text-xs text-muted-foreground'>{secondaryField.name}</span>
+                  )}
+                </div>
+                <Check className='size-4 opacity-100' />
               </div>
-              <Check className='size-4 opacity-100' />
+              <p className='text-xs text-muted-foreground mt-2 text-center'>Preview</p>
             </div>
-            <p className='text-xs text-muted-foreground mt-2 text-center'>Preview</p>
           </div>
         </div>
-      </div>
+      </SettingsSection>
     </div>
   )
 }

--- a/apps/web/src/components/datasets/settings/sections/chunking-settings-section.tsx
+++ b/apps/web/src/components/datasets/settings/sections/chunking-settings-section.tsx
@@ -11,6 +11,7 @@ import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { Book, Brain, FileText, Layers, Scissors } from 'lucide-react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { SettingsSection } from '~/components/global/settings-page'
 import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
@@ -151,191 +152,185 @@ export function ChunkingSettingsSection({
         <div className='flex flex-col lg:flex-row'>
           {/* Left Column - Strategy Selection */}
           <div className='flex-1 p-6 lg:pr-6'>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <Layers className='size-4' /> Chunking Strategy
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Choose how your documents will be split into chunks.
-              </p>
-            </div>
-
-            <FormField
-              control={form.control}
-              name='strategy'
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <RadioGroup
-                      value={field.value}
-                      onValueChange={field.onChange}
-                      disabled={readOnly || updateDataset.isPending}>
-                      {Object.entries(CHUNKING_STRATEGIES).map(([strategy, info]) => {
-                        const Icon = info.icon
-                        const isImplemented = strategy === 'FIXED_SIZE'
-                        return (
-                          <RadioGroupItemCard
-                            key={strategy}
-                            label={info.label}
-                            sublabel={isImplemented ? info.badge : 'Coming Soon'}
-                            value={strategy}
-                            icon={<Icon />}
-                            description={info.description}
-                            disabled={!isImplemented || readOnly || updateDataset.isPending}
-                          />
-                        )
-                      })}
-                    </RadioGroup>
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <SettingsSection
+              className='space-y-6'
+              icon={Layers}
+              title='Chunking Strategy'
+              description='Choose how your documents will be split into chunks.'>
+              <FormField
+                control={form.control}
+                name='strategy'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <RadioGroup
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        disabled={readOnly || updateDataset.isPending}>
+                        {Object.entries(CHUNKING_STRATEGIES).map(([strategy, info]) => {
+                          const Icon = info.icon
+                          const isImplemented = strategy === 'FIXED_SIZE'
+                          return (
+                            <RadioGroupItemCard
+                              key={strategy}
+                              label={info.label}
+                              sublabel={isImplemented ? info.badge : 'Coming Soon'}
+                              value={strategy}
+                              icon={<Icon />}
+                              description={info.description}
+                              disabled={!isImplemented || readOnly || updateDataset.isPending}
+                            />
+                          )
+                        })}
+                      </RadioGroup>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </SettingsSection>
           </div>
 
           {/* Right Column - Strategy Specific Options */}
           <div className='flex-1 border-t lg:border-t-0 lg:border-l p-6 lg:pl-6'>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <StrategyIcon className='size-4' /> {strategyInfo?.label} Parameters
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Configure chunk size and overlap settings.
-              </p>
-            </div>
+            <SettingsSection
+              className='space-y-6'
+              icon={StrategyIcon}
+              title={`${strategyInfo?.label} Parameters`}
+              description='Configure chunk size and overlap settings.'>
+              <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-60'>
+                <VarEditorFieldRow
+                  title='Chunk Size'
+                  description='Target size for each chunk in characters (100-5000)'
+                  type={BaseType.NUMBER}
+                  showIcon={true}>
+                  <ConstantInputAdapter
+                    value={form.watch('size') ?? ''}
+                    onChange={(_, val) => form.setValue('size', val)}
+                    varType={BaseType.NUMBER}
+                    placeholder='1000'
+                    disabled={readOnly}
+                  />
+                </VarEditorFieldRow>
 
-            <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-60'>
-              <VarEditorFieldRow
-                title='Chunk Size'
-                description='Target size for each chunk in characters (100-5000)'
-                type={BaseType.NUMBER}
-                showIcon={true}>
-                <ConstantInputAdapter
-                  value={form.watch('size') ?? ''}
-                  onChange={(_, val) => form.setValue('size', val)}
-                  varType={BaseType.NUMBER}
-                  placeholder='1000'
-                  disabled={readOnly}
-                />
-              </VarEditorFieldRow>
+                <VarEditorFieldRow
+                  title='Chunk Overlap'
+                  description='Overlapping characters between adjacent chunks (0-1000)'
+                  type={BaseType.NUMBER}
+                  showIcon={true}>
+                  <ConstantInputAdapter
+                    value={form.watch('overlap') ?? ''}
+                    onChange={(_, val) => form.setValue('overlap', val)}
+                    varType={BaseType.NUMBER}
+                    placeholder='200'
+                    disabled={readOnly}
+                  />
+                </VarEditorFieldRow>
 
-              <VarEditorFieldRow
-                title='Chunk Overlap'
-                description='Overlapping characters between adjacent chunks (0-1000)'
-                type={BaseType.NUMBER}
-                showIcon={true}>
-                <ConstantInputAdapter
-                  value={form.watch('overlap') ?? ''}
-                  onChange={(_, val) => form.setValue('overlap', val)}
-                  varType={BaseType.NUMBER}
-                  placeholder='200'
-                  disabled={readOnly}
-                />
-              </VarEditorFieldRow>
+                <VarEditorFieldRow
+                  title='Custom Delimiter'
+                  description='Split text at this delimiter. Default is double newline (paragraph breaks).'
+                  type={BaseType.STRING}
+                  showIcon={true}>
+                  <ConstantInputAdapter
+                    value={form.watch('delimiter') ?? ''}
+                    onChange={(_, val) => form.setValue('delimiter', val || '\n\n')}
+                    varType={BaseType.STRING}
+                    placeholder='\n\n'
+                    disabled={readOnly}
+                  />
+                </VarEditorFieldRow>
 
-              <VarEditorFieldRow
-                title='Custom Delimiter'
-                description='Split text at this delimiter. Default is double newline (paragraph breaks).'
-                type={BaseType.STRING}
-                showIcon={true}>
-                <ConstantInputAdapter
-                  value={form.watch('delimiter') ?? ''}
-                  onChange={(_, val) => form.setValue('delimiter', val || '\n\n')}
-                  varType={BaseType.STRING}
-                  placeholder='\n\n'
-                  disabled={readOnly}
-                />
-              </VarEditorFieldRow>
+                <VarEditorFieldRow
+                  title='Normalize Whitespace'
+                  description='Replace consecutive spaces, newlines, and tabs with single characters'
+                  type={BaseType.BOOLEAN}
+                  showIcon={true}>
+                  <ConstantInputAdapter
+                    value={form.watch('preprocessing.normalizeWhitespace')}
+                    onChange={(_, val) => form.setValue('preprocessing.normalizeWhitespace', val)}
+                    varType={BaseType.BOOLEAN}
+                    fieldOptions={{ variant: 'switch' }}
+                    disabled={readOnly}
+                  />
+                </VarEditorFieldRow>
 
-              <VarEditorFieldRow
-                title='Normalize Whitespace'
-                description='Replace consecutive spaces, newlines, and tabs with single characters'
-                type={BaseType.BOOLEAN}
-                showIcon={true}>
-                <ConstantInputAdapter
-                  value={form.watch('preprocessing.normalizeWhitespace')}
-                  onChange={(_, val) => form.setValue('preprocessing.normalizeWhitespace', val)}
-                  varType={BaseType.BOOLEAN}
-                  fieldOptions={{ variant: 'switch' }}
-                  disabled={readOnly}
-                />
-              </VarEditorFieldRow>
+                <VarEditorFieldRow
+                  title='Remove URLs & Emails'
+                  description='Delete all URLs and email addresses from content before chunking'
+                  type={BaseType.BOOLEAN}
+                  showIcon={true}>
+                  <ConstantInputAdapter
+                    value={form.watch('preprocessing.removeUrlsAndEmails')}
+                    onChange={(_, val) => form.setValue('preprocessing.removeUrlsAndEmails', val)}
+                    varType={BaseType.BOOLEAN}
+                    fieldOptions={{ variant: 'switch' }}
+                    disabled={readOnly}
+                  />
+                </VarEditorFieldRow>
+              </VarEditorField>
 
-              <VarEditorFieldRow
-                title='Remove URLs & Emails'
-                description='Delete all URLs and email addresses from content before chunking'
-                type={BaseType.BOOLEAN}
-                showIcon={true}>
-                <ConstantInputAdapter
-                  value={form.watch('preprocessing.removeUrlsAndEmails')}
-                  onChange={(_, val) => form.setValue('preprocessing.removeUrlsAndEmails', val)}
-                  varType={BaseType.BOOLEAN}
-                  fieldOptions={{ variant: 'switch' }}
-                  disabled={readOnly}
-                />
-              </VarEditorFieldRow>
-            </VarEditorField>
-
-            <div className='space-y-4 mt-4'>
-              {/* Overlap validation warning */}
-              {overlap >= size * 0.5 && (
-                <div className='p-3 rounded-lg bg-orange-50 border border-orange-200'>
-                  <div className='flex items-center gap-2 text-orange-600'>
-                    <span className='text-sm font-medium'>High overlap warning</span>
+              <div className='space-y-4 mt-4'>
+                {/* Overlap validation warning */}
+                {overlap >= size * 0.5 && (
+                  <div className='p-3 rounded-lg bg-orange-50 border border-orange-200'>
+                    <div className='flex items-center gap-2 text-orange-600'>
+                      <span className='text-sm font-medium'>High overlap warning</span>
+                    </div>
+                    <p className='text-sm text-orange-600 mt-1'>
+                      Overlap is {Math.round((overlap / size) * 100)}% of chunk size. Consider
+                      reducing overlap to improve efficiency.
+                    </p>
                   </div>
-                  <p className='text-sm text-orange-600 mt-1'>
-                    Overlap is {Math.round((overlap / size) * 100)}% of chunk size. Consider
-                    reducing overlap to improve efficiency.
-                  </p>
-                </div>
-              )}
+                )}
 
-              {/* Chunking Preview */}
-              <div className='space-y-2 pt-4'>
-                <h4 className='text-sm font-medium'>Preview</h4>
-
-                <div className='grid grid-cols-3 rounded-2xl border'>
-                  <div className='p-3 rounded-l-2xl bg-primary-100 text-center border-r'>
-                    <div className='text-xs font-medium mb-1'>Effective Size</div>
-                    <div className='text-lg font-bold'>{size - overlap}</div>
-                    <div className='text-xs text-muted-foreground'>chars</div>
-                  </div>
-
-                  <div className='p-3 bg-primary-100 text-center'>
-                    <div className='text-xs font-medium mb-1'>Overlap</div>
-                    <div className='text-lg font-bold'>{Math.round((overlap / size) * 100)}%</div>
-                    <div className='text-xs text-muted-foreground'>ratio</div>
-                  </div>
-
-                  <div className='p-3 rounded-r-2xl bg-primary-100 text-center border-l'>
-                    <div className='text-xs font-medium mb-1'>Est. Chunks</div>
-                    <div className='text-lg font-bold'>{estimateChunksPerDocument()}</div>
-                    <div className='text-xs text-muted-foreground'>per doc</div>
-                  </div>
-                </div>
-
-                {/* Visual chunk representation */}
+                {/* Chunking Preview */}
                 <div className='space-y-2 pt-4'>
-                  <div className='text-sm font-medium'>Visualization</div>
-                  <div className='flex items-center gap-0.5'>
-                    <div
-                      className='bg-blue-500 h-5 rounded-l-2xl rounded-r-md flex items-center justify-center text-white text-xs font-medium'
-                      style={{ width: `${Math.max(80, (size - overlap) / 25)}px` }}>
-                      Chunk 1
+                  <h4 className='text-sm font-medium'>Preview</h4>
+
+                  <div className='grid grid-cols-3 rounded-2xl border'>
+                    <div className='p-3 rounded-l-2xl bg-primary-100 text-center border-r'>
+                      <div className='text-xs font-medium mb-1'>Effective Size</div>
+                      <div className='text-lg font-bold'>{size - overlap}</div>
+                      <div className='text-xs text-muted-foreground'>chars</div>
                     </div>
-                    <div
-                      className='bg-purple-500 h-5 rounded-sm flex items-center justify-center text-white text-xs font-medium'
-                      style={{ width: `${Math.max(16, overlap / 25)}px` }}
-                    />
-                    <div
-                      className='bg-blue-500 h-5 rounded-r-2xl rounded-l-md flex items-center justify-center text-white text-xs font-medium'
-                      style={{ width: `${Math.max(80, (size - overlap) / 25)}px` }}>
-                      Chunk 2
+
+                    <div className='p-3 bg-primary-100 text-center'>
+                      <div className='text-xs font-medium mb-1'>Overlap</div>
+                      <div className='text-lg font-bold'>{Math.round((overlap / size) * 100)}%</div>
+                      <div className='text-xs text-muted-foreground'>ratio</div>
+                    </div>
+
+                    <div className='p-3 rounded-r-2xl bg-primary-100 text-center border-l'>
+                      <div className='text-xs font-medium mb-1'>Est. Chunks</div>
+                      <div className='text-lg font-bold'>{estimateChunksPerDocument()}</div>
+                      <div className='text-xs text-muted-foreground'>per doc</div>
+                    </div>
+                  </div>
+
+                  {/* Visual chunk representation */}
+                  <div className='space-y-2 pt-4'>
+                    <div className='text-sm font-medium'>Visualization</div>
+                    <div className='flex items-center gap-0.5'>
+                      <div
+                        className='bg-blue-500 h-5 rounded-l-2xl rounded-r-md flex items-center justify-center text-white text-xs font-medium'
+                        style={{ width: `${Math.max(80, (size - overlap) / 25)}px` }}>
+                        Chunk 1
+                      </div>
+                      <div
+                        className='bg-purple-500 h-5 rounded-sm flex items-center justify-center text-white text-xs font-medium'
+                        style={{ width: `${Math.max(16, overlap / 25)}px` }}
+                      />
+                      <div
+                        className='bg-blue-500 h-5 rounded-r-2xl rounded-l-md flex items-center justify-center text-white text-xs font-medium'
+                        style={{ width: `${Math.max(80, (size - overlap) / 25)}px` }}>
+                        Chunk 2
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
+            </SettingsSection>
           </div>
         </div>
 

--- a/apps/web/src/components/datasets/settings/sections/embedding-settings-section.tsx
+++ b/apps/web/src/components/datasets/settings/sections/embedding-settings-section.tsx
@@ -21,6 +21,7 @@ import { AlertTriangle, Brain, CheckCircle, Info, Lightbulb } from 'lucide-react
 import { useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { SettingsSection } from '~/components/global/settings-page'
 import { AiModelPicker, type ModelPickerItem } from '~/components/pickers/ai-model-picker'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
@@ -168,106 +169,105 @@ export function EmbeddingSettingsSection({
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
         <div className='p-6'>
-          {/* Header */}
-          <div className='space-y-1 mb-6'>
-            <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-              <Brain className='size-4' /> Embedding Model
-              {dataset.embeddingModel ? (
-                <Badge variant='default' className='flex items-center gap-1 ml-2'>
-                  <CheckCircle className='size-3' />
-                  Configured
-                </Badge>
-              ) : (
-                <Badge variant='destructive' className='flex items-center gap-1 ml-2'>
-                  <AlertTriangle className='size-3' />
-                  Not Configured
-                </Badge>
-              )}
-              {isUsingSystemDefault && (
-                <Badge variant='secondary' className='flex items-center gap-1'>
-                  <Info className='size-3' />
-                  System Default
-                </Badge>
-              )}
-            </div>
-            <p className='text-sm text-muted-foreground'>
-              Select an embedding model for vector search.
-            </p>
-          </div>
-
-          {/* Model Selection */}
-          <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-60'>
-            <VarEditorFieldRow
-              title='Embedding Model'
-              description='Select a text embedding model from your configured providers'>
-              <FormField
-                control={form.control}
-                name='embeddingModel'
-                render={({ field }) => (
-                  <FormItem className='flex-1'>
-                    <AiModelPicker
-                      data={unifiedModelData.data}
-                      value={field.value ?? null}
-                      onChange={handleModelChange}
-                      modelTypes={[ModelType.TEXT_EMBEDDING]}
-                      showUnconfigured={false}
-                      placeholder='Select embedding model...'
-                      triggerVariant='transparent'
-                      triggerClassName='w-full justify-between'
-                      isUpdating={unifiedModelData.isLoading}
-                    />
-                    <FormMessage />
-                  </FormItem>
+          <SettingsSection
+            icon={Brain}
+            title={
+              <>
+                Embedding Model
+                {dataset.embeddingModel ? (
+                  <Badge variant='default' className='flex items-center gap-1 ml-2'>
+                    <CheckCircle className='size-3' />
+                    Configured
+                  </Badge>
+                ) : (
+                  <Badge variant='destructive' className='flex items-center gap-1 ml-2'>
+                    <AlertTriangle className='size-3' />
+                    Not Configured
+                  </Badge>
                 )}
-              />
-            </VarEditorFieldRow>
-
-            {/* Dimension selector - only show if model supports configurable dimensions */}
-            {hasConfigurableDimensions && (
+                {isUsingSystemDefault && (
+                  <Badge variant='secondary' className='flex items-center gap-1'>
+                    <Info className='size-3' />
+                    System Default
+                  </Badge>
+                )}
+              </>
+            }
+            description='Select an embedding model for vector search.'>
+            {/* Model Selection */}
+            <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-60'>
               <VarEditorFieldRow
-                title='Embedding Dimensions'
-                description={
-                  dimensionRule?.help ||
-                  'Smaller dimensions use less storage but may reduce accuracy.'
-                }>
+                title='Embedding Model'
+                description='Select a text embedding model from your configured providers'>
                 <FormField
                   control={form.control}
-                  name='vectorDimension'
-                  className='space-y-0'
+                  name='embeddingModel'
                   render={({ field }) => (
-                    <FormItem className='flex-1 mb-0 space-y-0!'>
-                      <Select
-                        value={field.value?.toString() ?? defaultDimension.toString()}
-                        onValueChange={(v) => field.onChange(parseInt(v, 10))}>
-                        <SelectTrigger className='w-full ' size='sm' variant='transparent'>
-                          <SelectValue placeholder='Select dimension' />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {availableDimensions.map((dim) => (
-                            <SelectItem key={dim} value={dim.toString()}>
-                              {dim} dimensions {dim === defaultDimension && '(default)'}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                    <FormItem className='flex-1'>
+                      <AiModelPicker
+                        data={unifiedModelData.data}
+                        value={field.value ?? null}
+                        onChange={handleModelChange}
+                        modelTypes={[ModelType.TEXT_EMBEDDING]}
+                        showUnconfigured={false}
+                        placeholder='Select embedding model...'
+                        triggerVariant='transparent'
+                        triggerClassName='w-full justify-between'
+                        isUpdating={unifiedModelData.isLoading}
+                      />
                       <FormMessage />
                     </FormItem>
                   )}
                 />
               </VarEditorFieldRow>
-            )}
-          </VarEditorField>
 
-          {/* Warning for dimension changes on existing datasets */}
-          {dimensionChanged && (
-            <Alert variant='destructive' className='mt-4'>
-              <AlertTriangle className='h-4 w-4' />
-              <AlertDescription>
-                Changing dimensions from {dataset.vectorDimension} to {currentDimension} will
-                require re-indexing all document segments in this dataset.
-              </AlertDescription>
-            </Alert>
-          )}
+              {/* Dimension selector - only show if model supports configurable dimensions */}
+              {hasConfigurableDimensions && (
+                <VarEditorFieldRow
+                  title='Embedding Dimensions'
+                  description={
+                    dimensionRule?.help ||
+                    'Smaller dimensions use less storage but may reduce accuracy.'
+                  }>
+                  <FormField
+                    control={form.control}
+                    name='vectorDimension'
+                    className='space-y-0'
+                    render={({ field }) => (
+                      <FormItem className='flex-1 mb-0 space-y-0!'>
+                        <Select
+                          value={field.value?.toString() ?? defaultDimension.toString()}
+                          onValueChange={(v) => field.onChange(parseInt(v, 10))}>
+                          <SelectTrigger className='w-full ' size='sm' variant='transparent'>
+                            <SelectValue placeholder='Select dimension' />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {availableDimensions.map((dim) => (
+                              <SelectItem key={dim} value={dim.toString()}>
+                                {dim} dimensions {dim === defaultDimension && '(default)'}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </VarEditorFieldRow>
+              )}
+            </VarEditorField>
+
+            {/* Warning for dimension changes on existing datasets */}
+            {dimensionChanged && (
+              <Alert variant='destructive' className='mt-4'>
+                <AlertTriangle className='h-4 w-4' />
+                <AlertDescription>
+                  Changing dimensions from {dataset.vectorDimension} to {currentDimension} will
+                  require re-indexing all document segments in this dataset.
+                </AlertDescription>
+              </Alert>
+            )}
+          </SettingsSection>
         </div>
 
         {/* Action Buttons */}

--- a/apps/web/src/components/datasets/settings/sections/general-settings-section.tsx
+++ b/apps/web/src/components/datasets/settings/sections/general-settings-section.tsx
@@ -21,6 +21,7 @@ import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { Activity, Calendar, Database, FileText, Hash, Settings } from 'lucide-react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { SettingsSection } from '~/components/global/settings-page'
 import { api } from '~/trpc/react'
 
 interface GeneralSettingsSectionProps {
@@ -100,16 +101,11 @@ export function GeneralSettingsSection({
         <div className='flex flex-col lg:flex-row'>
           {/* Left Column - Form Fields */}
           <div className='flex-1 p-6 lg:pr-6'>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <Settings className='size-4' /> General Settings
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Configure the basic information for your dataset.
-              </p>
-            </div>
-
-            <div className='space-y-4'>
+            <SettingsSection
+              className='space-y-4'
+              icon={Settings}
+              title='General Settings'
+              description='Configure the basic information for your dataset.'>
               <FormField
                 control={form.control}
                 name='name'
@@ -158,103 +154,104 @@ export function GeneralSettingsSection({
                   />
                 )}
               />
-            </div>
+            </SettingsSection>
           </div>
 
           {/* Right Column - Dataset Information */}
           <div className='flex-1 border-t lg:border-t-0 lg:border-l p-6 lg:pl-6'>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <Database className='size-4' /> Dataset Information
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Read-only metadata about your dataset.
-              </p>
-            </div>
+            <SettingsSection
+              className='space-y-4'
+              icon={Database}
+              title='Dataset Information'
+              description='Read-only metadata about your dataset.'>
+              <div className='overflow-hidden rounded-md border bg-background'>
+                <Table>
+                  <TableBody>
+                    <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                      <TableCell className='bg-muted/50 py-2 font-medium'>
+                        <div className='flex items-center gap-1'>
+                          <FileText className='size-3.5 text-muted-foreground' />
+                          Documents
+                        </div>
+                      </TableCell>
+                      <TableCell className='py-2'>
+                        {dataset.documentCount.toLocaleString()}
+                      </TableCell>
+                    </TableRow>
 
-            <div className='overflow-hidden rounded-md border bg-background'>
-              <Table>
-                <TableBody>
-                  <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                    <TableCell className='bg-muted/50 py-2 font-medium'>
-                      <div className='flex items-center gap-1'>
-                        <FileText className='size-3.5 text-muted-foreground' />
-                        Documents
-                      </div>
-                    </TableCell>
-                    <TableCell className='py-2'>{dataset.documentCount.toLocaleString()}</TableCell>
-                  </TableRow>
+                    <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                      <TableCell className='bg-muted/50 py-2 font-medium'>
+                        <div className='flex items-center gap-1'>
+                          <Database className='size-3.5 text-muted-foreground' />
+                          Total Size
+                        </div>
+                      </TableCell>
+                      <TableCell className='py-2'>
+                        {formatBytes(Number(dataset.totalSize))}
+                      </TableCell>
+                    </TableRow>
 
-                  <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                    <TableCell className='bg-muted/50 py-2 font-medium'>
-                      <div className='flex items-center gap-1'>
-                        <Database className='size-3.5 text-muted-foreground' />
-                        Total Size
-                      </div>
-                    </TableCell>
-                    <TableCell className='py-2'>{formatBytes(Number(dataset.totalSize))}</TableCell>
-                  </TableRow>
-
-                  <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                    <TableCell className='bg-muted/50 py-2 font-medium'>
-                      <div className='flex items-center gap-1'>
-                        <Calendar className='size-3.5 text-muted-foreground' />
-                        Created
-                      </div>
-                    </TableCell>
-                    <TableCell className='py-2'>{formatDate(dataset.createdAt)}</TableCell>
-                  </TableRow>
-
-                  <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                    <TableCell className='bg-muted/50 py-2 font-medium'>
-                      <div className='flex items-center gap-1'>
-                        <Calendar className='size-3.5 text-muted-foreground' />
-                        Last Updated
-                      </div>
-                    </TableCell>
-                    <TableCell className='py-2'>{formatDate(dataset.updatedAt)}</TableCell>
-                  </TableRow>
-
-                  {dataset.lastIndexedAt && (
                     <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
                       <TableCell className='bg-muted/50 py-2 font-medium'>
                         <div className='flex items-center gap-1'>
                           <Calendar className='size-3.5 text-muted-foreground' />
-                          Last Indexed
+                          Created
                         </div>
                       </TableCell>
-                      <TableCell className='py-2'>{formatDate(dataset.lastIndexedAt)}</TableCell>
+                      <TableCell className='py-2'>{formatDate(dataset.createdAt)}</TableCell>
                     </TableRow>
-                  )}
 
-                  <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                    <TableCell className='bg-muted/50 py-2 font-medium'>
-                      <div className='flex items-center gap-1'>
-                        <Hash className='size-3.5 text-muted-foreground' />
-                        ID
-                      </div>
-                    </TableCell>
-                    <TableCell className='py-2'>
-                      <code className='text-xs bg-muted px-2 py-1 rounded'>{dataset.id}</code>
-                    </TableCell>
-                  </TableRow>
+                    <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                      <TableCell className='bg-muted/50 py-2 font-medium'>
+                        <div className='flex items-center gap-1'>
+                          <Calendar className='size-3.5 text-muted-foreground' />
+                          Last Updated
+                        </div>
+                      </TableCell>
+                      <TableCell className='py-2'>{formatDate(dataset.updatedAt)}</TableCell>
+                    </TableRow>
 
-                  <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
-                    <TableCell className='bg-muted/50 py-2 font-medium'>
-                      <div className='flex items-center gap-1'>
-                        <Activity className='size-3.5 text-muted-foreground' />
-                        Status
-                      </div>
-                    </TableCell>
-                    <TableCell className='py-2'>
-                      <Badge variant={STATUS_INFO[dataset.status].variant}>
-                        {STATUS_INFO[dataset.status].label}
-                      </Badge>
-                    </TableCell>
-                  </TableRow>
-                </TableBody>
-              </Table>
-            </div>
+                    {dataset.lastIndexedAt && (
+                      <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                        <TableCell className='bg-muted/50 py-2 font-medium'>
+                          <div className='flex items-center gap-1'>
+                            <Calendar className='size-3.5 text-muted-foreground' />
+                            Last Indexed
+                          </div>
+                        </TableCell>
+                        <TableCell className='py-2'>{formatDate(dataset.lastIndexedAt)}</TableCell>
+                      </TableRow>
+                    )}
+
+                    <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                      <TableCell className='bg-muted/50 py-2 font-medium'>
+                        <div className='flex items-center gap-1'>
+                          <Hash className='size-3.5 text-muted-foreground' />
+                          ID
+                        </div>
+                      </TableCell>
+                      <TableCell className='py-2'>
+                        <code className='text-xs bg-muted px-2 py-1 rounded'>{dataset.id}</code>
+                      </TableCell>
+                    </TableRow>
+
+                    <TableRow className='*:border-border hover:bg-transparent [&>:not(:last-child)]:border-r'>
+                      <TableCell className='bg-muted/50 py-2 font-medium'>
+                        <div className='flex items-center gap-1'>
+                          <Activity className='size-3.5 text-muted-foreground' />
+                          Status
+                        </div>
+                      </TableCell>
+                      <TableCell className='py-2'>
+                        <Badge variant={STATUS_INFO[dataset.status].variant}>
+                          {STATUS_INFO[dataset.status].label}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </div>
+            </SettingsSection>
           </div>
         </div>
 

--- a/apps/web/src/components/datasets/settings/sections/search-configuration-section.tsx
+++ b/apps/web/src/components/datasets/settings/sections/search-configuration-section.tsx
@@ -12,6 +12,7 @@ import { FileText, Lightbulb, Search, Sparkles, Zap } from 'lucide-react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { SettingsSection } from '~/components/global/settings-page'
 import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
@@ -401,57 +402,50 @@ export function SearchConfigurationSection({
         <div className='flex flex-col lg:flex-row'>
           {/* Left Column - Search Type Selection */}
           <div className='lg:max-w-[400px] p-6 lg:pr-6'>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <Search className='size-4' /> Search Type
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Choose how your dataset will be searched.
-              </p>
-            </div>
-
-            <FormField
-              control={form.control}
-              name='searchType'
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <RadioGroup
-                      value={field.value}
-                      onValueChange={field.onChange}
-                      disabled={readOnly || updateDataset.isPending}>
-                      {Object.entries(SEARCH_TYPE_INFO).map(([type, info]) => {
-                        const Icon = info.icon
-                        return (
-                          <RadioGroupItemCard
-                            key={type}
-                            label={info.label}
-                            sublabel={info.badge}
-                            value={type}
-                            icon={<Icon />}
-                            description={info.description}
-                          />
-                        )
-                      })}
-                    </RadioGroup>
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <SettingsSection
+              icon={Search}
+              title='Search Type'
+              description='Choose how your dataset will be searched.'>
+              <FormField
+                control={form.control}
+                name='searchType'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <RadioGroup
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        disabled={readOnly || updateDataset.isPending}>
+                        {Object.entries(SEARCH_TYPE_INFO).map(([type, info]) => {
+                          const Icon = info.icon
+                          return (
+                            <RadioGroupItemCard
+                              key={type}
+                              label={info.label}
+                              sublabel={info.badge}
+                              value={type}
+                              icon={<Icon />}
+                              description={info.description}
+                            />
+                          )
+                        })}
+                      </RadioGroup>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </SettingsSection>
           </div>
 
           {/* Right Column - Search Type Specific Options */}
           <div className='flex-1 border-t lg:border-t-0 lg:border-l p-6 lg:pl-6'>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <CurrentIcon className='size-4' /> {currentTypeInfo?.label} Options
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Configure settings specific to {currentTypeInfo?.label?.toLowerCase()}.
-              </p>
-            </div>
-            {renderSearchTypeOptions()}
+            <SettingsSection
+              icon={CurrentIcon}
+              title={`${currentTypeInfo?.label} Options`}
+              description={`Configure settings specific to ${currentTypeInfo?.label?.toLowerCase()}.`}>
+              {renderSearchTypeOptions()}
+            </SettingsSection>
           </div>
         </div>
 

--- a/apps/web/src/components/datasets/settings/sections/vector-db-settings-section.tsx
+++ b/apps/web/src/components/datasets/settings/sections/vector-db-settings-section.tsx
@@ -20,6 +20,7 @@ import { AlertTriangle, Cloud, Code, Database, Server, Settings } from 'lucide-r
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { SettingsSection } from '~/components/global/settings-page'
 import { api } from '~/trpc/react'
 
 interface VectorDbSettingsSectionProps {
@@ -159,105 +160,99 @@ export function VectorDbSettingsSection({
         <div className='flex flex-col lg:flex-row'>
           {/* Left Column - Database Type Selection */}
           <div className='flex-1 p-6 lg:pr-6'>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <Database className='size-4' /> Vector Database
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Select the vector database for storing embeddings.
-              </p>
-            </div>
-
-            <FormField
-              control={form.control}
-              name='vectorDbType'
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <RadioGroup
-                      value={field.value}
-                      onValueChange={(value) => handleDbTypeChange(value as VectorDbType)}
-                      disabled={readOnly || updateDataset.isPending}>
-                      {Object.entries(VECTOR_DB_INFO).map(([dbType, info]) => {
-                        const Icon = info.icon
-                        return (
-                          <RadioGroupItemCard
-                            key={dbType}
-                            label={info.label}
-                            sublabel={info.badge}
-                            value={dbType}
-                            icon={<Icon />}
-                            description={info.description}
-                          />
-                        )
-                      })}
-                    </RadioGroup>
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-
-          {/* Right Column - Database Configuration */}
-          <div className='flex-1 border-t lg:border-t-0 lg:border-l p-6 lg:pl-6'>
-            <div className='space-y-1 mb-6'>
-              <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
-                <DbIcon className='size-4' /> {dbInfo?.label} Configuration
-              </div>
-              <p className='text-sm text-muted-foreground'>
-                Configure connection and index settings.
-              </p>
-            </div>
-
-            <div className='space-y-4'>
+            <SettingsSection
+              className='space-y-6'
+              icon={Database}
+              title='Vector Database'
+              description='Select the vector database for storing embeddings.'>
               <FormField
                 control={form.control}
-                name='vectorDbConfig'
+                name='vectorDbType'
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Configuration (JSON)</FormLabel>
                     <FormControl>
-                      <Textarea
-                        placeholder={`{\n  "example": "configuration"\n}`}
-                        rows={6}
-                        className='font-mono text-sm'
-                        {...field}
-                        onChange={(e) => {
-                          field.onChange(e.target.value)
-                          validateJsonConfig(e.target.value)
-                        }}
-                        disabled={readOnly}
-                      />
+                      <RadioGroup
+                        value={field.value}
+                        onValueChange={(value) => handleDbTypeChange(value as VectorDbType)}
+                        disabled={readOnly || updateDataset.isPending}>
+                        {Object.entries(VECTOR_DB_INFO).map(([dbType, info]) => {
+                          const Icon = info.icon
+                          return (
+                            <RadioGroupItemCard
+                              key={dbType}
+                              label={info.label}
+                              sublabel={info.badge}
+                              value={dbType}
+                              icon={<Icon />}
+                              description={info.description}
+                            />
+                          )
+                        })}
+                      </RadioGroup>
                     </FormControl>
-                    <FormDescription className='flex items-start gap-2'>
-                      <Code className='size-3 mt-0.5 flex-shrink-0' />
-                      <span>Leave empty to use defaults.</span>
-                    </FormDescription>
-                    {configError && (
-                      <div className='flex items-center gap-2 text-red-600 text-sm'>
-                        <AlertTriangle className='size-4' />
-                        {configError}
-                      </div>
-                    )}
                     <FormMessage />
                   </FormItem>
                 )}
               />
+            </SettingsSection>
+          </div>
 
-              {/* Configuration Example */}
-              {dbInfo?.defaultConfig && (
-                <div className='p-3 rounded-lg bg-muted/50 border'>
-                  <div className='flex items-center gap-2 mb-2'>
-                    <Settings className='size-3' />
-                    <span className='font-medium text-xs'>Default Example</span>
+          {/* Right Column - Database Configuration */}
+          <div className='flex-1 border-t lg:border-t-0 lg:border-l p-6 lg:pl-6'>
+            <SettingsSection
+              className='space-y-6'
+              icon={DbIcon}
+              title={<>{dbInfo?.label} Configuration</>}
+              description='Configure connection and index settings.'>
+              <div className='space-y-4'>
+                <FormField
+                  control={form.control}
+                  name='vectorDbConfig'
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Configuration (JSON)</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder={`{\n  "example": "configuration"\n}`}
+                          rows={6}
+                          className='font-mono text-sm'
+                          {...field}
+                          onChange={(e) => {
+                            field.onChange(e.target.value)
+                            validateJsonConfig(e.target.value)
+                          }}
+                          disabled={readOnly}
+                        />
+                      </FormControl>
+                      <FormDescription className='flex items-start gap-2'>
+                        <Code className='size-3 mt-0.5 flex-shrink-0' />
+                        <span>Leave empty to use defaults.</span>
+                      </FormDescription>
+                      {configError && (
+                        <div className='flex items-center gap-2 text-red-600 text-sm'>
+                          <AlertTriangle className='size-4' />
+                          {configError}
+                        </div>
+                      )}
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {/* Configuration Example */}
+                {dbInfo?.defaultConfig && (
+                  <div className='p-3 rounded-lg bg-muted/50 border'>
+                    <div className='flex items-center gap-2 mb-2'>
+                      <Settings className='size-3' />
+                      <span className='font-medium text-xs'>Default Example</span>
+                    </div>
+                    <pre className='text-xs font-mono bg-background p-2 rounded border overflow-auto'>
+                      {JSON.stringify(dbInfo.defaultConfig, null, 2)}
+                    </pre>
                   </div>
-                  <pre className='text-xs font-mono bg-background p-2 rounded border overflow-auto'>
-                    {JSON.stringify(dbInfo.defaultConfig, null, 2)}
-                  </pre>
-                </div>
-              )}
-            </div>
+                )}
+              </div>
+            </SettingsSection>
           </div>
         </div>
 

--- a/apps/web/src/components/global/settings-page.tsx
+++ b/apps/web/src/components/global/settings-page.tsx
@@ -11,6 +11,7 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Separator } from '@auxx/ui/components/separator'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
+import type { LucideIcon } from 'lucide-react'
 import Link from 'next/link'
 import React, { useEffect, useRef, useState } from 'react'
 
@@ -143,5 +144,69 @@ export default function SettingsPage({
       <div ref={sentinelRef} className='h-px shrink-0' aria-hidden='true' />
       {children}
     </ScrollArea>
+  )
+}
+
+type SettingsSectionProps = {
+  /**
+   * Section icon. From client components pass a bare lucide icon (icon={Globe}); the
+   * component renders it as <Icon className='size-4' />. From server components pass a
+   * rendered element (icon={<Globe className='size-4' />}) — component references can't
+   * cross the server/client boundary.
+   */
+  icon?: LucideIcon | React.ReactNode
+  /** ReactNode so the title can include inline badges, counts, etc. */
+  title: React.ReactNode
+  /** Optional supporting copy under the title. */
+  description?: React.ReactNode
+  /** Optional right-aligned action (button/link/dropdown). */
+  action?: React.ReactNode
+  /** Section body. */
+  children?: React.ReactNode
+  /** Override classes on the root wrapper. */
+  className?: string
+}
+
+/** Render the icon prop: a rendered element passes through; a bare component gets sized. */
+function renderSectionIcon(icon: SettingsSectionProps['icon']) {
+  if (!icon) return null
+  if (React.isValidElement(icon)) return icon
+  const Icon = icon as LucideIcon
+  return <Icon className='size-4' />
+}
+
+/**
+ * A settings section: a titled header (icon + title + optional description/action)
+ * bound to its content. Pairs with {@link SettingsPage} — where SettingsPage wraps a
+ * page, SettingsSection wraps one section within it. The `section-header` and
+ * `section-content` data-slots are exposed for later styling/behavior overrides.
+ */
+export function SettingsSection({
+  icon,
+  title,
+  description,
+  action,
+  children,
+  className,
+}: SettingsSectionProps) {
+  return (
+    <div className={cn('space-y-4', className)}>
+      <div data-slot='section-header' className='space-y-1'>
+        <div className='flex items-center justify-between gap-2'>
+          <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-foreground'>
+            {renderSectionIcon(icon)}
+            {title}
+          </div>
+          {action && <div className='shrink-0'>{action}</div>}
+        </div>
+        {description && <p className='text-sm text-muted-foreground'>{description}</p>}
+      </div>
+      {/* space-y-4 stacks multiple content children; a no-op when content is a single wrapper. */}
+      {children && (
+        <div data-slot='section-content' className='space-y-4'>
+          {children}
+        </div>
+      )}
+    </div>
   )
 }

--- a/apps/web/src/components/mcp/ui/mcp-apps-section.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-apps-section.tsx
@@ -11,6 +11,7 @@ import {
 } from '@auxx/ui/components/dropdown-menu'
 import { LayoutTemplate, Plug } from 'lucide-react'
 import { type ReactNode, useState } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { useMcpServers } from '../hooks/use-mcp-servers'
 import { AddMcpServerDialog } from './add-mcp-server-dialog'
 import { McpAppCard } from './mcp-app-card'
@@ -107,13 +108,12 @@ export function McpAppsSection({ isAdminOrOwner, searchQuery = '' }: McpAppsSect
   if (!isAdminOrOwner && installed.length === 0) return null
 
   return (
-    <div className='space-y-2'>
-      <div className='flex items-center justify-between gap-2'>
-        <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-          <Plug className='size-4' />
-          MCP servers
-        </div>
-        {isAdminOrOwner && (
+    <SettingsSection
+      className='space-y-2'
+      icon={Plug}
+      title='MCP servers'
+      action={
+        isAdminOrOwner ? (
           <ConnectServerDropdown
             align='end'
             onCustom={() => setAddOpen(true)}
@@ -122,8 +122,8 @@ export function McpAppsSection({ isAdminOrOwner, searchQuery = '' }: McpAppsSect
               Connect server
             </Button>
           </ConnectServerDropdown>
-        )}
-      </div>
+        ) : undefined
+      }>
       {(installed.length > 0 || isAdminOrOwner) && (
         <div className='w-full @container'>
           <div className='grid w-full gap-2 @sm:grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3'>
@@ -170,6 +170,6 @@ export function McpAppsSection({ isAdminOrOwner, searchQuery = '' }: McpAppsSect
           />
         </>
       )}
-    </div>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/mcp/ui/mcp-server-connection-tab.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-server-connection-tab.tsx
@@ -8,6 +8,7 @@ import { KeyRound, Plug } from 'lucide-react'
 import { useState } from 'react'
 import { ConnectionList } from '~/components/apps/ui/connection-list'
 import { ConnectionRow, type ConnectionStatus } from '~/components/apps/ui/connection-row'
+import { SettingsSection } from '~/components/global/settings-page'
 import { api } from '~/trpc/react'
 import { useMcpOAuthPopup } from '../hooks/use-mcp-oauth-popup'
 import { ConnectCuratedDialog } from './connect-curated-dialog'
@@ -134,11 +135,7 @@ export function McpServerConnectionTab({
         )}
       </div>
 
-      <div className='space-y-2'>
-        <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-          <Plug className='size-4' />
-          Connection
-        </div>
+      <SettingsSection className='space-y-2' icon={Plug} title='Connection'>
         {needsManualSetup ? (
           <div className='flex flex-col gap-3 rounded-lg border p-4 text-sm'>
             <div className='font-medium'>Finish OAuth setup</div>
@@ -207,7 +204,7 @@ export function McpServerConnectionTab({
             />
           </ConnectionList>
         )}
-      </div>
+      </SettingsSection>
 
       <ConnectCuratedDialog
         open={dialogOpen}

--- a/apps/web/src/components/mcp/ui/mcp-server-tools-tab.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-server-tools-tab.tsx
@@ -10,6 +10,7 @@ import { TreeRow } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { AlertTriangle, Pencil, RefreshCw, ShieldCheck, Wrench } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { api } from '~/trpc/react'
 import type { McpDetailServer } from './mcp-server-detail'
 import { McpToolDetailPanel } from './mcp-tool-detail-panel'
@@ -87,12 +88,18 @@ export function McpServerToolsTab({ server, onChanged }: McpServerToolsTabProps)
   }
 
   return (
-    <div className='flex flex-col gap-3'>
-      <div className='flex items-center justify-between'>
-        <div className='flex items-center gap-2 tracking-tight font-semibold text-foreground text-base'>
-          <Wrench className='size-4' />
-          Tools
-        </div>
+    <SettingsSection
+      icon={Wrench}
+      title='Tools'
+      description={
+        <>
+          {server.tools.length} {server.tools.length === 1 ? 'tool' : 'tools'}
+          {server.lastSyncedAt
+            ? ` · synced ${new Date(server.lastSyncedAt).toLocaleString()}`
+            : ' · not synced yet'}
+        </>
+      }
+      action={
         <Button
           variant='outline'
           size='sm'
@@ -102,92 +109,86 @@ export function McpServerToolsTab({ server, onChanged }: McpServerToolsTabProps)
           <RefreshCw />
           Refresh
         </Button>
+      }>
+      <div className='flex flex-col gap-3'>
+        {server.lastSyncError && (
+          <div className='flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700'>
+            <AlertTriangle className='mt-0.5 size-4 shrink-0' />
+            <div>
+              <div className='font-medium'>Last sync failed</div>
+              <div className='text-red-600'>{server.lastSyncError}</div>
+            </div>
+          </div>
+        )}
+
+        <ToggleCard
+          title='Trust all tools'
+          description='Trusted tools run without approval. Which agents get the tools is configured per agent.'
+          icon={<ShieldCheck className='size-3.5' />}
+          checked={allTrusted}
+          onCheckedChange={toggleAll}
+          disabled={update.isPending || server.tools.length === 0}
+          switchSize='sm'
+          className='bg-primary-50'
+        />
+
+        {server.tools.length === 0 ? (
+          <div className='p-4 text-center text-sm text-muted-foreground'>
+            No tools — connect and refresh to populate the list.
+          </div>
+        ) : (
+          <div className='grid grid-cols-2 items-start gap-3'>
+            <div className='flex flex-col gap-0.5'>
+              {server.tools.map((tool) => (
+                <TreeRow
+                  rowClassName={cn(
+                    'bg-primary-100/50 hover:bg-primary-100',
+                    selectedTool === tool.name && 'bg-primary-100 ring-1 ring-primary-200'
+                  )}
+                  key={tool.name}
+                  icon={<Wrench className='size-4 text-muted-foreground' />}
+                  title={tool.title ?? tool.name}
+                  onToggleOpen={() => setSelectedTool(tool.name)}
+                  secondary={
+                    <Badge
+                      variant='outline'
+                      size='xs'
+                      title={
+                        tool.readOnlyHint
+                          ? 'Read-only tool'
+                          : 'Write tool — requires approval unless trusted'
+                      }>
+                      {tool.readOnlyHint ? 'Read' : <Pencil className='size-2.5' />}
+                      {tool.readOnlyHint ? '' : 'Write'}
+                    </Badge>
+                  }
+                  actions={
+                    <Switch
+                      size='xs'
+                      checked={trusted.has(tool.name)}
+                      onCheckedChange={(on) => toggleTool(tool.name, on)}
+                      disabled={update.isPending}
+                    />
+                  }
+                />
+              ))}
+            </div>
+
+            <div className='sticky top-0 self-start rounded-lg border bg-background p-3 text-sm mb-[300px]'>
+              {selected ? (
+                <McpToolDetailPanel
+                  key={selected.name}
+                  serverId={server.serverId}
+                  tool={selected}
+                  onChanged={onChanged}
+                />
+              ) : (
+                <div className='text-muted-foreground'>Select a tool to view its description.</div>
+              )}
+            </div>
+          </div>
+        )}
       </div>
-
-      <div className='text-sm text-muted-foreground'>
-        {server.tools.length} {server.tools.length === 1 ? 'tool' : 'tools'}
-        {server.lastSyncedAt
-          ? ` · synced ${new Date(server.lastSyncedAt).toLocaleString()}`
-          : ' · not synced yet'}
-      </div>
-
-      {server.lastSyncError && (
-        <div className='flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700'>
-          <AlertTriangle className='mt-0.5 size-4 shrink-0' />
-          <div>
-            <div className='font-medium'>Last sync failed</div>
-            <div className='text-red-600'>{server.lastSyncError}</div>
-          </div>
-        </div>
-      )}
-
-      <ToggleCard
-        title='Trust all tools'
-        description='Trusted tools run without approval. Which agents get the tools is configured per agent.'
-        icon={<ShieldCheck className='size-3.5' />}
-        checked={allTrusted}
-        onCheckedChange={toggleAll}
-        disabled={update.isPending || server.tools.length === 0}
-        switchSize='sm'
-        className='bg-primary-50'
-      />
-
-      {server.tools.length === 0 ? (
-        <div className='p-4 text-center text-sm text-muted-foreground'>
-          No tools — connect and refresh to populate the list.
-        </div>
-      ) : (
-        <div className='grid grid-cols-2 items-start gap-3'>
-          <div className='flex flex-col gap-0.5'>
-            {server.tools.map((tool) => (
-              <TreeRow
-                rowClassName={cn(
-                  'bg-primary-100/50 hover:bg-primary-100',
-                  selectedTool === tool.name && 'bg-primary-100 ring-1 ring-primary-200'
-                )}
-                key={tool.name}
-                icon={<Wrench className='size-4 text-muted-foreground' />}
-                title={tool.title ?? tool.name}
-                onToggleOpen={() => setSelectedTool(tool.name)}
-                secondary={
-                  <Badge
-                    variant='outline'
-                    size='xs'
-                    title={
-                      tool.readOnlyHint
-                        ? 'Read-only tool'
-                        : 'Write tool — requires approval unless trusted'
-                    }>
-                    {tool.readOnlyHint ? 'Read' : <Pencil className='size-2.5' />}
-                    {tool.readOnlyHint ? '' : 'Write'}
-                  </Badge>
-                }
-                actions={
-                  <Switch
-                    size='xs'
-                    checked={trusted.has(tool.name)}
-                    onCheckedChange={(on) => toggleTool(tool.name, on)}
-                    disabled={update.isPending}
-                  />
-                }
-              />
-            ))}
-          </div>
-
-          <div className='sticky top-0 self-start rounded-lg border bg-background p-3 text-sm mb-[300px]'>
-            {selected ? (
-              <McpToolDetailPanel
-                key={selected.name}
-                serverId={server.serverId}
-                tool={selected}
-                onChanged={onChanged}
-              />
-            ) : (
-              <div className='text-muted-foreground'>Select a tool to view its description.</div>
-            )}
-          </div>
-        </div>
-      )}
-    </div>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/organization/edit-organization-settings.tsx
+++ b/apps/web/src/components/organization/edit-organization-settings.tsx
@@ -24,6 +24,7 @@ import { Building, Check, Copy } from 'lucide-react'
 import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { SettingsSection } from '~/components/global/settings-page'
 import { useDemo } from '~/hooks/use-demo'
 import { useOrganization } from '~/hooks/use-organization'
 import { useDehydratedStateContext } from '~/providers/dehydrated-state-provider'
@@ -76,10 +77,7 @@ export function EditOrganizationSettings() {
   if (!organization) return null
 
   return (
-    <div className='space-y-4'>
-      <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
-        <Building className='size-4' /> General Settings
-      </div>
+    <SettingsSection icon={Building} title='General Settings'>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='max-w-xl space-y-4'>
           <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
@@ -138,6 +136,6 @@ export function EditOrganizationSettings() {
           </Button>
         </form>
       </Form>
-    </div>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/organization/profile-membership.tsx
+++ b/apps/web/src/components/organization/profile-membership.tsx
@@ -8,6 +8,7 @@ import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { Building, Loader2, MailPlus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import {
   LeaveOrganizationDialog,
   OrganizationItem,
@@ -115,50 +116,47 @@ export function ProfileMemberships() {
 
       {/* Pending Invitations Section */}
       {!isLoading && pendingInvites && pendingInvites.length > 0 && (
-        <div className='space-y-4'>
-          <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
-            <MailPlus className='size-4' /> Pending Invitations
+        <SettingsSection icon={MailPlus} title='Pending Invitations'>
+          <div className='space-y-4'>
+            {pendingInvites.map((invite) => (
+              <PendingInvitationItem
+                key={invite.id}
+                invitation={invite}
+                onAccept={() => acceptInvite.mutate({ invitationId: invite.id })}
+                isAccepting={
+                  acceptInvite.isPending && acceptInvite.variables?.invitationId === invite.id
+                }
+              />
+            ))}
+            <Separator />
           </div>
-          {pendingInvites.map((invite) => (
-            <PendingInvitationItem
-              key={invite.id}
-              invitation={invite}
-              onAccept={() => acceptInvite.mutate({ invitationId: invite.id })}
-              isAccepting={
-                acceptInvite.isPending && acceptInvite.variables?.invitationId === invite.id
-              }
-            />
-          ))}
-          <Separator />
-        </div>
+        </SettingsSection>
       )}
 
       {/* Existing Memberships Section */}
       {organizations.length > 0 && (
-        <div className='space-y-4'>
-          <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
-            <Building className='size-4' /> Your Organizations
+        <SettingsSection icon={Building} title='Your Organizations'>
+          <div className='space-y-4'>
+            {organizations.map((org) => {
+              const isOwner = org.role === OrganizationRoleEnum.OWNER
+              const canLeave = !isOwner || organizations.length > 1
+
+              return (
+                <OrganizationItem
+                  key={org.id}
+                  organization={org}
+                  isDefault={org.id === defaultOrganizationId}
+                  canLeave={canLeave}
+                  onLeave={() => {
+                    setSelectedOrgToLeave(org)
+                    setIsLeaveDialogOpen(true)
+                  }}
+                  isLeaving={leaveOrganization.isPending}
+                />
+              )
+            })}
           </div>
-
-          {organizations.map((org) => {
-            const isOwner = org.role === OrganizationRoleEnum.OWNER
-            const canLeave = !isOwner || organizations.length > 1
-
-            return (
-              <OrganizationItem
-                key={org.id}
-                organization={org}
-                isDefault={org.id === defaultOrganizationId}
-                canLeave={canLeave}
-                onLeave={() => {
-                  setSelectedOrgToLeave(org)
-                  setIsLeaveDialogOpen(true)
-                }}
-                isLeaving={leaveOrganization.isPending}
-              />
-            )
-          })}
-        </div>
+        </SettingsSection>
       )}
 
       {/* No Memberships and No Invites */}

--- a/apps/web/src/components/subscriptions/billing-address-card.tsx
+++ b/apps/web/src/components/subscriptions/billing-address-card.tsx
@@ -5,6 +5,7 @@ import { Button } from '@auxx/ui/components/button'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { MapPin, Pencil } from 'lucide-react'
 import { useState } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { useDemo } from '~/hooks/use-demo'
 import { api } from '~/trpc/react'
 import { BillingAddressDialog } from './billing-address-dialog'
@@ -35,14 +36,12 @@ export function BillingAddressCard() {
 
   return (
     <>
-      <div className='rounded-2xl border p-3 space-y-4'>
-        <div className='flex items-center justify-between'>
-          <div className='space-y-1'>
-            <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
-              <MapPin className='size-4' /> Address
-            </div>
-            <p className='text-sm text-muted-foreground'>Update your billing address</p>
-          </div>
+      <SettingsSection
+        className='rounded-2xl border p-3 space-y-4'
+        icon={MapPin}
+        title='Address'
+        description='Update your billing address'
+        action={
           <Button
             variant='outline'
             size='icon-sm'
@@ -51,8 +50,7 @@ export function BillingAddressCard() {
             disabled={isLoading || isDemo}>
             <Pencil />
           </Button>
-        </div>
-
+        }>
         {isLoading ? (
           <div className='space-y-3'>
             <div className='grid grid-cols-[100px_1fr] gap-4'>
@@ -90,7 +88,7 @@ export function BillingAddressCard() {
             </div>
           </div>
         )}
-      </div>
+      </SettingsSection>
 
       <BillingAddressDialog
         open={dialogOpen}

--- a/apps/web/src/components/subscriptions/payment-methods-card.tsx
+++ b/apps/web/src/components/subscriptions/payment-methods-card.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import { CreditCard, Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useDemo } from '~/hooks/use-demo'
 import { api } from '~/trpc/react'
@@ -72,14 +73,12 @@ export function PaymentMethodsCard() {
 
   return (
     <>
-      <div className='rounded-2xl border p-3 space-y-4'>
-        <div className='flex items-center justify-between'>
-          <div className='space-y-1'>
-            <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
-              <CreditCard className='size-4' /> Payment
-            </div>
-            <p className='text-sm text-muted-foreground'>Manage your payment methods</p>
-          </div>
+      <SettingsSection
+        className='rounded-2xl border p-3 space-y-4'
+        icon={CreditCard}
+        title='Payment'
+        description='Manage your payment methods'
+        action={
           <Button
             variant='outline'
             size='icon-sm'
@@ -88,8 +87,7 @@ export function PaymentMethodsCard() {
             disabled={isLoading || isDemo}>
             <Plus />
           </Button>
-        </div>
-
+        }>
         {isLoading ? (
           <div className='space-y-3'>
             {[1, 2].map((i) => (
@@ -158,7 +156,7 @@ export function PaymentMethodsCard() {
             No payment methods added yet
           </div>
         )}
-      </div>
+      </SettingsSection>
 
       <AddPaymentMethodDialog open={dialogOpen} onOpenChange={setDialogOpen} />
       <ConfirmDialog />

--- a/apps/web/src/components/subscriptions/plan-change-card.tsx
+++ b/apps/web/src/components/subscriptions/plan-change-card.tsx
@@ -11,6 +11,7 @@ import { CreditCard, X } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useState } from 'react'
+import { SettingsSection } from '~/components/global/settings-page'
 import { useDemo } from '~/hooks/use-demo'
 import { useUser } from '~/hooks/use-user'
 import { api } from '~/trpc/react'
@@ -89,11 +90,7 @@ export function PlanChangeCard() {
 
   return (
     <>
-      <div className='space-y-3'>
-        <div className='flex items-center gap-2 leading-none tracking-tight font-semibold text-foreground'>
-          <CreditCard className='size-4' /> Your Plan
-        </div>
-
+      <SettingsSection className='space-y-3' icon={CreditCard} title='Your Plan'>
         {subscriptionLoading ? (
           <div className='rounded-2xl border py-2 px-3'>
             <div className='flex items-center justify-between'>
@@ -188,7 +185,7 @@ export function PlanChangeCard() {
             </AlertDescription>
           </Alert>
         ) : null}
-      </div>
+      </SettingsSection>
 
       {dialogOpen ? <PlanChangeSummary open={dialogOpen} onOpenChange={setDialogOpen} /> : null}
     </>


### PR DESCRIPTION
## What

Adds a reusable `SettingsSection` component to `settings-page.tsx` — a titled section header (icon + title + optional description + right-aligned action) bound to its content via `section-header` / `section-content` data-slots.

Adopts it across the app, replacing hand-rolled header markup that was duplicated in each section:

- **Settings**: apps, channels, kopilot, members, plans, tickets, domains
- **Chat widget**: ai / appearance / behavior / general / identity / setup sections
- **Datasets**: chunking / embedding / general / search / vector-db sections
- **Apps**: app-connections
- **MCP**: apps-section, server-connection-tab, server-tools-tab (header markup only)
- **Custom fields, organization, subscriptions**

## Notes

- The `icon` prop accepts a bare lucide component (`icon={Globe}`) from client components, or a rendered element (`icon={<Globe className='size-4' />}`) from server components, since component references can't cross the server/client boundary.
- Pure header-markup refactor — no behavior changes.