### PR TITLE
feat(editor): arrow-key drilling + inline article-link drill in the slash menu

### DIFF
--- a/apps/web/src/components/editor/inline-picker/nodes/reference-picker-node.tsx
+++ b/apps/web/src/components/editor/inline-picker/nodes/reference-picker-node.tsx
@@ -101,11 +101,18 @@ interface ReferencePickerOptions {
   /** ArrowUp/Down inside a `/` chip — move the slash list highlight. */
   onSlashArrowVertical?: (direction: 1 | -1) => boolean
   /**
-   * Backspace on an EMPTY, drilled `/` chip (`tab !== null`). Return true if
-   * a drill level was popped (the popover owns the drill stack); false falls
-   * through to deleting the chip.
+   * Backspace or ArrowLeft on an EMPTY, drilled `/` chip (`tab !== null`).
+   * Return true if a drill level was popped (the popover owns the drill
+   * stack); false falls through (Backspace deletes the chip, ArrowLeft moves
+   * the caret).
    */
   onSlashBackspacePop?: () => boolean
+  /**
+   * ArrowRight inside a `/` chip — drill into the highlighted slash item if
+   * it's drillable. Return true to consume the key (drill-first: takes
+   * priority over caret movement); false falls through to caret movement.
+   */
+  onSlashArrowRight?: () => boolean
 }
 
 function findPickerNode(state: import('@tiptap/pm/state').EditorState) {
@@ -282,6 +289,7 @@ export const ReferencePickerNode = Node.create<ReferencePickerOptions>({
       onSlashEnter: undefined,
       onSlashArrowVertical: undefined,
       onSlashBackspacePop: undefined,
+      onSlashArrowRight: undefined,
     }
   },
 
@@ -571,6 +579,16 @@ export const ReferencePickerNode = Node.create<ReferencePickerOptions>({
                 view.dispatch(tr.scrollIntoView())
                 return true
               }
+              // Empty drilled `/` chip: pop a drill level (mirrors Backspace).
+              if (
+                isSlash &&
+                realQueryLen === 0 &&
+                pickerNode.attrs.tab !== null &&
+                options.onSlashBackspacePop?.()
+              ) {
+                event.preventDefault()
+                return true
+              }
               // Effective content start sits AFTER the seed ZWSP — don't let
               // the user park the cursor before it.
               const hasZwsp = pickerNode.textContent.startsWith(ZWSP)
@@ -589,6 +607,12 @@ export const ReferencePickerNode = Node.create<ReferencePickerOptions>({
                 // Enter the chip from the badge
                 const tr = state.tr.setSelection(TextSelection.create(state.doc, contentStart))
                 view.dispatch(tr.scrollIntoView())
+                return true
+              }
+              // `/` chip: drill into the highlighted item if it's drillable —
+              // drill-first, so it wins over caret movement.
+              if (isSlash && options.onSlashArrowRight?.()) {
+                event.preventDefault()
                 return true
               }
               if (parentOffset === parentContentSize) {

--- a/apps/web/src/components/editor/kb-article/block-node.ts
+++ b/apps/web/src/components/editor/kb-article/block-node.ts
@@ -72,7 +72,7 @@ export const Block = Node.create<BlockOptions>({
   defining: true,
 
   addOptions() {
-    return { placeholderText: "Press '/' for commands" }
+    return { placeholderText: "Press '/' for commands, '@' for mentions" }
   },
 
   addAttributes() {

--- a/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-article-editor.tsx
@@ -56,8 +56,8 @@ interface KBArticleEditorProps {
 
 interface LinkPopoverState {
   rect: DOMRect
-  /** When set, replaces this range; otherwise inserts at the cursor. */
-  range?: { from: number; to: number }
+  /** Selection / existing-link range the picked link replaces. */
+  range: { from: number; to: number }
   /** Prefill values when editing an existing link. */
   edit?: ArticleLinkEditMode
 }
@@ -92,6 +92,7 @@ export function KBArticleEditor({
     []
   )
   const onSlashBackspacePop = useCallback(() => slashRef.current?.popLevel() ?? false, [])
+  const onSlashArrowRight = useCallback(() => slashRef.current?.drillHighlighted() ?? false, [])
 
   const { editor, gutterCharWidth } = useKBArticleEditor({
     initialContent,
@@ -101,6 +102,7 @@ export function KBArticleEditor({
     onSlashEnter,
     onSlashArrowVertical,
     onSlashBackspacePop,
+    onSlashArrowRight,
   })
   const activePicker = useActivePicker(editor)
   const [linkPopover, setLinkPopover] = useState<LinkPopoverState | null>(null)
@@ -156,17 +158,6 @@ export function KBArticleEditor({
     })
   }
 
-  const handleLinkArticle = useCallback((editorInstance: Editor, insertPos: number) => {
-    const coords = editorInstance.view.coordsAtPos(insertPos)
-    const rect = new DOMRect(
-      coords.left,
-      coords.top,
-      Math.max(1, coords.right - coords.left),
-      Math.max(1, coords.bottom - coords.top)
-    )
-    setLinkPopover({ rect })
-  }, [])
-
   const handleBubbleLinkRequest = useCallback(() => {
     if (!editor) return
     const { from, to } = editor.state.selection
@@ -199,12 +190,7 @@ export function KBArticleEditor({
         attrs: { href: pick.href, target: isInternal ? null : '_blank' },
       }
       const node = { type: 'text', text: pick.text, marks: [mark] }
-      const chain = editor.chain().focus()
-      if (linkPopover.range) {
-        chain.insertContentAt(linkPopover.range, node)
-      } else {
-        chain.insertContent(node)
-      }
+      const chain = editor.chain().focus().insertContentAt(linkPopover.range, node)
       // Strip the stored link mark so the next typed character isn't linked.
       chain
         .command(({ tr }) => {
@@ -300,7 +286,6 @@ export function KBArticleEditor({
             }}
             onClose={() => editor?.commands.closeReferencePicker({ keepText: true })}
             onScopeChange={(scope) => editor?.commands.setPickerScope(scope, { clearQuery: true })}
-            onLinkArticle={handleLinkArticle}
             editor={editor}
           />
         </InlinePickerPopover>

--- a/apps/web/src/components/editor/kb-article/kb-slash-content.tsx
+++ b/apps/web/src/components/editor/kb-article/kb-slash-content.tsx
@@ -7,7 +7,7 @@ import {
   useCommandNavigation,
 } from '@auxx/ui/components/command'
 import { EntityIcon } from '@auxx/ui/components/icons'
-import { generateId } from '@auxx/utils'
+import { buildAuxxArticleUrl, generateId } from '@auxx/utils'
 import { TextSelection } from '@tiptap/pm/state'
 import type { Editor } from '@tiptap/react'
 import { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
@@ -22,8 +22,11 @@ import type {
   SlashCommandSection,
 } from '~/components/editor/slash-commands/slash-command-picker'
 import { type SlashContentHandle, SlashList } from '~/components/editor/slash-commands/slash-list'
+import { useArticleList } from '~/components/kb/hooks/use-article-list'
+import { ArticlePicker } from '~/components/kb/ui/articles/article-picker'
 import { useCmdkRemote } from '~/components/pickers/use-cmdk-remote'
 import { api } from '~/trpc/react'
+import { useKBEditorContext } from './editor-context'
 
 type Range = { from: number; to: number }
 
@@ -39,9 +42,6 @@ interface KBSlashContentProps {
    * Called on every drill push/pop so the pill reads `/ SNIPPETS …`.
    */
   onScopeChange: (scope: string | null) => void
-  /** Open the article-link dialog. The picker deletes the slash range first
-   * and passes the resulting cursor position to the host. */
-  onLinkArticle?: (editor: Editor, insertPos: number) => void
   /** Live editor instance — used to filter container blocks (`tabs`,
    * `accordion`) out of the menu when the cursor is inside a panel. */
   editor?: Editor | null
@@ -258,6 +258,7 @@ const TOOL_COMMANDS: SlashCommandItem[] = [
     description: 'Insert a link to another KB article',
     keywords: ['link', 'article', 'reference', 'href', 'url'],
     iconId: 'link',
+    drillDown: true,
   },
 ]
 
@@ -331,9 +332,9 @@ interface SnippetItem extends SlashCommandItem {
  * level starts with a fresh filter.
  */
 export function KBSlashContent(props: KBSlashContentProps) {
-  const [mode, setMode] = useState<'default' | 'placeholder'>('default')
+  const [mode, setMode] = useState<'default' | 'placeholder' | 'articleLink'>('default')
 
-  const exitPlaceholderMode = useCallback(() => {
+  const exitMode = useCallback(() => {
     setMode('default')
     props.onScopeChange(null)
   }, [props.onScopeChange])
@@ -342,7 +343,7 @@ export function KBSlashContent(props: KBSlashContentProps) {
     return (
       <PlaceholderMode
         ref={props.ref}
-        onBack={exitPlaceholderMode}
+        onBack={exitMode}
         onClose={props.onClose}
         onSelect={(id) => {
           props.onExecute((editor, range) => {
@@ -359,6 +360,17 @@ export function KBSlashContent(props: KBSlashContentProps) {
     )
   }
 
+  if (mode === 'articleLink') {
+    return (
+      <ArticleLinkMode
+        ref={props.ref}
+        onBack={exitMode}
+        onClose={props.onClose}
+        onExecute={props.onExecute}
+      />
+    )
+  }
+
   return (
     <CommandNavigation<SlashCommandNavItem>>
       <KBSlashContentInner
@@ -366,6 +378,10 @@ export function KBSlashContent(props: KBSlashContentProps) {
         onEnterPlaceholderMode={() => {
           setMode('placeholder')
           props.onScopeChange('Placeholder')
+        }}
+        onEnterArticleLinkMode={() => {
+          setMode('articleLink')
+          props.onScopeChange('Link article')
         }}
       />
     </CommandNavigation>
@@ -416,16 +432,92 @@ function PlaceholderMode({
   )
 }
 
+/**
+ * Article-link mode embeds `ArticlePicker` (the same form the bubble-menu
+ * link flow uses) as a drilled level — no separate popover. Like placeholder
+ * mode it's an input-driven picker whose own search takes real focus; the
+ * chip goes inert for the duration. Picking deletes the chip and inserts the
+ * linked title in one transaction.
+ */
+function ArticleLinkMode({
+  ref,
+  onBack,
+  onClose,
+  onExecute,
+}: {
+  ref?: React.Ref<SlashContentHandle>
+  onBack: () => void
+  onClose: () => void
+  onExecute: KBSlashContentProps['onExecute']
+}) {
+  const { knowledgeBaseId } = useKBEditorContext()
+  const articles = useArticleList(knowledgeBaseId)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const remote = useCmdkRemote(containerRef, 'article-link')
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      ...remote,
+      popLevel: () => {
+        onBack()
+        return true
+      },
+    }),
+    [remote, onBack]
+  )
+
+  return (
+    <div ref={containerRef} className='w-72 overflow-hidden'>
+      <ArticlePicker
+        knowledgeBaseId={knowledgeBaseId}
+        allowedKinds={['page', 'link']}
+        drillableKinds={['tab', 'category', 'header']}
+        rootLabel='Link to article'
+        searchPlaceholder='Search articles…'
+        flattenSearch
+        autoFocusSearch
+        onBack={onBack}
+        backLabel='Commands'
+        onPick={(articleId) => {
+          const found = articles.find((a) => a.id === articleId)
+          const href = buildAuxxArticleUrl(articleId)
+          const text = found?.title || 'article'
+          onExecute((editor, range) => {
+            editor
+              .chain()
+              .focus()
+              .deleteRange(range)
+              .insertContent({
+                type: 'text',
+                text,
+                marks: [{ type: 'link', attrs: { href, target: null } }],
+              })
+              // Strip the stored link mark so the next typed character isn't linked.
+              .command(({ tr }) => {
+                tr.removeStoredMark(editor.schema.marks.link)
+                return true
+              })
+              .run()
+          })
+        }}
+        onClose={onClose}
+      />
+    </div>
+  )
+}
+
 function KBSlashContentInner({
   ref,
   query,
   onExecute,
   onScopeChange,
-  onLinkArticle,
   editor,
   onEnterPlaceholderMode,
+  onEnterArticleLinkMode,
 }: KBSlashContentProps & {
   onEnterPlaceholderMode: () => void
+  onEnterArticleLinkMode: () => void
 }) {
   const { push, pop, isAtRoot, current, stack } = useCommandNavigation<SlashCommandNavItem>()
   const containerRef = useRef<HTMLDivElement>(null)
@@ -494,9 +586,6 @@ function KBSlashContentInner({
   // and rendering as a single CommandGroup.
   const suggestionItems: SlashCommandItem[] = useMemo(() => {
     if (isInSnippets) return []
-    const tools = onLinkArticle
-      ? TOOL_COMMANDS
-      : TOOL_COMMANDS.filter((c) => c.id !== 'article-link')
     let blocks: BlockCommandDef[] = [...BASIC_BLOCK_COMMANDS, ...KB_BLOCK_COMMANDS]
     // Containers can't nest inside a panel — ProseMirror's schema would
     // reject the insert, but hiding from the menu keeps it tidy.
@@ -508,8 +597,8 @@ function KBSlashContentInner({
     if (editor && selectionIsInsideTableCell(editor)) {
       blocks = blocks.filter((c) => !CELL_RESTRICTED_COMMAND_IDS.has(c.id))
     }
-    return [...tools, ...blocks]
-  }, [isInSnippets, onLinkArticle, editor])
+    return [...TOOL_COMMANDS, ...blocks]
+  }, [isInSnippets, editor])
 
   const enterSnippetsDrillDown = useCallback(() => {
     push({ id: 'snippets', label: 'Snippets', type: 'snippets' })
@@ -553,18 +642,15 @@ function KBSlashContentInner({
         onEnterPlaceholderMode()
         return
       }
-      if (item.id === 'article-link' && onLinkArticle) {
-        onExecute((editor, range) => {
-          editor.chain().focus().deleteRange(range).run()
-          onLinkArticle(editor, range.from)
-        })
+      if (item.id === 'article-link') {
+        onEnterArticleLinkMode()
         return
       }
       // Anything left is a block command.
       if (TOOL_IDS.has(item.id)) return
       onExecute(runBlockCommand(item as BlockCommandDef))
     },
-    [enterSnippetsDrillDown, onEnterPlaceholderMode, onLinkArticle, onExecute]
+    [enterSnippetsDrillDown, onEnterPlaceholderMode, onEnterArticleLinkMode, onExecute]
   )
 
   const sections: SlashCommandSection<SlashCommandItem>[] = useMemo(() => {

--- a/apps/web/src/components/editor/kb-article/use-kb-article-editor.tsx
+++ b/apps/web/src/components/editor/kb-article/use-kb-article-editor.tsx
@@ -15,6 +15,7 @@ interface UseKBArticleEditorOptions {
   onSlashEnter?: () => boolean
   onSlashArrowVertical?: (direction: 1 | -1) => boolean
   onSlashBackspacePop?: () => boolean
+  onSlashArrowRight?: () => boolean
 }
 
 /**
@@ -30,6 +31,7 @@ export function useKBArticleEditor({
   onSlashEnter,
   onSlashArrowVertical,
   onSlashBackspacePop,
+  onSlashArrowRight,
 }: UseKBArticleEditorOptions) {
   const { editor, gutterCharWidth } = useRichTextEditor({
     initialContent,
@@ -38,6 +40,7 @@ export function useKBArticleEditor({
     onSlashEnter,
     onSlashArrowVertical,
     onSlashBackspacePop,
+    onSlashArrowRight,
     enableReferencePicker: true,
     onPickerEnter,
     onPickerArrowVertical,

--- a/apps/web/src/components/editor/placeholders/placeholder-picker-content.tsx
+++ b/apps/web/src/components/editor/placeholders/placeholder-picker-content.tsx
@@ -336,14 +336,14 @@ function FieldPickerForRoot({
 }
 
 /**
- * Small back-to-parent-picker header shown at the root level of the
- * placeholder picker when it's embedded inside a larger picker (e.g.
- * slash-command). Mirrors `CommandBreadcrumb`'s visual language (ghost
- * back icon + ghost-button label) rather than being a full-width clickable
- * row — the old `BackBar` looked like a `CommandItem` because it had
- * `hover:bg-accent w-full`, which confused users.
+ * Small back-to-parent-picker header shown at the root level of a picker
+ * embedded inside a larger picker (e.g. slash-command). Mirrors
+ * `CommandBreadcrumb`'s visual language (ghost back icon + ghost-button
+ * label) rather than being a full-width clickable row — the old `BackBar`
+ * looked like a `CommandItem` because it had `hover:bg-accent w-full`,
+ * which confused users.
  */
-function ParentBackHeader({ label, onBack }: { label: string; onBack: () => void }) {
+export function ParentBackHeader({ label, onBack }: { label: string; onBack: () => void }) {
   return (
     <div className='flex items-center border-b px-2 py-1 text-sm shrink-0'>
       <Button variant='ghost' size='icon-xs' onClick={onBack}>

--- a/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
+++ b/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
@@ -148,6 +148,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
     []
   )
   const onSlashBackspacePop = useCallback(() => slashRef.current?.popLevel() ?? false, [])
+  const onSlashArrowRight = useCallback(() => slashRef.current?.drillHighlighted() ?? false, [])
 
   const { editor } = useRichTextEditor({
     initialContent,
@@ -156,6 +157,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
     onSlashEnter,
     onSlashArrowVertical,
     onSlashBackspacePop,
+    onSlashArrowRight,
     enableReferencePicker: true,
     onPickerEnter,
     onPickerArrowVertical,

--- a/apps/web/src/components/editor/rich-text/reference-picker-extensions.ts
+++ b/apps/web/src/components/editor/rich-text/reference-picker-extensions.ts
@@ -25,8 +25,10 @@ export interface BuildReferencePickerExtensionsOptions {
   onSlashEnter?: () => boolean
   /** ArrowUp/Down inside an open `/` chip — move the slash list highlight. */
   onSlashArrowVertical?: (direction: 1 | -1) => boolean
-  /** Backspace on an empty, drilled `/` chip — pop a drill level. */
+  /** Backspace/ArrowLeft on an empty, drilled `/` chip — pop a drill level. */
   onSlashBackspacePop?: () => boolean
+  /** ArrowRight inside an open `/` chip — drill into the highlighted item. */
+  onSlashArrowRight?: () => boolean
 }
 
 /**
@@ -74,6 +76,7 @@ export function buildReferencePickerExtensions(
       onSlashEnter: options.onSlashEnter,
       onSlashArrowVertical: options.onSlashArrowVertical,
       onSlashBackspacePop: options.onSlashBackspacePop,
+      onSlashArrowRight: options.onSlashArrowRight,
     }),
   ]
 }

--- a/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
+++ b/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
@@ -104,8 +104,10 @@ export interface UseRichTextEditorOptions {
   onSlashEnter?: () => boolean
   /** ArrowUp/Down inside an open `/` chip — move the slash list highlight. */
   onSlashArrowVertical?: (direction: 1 | -1) => boolean
-  /** Backspace on an empty, drilled `/` chip — pop a drill level. */
+  /** Backspace/ArrowLeft on an empty, drilled `/` chip — pop a drill level. */
   onSlashBackspacePop?: () => boolean
+  /** ArrowRight inside an open `/` chip — drill into the highlighted item. */
+  onSlashArrowRight?: () => boolean
   /**
    * Default `true`. When set, mounts the `@`-mention picker extensions
    * (referenceBadgeNode + ReferencePickerNode). The consumer mounts the
@@ -133,7 +135,7 @@ export interface UseRichTextEditorOptions {
   /**
    * Overrides the default-branch placeholder rendered inside an empty text
    * `Block`. Heading and table-cell branches still use their own placeholders.
-   * Defaults to `"Press '/' for commands"`.
+   * Defaults to `"Press '/' for commands, '@' for mentions"`.
    */
   placeholderText?: string
   /**
@@ -179,6 +181,7 @@ export function useRichTextEditor({
   onSlashEnter,
   onSlashArrowVertical,
   onSlashBackspacePop,
+  onSlashArrowRight,
   enableReferencePicker = true,
   onPickerEnter,
   onPickerArrowVertical,
@@ -211,6 +214,7 @@ export function useRichTextEditor({
             onSlashEnter,
             onSlashArrowVertical,
             onSlashBackspacePop,
+            onSlashArrowRight,
           })
         : [],
     [
@@ -222,6 +226,7 @@ export function useRichTextEditor({
       onSlashEnter,
       onSlashArrowVertical,
       onSlashBackspacePop,
+      onSlashArrowRight,
     ]
   )
 

--- a/apps/web/src/components/editor/slash-commands/slash-list.tsx
+++ b/apps/web/src/components/editor/slash-commands/slash-list.tsx
@@ -95,6 +95,7 @@ export function SlashList({
                       key={item.id}
                       value={value}
                       onSelect={() => section.onSelect(item)}
+                      data-drilldown={item.drillDown ? '' : undefined}
                       className='flex items-center justify-between'>
                       {section.renderItem ? (
                         section.renderItem(item)

--- a/apps/web/src/components/kb/ui/articles/article-picker.tsx
+++ b/apps/web/src/components/kb/ui/articles/article-picker.tsx
@@ -16,6 +16,7 @@ import {
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { ChevronRight, CornerDownRight, Loader2 } from 'lucide-react'
 import { type KeyboardEvent, useCallback, useMemo, useState } from 'react'
+import { ParentBackHeader } from '~/components/editor/placeholders/placeholder-picker-content'
 import { api } from '~/trpc/react'
 import { useArticleList } from '../../hooks/use-article-list'
 import { useKnowledgeBases } from '../../hooks/use-knowledge-bases'
@@ -62,6 +63,14 @@ export interface ArticlePickerProps {
   knowledgeBasesOverride?: { id: string; name: string }[]
   /** Focus the search input on mount (e.g. when embedded in a morphing dropdown). */
   autoFocusSearch?: boolean
+  /**
+   * Embedded use (e.g. inside the slash-command drill): shows a back-to-parent
+   * header at the root and routes Backspace/ArrowLeft on an empty root search
+   * to it instead of closing.
+   */
+  onBack?: () => void
+  /** Label for the back header — the parent picker's name (e.g. 'Commands'). */
+  backLabel?: string
   onPick: (articleId: string) => void
   onClose: () => void
 }
@@ -88,6 +97,8 @@ function ArticlePickerContent({
   flattenSearch,
   knowledgeBasesOverride,
   autoFocusSearch,
+  onBack,
+  backLabel = 'Back',
   onPick,
   onClose,
 }: ArticlePickerProps) {
@@ -183,13 +194,29 @@ function ArticlePickerContent({
           pop()
           return
         }
+        if (onBack) {
+          e.preventDefault()
+          onBack()
+          return
+        }
         if (e.key === 'Backspace') {
           e.preventDefault()
           onClose()
         }
+        return
+      }
+      if (e.key === 'ArrowRight') {
+        // Drill into the highlighted entry (KB / tab / category) — same
+        // DOM-query pattern as `useCmdkRemote.drillHighlighted`.
+        const selected = (e.currentTarget as HTMLElement).querySelector<HTMLElement>(
+          '[cmdk-item][data-selected="true"][data-drilldown]'
+        )
+        if (!selected) return
+        e.preventDefault()
+        selected.click()
       }
     },
-    [isAtRoot, onClose, pop, search]
+    [isAtRoot, onBack, onClose, pop, search]
   )
 
   const placeholder =
@@ -202,6 +229,7 @@ function ArticlePickerContent({
 
   return (
     <Command className='w-72 overflow-hidden' shouldFilter={false} onKeyDown={handleKeyDown}>
+      {onBack && isAtRoot && <ParentBackHeader label={backLabel} onBack={onBack} />}
       <CommandBreadcrumb rootLabel={rootLabel} />
       <CommandInput
         placeholder={placeholder}
@@ -222,6 +250,7 @@ function ArticlePickerContent({
                   push({ id: kb.id, label: kb.name || 'Untitled', kind: 'kb' })
                   setSearch('')
                 }}
+                data-drilldown=''
                 className='flex items-center justify-between'>
                 <div className='flex items-center gap-2'>
                   <EntityIcon iconId='book-open' size='xs' className='text-muted-foreground' />
@@ -274,6 +303,7 @@ function ArticlePickerContent({
                   value={a.title || a.id}
                   onSelect={onSelect}
                   data-current={currentParentId === a.id || undefined}
+                  data-drilldown={drill ? '' : undefined}
                   className='flex items-center justify-between'>
                   <div className='flex items-center gap-2'>
                     <EntityIcon

--- a/apps/web/src/components/pickers/use-cmdk-remote.ts
+++ b/apps/web/src/components/pickers/use-cmdk-remote.ts
@@ -9,6 +9,12 @@ export interface CmdkRemoteHandle {
   moveHighlight: (direction: 1 | -1) => boolean
   /** Confirm the currently-highlighted item. Returns whether handled. */
   confirmHighlighted: () => boolean
+  /**
+   * Drill into the highlighted item if it's drillable (ArrowRight). Only
+   * items stamped with `data-drilldown` are confirmed; anything else returns
+   * false so the caller can fall through to caret movement.
+   */
+  drillHighlighted: () => boolean
 }
 
 /**
@@ -90,5 +96,15 @@ export function useCmdkRemote(
     return true
   }, [containerRef])
 
-  return { moveHighlight, confirmHighlighted }
+  const drillHighlighted = useCallback(() => {
+    const root = containerRef.current?.querySelector('[cmdk-root]')
+    if (!root) return false
+    const current = root.querySelector<HTMLElement>('[cmdk-item][data-selected="true"]')
+    if (!current || !current.hasAttribute('data-drilldown')) return false
+    // For drillable items, selecting IS drilling — onSelect pushes the level.
+    current.click()
+    return true
+  }, [containerRef])
+
+  return { moveHighlight, confirmHighlighted, drillHighlighted }
 }


### PR DESCRIPTION
## Summary

Follow-ups to the slash-chip unification (#830):

- **Restores left/right arrow navigation in the `/` menu.** The chip migration consumed ArrowLeft/Right for caret movement only; the pre-refactor pickers used them to drill. Now ArrowRight drills into the highlighted item when it's drillable (Insert snippet, snippet folders, Insert placeholder, Link to article, procedure step drills) with drill taking priority over caret movement, and ArrowLeft on an empty drilled chip pops a level (mirrors Backspace). Wired via a new `onSlashArrowRight` chip option and `drillHighlighted()` on `useCmdkRemote`; `SlashList` stamps drillable rows with `data-drilldown`.
- **"Link to article" is now a drill inside the slash popover** instead of opening a second popover. It embeds the same `ArticlePicker` form (KB tree drilling, flatten-on-search) the way placeholder mode embeds its picker — chip sublabel reads `/ LINK ARTICLE`, "← Commands" back header at root, Backspace/ArrowLeft pops back. Picking deletes the chip and inserts the linked title in one transaction (the old flow split it across the popover hand-off). `ArticleLinkPopover` remains for the bubble-menu link and right-click → Edit flows; its now-dead "insert at cursor" branch is removed.
- **`ArticlePicker`** gains `onBack`/`backLabel` for embedded use and ArrowRight-to-drill on KB/tab/category rows.
- **Placeholder text**: empty blocks now read "Press '/' for commands, '@' for mentions"; table cells keep the compact "Press '/'". (Mail composer's legacy placeholder untouched — no `@` chip there until phase 4.)

## Test plan

- [ ] KB editor: `/` → ArrowRight on "Insert snippet" drills in; ArrowRight on a folder drills; ArrowLeft/Backspace on empty query pops back; Enter still confirms.
- [ ] KB editor: `/` → "Link to article" (Enter, click, or ArrowRight) shows the article picker inline; drilling tabs/categories, flatten search, pick inserts the link; Backspace/ArrowLeft at empty root returns to Commands; Escape collapses the chip.
- [ ] Bubble-menu link button and right-click → Edit link still work via the popover.
- [ ] Procedure editor: `/` → ArrowRight drills Switch-to / Code / Sub-procedure / Create-attribute.
- [ ] `@` picker unaffected (arrows still move caret / exit chip).
- [ ] `npx vitest run src/components/editor/inline-picker` passes (7/7).