### PR TITLE
fix(lambda): add --allow-sys to dev-server deno compile

### DIFF
--- a/apps/lambda/Dockerfile.server
+++ b/apps/lambda/Dockerfile.server
@@ -31,7 +31,7 @@ RUN deno cache src/dev-server.ts
 
 # Compile to standalone binary
 RUN deno compile \
-  --allow-net --allow-env --allow-read --allow-write=/tmp \
+  --allow-net --allow-env --allow-read --allow-write=/tmp --allow-sys \
   --output dist/server \
   src/dev-server.ts
 


### PR DESCRIPTION
## Problem

Running a FedEx v2 app workflow in **production** (Railway) fails with:

```
Requires sys access to "osRelease", specify the required permissions during compilation using `deno compile --allow-sys`
```

This is a Deno **permissions** issue, not a bug in the app. Deno bakes a fixed permission set into the standalone binary at compile time. Something in the app workflow runtime path (the `@auxx/sdk` → `npm:` dependency chain — `osRelease` reads are common in HTTP user-agent strings and AWS SDK runtime detection) calls `Deno.osRelease()`, which needs `sys` access.

It works elsewhere because:
- **dev** — `deno.json` `dev` task uses `--allow-all`
- **AWS Lambda binary** — `build.sh` already passes `--allow-sys`

It fails on **Railway** because `Dockerfile.server` (the self-hosted server variant that compiles `dev-server.ts`, the prod entry) omits `--allow-sys`.

## Fix

Add `--allow-sys` to the `deno compile` in `Dockerfile.server`, matching `build.sh` and the dev task.

## Deploy note

The permission is baked in at build time, so the lambda service must be **rebuilt/redeployed** on Railway for this to take effect.