### PR TITLE
fix(chat): make CDN purge non-fatal in chat-publish

### DIFF
--- a/.github/workflows/chat-publish.yml
+++ b/.github/workflows/chat-publish.yml
@@ -137,15 +137,6 @@ jobs:
             --content-type 'application/javascript; charset=utf-8' \
             --cache-control 'public, max-age=300, stale-while-revalidate=86400'
 
-      - name: Purge CDN edge cache for stable alias
-        if: ${{ !inputs.dry-run }}
-        run: |
-          curl -fsS -X POST \
-            "https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/purge_cache" \
-            -H "Authorization: Bearer ${{ secrets.CF_API_TOKEN }}" \
-            -H 'Content-Type: application/json' \
-            --data '{"files":["https://cdn.auxx.ai/scripts/chat-widget.js"]}'
-
       - name: Publish to npm
         if: ${{ !inputs.dry-run }}
         working-directory: packages/chat
@@ -178,3 +169,20 @@ jobs:
             --target "${{ github.sha }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Best-effort: the npm + CDN artifacts are already live by now, so a purge
+      # failure must never fail the release. The Worker forces its own edge TTL,
+      # so the stable alias needs purging to update promptly; the immutable
+      # versioned URL is unaffected either way. Logs the CF response on failure.
+      - name: Purge CDN edge cache for stable alias
+        if: ${{ !inputs.dry-run }}
+        continue-on-error: true
+        run: |
+          resp=$(curl -sS -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CF_API_TOKEN }}" \
+            -H 'Content-Type: application/json' \
+            --data '{"files":["https://cdn.auxx.ai/scripts/chat-widget.js"]}') || true
+          echo "$resp"
+          echo "$resp" | grep -q '"success":true' \
+            || echo "::warning::Cloudflare purge did not succeed (see response above). Stable alias self-heals within the edge TTL; the immutable versioned URL is unaffected."


### PR DESCRIPTION
Follow-up to #850. The first real run uploaded the bundle to the CDN successfully but the Cloudflare purge step returned HTTP 401 and **halted the job before npm publish**.

This makes the purge resilient:
- Moved to the **last** step (after npm publish, tag, and GitHub release), so the release is already complete before it runs.
- `continue-on-error: true` + drops `curl -f`, logging the Cloudflare response body and emitting a `::warning::` instead of failing.

The 401 itself is a bad `CF_API_TOKEN` secret (separate fix on the Cloudflare side). With this change, even a broken token won't block releases — the immutable versioned URL is served regardless; only the stable alias's freshness depends on the purge.