### PR TITLE
fix(ui): respect iOS safe-area insets on mobile

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -20,6 +20,10 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  // Render edge-to-edge so the iOS notch / Dynamic Island / home-indicator
+  // insets become available via env(safe-area-inset-*). See the `*-safe`
+  // utilities in @auxx/ui/global.css that consume them.
+  viewportFit: 'cover',
 }
 
 export const metadata: Metadata = {

--- a/apps/web/src/components/global/dashboard.tsx
+++ b/apps/web/src/components/global/dashboard.tsx
@@ -128,7 +128,7 @@ export const Dashboard = ({
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}>
         <DndStateProvider activeDndItem={activeDndItem}>
-          <div className='flex h-screen overflow-hidden w-full'>
+          <div className='flex h-screen overflow-hidden w-full pt-safe pb-safe pl-safe pr-safe'>
             <AppSidebar className='min-w-0' user={user} />
             <SidebarInset className='min-h-0'>
               <DemoBanner />

--- a/apps/web/src/components/kopilot/ui/kopilot-dock.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-dock.tsx
@@ -47,7 +47,7 @@ export function KopilotDock() {
       <AnimatePresence initial={false}>
         {panelOpen && (
           <motion.div
-            className='fixed inset-0 z-50 bg-background'
+            className='fixed inset-0 z-50 bg-background pt-safe pb-safe pl-safe pr-safe'
             initial={{ opacity: 0, y: '100%' }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: '100%' }}

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -177,7 +177,7 @@ function Sidebar({
           className='w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden'
           style={{ '--sidebar-width': SIDEBAR_WIDTH_MOBILE } as React.CSSProperties}
           side={side}>
-          <div className='flex h-full w-full flex-col select-none'>{children}</div>
+          <div className='flex h-full w-full flex-col select-none pt-safe pb-safe'>{children}</div>
         </SheetContent>
       </Sheet>
     )

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -1020,6 +1020,29 @@ input[data-variant='translucent']:-webkit-autofill:active {
   }
 }
 
+/*
+ * Safe-area utilities — pad an element by the iOS notch / Dynamic Island /
+ * home-indicator insets. Require `viewportFit: 'cover'` on the viewport to
+ * resolve to non-zero values; they fall back to 0 everywhere else, so they
+ * are safe to apply unconditionally (no-op on desktop/Android).
+ *
+ * Apply to a full-bleed element that also paints its own background (the bg
+ * extends under the padding, so the notch area stays filled while content
+ * sits inside the safe area).
+ */
+@utility pt-safe {
+  padding-top: env(safe-area-inset-top);
+}
+@utility pr-safe {
+  padding-right: env(safe-area-inset-right);
+}
+@utility pb-safe {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+@utility pl-safe {
+  padding-left: env(safe-area-inset-left);
+}
+
 @layer components {
   .timeline-events .emphasis {
     color: rgb(var(--primary-700));


### PR DESCRIPTION
## What

Pad the app's full-bleed mobile surfaces by the iOS safe-area insets (notch / Dynamic Island / home indicator) so content no longer sits under them.

## How

- `viewportFit: 'cover'` on the viewport (`apps/web/src/app/layout.tsx`) so `env(safe-area-inset-*)` resolves to non-zero values.
- New Tailwind utilities `pt-safe / pr-safe / pb-safe / pl-safe` (`packages/ui/src/styles/global.css`) that pad by the corresponding inset.
- Applied to the full-bleed containers that paint their own background: the dashboard shell, the mobile sidebar sheet, and the Kopilot mobile dock.

The utilities resolve to `0` everywhere except iOS standalone/cover viewports, so they're no-ops on desktop and Android — safe to apply unconditionally.

## Risk

CSS-only / layout padding. No behavior or data changes.