### PR TITLE
fix(sdk): app KV storage host signature + connection-dialog suppression

### DIFF
--- a/apps/lambda/src/runtime-helpers/__tests__/server-sdk-storage.test.ts
+++ b/apps/lambda/src/runtime-helpers/__tests__/server-sdk-storage.test.ts
@@ -1,10 +1,15 @@
 // apps/lambda/src/runtime-helpers/__tests__/server-sdk-storage.test.ts
 
 /**
- * Tests for the app KV storage host wired into the server SDK: scope
- * resolution (connection vs installation), the no-connection throw, collection
- * passthrough, and the `{ value }` unwrapping. The host is exercised through
- * `createServerSDK(context).storage` with a stubbed `context.fetch`.
+ * Tests for the app KV storage host wired into the server SDK.
+ *
+ * `@auxx/sdk/server` is externalized to the `AUXX_SERVER_SDK` global at app
+ * build time, so the SDK wrapper is never bundled — the sandbox calls
+ * `AUXX_SERVER_SDK.storage` directly with the public POSITIONAL surface
+ * (`get(key, opts)`, `set(key, value, opts)`, `collection(name).set(...)`).
+ * These tests exercise the host through that surface (the contract production
+ * relies on) with a stubbed `context.fetch`, including the regression guard
+ * that positional args reach the URL/body instead of becoming `undefined`.
  */
 
 import { assertEquals, assertRejects } from 'jsr:@std/assert'
@@ -51,43 +56,59 @@ Deno.test('connection scope throws when no connection is in context', async () =
   const { context } = makeContext({ data: { item: null } })
   const sdk = createServerSDK(context)
   await assertRejects(
-    () => sdk.storage.get({ collection: '', key: 'k', scope: 'connection' }),
+    () => sdk.storage.get('k', { scope: 'connection' }),
     Error,
     'requires a connection'
   )
 })
 
-Deno.test('connection scope sends X-App-Connection-Id from the bound connection', async () => {
+Deno.test('connection scope sends X-App-Connection-Id and the key reaches the URL', async () => {
   const { context, calls } = makeContext(
     { data: { item: { value: { token: 'abc' } } } },
     { userConnection: { id: 'conn_1', type: 'secret', value: 'x' } }
   )
   const sdk = createServerSDK(context)
-  const item = await sdk.storage.get({ collection: '', key: 'bearer', scope: 'connection' })
+  const item = await sdk.storage.get('bearer', { scope: 'connection' })
 
   assertEquals(item, { value: { token: 'abc' } })
+  assertEquals(calls[0].url, 'https://api.test/api/v1/sdk/storage/item/bearer?collection=')
   assertEquals(calls[0].headers['X-App-Connection-Id'], 'conn_1')
   assertEquals(calls[0].headers['X-App-Installation-Id'], 'inst')
 })
 
-Deno.test('installation scope omits the connection header', async () => {
+Deno.test('installation scope omits the connection header and defaults collection to ""', async () => {
   const { context, calls } = makeContext({ data: { item: null } })
   const sdk = createServerSDK(context)
-  await sdk.storage.get({ collection: '', key: 'k', scope: 'installation' })
+  await sdk.storage.get('k')
+  assertEquals(calls[0].url, 'https://api.test/api/v1/sdk/storage/item/k?collection=')
   assertEquals(calls[0].headers['X-App-Connection-Id'], undefined)
 })
 
-Deno.test('set passes collection + ttl in the body', async () => {
+Deno.test('regression: positional set reaches the URL/body (not item/undefined)', async () => {
+  const { context, calls } = makeContext(
+    { data: { success: true } },
+    { userConnection: { id: 'conn_1', type: 'secret', value: 'x' } }
+  )
+  const sdk = createServerSDK(context)
+  // The exact FedEx token-cache call that produced `item/undefined?collection=undefined`.
+  await sdk.storage.set('bearer-token', { token: 'abc' }, { scope: 'connection', ttlSeconds: 3300 })
+  assertEquals(calls[0].method, 'PUT')
+  assertEquals(calls[0].url, 'https://api.test/api/v1/sdk/storage/item/bearer-token')
+  assertEquals(calls[0].body, {
+    value: { token: 'abc' },
+    collection: '',
+    ttlSeconds: 3300,
+  })
+})
+
+Deno.test('collection().set passes collection + ttl in the body', async () => {
   const { context, calls } = makeContext({ data: { success: true } })
   const sdk = createServerSDK(context)
-  await sdk.storage.set({
-    collection: 'watch',
-    key: '1Z',
-    value: { status: 'in_transit' },
-    scope: 'installation',
-    ttlSeconds: 100,
-  })
+  await sdk.storage
+    .collection('watch', { scope: 'installation' })
+    .set('1Z', { status: 'in_transit' }, { ttlSeconds: 100 })
   assertEquals(calls[0].method, 'PUT')
+  assertEquals(calls[0].url, 'https://api.test/api/v1/sdk/storage/item/1Z')
   assertEquals(calls[0].body, {
     value: { status: 'in_transit' },
     collection: 'watch',
@@ -95,23 +116,22 @@ Deno.test('set passes collection + ttl in the body', async () => {
   })
 })
 
-Deno.test('setIfAbsent returns data.created and sets ifAbsent in the body', async () => {
+Deno.test('collection().setIfAbsent returns data.created and sets ifAbsent in the body', async () => {
   const { context, calls } = makeContext({ data: { created: false } })
   const sdk = createServerSDK(context)
-  const created = await sdk.storage.setIfAbsent({
-    collection: 'webhook-events',
-    key: 'evt_1',
-    value: {},
-    scope: 'installation',
-  })
+  const created = await sdk.storage.collection('webhook-events').setIfAbsent('evt_1', {})
   assertEquals(created, false)
   assertEquals((calls[0].body as { ifAbsent: boolean }).ifAbsent, true)
 })
 
-Deno.test('list unwraps data.entries and encodes the collection in the query', async () => {
-  const { context, calls } = makeContext({ data: { entries: [{ key: 'a', value: 1 }] } })
+Deno.test('collection().list unwraps data.entries and encodes the collection + bound scope', async () => {
+  const { context, calls } = makeContext(
+    { data: { entries: [{ key: 'a', value: 1 }] } },
+    { userConnection: { id: 'conn_1', type: 'secret', value: 'x' } }
+  )
   const sdk = createServerSDK(context)
-  const out = await sdk.storage.list({ collection: 'watch', scope: 'installation', limit: 5 })
+  const out = await sdk.storage.collection('watch', { scope: 'connection' }).list({ limit: 5 })
   assertEquals(out, { entries: [{ key: 'a', value: 1 }] })
   assertEquals(calls[0].url, 'https://api.test/api/v1/sdk/storage/list?collection=watch&limit=5')
+  assertEquals(calls[0].headers['X-App-Connection-Id'], 'conn_1')
 })

--- a/apps/lambda/src/runtime-helpers/server-sdk.ts
+++ b/apps/lambda/src/runtime-helpers/server-sdk.ts
@@ -215,44 +215,47 @@ export interface WebhookHandler {
   metadata?: Record<string, unknown>
 }
 
+type StorageScope = 'installation' | 'connection'
+
+interface StorageOptions {
+  scope?: StorageScope
+}
+interface StorageSetOptions extends StorageOptions {
+  ttlSeconds?: number
+}
+interface StorageListOptions {
+  limit?: number
+}
+
+/** Item-level operations, available on both `storage` and a bound collection. */
+interface StorageItemApi {
+  get: <T = unknown>(key: string, opts?: StorageOptions) => Promise<{ value: T } | null>
+  set: (key: string, value: unknown, opts?: StorageSetOptions) => Promise<void>
+  setIfAbsent: (key: string, value: unknown, opts?: StorageSetOptions) => Promise<boolean>
+  remove: (key: string, opts?: StorageOptions) => Promise<void>
+}
+
+/** A bound collection adds enumeration over its keys. */
+interface StorageCollectionApi extends StorageItemApi {
+  list: <T = unknown>(
+    opts?: StorageListOptions
+  ) => Promise<{ entries: Array<{ key: string; value: T }> }>
+}
+
 /**
- * App KV storage host interface (matches @auxx/sdk/server `storage`).
+ * App KV storage host — the object exposed at `AUXX_SERVER_SDK.storage`.
  *
- * Flat methods taking `collection`/`scope` as arguments — the SDK's
- * `collection()` accessor is pure sugar on the sandbox side. Backed by the
- * `/api/v1/sdk/storage` routes.
+ * This MUST mirror the public `@auxx/sdk/server` `storage` surface exactly
+ * (positional args + a stateful `collection()` accessor). `@auxx/sdk/server` is
+ * externalized to this global at app build time, so the SDK's wrapper code is
+ * never bundled into the sandbox — the app calls these methods directly. A
+ * signature mismatch silently turns every argument into `undefined`.
  *
  * @interface StorageHost
  */
-export interface StorageHost {
-  get: (args: {
-    collection: string
-    key: string
-    scope: StorageScope
-  }) => Promise<{ value: unknown } | null>
-  set: (args: {
-    collection: string
-    key: string
-    value: unknown
-    scope: StorageScope
-    ttlSeconds?: number
-  }) => Promise<void>
-  setIfAbsent: (args: {
-    collection: string
-    key: string
-    value: unknown
-    scope: StorageScope
-    ttlSeconds?: number
-  }) => Promise<boolean>
-  remove: (args: { collection: string; key: string; scope: StorageScope }) => Promise<void>
-  list: (args: {
-    collection: string
-    scope: StorageScope
-    limit?: number
-  }) => Promise<{ entries: Array<{ key: string; value: unknown }> }>
+export interface StorageHost extends StorageItemApi {
+  collection: (name: string, defaults?: StorageSetOptions) => StorageCollectionApi
 }
-
-type StorageScope = 'installation' | 'connection'
 
 /**
  * Server SDK interface injected into global scope
@@ -1068,9 +1071,11 @@ export function createServerSDK(context: RuntimeContext): ServerSDK {
 }
 
 /**
- * Build the app KV storage host. Flat methods over the `/api/v1/sdk/storage`
- * routes; `connection` scope resolves the bound connection from the runtime
- * context and throws (before any HTTP) when the invocation carries none.
+ * Build the app KV storage host — the public `storage` surface (positional
+ * `get`/`set`/`setIfAbsent`/`remove` + a `collection()` accessor) over the
+ * `/api/v1/sdk/storage` routes. `connection` scope resolves the bound
+ * connection from the runtime context and throws (before any HTTP) when the
+ * invocation carries none.
  */
 function createStorageHost(
   context: RuntimeContext,
@@ -1100,70 +1105,102 @@ function createStorageHost(
     return headers
   }
 
+  // Low-level HTTP calls against the storage routes. The positional public
+  // surface below is pure sugar over these — `collection()` binding and the
+  // `installation`/`''` defaults all resolve here, on the object the sandbox
+  // actually touches (the SDK wrapper is externalized away at app build time).
+  async function fetchGet(collection: string, key: string, scope: StorageScope) {
+    const response = await sdkFetch({
+      method: 'GET',
+      url: `${baseUrl}/item/${encodeURIComponent(key)}?collection=${encodeURIComponent(collection)}`,
+      headers: headersForScope(scope),
+    })
+    if (response.status !== 200) {
+      throw new Error(`Failed to get storage item: ${response.status}`)
+    }
+    const data = response.data as { data: { item: { value: unknown } | null } }
+    return data.data.item
+  }
+
+  async function fetchSet(
+    collection: string,
+    key: string,
+    value: unknown,
+    scope: StorageScope,
+    ttlSeconds: number | undefined,
+    ifAbsent: boolean
+  ): Promise<ServerSDKFetchResponse> {
+    const response = await sdkFetch({
+      method: 'PUT',
+      url: `${baseUrl}/item/${encodeURIComponent(key)}`,
+      headers: headersForScope(scope),
+      body: ifAbsent
+        ? { value, collection, ttlSeconds, ifAbsent: true }
+        : { value, collection, ttlSeconds },
+    })
+    if (response.status !== 200) {
+      throw new Error(`Failed to set storage item: ${response.status}`)
+    }
+    return response
+  }
+
+  async function fetchRemove(collection: string, key: string, scope: StorageScope) {
+    const response = await sdkFetch({
+      method: 'DELETE',
+      url: `${baseUrl}/item/${encodeURIComponent(key)}?collection=${encodeURIComponent(collection)}`,
+      headers: headersForScope(scope),
+    })
+    if (response.status !== 200) {
+      throw new Error(`Failed to remove storage item: ${response.status}`)
+    }
+  }
+
+  async function fetchList(collection: string, scope: StorageScope, limit: number | undefined) {
+    const params = new URLSearchParams({ collection })
+    if (limit !== undefined) params.set('limit', String(limit))
+    const response = await sdkFetch({
+      method: 'GET',
+      url: `${baseUrl}/list?${params.toString()}`,
+      headers: headersForScope(scope),
+    })
+    if (response.status !== 200) {
+      throw new Error(`Failed to list storage: ${response.status}`)
+    }
+    const data = response.data as { data: { entries: Array<{ key: string; value: unknown }> } }
+    return { entries: data.data.entries }
+  }
+
+  /** Build the positional item API for a (collection, defaults) pair. */
+  function itemApi(collection: string, defaults: StorageSetOptions): StorageItemApi {
+    const scopeOf = (opts?: StorageOptions): StorageScope =>
+      opts?.scope ?? defaults.scope ?? 'installation'
+    const ttlOf = (opts?: StorageSetOptions): number | undefined =>
+      opts?.ttlSeconds ?? defaults.ttlSeconds
+    return {
+      get: (key, opts) =>
+        fetchGet(collection, key, scopeOf(opts)) as Promise<{ value: never } | null>,
+      set: async (key, value, opts) => {
+        await fetchSet(collection, key, value, scopeOf(opts), ttlOf(opts), false)
+      },
+      setIfAbsent: async (key, value, opts) => {
+        const response = await fetchSet(collection, key, value, scopeOf(opts), ttlOf(opts), true)
+        const data = response.data as { data: { created: boolean } }
+        return data.data.created
+      },
+      remove: (key, opts) => fetchRemove(collection, key, scopeOf(opts)),
+    }
+  }
+
   return {
-    get: async ({ collection, key, scope }) => {
-      const response = await sdkFetch({
-        method: 'GET',
-        url: `${baseUrl}/item/${encodeURIComponent(key)}?collection=${encodeURIComponent(collection)}`,
-        headers: headersForScope(scope),
-      })
-      if (response.status !== 200) {
-        throw new Error(`Failed to get storage item: ${response.status}`)
+    ...itemApi('', {}),
+    collection(name: string, defaults: StorageSetOptions = {}): StorageCollectionApi {
+      return {
+        ...itemApi(name, defaults),
+        list: (opts) =>
+          fetchList(name, defaults.scope ?? 'installation', opts?.limit) as Promise<{
+            entries: Array<{ key: string; value: never }>
+          }>,
       }
-      const data = response.data as { data: { item: { value: unknown } | null } }
-      return data.data.item
-    },
-
-    set: async ({ collection, key, value, scope, ttlSeconds }) => {
-      const response = await sdkFetch({
-        method: 'PUT',
-        url: `${baseUrl}/item/${encodeURIComponent(key)}`,
-        headers: headersForScope(scope),
-        body: { value, collection, ttlSeconds },
-      })
-      if (response.status !== 200) {
-        throw new Error(`Failed to set storage item: ${response.status}`)
-      }
-    },
-
-    setIfAbsent: async ({ collection, key, value, scope, ttlSeconds }) => {
-      const response = await sdkFetch({
-        method: 'PUT',
-        url: `${baseUrl}/item/${encodeURIComponent(key)}`,
-        headers: headersForScope(scope),
-        body: { value, collection, ttlSeconds, ifAbsent: true },
-      })
-      if (response.status !== 200) {
-        throw new Error(`Failed to set storage item: ${response.status}`)
-      }
-      const data = response.data as { data: { created: boolean } }
-      return data.data.created
-    },
-
-    remove: async ({ collection, key, scope }) => {
-      const response = await sdkFetch({
-        method: 'DELETE',
-        url: `${baseUrl}/item/${encodeURIComponent(key)}?collection=${encodeURIComponent(collection)}`,
-        headers: headersForScope(scope),
-      })
-      if (response.status !== 200) {
-        throw new Error(`Failed to remove storage item: ${response.status}`)
-      }
-    },
-
-    list: async ({ collection, scope, limit }) => {
-      const params = new URLSearchParams({ collection })
-      if (limit !== undefined) params.set('limit', String(limit))
-      const response = await sdkFetch({
-        method: 'GET',
-        url: `${baseUrl}/list?${params.toString()}`,
-        headers: headersForScope(scope),
-      })
-      if (response.status !== 200) {
-        throw new Error(`Failed to list storage: ${response.status}`)
-      }
-      const data = response.data as { data: { entries: Array<{ key: string; value: unknown }> } }
-      return { entries: data.data.entries }
     },
   }
 }

--- a/apps/web/src/lib/extensions/connection-dialog-suppression.ts
+++ b/apps/web/src/lib/extensions/connection-dialog-suppression.ts
@@ -1,0 +1,35 @@
+// apps/web/src/lib/extensions/connection-dialog-suppression.ts
+
+/**
+ * Ref-counted registry of installation IDs for which the auto-popping
+ * {@link ConnectionExpiredDialog} should be suppressed.
+ *
+ * The workflow builder renders an app node's config by asking the app bundle to
+ * draw its panel, which auto-calls server functions to populate fields. When the
+ * connection is expired those calls return `CONNECTION_REQUIRED` — but during
+ * regular config editing we don't want an unprompted modal hijacking the screen.
+ * The App Settings status dot + connection picker already surface that state.
+ *
+ * Run/test paths go through tRPC (`workflow.runSingleNode`) and the app-trigger
+ * test endpoint — not the server-function bridge — so they are unaffected and
+ * keep their existing connection feedback.
+ */
+const counts = new Map<string, number>()
+
+/**
+ * Suppress the connection-expired modal for `installationId` until the returned
+ * disposer runs. Ref-counted so overlapping mounts compose correctly.
+ */
+export function suppressConnectionDialog(installationId: string): () => void {
+  counts.set(installationId, (counts.get(installationId) ?? 0) + 1)
+  return () => {
+    const next = (counts.get(installationId) ?? 0) - 1
+    if (next <= 0) counts.delete(installationId)
+    else counts.set(installationId, next)
+  }
+}
+
+/** Whether the connection-expired modal is currently suppressed for `installationId`. */
+export function isConnectionDialogSuppressed(installationId: string): boolean {
+  return (counts.get(installationId) ?? 0) > 0
+}

--- a/apps/web/src/lib/extensions/server-function-handler.ts
+++ b/apps/web/src/lib/extensions/server-function-handler.ts
@@ -1,6 +1,7 @@
 // apps/web/src/lib/extensions/server-function-handler.ts
 
 import { toastError } from '@auxx/ui/components/toast'
+import { isConnectionDialogSuppressed } from './connection-dialog-suppression'
 import { connectionExpiredEmitter } from './connection-expired-emitter'
 import type { MessageClient } from './message-client'
 
@@ -86,6 +87,15 @@ export function setupServerFunctionHandler(
               const isExpired = errorData.error.message?.toLowerCase().includes('expired')
 
               if (context.connectionDefinition) {
+                // Suppressed surfaces (e.g. the workflow builder editing an app
+                // node) auto-load options via server functions — an expired
+                // connection there shouldn't pop an unprompted modal. The App
+                // Settings status dot already surfaces it. Run/test use a
+                // different path and keep the dialog.
+                if (isConnectionDialogSuppressed(context.appInstallationId)) {
+                  return { error: 'connection-expired-awaiting-reauth' }
+                }
+
                 // Show inline reconnect dialog for both expired and missing connections
                 connectionExpiredEmitter.emit({
                   appId: context.appId,

--- a/apps/web/src/lib/workflow/components/app-workflow-panel.tsx
+++ b/apps/web/src/lib/workflow/components/app-workflow-panel.tsx
@@ -9,6 +9,7 @@ import { useNodeCrud } from '~/components/workflow/hooks'
 import { AppTriggerTestSection } from '~/components/workflow/nodes/core/app-trigger/app-trigger-test-section'
 import { BasePanel } from '~/components/workflow/nodes/shared/base/base-panel'
 import { OutputVariablesDisplay } from '~/components/workflow/ui/output-variables'
+import { suppressConnectionDialog } from '~/lib/extensions/connection-dialog-suppression'
 import { reconstructReactTree } from '~/lib/extensions/reconstruct-react-tree'
 import { useOptionalMessageClient } from '~/lib/extensions/use-optional-message-client'
 import { useExtensionsContext } from '~/providers/extensions/extensions-context'
@@ -89,6 +90,12 @@ export const AppWorkflowPanel = memo<AppWorkflowPanelProps>(
     useEffect(() => {
       nodeDataRef.current = nodeData
     }, [nodeData])
+
+    // Suppress the global connection-expired modal while editing this app node's
+    // config. The panel auto-loads field options via server functions; an
+    // expired connection shouldn't pop an unprompted dialog here. Status is
+    // still shown via the App Settings dot, and run/test use a separate path.
+    useEffect(() => suppressConnectionDialog(resolvedInstallationId), [resolvedInstallationId])
 
     /**
      * Handle field value changes from VarEditor-backed input components.

--- a/packages/sdk/src/server/__tests__/storage.test.ts
+++ b/packages/sdk/src/server/__tests__/storage.test.ts
@@ -3,12 +3,28 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { storage } from '../storage'
 
-/** Capture every host call so we can assert what the sugar forwarded. */
+/**
+ * The wrapper is a thin passthrough to `AUXX_SERVER_SDK.storage` — in an app
+ * build `@auxx/sdk/server` is externalized to that global, so the wrapper code
+ * never runs in the sandbox and the host owns the real implementation. These
+ * tests assert the wrapper forwards positional calls verbatim and that the host
+ * it forwards to exposes the public surface (positional args + `collection()`),
+ * which is the contract production actually relies on.
+ */
 function installHost() {
-  const calls: Array<{ method: string; args: unknown }> = []
-  const record = (method: string, ret: unknown) => async (args: unknown) => {
-    calls.push({ method, args })
-    return ret
+  const calls: Array<{ method: string; args: unknown[] }> = []
+  const record =
+    (method: string, ret: unknown) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args })
+      return Promise.resolve(ret)
+    }
+  const collectionApi = {
+    get: record('collection.get', { value: 7 }),
+    set: record('collection.set', undefined),
+    setIfAbsent: record('collection.setIfAbsent', true),
+    remove: record('collection.remove', undefined),
+    list: record('collection.list', { entries: [{ key: 'a', value: 1 }] }),
   }
   ;(global as { AUXX_SERVER_SDK?: unknown }).AUXX_SERVER_SDK = {
     storage: {
@@ -16,7 +32,10 @@ function installHost() {
       set: record('set', undefined),
       setIfAbsent: record('setIfAbsent', true),
       remove: record('remove', undefined),
-      list: record('list', { entries: [{ key: 'a', value: 1 }] }),
+      collection: (name: string, defaults?: unknown) => {
+        calls.push({ method: 'collection', args: [name, defaults] })
+        return collectionApi
+      },
     },
   }
   return calls
@@ -27,70 +46,49 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-describe('storage sugar', () => {
+describe('storage wrapper (passthrough)', () => {
   let calls: ReturnType<typeof installHost>
   beforeEach(() => {
     calls = installHost()
   })
 
-  it('plain key defaults to installation scope and collection ""', async () => {
+  it('forwards get positionally', async () => {
     await storage.get('k')
-    expect(calls[0]).toEqual({
-      method: 'get',
-      args: { collection: '', key: 'k', scope: 'installation' },
-    })
+    expect(calls[0]).toEqual({ method: 'get', args: ['k', undefined] })
   })
 
-  it('forwards explicit scope + ttl on set', async () => {
+  it('forwards set with value + opts positionally', async () => {
     await storage.set('k', { a: 1 }, { scope: 'connection', ttlSeconds: 60 })
-    expect(calls[0].args).toEqual({
-      collection: '',
-      key: 'k',
-      value: { a: 1 },
-      scope: 'connection',
-      ttlSeconds: 60,
+    expect(calls[0]).toEqual({
+      method: 'set',
+      args: ['k', { a: 1 }, { scope: 'connection', ttlSeconds: 60 }],
     })
   })
 
-  it('get returns the host wrapper verbatim (a stored null is { value: null })', async () => {
+  it('returns the host get wrapper verbatim (a stored null is { value: null })', async () => {
     ;(global as any).AUXX_SERVER_SDK.storage.get = async () => ({ value: null })
     await expect(storage.get('k')).resolves.toEqual({ value: null })
     ;(global as any).AUXX_SERVER_SDK.storage.get = async () => null
     await expect(storage.get('k')).resolves.toBeNull()
   })
 
-  it('collection() binds the name and applies defaults to every call', async () => {
+  it('forwards collection() to the host and uses the host-bound collection api', async () => {
     const watches = storage.collection('watch', { scope: 'connection' })
     await watches.set('1Z', { status: 'in_transit' }, { ttlSeconds: 100 })
     await watches.get('1Z')
     await watches.remove('1Z')
-    expect(calls.map((c) => c.args)).toEqual([
-      {
-        collection: 'watch',
-        key: '1Z',
-        value: { status: 'in_transit' },
-        scope: 'connection',
-        ttlSeconds: 100,
-      },
-      { collection: 'watch', key: '1Z', scope: 'connection' },
-      { collection: 'watch', key: '1Z', scope: 'connection' },
+    expect(calls).toEqual([
+      { method: 'collection', args: ['watch', { scope: 'connection' }] },
+      { method: 'collection.set', args: ['1Z', { status: 'in_transit' }, { ttlSeconds: 100 }] },
+      { method: 'collection.get', args: ['1Z'] },
+      { method: 'collection.remove', args: ['1Z'] },
     ])
   })
 
-  it('per-call scope overrides the collection default', async () => {
-    const c = storage.collection('watch', { scope: 'connection' })
-    await c.get('k', { scope: 'installation' })
-    expect(calls[0].args).toMatchObject({ scope: 'installation' })
-  })
-
-  it('list exists only on a collection and forwards the bound scope + limit', async () => {
-    const c = storage.collection('watch', { scope: 'connection' })
-    const out = await c.list({ limit: 10 })
+  it('list lives on the bound collection and forwards opts', async () => {
+    const out = await storage.collection('watch', { scope: 'connection' }).list({ limit: 10 })
     expect(out).toEqual({ entries: [{ key: 'a', value: 1 }] })
-    expect(calls[0]).toEqual({
-      method: 'list',
-      args: { collection: 'watch', scope: 'connection', limit: 10 },
-    })
+    expect(calls.at(-1)).toEqual({ method: 'collection.list', args: [{ limit: 10 }] })
     // No `list` on the top-level handle.
     expect((storage as unknown as { list?: unknown }).list).toBeUndefined()
   })

--- a/packages/sdk/src/server/storage.ts
+++ b/packages/sdk/src/server/storage.ts
@@ -80,41 +80,17 @@ export interface Storage extends StorageItemApi {
 }
 
 /**
- * Host-side storage implementation injected on the `AUXX_SERVER_SDK` global.
- * Flat methods taking `collection` as an argument — `collection()` is pure
- * client-side sugar over these.
+ * Resolve the host `storage` implementation or throw the standard SDK error.
+ *
+ * In an app build `@auxx/sdk/server` is externalized to the `AUXX_SERVER_SDK`
+ * global, so the `storage` export below is replaced wholesale by
+ * `AUXX_SERVER_SDK.storage` and this passthrough never runs. It exists only for
+ * non-externalized consumers (and tests). The host therefore owns the real
+ * implementation and MUST expose this exact public surface — see
+ * `apps/lambda/src/runtime-helpers/server-sdk.ts` `createStorageHost`.
  */
-interface StorageHost {
-  get(args: {
-    collection: string
-    key: string
-    scope: StorageScope
-  }): Promise<{ value: unknown } | null>
-  set(args: {
-    collection: string
-    key: string
-    value: unknown
-    scope: StorageScope
-    ttlSeconds?: number
-  }): Promise<void>
-  setIfAbsent(args: {
-    collection: string
-    key: string
-    value: unknown
-    scope: StorageScope
-    ttlSeconds?: number
-  }): Promise<boolean>
-  remove(args: { collection: string; key: string; scope: StorageScope }): Promise<void>
-  list(args: {
-    collection: string
-    scope: StorageScope
-    limit?: number
-  }): Promise<{ entries: Array<{ key: string; value: unknown }> }>
-}
-
-/** Resolve the host storage implementation or throw the standard SDK error. */
-function host(): StorageHost {
-  const sdk = (global as { AUXX_SERVER_SDK?: { storage?: StorageHost } }).AUXX_SERVER_SDK
+function host(): Storage {
+  const sdk = (global as { AUXX_SERVER_SDK?: { storage?: Storage } }).AUXX_SERVER_SDK
   if (sdk?.storage && typeof sdk.storage.get === 'function') {
     return sdk.storage
   }
@@ -123,35 +99,10 @@ function host(): StorageHost {
   )
 }
 
-/** Build the item-level API for a (collection, defaults) pair — used for both plain keys and collections. */
-function itemApi(collection: string, defaults: StorageSetOptions): StorageItemApi {
-  const scopeOf = (opts?: StorageOptions): StorageScope =>
-    opts?.scope ?? defaults.scope ?? 'installation'
-  const ttlOf = (opts?: StorageSetOptions): number | undefined =>
-    opts?.ttlSeconds ?? defaults.ttlSeconds
-
-  return {
-    get: (key, opts) =>
-      host().get({ collection, key, scope: scopeOf(opts) }) as Promise<{ value: never } | null>,
-    set: (key, value, opts) =>
-      host().set({ collection, key, value, scope: scopeOf(opts), ttlSeconds: ttlOf(opts) }),
-    setIfAbsent: (key, value, opts) =>
-      host().setIfAbsent({ collection, key, value, scope: scopeOf(opts), ttlSeconds: ttlOf(opts) }),
-    remove: (key, opts) => host().remove({ collection, key, scope: scopeOf(opts) }),
-  }
-}
-
 export const storage: Storage = {
-  ...itemApi('', {}),
-  collection(name: string, defaults: StorageSetOptions = {}): StorageCollectionApi {
-    return {
-      ...itemApi(name, defaults),
-      list: (opts) =>
-        host().list({
-          collection: name,
-          scope: defaults.scope ?? 'installation',
-          limit: opts?.limit,
-        }) as Promise<{ entries: Array<{ key: string; value: never }> }>,
-    }
-  },
+  get: <T = unknown>(key: string, opts?: StorageOptions) => host().get<T>(key, opts),
+  set: (key, value, opts) => host().set(key, value, opts),
+  setIfAbsent: (key, value, opts) => host().setIfAbsent(key, value, opts),
+  remove: (key, opts) => host().remove(key, opts),
+  collection: (name, defaults) => host().collection(name, defaults),
 }


### PR DESCRIPTION
## Summary

Two changes, bundled for a new `@auxx/sdk` release:

### 1. `fix(sdk)` — app KV storage host signature (the FedEx blocker)

The app KV storage surface (shipped in #833) failed at runtime with
`Failed to set storage item: 400` — the request hit
`PUT /api/v1/sdk/storage/item/undefined?collection=undefined`.

**Root cause:** `@auxx/sdk/server` is externalized to the `AUXX_SERVER_SDK`
global at app-build time (`create-server-build-config.ts`), so the SDK wrapper
is never bundled — the sandbox calls the lambda host (`createStorageHost`)
directly. Every other server SDK function holds the invariant that the host
method signature equals the public positional signature, so calling the host
directly is transparent. Storage broke it: the public surface is positional with
a stateful `collection()` accessor, but the host took a single options object.
`storage.set('bearer-token', v, opts)` made the host destructure
`{collection,key,value,...}` out of the **string** `'bearer-token'` → every field
`undefined`.

**Fix:** `createStorageHost` now exposes the exact public `Storage` surface
(positional `get`/`set`/`setIfAbsent`/`remove` + `collection()`), with the HTTP
calls as private helpers. The SDK wrapper is reduced to a thin passthrough,
matching `getConnection`/`setOrganizationSetting`/etc.

Both test suites previously encoded the wrong (object-arg) contract — which is
why they passed while production broke. Rewrote them to assert the positional
contract, including a named regression test that args reach the URL/body instead
of becoming `undefined`.

Verified end-to-end against the FedEx app: token mint → connection-scoped KV
write-through → tracking response.

### 2. `feat(web)` — suppress connection-expired dialog during app-node config editing

The workflow builder renders an app node's panel by auto-calling server functions
to populate fields; when the connection is expired those return
`CONNECTION_REQUIRED` and pop the `ConnectionExpiredDialog` mid-edit. Adds a
ref-counted suppression registry so the builder can silence the auto-modal during
config editing (the App Settings status dot + connection picker already surface
that state). Run/test paths go through tRPC, not the server-function bridge, so
they keep their existing connection feedback.

## Test plan

- [x] `deno test` — lambda storage host: 7/7 pass (incl. `item/undefined` regression guard)
- [x] `@auxx/sdk` vitest: 34/34 pass
- [x] Manual: FedEx track block returns a real result with the token cached in KV
- [ ] Confirm token-reuse path on a second call within TTL (cache read)

## Deploy notes

- No DB migration — `AppStorage` already shipped in #833.
- The host fix deploys with `apps/lambda`; the SDK wrapper change is externalized
  away (types unchanged), so no extra app rebuild is needed beyond the normal
  `@auxx/sdk` release.