### PR TITLE
docs(blog): "Building an AI Agent Engine" three-part series

### DIFF
--- a/apps/homepage/content/blog/agent-engine-part-1-domain-agnostic-harness.mdx
+++ b/apps/homepage/content/blog/agent-engine-part-1-domain-agnostic-harness.mdx
@@ -1,0 +1,228 @@
+---
+title: "Building an AI Agent Engine, Part 1: A Domain-Agnostic Harness"
+description: "How we built the runtime that powers Kopilot: parts-based messages, async-generator streaming, and the safety valves that keep a model from running away. The first of a three-part deep dive."
+date: "2026-05-12"
+slug: "agent-engine-part-1-domain-agnostic-harness"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["ai", "agents", "architecture", "typescript", "open-source"]
+published: true
+---
+
+The interesting part of an AI agent isn't the prompt. It's the runtime around it: the loop that takes a message, streams a model response, runs tools, decides when to stop, and refuses to spin forever when the model gets confused.
+
+We [wrote about this harness once before](/blog/how-we-built-kopilot-agent-loop). Since then we rebuilt it. The old version routed every message through a pipeline of specialized agents: a supervisor that classified intent, then a planner, an executor, and a responder. The new version runs a single agent instead of a pipeline, and does far more with it. This is the first of three posts on how it works.
+
+The plan for the series:
+
+1. **This post** covers the generic engine: the loop, how messages are stored, how everything streams, and the guardrails.
+2. **[Part 2](/blog/agent-engine-part-2-tools-approval-determinism)** is about making the agent act: tools, human-in-the-loop approval, and how you test a system built on a non-deterministic model.
+3. **[Part 3](/blog/agent-engine-part-3-kopilot-domain-layer)** is the domain layer: how this generic engine becomes Kopilot, the copilot embedded in the app.
+
+One idea runs through all three. The engine knows nothing about CRMs, email, or tickets. It speaks one interface, and domains plug into it. Kopilot is one such domain. So are our workflow AI nodes and our autonomous, triggered runs. This post is where that claim gets earned.
+
+The code lives in `packages/lib/src/ai/agent-framework/`. Auxx.ai is [open source](https://github.com/auxxai/auxx), so you can read along.
+
+## The loop is the product
+
+An agent, stripped down, is three things: a model, a set of tools, and a loop that decides when to call them and when to stop. The model is a commodity you can swap out. The tools are domain-specific. The loop is the part you own, and it holds every hard decision.
+
+Our loop has two layers.
+
+`AgentEngine` owns a *turn*. It takes a user message, runs the agent to completion, enforces budgets, accumulates usage, persists the result, and knows how to pause and resume. It is the orchestrator.
+
+`agentQueryLoop` is the inner loop. It builds the prompt, calls the model, collects tool calls, executes them, appends the results, and goes around again until the model stops asking for tools. It is the executor.
+
+Keeping these two separate is what lets the same inner loop run under interactive chat, inside a workflow step, and in a headless eval simulation. The orchestration around it changes. The loop itself does not.
+
+```
+User message
+  → Engine.submitMessage
+    → buildMessages (system prompt + history)
+    → callModel (stream)
+    → tool calls?
+        yes → execute → append results → loop
+        no  → finalize
+  → persist
+```
+
+## One message, many parts
+
+The first decision shaped everything downstream: how do you store a turn?
+
+The obvious answer is a flat list of role-tagged messages. User, assistant, tool, tool, assistant, and so on. It maps cleanly to the chat-completions API, but it is painful to render. A single turn, where the model thinks, calls two tools, then writes a reply, becomes four or five rows that the UI has to stitch back together every time.
+
+We went the other way. A turn is one assistant message holding an ordered array of *parts*:
+
+```typescript
+type ContentPart = TextPart | ThinkingPart | ToolCallPart
+
+type AssistantSessionMessage = {
+  role: 'assistant'
+  parts: ContentPart[] // [thinking, tool_call, text, tool_call, text, ...]
+  metadata: { usage: IterationUsage[] }
+}
+```
+
+Text, reasoning, and tool calls interleave in the exact order they happened. The important property is that the persisted shape matches the streamed shape exactly. What the UI renders live as the turn unfolds is byte-for-byte what gets saved, so there is no reconciliation step between the streaming view and the reloaded view. That gap is the source of a whole category of chat-UI bugs, and parts close it.
+
+Each tool-call part carries its own status, which drives the UI directly:
+
+```typescript
+type ToolCallStatus =
+  | 'running'
+  | 'awaiting-approval'
+  | 'completed'
+  | 'error'
+  | 'rejected'
+```
+
+There is no separate state machine for "is this tool waiting on the user." It is a field on the part.
+
+We pay for this in one place: replay. The model's API still wants the classic assistant-then-tool-result shape, so when we build the prompt for the next call we expand each `tool_call` part back into the message pair the API expects:
+
+```typescript
+// utils.ts: parts become wire format only at call time
+const wire = sessionMessagesToWire(messages)
+```
+
+A single bubble for humans, a spec-compliant transcript for the model. The conversion happens once, at the boundary, and nowhere else.
+
+## Async generators all the way down
+
+The whole pipeline streams, and it streams using async generators. The engine is a generator. The inner loop is a generator. The model adapter is a generator. They compose with `yield*`:
+
+```typescript
+async *submitMessage(message): AsyncGenerator<AgentEvent> {
+  yield* this.runTurn(message)
+}
+```
+
+Every meaningful thing that happens is an `AgentEvent`. There are around twenty of them:
+
+```typescript
+type AgentEvent =
+  | { type: 'turn-started' }
+  | { type: 'agent-started'; agent: string }
+  | { type: 'text-delta'; delta: string }
+  | { type: 'thinking-delta'; delta: string }
+  | { type: 'tool-call-started'; toolCallId: string; name: string }
+  | { type: 'tool-call-completed'; toolCallId: string; digest: unknown }
+  | { type: 'tool-call-failed'; toolCallId: string; error: string }
+  | { type: 'approval-required'; toolCallId: string; args: unknown }
+  | { type: 'assistant-message-finished'; parts: ContentPart[] }
+  | { type: 'turn-completed' }
+  // ...and more
+```
+
+These events bubble up out of the engine, get written to the SSE endpoint, fan out over Redis pub/sub, and land in a Zustand store on the frontend that turns them into thinking steps, streaming text, and tool-status pills.
+
+Generators beat callbacks or an event emitter here for four reasons. Events flow upstream the moment they are produced, with no buffering. Backpressure is free, so a slow consumer pauses the producer and nothing overflows. `yield*` delegates into a sub-generator without the parent knowing its internals. And cancellation is clean: an `AbortController` threads through every layer, so when the user hits stop the signal fires and each layer bails on its next iteration.
+
+One detail is worth pulling out. The terminal `assistant-message-finished` event carries the complete parts array. It acts as a checksum. Even if a delta got dropped or the client reconnected mid-stream, that final event reconciles the rendered message to the truth before it is persisted. Streaming and storage never disagree.
+
+## The safety valves
+
+This is the least glamorous and most important part of an agent harness. A model that can call tools in a loop can also get stuck in one. Here is what keeps it honest.
+
+A three-part turn budget, enforced at the engine level so it spans every iteration:
+
+```typescript
+const TURN_BUDGET = {
+  maxTokensPerTurn: 200_000,
+  maxTotalIterations: 50,
+  maxApprovalsPerTurn: 5,
+}
+```
+
+Idempotent tool caching. If the model calls the same tool with the same arguments twice in a turn, which happens more than you would expect, we serve the first result instead of hitting the database again. The cache key is the tool name plus a stable serialization of the arguments:
+
+```typescript
+const cacheKey = `${toolName}::${stableStringify(args)}`
+```
+
+Streak detection. A raw iteration cap is a blunt instrument that lets a stuck model burn forty iterations before giving up. Streak detection catches the two failure modes much earlier. On a failure streak, where the same tool fails the same way three times in a row, the turn aborts with an error, because the model is looping on something that will not work. On a success streak, where the same tool succeeds with identical arguments and the model keeps emitting the same surrounding text, the turn finalizes gracefully, because the model is done and only repeating itself.
+
+```typescript
+if (sameToolFailedIdentically(history, 3)) {
+  yield { type: 'turn-aborted', reason: 'tool-failure-streak' }
+  return
+}
+```
+
+Terminal tools. Some tool calls are themselves the answer. A tool marked `endsTurn: true` is a UI directive, like one that hands the user a set of suggested replies. When every tool call in an iteration is one of these and they all succeed, the loop finalizes immediately without calling the model again, and the prose the model already wrote becomes the reply. That saves a full round-trip on a common path.
+
+The `minToolCalls` nudge. Sometimes the model writes the answer as prose when it should have looked something up first. An agent can require a minimum number of tool calls before a text-only exit. If the model tries to skip ahead, we inject a synthetic nudge and let it try again.
+
+Text de-duplication. Models like to restate themselves. A normalized containment check drops an earlier text part when a later one repeats it verbatim, so the user does not read the same sentence twice.
+
+None of these are exotic. Together they are the difference between a demo and something you can leave running.
+
+## The adapter is the only provider-aware file
+
+Everything above the model is provider-agnostic. The one file that knows the difference between Anthropic and OpenAI is `llm-adapter.ts`, which exposes a single `callModel` generator. (We covered the provider routing underneath it in our [multi-provider AI system](/blog/multi-provider-ai-system-part-1) write-up.)
+
+It does three jobs worth mentioning.
+
+It buffers deltas. Token-level deltas are batched by a small character threshold and a short timer before they go out as events, which cuts SSE event volume sharply with no visible hit to how fast text appears.
+
+It detects truncation. If the model stops because it hit its output limit, the adapter flags it. Without that you get a half-emitted tool call that fails to parse downstream with no explanation.
+
+It captures cost. Every call records actual usage, including prompt-cache reads and writes. There is a provider quirk here: OpenAI folds cached-read tokens into `prompt_tokens` while Anthropic reports them separately, so the adapter normalizes both and the billing math upstream stays provider-neutral. How that becomes credits is its own topic. The point for now is that the adapter is the single place where the truth about cost is captured.
+
+## Keeping the conversation in budget
+
+Long conversations eventually exceed the model's window. A context manager keeps the system prompt and the most recent messages intact, and when a turn runs over budget it summarizes everything in between with a single model call:
+
+```typescript
+return [systemMessage, summaryMessage, ...recentMessages]
+```
+
+Token counts come from a four-characters-per-token estimate, not a real tokenizer. The number only has to be good enough to stay under a ceiling. The manager also drops chain-of-thought from older turns: reasoning earns its tokens on the turn that produces it and never again.
+
+## What the engine refuses to know
+
+Notice what never appeared in this post: tickets, emails, contacts, pages. The engine does not know they exist. It speaks exactly two interfaces:
+
+```typescript
+interface AgentDefinition<TDomainState> {
+  buildMessages(state, deps): Promise<WireMessage[]>
+  processResult(content, toolCalls, state, deps): Promise<AgentState>
+  tools: AgentToolDefinition[]
+  model?: string
+}
+
+interface AgentDomainConfig<TDomainState> {
+  agents: Record<string, AgentDefinition<TDomainState>>
+  routes: Route[]
+  createInitialState(context): TDomainState
+  // lifecycle hooks...
+}
+```
+
+The generic `TDomainState` lets a domain thread its own shape through the engine without the framework caring what is in it. Kopilot fills this in with everything that makes it a product, which is the subject of Part 3.
+
+## What we'd do differently
+
+Tighter token counting. The four-characters estimate has never caused a real incident, but as we push longer contexts that imprecision will eventually bite. A real tokenizer is on the list.
+
+Parallel tool execution within an iteration. When the model asks for two independent tools in one step, we still run them in sequence. The loop is structured to support running them concurrently, we just have not wired it up. Most iterations call only one tool, so the payoff is narrow, but it is there.
+
+## Next up
+
+We have a loop that streams, stores turns cleanly, and will not run away. So far it can only read. The harder engineering is in making an agent take actions you cannot undo, like sending an email or mutating a record, and then making that same agent deterministically testable, which sounds impossible for a system built on a non-deterministic model.
+
+That is [Part 2](/blog/agent-engine-part-2-tools-approval-determinism).
+
+If you want to read ahead, the entry points are:
+
+- `packages/lib/src/ai/agent-framework/engine.ts`, the orchestrator
+- `packages/lib/src/ai/agent-framework/query-loop.ts`, the inner loop
+- `packages/lib/src/ai/agent-framework/types.ts`, the core types
+- `packages/lib/src/ai/agent-framework/llm-adapter.ts`, the provider boundary
+
+Auxx.ai is [open source](https://github.com/auxxai/auxx). PRs welcome.

--- a/apps/homepage/content/blog/agent-engine-part-2-tools-approval-determinism.mdx
+++ b/apps/homepage/content/blog/agent-engine-part-2-tools-approval-determinism.mdx
@@ -1,0 +1,215 @@
+---
+title: "Building an AI Agent Engine, Part 2: Tools, Approval & Determinism"
+description: "A read-only chat loop is easy. An agent that sends emails, mutates records, and can still be replayed deterministically in a test suite is where the engineering lives. Part two of three."
+date: "2026-05-26"
+slug: "agent-engine-part-2-tools-approval-determinism"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["ai", "agents", "tools", "human-in-the-loop", "evals", "typescript", "open-source"]
+published: true
+---
+
+[Part 1](/blog/agent-engine-part-1-domain-agnostic-harness) covered the generic engine: the loop, parts-based messages, async-generator streaming, and the safety valves that keep a model from running away. That engine could only read. It called tools and looked at the results.
+
+This post is about the harder part, making an agent act. There are three problems to solve.
+
+Acting safely. Some actions cannot be undone, like sending a reply to a customer or mutating a record. Those need a human's confirmation.
+
+Acting headlessly. An autonomous run triggered by a schedule or an event has no human to confirm anything. It needs a different way to handle the same dangerous tools.
+
+Testing the untestable. An agent that calls real APIs cannot be unit-tested in the normal sense. We need to run the same agent against mocked tools and make assertions about how it behaves.
+
+All three turn out to share the same handful of abstractions. Here they are.
+
+## A tool is a contract, not a function
+
+The naive mental model of a tool is a function the model can call. Ours is a richer object, because the function is the least interesting part of it:
+
+```typescript
+interface AgentToolDefinition {
+  name: string
+  description: string
+  inputSchema: ZodSchema          // projected to the model's tool schema
+  outputSchema?: ZodSchema        // typed .infer for consumers
+  outputsJsonSchema?: JsonSchema  // discoverable in catalogs and eval mocks
+
+  execute(args, ctx): Promise<unknown> | AsyncGenerator<ToolProgress, unknown>
+  validateInputs?(args): ParseResult<unknown>
+  buildDigest?(output): ToolDigest
+
+  requiresApproval?: boolean
+  endsTurn?: boolean
+  category?: 'control' | 'system' | 'capability'
+  inputBindings?: InputBinding[]
+  inputAmendmentSchema?: ZodSchema
+  captureMint?(args, ctx): unknown
+}
+```
+
+A few of these matter right away. `buildDigest` produces the small projection of an output that renders as a status pill or an approval card, because you do not want a 4KB raw JSON output in the UI. `captureMint` predicts an output without executing, which we will get to. `inputAmendmentSchema` describes which arguments a human can edit on an approval card.
+
+`validateInputs` does something specific. It is lenient. The model emits fuzzy arguments, sometimes a bare id, sometimes a `slug:id`, sometimes a fully qualified `defId:instId`. A strict schema rejects all but one form and forces a retry, which wastes a round-trip. Our normalizers accept every form and canonicalize it, returning a result type that carries an actionable error on failure and silent warnings on success:
+
+```typescript
+type ParseResult<T> =
+  | { ok: true; value: T; warnings?: string[] }
+  | { ok: false; error: string } // surfaced back to the model
+```
+
+Meeting the model where it is beats forcing it to guess your exact schema.
+
+## What happens on every tool call
+
+When the loop dispatches a tool call, it runs an ordered pipeline. None of the steps are optional, and the order matters:
+
+1. **Parse** the model's JSON arguments.
+2. **Transform** with a domain hook that injects defaults and pre-fills from session context.
+3. **Bind** any argument wired to a context source, clamping it to that source.
+4. **Validate** with the tool's own `validateInputs` and the lenient normalization above.
+5. **Cache check** against the idempotent cache from Part 1.
+6. **Execute** the handler, or drain its async generator if it streams progress.
+7. **Digest** the output into the small UI projection.
+8. **Capture** the result in the execution-context store.
+9. **Domain hooks** run: `onToolResult` mines the output for state, `transformToolResult` rewrites what the model sees versus what gets stored.
+10. **Stamp** status, output, and digest onto the tool-call part.
+
+Every handler receives a single `ToolContext`, the dependency bundle with the database handle, the org and user, the shared context store, and the current subject. One type, threaded everywhere, so a tool never reaches for an ambient global.
+
+## Human-in-the-loop: pause, approve, resume
+
+A tool marked `requiresApproval` does not execute when the model calls it. The loop flips its part to `awaiting-approval` and yields an `approval-required` event.
+
+What makes this robust rather than flaky is that the approval card is persisted as a message, not held in memory as a live event. It is stored as a `system` message with an approval payload:
+
+```typescript
+type ApprovalCard = {
+  role: 'system'
+  approval: {
+    toolName: string
+    toolCallId: string
+    args: unknown
+    status: 'pending' | 'approved' | 'rejected'
+  }
+}
+```
+
+Because it is persisted, a page refresh re-renders the same card from storage. The user can close the tab, come back an hour later, and the decision point is still there. An approval that only exists as a live SSE event evaporates the moment the connection drops. This one does not.
+
+When the user decides, `engine.resume()` picks up. It re-validates the arguments in case they changed, re-applies bindings, runs `validateInputs` again, and only then executes. The result is captured and the loop re-enters at the same `messageId`:
+
+```typescript
+async *resume(decision): AsyncGenerator<AgentEvent> {
+  if (decision.action === 'reject') {
+    // record the rejection, let the model acknowledge it
+    yield* this.continueTurn({ rejected: decision.toolCallId })
+    return
+  }
+
+  const finalArgs = decision.amendment
+    ? { ...pending.args, ...decision.amendment }
+    : pending.args
+
+  const result = await tool.execute(finalArgs, ctx) // no model re-call
+  yield* this.continueTurn({ resumeFrom: pending, result })
+}
+```
+
+That `resumeFrom` hint keeps the experience clean. The turn does not split into two bubbles across the pause. It is one assistant message that grows: the same `messageId`, with more parts appended after the human says yes.
+
+Input amendment is the feature people like. `inputAmendmentSchema` declares which fields are editable, and the approval card renders them. To fix a recipient or tweak a reply body before it sends, you edit it on the card. The amended arguments flow back through validation like any other input, so they do not bypass it.
+
+The budget ties in too. `maxApprovalsPerTurn` from Part 1 bounds how many times a single turn can stop for a human, so a misbehaving agent cannot wear you down with prompts.
+
+## Capture mode: acting without a human
+
+Now the second problem. An autonomous run fired by a schedule, an inbound event, or a workflow has no human to approve anything, and an eval simulation must never send a real email. Pausing is not an option in either case.
+
+The answer is capture mode, an alternate dispatch for approval-required tools. Instead of executing, we call the tool's `captureMint` to predict its output, wrap it as captured, and record the action:
+
+```typescript
+const minted = tool.captureMint?.(args, { localIndex })
+  ?? { status: 'queued_for_approval' }
+
+state.capturedActions.push({
+  toolCallId,
+  toolName,
+  args,
+  localIndex,
+  predictedOutput: minted, // e.g. { id: 'temp_0', ... }
+})
+```
+
+The reason to predict an output rather than return a stub is chaining. If `create_task` returns `{ id: 'temp_0' }`, the model can immediately call another tool that references `temp_0`, which produces `temp_1`, and so on. The agent builds up a whole sequence of dependent actions, none of which have actually run. A later apply phase substitutes the real ids for the temp ones when the actions are performed for real, or surfaced for a single batch approval.
+
+Two constraints make this work. `localIndex` is monotonic across the entire run, so the temp ids stay stable even when several agent invocations chain together. And `captureMint` must be pure and cheap, with no database or network access. That purity is exactly what makes eval simulations deterministic and fast. A mint that did IO would reintroduce the non-determinism we are trying to remove.
+
+Read-only tools still execute for real in capture mode. Only the mutating, approval-gated ones get minted. So an eval exercises your real lookup logic and only fakes the parts with side effects.
+
+## The execution-context store
+
+Tools need to share state within a turn. A single `ContextManager` interface is threaded onto every `ToolContext` as `ctx.context`, so a tool reads and writes turn state the same way whether it runs in chat, in internal Kopilot, or inside a [workflow node](/blog/workflows-part-2-execution-engine). Two different stores implement the interface behind thin adapters.
+
+Values are addressed by a typed string grammar, parsed once into `(kind, root, path)`:
+
+```
+var:cart.total          // scratch namespace, persists across turns
+tool:search_entities    // latest call of that tool, turn-scoped
+tool:search_entities[]  // all calls of that tool, turn-scoped
+call:<toolCallId>        // one exact call, turn-scoped
+sys:userId              // read-only system value
+```
+
+The paths are walked by one shared path walker: dotted descent, array indexing like `items[0]` and `items[-1]`, splat like `items[*]`, and `.first` and `.last`. The fact that there is only one walker is the point. The same code backs both the Kopilot store and the workflow store, so they cannot drift into subtly different behavior. Separate implementations would produce bugs that only reproduce on one surface.
+
+Tools wire arguments to context with input bindings:
+
+```typescript
+inputBindings: [{ name: 'cartId', default: 'var:cart.id' }]
+```
+
+If the model omits `cartId`, the pipeline fills it from `var:cart.id` before dispatch. The store persists onto the session. The `var:` namespace survives across turns, while captured tool outputs are turn-scoped. They survive an approval pause, so a resumed turn still sees what it found before pausing, but they get wiped when a new user message starts a fresh turn. A size cap drops the turn slice on overflow, so a runaway cannot bloat the session row.
+
+## One agent, three execution modes
+
+Count the ways the same agent has to run. Live, in production chat. Captured, in an autonomous job. Mocked, in an eval. Three slightly different assemblies would inevitably drift, and then "it passed in evals" would stop meaning anything.
+
+So there is exactly one builder. `effective-runtime.ts` assembles the runtime for all three from a single function. It resolves the model with a per-turn override, then the agent config, then the org default. It builds the capability registry, filters the toolset, projects the effective input bindings, and exposes an optional `wrapTools` hook that evals use to swap in mocks:
+
+```typescript
+const runtime = buildEffectiveRuntime({
+  agentConfig,
+  page,
+  modelOverride,
+  wrapTools, // evals pass a mock wrapper; production passes nothing
+})
+```
+
+Because production and evals build from the same function, the eval harness is not a parallel reimplementation that is subtly wrong. It is the real runtime with mocked leaves. This consolidation has already caught real bugs. A pre-extraction path that read the tool list from the wrong place worked in chat and crashed only on autonomous runs, because chat happened to populate the field and autonomous runs did not. One runtime, one code path, no divergence.
+
+## Determinism, paid off
+
+Put the three pieces together, pure minting, a deterministic context store, and one runtime with a mock hook, and an agent becomes replayable. That is what our evals framework runs on.
+
+An eval suite is a set of assertion-graded simulations. You give the agent a scenario, mock its tools, run it through the effective runtime, and assert on the captured actions and the final output. It supports comparing a draft procedure against the pinned one, and diffing a run against a baseline to catch regressions. When a suite finishes it reports back into chat, though how it does that, by kicking off long work and resuming the conversation when it completes, is a mechanism that belongs in Part 3.
+
+Evals deserve their own write-up, so I will stop there. The lesson for this post is narrower and more useful. Determinism was not bolted on afterward. It fell out of decisions we made for other reasons: pure capture minting, a single shared context store, one runtime builder. Build those right and testability is a consequence, not a separate project.
+
+## Next up
+
+We now have an agent that acts safely, acts headlessly, and can be pinned down in a test suite. What we do not have yet is a product. The engine still knows nothing about pages, cards, or the actual shape of a support conversation.
+
+[Part 3](/blog/agent-engine-part-3-kopilot-domain-layer) is the domain layer: how this generic engine becomes Kopilot, with page-aware tools, prompt assembly built for caching, the reference cards the model renders into the UI, and autonomous runs on a trigger.
+
+The files for this post:
+
+- `packages/lib/src/ai/agent-framework/types.ts`, the tool contract
+- `packages/lib/src/ai/agent-framework/query-loop.ts`, the execution pipeline
+- `packages/lib/src/ai/agent-framework/capture-mode.ts`, minting for headless and eval runs
+- `packages/lib/src/ai/agent-framework/context/`, the execution-context store
+- `packages/lib/src/ai/agent-framework/effective-runtime.ts`, one runtime for all three modes
+
+Auxx.ai is [open source](https://github.com/auxxai/auxx). PRs welcome.

--- a/apps/homepage/content/blog/agent-engine-part-3-kopilot-domain-layer.mdx
+++ b/apps/homepage/content/blog/agent-engine-part-3-kopilot-domain-layer.mdx
@@ -1,0 +1,165 @@
+---
+title: "Building an AI Agent Engine, Part 3: The Domain Layer"
+description: "A generic engine is a runtime, not a product. This is how ours becomes Kopilot: page-scoped tools, prompt assembly built for caching, reference cards the model renders into the UI, and autonomous runs. The final part."
+date: "2026-06-09"
+slug: "agent-engine-part-3-kopilot-domain-layer"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["ai", "agents", "prompt-caching", "ui", "typescript", "open-source"]
+published: true
+---
+
+[Part 1](/blog/agent-engine-part-1-domain-agnostic-harness) built a generic engine, a streaming loop with safety valves. [Part 2](/blog/agent-engine-part-2-tools-approval-determinism) made it act, with tools, approval, capture mode, and deterministic evals. Both posts insisted on the same thing: the engine knows nothing about CRMs, email, pages, or cards.
+
+This post is about everything it deliberately does not know. The gap between "it can call tools in a loop" and "it is a copilot embedded in your app that renders interactive cards, caches prompts efficiently, and runs on a schedule" is the domain layer. For us that layer is Kopilot, and it plugs into the engine through a single interface, `AgentDomainConfig`.
+
+The code is in `packages/lib/src/ai/kopilot/`.
+
+## A single agent, not a pipeline
+
+Start with the biggest change from our earlier design, because it frames everything else.
+
+The original Kopilot was a pipeline. A supervisor agent classified each message into a route, and the route ran a sequence of specialized agents: a planner, then an executor, then a responder. It worked, but it had many moving parts, and the hand-offs between agents were a steady source of subtle state bugs.
+
+It is now a single agent on a single route. No supervisor, no planner, no separate responder. One agent owns the whole turn. It calls tools in a loop and writes the reply.
+
+Multi-step planning did not disappear, it became a tool. The agent calls `plan_create` to publish a list of steps and `plan_update_step` to advance them. The plan lives in the context store under `var:plan` and persists across turns. This fits better, because planning is something the agent does when a task warrants it, not a stage every message is forced through. A quick question no longer pays for a planner it never needed.
+
+```typescript
+// The entire routing table now
+routes: [{ name: 'default', agents: ['agent'] }]
+// no supervisorAgent, so the engine skips classification and runs the route directly
+```
+
+## The domain config
+
+`createKopilotDomainConfig()` returns the object the engine consumes. It is almost entirely hooks:
+
+```typescript
+{
+  agents: { agent: kopilotAgent },
+  routes: [{ name: 'default', agents: ['agent'] }],
+  createInitialState(context) { /* per-turn UI context */ },
+  applyContext(state, context) { /* refresh it each message */ },
+
+  transformToolInput(name, args, state) { /* pre-fill from context */ },
+  onToolResult(name, result, state) { /* mine snapshots */ },
+  onTurnEnd(state, outcome) { /* fan cleanup to capabilities */ },
+  postProcessFinalContent(content, state) { /* inject snapshots */ },
+  resetTurnDomainState(domainState) { /* drop turn captures, keep var:* */ },
+}
+```
+
+The config never inspects an individual tool. It does not sniff "is this the mail tool" anywhere. Tool behavior lives with the tool, and the config only wires generic lifecycle hooks. You add a tool, register it in a capability, and the config runs unchanged. That discipline is what has kept this file small while the tool count grew into the dozens.
+
+## Page-scoped capabilities
+
+A generic engine cannot answer one question: which tools should the agent even have? All of them is wrong. A model handed eighty tools picks worse than one handed eight, and half of them do not apply to where the user is.
+
+So tools are grouped into capabilities, and capabilities are scoped to pages. A `CapabilityRegistry` maps a page to its tools, its prompt fragments, a human-readable summary of what it can do there, and any turn-lifecycle hooks:
+
+```typescript
+interface PageCapability {
+  page: string
+  tools: AgentToolDefinition[]
+  systemPromptAddition?: string | ((ctx) => string)
+  excludeGlobalTools?: string[]
+  lifecycle?: CapabilityLifecycle
+}
+```
+
+Mail tools, such as find threads, reply, and manage drafts and tags, exist only on the mail page. Entity, knowledge, task, and plan tools are global. Some pages exclude globals to stay focused. The agent-builder page drops mail and entity-write tools because they would only distract.
+
+One detail turned out to matter. A capability's prompt fragment can be a function of which tools actually survived filtering. Tools get filtered at runtime for many reasons: a per-agent toolset, approval mode, the invoker's scope. If the prompt mentions a tool that got filtered out, the model tries to call something it does not have and fails in a confusing way. So the fragment receives the surviving tool names and gates its bullets on them:
+
+```typescript
+systemPromptAddition: (ctx) =>
+  ctx.toolNames.has('reply_to_thread')
+    ? '- You can reply directly to a thread with reply_to_thread.'
+    : ''
+```
+
+Never tell the model about a tool it cannot call.
+
+## Prompt assembly built for caching
+
+Prompt caching pays off only when the prompt is laid out for it, and most are not. The usual pattern is one large template string with stable and volatile content interleaved, which breaks the cache on nearly every call and pays full price every time.
+
+Our system prompt is composed from ordered sections, and every section declares a stability tier. Static sections are identical across every org and turn and change only on deploy, such as the persona, the house rules, and the block catalog. Org sections are stable until an admin edits something, such as the entity catalog, the integration catalog, and the available tools. Turn sections are rebuilt on every call, such as the active references, the current plan step, and the caller preamble.
+
+Sections are emitted static, then org, then turn, so the cache breakpoints line up exactly with what changes and when. The stable prefix stays cached across turns, and only the cheap tail at the end is ever re-billed. A dev-mode check enforces the ordering, so a careless edit cannot drop a turn-volatile section into the middle of the stable prefix and bust the whole cache.
+
+The run mode selects sections too. An interactive chat turn and an autonomous, triggered turn get different prompts. The autonomous one carries a banner that tells the model no human is reading this turn, that approval-gated tools will execute via capture mode, and that it should end with an audit summary rather than a question to a caller who is not there.
+
+## Reference cards: rich UI without coupling
+
+This is the part you see. When Kopilot shows an entity card, a list of threads, or a task, that did not come from a tool emitting HTML. It came from the model writing a fenced reference in its prose:
+
+````
+```auxx:entity-list
+{ "ids": ["contacts:abc", "contacts:def"] }
+```
+````
+
+The frontend resolves that fence into interactive cards. The question is where the card data comes from, and the answer is the interesting part.
+
+Snapshot mining is generic. Rather than every tool emitting card payloads, one shape-based walker inspects every tool output, recursively and at bounded depth, and harvests ids by shape. It recognizes a record id like `defId:instId`, a thread signature, a task signature, and the common container shapes such as `{ items }`, `{ threads }`, and `{ results }`. It mines them into a per-turn snapshot map. Doing it by shape means it works for tools written long after the walker shipped, so nobody has to remember to register a new tool's outputs.
+
+Injection happens at the end. After the turn, `postProcessFinalContent` finds each `auxx:*` fence, looks up its ids in the snapshot map, and embeds the display data, normalizing the over-prefixed ids the model sometimes writes. The model never sees snapshot data. It only ever writes ids. Snapshots are strictly a view-layer concern.
+
+The model gets a cheaper view. On each call, those same fences render to the model as compact numbered text, like "Showed entity-list (2 records): 1. ACME Corp, 2. Globex," so a smaller model can refer to result two without parsing JSON. The persisted message keeps the rich fence, the model sees the cheap version, and the two are deliberately different representations of the same thing.
+
+There is a smaller cousin for inline links. A reference dropped into prose like `[ACME](auxx://entity/companies/abc)` gets a per-message snapshot lookup, so the hover card still works after a reload with no tool replay needed. The knowledge tools draw on the same [dataset and vector search](/blog/datasets-part-2-embeddings-and-vector-search) layer we wrote about separately.
+
+## Knowing when not to auto-fill
+
+The composer's chips, the current page and any `@`-mention, flow in as session references, and the agent pre-fills tool arguments from them. Mentions win over page context, and that precedence is consistent across the prompt, the pre-fill step, and direct tool access.
+
+The interesting decision is what we do not auto-fill. A page often has several record-ish things live at once: an open drawer, a filtered list, a highlighted row. So `record` is deliberately not auto-bound. Silently routing the wrong record into a tool is worse than asking which one you meant. Most of the time the right move for an agent is to be helpful. Sometimes it is to know the limits of what it can safely infer.
+
+Approval-resume and notification turns posed a related problem. They post back without a page, which used to strip the page-scoped tools mid-conversation. So a continuation turn restores the page context it was on, but only a continuation. A fresh message stays page-less on purpose, and a live page value always wins. Statefulness by exception, not by default.
+
+## Fire and continue: async task notifications
+
+Some tools kick off work that takes minutes, such as an eval suite or a long background job. Blocking the loop on that is wrong. The agent should hand off and move on.
+
+So those tools return immediately with a notification reference:
+
+```typescript
+return { ok: true, taskNotification: { kind: 'eval-suite', ref: runId } }
+```
+
+The client watches that reference. When the task reaches a terminal state, the server builds a `<task-notification>` message and injects it, which automatically starts a new Kopilot turn that summarizes the outcome. From the user's point of view, the conversation picks back up on its own once the work is done. The background jobs themselves run on the [BullMQ queue](/blog/bullmq-job-queue-architecture-part-1) we use across the platform.
+
+Each kind of task has a small handler that knows how to load it, decide whether it is terminal, and summarize it. The eval suite from Part 2 was the first kind. A new kind is a new handler file and a registry entry, and the conversational machinery does not change. This is how long-running platform work closes the loop back into the chat without polling hacks or a blocked agent.
+
+## The same engine, everywhere
+
+The payoff of all that domain-agnostic discipline from Parts 1 and 2 is that the same engine runs far outside of chat.
+
+[Workflow AI nodes](/blog/workflows-part-3-ai-nodes-tools-public-workflows) reuse the engine through a minimal domain config, with pre-built messages, no persona assembly, and the workflow's own execution context threaded in as `ctx.context`, so the agent's context tools read and write the run's variables directly. Structured extraction runs a single pass through the same machinery to pull typed data out of text. Autonomous runs, triggered by a schedule, an event, a mention, or an assignment, run the same agent headlessly on the job queue, using the capture mode and autonomous prompt from earlier in the series.
+
+Session management rounds it out. There is one long-lived session per thread per agent, serialized per thread so two messages cannot race, and a catch-up replay that hydrates a session from the message history. It maps inbound messages to the user role, the agent's own past replies to assistant, and a teammate's messages to system context, so the model reads those as background rather than as its own prior output.
+
+All of it, the messages, the domain state, the context slice, and the link snapshots, persists as a single JSONB row per session. Conversations are read and written as a unit and never queried field by field, so one row, one read, one write is the right shape. Schema tweaks to the message format do not need migrations either.
+
+## From runtime to product
+
+That is the whole arc. Part 1 built a loop that streams and will not run away. Part 2 made it act safely and made it testable. Part 3 turned it into Kopilot, page-aware, cache-efficient, rendering real cards, and running on triggers, all through one `AgentDomainConfig` seam without the engine learning a single thing about support tickets.
+
+The lesson I would take from building it is that the leverage is in the boundary. We spent the effort to make the engine genuinely domain-agnostic, and the reward is that chat, workflow nodes, structured extraction, and autonomous agents are all the same engine with a different config bolted on. Write the hard part once, and plug in domains forever.
+
+The files for this post:
+
+- `packages/lib/src/ai/kopilot/domain-config.ts`, the config and its hooks
+- `packages/lib/src/ai/kopilot/capabilities/`, page-scoped tools
+- `packages/lib/src/ai/kopilot/prompts/`, tiered prompt assembly
+- `packages/lib/src/ai/kopilot/blocks/`, snapshot mining and reference fences
+- `packages/lib/src/ai/kopilot/task-notifications/`, async continuation
+- `packages/lib/src/ai/kopilot/runners/`, reuse beyond chat
+
+Auxx.ai is [open source](https://github.com/auxxai/auxx). PRs welcome, and if you build something on top of the engine, I would love to see it.


### PR DESCRIPTION
## What

Adds a three-part engineering blog series on the agent engine behind Kopilot (`apps/homepage/content/blog/`).

| Part | Title | Focus |
| --- | --- | --- |
| 1 | A Domain-Agnostic Harness | Parts-based messages, async-generator streaming, runaway safety valves |
| 2 | Tools, Approval & Determinism | Side-effecting tools, human-in-the-loop approval, deterministic replay for tests |
| 3 | The Domain Layer | Page-scoped tools, cache-friendly prompt assembly, reference cards, autonomous runs |

## Notes

- Content-only (MDX under `apps/homepage`). No code changes.
- Authored by Markus Klooth; category "Coding"; dated May–June 2026.