### PR TITLE
fix(lambda): wire workflow-block tool dispatch (__AUXX_TOOLS__ → global)

### DIFF
--- a/apps/lambda/.gitignore
+++ b/apps/lambda/.gitignore
@@ -1,0 +1,7 @@
+# Local SDK provisioning for `deno test` — populated from packages/sdk/lib by
+# the `pretest` step. The dist build (build.sh) copies it into its own BUILD_DIR.
+packages/
+
+# Build / runtime artifacts
+dist/
+.deno/

--- a/apps/lambda/package.json
+++ b/apps/lambda/package.json
@@ -10,6 +10,7 @@
     "dev:restart": "docker compose restart lambda-dev",
     "dev:bash": "docker compose exec lambda-dev bash",
     "build": "pnpm --filter @auxx/sdk build && ./build.sh",
+    "pretest": "pnpm --filter @auxx/sdk build && mkdir -p packages/sdk && ln -sfn ../../../../packages/sdk/lib packages/sdk/lib",
     "test": "deno test --allow-all",
     "typecheck": "deno check src/index.ts",
     "clean": "docker compose down -v && rm -rf .deno dist"

--- a/apps/lambda/src/executors/__tests__/workflow-block-executor.test.ts
+++ b/apps/lambda/src/executors/__tests__/workflow-block-executor.test.ts
@@ -1,0 +1,97 @@
+// apps/lambda/src/executors/__tests__/workflow-block-executor.test.ts
+
+/**
+ * Regression tests for the workflow-block executor's tool dispatch.
+ *
+ * Router-style blocks delegate to internal tools via `ctx.runTool(toolId)`,
+ * which resolves off `globalThis.__AUXX_TOOLS__`. The bundle keeps that registry
+ * as a function-local const, so the executor must lift it onto the global before
+ * invoking the block and clear it afterward. These tests pin that contract — the
+ * dispatch path that previously threw "Tool not found" for every tool id.
+ */
+
+import { assertEquals } from 'jsr:@std/assert'
+import { executeWorkflowBlock } from '../workflow-block-executor.ts'
+
+/**
+ * A minimal fake server bundle. Defines a router block whose `execute` dispatches
+ * to an internal tool via `ctx.runTool`, plus the `__AUXX_TOOLS__` registry the
+ * real generated bundle emits. Both are top-level consts so the executor's
+ * appended `return { __AUXX_WORKFLOW_BLOCKS__, __AUXX_TOOLS__ }` can lift them.
+ */
+const FAKE_BUNDLE = `
+  const __AUXX_TOOLS__ = {
+    t_echo: { execute: (input) => ({ ok: true, echo: input }) },
+  };
+  const __AUXX_WORKFLOW_BLOCKS__ = {
+    demo: {
+      execute: async (input, ctx) => {
+        return await ctx.runTool(input.toolId, { value: input.value });
+      },
+    },
+  };
+`
+
+const workflowContext = {
+  workflowId: 'wf_test',
+  executionId: 'exec_test',
+  nodeId: 'node_test',
+  variables: {},
+  user: { id: 'u1', email: 'test@example.com', name: 'Test' },
+  organization: { id: 'org1', handle: 'acme', name: 'Acme' },
+}
+
+const runtimeContext = {
+  organizationId: 'org1',
+  organizationHandle: 'acme',
+  app: { installationId: 'inst1' },
+  user: { id: 'u1', email: 'test@example.com', name: 'Test' },
+}
+
+Deno.test('workflow block dispatches to an internal tool via runTool', async () => {
+  const result = await executeWorkflowBlock({
+    type: 'workflow-block',
+    blockId: 'demo',
+    bundleCode: FAKE_BUNDLE,
+    workflowContext,
+    workflowInput: { toolId: 't_echo', value: 42 },
+    context: runtimeContext,
+    timeout: 5000,
+    memoryLimit: 128,
+  })
+
+  assertEquals(result.result, { ok: true, echo: { value: 42 } })
+})
+
+Deno.test('tool registry is cleared from global scope after execution', async () => {
+  await executeWorkflowBlock({
+    type: 'workflow-block',
+    blockId: 'demo',
+    bundleCode: FAKE_BUNDLE,
+    workflowContext,
+    workflowInput: { toolId: 't_echo', value: 1 },
+    context: runtimeContext,
+    timeout: 5000,
+    memoryLimit: 128,
+  })
+
+  assertEquals((globalThis as { __AUXX_TOOLS__?: unknown }).__AUXX_TOOLS__, undefined)
+})
+
+Deno.test('unmapped tool id surfaces a structured runtime error, not a throw', async () => {
+  const result = await executeWorkflowBlock({
+    type: 'workflow-block',
+    blockId: 'demo',
+    bundleCode: FAKE_BUNDLE,
+    workflowInput: { toolId: 't_missing', value: 1 },
+    workflowContext,
+    context: runtimeContext,
+    timeout: 5000,
+    memoryLimit: 128,
+  })
+
+  assertEquals(result.result, null)
+  assertEquals(result.metadata?.runtimeError?.message, 'Tool not found: t_missing')
+  // Global is cleaned up even on the error path.
+  assertEquals((globalThis as { __AUXX_TOOLS__?: unknown }).__AUXX_TOOLS__, undefined)
+})

--- a/apps/lambda/src/executors/workflow-block-executor.ts
+++ b/apps/lambda/src/executors/workflow-block-executor.ts
@@ -12,8 +12,10 @@ import {
 } from '../runtime-helpers/index.ts'
 import {
   cleanupWorkflowSDK,
+  clearToolRegistry,
   createWorkflowExecutionContext,
   injectWorkflowSDK,
+  setToolRegistry,
 } from '../runtime-helpers/workflow-sdk.ts'
 import type {
   // WorkflowExecutionInput,
@@ -51,18 +53,22 @@ export async function executeWorkflowBlock(
   // Execute with timeout
   const executionPromise = executeInSandbox(bundleCode, blockId, workflowInput, executionContext)
 
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
   const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(
+    timeoutId = setTimeout(
       () => reject(new Error(`Workflow block execution timeout after ${timeout}ms`)),
       timeout
     )
   })
 
-  const result = await Promise.race([executionPromise, timeoutPromise])
-
-  console.log('[WorkflowBlockExecutor] Execution complete:', { blockId })
-
-  return result
+  try {
+    const result = await Promise.race([executionPromise, timeoutPromise])
+    console.log('[WorkflowBlockExecutor] Execution complete:', { blockId })
+    return result
+  } finally {
+    // Clear the timeout timer so it doesn't leak past a fast execution.
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+  }
 }
 
 /**
@@ -81,8 +87,12 @@ async function executeInSandbox(
     // 2. Inject Workflow SDK (extends Server SDK)
     injectWorkflowSDK(context)
 
-    // 3. Execute bundle to register workflow blocks
-    const codeWithReturn = bundleCode + '\nreturn { __AUXX_WORKFLOW_BLOCKS__ };'
+    // 3. Execute bundle to register workflow blocks and the tool registry.
+    // Both are function-local consts in the bundle; we lift them out via the
+    // appended return. `__AUXX_TOOLS__` must reach `globalThis` so router-style
+    // blocks can dispatch to internal tools via `ctx.runTool` (which resolves
+    // off `globalThis.__AUXX_TOOLS__`). Cleared in the `finally` below.
+    const codeWithReturn = bundleCode + '\nreturn { __AUXX_WORKFLOW_BLOCKS__, __AUXX_TOOLS__ };'
     const fn = new Function(codeWithReturn)
     const result = fn()
     const workflowBlocks = result.__AUXX_WORKFLOW_BLOCKS__
@@ -90,6 +100,8 @@ async function executeInSandbox(
     if (!workflowBlocks) {
       throw new Error('Server bundle does not export workflow blocks')
     }
+
+    setToolRegistry(result.__AUXX_TOOLS__)
 
     // 4. Get the specific workflow block
     const workflowBlock = workflowBlocks[blockId]
@@ -195,6 +207,7 @@ async function executeInSandbox(
     throw error
   } finally {
     // 9. Clean up
+    clearToolRegistry()
     cleanupWorkflowSDK()
     cleanupServerRuntimeHelpers()
   }

--- a/apps/lambda/src/runtime-helpers/workflow-sdk.ts
+++ b/apps/lambda/src/runtime-helpers/workflow-sdk.ts
@@ -159,6 +159,30 @@ export function cleanupWorkflowSDK(): void {
   delete g.__AUXX_WORKFLOW_SDK__
 }
 
+/** Shape of the bundle's `__AUXX_TOOLS__` registry, keyed by tool id. */
+type ToolRegistry = Record<string, { execute: (input: any, ctx?: any) => unknown }>
+
+/**
+ * Expose the bundle's tool registry on `globalThis.__AUXX_TOOLS__`.
+ *
+ * Router-style workflow blocks dispatch to internal tools via `ctx.runTool`,
+ * which resolves the tool off `globalThis.__AUXX_TOOLS__` (see `runTool` above).
+ * The generated bundle keeps `__AUXX_TOOLS__` as a function-local const, so the
+ * executor must lift it onto the global after running the bundle and before
+ * invoking the block — mirroring the `__AUXX_WORKFLOW_SDK__` inject/cleanup
+ * lifecycle. Always pair with `clearToolRegistry()` in a `finally`.
+ */
+export function setToolRegistry(tools: ToolRegistry | undefined): void {
+  const g = globalThis as typeof globalThis & { __AUXX_TOOLS__?: ToolRegistry }
+  g.__AUXX_TOOLS__ = tools ?? {}
+}
+
+/** Remove the tool registry from global scope. */
+export function clearToolRegistry(): void {
+  const g = globalThis as typeof globalThis & { __AUXX_TOOLS__?: ToolRegistry }
+  delete g.__AUXX_TOOLS__
+}
+
 /**
  * Create workflow execution context from Lambda event and runtime context
  */

--- a/apps/lambda/test/runtime-helpers.test.ts
+++ b/apps/lambda/test/runtime-helpers.test.ts
@@ -26,6 +26,7 @@ function createTestContext(): RuntimeContext {
     user: {
       id: 'user_test456',
       email: 'test@example.com',
+      name: 'Test User',
     },
     app: {
       id: 'app_test789',
@@ -33,13 +34,14 @@ function createTestContext(): RuntimeContext {
     },
     fetch: globalThis.fetch,
     env: 'test',
+    apiUrl: 'https://api.test',
   }
 }
 
 Deno.test('registerSettingsSchema - stores schema', () => {
   const schema = {
     user: { name: 'string' },
-    config: { enabled: 'boolean' },
+    organization: { enabled: 'boolean' },
   }
 
   registerSettingsSchema(schema)
@@ -55,7 +57,7 @@ Deno.test('getRegisteredSettingsSchema - returns null when no schema registered'
 })
 
 Deno.test('resetSettingsSchema - clears registered schema', () => {
-  const schema = { test: 'value' }
+  const schema = { user: { test: 'value' } }
   registerSettingsSchema(schema)
   assertEquals(getRegisteredSettingsSchema(), schema)
 
@@ -100,7 +102,7 @@ Deno.test('cleanupServerRuntimeHelpers - removes globals', () => {
 })
 
 Deno.test('cleanupServerRuntimeHelpers - resets settings schema', () => {
-  const schema = { test: 'value' }
+  const schema = { user: { test: 'value' } }
   registerSettingsSchema(schema)
   assertEquals(getRegisteredSettingsSchema(), schema)
 
@@ -116,7 +118,7 @@ Deno.test('Server SDK - getCurrentUser returns context user', async () => {
 
   assertEquals(user.id, 'user_test456')
   assertEquals(user.email, 'test@example.com')
-  assertEquals(user.name, 'test') // Email prefix
+  assertEquals(user.name, 'Test User') // context.user.name takes precedence over the email prefix
   assertEquals(user.avatar, undefined)
   assertEquals(user.role, undefined)
 
@@ -154,50 +156,10 @@ Deno.test('Server SDK - query throws not implemented', async () => {
   cleanupServerRuntimeHelpers()
 })
 
-Deno.test('Server SDK - storage.get throws not implemented', async () => {
-  const context = createTestContext()
-  injectServerRuntimeHelpers(context)
-
-  try {
-    await (globalThis as any).AUXX_SERVER_SDK.storage.get('test-key')
-    throw new Error('Should have thrown')
-  } catch (error: any) {
-    assertEquals(error.message, 'Storage not yet implemented')
-  }
-
-  // Cleanup
-  cleanupServerRuntimeHelpers()
-})
-
-Deno.test('Server SDK - storage.set throws not implemented', async () => {
-  const context = createTestContext()
-  injectServerRuntimeHelpers(context)
-
-  try {
-    await (globalThis as any).AUXX_SERVER_SDK.storage.set('test-key', 'test-value')
-    throw new Error('Should have thrown')
-  } catch (error: any) {
-    assertEquals(error.message, 'Storage not yet implemented')
-  }
-
-  // Cleanup
-  cleanupServerRuntimeHelpers()
-})
-
-Deno.test('Server SDK - storage.delete throws not implemented', async () => {
-  const context = createTestContext()
-  injectServerRuntimeHelpers(context)
-
-  try {
-    await (globalThis as any).AUXX_SERVER_SDK.storage.delete('test-key')
-    throw new Error('Should have thrown')
-  } catch (error: any) {
-    assertEquals(error.message, 'Storage not yet implemented')
-  }
-
-  // Cleanup
-  cleanupServerRuntimeHelpers()
-})
+// The storage host is now implemented (see #833). Its behaviour — scope
+// resolution, HTTP plumbing, the `{ value }` wrapper — is covered by
+// `src/runtime-helpers/__tests__/server-sdk-storage.test.ts`. The old
+// "throws not implemented" stub tests were removed when the stub was replaced.
 
 Deno.test('Server SDK context is injected correctly', () => {
   const context = createTestContext()

--- a/deno.lock
+++ b/deno.lock
@@ -49,10 +49,13 @@
             "npm:@hookform/resolvers@^4.1.0",
             "npm:@trpc/client@^11.0.0-rc.446",
             "npm:@trpc/react-query@^11.0.0-rc.446",
+            "npm:imapflow@^1.2.13",
             "npm:next-themes@~0.4.4",
+            "npm:pino@^10.3.1",
             "npm:react-hook-form@^7.54.2",
             "npm:sonner@^2.0.7",
-            "npm:superjson@^2.2.1"
+            "npm:superjson@^2.2.1",
+            "npm:thread-stream@4"
           ]
         }
       },
@@ -67,6 +70,22 @@
           ]
         }
       },
+      "apps/extension": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@crxjs/vite-plugin@^2.0.0-beta.32",
+            "npm:@radix-ui/react-avatar@^1.1.10",
+            "npm:@radix-ui/react-slot@^1.2.3",
+            "npm:@types/chrome@^0.0.290",
+            "npm:class-variance-authority@~0.7.1",
+            "npm:clsx@^2.1.1",
+            "npm:radix-ui@^1.4.2",
+            "npm:tailwind-merge@^3.0.1",
+            "npm:tailwindcss-animate@^1.0.7",
+            "npm:tw-animate-css@^1.3.6"
+          ]
+        }
+      },
       "apps/homepage": {
         "packageJson": {
           "dependencies": [
@@ -78,15 +97,31 @@
             "npm:@radix-ui/react-navigation-menu@^1.2.14",
             "npm:@radix-ui/react-slot@^1.2.3",
             "npm:@radix-ui/react-tooltip@^1.2.8",
+            "npm:@shikijs/rehype@^4.0.2",
             "npm:@tailwindcss/postcss@4",
+            "npm:@types/mdx@^2.0.13",
             "npm:class-variance-authority@~0.7.1",
             "npm:clsx@^2.1.1",
+            "npm:gray-matter@^4.0.3",
             "npm:motion@^12.23.16",
+            "npm:next-mdx-remote@6",
             "npm:next-themes@~0.4.4",
+            "npm:reading-time@^1.5.0",
             "npm:recharts@^2.15.4",
+            "npm:remark-gfm@^4.0.1",
             "npm:tailwind-merge@^3.3.1",
             "npm:tailwindcss@4",
             "npm:tw-animate-css@^1.4.0"
+          ]
+        }
+      },
+      "apps/kb": {
+        "packageJson": {
+          "dependencies": [
+            "npm:imapflow@^1.2.13",
+            "npm:pino@^10.3.1",
+            "npm:prettier@^3.8.1",
+            "npm:thread-stream@4"
           ]
         }
       },
@@ -101,12 +136,21 @@
           ]
         }
       },
+      "apps/mail-ingress": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@types/aws-lambda@^8.10.152"
+          ]
+        }
+      },
       "apps/web": {
         "packageJson": {
           "dependencies": [
+            "npm:@base-ui-components/react@1.0.0-rc.0",
             "npm:@better-auth/passkey@^1.4.19",
             "npm:@formkit/auto-animate@~0.8.2",
             "npm:@hookform/resolvers@^4.1.0",
+            "npm:@marsidev/react-turnstile@^1.4.2",
             "npm:@monaco-editor/react@^4.7.0",
             "npm:@next/bundle-analyzer@^15.3.1",
             "npm:@noble/hashes@^2.0.1",
@@ -119,6 +163,7 @@
             "npm:@radix-ui/react-slot@^1.2.3",
             "npm:@tailwindcss/container-queries@~0.1.1",
             "npm:@tailwindcss/typography@~0.5.16",
+            "npm:@tanstack/react-hotkeys@~0.9.1",
             "npm:@tanstack/react-query-devtools@^5.72.1",
             "npm:@tanstack/react-table@^8.21.2",
             "npm:@tanstack/react-virtual@^3.13.2",
@@ -160,6 +205,7 @@
             "npm:dagre@~0.8.5",
             "npm:date-fns-tz@^3.2.0",
             "npm:dompurify@^3.2.4",
+            "npm:imapflow@^1.2.13",
             "npm:immer@^10.1.1",
             "npm:import-in-the-middle@^1.14.2",
             "npm:input-otp@^1.4.2",
@@ -171,6 +217,7 @@
             "npm:next-themes@~0.4.4",
             "npm:nuqs@^2.4.0",
             "npm:papaparse@^5.5.3",
+            "npm:pino@^10.3.1",
             "npm:prettier@^3.8.1",
             "npm:prosemirror-state@^1.4.3",
             "npm:radix-ui@^1.4.2",
@@ -183,15 +230,18 @@
             "npm:react-markdown@^10.1.0",
             "npm:react-phone-input-2@^2.15.1",
             "npm:react-phone-number-input@^3.4.14",
+            "npm:react-player@^2.16.0",
             "npm:react-qr-code@^2.0.15",
             "npm:react-resizable-panels@^2.1.7",
             "npm:react-select@^5.10.0",
             "npm:recharts@^2.15.4",
+            "npm:remark-gfm@^4.0.1",
             "npm:require-in-the-middle@^7.5.2",
             "npm:sonner@^2.0.7",
             "npm:superjson@^2.2.1",
             "npm:tailwind-merge@^3.0.1",
             "npm:tailwindcss-animate@^1.0.7",
+            "npm:thread-stream@4",
             "npm:tippy.js@^6.3.7",
             "npm:tiptap-markdown@~0.8.10",
             "npm:tw-animate-css@^1.3.6",
@@ -206,9 +256,26 @@
         "packageJson": {
           "dependencies": [
             "npm:@hono/node-server@^1.13.7",
+            "npm:@types/fluent-ffmpeg@^2.1.27",
+            "npm:fluent-ffmpeg@^2.1.3",
             "npm:hono@^4.9.7",
+            "npm:neverthrow@^6.2.2",
             "npm:socket.io@^4.8.1",
             "npm:sst@^3.19.0"
+          ]
+        }
+      },
+      "packages/chat": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@tailwindcss/vite@^4.1.7",
+            "npm:@types/jsonwebtoken@^9.0.7",
+            "npm:class-variance-authority@~0.7.1",
+            "npm:clsx@^2.1.1",
+            "npm:jsonwebtoken@^9.0.2",
+            "npm:preact@^10.24.0",
+            "npm:radix-ui@^1.4.2",
+            "npm:tailwind-merge@^3.3.1"
           ]
         }
       },
@@ -255,34 +322,51 @@
             "npm:@google/generative-ai@0.24",
             "npm:@langchain/openai@~0.5.1",
             "npm:@microsoft/microsoft-graph-client@^3.0.7",
+            "npm:@modelcontextprotocol/sdk@1.29.0",
             "npm:@types/addressparser@^1.0.3",
             "npm:@types/email-reply-parser@^1.4.2",
             "npm:@types/html-to-text@^9.0.4",
             "npm:@types/jsdom@^21.1.7",
+            "npm:@types/ldapjs@^3.0.6",
             "npm:@types/pdf-parse@^1.1.5",
             "npm:addressparser@^1.0.1",
+            "npm:ajv@8",
             "npm:cheerio@^1.1.2",
             "npm:cohere-ai@^7.18.1",
             "npm:commander@12",
+            "npm:cronstrue@^3.14.0",
             "npm:csv-parser@^3.2.0",
             "npm:date-fns-tz@^3.2.0",
             "npm:email-reply-parser@^1.9.4",
+            "npm:fast-diff@^1.3.0",
             "npm:file-type@19",
             "npm:form-data@^4.0.2",
+            "npm:free-email-domains@^1.2.26",
             "npm:gmail-api-parse-message@^2.1.2",
             "npm:google-auth-library@^9.15.1",
             "npm:groq-sdk@0.19",
             "npm:html-to-text@^9.0.5",
+            "npm:imapflow@^1.2.13",
             "npm:jsep@^1.4.0",
             "npm:json-logic-js@^2.0.5",
             "npm:langsmith@0.3",
+            "npm:ldapjs@^3.0.7",
             "npm:lru-cache@11.1.0",
             "npm:mailgun.js@^12.0.1",
             "npm:mammoth@^1.10.0",
+            "npm:maxmind@^4.3.20",
+            "npm:mdast-util-to-string@4",
             "npm:nanoid@^5.1.5",
             "npm:neverthrow@^6.2.2",
             "npm:p-limit@^6.2.0",
             "npm:pdf-parse@^1.1.1",
+            "npm:planer@^1.2.0",
+            "npm:postal-mime@^2.7.3",
+            "npm:remark-directive@3",
+            "npm:remark-gfm@4",
+            "npm:remark-parse@11",
+            "npm:tldts@^7.0.28",
+            "npm:unified@^11.0.5",
             "npm:xlsx@~0.18.5",
             "npm:zod-to-json-schema@^3.24.0"
           ]
@@ -366,6 +450,7 @@
       "packages/ui": {
         "packageJson": {
           "dependencies": [
+            "npm:@base-ui-components/react@1.0.0-rc.0",
             "npm:@radix-ui/react-accordion@^1.2.12",
             "npm:@radix-ui/react-avatar@^1.1.10",
             "npm:@radix-ui/react-context-menu@^2.2.16",


### PR DESCRIPTION
## Problem

Router-style workflow blocks delegate to internal tools via `ctx.runTool(toolId)`, which resolves the tool off `globalThis.__AUXX_TOOLS__`. The generated server bundle keeps `__AUXX_TOOLS__` as a **function-local const**, so it never reached the global — every `runTool` call threw `Tool not found: <id>`.

## Fix

The executor now lifts `__AUXX_TOOLS__` onto the global after running the bundle (alongside the existing `__AUXX_WORKFLOW_BLOCKS__` extraction) and clears it in `finally`, mirroring the `__AUXX_WORKFLOW_SDK__` inject/cleanup lifecycle.

- **`workflow-sdk.ts`** — `setToolRegistry()` / `clearToolRegistry()` helpers.
- **`workflow-block-executor.ts`** — lift the registry before invoking the block, clear it on every exit path. Also clears the timeout timer in a `finally` so it can't leak past a fast execution.

## Tests & infra

- New `workflow-block-executor.test.ts` — regression tests pinning the dispatch contract: a block reaches an internal tool via `runTool`, the global is cleared after execution (success **and** error paths), and an unmapped tool id surfaces a structured `runtimeError` rather than throwing.
- `pretest` step + `apps/lambda/.gitignore` so `deno test` can resolve the built `@auxx/sdk` (symlinked into a gitignored `packages/` dir).
- `runtime-helpers.test.ts` — the test context now carries the required `name` / `apiUrl` fields, and the `getCurrentUser` assertion expects `context.user.name`. **Also removes 3 `storage.* throws not implemented` stub tests left stale when #833 replaced the storage host** — the host is now covered by `server-sdk-storage.test.ts` (merged in #833).

## Verification

`deno test` for `workflow-block-executor.test.ts` + `runtime-helpers.test.ts` → **14 passed, 0 failed**.

> Note: `apps/lambda/test/integration.test.ts` is red independent of this PR — it imports a nonexistent `../src/executor.ts` on `main`. Left untouched (out of scope; pre-existing).