### PR TITLE
docs: add AI Agents help section (agents, procedures, simulations)

### DIFF
--- a/apps/docs/content/docs/help/agents/approvals.mdx
+++ b/apps/docs/content/docs/help/agents/approvals.mdx
@@ -1,0 +1,55 @@
+---
+title: Tool approvals
+description: Add a confirmation gate before sensitive tools run, so a person reviews and approves the agent's proposed action before it executes.
+---
+
+Some actions are too sensitive or irreversible to run without a person's say-so. **Tool approvals** add a confirmation gate: the agent proposes the action, and someone approves or rejects it before it runs.
+
+## How approval works
+
+<Steps>
+<Step>
+
+### The agent proposes an action
+
+When the agent decides to call a tool that requires approval, it pauses instead of running it.
+
+</Step>
+<Step>
+
+### An approval card appears
+
+The chat shows a card with the tool name and the exact inputs the agent wants to use.
+
+</Step>
+<Step>
+
+### You approve or reject
+
+- **Approve** — the tool runs and the agent continues with the result.
+- **Reject** — the tool is skipped and the agent continues without it.
+
+</Step>
+</Steps>
+
+## Action states
+
+While an agent is working, each tool call shows its current state:
+
+| State | Meaning |
+|-------|---------|
+| **Running** | The tool is executing |
+| **Awaiting approval** | Paused, waiting for someone to confirm |
+| **Completed** | Finished successfully |
+| **Rejected** | A person declined the action |
+| **Error** | The tool failed to run |
+
+## Approvals and autonomous runs
+
+Approvals are especially useful with [triggers](/help/agents/triggers), where the agent runs on its own. A trigger can do all the analysis automatically and still stop for a human before it sends a reply or changes data.
+
+<Callout type="info" title="Related: workflow approvals">
+  Automation workflows have their own approval step. See
+  [Workflow approvals](/help/ai/workflow-approvals) to build human-in-the-loop
+  automations.
+</Callout>

--- a/apps/docs/content/docs/help/agents/concepts.mdx
+++ b/apps/docs/content/docs/help/agents/concepts.mdx
@@ -1,0 +1,54 @@
+---
+title: Core concepts
+description: A glossary of the key terms used across agents, procedures, and simulations so the rest of the guides make sense at a glance.
+---
+
+These are the terms used throughout the agent guides. Skim them once and the rest of the documentation will read more easily.
+
+## Agent
+
+The AI teammate you configure. An agent has a persona, a set of tools, a knowledge scope, optional procedures, and triggers. When it's set up, it becomes a real member of your workspace that you can @mention, assign, and message.
+
+## Persona prompt
+
+The agent's core instructions — its personality, tone, rules, and what it should and shouldn't do. You write the persona in the **Prompt** tab. See [The persona prompt](/help/agents/persona).
+
+## Tool
+
+A single action an agent can take, such as "send email," "create ticket," or "find Shopify order." Tools come from Auxx, from installed apps, or from connected MCP servers.
+
+## Toolset
+
+A bundle of related tools you enable as a unit — for example the email toolset, or all the tools from one installed app. See [Tools & app accounts](/help/agents/tools).
+
+## Knowledge scope
+
+The set of records and knowledge bases an agent is allowed to read and reason about. You control it on the **Knowledge** tab. See [Knowledge scope](/help/agents/knowledge).
+
+## Procedure
+
+A reusable, step-by-step playbook an agent follows for a specific situation — like processing a refund or verifying a customer's identity. An agent picks the right procedure automatically based on the customer's message. See [Procedures](/help/agents/procedures).
+
+## Trigger
+
+What makes an agent run on its own: a mention, an assignment, a direct message, a schedule, a record change, or an app event. See [Triggers](/help/agents/triggers).
+
+## Version
+
+An immutable, numbered snapshot of an agent's behavior. The agent you edit is a **draft**; **publishing** captures the draft as a version that production runs use. See [Versions & publishing](/help/agents/versions).
+
+## Simulation
+
+A repeatable, offline test of an agent or procedure — a synthetic customer scenario plus checks on what the agent should do. See [Simulations](/help/agents/simulations).
+
+## Approval
+
+A confirmation gate before a sensitive tool runs. The agent proposes the action, and a person approves or rejects it before it executes. See [Tool approvals](/help/agents/approvals).
+
+## The build panel
+
+On the agent detail page, the docked panel on the right has three tabs:
+
+- **Build** — an AI assistant that helps you configure the agent by chatting.
+- **Chat** — talk to the agent yourself to test it informally.
+- **Simulations** — your saved, repeatable test cases.

--- a/apps/docs/content/docs/help/agents/creating-an-agent.mdx
+++ b/apps/docs/content/docs/help/agents/creating-an-agent.mdx
@@ -1,0 +1,84 @@
+---
+title: Create an agent
+description: Build your first agent with the guided setup flow, or start from a template, then complete setup to bring it live in your workspace.
+---
+
+You create agents from the **Agents** list in your workspace. You can start from a blank agent or pick a template that pre-fills a starter prompt.
+
+## Start a new agent
+
+<Steps>
+<Step>
+
+### Open the Agents list
+
+Go to **Agents** in the sidebar and click **Create agent**.
+
+</Step>
+<Step>
+
+### Choose a starting point
+
+Start blank, or pick a [template](/help/agents/templates) such as a support triage assistant or a storefront concierge. A template fills in a starter prompt and a suggested name, avatar, and color — you can change everything later.
+
+</Step>
+<Step>
+
+### Complete setup
+
+A guided flow walks you through the essentials. When you finish, the agent goes live.
+
+</Step>
+</Steps>
+
+## The guided setup flow
+
+When you create an agent, a docked **Build** assistant opens and asks what the agent should do. It walks you through four essentials:
+
+1. **Name** — what the agent is called.
+2. **Persona** — the [prompt](/help/agents/persona) that defines its behavior.
+3. **Tools** — the [actions](/help/agents/tools) it can take.
+4. **Knowledge** — the [records](/help/agents/knowledge) it can read.
+
+You can describe what you want in plain language and let the assistant fill things in, or click **Configure manually** to skip the guided flow and edit each tab yourself.
+
+<Callout type="info" title="You can always change it later">
+  Setup just gets the agent live with sensible defaults. Every part of the agent
+  is fully editable afterward from the detail page tabs.
+</Callout>
+
+## What "complete setup" does
+
+Finishing setup does three things:
+
+- **Brings the agent live** — it becomes a real member of your workspace that you can @mention, assign to tickets, and message directly.
+- **Publishes its first version** — the current configuration is captured as version 1. See [Versions & publishing](/help/agents/versions).
+- **Activates its built-in triggers** — it can respond to mentions, assignments, and direct messages right away. See [Triggers](/help/agents/triggers).
+
+Setup requires a non-empty name, a persona prompt, and at least one tool.
+
+## The agent detail page
+
+Once setup is complete, the detail page opens with configuration tabs across the top:
+
+| Tab | What you configure |
+|-----|--------------------|
+| **Prompt** | The [persona](/help/agents/persona) — personality, tone, and rules |
+| **Procedures** | Attached [playbooks](/help/agents/procedures) for specific situations |
+| **Tools** | The [tools and app accounts](/help/agents/tools) the agent can use |
+| **Bindings** | Advanced overrides for how tool inputs are filled |
+| **Knowledge** | The [records and knowledge](/help/agents/knowledge) the agent can read |
+| **Triggers** | Rules for [running automatically](/help/agents/triggers) |
+
+The docked panel on the right has **Build**, **Chat**, and **Simulations** tabs for configuring, testing, and validating the agent as you work.
+
+## Next steps
+
+<Cards>
+  <Card title="Write the persona" href="/help/agents/persona" icon="FileText">
+    Define how the agent thinks and talks.
+  </Card>
+  <Card title="Add tools" href="/help/agents/tools" icon="Wrench">
+    Give the agent actions it can take.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/index.mdx
+++ b/apps/docs/content/docs/help/agents/index.mdx
@@ -1,0 +1,79 @@
+---
+title: AI Agents
+description: Build AI teammates that draft replies, take actions through tools, reason over your CRM, and run on their own from triggers.
+---
+
+An **agent** is an AI teammate you configure once and reuse across your workspace. An agent has a personality, a set of tools it can use, a slice of your knowledge it can read, and rules for when it runs on its own. Once it's set up, you can @mention it in a thread, assign it to a ticket, message it directly, or let it run automatically.
+
+## What an agent can do
+
+- **Draft and send replies** using your knowledge base, conversation history, and connected data.
+- **Take actions through tools** — create a ticket, look up an order, update a record, or call any installed app or MCP server.
+- **Follow procedures** — step-by-step playbooks for specific situations like refunds or cancellations.
+- **Run on its own** from triggers — a mention, an assignment, a schedule, a record change, or an app event.
+
+## Two kinds of agent
+
+| Kind | Who it serves | Where it runs |
+|------|---------------|---------------|
+| **Internal agent** | Your team | Chat, mentions, assignments, and autonomous runs |
+| **Chat agent** | Your customers | The chat widget, with a safety-filtered set of tools |
+
+## The build loop
+
+Building a reliable agent follows a simple loop. Each step has its own article:
+
+<Steps>
+<Step>
+
+### Write the persona
+
+Define the agent's character, tone, and rules in the [persona prompt](/help/agents/persona).
+
+</Step>
+<Step>
+
+### Give it tools and knowledge
+
+Choose which [tools](/help/agents/tools) it can use and which [records](/help/agents/knowledge) it can read.
+
+</Step>
+<Step>
+
+### Add procedures
+
+For repeatable situations, attach a [procedure](/help/agents/procedures) — a precise playbook the agent follows.
+
+</Step>
+<Step>
+
+### Prove it with simulations
+
+Run [simulations](/help/agents/simulations) to test the agent's behavior before it goes live.
+
+</Step>
+<Step>
+
+### Publish
+
+[Publish a version](/help/agents/versions) to make your changes live.
+
+</Step>
+</Steps>
+
+## Where to start
+
+<Cards>
+  <Card title="Core concepts" href="/help/agents/concepts" icon="BookOpen">
+    A glossary of the terms used throughout these guides.
+  </Card>
+  <Card title="Create an agent" href="/help/agents/creating-an-agent" icon="Plus">
+    Build your first agent with the guided setup flow.
+  </Card>
+  <Card title="Procedures" href="/help/agents/procedures" icon="ListChecks">
+    Give agents step-by-step playbooks for specific situations.
+  </Card>
+  <Card title="Simulations" href="/help/agents/simulations" icon="FlaskConical">
+    Test agent behavior with repeatable, offline scenarios.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/knowledge.mdx
+++ b/apps/docs/content/docs/help/agents/knowledge.mdx
@@ -1,0 +1,56 @@
+---
+title: Knowledge scope
+description: Control exactly which records and knowledge bases your agent can read and reason about, so it stays focused, private, and efficient.
+---
+
+**Knowledge scope** controls which records and knowledge bases an agent is allowed to see. You set it in the **Knowledge** tab on the agent detail page.
+
+Scoping matters for three reasons: **privacy** (the agent only sees what it should), **focus** (it reasons over the right data), and **cost** (less irrelevant context to process).
+
+## How scoping works
+
+The Knowledge tab shows a tree of your resource types. For each, you choose how the agent may access it:
+
+| Mode | Meaning |
+|------|---------|
+| **Include** | The agent can read this record type, or a single record |
+| **Include with children** | The agent can read this record and everything beneath it |
+| **Exclude** | The agent explicitly cannot read this — exclusions always win |
+
+You can scope at two levels:
+
+- **A whole type** — for example, all tickets or all contacts.
+- **A single record** — just one specific contact, ticket, or article.
+
+## Resource types you can scope
+
+Scoping covers system resources and your own custom data:
+
+- Knowledge Bases
+- Contacts and Companies
+- Tickets
+- Datasets
+- Any [custom entities](/help/custom-entities/overview) you've defined
+
+## Pinning vs. mentioning
+
+There are two ways to add a record to the scope:
+
+- **Pin it** in the tree — a normal grant you can remove anytime.
+- **Mention it** in the [persona prompt](/help/agents/persona) — this locks it into the scope until you remove the mention, the same way tool mentions work.
+
+<Callout type="info" title="Exclusions take priority">
+  If a record is both included by a broad grant and excluded specifically, the
+  exclusion wins. Use this to carve out exceptions from a wide grant.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Triggers" href="/help/agents/triggers" icon="Zap">
+    Let the agent run on its own.
+  </Card>
+  <Card title="Datasets" href="/help/datasets/overview" icon="Database">
+    Build the knowledge your agents read from.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/meta.json
+++ b/apps/docs/content/docs/help/agents/meta.json
@@ -1,0 +1,21 @@
+{
+  "title": "AI Agents",
+  "icon": "Bot",
+  "pages": [
+    "index",
+    "concepts",
+    "creating-an-agent",
+    "persona",
+    "tools",
+    "knowledge",
+    "triggers",
+    "models",
+    "versions",
+    "approvals",
+    "templates",
+    "---Procedures---",
+    "procedures",
+    "---Simulations---",
+    "simulations"
+  ]
+}

--- a/apps/docs/content/docs/help/agents/models.mdx
+++ b/apps/docs/content/docs/help/agents/models.mdx
@@ -1,0 +1,38 @@
+---
+title: Models & bring-your-own-key
+description: Choose which AI model powers an agent, override the workspace default per agent, and bill usage to your own provider account with BYOK.
+---
+
+Every agent runs on an AI model. By default it uses your workspace's default model, but you can override the model per agent.
+
+## Choosing a model
+
+Your workspace has a default model set in **Settings → AI Models**. An individual agent can either:
+
+- **Inherit the default** — the agent uses whatever your workspace default is.
+- **Use a per-agent model** — override it for this agent only, for example to use a more capable model for a complex agent and a faster one elsewhere.
+
+Auxx supports models from multiple providers, including Claude and GPT. See [AI models & providers](/help/ai/models-providers) for the full list and how to configure them.
+
+## Bring your own key (BYOK)
+
+If you supply your own provider API key, the agent's usage is billed to **your** provider account instead of counting against your Auxx credits. This is useful if you already have provider capacity or want direct control over model spend.
+
+You connect provider keys at the workspace level, and agents can be pinned to them through [app accounts](/help/agents/tools).
+
+<Callout type="info" title="Model parameters are matched to the model">
+  Each model supports different settings (like temperature or reasoning effort).
+  Auxx automatically applies only the parameters the selected model accepts, so
+  you don't have to track per-model compatibility.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="AI models & providers" href="/help/ai/models-providers" icon="Cpu">
+    Configure the models available to your workspace.
+  </Card>
+  <Card title="Usage & billing" href="/help/billing/overview" icon="CreditCard">
+    Understand how AI usage is tracked.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/persona.mdx
+++ b/apps/docs/content/docs/help/agents/persona.mdx
@@ -1,0 +1,51 @@
+---
+title: The persona prompt
+description: Write the instructions that define your agent's personality, tone, and rules, and reference tools directly from the prompt to lock them on.
+---
+
+The **persona** is your agent's core instructions — its personality, tone, the rules it follows, and what it should and shouldn't do. You write it in the **Prompt** tab on the agent detail page.
+
+Think of the persona as the agent's character and standing orders. For precise, repeatable workflows like refunds, pair the persona with a [procedure](/help/agents/procedures) instead of cramming every step into the prompt.
+
+## Writing the prompt
+
+The Prompt tab is a rich editor. You can use paragraphs, lists, and formatting to structure your instructions, and expand it into a full-screen dialog for longer prompts. A character count is shown as you write.
+
+Your changes **autosave** as you type — there's no save button. The prompt doesn't go live until you [publish a version](/help/agents/versions).
+
+A good persona usually covers:
+
+- **Role and scope** — what the agent handles, and what it should hand off.
+- **Tone** — how it should sound (friendly, concise, formal).
+- **Rules** — hard limits, like "never promise a refund without checking eligibility."
+- **Escalation** — when to bring in a human.
+
+## Mentioning tools and knowledge
+
+Type `@` in the prompt to reference a specific **tool**, **toolset**, **field**, or **record** directly inside your instructions. For example, you might write: "When a customer asks about delivery, use `@find order` to look up their order."
+
+Mentioning a capability inline makes your instructions concrete and keeps the agent's behavior tied to the tools you actually want it to use.
+
+## Auto-locking
+
+When you mention a tool or toolset in the prompt, Auxx automatically **enables and locks it on**. This prevents you from accidentally turning off a tool your instructions depend on. Locked tools show a lock badge in the [Tools](/help/agents/tools) tab.
+
+<Callout type="info" title="To remove a locked tool">
+  Delete the mention from the prompt first. Once nothing references the tool,
+  it unlocks and you can disable it normally.
+</Callout>
+
+## Chat agents
+
+For [chat agents](/help/agents) that answer customers in the chat widget, the persona is where you set tone, escalation rules, and guardrails. Their tools are configured separately and filtered to a customer-safe set.
+
+## Next steps
+
+<Cards>
+  <Card title="Tools & app accounts" href="/help/agents/tools" icon="Wrench">
+    Choose which actions the agent can take.
+  </Card>
+  <Card title="Versions & publishing" href="/help/agents/versions" icon="GitBranch">
+    Make your prompt changes live.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/procedures/authoring.mdx
+++ b/apps/docs/content/docs/help/agents/procedures/authoring.mdx
@@ -1,0 +1,47 @@
+---
+title: Authoring a procedure
+description: Write a procedure as a rich-text document with inline step badges, then reuse blocks, declare variables, and reference tools as you go.
+---
+
+You author procedures from an agent's **Procedures** tab. Click **Add procedure** to open the editor.
+
+## The editor
+
+A procedure is written like a document — prose interleaved with **step badges** — not a drag-and-drop flowchart. You describe what the agent should do in plain language, and drop in special steps where you need branching, routing, or logic.
+
+The editor works like the [persona editor](/help/agents/persona): rich text, a character count, and the ability to expand into a full-screen dialog. Your changes **autosave** as a draft and don't go live until you [publish](/help/agents/procedures/versions).
+
+## Building blocks
+
+A **Building blocks** popover gives you the pieces you'll assemble:
+
+| Block | What it's for |
+|-------|---------------|
+| **Sub-procedures** | Named, reusable blocks inside this procedure |
+| **Code blocks** | Small scripts that run deterministically |
+| **Local attributes** | Variables you reuse across steps |
+
+Sub-procedures and code blocks are covered in [Code & variables](/help/agents/procedures/code-and-variables) and [Steps & conditions](/help/agents/procedures/steps-and-conditions).
+
+## Mentioning tools and data
+
+Type `@` anywhere in the procedure to reference a **tool**, **field**, **entity**, or **variable**. For example, an instruction might read: "Look up the order with `@find order`, then confirm the shipping address."
+
+Mentioning a tool in a procedure enables and locks it on the agent the same way [prompt mentions](/help/agents/persona) do.
+
+## Writing good instructions
+
+- **One goal per instruction step** — keep each step focused on a single thing to accomplish.
+- **Be explicit about tools** — name the tool the agent should use rather than hoping it picks the right one.
+- **Say what "done" looks like** — describe the condition that means the step is complete.
+
+## Next steps
+
+<Cards>
+  <Card title="Steps & conditions" href="/help/agents/procedures/steps-and-conditions" icon="GitBranch">
+    Add branching and routing to your procedure.
+  </Card>
+  <Card title="Code & variables" href="/help/agents/procedures/code-and-variables" icon="Code">
+    Compute values and pass data between steps.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/procedures/code-and-variables.mdx
+++ b/apps/docs/content/docs/help/agents/procedures/code-and-variables.mdx
@@ -1,0 +1,47 @@
+---
+title: Code blocks & variables
+description: Store and reuse data across a procedure with local attributes, and run deterministic logic with code blocks that produce named outputs.
+---
+
+Procedures can carry data between steps and run small pieces of logic. Two building blocks make this possible: **local attributes** and **code blocks**.
+
+## Local attributes (variables)
+
+A **local attribute** is a variable scoped to the procedure — a piece of scratch data you set in one step and read in another. For example, you might store an order's status, then check it in a later condition.
+
+You declare local attributes from the **Building blocks** popover, giving each one a name and type. Once declared, you can reference it with `@` in instruction prose, in [conditions](/help/agents/procedures/steps-and-conditions), and in code blocks.
+
+## Code blocks
+
+A **code block** is a small JavaScript snippet that runs **deterministically** every time its step is reached. It can read the procedure's inputs and variables, do a calculation or transformation, and write the result to named **outputs** that bind to local attributes.
+
+Use code blocks for things that should happen the same way every time — formatting a value, computing a total, or mapping one value to another.
+
+## Code blocks vs. tools
+
+These look similar but behave differently:
+
+| | Code block | Tool |
+|--|-----------|------|
+| **When it runs** | Always, when its step is reached | Only if the agent chooses to call it |
+| **Decided by** | The procedure (deterministic) | The agent (its judgment) |
+| **Best for** | Logic and computation | Taking actions and fetching data |
+
+In short: **code always runs; tools are options the agent may use.**
+
+<Callout type="info" title="Keep logic in code, judgment in instructions">
+  Put deterministic rules in code blocks and structured conditions. Leave
+  open-ended decisions to instruction steps, where the agent can reason about
+  the conversation.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Selection & runtime" href="/help/agents/procedures/selection-and-runtime" icon="Workflow">
+    How variables and code run during a conversation.
+  </Card>
+  <Card title="Versions" href="/help/agents/procedures/versions" icon="GitBranch">
+    Publishing checks that code outputs and variables resolve.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/procedures/index.mdx
+++ b/apps/docs/content/docs/help/agents/procedures/index.mdx
@@ -1,0 +1,78 @@
+---
+title: Procedures
+description: Give agents reusable, step-by-step playbooks for specific situations like refunds or cancellations, selected automatically from the conversation.
+---
+
+A **procedure** is a reusable, step-by-step playbook an agent follows for a specific situation — processing a refund, cancelling a subscription, or verifying a customer's identity. When a conversation matches, the agent follows the procedure step by step instead of improvising.
+
+<Callout type="info" title="Procedures may require a plan">
+  Procedures are an advanced feature and may not be available on every plan. If
+  you don't see the Procedures tab, check your plan or contact your workspace
+  admin.
+</Callout>
+
+## Persona vs. procedure
+
+The two work together:
+
+- The **[persona](/help/agents/persona)** is the agent's general character — how it thinks and talks across every conversation.
+- A **procedure** is a precise script for one situation, used only when that situation comes up.
+
+Use the persona for tone and broad rules. Use a procedure when you need the agent to follow exact steps every time.
+
+## Why procedures
+
+- **Consistency** — the same situation is handled the same way, every time.
+- **Reusable** — write a procedure once and attach it to multiple agents.
+- **Versioned** — edit safely as a draft and publish when ready.
+- **Automatic** — the agent picks the right procedure from the customer's message; you don't route manually.
+
+## How it fits together
+
+<Steps>
+<Step>
+
+### Author the procedure
+
+Write the steps, conditions, and routing in the [editor](/help/agents/procedures/authoring).
+
+</Step>
+<Step>
+
+### Set when it applies
+
+Describe [when the agent should use it](/help/agents/procedures/selection-and-runtime) so it gets selected at the right moment.
+
+</Step>
+<Step>
+
+### Publish it
+
+[Publish a version](/help/agents/procedures/versions) to make it live.
+
+</Step>
+<Step>
+
+### Test it
+
+Run [simulations](/help/agents/simulations) to confirm it behaves the way you expect.
+
+</Step>
+</Steps>
+
+## In this section
+
+<Cards>
+  <Card title="Authoring" href="/help/agents/procedures/authoring" icon="PencilLine">
+    Write a procedure in the editor.
+  </Card>
+  <Card title="Steps & conditions" href="/help/agents/procedures/steps-and-conditions" icon="GitBranch">
+    Instruction steps, branching, and routing.
+  </Card>
+  <Card title="Code & variables" href="/help/agents/procedures/code-and-variables" icon="Code">
+    Run logic and reuse data across steps.
+  </Card>
+  <Card title="Selection & runtime" href="/help/agents/procedures/selection-and-runtime" icon="Workflow">
+    How procedures get chosen and run.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/procedures/meta.json
+++ b/apps/docs/content/docs/help/agents/procedures/meta.json
@@ -1,0 +1,11 @@
+{
+  "title": "Procedures",
+  "pages": [
+    "index",
+    "authoring",
+    "steps-and-conditions",
+    "code-and-variables",
+    "selection-and-runtime",
+    "versions"
+  ]
+}

--- a/apps/docs/content/docs/help/agents/procedures/selection-and-runtime.mdx
+++ b/apps/docs/content/docs/help/agents/procedures/selection-and-runtime.mdx
@@ -1,0 +1,59 @@
+---
+title: Selection & runtime
+description: How an agent picks the right procedure from a conversation and runs through it, including digressions, handoffs, and per-agent overrides.
+---
+
+You don't route procedures manually. The agent **selects** the right one from the conversation, then runs through its steps. This page explains how that works.
+
+## Telling the agent when to use a procedure
+
+Each procedure has selection criteria you set when authoring it:
+
+- **When to use** — a plain-English description of the situation, like "the customer wants to cancel their subscription." This is the main signal.
+- **Trigger examples** — "use when" and "avoid when" phrases that sharpen the choice.
+- **Rulesets** — optional structured conditions that pre-filter candidates cheaply before the agent decides.
+
+<Callout type="warn" title='"When to use" is required'>
+  A procedure with an empty "when to use" can't be selected and won't publish.
+  Describe the situation clearly so the agent knows when it applies.
+</Callout>
+
+## How selection happens
+
+Each turn, the agent:
+
+1. **Pre-filters** candidates using any rulesets (fast, deterministic).
+2. **Picks the best match** among the survivors based on the conversation and each procedure's "when to use" and examples.
+3. **Pins the version** — the selected procedure's active version is locked in for that conversation.
+
+If nothing matches, the agent stays in free-form mode and just uses its [persona](/help/agents/persona) and tools.
+
+## During the conversation
+
+While running a procedure, two things can interrupt the flow:
+
+- **Digression** — the customer asks something off-script. The agent handles it and then returns to where it left off.
+- **Handoff** — the situation needs a person. The agent escalates to a human and leaves the procedure.
+
+## Version pinning
+
+Once a conversation has started running a procedure, it keeps the **pinned version** even if you publish a change mid-conversation. The next conversation that selects the procedure gets the new active version. This means edits never disrupt a conversation that's already in flight. See [Procedure versions](/help/agents/procedures/versions).
+
+## Per-agent overrides
+
+The same procedure can behave differently on different agents. When you attach a procedure to an agent, you can:
+
+- Override its **when to use**, examples, and rulesets for that agent.
+- **Enable or disable** the attachment.
+- Set a **priority** so it's considered before or after others.
+
+## Next steps
+
+<Cards>
+  <Card title="Procedure versions" href="/help/agents/procedures/versions" icon="GitBranch">
+    Draft, publish, and pin procedure versions.
+  </Card>
+  <Card title="Simulations" href="/help/agents/simulations" icon="FlaskConical">
+    Test selection and runtime behavior.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/procedures/steps-and-conditions.mdx
+++ b/apps/docs/content/docs/help/agents/procedures/steps-and-conditions.mdx
@@ -1,0 +1,53 @@
+---
+title: Steps, conditions & routing
+description: The building blocks of a procedure — instruction steps where the agent acts, conditions that branch, and routing that ends or redirects the flow.
+---
+
+A procedure is made of steps. Most are **instruction steps**; the rest control the flow with **conditions** and **routing**.
+
+## Instruction steps
+
+An instruction step is prose telling the agent what to do at this point — "Ask the customer for their order number," or "Confirm the refund amount." This is where the agent does its work: it reads the instruction, talks to the customer, and calls tools as needed.
+
+When the step's goal is met, the procedure moves on to the next step automatically.
+
+## Conditions
+
+A **condition** branches the procedure with if / else-if / else logic. Conditions come in two modes:
+
+| Mode | How the branch is decided | Use when |
+|------|---------------------------|----------|
+| **Text** | The agent judges it in natural language | The decision needs understanding — "the order has shipped" |
+| **Structured** | Exact rules over CRM fields and variables | The decision is a precise data check — "order total > $100" |
+
+Text mode is flexible and reads like a human instruction. Structured mode is deterministic and uses the same condition builder you'll find elsewhere in Auxx.
+
+## Routing
+
+**Routing** steps decide where the procedure goes next:
+
+| Routing | What it does |
+|---------|--------------|
+| **Finished** | Ends the procedure successfully |
+| **Handoff** | Escalates to a human and leaves the procedure |
+| **Switch** | Jumps to a different procedure with no return |
+
+## Sub-procedures
+
+A **sub-procedure** is a named, reusable block *inside* a procedure — for example "Validate refund eligibility." Unlike a switch, calling a sub-procedure **returns** to where it was called, and it **shares the same variables** as the rest of the procedure. Use sub-procedures to avoid repeating the same steps in multiple branches.
+
+<Callout type="info" title="Switch vs. sub-procedure">
+  Use **switch** to permanently hand off to another standalone procedure. Use a
+  **sub-procedure** when you want to do some work and then come back.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Code & variables" href="/help/agents/procedures/code-and-variables" icon="Code">
+    Compute values and reuse data across steps.
+  </Card>
+  <Card title="Selection & runtime" href="/help/agents/procedures/selection-and-runtime" icon="Workflow">
+    How the agent runs through these steps.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/procedures/versions.mdx
+++ b/apps/docs/content/docs/help/agents/procedures/versions.mdx
@@ -1,0 +1,36 @@
+---
+title: Procedure versions
+description: Edit procedures safely as drafts, publish immutable versions, and rely on version pinning so live conversations are never disrupted mid-run.
+---
+
+Procedures use the same **draft-and-publish** model as agents, with one important addition: **version pinning** keeps in-flight conversations stable.
+
+## Draft vs. published
+
+- **Draft** — the procedure you're editing. Changes autosave but don't affect live conversations.
+- **Published version** — a numbered, immutable snapshot. The active version is what agents run.
+
+When the draft differs from the active version, the procedure shows an unpublished-changes indicator.
+
+## Publishing
+
+Publishing snapshots the draft as the next numbered version and makes it active. Before it publishes, Auxx checks that the procedure is valid — for example:
+
+- **"When to use" is filled in** so the procedure can actually be selected.
+- **Code outputs and variables resolve** — every referenced [code block output and variable](/help/agents/procedures/code-and-variables) exists.
+
+If a check fails, fix the issue and publish again.
+
+## Version pinning
+
+When a conversation starts running a procedure, it pins the active version at that moment. If you publish a change while that conversation is still going, it keeps running the pinned version — the change only affects **new** conversations. This means you can edit and publish anytime without disrupting customers mid-conversation.
+
+## Version history
+
+You can browse published versions, **restore** an older one as your new draft, and **label** versions (for example "before refund rules") to keep track of changes.
+
+<Callout type="info" title="Reused across agents">
+  A procedure can be attached to several agents. Publishing a new version
+  updates it everywhere it's used — so test with
+  [simulations](/help/agents/simulations) before you publish.
+</Callout>

--- a/apps/docs/content/docs/help/agents/simulations/assertions.mdx
+++ b/apps/docs/content/docs/help/agents/simulations/assertions.mdx
@@ -1,0 +1,56 @@
+---
+title: Assertions
+description: Define the checks that decide whether a simulation passes — from how the conversation ends to which tools the agent must and must not call.
+---
+
+An **assertion** is a check that runs after a simulation completes and decides whether it passed. Every simulation needs at least one.
+
+## The assertion types
+
+| Type | Checks | Example |
+|------|--------|---------|
+| **Terminal outcome** | How the conversation should end | Should **finish**, not hand off to a human |
+| **Response criteria** | Natural-language checks on the reply | "Mentioned the order number," "stayed empathetic" |
+| **Tool called** | The agent must call a specific tool | Must call **find order** with the order number |
+| **Tool not called** | The agent must **not** call a tool | Must **not** issue a refund for an ineligible item |
+
+**Terminal outcome** can expect the conversation to finish, hand off, or switch to another procedure.
+
+**Response criteria** is a list of independent statements — each one is checked separately, and the assertion fails if any of them isn't met.
+
+**Tool called / not called** can optionally match the tool's inputs, using **exact** or **subset** matching just like [mocks](/help/agents/simulations/mocks).
+
+## How grading works
+
+Assertions are graded two ways:
+
+- **Deterministic checks** — terminal outcome and tool called/not called are checked instantly and exactly.
+- **AI-judged checks** — response criteria are judged by a model, one statement at a time, because they involve understanding language.
+
+## Verdicts
+
+Each run ends with one of three verdicts:
+
+| Verdict | Meaning |
+|---------|---------|
+| **Passed** | Every assertion passed |
+| **Failed** | The run completed, but at least one assertion failed |
+| **Error** | The run couldn't complete cleanly |
+
+<Callout type="warn" title="Errors override a pass">
+  If the run hits an error — such as the agent calling an
+  [unmocked tool](/help/agents/simulations/mocks) or exceeding the turn limit —
+  the verdict is **error**, even if the assertions would have passed. The run is
+  incomplete, so the result can't be trusted.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Running & results" href="/help/agents/simulations/running-and-results" icon="Play">
+    Run the simulation and read each assertion's result.
+  </Card>
+  <Card title="Suggested simulations" href="/help/agents/simulations/suggestions" icon="Sparkles">
+    Get ready-made cases with assertions already filled in.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/simulations/creating-a-simulation.mdx
+++ b/apps/docs/content/docs/help/agents/simulations/creating-a-simulation.mdx
@@ -1,0 +1,49 @@
+---
+title: Create a simulation
+description: Build a simulation by defining a customer scenario, mocking the tools it touches, and adding the assertions that decide whether it passes.
+---
+
+You create simulations from the **Simulations** tab on the agent detail page. Each simulation is built from three parts: a customer scenario, tool mocks, and assertions.
+
+## The customer scenario
+
+The scenario describes the synthetic customer the agent will talk to:
+
+| Field | What it sets |
+|-------|--------------|
+| **Opening message** | The customer's first message, word for word |
+| **Customer context** | The backstory — what the customer wants, knows, or refuses to share |
+| **Claimed identity** | Who the customer says they are (optional, for identity-verification flows) |
+| **Channel** | Whether the conversation is **chat** or **email** |
+| **Max customer turns** | How many times the customer can reply, so the test can't run forever |
+
+A good context gives the simulation realism — for example: "Customer has order #1234, knows the tracking number, but won't share their email."
+
+## Add mocks and assertions
+
+With the scenario set, define:
+
+- **[Tool mocks](/help/agents/simulations/mocks)** — fake responses for any tools the agent will call, so the run stays offline.
+- **[Assertions](/help/agents/simulations/assertions)** — the checks that decide pass or fail. Every simulation needs at least one.
+
+## Saving
+
+Simulations **autosave** as you edit. Once saved, a simulation is reusable — run it as often as you like, including after every change, to catch regressions.
+
+<Callout type="info" title="Let the assistant draft one for you">
+  In the **Build** tab, you can ask the assistant to create a simulation — for
+  example, "Create a simulation where the customer asks for a refund on an
+  out-of-warranty item." It drafts the scenario, mocks, and assertions for you to
+  review before saving.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Mocks" href="/help/agents/simulations/mocks" icon="TestTube">
+    Keep the run offline with fake tool responses.
+  </Card>
+  <Card title="Assertions" href="/help/agents/simulations/assertions" icon="CircleCheck">
+    Define what the agent must and must not do.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/simulations/index.mdx
+++ b/apps/docs/content/docs/help/agents/simulations/index.mdx
@@ -1,0 +1,76 @@
+---
+title: Simulations
+description: Test agents and procedures with repeatable, offline scenarios that grade behavior, so you can catch problems before changes go live.
+---
+
+A **simulation** is a repeatable, offline test of an agent or procedure. It pairs a synthetic customer scenario with checks on what the agent should do, then grades the result. Run simulations to prove behavior before you publish — without ever touching real customer data, Shopify, or email.
+
+You'll find simulations in the **Simulations** tab of the docked panel on the agent detail page.
+
+## Why simulate
+
+- **Confidence** — verify the agent does the right thing before it goes live.
+- **Regression safety** — re-run your tests after every change to catch breakage.
+- **Safe and fast** — runs are offline, so there are no side effects and no waiting on real APIs.
+
+## A quick note on terms
+
+The feature is called **Simulations**. A few related words you'll see:
+
+| Term | Meaning |
+|------|---------|
+| **Simulation** | The feature, and a single test scenario |
+| **Eval case** | The saved definition of a simulation |
+| **Run** | One execution of a simulation, with its result |
+
+## Two scopes
+
+A simulation tests one of two things:
+
+- **Procedure simulation** — a focused test of a single [procedure](/help/agents/procedures), pinned to a version. Like a unit test.
+- **Agent simulation** — a test of the whole agent, including which procedure it selects. Like an integration test.
+
+## What's in a simulation
+
+Every simulation has three parts:
+
+<Steps>
+<Step>
+
+### A customer scenario
+
+The opening message and context — who the customer is and what they want.
+
+</Step>
+<Step>
+
+### Tool mocks
+
+Fake responses that stand in for real tool and API calls. See [Mocks](/help/agents/simulations/mocks).
+
+</Step>
+<Step>
+
+### Assertions
+
+The pass/fail checks on what the agent should do. See [Assertions](/help/agents/simulations/assertions).
+
+</Step>
+</Steps>
+
+## In this section
+
+<Cards>
+  <Card title="Create a simulation" href="/help/agents/simulations/creating-a-simulation" icon="Plus">
+    Set up a scenario, mocks, and assertions.
+  </Card>
+  <Card title="Mocks" href="/help/agents/simulations/mocks" icon="TestTube">
+    Replace real tool calls with fake responses.
+  </Card>
+  <Card title="Assertions" href="/help/agents/simulations/assertions" icon="CircleCheck">
+    Define what counts as a pass.
+  </Card>
+  <Card title="Running & results" href="/help/agents/simulations/running-and-results" icon="Play">
+    Run simulations and read the verdict.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/simulations/meta.json
+++ b/apps/docs/content/docs/help/agents/simulations/meta.json
@@ -1,0 +1,11 @@
+{
+  "title": "Simulations",
+  "pages": [
+    "index",
+    "creating-a-simulation",
+    "mocks",
+    "assertions",
+    "running-and-results",
+    "suggestions"
+  ]
+}

--- a/apps/docs/content/docs/help/agents/simulations/mocks.mdx
+++ b/apps/docs/content/docs/help/agents/simulations/mocks.mdx
@@ -1,0 +1,47 @@
+---
+title: Tool mocks
+description: Replace real tool and API calls with fake responses so simulations run offline, stay deterministic, and never cause real side effects.
+---
+
+A **mock** is a fake response that stands in for a real tool call during a simulation. Mocks are what make simulations safe and repeatable — the agent thinks it called Shopify or sent an email, but nothing real happens.
+
+## Why mock
+
+- **Offline** — no real calls to Shopify, Stripe, email, or any app.
+- **Deterministic** — the same mock returns the same result every run, so tests are stable.
+- **Fast and safe** — no API latency and no side effects.
+
+## Defining a mock
+
+Each mock specifies:
+
+| Field | What it does |
+|-------|--------------|
+| **Tool name** | Which tool to intercept |
+| **Output** | The fake response to return (as JSON) |
+| **Usage** | `repeat` returns the output every time; `once` returns it a single time |
+
+You can also add an optional **argument matcher** so a mock only applies to specific calls — for example, only mocking a lookup for `orderId: "1234"`. Matching can be **exact** (the whole input matches) or **subset** (the keys you specify match, others are ignored).
+
+## When a tool isn't mocked
+
+If the agent calls a tool you didn't mock, the simulation follows its **unmatched-tool policy**:
+
+- **Error** (default) — the run fails immediately, so you notice the missing mock.
+- **Read-only passthrough** — read-only tools are allowed to run for real; anything that writes still fails.
+
+<Callout type="info" title="Control signals aren't mocked">
+  Procedures use internal control signals (like advancing a step or handing off).
+  Those aren't external tool calls, so you never need to mock them.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Assertions" href="/help/agents/simulations/assertions" icon="CircleCheck">
+    Decide what counts as a pass.
+  </Card>
+  <Card title="Running & results" href="/help/agents/simulations/running-and-results" icon="Play">
+    See how unmatched mocks show up in results.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/simulations/running-and-results.mdx
+++ b/apps/docs/content/docs/help/agents/simulations/running-and-results.mdx
@@ -1,0 +1,52 @@
+---
+title: Running & reading results
+description: Run one simulation or a whole suite, choose draft or published behavior, and read the verdict, assertion results, and full conversation trace.
+---
+
+Once a simulation is saved, you can run it as often as you like and inspect the results in detail.
+
+## Run one, or run all
+
+- **Run one** — execute a single simulation to check a specific scenario.
+- **Run all** — execute every simulation as a **suite**. This is how you catch regressions: one click confirms a change didn't break anything else.
+
+## Draft or published behavior
+
+You choose what the simulation runs against:
+
+| Mode | Runs against | Use for |
+|------|--------------|---------|
+| **Pinned** | The published version | The authoritative result |
+| **Draft** | Your current working draft | Checking edits before you publish |
+
+A draft run never becomes the official status of a simulation — the **pinned** result is always the verdict of record. This lets you experiment freely while keeping a trustworthy history.
+
+## Reading a run
+
+A completed run shows:
+
+- **The verdict** — passed, failed, or error (see [Assertions](/help/agents/simulations/assertions)).
+- **Assertion results** — one row per assertion, with what was expected versus what actually happened.
+- **The conversation trace** — the full back-and-forth, every tool call, and the procedure steps the agent took.
+- **AI credits used** — what the run cost.
+
+## History and comparison
+
+Suite runs are kept over time so you can compare results across changes and spot when something regressed. A pulse indicator on the **Simulations** tab shows when a suite is currently running.
+
+<Callout type="info" title="A green suite before publishing">
+  Make it a habit to get your simulation suite passing before you
+  [publish a version](/help/agents/versions). It's the cheapest way to keep a
+  reliable agent reliable.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Suggested simulations" href="/help/agents/simulations/suggestions" icon="Sparkles">
+    Grow your suite with AI-proposed cases.
+  </Card>
+  <Card title="Versions & publishing" href="/help/agents/versions" icon="GitBranch">
+    Publish once your suite is green.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/simulations/suggestions.mdx
+++ b/apps/docs/content/docs/help/agents/simulations/suggestions.mdx
@@ -1,0 +1,39 @@
+---
+title: Suggested simulations
+description: Let Auxx propose ready-to-run test cases for a procedure — happy paths, branches, and edge cases — so you can build coverage with one click.
+---
+
+You don't have to write every simulation from scratch. Auxx can read a [procedure](/help/agents/procedures) and propose **suggested simulations** — ready-to-run cases that cover the scenarios worth testing.
+
+## What gets suggested
+
+Suggestions aim for good coverage of a procedure, including:
+
+- The **happy path** — the procedure succeeds normally.
+- **Each major branch** — the different ways a [condition](/help/agents/procedures/steps-and-conditions) can go.
+- **Missing information** — the customer doesn't provide something the procedure needs.
+- **Edge and refusal cases** — unusual or out-of-scope requests.
+
+Each suggestion arrives complete with a scenario, mocks, and assertions.
+
+## Using a suggestion
+
+- **Add** — one click creates the case and opens it in the editor, where you can refine it.
+- **Dismiss** — hide a suggestion you don't want.
+
+<Callout type="info" title="Suggestions are temporary until you add them">
+  A suggestion only becomes a saved simulation when you add it. Some proposed
+  cases may be dropped automatically if they don't pass validation — that's
+  expected, and the rest are still good to use.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Running & results" href="/help/agents/simulations/running-and-results" icon="Play">
+    Run your new cases and read the verdicts.
+  </Card>
+  <Card title="Procedures" href="/help/agents/procedures" icon="ListChecks">
+    Suggestions are generated from a procedure's steps.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/templates.mdx
+++ b/apps/docs/content/docs/help/agents/templates.mdx
@@ -1,0 +1,49 @@
+---
+title: Agent templates
+description: Start from a pre-built template instead of a blank agent to get a tested starting prompt and sensible defaults for common support roles.
+---
+
+When you create an agent, you can start from a **template** instead of a blank slate. A template gives you a tested starter prompt and sensible defaults so you're not staring at an empty editor.
+
+## What a template provides
+
+- **A starter prompt** — opening instructions tailored to the role, ready to refine.
+- **A suggested identity** — a name, avatar, and color you can change.
+
+You still complete the [setup flow](/help/agents/creating-an-agent), so you choose the tools and knowledge that fit your workspace.
+
+## Internal agent templates
+
+Templates for agents that help your team, covering common roles such as:
+
+- Support triage
+- Refund handling
+- Escalation for high-value customers
+- Sales lead qualification and quote follow-up
+- Scheduled digests and standups
+- Team onboarding
+
+## Chat agent templates
+
+Templates for agents that answer your customers in the chat widget, such as:
+
+- Storefront support concierge
+- Order status assistant
+- Product Q&A
+
+<Callout type="info" title="Templates are a starting point">
+  A template just pre-fills the prompt and identity. Treat it as a draft to
+  shape — adjust the persona, tools, and knowledge to match your business before
+  you publish.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Create an agent" href="/help/agents/creating-an-agent" icon="Plus">
+    Start from a template or a blank agent.
+  </Card>
+  <Card title="Write the persona" href="/help/agents/persona" icon="FileText">
+    Refine the template's starter prompt.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/tools.mdx
+++ b/apps/docs/content/docs/help/agents/tools.mdx
@@ -1,0 +1,52 @@
+---
+title: Tools & app accounts
+description: Give your agent actions to take by enabling toolsets and tools, and pin it to specific connected accounts with app accounts.
+---
+
+**Tools** are the actions an agent can take — sending an email, creating a ticket, looking up a Shopify order, or anything a custom app exposes. You manage them in the **Tools** tab on the agent detail page.
+
+## Toolsets vs. tools
+
+A **tool** is a single action. A **toolset** is a bundle of related tools you can enable as a unit. Toolsets come from three sources:
+
+| Source | Examples |
+|--------|----------|
+| **Native** — built into Auxx | Core, email, knowledge, entities |
+| **Apps** — one per installed app | Shopify, Slack, and other [installed apps](/help/apps/overview) |
+| **MCP servers** — your connected servers | Any tool exposed by a [connected MCP server](/help/ai/mcp-connect) |
+
+You can enable an entire toolset, or open it and pick individual tools with a per-tool allow-list.
+
+## How a tool becomes enabled
+
+A tool can be turned on three ways:
+
+1. **Manually** — you add it from the **Add tools** dialog.
+2. **By default** — a starter set of toolsets is added when the agent is created.
+3. **By mention** — referencing a tool in the [persona prompt](/help/agents/persona) or a [procedure](/help/agents/procedures) automatically enables and **locks** it on.
+
+Locked tools show a lock badge. To remove one, delete the mention that locked it first.
+
+## App accounts
+
+When an app is connected to more than one account — say two Shopify stores — you can pin the agent to a specific one with an **app account**. This makes sure the agent always acts on the right store, workspace, or inbox.
+
+## Chat agents get a filtered set
+
+[Chat agents](/help/agents) that serve customers only see tools marked safe for untrusted callers. Sensitive actions are hidden from the chat surface automatically, even if the same tool is available to internal agents.
+
+<Callout type="info" title="Tools that need approval">
+  Some tools require a person to confirm before they run. See
+  [Tool approvals](/help/agents/approvals).
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Knowledge scope" href="/help/agents/knowledge" icon="BookOpen">
+    Control which records the agent can read.
+  </Card>
+  <Card title="Connect an MCP server" href="/help/ai/mcp-connect" icon="Plug">
+    Bring external tools into your agents.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/triggers.mdx
+++ b/apps/docs/content/docs/help/agents/triggers.mdx
@@ -1,0 +1,53 @@
+---
+title: Triggers
+description: Let agents run on their own — from mentions and assignments to schedules, record events, and app events — without anyone prompting them.
+---
+
+**Triggers** let an agent act without a person prompting it. You manage them in the **Triggers** tab on the agent detail page. (Triggers don't apply to [chat agents](/help/agents), which run from the chat widget instead.)
+
+## Built-in triggers
+
+Every internal agent can respond to three things as soon as it's live:
+
+- **Mention** — someone @mentions the agent in a comment or thread.
+- **Assignment** — the agent is assigned to a ticket.
+- **Direct message** — a user messages the agent directly in chat.
+
+## Autonomous triggers
+
+From the **Add trigger** menu, you can add triggers that fire on their own:
+
+| Trigger | Fires when | Example |
+|---------|-----------|---------|
+| **Scheduled** | A time or interval is reached | Post a metrics digest every morning |
+| **Event** | A record is created, updated, or deleted | Reply when a new ticket comes in |
+| **App** | An installed app emits an event | Act when an order is paid in Shopify |
+
+- **Scheduled** triggers run on a recurring interval or a custom schedule.
+- **Event** triggers can include filters so the agent only runs on records that match a condition.
+- **App** triggers require the app to be installed and pinned to the agent with an [app account](/help/agents/tools).
+
+## Per-trigger settings
+
+Each trigger has its own controls:
+
+- **Enable / disable** — turn the trigger on or off without deleting it.
+- **Instructions** — extra prompt guidance applied only when this trigger fires.
+- **Activity** — see when it last ran and surface the last error if something failed.
+
+<Callout type="info" title="Keep a human in the loop">
+  Pair autonomous triggers with [tool approvals](/help/agents/approvals) or
+  [workflow approvals](/help/ai/workflow-approvals) so a person signs off before
+  sensitive actions are taken.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Tool approvals" href="/help/agents/approvals" icon="ShieldCheck">
+    Add confirmation gates to sensitive actions.
+  </Card>
+  <Card title="Models & BYOK" href="/help/agents/models" icon="Cpu">
+    Choose which model powers the agent.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/agents/versions.mdx
+++ b/apps/docs/content/docs/help/agents/versions.mdx
@@ -1,0 +1,51 @@
+---
+title: Versions & publishing
+description: Edit an agent safely as a draft, then publish numbered, immutable versions that control exactly what your production agents run.
+---
+
+Agents use a **draft-and-publish** model so you can edit safely without changing live behavior. The agent you edit is the draft; **publishing** captures it as a version that production runs use.
+
+## Draft vs. published
+
+- **Draft** — the agent you see and edit. Every change autosaves, but **none of it goes live** until you publish.
+- **Version** — a numbered, immutable snapshot of the agent's behavior. The active version is what your production agent actually runs.
+
+When your draft differs from the active version, the agent shows an **unpublished changes** indicator.
+
+## What's included in a version
+
+Publishing snapshots the agent's behavior:
+
+| Versioned | Not versioned |
+|-----------|---------------|
+| Persona prompt | Name, avatar, color |
+| Tools and app accounts | Triggers |
+| Knowledge scope | Attached procedures |
+| Tool bindings | |
+| Model | |
+
+[Procedures](/help/agents/procedures) have their own independent versions, so they're not captured inside the agent's version.
+
+## Publishing, reverting, and discarding
+
+- **Publish** — snapshot the current draft as the next numbered version and make it active.
+- **Revert** — restore the active version's behavior back into the draft.
+- **Discard** — throw away draft changes and return to the active version.
+
+You can also label versions (for example "prod" or "v2.1") and browse version history.
+
+<Callout type="info" title="Test before you publish">
+  Run your [simulations](/help/agents/simulations) against the draft and get
+  them passing before you publish. Publishing is what changes live behavior.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Simulations" href="/help/agents/simulations" icon="FlaskConical">
+    Validate the draft before publishing.
+  </Card>
+  <Card title="Procedures" href="/help/agents/procedures" icon="ListChecks">
+    Versioned separately from the agent.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/index.mdx
+++ b/apps/docs/content/docs/help/index.mdx
@@ -15,8 +15,11 @@ toc: false
   <Card title="Workspace" href="/help/workspace/overview" icon="LayoutDashboard">
     Manage your organization, members, roles, and workspace settings
   </Card>
-  <Card title="AI & Automation" href="/help/ai/overview" icon="Bot">
+  <Card title="AI & Automation" href="/help/ai/overview" icon="Sparkles">
     Configure AI models, build workflows, and automate responses
+  </Card>
+  <Card title="AI Agents" href="/help/agents" icon="Bot">
+    Build AI teammates with personas, tools, procedures, and simulations
   </Card>
   <Card title="Messaging" href="/help/messaging/sync-messages" icon="Mail">
     Send and sync messages across your connected inboxes

--- a/apps/docs/content/docs/help/meta.json
+++ b/apps/docs/content/docs/help/meta.json
@@ -12,6 +12,7 @@
     "tickets",
     "apps",
     "ai",
+    "agents",
     "datasets",
     "files",
     "tasks",


### PR DESCRIPTION
## Summary

Adds a new **AI Agents** help section to `apps/docs`, documenting the agent system end-to-end: agents, procedures, and simulations. The existing `ai` section only covered org-level AI (models, workflows, MCP), so agents now get their own top-level section.

23 articles grounded in the actual UI (verified tab labels and navigation), following `apps/docs/CLAUDE.md` conventions (no H1s, action-oriented voice, registered Fumadocs components, internal cross-linking).

## Structure

`content/docs/help/agents/`

- **Agents (11)** — overview, concepts glossary, creating an agent, persona prompt, tools & app accounts, knowledge scope, triggers, models & BYOK, versions & publishing, approvals, templates
- **Procedures (6)** — overview, authoring, steps & conditions, code & variables, selection & runtime, versions
- **Simulations (6)** — overview, creating a simulation, mocks, assertions, running & results, suggested simulations

## Navigation

- Added `agents` to `help/meta.json` (after `ai`)
- Added an "AI Agents" card to the help homepage; switched the AI & Automation card to a `Sparkles` icon so the two are visually distinct

## Notes

- Standardized on **"Simulations"** in prose (defining "eval case"/"run" once); no internal class names exposed
- Flagged **Procedures** as plan-gated/advanced via a Callout, matching the entitlement gate in code
- Documented **version pinning** (in-flight conversations keep their pinned procedure version)
- No images referenced — nothing renders broken. Screenshots can be a follow-up
- `npx fumadocs-mdx` regenerates the source index cleanly (frontmatter + meta.json all valid)