### PR TITLE
fix(lambda): add fields to ConnectionData type + validator

### DIFF
--- a/apps/lambda/src/types.ts
+++ b/apps/lambda/src/types.ts
@@ -43,6 +43,8 @@ export interface ConnectionData {
   id: string
   type: 'oauth2-code' | 'secret'
   value: string // Decrypted token/key/secret
+  /** Merged connection-variable map (plain + decrypted secret-flagged), keyed by variable key. */
+  fields?: Record<string, string>
   metadata?: {
     scope?: string
     externalUserId?: string

--- a/apps/lambda/src/validator.ts
+++ b/apps/lambda/src/validator.ts
@@ -12,6 +12,7 @@ const ConnectionDataSchema = z.object({
   id: z.string(),
   type: z.enum(['oauth2-code', 'secret']),
   value: z.string(),
+  fields: z.record(z.string(), z.string()).optional(),
   metadata: z.record(z.string(), z.any()).optional(),
   expiresAt: z.string().optional(), // ISO date string
 })

--- a/deno.lock
+++ b/deno.lock
@@ -15,6 +15,10 @@
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     }
   },
+  "remote": {
+    "https://deno.land/std@0.224.0/async/delay.ts": "f90dd685b97c2f142b8069082993e437b1602b8e2561134827eeb7c12b95c499",
+    "https://deno.land/std@0.224.0/http/server.ts": "f9313804bf6467a1704f45f76cb6cd0a3396a3b31c316035e6a4c2035d1ea514"
+  },
   "workspace": {
     "packageJson": {
       "dependencies": [


### PR DESCRIPTION
## What's broken

Commit #835 (*top-level connectionVariables + multi-field secret connections*) added a connection-variable `fields` map across the platform and to the lambda's exported `Connection` interface + the `server-sdk.ts` read sites — but left the source `ConnectionData` type and its zod validator without `fields`.

`deno compile` type-check then failed with three `TS2339: Property 'fields' does not exist on type 'ConnectionData'` errors (`server-sdk.ts:594/635/671`), breaking both the **sst-platform-deploy** and **Docker lambda-server** jobs of `release-please.yml`. The platform already forwards `fields` at runtime (`RuntimeConnectionData.fields` in `resolve-app-connection-for-runtime.ts`), so this is purely a stale local type.

## Fix

- `apps/lambda/src/types.ts` — add `fields?: Record<string, string>` to the `ConnectionData` interface (matches `Connection` + `RuntimeConnectionData`).
- `apps/lambda/src/validator.ts` — add `fields` to `ConnectionDataSchema` so the validated payload retains it instead of stripping it.

No logic changes, no migration.

## Verification

`deno check src/dev-server.ts` in `apps/lambda` passes clean — the same type-check both failing jobs run.