### PR TITLE
feat(mcp): output schemas with non-object roots + untrusted-output fencing

### DIFF
--- a/apps/web/src/components/mcp/ui/mcp-tool-run-panel.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-tool-run-panel.tsx
@@ -169,7 +169,7 @@ export function McpToolRunPanel({ serverId, tool, onResult }: McpToolRunPanelPro
           variant='outline'
           className='self-start'
           onClick={handleRun}
-          disabled={!canRun}
+          disabled={!canRun || testTool.isPending}
           loading={testTool.isPending}
           loadingText='Running...'>
           <Play />

--- a/apps/web/src/components/mcp/ui/mcp-tool-schema-section.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-tool-schema-section.tsx
@@ -5,7 +5,7 @@ import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { toastError } from '@auxx/ui/components/toast'
 import { FileCheck2, Pencil, RotateCcw, Sparkles, X } from 'lucide-react'
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 import {
   SchemaEditorDialog,
@@ -36,8 +36,9 @@ const SOURCE_LABEL: Record<NonNullable<McpTool['outputSchemaSource']>, string> =
 /**
  * Output-schema section of the tool panel: a provenance badge (Server / Inferred / Manual / None),
  * Edit + Reset, and — after a test run — "Generate from result" and "Save as example output".
- * Editing opens the shared `SchemaEditorDialog` (`policy.emitRequired: false`); saves persist via
- * `mcp.updateToolSchema`.
+ * A successful run on a tool with NO schema auto-sets the inferred schema (`source: 'inferred'`) +
+ * example silently. Editing opens the shared `SchemaEditorDialog` (`emitRequired: false`,
+ * `root: 'any'` so array/scalar result roots are editable); saves persist via `mcp.updateToolSchema`.
  */
 export function McpToolSchemaSection({
   serverId,
@@ -56,36 +57,66 @@ export function McpToolSchemaSection({
     ? (SOURCE_LABEL[tool.outputSchemaSource ?? 'manual'] ?? 'Manual')
     : 'None'
 
-  // "Generate from result" only makes sense for an object-rooted inference (the editor's root must
-  // be an object); scalar/array results stay hand-authored via Edit.
-  const canGenerate =
-    (lastResult?.inferredSchema as { type?: unknown } | undefined)?.type === 'object'
+  // The editor now accepts any root (MCP passes `root: 'any'`), so "Generate from
+  // result" is offered whenever a run produced an inferred schema — object, array,
+  // or scalar.
+  const canGenerate = !!lastResult?.inferredSchema
 
-  async function persist(
-    args: Parameters<typeof updateSchema.mutateAsync>[0],
-    failTitle: string
-  ): Promise<boolean> {
-    try {
-      const res = await updateSchema.mutateAsync(args)
-      if (!res.ok) {
-        toastError({ title: failTitle, description: res.error ?? 'Unknown error' })
+  const persist = useCallback(
+    async (
+      args: Parameters<typeof updateSchema.mutateAsync>[0],
+      failTitle: string
+    ): Promise<boolean> => {
+      try {
+        const res = await updateSchema.mutateAsync(args)
+        if (!res.ok) {
+          toastError({ title: failTitle, description: res.error ?? 'Unknown error' })
+          return false
+        }
+        onChanged()
+        return true
+      } catch (err) {
+        toastError({
+          title: failTitle,
+          description: err instanceof Error ? err.message : 'Unknown error',
+        })
         return false
       }
-      onChanged()
-      return true
-    } catch (err) {
-      toastError({
-        title: failTitle,
-        description: err instanceof Error ? err.message : 'Unknown error',
-      })
-      return false
-    }
-  }
+    },
+    [updateSchema, onChanged]
+  )
+
+  // Auto-set on test run: when a run produces a result and the tool has NO schema
+  // yet, silently persist the inferred schema (`source: 'inferred'`) + the example
+  // in one call. Only when none exists — never touches server/manual/inferred. The
+  // ref guards against re-firing for the same result across re-renders.
+  const autoSetFor = useRef<McpToolRunSuccess | null>(null)
+  useEffect(() => {
+    if (!lastResult || hasSchema || !lastResult.inferredSchema) return
+    if (autoSetFor.current === lastResult) return
+    autoSetFor.current = lastResult
+    void persist(
+      {
+        serverId,
+        toolName: tool.name,
+        outputSchema: lastResult.inferredSchema as Record<string, unknown>,
+        source: 'inferred',
+        exampleOutput: exampleFromResult(lastResult),
+      },
+      'Failed to save inferred schema'
+    )
+  }, [lastResult, hasSchema, serverId, tool.name, persist])
 
   function openEdit() {
     setSeed({
       schema: (tool.outputSchema as Record<string, unknown>) ?? EMPTY_SCHEMA,
-      seededFrom: hasSchema ? 'existing' : 'empty',
+      // Seed as 'inferred' when the stored schema is the unmodified inference, so a
+      // no-op edit-save round-trips back to `inferred` instead of flipping to manual.
+      seededFrom: hasSchema
+        ? tool.outputSchemaSource === 'inferred'
+          ? 'inferred'
+          : 'existing'
+        : 'empty',
     })
   }
 
@@ -191,7 +222,7 @@ export function McpToolSchemaSection({
         onOpenChange={(open) => !open && setSeed(null)}
         title={tool.title ?? tool.name}
         initial={seed ?? { schema: EMPTY_SCHEMA, seededFrom: 'empty' }}
-        policy={{ emitRequired: false }}
+        policy={{ emitRequired: false, root: 'any' }}
         onSave={handleSave}
       />
     </div>

--- a/apps/web/src/components/schema-editor/__tests__/schema-draft.test.ts
+++ b/apps/web/src/components/schema-editor/__tests__/schema-draft.test.ts
@@ -2,7 +2,12 @@
 
 import { FieldType } from '@auxx/database/enums'
 import { describe, expect, it } from 'vitest'
-import { draftToJsonSchema, jsonSchemaToDraft, type SchemaPolicy } from '../schema-draft'
+import {
+  draftToJsonSchema,
+  jsonSchemaRootKind,
+  jsonSchemaToDraft,
+  type SchemaPolicy,
+} from '../schema-draft'
 
 const MCP: SchemaPolicy = { emitRequired: false }
 const WORKFLOW: SchemaPolicy = { emitRequired: true }
@@ -188,6 +193,36 @@ describe('round-trip losslessness', () => {
       properties: { name: { type: 'string' } },
     })
     expect(draftToJsonSchema(draft, MCP)).not.toHaveProperty('required')
+  })
+})
+
+describe('non-object roots (MCP root: any)', () => {
+  it('classifies root kinds', () => {
+    expect(jsonSchemaRootKind({ type: 'object', properties: {} })).toBe('object')
+    expect(
+      jsonSchemaRootKind({ type: 'array', items: { type: 'object', properties: { id: {} } } })
+    ).toBe('array-of-objects')
+    expect(jsonSchemaRootKind({ type: 'array', items: { type: 'string' } })).toBe('other')
+    expect(jsonSchemaRootKind({ type: 'string' })).toBe('other')
+  })
+
+  it('seeds rows from an array-of-objects root and re-wraps on save (no clobber)', () => {
+    const schema = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { id: { type: 'number' }, name: { type: 'string' } },
+      },
+    }
+    const rows = jsonSchemaToDraft(schema)
+    expect(rows.map((r) => r.name)).toEqual(['id', 'name'])
+    const out = draftToJsonSchema(rows, MCP, 'array-of-objects')
+    expect(normalize(out, { keepRequired: false })).toEqual(schema)
+  })
+
+  it('yields zero rows for a non-representable root (handled as JSON-only)', () => {
+    expect(jsonSchemaToDraft({ type: 'array', items: { type: 'string' } })).toEqual([])
+    expect(jsonSchemaToDraft({ type: 'string' })).toEqual([])
   })
 })
 

--- a/apps/web/src/components/schema-editor/schema-draft.ts
+++ b/apps/web/src/components/schema-editor/schema-draft.ts
@@ -44,6 +44,28 @@ export interface SchemaFieldDraft {
 export interface SchemaPolicy {
   /** Workflow mode emits the `required` array; MCP mode never does. */
   emitRequired: boolean
+  /**
+   * Root JSON Schema type the editor accepts. `'object'` (the default) keeps the
+   * load-bearing object-root contract that workflow LLM structured-output needs
+   * (the provider APIs and output-variable mapping require an object root). `'any'`
+   * lets MCP edit array/scalar-rooted result schemas — list tools commonly produce
+   * top-level arrays.
+   */
+  root?: 'object' | 'any'
+}
+
+/**
+ * The shape of a schema's root, as far as the visual editor can author it. An
+ * object root or an array-of-objects root both seed the row tree; anything else
+ * (scalar root, array of scalars) is JSON-tab only.
+ */
+export type SchemaRootKind = 'object' | 'array-of-objects' | 'other'
+
+/** Classify a root JSON Schema into a {@link SchemaRootKind}. */
+export function jsonSchemaRootKind(schema: Record<string, unknown>): SchemaRootKind {
+  if (isObjectNode(schema)) return 'object'
+  if (isArrayOfObjectsNode(schema)) return 'array-of-objects'
+  return 'other'
 }
 
 /** The vendor-extension keyword carrying FieldType metadata on leaf nodes. */
@@ -74,13 +96,15 @@ type JsonNode = Record<string, unknown>
 // ---------------------------------------------------------------------------
 
 /**
- * Convert a root JSON Schema (`type: 'object'`) into editor rows. Non-object
- * roots and missing `properties` yield an empty list — the dialog only edits
- * object-rooted schemas (the validation pipeline blocks others).
+ * Convert a root JSON Schema into editor rows. An object root seeds rows from its
+ * `properties`; an **array-of-objects** root seeds them from `items.properties`
+ * (the rows describe one element — the dialog re-wraps on save). Any other root
+ * (scalar, array of scalars) yields an empty list and is JSON-tab only.
  */
 export function jsonSchemaToDraft(schema: Record<string, unknown>): SchemaFieldDraft[] {
-  if (!isObjectNode(schema)) return []
-  return objectChildren(schema)
+  if (isObjectNode(schema)) return objectChildren(schema)
+  if (isArrayOfObjectsNode(schema)) return objectChildren(schema.items as JsonNode)
+  return []
 }
 
 function objectChildren(node: JsonNode): SchemaFieldDraft[] {
@@ -230,9 +254,12 @@ function rawLeaf(node: JsonNode, base: SchemaFieldDraft): SchemaFieldDraft {
  */
 export function draftToJsonSchema(
   rows: SchemaFieldDraft[],
-  policy: SchemaPolicy
+  policy: SchemaPolicy,
+  rootKind: SchemaRootKind = 'object'
 ): Record<string, unknown> {
-  return objectNode(rows, policy)
+  const obj = objectNode(rows, policy)
+  // An array-of-objects root re-wraps the row object as the element schema.
+  return rootKind === 'array-of-objects' ? { type: 'array', items: obj } : obj
 }
 
 function objectNode(rows: SchemaFieldDraft[], policy: SchemaPolicy): JsonNode {
@@ -354,6 +381,13 @@ function isObjectNode(node: unknown): node is JsonNode {
     !Array.isArray(node) &&
     (node as JsonNode).type === 'object'
   )
+}
+
+/** An `{ type: 'array', items: { type: 'object', … } }` root — editable as rows. */
+function isArrayOfObjectsNode(node: unknown): node is JsonNode {
+  if (!node || typeof node !== 'object' || Array.isArray(node)) return false
+  if ((node as JsonNode).type !== 'array') return false
+  return isObjectNode((node as JsonNode).items)
 }
 
 function asStringArray(value: unknown): string[] {

--- a/apps/web/src/components/schema-editor/ui/json-importer.tsx
+++ b/apps/web/src/components/schema-editor/ui/json-importer.tsx
@@ -12,6 +12,12 @@ import { CodeEditor } from './code-editor'
 interface JsonImporterProps {
   /** Receives the JSON Schema inferred from the pasted sample value. */
   onImport: (schema: Record<string, unknown>) => void
+  /**
+   * Root types the editor accepts. `'object'` (default) rejects array/scalar
+   * samples; `'any'` (MCP) accepts any JSON sample — `inferJsonSchema` already
+   * handles array/scalar roots by design.
+   */
+  root?: 'object' | 'any'
 }
 
 /**
@@ -20,7 +26,7 @@ interface JsonImporterProps {
  * importer; the inference policy (no `required`, no `additionalProperties`) now
  * matches the rest of the editor.
  */
-export function JsonImporter({ onImport }: JsonImporterProps) {
+export function JsonImporter({ onImport, root = 'object' }: JsonImporterProps) {
   const [open, setOpen] = useState(false)
   const [json, setJson] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -35,7 +41,7 @@ export function JsonImporter({ onImport }: JsonImporterProps) {
       setError('Invalid JSON')
       return
     }
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    if (root === 'object' && (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))) {
       setError('Paste a sample object, not an array or primitive value.')
       return
     }
@@ -47,7 +53,7 @@ export function JsonImporter({ onImport }: JsonImporterProps) {
     onImport(schema)
     setError(null)
     setOpen(false)
-  }, [json, onImport])
+  }, [json, onImport, root])
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/apps/web/src/components/schema-editor/ui/schema-editor-dialog.tsx
+++ b/apps/web/src/components/schema-editor/ui/schema-editor-dialog.tsx
@@ -15,9 +15,11 @@ import { AlertTriangle, Braces, GitBranch } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import {
   draftToJsonSchema,
+  jsonSchemaRootKind,
   jsonSchemaToDraft,
   type SchemaFieldDraft,
   type SchemaPolicy,
+  type SchemaRootKind,
 } from '../schema-draft'
 import { parseSchemaText, validateSchema } from '../validation'
 import { CodeEditor } from './code-editor'
@@ -91,7 +93,22 @@ function SchemaEditorBody({
   const [tab, setTab] = useState<Tab>('visual')
   const [rows, setRows] = useState<SchemaFieldDraft[]>(() => jsonSchemaToDraft(initial.schema))
   const [jsonText, setJsonText] = useState(() => JSON.stringify(initial.schema, null, 2))
+  const [rootKind, setRootKind] = useState<SchemaRootKind>(() => jsonSchemaRootKind(initial.schema))
   const [error, setError] = useState<string | null>(null)
+
+  const rootPolicy = policy.root ?? 'object'
+
+  // Serialize the current visual-tab state to a JSON Schema document.
+  //  - object / array-of-objects roots round-trip through the row model;
+  //  - an 'other' root (scalar, array of scalars) can't be represented as rows,
+  //    so the JSON-tab document passes through UNCHANGED (never an empty object).
+  const serializeVisual = useCallback((): Record<string, unknown> => {
+    if (rootKind === 'object' || rootKind === 'array-of-objects') {
+      return draftToJsonSchema(rows, policy, rootKind)
+    }
+    const parsed = parseSchemaText(jsonText)
+    return parsed.ok ? parsed.schema : initial.schema
+  }, [rootKind, rows, policy, jsonText, initial.schema])
 
   // Keyboard submit (Enter / ⌘↵) on the dialog — handled here so it works from
   // either tab without a real <form>.
@@ -113,33 +130,35 @@ function SchemaEditorBody({
       const next = value as Tab
       if (next === tab) return
       if (next === 'json') {
-        setJsonText(JSON.stringify(draftToJsonSchema(rows, policy), null, 2))
+        setJsonText(JSON.stringify(serializeVisual(), null, 2))
         setError(null)
         setTab('json')
         return
       }
-      // json → visual: validate before leaving the JSON tab.
+      // json → visual: validate before leaving the JSON tab, then re-derive the
+      // root kind (a JSON edit can change object ⇄ array ⇄ scalar root).
       const parsed = parseSchemaText(jsonText)
       if (!parsed.ok) {
         setError(parsed.error)
         return
       }
-      const result = validateSchema(parsed.schema)
+      const result = validateSchema(parsed.schema, rootPolicy)
       if (!result.ok) {
         setError(result.error ?? 'Invalid schema')
         return
       }
       setRows(jsonSchemaToDraft(parsed.schema))
+      setRootKind(jsonSchemaRootKind(parsed.schema))
       setError(null)
       setTab('visual')
     },
-    [tab, rows, jsonText, policy]
+    [tab, serializeVisual, jsonText, rootPolicy]
   )
 
   const handleImport = useCallback(
     (schema: Record<string, unknown>) => {
-      const imported = jsonSchemaToDraft(schema)
-      setRows(imported)
+      setRows(jsonSchemaToDraft(schema))
+      setRootKind(jsonSchemaRootKind(schema))
       if (tab === 'json') setJsonText(JSON.stringify(schema, null, 2))
       setError(null)
     },
@@ -154,20 +173,20 @@ function SchemaEditorBody({
         setError(parsed.error)
         return
       }
-      const result = validateSchema(parsed.schema)
+      const result = validateSchema(parsed.schema, rootPolicy)
       if (!result.ok) {
         setError(result.error ?? 'Invalid schema')
         return
       }
       schema = parsed.schema
     } else {
-      schema = draftToJsonSchema(rows, policy)
+      schema = serializeVisual()
     }
     const source: SaveSource =
       initial.seededFrom === 'inferred' && deepEqual(schema, initial.schema) ? 'inferred' : 'manual'
     onSave(schema, source)
     onClose()
-  }, [tab, jsonText, rows, policy, initial, onSave, onClose])
+  }, [tab, jsonText, serializeVisual, rootPolicy, initial, onSave, onClose])
 
   return (
     <div className='relative flex h-full flex-1 flex-col overflow-hidden'>
@@ -191,12 +210,21 @@ function SchemaEditorBody({
             JSON
           </RadioTabItem>
         </RadioTab>
-        <JsonImporter onImport={handleImport} />
+        <JsonImporter onImport={handleImport} root={rootPolicy} />
       </div>
 
       <div className='flex grow flex-col gap-y-1 overflow-hidden'>
         {tab === 'visual' ? (
-          <SchemaFieldTree rows={rows} onChange={setRows} policy={policy} />
+          rootKind === 'other' ? (
+            <NonObjectRootNotice />
+          ) : (
+            <SchemaFieldTree
+              rows={rows}
+              onChange={setRows}
+              policy={policy}
+              rootTypeLabel={rootKind === 'array-of-objects' ? 'array of objects' : 'object'}
+            />
+          )
         ) : (
           <CodeEditor
             className='grow rounded-xl'
@@ -223,6 +251,25 @@ function SchemaEditorBody({
           Save <KbdSubmit variant='outline' size='sm' />
         </Button>
       </DialogFooter>
+    </div>
+  )
+}
+
+/**
+ * Visual-tab placeholder for a root the row model can't represent (a scalar root,
+ * or an array of scalars). The JSON tab edits it directly; saving from the visual
+ * tab passes the JSON document through unchanged.
+ */
+function NonObjectRootNotice() {
+  return (
+    <div className='flex h-full items-center justify-center rounded-xl bg-primary-100 p-6'>
+      <div className='flex max-w-sm items-start gap-x-2 text-center'>
+        <Braces className='mt-0.5 size-4 shrink-0 text-muted-foreground' />
+        <p className='text-muted-foreground text-sm'>
+          This schema's root isn't an object, so it can't be edited as fields. Switch to the JSON
+          tab to edit it.
+        </p>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/schema-editor/ui/schema-field-tree.tsx
+++ b/apps/web/src/components/schema-editor/ui/schema-field-tree.tsx
@@ -17,6 +17,9 @@ interface SchemaFieldTreeProps {
   rows: SchemaFieldDraft[]
   onChange: (rows: SchemaFieldDraft[]) => void
   policy: SchemaPolicy
+  /** Type annotation on the synthetic root (e.g. `array of objects` for an
+   *  array-of-objects root). Defaults to `object`. */
+  rootTypeLabel?: string
 }
 
 /**
@@ -28,7 +31,12 @@ interface SchemaFieldTreeProps {
  * row-to-row moves make exactly one transition — no timers. A field actively
  * being typed in stays open via `focusedId` regardless of the pointer.
  */
-export function SchemaFieldTree({ rows, onChange, policy }: SchemaFieldTreeProps) {
+export function SchemaFieldTree({
+  rows,
+  onChange,
+  policy,
+  rootTypeLabel = 'object',
+}: SchemaFieldTreeProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null)
   const [focusedId, setFocusedId] = useState<string | null>(null)
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set())
@@ -140,7 +148,7 @@ export function SchemaFieldTree({ rows, onChange, policy }: SchemaFieldTreeProps
             <span className='border border-transparent px-1 py-px font-semibold text-sm text-primary-800'>
               structured_output
             </span>
-            <span className='px-1 py-0.5 text-xs text-muted-foreground'>object</span>
+            <span className='px-1 py-0.5 text-xs text-muted-foreground'>{rootTypeLabel}</span>
           </div>
         </div>
         <div className='absolute top-7 z-0 flex h-[calc(100%-1.75rem)] w-5 justify-center left-0'>

--- a/apps/web/src/components/schema-editor/validation.ts
+++ b/apps/web/src/components/schema-editor/validation.ts
@@ -33,14 +33,26 @@ export function parseSchemaText(text: string):
     return { ok: false, error: `Invalid JSON: ${(err as Error).message}` }
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return { ok: false, error: 'Schema must be a JSON object' }
+    // A JSON Schema *document* is always an object — a raw array/primitive here is
+    // almost always a pasted sample value, so point at Import (which infers one).
+    return {
+      ok: false,
+      error: 'This looks like a sample value, not a schema. Use “Import” to infer one.',
+    }
   }
   return { ok: true, schema: parsed as Record<string, unknown> }
 }
 
-/** Run the full structural pipeline over a parsed schema object. */
-export function validateSchema(schema: Record<string, unknown>): SchemaValidationResult {
-  const pre = preValidateSchema(schema)
+/**
+ * Run the full structural pipeline over a parsed schema object. `root` controls
+ * whether a non-object root is rejected (`'object'`, the workflow contract) or
+ * allowed (`'any'`, MCP).
+ */
+export function validateSchema(
+  schema: Record<string, unknown>,
+  root: 'object' | 'any' = 'object'
+): SchemaValidationResult {
+  const pre = preValidateSchema(schema, root)
   if (!pre.ok) return pre
 
   if (checkJsonSchemaDepth(schema) > JSON_SCHEMA_MAX_DEPTH) {
@@ -52,12 +64,19 @@ export function validateSchema(schema: Record<string, unknown>): SchemaValidatio
   return { ok: true }
 }
 
-/** The root must be an object schema — that is the editor's contract. */
-export function preValidateSchema(schema: Record<string, unknown>): SchemaValidationResult {
+/**
+ * Structural root check. Under `root: 'object'` (the default / workflow contract)
+ * the root must be an object schema; under `root: 'any'` (MCP) any root passes —
+ * array/scalar result schemas are first-class there.
+ */
+export function preValidateSchema(
+  schema: Record<string, unknown>,
+  root: 'object' | 'any' = 'object'
+): SchemaValidationResult {
   if (typeof schema !== 'object' || schema === null) {
     return { ok: false, error: 'Schema must be an object' }
   }
-  if (schema.type !== 'object') {
+  if (root === 'object' && schema.type !== 'object') {
     return { ok: false, error: 'Root schema type must be "object"' }
   }
   return { ok: true }

--- a/packages/lib/src/ai/agent-framework/__tests__/wire-format-conversion.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/wire-format-conversion.test.ts
@@ -191,6 +191,69 @@ describe('partsToWireFormat — in-flight / awaiting / errored tools', () => {
   })
 })
 
+describe('partsToWireFormat — untrusted MCP output boundary', () => {
+  it('re-fences a completed part carrying an outputBoundary, output stays walkable', () => {
+    const parts: ContentPart[] = [
+      {
+        type: 'tool_call',
+        toolCallId: 'tc_1',
+        name: 'mcp__demo__list',
+        args: {},
+        status: 'completed',
+        output: [{ id: 1 }, { id: 2 }],
+        outputBoundary: { server: 'demo', tool: 'list' },
+      },
+    ]
+    const wire = partsToWireFormat(parts, messageId)
+    const toolMsg = wire.find((m) => m.role === 'tool')
+    expect(toolMsg).toBeDefined()
+    const content = toolMsg?.content as string
+    expect(content).toContain('<mcp_tool_output server="demo" tool="list">')
+    expect(content).toContain('</mcp_tool_output>')
+    // The JSON output is embedded inside the fence.
+    expect(content).toContain('"id": 1')
+  })
+
+  it('does NOT fence a completed part without an outputBoundary (pre-change part)', () => {
+    const parts: ContentPart[] = [
+      {
+        type: 'tool_call',
+        toolCallId: 'tc_1',
+        name: 'mcp__demo__list',
+        args: {},
+        status: 'completed',
+        // Pre-change parts hold an already-embedded fence string + no marker.
+        output: '<mcp_tool_output server="demo" tool="list">\n[]\n</mcp_tool_output>',
+      },
+    ]
+    const wire = partsToWireFormat(parts, messageId)
+    const toolMsg = wire.find((m) => m.role === 'tool')
+    const content = toolMsg?.content as string
+    // Exactly one fence — JSON.stringify of the already-fenced string, never double-wrapped.
+    expect(content.match(/<mcp_tool_output/g)).toHaveLength(1)
+  })
+
+  it('fences the output of an errored MCP part', () => {
+    const parts: ContentPart[] = [
+      {
+        type: 'tool_call',
+        toolCallId: 'tc_1',
+        name: 'mcp__demo__list',
+        args: {},
+        status: 'error',
+        error: 'nope',
+        output: { message: 'nope' },
+        outputBoundary: { server: 'demo', tool: 'list' },
+      },
+    ]
+    const wire = partsToWireFormat(parts, messageId)
+    const toolMsg = wire.find((m) => m.role === 'tool')
+    const parsed = JSON.parse(toolMsg?.content as string)
+    expect(parsed.error).toBe('nope')
+    expect(parsed.output).toContain('<mcp_tool_output server="demo" tool="list">')
+  })
+})
+
 describe('partsToWireFormat — thinking parts', () => {
   it('drops thinking parts from assistant content (or surfaces them via reasoning_content)', () => {
     const parts: ContentPart[] = [

--- a/packages/lib/src/ai/agent-framework/query-loop.ts
+++ b/packages/lib/src/ai/agent-framework/query-loop.ts
@@ -968,6 +968,8 @@ export async function* agentQueryLoop(
         part.error = r.error ?? 'Unknown error'
         if (r.output !== undefined) part.output = r.output
       }
+      // Untrusted-output marker (MCP) — drives the wire-layer injection fence.
+      if (r.outputBoundary) part.outputBoundary = r.outputBoundary
     }
 
     currentState = upsertAssistantMessage()
@@ -1371,6 +1373,7 @@ async function* executeToolCalls(
           success: cached.success,
           error: cached.error,
           digest: cached.digest,
+          ...(cached.outputBoundary ? { outputBoundary: cached.outputBoundary } : {}),
         })
         continue
       }
@@ -1446,6 +1449,7 @@ async function* executeToolCalls(
         success: result.success,
         error: result.error,
         digest,
+        ...(tool.outputBoundary ? { outputBoundary: tool.outputBoundary } : {}),
       }
       results.push(execResult)
       if (cacheKey && result.success) idempotentCache.set(cacheKey, execResult)

--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -41,6 +41,16 @@ export interface ToolCallPart {
   output?: unknown
   /** Display projection of `output` produced by the tool's `buildDigest`. */
   digest?: unknown
+  /**
+   * Present when `output` is untrusted external data (MCP tool results). The
+   * stored value stays the raw, walkable structured output so `tool:<name>.path`
+   * resolves at runtime; `partsToWireFormat` re-fences it as
+   * `<mcp_tool_output server tool>…</mcp_tool_output>` for model replay. Absent on
+   * parts persisted before this field existed → never re-wrapped (the fence is
+   * already embedded in their string `output`). Copied from the tool's
+   * `outputBoundary` by the query loop when the result is stamped.
+   */
+  outputBoundary?: { server: string; tool: string }
   /** Error message when status === 'error'. */
   error?: string
   agent?: string
@@ -265,6 +275,25 @@ export interface AgentToolDefinition {
    * schema*, not a competing one. Optional so migration is incremental.
    */
   outputSchema?: z.ZodType
+  /**
+   * The tool's output shape as a **JSON Schema** — the serializable read currency
+   * for the discoverability / output→input binding surface (the catalog field of
+   * the same name, `ToolCatalogEntry.outputsJsonSchema`, carries this verbatim).
+   * Distinct from `outputSchema` (Zod, the native authoring source used for
+   * `.infer` typing): consumers that need a document — the client-side binding
+   * picker, a future server-side enumerator — read this. MCP tools set it from
+   * their stored result schema; app tools carry it from the catalog; native tools
+   * may derive it from `z.toJSONSchema(outputSchema)` only if a consumer needs it.
+   * Declarative and optional. See plans/chat/v9/OUTPUT-SCHEMAS.md.
+   */
+  outputsJsonSchema?: Record<string, unknown>
+  /**
+   * Declares this tool's success `output` as untrusted external data: the query
+   * loop stamps the matching `ToolCallPart.outputBoundary` and the wire layer
+   * fences it for model replay. MCP tools set `{ server, tool }`; native/app tools
+   * leave it unset (their output is trusted, walkable as-is).
+   */
+  outputBoundary?: { server: string; tool: string }
   /**
    * One realistic example of this tool's success `output` — the same shape as
    * `outputSchema` describes. Authored once by the tool owner; consumed by eval

--- a/packages/lib/src/ai/agent-framework/utils.ts
+++ b/packages/lib/src/ai/agent-framework/utils.ts
@@ -28,6 +28,22 @@ export interface ToolExecResult {
   error?: string
   /** Display projection of the tool output, computed via `buildDigest`. */
   digest?: unknown
+  /**
+   * Carried from the tool's `outputBoundary` — set only for tools whose `output`
+   * is untrusted external data (MCP). The query loop copies it onto the
+   * `ToolCallPart` so the wire layer can re-fence the output for the model.
+   */
+  outputBoundary?: { server: string; tool: string }
+}
+
+/**
+ * Wrap untrusted external tool output (MCP results) in a prompt-injection
+ * boundary the model is told to treat as data. The fence is re-applied here, at
+ * the wire layer, so the stored `ToolCallPart.output` stays a raw, walkable
+ * structured value while the model only ever sees the fenced form.
+ */
+export function wrapMcpOutput(serverSlug: string, toolName: string, text: string): string {
+  return `<mcp_tool_output server="${serverSlug}" tool="${toolName}">\n${text}\n</mcp_tool_output>`
 }
 
 /**
@@ -231,12 +247,24 @@ export function partsToWireFormat(parts: ContentPart[]): Message[] {
       // awaiting-approval). The assistant's tool_calls[] still references the
       // id; on resume we splice the tool message in.
       if (part.status === 'completed' || part.status === 'error' || part.status === 'rejected') {
+        // Untrusted MCP output is re-fenced here (the stored value is the raw,
+        // walkable structured output). Pretty-print inside the fence to match the
+        // model-facing format the adapter used to emit before the wrap moved here.
+        const wireOutput = part.outputBoundary
+          ? wrapMcpOutput(
+              part.outputBoundary.server,
+              part.outputBoundary.tool,
+              JSON.stringify(part.output ?? null, null, 2)
+            )
+          : (part.output ?? null)
         const toolContent =
           part.status === 'completed'
-            ? JSON.stringify(part.output ?? null)
+            ? part.outputBoundary
+              ? (wireOutput as string)
+              : JSON.stringify(part.output ?? null)
             : JSON.stringify({
                 error: part.error ?? 'Unknown error',
-                output: part.output ?? null,
+                output: wireOutput,
               })
         toolMessages.push({
           role: 'tool',

--- a/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/apps/index.ts
@@ -241,6 +241,11 @@ export async function createAppCapabilities(deps: {
         displayName: tool.name || registeredName,
         description: tool.description,
         parameters: tool.inputsJsonSchema,
+        // JSON-Schema read currency for the discoverability / binding surface,
+        // carried verbatim from the catalog (empty `{}` ⇒ no schema → omit).
+        ...(tool.outputsJsonSchema && Object.keys(tool.outputsJsonSchema).length > 0
+          ? { outputsJsonSchema: tool.outputsJsonSchema }
+          : {}),
         exampleOutput,
         // App tools have no native captureMint; fall back to the declared
         // example (args-agnostic) so capture mode can predict output. The

--- a/packages/lib/src/ai/mcp/__tests__/tool-adapter.test.ts
+++ b/packages/lib/src/ai/mcp/__tests__/tool-adapter.test.ts
@@ -123,21 +123,25 @@ describe('buildMcpAgentTools — validateInputs (ajv)', () => {
   })
 })
 
-describe('execute output wrapping', () => {
-  it('wraps successful output in the injection boundary', async () => {
+describe('execute structured (walkable) output', () => {
+  it('declares the injection-boundary marker on the tool definition', () => {
+    const [echo] = buildMcpAgentTools({ server: makeServer(), autonomous: false })
+    expect(echo!.outputBoundary).toEqual({ server: 'demo', tool: 'echo' })
+    // The fence helper is still exported (re-exported from the wire layer).
+    expect(wrapMcpOutput('demo', 'echo', 'x')).toContain('<mcp_tool_output')
+  })
+
+  it('returns a plain-text result as a raw string (not walkable, no fence)', async () => {
     callToolMock.mockResolvedValueOnce({ text: 'tool said hi', isError: false })
     const [echo] = buildMcpAgentTools({ server: makeServer(), autonomous: false })
     const result = await echo!.execute({ message: 'x' }, {
       organizationId: 'org-1',
       turnId: 't1',
     } as never)
-    expect(result).toMatchObject({ success: true })
-    expect(String((result as { output: string }).output)).toBe(
-      wrapMcpOutput('demo', 'echo', 'tool said hi')
-    )
+    expect(result).toEqual({ success: true, output: 'tool said hi' })
   })
 
-  it('serializes structuredContent as the canonical model-facing string', async () => {
+  it('returns structuredContent verbatim as the walkable output', async () => {
     callToolMock.mockResolvedValueOnce({
       text: 'ignored when structured present',
       structuredContent: { count: 2, items: ['a'] },
@@ -148,8 +152,37 @@ describe('execute output wrapping', () => {
       organizationId: 'org-1',
       turnId: 't1',
     } as never)
-    expect(String((result as { output: string }).output)).toBe(
-      wrapMcpOutput('demo', 'echo', JSON.stringify({ count: 2, items: ['a'] }, null, 2))
-    )
+    expect(result).toEqual({ success: true, output: { count: 2, items: ['a'] } })
+  })
+
+  it('parses a JSON-text result (incl. top-level arrays) into structured output', async () => {
+    callToolMock.mockResolvedValueOnce({
+      text: JSON.stringify([{ id: 1 }, { id: 2 }]),
+      isError: false,
+    })
+    const [echo] = buildMcpAgentTools({ server: makeServer(), autonomous: false })
+    const result = await echo!.execute({ message: 'x' }, {
+      organizationId: 'org-1',
+      turnId: 't1',
+    } as never)
+    expect(result).toEqual({ success: true, output: [{ id: 1 }, { id: 2 }] })
+  })
+
+  it('keeps the structured value on output for an isError result, with a readable error', async () => {
+    callToolMock.mockResolvedValueOnce({
+      text: JSON.stringify({ message: 'nope' }),
+      structuredContent: { message: 'nope' },
+      isError: true,
+    })
+    const [echo] = buildMcpAgentTools({ server: makeServer(), autonomous: false })
+    const result = await echo!.execute({ message: 'x' }, {
+      organizationId: 'org-1',
+      turnId: 't1',
+    } as never)
+    expect(result).toMatchObject({
+      success: false,
+      output: { message: 'nope' },
+      error: JSON.stringify({ message: 'nope' }),
+    })
   })
 })

--- a/packages/lib/src/ai/mcp/tool-adapter.ts
+++ b/packages/lib/src/ai/mcp/tool-adapter.ts
@@ -6,6 +6,10 @@ import Ajv, { type ValidateFunction } from 'ajv'
 // identical names (disable-lists must match exactly).
 import { mcpToolName } from '../../agents/client'
 import type { AgentToolDefinition } from '../agent-framework/types'
+// The injection-boundary fence now lives at the wire layer (`partsToWireFormat`):
+// the adapter returns raw, walkable output and the boundary is re-applied on
+// model replay. Re-exported here for the MCP barrel + tests.
+import { wrapMcpOutput } from '../agent-framework/utils'
 import { buildMcpRequestContext } from './auth'
 import { mcpCallTool } from './client'
 import { markMcpConnectionFailed } from './connections'
@@ -13,19 +17,30 @@ import { McpAuthError, mapMcpError } from './errors'
 import { checkAndCountMcpCall } from './rate-limiter'
 import type { CachedMcpServer } from './types'
 
-export { mcpToolName }
+export { mcpToolName, wrapMcpOutput }
 
 const logger = createScopedLogger('mcp-tool-adapter')
 
 // Ajv tolerant of nonstandard MCP schemas — never brick a tool on an exotic schema.
 const ajv = new Ajv({ allErrors: true, strict: false, validateSchema: false })
 
-/** Wrap MCP tool output in a prompt-injection boundary the model is told to treat as data. */
-export function wrapMcpOutput(serverSlug: string, toolName: string, text: string): string {
-  return `<mcp_tool_output server="${serverSlug}" tool="${toolName}">\n${text}\n</mcp_tool_output>`
-}
-
 type CachedTool = CachedMcpServer['tools'][number]
+
+/**
+ * Parse MCP text output into a structured value when it is a JSON object/array;
+ * otherwise return `undefined` so the caller falls back to the raw string. Only
+ * objects/arrays are walkable (`tool:<name>.path`); scalars stay strings.
+ */
+function tryParseJson(text: string): Record<string, unknown> | unknown[] | undefined {
+  try {
+    const value = JSON.parse(text)
+    return value !== null && typeof value === 'object'
+      ? (value as Record<string, unknown> | unknown[])
+      : undefined
+  } catch {
+    return undefined
+  }
+}
 
 /**
  * Build `AgentToolDefinition`s for one connected MCP server's snapshot.
@@ -34,8 +49,10 @@ type CachedTool = CachedMcpServer['tools'][number]
  * - `requiresApproval` = not readOnly and not trusted.
  * - `validateInputs` lazily compiles ajv against the tool's inputSchema; an uncompilable schema
  *   means "no validation" rather than a dead tool.
- * - `execute` enforces the per-turn/org rate limit, calls the tool, wraps output, and maps errors
- *   to tool-result failures (never throws); a 401 also flags the connection for reconnect.
+ * - `execute` enforces the per-turn/org rate limit, calls the tool, returns the structured
+ *   (walkable) output, and maps errors to tool-result failures (never throws); a 401 also flags the
+ *   connection for reconnect. The prompt-injection boundary is re-applied at the wire layer via the
+ *   `outputBoundary` marker — see `partsToWireFormat`.
  */
 export function buildMcpAgentTools(opts: {
   server: CachedMcpServer
@@ -72,6 +89,12 @@ function buildOne(server: CachedMcpServer, tool: CachedTool): AgentToolDefinitio
     displayName: tool.title ?? tool.name,
     description: `${tool.description ?? tool.name}\n(via ${server.name} MCP server)`,
     parameters: tool.inputSchema,
+    // The stored result schema (server/inferred/manual) as the JSON-Schema read
+    // currency for the discoverability / binding surface. One line, no conversion.
+    ...(tool.outputSchema ? { outputsJsonSchema: tool.outputSchema } : {}),
+    // Marks this tool's output as untrusted external data: the wire layer fences
+    // it for model replay while the stored value stays raw and walkable.
+    outputBoundary: { server: server.slug, tool: tool.name },
     requiresApproval,
     toolsetSlug: server.toolsetSlug,
     validateInputs: async (args) => {
@@ -86,7 +109,12 @@ function buildOne(server: CachedMcpServer, tool: CachedTool): AgentToolDefinitio
     buildDigest: (output) => ({
       server: server.name,
       tool: tool.name,
-      preview: typeof output === 'string' ? output.slice(0, 200) : undefined,
+      preview:
+        typeof output === 'string'
+          ? output.slice(0, 200)
+          : output != null
+            ? JSON.stringify(output).slice(0, 200)
+            : undefined,
     }),
     execute: async (args, ctx) => {
       // Per-call telemetry — server/tool/duration/outcome only. Never args, results, or tokens.
@@ -128,25 +156,22 @@ function buildOne(server: CachedMcpServer, tool: CachedTool): AgentToolDefinitio
           tool.name,
           args
         )
-        // When the server returns a typed result, the serialized JSON is the canonical
-        // model-facing string (per spec the text block SHOULD already be this JSON).
-        const body =
+        // Return the structured value (or parsed JSON text) so `tool:<name>.path`
+        // resolves at runtime; the injection boundary is re-applied at the wire
+        // layer from the tool's `outputBoundary` marker. Genuinely textual tools
+        // stay a scalar string — correct, just not walkable.
+        const value =
           result.structuredContent !== undefined
-            ? JSON.stringify(result.structuredContent, null, 2)
-            : result.text
+            ? result.structuredContent
+            : (tryParseJson(result.text) ?? result.text)
         if (result.isError) {
           logCall(false, 'tool_error')
-          return {
-            success: false,
-            output: null,
-            error: wrapMcpOutput(server.slug, tool.name, body),
-          }
+          // Keep the structured value on `output` (still wire-fenced) and a
+          // human-readable error string alongside it.
+          return { success: false, output: value, error: result.text }
         }
         logCall(true)
-        return {
-          success: true,
-          output: wrapMcpOutput(server.slug, tool.name, body),
-        }
+        return { success: true, output: value }
       } catch (error) {
         const mapped = mapMcpError(error)
         if (error instanceof McpAuthError) {


### PR DESCRIPTION
## What

Extends MCP tool output schemas to non-object roots and adds untrusted-output fencing in the agent framework.

### Schema editor
- New `root: 'object' | 'any'` policy on `SchemaPolicy`. Workflow mode keeps the load-bearing **object-root** contract (provider structured-output + output-variable mapping require it); MCP passes `root: 'any'`.
- `'any'` makes **array/scalar-rooted** result schemas first-class — list tools commonly produce top-level arrays. An **array-of-objects** root seeds the visual row tree from `items.properties` and re-wraps on save (`jsonSchemaRootKind` / `isArrayOfObjectsNode`).
- Pasting a raw array/primitive now returns "This looks like a sample value, not a schema. Use Import to infer one." instead of a generic error.

### MCP tool panel
- A successful test run on a tool with **no schema** silently auto-sets the inferred schema (`source: 'inferred'`) + example in one call — never touches server/manual/inferred.
- "Generate from result" is offered for any inferred root (object, array, or scalar).
- Run button is disabled while a test run is pending.

### Agent framework
- `AgentToolDefinition.outputsJsonSchema` — serializable JSON-Schema read currency for the discoverability / output→input binding surface, carried verbatim from the catalog (`ToolCatalogEntry.outputsJsonSchema`). Distinct from the Zod `outputSchema` authoring source.
- `ToolCallPart.outputBoundary` — marks a tool's `output` as untrusted external data. The stored value stays the raw walkable structured output so `tool:<name>.path` resolves at runtime; `partsToWireFormat` re-fences it as `<mcp_tool_output server tool>…</mcp_tool_output>` for model replay. Absent on pre-existing parts → never re-wrapped.

## Tests
Updated `schema-draft`, `tool-adapter`, and `wire-format-conversion` test suites.