### PR TITLE
fix(mcp): auto-refresh OAuth tokens (lazy refresh + 401 retry + scanner enrollment)

### DIFF
--- a/apps/web/src/app/api/mcp/[serverId]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/mcp/[serverId]/oauth2/callback/route.ts
@@ -1,12 +1,13 @@
 // apps/web/src/app/api/mcp/[serverId]/oauth2/callback/route.ts
 
 import { WEBAPP_URL } from '@auxx/config/urls'
-import { database as db } from '@auxx/database'
+import { database as db, schema } from '@auxx/database'
 import { saveMcpConnection, syncMcpTools } from '@auxx/lib/ai/mcp'
 import { onCacheEvent } from '@auxx/lib/cache'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { interpolateConnectionFields } from '@auxx/services/app-connections'
+import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 
 const OAUTH_REDIRECT_BASE = process.env.NGROK_URL || WEBAPP_URL
@@ -161,6 +162,19 @@ export async function GET(
       connectionId: metadata.connectionId as string | undefined,
     })
     if (saved.isErr()) throw saved.error
+
+    // Enroll the credential in the proactive refresh scanner: stamp the refresh cadence from the
+    // token TTL (30-min floor — the 15-min scanner can't keep shorter tokens warm; the lazy
+    // refresh-on-expiry and 401-retry paths carry those).
+    if (tokens.expires_in && tokens.refresh_token) {
+      const intervalSeconds = Math.max(Number(tokens.expires_in), 1800)
+      if (intervalSeconds !== connDef.oauth2RefreshTokenIntervalSeconds) {
+        await db
+          .update(schema.ConnectionDefinition)
+          .set({ oauth2RefreshTokenIntervalSeconds: intervalSeconds })
+          .where(eq(schema.ConnectionDefinition.id, connDef.id))
+      }
+    }
 
     // First snapshot needs the token — best effort, never fail the connect on a sync error.
     try {

--- a/apps/web/src/components/evals/ui/eval-case-row.tsx
+++ b/apps/web/src/components/evals/ui/eval-case-row.tsx
@@ -82,10 +82,10 @@ export function EvalCaseRow({
         isOpen={isOpen}
         onToggleOpen={() => setIsOpen((o) => !o)}
         secondary={
-          <span className='flex items-center gap-1.5'>
+          <span className='flex items-center gap-1.5 shrink-0'>
             <EvalStatusPill status={primary?.status ?? null} />
             {draft ? (
-              <span className='flex items-center gap-1'>
+              <span className='flex items-center gap-1 shrink-0'>
                 <EvalDraftBadge />
                 <EvalStatusDot status={draft.status} />
               </span>

--- a/apps/web/src/components/evals/ui/eval-status-pill.tsx
+++ b/apps/web/src/components/evals/ui/eval-status-pill.tsx
@@ -104,10 +104,10 @@ export function EvalDraftBadge({ contentHash, className }: EvalDraftBadgeProps) 
   const badge = (
     <span
       className={cn(
-        'inline-flex items-center rounded border border-violet-300 bg-violet-50 px-1 py-px text-[10px] font-medium uppercase tracking-wide text-violet-700',
+        'shrink-0 inline-flex items-center rounded border border-violet-300 bg-violet-50 px-1 py-px text-[10px] font-medium uppercase tracking-wide text-violet-700',
         className
       )}>
-      Draft
+      D
     </span>
   )
   if (!contentHash) return badge

--- a/packages/lib/scripts/check-mcp-token-refresh.ts
+++ b/packages/lib/scripts/check-mcp-token-refresh.ts
@@ -1,0 +1,58 @@
+// packages/lib/scripts/check-mcp-token-refresh.ts
+// One-off check: force-expire the Stripe MCP credential, then exercise the lazy refresh path.
+// Run from apps/worker: npx dotenv -e ../../.env -- node --conditions source --import tsx/esm ../../packages/lib/scripts/check-mcp-token-refresh.ts
+
+import { database as db, schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import { testMcpTool } from '../src/ai/mcp/test-tool'
+
+const organizationId = process.argv[2] ?? 'abgwpa1l81reht2zmwrcihfu'
+const serverId = process.argv[3] ?? 'qxd28mjsqakvuadbp9jg3zgh'
+
+const [before] = await db
+  .select({
+    id: schema.Credential.id,
+    expiresAt: schema.Credential.expiresAt,
+    lastRefreshAt: schema.Credential.lastRefreshAt,
+  })
+  .from(schema.Credential)
+  .where(eq(schema.Credential.mcpServerId, serverId))
+if (!before) throw new Error('No credential found')
+
+// Force-expire so the lazy path must refresh.
+await db
+  .update(schema.Credential)
+  .set({ expiresAt: new Date(Date.now() - 60_000) })
+  .where(eq(schema.Credential.id, before.id))
+console.log('forced expiresAt to past for', before.id)
+
+const result = await testMcpTool({
+  organizationId,
+  userId: 'script-check',
+  serverId,
+  toolName: 'search_stripe_documentation',
+  args: { question: 'How do refunds work?' },
+})
+
+const [after] = await db
+  .select({
+    expiresAt: schema.Credential.expiresAt,
+    lastRefreshAt: schema.Credential.lastRefreshAt,
+    failures: schema.Credential.consecutiveRefreshFailures,
+  })
+  .from(schema.Credential)
+  .where(eq(schema.Credential.id, before.id))
+
+console.log(
+  JSON.stringify(
+    {
+      call: result.ok
+        ? { ok: true, isError: result.isError, durationMs: result.durationMs }
+        : result,
+      credential: after,
+    },
+    null,
+    2
+  )
+)
+process.exit(result.ok ? 0 : 1)

--- a/packages/lib/src/ai/mcp/__tests__/call-with-auth-retry.test.ts
+++ b/packages/lib/src/ai/mcp/__tests__/call-with-auth-retry.test.ts
@@ -1,0 +1,144 @@
+// packages/lib/src/ai/mcp/__tests__/call-with-auth-retry.test.ts
+//
+// Auth context, the MCP client, and the connections module are mocked; the tests assert the
+// 401 → refresh → retry decision tree and that only unrecoverable auth failures flag the
+// connection for reconnect.
+
+import { ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { McpAuthError } from '../errors'
+
+const state = {
+  /** Headers returned by successive buildMcpRequestContext calls. */
+  contexts: [] as { token: string }[],
+  contextError: null as string | null,
+  connectionType: 'oauth2-code' as 'oauth2-code' | 'secret' | 'none',
+  hasRefreshToken: true,
+  /** Outcomes for successive mcpCallTool calls: 'ok' | 'auth' | Error. */
+  callOutcomes: [] as ('ok' | 'auth' | Error)[],
+  refreshCalls: [] as { credentialId: string; force?: boolean }[],
+  markedFailed: [] as string[],
+}
+
+vi.mock('../auth', () => ({
+  buildMcpRequestContext: async () => {
+    if (state.contextError) {
+      const { err } = await import('neverthrow')
+      return err({ code: 'CONNECTION_ERROR', message: state.contextError })
+    }
+    const next = state.contexts.shift() ?? { token: 'tok' }
+    return ok({
+      endpoint: 'https://mcp.example.com',
+      headers: { Authorization: `Bearer ${next.token}` },
+      connectionId: 'cred-1',
+      connectionType: state.connectionType,
+      hasRefreshToken: state.hasRefreshToken,
+    })
+  },
+}))
+
+vi.mock('../client', () => ({
+  mcpCallTool: async () => {
+    const outcome = state.callOutcomes.shift() ?? 'ok'
+    if (outcome === 'ok') return { text: 'result', isError: false }
+    if (outcome === 'auth') throw new McpAuthError('401', {})
+    throw outcome
+  },
+}))
+
+vi.mock('../connections', () => ({
+  ensureFreshMcpToken: async (input: { credentialId: string; force?: boolean }) => {
+    state.refreshCalls.push(input)
+    return true
+  },
+  markMcpConnectionFailed: async (input: { mcpServerId: string }) => {
+    state.markedFailed.push(input.mcpServerId)
+  },
+}))
+
+import { callMcpToolWithAuthRetry } from '../call-with-auth-retry'
+
+const opts = {
+  mcpServerId: 'srv-1',
+  organizationId: 'org-1',
+  toolName: 'search',
+  args: {},
+}
+
+beforeEach(() => {
+  state.contexts = []
+  state.contextError = null
+  state.connectionType = 'oauth2-code'
+  state.hasRefreshToken = true
+  state.callOutcomes = []
+  state.refreshCalls = []
+  state.markedFailed = []
+})
+
+describe('callMcpToolWithAuthRetry', () => {
+  it('returns the result on first-try success', async () => {
+    state.callOutcomes = ['ok']
+    const outcome = await callMcpToolWithAuthRetry(opts)
+    expect(outcome).toEqual({ ok: true, result: { text: 'result', isError: false } })
+    expect(state.refreshCalls).toHaveLength(0)
+  })
+
+  it('maps a context failure', async () => {
+    state.contextError = 'connection missing'
+    const outcome = await callMcpToolWithAuthRetry(opts)
+    expect(outcome).toEqual({ ok: false, kind: 'context', message: 'connection missing' })
+  })
+
+  it('passes non-auth errors through for the caller to map', async () => {
+    const boom = new Error('ECONNRESET')
+    state.callOutcomes = [boom]
+    const outcome = await callMcpToolWithAuthRetry(opts)
+    expect(outcome).toEqual({ ok: false, kind: 'error', error: boom })
+    expect(state.refreshCalls).toHaveLength(0)
+    expect(state.markedFailed).toHaveLength(0)
+  })
+
+  it('recovers from a 401 via force refresh + retry, without flagging the connection', async () => {
+    state.callOutcomes = ['auth', 'ok']
+    const outcome = await callMcpToolWithAuthRetry(opts)
+    expect(outcome.ok).toBe(true)
+    expect(state.refreshCalls).toEqual([
+      { credentialId: 'cred-1', organizationId: 'org-1', hasRefreshToken: true, force: true },
+    ])
+    expect(state.markedFailed).toHaveLength(0)
+  })
+
+  it('flags the connection when the retry also fails auth', async () => {
+    state.callOutcomes = ['auth', 'auth']
+    const outcome = await callMcpToolWithAuthRetry(opts)
+    expect(outcome).toMatchObject({ ok: false, kind: 'auth' })
+    expect(state.refreshCalls).toHaveLength(1)
+    expect(state.markedFailed).toEqual(['srv-1'])
+  })
+
+  it('skips the refresh attempt without a refresh token and flags immediately', async () => {
+    state.hasRefreshToken = false
+    state.callOutcomes = ['auth']
+    const outcome = await callMcpToolWithAuthRetry(opts)
+    expect(outcome).toMatchObject({ ok: false, kind: 'auth' })
+    expect(state.refreshCalls).toHaveLength(0)
+    expect(state.markedFailed).toEqual(['srv-1'])
+  })
+
+  it('skips the refresh attempt for non-oauth connections', async () => {
+    state.connectionType = 'secret'
+    state.callOutcomes = ['auth']
+    const outcome = await callMcpToolWithAuthRetry(opts)
+    expect(outcome).toMatchObject({ ok: false, kind: 'auth' })
+    expect(state.refreshCalls).toHaveLength(0)
+    expect(state.markedFailed).toEqual(['srv-1'])
+  })
+
+  it('passes a non-auth retry error through', async () => {
+    const boom = new Error('500 after refresh')
+    state.callOutcomes = ['auth', boom]
+    const outcome = await callMcpToolWithAuthRetry(opts)
+    expect(outcome).toEqual({ ok: false, kind: 'error', error: boom })
+    expect(state.markedFailed).toHaveLength(0)
+  })
+})

--- a/packages/lib/src/ai/mcp/auth.ts
+++ b/packages/lib/src/ai/mcp/auth.ts
@@ -1,14 +1,16 @@
 // packages/lib/src/ai/mcp/auth.ts
 
-import { database as db, schema } from '@auxx/database'
-import { eq } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
+import { getOrgCache } from '../../cache'
 import { resolveMcpConnectionForRuntime } from './connections'
 
 export interface McpRequestContext {
   endpoint: string
   headers: Record<string, string>
   connectionId?: string
+  connectionType?: 'oauth2-code' | 'secret' | 'none'
+  /** True when a stored refresh token makes a refresh-and-retry on 401 worthwhile. */
+  hasRefreshToken?: boolean
 }
 
 export interface McpAuthErrorResult {
@@ -35,8 +37,10 @@ function interpolateEndpoint(endpoint: string, variables: Record<string, string>
 
 /**
  * Build the per-call request context (endpoint + auth headers) for an MCP server:
- * 1. Load the McpServer row → endpoint.
- * 2. Resolve the org-wide connection (none / secret / oauth2-code).
+ * 1. Resolve the server's endpoint + connection type from the org cache (the same snapshot the
+ *    tool adapter runs against — no per-call DB roundtrips for static server data).
+ * 2. Resolve the org-wide connection (none / secret / oauth2-code) — credential secrets always
+ *    come fresh from the DB, never the cache.
  * 3. `none` → no header; `secret`/`oauth2-code` → `Authorization: Bearer <value>`.
  * 4. Interpolate `{placeholders}` in the endpoint from `metadata.connectionVariables`.
  */
@@ -44,10 +48,8 @@ export async function buildMcpRequestContext(opts: {
   mcpServerId: string
   organizationId: string
 }): Promise<Result<McpRequestContext, McpAuthErrorResult>> {
-  const server = await db.query.McpServer.findFirst({
-    where: eq(schema.McpServer.id, opts.mcpServerId),
-    columns: { endpoint: true },
-  })
+  const servers = await getOrgCache().get(opts.organizationId, 'mcpServers')
+  const server = servers.find((s) => s.serverId === opts.mcpServerId)
   if (!server) {
     return err({ code: 'SERVER_NOT_FOUND', message: `MCP server ${opts.mcpServerId} not found` })
   }
@@ -55,6 +57,7 @@ export async function buildMcpRequestContext(opts: {
   const resolved = await resolveMcpConnectionForRuntime({
     mcpServerId: opts.mcpServerId,
     organizationId: opts.organizationId,
+    connectionType: server.connectionType ?? 'none',
   })
   if (resolved.isErr()) {
     return err({ code: 'CONNECTION_ERROR', message: resolved.error.message })
@@ -81,5 +84,11 @@ export async function buildMcpRequestContext(opts: {
     }
   }
 
-  return ok({ endpoint, headers, connectionId: connection.id || undefined })
+  return ok({
+    endpoint,
+    headers,
+    connectionId: connection.id || undefined,
+    connectionType: connection.type,
+    hasRefreshToken: connection.hasRefreshToken,
+  })
 }

--- a/packages/lib/src/ai/mcp/call-with-auth-retry.ts
+++ b/packages/lib/src/ai/mcp/call-with-auth-retry.ts
@@ -1,0 +1,84 @@
+// packages/lib/src/ai/mcp/call-with-auth-retry.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { buildMcpRequestContext } from './auth'
+import { mcpCallTool } from './client'
+import { ensureFreshMcpToken, markMcpConnectionFailed } from './connections'
+import { McpAuthError } from './errors'
+import type { McpCallResult } from './types'
+
+const logger = createScopedLogger('mcp-call-with-auth-retry')
+
+export type McpCallOutcome =
+  | { ok: true; result: McpCallResult }
+  /** Request context could not be built (server/connection missing). */
+  | { ok: false; kind: 'context'; message: string }
+  /** Auth failed and could not be recovered — connection flagged for reconnect. */
+  | { ok: false; kind: 'auth'; message: string }
+  /** Any other transport/tool failure — caller maps via `mapMcpError`. */
+  | { ok: false; kind: 'error'; error: unknown }
+
+const AUTH_FAILED_MESSAGE = 'MCP server auth failed — an admin may need to reconnect.'
+
+/**
+ * Build the request context and call one MCP tool, recovering from auth failures: on a 401, if
+ * the connection is OAuth with a stored refresh token, force-refresh the credential (single-flight
+ * — the lazy expiry check is bypassed because the token just failed live), rebuild the context,
+ * and retry once. A recovered call never touches the failure counter; only an unrecoverable auth
+ * failure marks the connection for reconnect. Shared by the agent tool adapter and the admin
+ * test-run path.
+ */
+export async function callMcpToolWithAuthRetry(opts: {
+  mcpServerId: string
+  organizationId: string
+  toolName: string
+  args: Record<string, unknown>
+}): Promise<McpCallOutcome> {
+  const { mcpServerId, organizationId, toolName, args } = opts
+
+  const ctxResult = await buildMcpRequestContext({ mcpServerId, organizationId })
+  if (ctxResult.isErr()) {
+    return { ok: false, kind: 'context', message: ctxResult.error.message }
+  }
+
+  try {
+    const result = await mcpCallTool(
+      { endpoint: ctxResult.value.endpoint, headers: ctxResult.value.headers },
+      toolName,
+      args
+    )
+    return { ok: true, result }
+  } catch (error) {
+    if (!(error instanceof McpAuthError)) return { ok: false, kind: 'error', error }
+
+    const { connectionType, hasRefreshToken, connectionId } = ctxResult.value
+    if (connectionType === 'oauth2-code' && hasRefreshToken && connectionId) {
+      logger.info('MCP call got 401 — refreshing token and retrying', { mcpServerId, toolName })
+      await ensureFreshMcpToken({
+        credentialId: connectionId,
+        organizationId,
+        hasRefreshToken: true,
+        force: true,
+      })
+      const retryCtx = await buildMcpRequestContext({ mcpServerId, organizationId })
+      if (retryCtx.isOk()) {
+        try {
+          const result = await mcpCallTool(
+            { endpoint: retryCtx.value.endpoint, headers: retryCtx.value.headers },
+            toolName,
+            args
+          )
+          return { ok: true, result }
+        } catch (retryError) {
+          if (!(retryError instanceof McpAuthError)) {
+            return { ok: false, kind: 'error', error: retryError }
+          }
+        }
+      }
+    }
+
+    // Unrecoverable: no refresh possible, or the refreshed token still 401s.
+    void markMcpConnectionFailed({ mcpServerId, organizationId })
+    return { ok: false, kind: 'auth', message: AUTH_FAILED_MESSAGE }
+  }
+}

--- a/packages/lib/src/ai/mcp/connections/__tests__/ensure-fresh-mcp-token.test.ts
+++ b/packages/lib/src/ai/mcp/connections/__tests__/ensure-fresh-mcp-token.test.ts
@@ -1,0 +1,148 @@
+// packages/lib/src/ai/mcp/connections/__tests__/ensure-fresh-mcp-token.test.ts
+//
+// Redis and the (lazily imported) oauth2-workflow are mocked wholesale; the tests assert the
+// skip/refresh/lock decisions and the adaptive expiry skew.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const refreshCalls: { credentialId: string; organizationId: string }[] = []
+const redisState = {
+  available: true,
+  /** Lock value returned by `set NX` — null simulates "already held". */
+  setResult: 'OK' as string | null,
+  /** Values returned by successive `get` polls on the lock key. */
+  getResults: [] as (string | null)[],
+  setCalls: [] as unknown[][],
+  delCalls: [] as string[],
+}
+
+vi.mock('@auxx/redis', () => ({
+  getRedisClient: async () => {
+    if (!redisState.available) return undefined
+    return {
+      set: async (...args: unknown[]) => {
+        redisState.setCalls.push(args)
+        return redisState.setResult
+      },
+      get: async () => redisState.getResults.shift() ?? null,
+      del: async (key: string) => {
+        redisState.delCalls.push(key)
+        return 1
+      },
+    }
+  },
+}))
+
+vi.mock('../../../../workflows/oauth2-workflow', () => ({
+  refreshCredentialTokens: async (credentialId: string, organizationId: string) => {
+    refreshCalls.push({ credentialId, organizationId })
+    return { success: true, expiresAt: new Date(Date.now() + 3600_000) }
+  },
+}))
+
+import { ensureFreshMcpToken } from '../ensure-fresh-mcp-token'
+
+const base = {
+  credentialId: 'cred-1',
+  organizationId: 'org-1',
+  hasRefreshToken: true,
+}
+
+beforeEach(() => {
+  refreshCalls.length = 0
+  redisState.available = true
+  redisState.setResult = 'OK'
+  redisState.getResults = []
+  redisState.setCalls = []
+  redisState.delCalls = []
+})
+
+describe('ensureFreshMcpToken', () => {
+  it('skips when there is no refresh token', async () => {
+    const changed = await ensureFreshMcpToken({
+      ...base,
+      hasRefreshToken: false,
+      expiresAt: new Date(Date.now() - 1000),
+    })
+    expect(changed).toBe(false)
+    expect(refreshCalls).toHaveLength(0)
+  })
+
+  it('skips when no expiresAt is stored (401 path owns it)', async () => {
+    const changed = await ensureFreshMcpToken({ ...base, expiresAt: null })
+    expect(changed).toBe(false)
+    expect(refreshCalls).toHaveLength(0)
+  })
+
+  it('skips when the token is comfortably fresh', async () => {
+    const changed = await ensureFreshMcpToken({
+      ...base,
+      expiresAt: new Date(Date.now() + 3600_000),
+      createdAt: new Date(),
+    })
+    expect(changed).toBe(false)
+    expect(refreshCalls).toHaveLength(0)
+  })
+
+  it('refreshes an expired token and releases the lock', async () => {
+    const changed = await ensureFreshMcpToken({
+      ...base,
+      expiresAt: new Date(Date.now() - 1000),
+      createdAt: new Date(Date.now() - 3600_000),
+    })
+    expect(changed).toBe(true)
+    expect(refreshCalls).toEqual([{ credentialId: 'cred-1', organizationId: 'org-1' }])
+    expect(redisState.setCalls[0]?.[0]).toBe('mcp:token-refresh:cred-1')
+    expect(redisState.delCalls).toEqual(['mcp:token-refresh:cred-1'])
+  })
+
+  it('refreshes a 1h token inside the 120s window', async () => {
+    const changed = await ensureFreshMcpToken({
+      ...base,
+      expiresAt: new Date(Date.now() + 60_000),
+      lastRefreshAt: new Date(Date.now() - 3540_000), // 1h lifetime → 120s skew applies
+    })
+    expect(changed).toBe(true)
+    expect(refreshCalls).toHaveLength(1)
+  })
+
+  it('adapts the skew for short-lived tokens — a fresh 60s token is NOT "expiring"', async () => {
+    const changed = await ensureFreshMcpToken({
+      ...base,
+      expiresAt: new Date(Date.now() + 50_000),
+      lastRefreshAt: new Date(Date.now() - 10_000), // 60s lifetime → 15s skew, 50s left
+    })
+    expect(changed).toBe(false)
+    expect(refreshCalls).toHaveLength(0)
+  })
+
+  it('force bypasses the expiry check entirely', async () => {
+    const changed = await ensureFreshMcpToken({ ...base, force: true })
+    expect(changed).toBe(true)
+    expect(refreshCalls).toHaveLength(1)
+  })
+
+  it('waits out a held lock without refreshing, and reports a possible rotation', async () => {
+    redisState.setResult = null // lock held elsewhere
+    redisState.getResults = ['1', null] // released on the second poll
+    const changed = await ensureFreshMcpToken({
+      ...base,
+      expiresAt: new Date(Date.now() - 1000),
+      createdAt: new Date(Date.now() - 3600_000),
+    })
+    expect(changed).toBe(true)
+    expect(refreshCalls).toHaveLength(0)
+    expect(redisState.delCalls).toHaveLength(0)
+  })
+
+  it('still refreshes when Redis is unavailable', async () => {
+    redisState.available = false
+    const changed = await ensureFreshMcpToken({
+      ...base,
+      expiresAt: new Date(Date.now() - 1000),
+      createdAt: new Date(Date.now() - 3600_000),
+    })
+    expect(changed).toBe(true)
+    expect(refreshCalls).toHaveLength(1)
+  })
+})

--- a/packages/lib/src/ai/mcp/connections/ensure-fresh-mcp-token.ts
+++ b/packages/lib/src/ai/mcp/connections/ensure-fresh-mcp-token.ts
@@ -1,0 +1,113 @@
+// packages/lib/src/ai/mcp/connections/ensure-fresh-mcp-token.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { getRedisClient } from '@auxx/redis'
+
+const logger = createScopedLogger('ensure-fresh-mcp-token')
+
+/** Hard ceiling on the refresh-ahead window. */
+const MAX_SKEW_MS = 120_000
+/** Fraction of the token lifetime used as the refresh-ahead window for short-lived tokens. */
+const SKEW_LIFETIME_FRACTION = 0.25
+/** Lock TTL — bounds a crashed holder; a refresh roundtrip is well under this. */
+const LOCK_TTL_SECONDS = 30
+const LOCK_POLLS = 3
+const LOCK_POLL_DELAY_MS = 500
+
+const lockKey = (credentialId: string) => `mcp:token-refresh:${credentialId}`
+
+/**
+ * Refresh-ahead window: `min(120s, 25% of token lifetime)`. A fixed window would make any token
+ * with a TTL at or under it permanently "expiring" — refreshing on every call and rotating the
+ * refresh token each time.
+ */
+function expirySkewMs(input: {
+  expiresAt: Date
+  lastRefreshAt?: Date | null
+  createdAt?: Date
+}): number {
+  const issuedAt = input.lastRefreshAt ?? input.createdAt
+  if (!issuedAt) return MAX_SKEW_MS
+  const lifetimeMs = input.expiresAt.getTime() - issuedAt.getTime()
+  if (lifetimeMs <= 0) return MAX_SKEW_MS
+  return Math.min(MAX_SKEW_MS, lifetimeMs * SKEW_LIFETIME_FRACTION)
+}
+
+/**
+ * If the credential's access token is expired or within the refresh-ahead window of expiry and a
+ * refresh token exists, refresh it — single-flight per credential via a Redis NX lock (refresh
+ * tokens may rotate; concurrent refreshes would persist a dead rotation). Returns `true` when the
+ * stored secrets may have changed (a refresh ran here, or another process held the lock) so the
+ * caller knows to re-reveal; `false` means the token was fresh and nothing happened. Never throws:
+ * a failed refresh leaves the stored token in place for the caller's 401 path, and
+ * `refreshCredentialTokens` already stamps the breaker.
+ */
+export async function ensureFreshMcpToken(input: {
+  credentialId: string
+  organizationId: string
+  expiresAt?: Date | null
+  lastRefreshAt?: Date | null
+  createdAt?: Date
+  hasRefreshToken: boolean
+  /** Skip the expiry check — used by the 401 retry path where the token just failed live. */
+  force?: boolean
+}): Promise<boolean> {
+  const { credentialId, organizationId, expiresAt, hasRefreshToken, force } = input
+
+  if (!hasRefreshToken) return false
+  if (!force) {
+    if (!expiresAt) return false // can't tell — leave it to the 401 path
+    const skew = expirySkewMs({
+      expiresAt,
+      lastRefreshAt: input.lastRefreshAt,
+      createdAt: input.createdAt,
+    })
+    if (expiresAt.getTime() - Date.now() > skew) return false
+  }
+
+  let redis: Awaited<ReturnType<typeof getRedisClient>> | null = null
+  try {
+    redis = await getRedisClient(false)
+  } catch {
+    // Redis unavailable → refresh without the lock; correctness beats stampede protection.
+  }
+
+  if (redis) {
+    try {
+      const acquired = await redis.set(lockKey(credentialId), '1', 'EX', LOCK_TTL_SECONDS, 'NX')
+      if (!acquired) {
+        // Someone else is refreshing — wait for the lock to clear, then let the caller re-read
+        // whatever the winner persisted. Never fail the call over lock contention.
+        for (let i = 0; i < LOCK_POLLS; i++) {
+          await new Promise((resolve) => setTimeout(resolve, LOCK_POLL_DELAY_MS))
+          if (!(await redis.get(lockKey(credentialId)))) break
+        }
+        return true
+      }
+    } catch {
+      redis = null // lock machinery failed — refresh anyway
+    }
+  }
+
+  try {
+    // Lazy import: oauth2-workflow pulls in the heavy workflow-nodes/services graph, which a
+    // low-level connections module must not load statically (breaks test mock interception too).
+    const { refreshCredentialTokens } = await import('../../../workflows/oauth2-workflow')
+    const result = await refreshCredentialTokens(credentialId, organizationId)
+    if (!result.success) {
+      logger.warn('MCP token refresh failed', { credentialId, error: result.error })
+    }
+  } catch (error) {
+    logger.warn('MCP token refresh threw', {
+      credentialId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  } finally {
+    if (redis) {
+      try {
+        await redis.del(lockKey(credentialId))
+      } catch {}
+    }
+  }
+  return true
+}

--- a/packages/lib/src/ai/mcp/connections/index.ts
+++ b/packages/lib/src/ai/mcp/connections/index.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/ai/mcp/connections/index.ts
 
 export { deleteMcpConnection } from './delete-mcp-connection'
+export { ensureFreshMcpToken } from './ensure-fresh-mcp-token'
 export { markMcpConnectionFailed } from './mark-mcp-connection-failed'
 export { resolveMcpConnectionForRuntime } from './resolve-mcp-connection-for-runtime'
 export { saveMcpConnection } from './save-mcp-connection'

--- a/packages/lib/src/ai/mcp/connections/resolve-mcp-connection-for-runtime.ts
+++ b/packages/lib/src/ai/mcp/connections/resolve-mcp-connection-for-runtime.ts
@@ -4,6 +4,7 @@ import { findCredential, revealSecrets } from '@auxx/credentials/store'
 import { database as db } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { err, ok, type Result } from 'neverthrow'
+import { ensureFreshMcpToken } from './ensure-fresh-mcp-token'
 import type { McpConnectionError, McpRuntimeConnection } from './types'
 
 const logger = createScopedLogger('resolve-mcp-connection-for-runtime')
@@ -20,29 +21,34 @@ interface McpSecrets {
  * Resolve the org-wide connection for an MCP server, ready for runtime use.
  *
  * Simpler than the app version (org-only, no per-user scope):
- * 1. Look up the ConnectionDefinition for the server to learn its `connectionType`.
+ * 1. Learn the server's `connectionType` — from the caller when it already has it (the cached
+ *    snapshot on the hot tool-call path), otherwise from the ConnectionDefinition.
  * 2. `none` with no credential → return `{ type: 'none', value: '' }`.
  * 3. Otherwise reveal the org-wide `mcp` credential and return its token/secret + metadata.
  */
 export async function resolveMcpConnectionForRuntime(input: {
   mcpServerId: string
   organizationId: string
+  /** Skips the ConnectionDefinition lookup when the caller already knows it (org cache). */
+  connectionType?: 'oauth2-code' | 'secret' | 'none'
 }): Promise<Result<McpRuntimeConnection, McpConnectionError>> {
   const { mcpServerId, organizationId } = input
 
-  let connectionType: 'oauth2-code' | 'secret' | 'none'
-  try {
-    const connDef = await db.query.ConnectionDefinition.findFirst({
-      where: (def, { eq }) => eq(def.mcpServerId, mcpServerId),
-      columns: { connectionType: true },
-    })
-    connectionType = (connDef?.connectionType ?? 'none') as 'oauth2-code' | 'secret' | 'none'
-  } catch (error) {
-    logger.error('Failed to load MCP connection definition', {
-      mcpServerId,
-      error: error instanceof Error ? error.message : String(error),
-    })
-    return err({ code: 'DATABASE_ERROR', message: 'Failed to load connection definition' })
+  let connectionType = input.connectionType
+  if (!connectionType) {
+    try {
+      const connDef = await db.query.ConnectionDefinition.findFirst({
+        where: (def, { eq }) => eq(def.mcpServerId, mcpServerId),
+        columns: { connectionType: true },
+      })
+      connectionType = (connDef?.connectionType ?? 'none') as 'oauth2-code' | 'secret' | 'none'
+    } catch (error) {
+      logger.error('Failed to load MCP connection definition', {
+        mcpServerId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return err({ code: 'DATABASE_ERROR', message: 'Failed to load connection definition' })
+    }
   }
 
   const found = await findCredential({ kind: 'mcp', mcpServerId, organizationId, userId: null })
@@ -72,7 +78,26 @@ export async function resolveMcpConnectionForRuntime(input: {
     return err({ code: 'DECRYPTION_ERROR', message: 'Failed to decrypt MCP credential' })
   }
 
-  const { record, secrets } = revealed.value
+  let { record, secrets } = revealed.value
+
+  // Lazy refresh: OAuth tokens expire (Stripe: 1h) and nothing else refreshes org MCP
+  // credentials proactively. If the token is at/near expiry, refresh and re-reveal the rotated
+  // secrets. The hot path (fresh token) stays at a single reveal.
+  if (connectionType === 'oauth2-code' && secrets.refreshToken) {
+    const maybeRotated = await ensureFreshMcpToken({
+      credentialId: record.id,
+      organizationId,
+      expiresAt: record.expiresAt,
+      lastRefreshAt: record.lastRefreshAt,
+      createdAt: record.createdAt,
+      hasRefreshToken: true,
+    })
+    if (maybeRotated) {
+      const refreshed = await revealSecrets<McpSecrets>(credential.id, organizationId)
+      if (refreshed.isOk()) ({ record, secrets } = refreshed.value)
+    }
+  }
+
   return ok({
     id: record.id,
     type: connectionType,
@@ -80,5 +105,6 @@ export async function resolveMcpConnectionForRuntime(input: {
     headers: secrets.headers,
     metadata: record.metadata,
     expiresAt: record.expiresAt ? record.expiresAt.toISOString() : undefined,
+    hasRefreshToken: !!secrets.refreshToken,
   })
 }

--- a/packages/lib/src/ai/mcp/connections/types.ts
+++ b/packages/lib/src/ai/mcp/connections/types.ts
@@ -25,6 +25,8 @@ export interface McpRuntimeConnection {
   headers?: Record<string, string>
   metadata?: Record<string, unknown>
   expiresAt?: string
+  /** True when a refresh token is stored — the 401 retry path is worth attempting. */
+  hasRefreshToken?: boolean
 }
 
 /** Error shape for the neverthrow connection results. */

--- a/packages/lib/src/ai/mcp/index.ts
+++ b/packages/lib/src/ai/mcp/index.ts
@@ -4,6 +4,8 @@
 
 export type { McpRequestContext } from './auth'
 export { buildMcpRequestContext } from './auth'
+export type { McpCallOutcome } from './call-with-auth-retry'
+export { callMcpToolWithAuthRetry } from './call-with-auth-retry'
 export { createMcpCapabilities } from './capabilities'
 export { mcpCallTool, mcpListTools, withMcpSession } from './client'
 export type {

--- a/packages/lib/src/ai/mcp/test-tool.ts
+++ b/packages/lib/src/ai/mcp/test-tool.ts
@@ -7,10 +7,8 @@ import { createScopedLogger } from '@auxx/logger'
 import Ajv from 'ajv'
 import { getOrgCache } from '../../cache'
 import { inferJsonSchema, type JsonSchema } from '../../json-schema'
-import { buildMcpRequestContext } from './auth'
-import { mcpCallTool } from './client'
-import { markMcpConnectionFailed } from './connections'
-import { McpAuthError, mapMcpError } from './errors'
+import { callMcpToolWithAuthRetry } from './call-with-auth-retry'
+import { mapMcpError } from './errors'
 import { checkAndCountMcpCall } from './rate-limiter'
 
 const logger = createScopedLogger('mcp-test-tool')
@@ -101,40 +99,38 @@ export async function testMcpTool(opts: {
     }
   }
 
-  const ctxResult = await buildMcpRequestContext({ mcpServerId: serverId, organizationId })
-  if (ctxResult.isErr()) {
-    logCall(false, 'context_unavailable')
-    return { ok: false, code: 'server_unavailable', error: ctxResult.error.message }
-  }
+  // Handles context build, the call, and 401 refresh-and-retry; an unrecoverable
+  // auth failure is already flagged for reconnect when it comes back here.
+  const outcome = await callMcpToolWithAuthRetry({
+    mcpServerId: serverId,
+    organizationId,
+    toolName,
+    args,
+  })
 
-  try {
-    const result = await mcpCallTool(
-      { endpoint: ctxResult.value.endpoint, headers: ctxResult.value.headers },
-      toolName,
-      args
-    )
-    logCall(!result.isError, result.isError ? 'tool_error' : undefined)
-    return {
-      ok: true,
-      isError: result.isError,
-      text: result.text,
-      structuredContent: result.structuredContent,
-      durationMs: Date.now() - startedAt,
-      inferredSchema: inferResultSchema(result),
+  if (!outcome.ok) {
+    if (outcome.kind === 'context') {
+      logCall(false, 'context_unavailable')
+      return { ok: false, code: 'server_unavailable', error: outcome.message }
     }
-  } catch (error) {
-    if (error instanceof McpAuthError) {
-      void markMcpConnectionFailed({ mcpServerId: serverId, organizationId })
+    if (outcome.kind === 'auth') {
       logCall(false, 'auth')
-      return {
-        ok: false,
-        code: 'auth',
-        error: 'MCP server auth failed — an admin may need to reconnect.',
-      }
+      return { ok: false, code: 'auth', error: outcome.message }
     }
-    const mapped = mapMcpError(error)
+    const mapped = mapMcpError(outcome.error)
     logCall(false, mapped.code)
     return { ok: false, code: 'error', error: mapped.message }
+  }
+
+  const result = outcome.result
+  logCall(!result.isError, result.isError ? 'tool_error' : undefined)
+  return {
+    ok: true,
+    isError: result.isError,
+    text: result.text,
+    structuredContent: result.structuredContent,
+    durationMs: Date.now() - startedAt,
+    inferredSchema: inferResultSchema(result),
   }
 }
 

--- a/packages/lib/src/ai/mcp/tool-adapter.ts
+++ b/packages/lib/src/ai/mcp/tool-adapter.ts
@@ -10,10 +10,8 @@ import type { AgentToolDefinition } from '../agent-framework/types'
 // the adapter returns raw, walkable output and the boundary is re-applied on
 // model replay. Re-exported here for the MCP barrel + tests.
 import { wrapMcpOutput } from '../agent-framework/utils'
-import { buildMcpRequestContext } from './auth'
-import { mcpCallTool } from './client'
-import { markMcpConnectionFailed } from './connections'
-import { McpAuthError, mapMcpError } from './errors'
+import { callMcpToolWithAuthRetry } from './call-with-auth-retry'
+import { mapMcpError } from './errors'
 import { checkAndCountMcpCall } from './rate-limiter'
 import type { CachedMcpServer } from './types'
 
@@ -141,56 +139,47 @@ function buildOne(server: CachedMcpServer, tool: CachedTool): AgentToolDefinitio
         }
       }
 
-      const ctxResult = await buildMcpRequestContext({
+      // Handles context build, the call, and 401 refresh-and-retry; an unrecoverable
+      // auth failure is already flagged for reconnect when it comes back here.
+      const outcome = await callMcpToolWithAuthRetry({
         mcpServerId: server.serverId,
         organizationId: ctx.organizationId,
+        toolName: tool.name,
+        args,
       })
-      if (ctxResult.isErr()) {
-        logCall(false, 'context_unavailable')
-        return { success: false, output: null, error: ctxResult.error.message }
-      }
 
-      try {
-        const result = await mcpCallTool(
-          { endpoint: ctxResult.value.endpoint, headers: ctxResult.value.headers },
-          tool.name,
-          args
-        )
-        // Return the structured value (or parsed JSON text) so `tool:<name>.path`
-        // resolves at runtime; the injection boundary is re-applied at the wire
-        // layer from the tool's `outputBoundary` marker. Genuinely textual tools
-        // stay a scalar string — correct, just not walkable.
-        const value =
-          result.structuredContent !== undefined
-            ? result.structuredContent
-            : (tryParseJson(result.text) ?? result.text)
-        if (result.isError) {
-          logCall(false, 'tool_error')
-          // Keep the structured value on `output` (still wire-fenced) and a
-          // human-readable error string alongside it.
-          return { success: false, output: value, error: result.text }
+      if (!outcome.ok) {
+        if (outcome.kind === 'context') {
+          logCall(false, 'context_unavailable')
+          return { success: false, output: null, error: outcome.message }
         }
-        logCall(true)
-        return { success: true, output: value }
-      } catch (error) {
-        const mapped = mapMcpError(error)
-        if (error instanceof McpAuthError) {
-          // Fire-and-forget: flag the connection so the settings UI shows "reconnect".
-          void markMcpConnectionFailed({
-            mcpServerId: server.serverId,
-            organizationId: ctx.organizationId,
-          })
+        if (outcome.kind === 'auth') {
           logCall(false, 'auth')
-          return {
-            success: false,
-            output: null,
-            error: 'MCP server auth failed — an admin may need to reconnect.',
-          }
+          return { success: false, output: null, error: outcome.message }
         }
+        const mapped = mapMcpError(outcome.error)
         logCall(false, mapped.code)
         logger.warn('MCP tool execute failed', { server: server.slug, tool: tool.name, mapped })
         return { success: false, output: null, error: mapped.message }
       }
+
+      const result = outcome.result
+      // Return the structured value (or parsed JSON text) so `tool:<name>.path`
+      // resolves at runtime; the injection boundary is re-applied at the wire
+      // layer from the tool's `outputBoundary` marker. Genuinely textual tools
+      // stay a scalar string — correct, just not walkable.
+      const value =
+        result.structuredContent !== undefined
+          ? result.structuredContent
+          : (tryParseJson(result.text) ?? result.text)
+      if (result.isError) {
+        logCall(false, 'tool_error')
+        // Keep the structured value on `output` (still wire-fenced) and a
+        // human-readable error string alongside it.
+        return { success: false, output: value, error: result.text }
+      }
+      logCall(true)
+      return { success: true, output: value }
     },
   }
 }

--- a/packages/lib/src/evals/__tests__/suggestions.test.ts
+++ b/packages/lib/src/evals/__tests__/suggestions.test.ts
@@ -327,6 +327,24 @@ describe('suggestAgentSimulations — drop pipeline', () => {
     })
   })
 
+  it('rescues a toolName wrapped in backticks copied from the prompt', async () => {
+    const result = await run(
+      envelope([
+        validItem({
+          mocks: [{ toolName: '`get_order`', output: JSON.stringify({ status: 'shipped' }) }],
+          assertions: [{ type: 'tool_called', toolName: '`shopify_find_shopify_order`' }],
+        }),
+      ])
+    )
+    const value = result._unsafeUnwrap()
+    expect(value.dropped).toBe(0)
+    expect(value.suggestions[0]?.config.connectorMocks[0]?.toolName).toBe('get_order')
+    expect(value.suggestions[0]?.assertions[0]).toMatchObject({
+      type: 'tool_called',
+      data: { toolName: 'shopify_find_shopify_order' },
+    })
+  })
+
   it('drops an ambiguous tail name instead of guessing', async () => {
     // Both get_order and shopify_find_shopify_order end with `_order`.
     await dropCase(validItem({ mocks: [{ toolName: 'order', output: '{}' }] }))

--- a/packages/lib/src/evals/suggestions.ts
+++ b/packages/lib/src/evals/suggestions.ts
@@ -630,8 +630,10 @@ type AuthoringSuggestion = z.infer<typeof authoringSuggestionSchema>
  * `null` → the item is dropped.
  */
 function resolveToolName(name: string, toolMap: Map<string, AgentToolDefinition>): string | null {
-  if (toolMap.has(name)) return name
-  const matches = [...toolMap.keys()].filter((n) => n.endsWith(`_${name}`))
+  // Small models copy the prompt's backticks into the JSON value (`mcp__…`).
+  const cleaned = name.trim().replace(/^`+|`+$/g, '')
+  if (toolMap.has(cleaned)) return cleaned
+  const matches = [...toolMap.keys()].filter((n) => n.endsWith(`_${cleaned}`))
   return matches.length === 1 ? (matches[0] ?? null) : null
 }
 

--- a/packages/lib/src/workflows/__tests__/oauth2-refresh-request.test.ts
+++ b/packages/lib/src/workflows/__tests__/oauth2-refresh-request.test.ts
@@ -1,0 +1,180 @@
+// packages/lib/src/workflows/__tests__/oauth2-refresh-request.test.ts
+//
+// Covers the MCP branch of `refreshCredentialTokens`: the RFC 8707 `resource` indicator on the
+// refresh request, the conditional `client_secret` (DCR public clients have none), and the
+// scanner-interval re-stamp from `expires_in`. Heavy deps are mocked wholesale; the token
+// request itself is asserted via a fetch stub.
+
+import { ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@auxx/config/server', () => ({ WEBAPP_URL: 'https://app.example.com' }))
+vi.mock('@auxx/credentials', () => ({
+  CredentialTypeRegistry: class {},
+  configService: { get: () => null },
+}))
+vi.mock('@auxx/workflow-nodes/server', () => ({ URLTemplateService: {} }))
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+}))
+
+const storeCalls = {
+  rotated: [] as Record<string, unknown>[],
+  refreshSuccess: [] as { expiresAt: Date | null }[],
+}
+const storeState = {
+  record: {} as Record<string, unknown>,
+  secrets: {} as Record<string, unknown>,
+}
+
+vi.mock('@auxx/credentials/store', () => ({
+  insertCredential: async () => ok({ id: 'cred-1' }),
+  recordRefreshFailure: async () => ok(undefined),
+  recordRefreshSuccess: async (_id: string, _org: string, opts: { expiresAt: Date | null }) => {
+    storeCalls.refreshSuccess.push(opts)
+    return ok(undefined)
+  },
+  revealSecrets: async () => ok({ record: storeState.record, secrets: storeState.secrets }),
+  rotateSecrets: async (_id: string, _org: string, secrets: Record<string, unknown>) => {
+    storeCalls.rotated.push(secrets)
+    return ok(undefined)
+  },
+}))
+
+const dbState = {
+  connectionDefinition: null as Record<string, unknown> | null,
+  mcpServer: null as { endpoint: string } | null,
+  updates: [] as Record<string, unknown>[],
+}
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    query: {
+      ConnectionDefinition: { findFirst: async () => dbState.connectionDefinition },
+      McpServer: { findFirst: async () => dbState.mcpServer },
+    },
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: async () => {
+          dbState.updates.push(values)
+        },
+      }),
+    }),
+  },
+  schema: {
+    ConnectionDefinition: {
+      id: 'ConnectionDefinition.id',
+      mcpServerId: 'cd.mcpServerId',
+      appId: 'cd.appId',
+      connectionType: 'cd.connectionType',
+    },
+    McpServer: { id: 'McpServer.id' },
+  },
+}))
+
+const interpolated = {
+  clientSecret: undefined as string | undefined,
+}
+
+vi.mock('@auxx/services/app-connections', () => ({
+  interpolateConnectionFields: () => ({
+    authorizeUrl: 'https://as.example.com/authorize',
+    accessTokenUrl: 'https://as.example.com/token',
+    clientId: 'client-123',
+    clientSecret: interpolated.clientSecret,
+  }),
+}))
+
+import { refreshCredentialTokens } from '../oauth2-workflow'
+
+const fetchCalls: { url: string; body: URLSearchParams }[] = []
+
+beforeEach(() => {
+  fetchCalls.length = 0
+  storeCalls.rotated.length = 0
+  storeCalls.refreshSuccess.length = 0
+  dbState.updates.length = 0
+  interpolated.clientSecret = undefined
+  storeState.record = {
+    id: 'cred-1',
+    kind: 'mcp',
+    mcpServerId: 'srv-1',
+    metadata: {},
+    consecutiveRefreshFailures: 0,
+  }
+  storeState.secrets = { accessToken: 'old-token', refreshToken: 'refresh-1' }
+  dbState.connectionDefinition = {
+    id: 'def-1',
+    oauth2AccessTokenUrl: 'https://as.example.com/token',
+    oauth2TokenRequestAuthMethod: null,
+    oauth2RefreshTokenIntervalSeconds: null,
+  }
+  dbState.mcpServer = { endpoint: 'https://mcp.stripe.com' }
+
+  vi.stubGlobal('fetch', async (url: string, init: { body: string }) => {
+    fetchCalls.push({ url, body: new URLSearchParams(init.body) })
+    return {
+      ok: true,
+      json: async () => ({
+        access_token: 'new-token',
+        refresh_token: 'refresh-2',
+        expires_in: 3600,
+      }),
+    }
+  })
+})
+
+describe('refreshCredentialTokens (mcp)', () => {
+  it('sends the RFC 8707 resource indicator and omits client_secret for public clients', async () => {
+    const result = await refreshCredentialTokens('cred-1', 'org-1')
+
+    expect(result.success).toBe(true)
+    const body = fetchCalls[0]?.body
+    expect(body?.get('grant_type')).toBe('refresh_token')
+    expect(body?.get('refresh_token')).toBe('refresh-1')
+    expect(body?.get('client_id')).toBe('client-123')
+    expect(body?.get('resource')).toBe('https://mcp.stripe.com')
+    expect(body?.has('client_secret')).toBe(false)
+  })
+
+  it('includes client_secret when the definition has one', async () => {
+    interpolated.clientSecret = 'shh'
+    await refreshCredentialTokens('cred-1', 'org-1')
+    expect(fetchCalls[0]?.body.get('client_secret')).toBe('shh')
+  })
+
+  it('rotates secrets and re-stamps the scanner interval from expires_in', async () => {
+    const result = await refreshCredentialTokens('cred-1', 'org-1')
+
+    expect(result.success).toBe(true)
+    expect(storeCalls.rotated[0]).toMatchObject({
+      accessToken: 'new-token',
+      refreshToken: 'refresh-2',
+    })
+    expect(storeCalls.refreshSuccess[0]?.expiresAt).toBeInstanceOf(Date)
+    expect(dbState.updates).toEqual([{ oauth2RefreshTokenIntervalSeconds: 3600 }])
+  })
+
+  it('skips the interval update when it already matches', async () => {
+    dbState.connectionDefinition = {
+      ...dbState.connectionDefinition!,
+      oauth2RefreshTokenIntervalSeconds: 3600,
+    }
+    await refreshCredentialTokens('cred-1', 'org-1')
+    expect(dbState.updates).toHaveLength(0)
+  })
+
+  it('does not send a resource indicator for app credentials', async () => {
+    storeState.record = {
+      id: 'cred-1',
+      kind: 'app',
+      appId: 'app-1',
+      metadata: {},
+      consecutiveRefreshFailures: 0,
+    }
+    await refreshCredentialTokens('cred-1', 'org-1')
+    expect(fetchCalls[0]?.body.has('resource')).toBe(false)
+    expect(dbState.updates).toHaveLength(0)
+  })
+})

--- a/packages/lib/src/workflows/oauth2-workflow.ts
+++ b/packages/lib/src/workflows/oauth2-workflow.ts
@@ -196,6 +196,8 @@ export async function refreshCredentialTokens(
       refresh_token?: string
       expires_in?: number
     }
+    // For MCP: re-stamped from `expires_in` after a successful refresh (TTLs drift server-side).
+    let mcpConnDef: { id: string; oauth2RefreshTokenIntervalSeconds: number | null } | null = null
 
     if (record.kind === 'app' || record.kind === 'mcp') {
       // App- and mcp-connections share the oauth2 columns + circuit-breaker path; only the owner
@@ -213,6 +215,7 @@ export async function refreshCredentialTokens(
           oauth2ClientId: true,
           oauth2ClientSecret: true,
           oauth2TokenRequestAuthMethod: true,
+          oauth2RefreshTokenIntervalSeconds: true,
         },
       })
 
@@ -223,12 +226,26 @@ export async function refreshCredentialTokens(
       const variables = (record.metadata.connectionVariables as Record<string, string>) ?? {}
       const resolved = interpolateConnectionFields(connDef, variables)
 
+      // RFC 8707 resource indicator — the MCP spec requires it on every token request, and it
+      // must match the value the authorize/code-exchange steps sent (the raw endpoint).
+      let resource: string | undefined
+      if (record.kind === 'mcp' && record.mcpServerId) {
+        const server = await db.query.McpServer.findFirst({
+          where: eq(schema.McpServer.id, record.mcpServerId),
+          columns: { endpoint: true },
+        })
+        resource = server?.endpoint
+      }
+
+      if (record.kind === 'mcp') mcpConnDef = connDef
+
       tokenData = await makeTokenRefreshRequest(
         resolved.accessTokenUrl,
         resolved.clientId,
         resolved.clientSecret,
         secrets.refreshToken,
-        connDef.oauth2TokenRequestAuthMethod || 'request-body'
+        connDef.oauth2TokenRequestAuthMethod || 'request-body',
+        resource
       )
     } else {
       // Workflow credentials — resolve the OAuth2 config from the registry.
@@ -261,6 +278,18 @@ export async function refreshCredentialTokens(
 
     // Reset the breaker + stamp lastRefreshAt + new expiry.
     await recordRefreshSuccess(credentialId, organizationId, { expiresAt: newExpiresAt })
+
+    // Keep the scanner's cadence tracking the actual MCP token TTL (30-min floor — the 15-min
+    // scanner can't keep shorter tokens warm; the lazy/401 paths carry those).
+    if (mcpConnDef && tokenData.expires_in) {
+      const intervalSeconds = Math.max(tokenData.expires_in, 1800)
+      if (intervalSeconds !== mcpConnDef.oauth2RefreshTokenIntervalSeconds) {
+        await db
+          .update(schema.ConnectionDefinition)
+          .set({ oauth2RefreshTokenIntervalSeconds: intervalSeconds })
+          .where(eq(schema.ConnectionDefinition.id, mcpConnDef.id))
+      }
+    }
 
     logger.info('Token refresh succeeded', {
       credentialId,
@@ -475,15 +504,19 @@ function validateState(state: OAuth2State): void {
 async function makeTokenRefreshRequest(
   tokenUrl: string,
   clientId: string,
-  clientSecret: string,
+  clientSecret: string | null | undefined,
   refreshToken: string,
-  authMethod: string
+  authMethod: string,
+  resource?: string
 ): Promise<{ access_token: string; refresh_token?: string; expires_in?: number }> {
   const tokenRequestBody: Record<string, string> = {
     grant_type: 'refresh_token',
     refresh_token: refreshToken,
     client_id: clientId,
-    client_secret: clientSecret,
+    // Public clients (e.g. DCR-minted MCP clients, PKCE-only) have no secret — omit the field
+    // rather than sending an empty value some ASes reject.
+    ...(clientSecret ? { client_secret: clientSecret } : {}),
+    ...(resource ? { resource } : {}),
   }
 
   const headers: Record<string, string> = {
@@ -492,7 +525,7 @@ async function makeTokenRefreshRequest(
   }
 
   if (authMethod === 'basic-auth') {
-    const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+    const basicAuth = Buffer.from(`${clientId}:${clientSecret ?? ''}`).toString('base64')
     headers.Authorization = `Basic ${basicAuth}`
     delete tokenRequestBody.client_id
     delete tokenRequestBody.client_secret


### PR DESCRIPTION
## Problem

OAuth MCP connections die after their access-token TTL (Stripe: exactly 1 hour) and never recover without a manual reconnect — every call fails with `errorCode: 'auth'`. Three gaps:

1. The proactive refresh scanner filters on `oauth2RefreshTokenIntervalSeconds IS NOT NULL`, which was never set for MCP ConnectionDefinitions — MCP credentials were invisible to it.
2. `resolveMcpConnectionForRuntime` returned the stored access token as-is, ignoring `expiresAt`.
3. Both call sites caught `McpAuthError`, bumped the failure counter, and gave up.

Plus two latent bugs in the (never-exercised) MCP branch of `refreshCredentialTokens`: no RFC 8707 `resource` indicator on the refresh request, and `client_secret` sent unconditionally (public DCR clients have none).

## Changes

- **Lazy refresh-on-expiry** (`ensureFreshMcpToken`): hooked into `resolveMcpConnectionForRuntime`; adaptive skew `min(120s, 25% of token lifetime)` so short-TTL tokens don't degrade to refresh-per-call; Redis NX single-flight lock per credential (refresh tokens rotate — concurrent refreshes would persist a dead rotation); lock losers poll then proceed.
- **401 refresh-and-retry** (`callMcpToolWithAuthRetry`): shared by the agent tool adapter and the admin test-run path (replaces their duplicated catch blocks). Force-refresh once, rebuild context, retry once. A recovered call never touches the failure counter — expiry-driven 401s can no longer open the circuit breaker that would block their own fix.
- **Refresh request fixes**: MCP refreshes now send the RFC 8707 `resource` (raw endpoint, matching the authorize + code-exchange steps) and omit `client_secret` when absent.
- **Scanner enrollment**: `oauth2RefreshTokenIntervalSeconds` stamped from `expires_in` at connect time and re-stamped on refresh when the TTL drifts (30-min floor — the 15-min scanner can't keep shorter tokens warm; lazy + 401 paths carry those).
- **Perf**: `buildMcpRequestContext` resolves endpoint + connectionType from the cached `mcpServers` org-cache snapshot instead of two per-call DB queries (credential secrets still come fresh from the DB, never the cache). Per-call DB roundtrips: 4 → 2.

Also includes a small separate commit: evals suggestion tool-name backtick stripping + compact draft badge.

## Verification

- Live against Stripe: force-expired the dev credential and ran the real path (`packages/lib/scripts/check-mcp-token-refresh.ts`) — transparent refresh (`Token refresh succeeded`), successful tool call, `lastRefreshAt` stamped, failures 0, interval stamped to 3600. Stripe accepted the refresh with `resource` and no `client_secret`.
- 139 tests pass across `src/ai/mcp` + `src/workflows` (22 new: skew/lock/force behavior, 401 retry decision tree, refresh request body + interval re-stamp).

Plan: `plans/mcp/v5/mcp-oauth-token-refresh.md` (local).