### PR TITLE
feat(chat): serve widget bundle from cdn.auxx.ai

### DIFF
--- a/.github/workflows/chat-publish.yml
+++ b/.github/workflows/chat-publish.yml
@@ -112,6 +112,40 @@ jobs:
         working-directory: packages/chat
         run: pnpm pack
 
+      # Publish the built widget bundle to the CDN (auxx-public S3, served by
+      # cdn.auxx.ai). Runs before the npm publish so the CDN is current the
+      # moment the version is public. The deploy role already grants s3:*.
+      - name: Configure AWS credentials
+        if: ${{ !inputs.dry-run }}
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::716542960845:role/AuxxGithubDeployRole
+          aws-region: us-west-1
+
+      - name: Upload widget bundle to CDN
+        if: ${{ !inputs.dry-run }}
+        env:
+          BUCKET: auxx-public
+          BUNDLE: packages/chat/dist/widget-bundle/auxx-chat.js
+        run: |
+          # Immutable, version-pinned artifact — safe to cache forever.
+          aws s3 cp "$BUNDLE" "s3://$BUCKET/scripts/chat-widget-${CHAT_VERSION}.js" \
+            --content-type 'application/javascript; charset=utf-8' \
+            --cache-control 'public, max-age=31536000, immutable'
+          # Stable alias the embed snippet points at — short TTL, purged below.
+          aws s3 cp "$BUNDLE" "s3://$BUCKET/scripts/chat-widget.js" \
+            --content-type 'application/javascript; charset=utf-8' \
+            --cache-control 'public, max-age=300, stale-while-revalidate=86400'
+
+      - name: Purge CDN edge cache for stable alias
+        if: ${{ !inputs.dry-run }}
+        run: |
+          curl -fsS -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CF_API_TOKEN }}" \
+            -H 'Content-Type: application/json' \
+            --data '{"files":["https://cdn.auxx.ai/scripts/chat-widget.js"]}'
+
       - name: Publish to npm
         if: ${{ !inputs.dry-run }}
         working-directory: packages/chat

--- a/apps/docs/content/docs/help/channels/chat-widget.mdx
+++ b/apps/docs/content/docs/help/channels/chat-widget.mdx
@@ -23,7 +23,7 @@ Paste this just before `</body>` on every page that should show the widget. No b
 
 ```html
 <script
-  src="https://app.auxx.ai/scripts/chat-widget.js"
+  src="https://cdn.auxx.ai/scripts/chat-widget.js"
   data-channel-id="<channelId>"
   async defer></script>
 ```
@@ -234,7 +234,7 @@ If your visitor data is rendered into the page server-side (e.g. a Rails or Djan
   }]);
 </script>
 <script
-  src="https://app.auxx.ai/scripts/chat-widget.js"
+  src="https://cdn.auxx.ai/scripts/chat-widget.js"
   data-channel-id="<channelId>"
   async defer></script>
 ```

--- a/apps/web/src/components/chat-widget/ui/settings/sections/setup-snippets.ts
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/setup-snippets.ts
@@ -64,7 +64,7 @@ export function getSetupSnippets(
               serverBlock,
               {
                 language: CodeLanguage.html,
-                value: `<script src="https://app.auxx.ai/scripts/chat-widget.js" async defer></script>
+                value: `<script src="https://cdn.auxx.ai/scripts/chat-widget.js" async defer></script>
 <script>
   // Replace TOKEN_FROM_SERVER with the JWT minted above
   // (server-render it into the page, or fetch it before booting).
@@ -86,7 +86,7 @@ export function getSetupSnippets(
               {
                 language: CodeLanguage.html,
                 value: `<script
-  src="https://app.auxx.ai/scripts/chat-widget.js"
+  src="https://cdn.auxx.ai/scripts/chat-widget.js"
   data-channel-id="${id}"
   async defer></script>`,
                 title: 'Basic JS',

--- a/apps/web/src/components/global/dashboard.tsx
+++ b/apps/web/src/components/global/dashboard.tsx
@@ -128,9 +128,12 @@ export const Dashboard = ({
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}>
         <DndStateProvider activeDndItem={activeDndItem}>
-          <div className='flex h-screen overflow-hidden w-full pt-safe pb-safe pl-safe pr-safe'>
+          <div className='flex h-screen overflow-hidden w-full'>
             <AppSidebar className='min-w-0' user={user} />
-            <SidebarInset className='min-h-0'>
+            {/* Safe-area insets live on the content surface (not the bare
+                shell) so its bg paints full-bleed to the screen edges while
+                content stays clear of the notch / home indicator. */}
+            <SidebarInset className='min-h-0 pt-safe pb-safe pl-safe pr-safe'>
               <DemoBanner />
               <OverageBanner overages={overages} />
               {children}

--- a/packages/chat/src/client/index.ts
+++ b/packages/chat/src/client/index.ts
@@ -11,7 +11,7 @@
  *     Auxx.update({ plan: 'pro' })
  *     Auxx.shutdown()
  *
- * Defaults to the hosted bundle at `app.auxx.ai/scripts/chat-widget.js`.
+ * Defaults to the hosted bundle at `cdn.auxx.ai/scripts/chat-widget.js`.
  * Customers self-hosting can pass `widgetBase` (or set `AUXX_WIDGET_URL` at
  * build time). `apiBase` is propagated to the bundle via
  * `window.__AUXX_CONFIG__` *before* the script tag is injected, so the same

--- a/packages/chat/src/shared/env.ts
+++ b/packages/chat/src/shared/env.ts
@@ -30,5 +30,5 @@ export const API_URL =
 export const WIDGET_URL =
   readEnv('AUXX_WIDGET_URL') ??
   (IS_PROD
-    ? 'https://app.auxx.ai/scripts/chat-widget.js'
+    ? 'https://cdn.auxx.ai/scripts/chat-widget.js'
     : 'http://localhost:3000/scripts/chat-widget.js')

--- a/packages/chat/src/views/conversation/bubble.tsx
+++ b/packages/chat/src/views/conversation/bubble.tsx
@@ -109,7 +109,7 @@ function pillClass(isUser: boolean, first: boolean, last: boolean): string {
     'whitespace-pre-wrap break-words rounded-2xl px-3 py-1.5 text-sm',
     isUser
       ? 'bg-primary text-primary-foreground'
-      : 'bg-[color:var(--auxx-chat-surface-loud)] text-[color:var(--auxx-chat-text-loud)]',
+      : 'bg-[color:var(--auxx-chat-surface-dark-default)] text-[color:var(--auxx-chat-text-loud)]',
     !first && (isUser ? 'rounded-tr-md' : 'rounded-tl-md'),
     !last && (isUser ? 'rounded-br-md' : 'rounded-bl-md'),
     last && (isUser ? 'rounded-br-sm' : 'rounded-bl-sm')


### PR DESCRIPTION
## What

Moves the embeddable chat widget off the apps/web Next.js origin and onto `cdn.auxx.ai` (the Cloudflare Worker over the `auxx-public` S3 bucket), published by the same workflow that cuts the `@auxx/chat` npm release. Also fixes a light-mode rendering bug and bundles an unrelated dashboard safe-area tweak.

## Why

The widget script customers embed resolved to `app.auxx.ai/scripts/chat-widget.js` — served straight out of the Next.js app's `public/` folder. For a script embedded on every customer site that means app-origin (not edge) delivery, availability coupling to apps/web deploys, and no immutable caching/versioning.

## Changes

**`feat(chat): serve widget bundle from cdn.auxx.ai`**
- `chat-publish.yml`: after build, assume `AuxxGithubDeployRole` via OIDC and upload the bundle to `auxx-public` as an immutable version-pinned artifact (`scripts/chat-widget-<version>.js`, 1y immutable) plus a short-TTL stable alias (`scripts/chat-widget.js`), then purge the Cloudflare edge cache for the alias. Gated on `!dry-run`.
- Repoint prod `WIDGET_URL`, the dashboard install snippets, and the docs to `cdn.auxx.ai`. Dev still serves from `localhost:3000` via the vite copy plugin.

**`fix(chat): agent bubble invisible in light mode`**
- Agent bubble used `--auxx-chat-surface-loud`, which only contrasts in dark mode (in light mode it's the same near-white tone as the panel). Switch to `--auxx-chat-surface-dark-default`, the per-theme contrast token.

**`fix(web): dashboard safe-area insets`**
- Pre-existing local change, bundled in per request: move `*-safe` insets onto `SidebarInset` so the shell background paints full-bleed.

## Follow-ups / risks

- New CDN steps run only on a **real** publish (skipped on dry-run). First real run will exercise the **Configure AWS credentials** step — if `AuxxGithubDeployRole`'s OIDC trust is scoped to specific workflows/environments, it may need widening for `chat-publish.yml` / the `npm-publish` environment.
- Requires `CF_API_TOKEN` + `CF_ZONE_ID` secrets in the `npm-publish` environment (added).
- Confirm the Worker maps `cdn.auxx.ai/scripts/X` → S3 key `scripts/X` and honors the alias' `Cache-Control`.