### PR TITLE
feat(chat-widget): mobile-responsive settings + full-screen preview

### DIFF
--- a/apps/web/src/app/(protected)/preview/widget/[integrationId]/embed/page.tsx
+++ b/apps/web/src/app/(protected)/preview/widget/[integrationId]/embed/page.tsx
@@ -35,6 +35,10 @@ export default function PreviewWidgetEmbedPage() {
   const v = search?.get('v') ?? null
   const rawTheme = (search?.get('theme') ?? 'system') as PreviewTheme
   const theme: PreviewTheme = VALID_THEMES.includes(rawTheme) ? rawTheme : 'system'
+  // The desktop pane frames the widget in a rounded phone card, so it keeps the
+  // widget's rounded shell. The mobile sheet is genuinely full-screen and wants
+  // the widget edge-to-edge — it passes `rounded=0` to opt out.
+  const rounded = (search?.get('rounded') ?? '1') !== '0'
 
   // `useEnv().apiUrl` is the v1 SDK base (`<origin>/api/v1`). The chat routes
   // live at the bare origin under `/api/chat/*` — strip the v1 suffix so the
@@ -48,14 +52,15 @@ export default function PreviewWidgetEmbedPage() {
 
     // Force the widget open on mount — the preview pane is useless if the
     // tester has to click the launcher every reload.
-    // `previewRounded` keeps the rounded shell in the mobile-fullscreen
-    // layout (the iframe is phone-narrow so the mobile media query fires).
+    // `previewRounded` keeps the rounded shell when the iframe is phone-narrow
+    // (the mobile media query fires) — wanted in the desktop pane's phone card,
+    // opted out of by the full-screen mobile sheet via `rounded=0`.
     // `previewBypassAudience` keeps the launcher visible on `users`-audience
     // channels so admins can preview them without signing a fake JWT.
     const programmaticConfig = {
       apiBase: chatApiBase,
       open: true,
-      previewRounded: true,
+      previewRounded: rounded,
       previewBypassAudience: true,
     }
     const bootHtml = `<script>
@@ -79,7 +84,7 @@ export default function PreviewWidgetEmbedPage() {
     ${bootHtml}
   </body>
 </html>`
-  }, [appUrl, chatApiBase, integrationId, theme, v])
+  }, [appUrl, chatApiBase, integrationId, theme, v, rounded])
 
   if (!integrationId || !srcDoc) {
     return null

--- a/apps/web/src/components/chat-widget/ui/settings/chat-widget-settings.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/chat-widget-settings.tsx
@@ -3,7 +3,7 @@
 import type { ChatWidgetWithIntegration } from '@auxx/lib/chat-widget/config'
 import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
-import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
+import { ResponsiveTabs } from '@auxx/ui/components/responsive-tabs'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import {
@@ -18,11 +18,12 @@ import {
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useQueryState } from 'nuqs'
+import { useState } from 'react'
 import SettingsPage from '~/components/global/settings-page'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { useChatWidget } from '../../hooks/use-chat-widget'
-import { MobilePreviewLauncher, PreviewPane } from './preview-pane'
+import { MobilePreviewSheet, MobilePreviewTrigger, PreviewPane } from './preview-pane'
 import { AiSection } from './sections/ai-section'
 import { AppearanceSection } from './sections/appearance-section'
 import { BehaviorSection } from './sections/behavior-section'
@@ -52,6 +53,7 @@ export function ChatWidgetSettings({ channelId }: ChatWidgetSettingsProps) {
   const [activeSection, setActiveSection] = useQueryState('s', {
     defaultValue: 'general',
   }) as [SectionId, (s: string) => void]
+  const [previewOpen, setPreviewOpen] = useState(false)
 
   const { data, isLoading, error } = useChatWidget(channelId)
   const disconnectChannel = api.channel.disconnect.useMutation()
@@ -113,7 +115,7 @@ export function ChatWidgetSettings({ channelId }: ChatWidgetSettingsProps) {
           { title: 'Channels', href: '/app/settings/channels' },
           { title: 'Chat Widget' },
         ]}>
-        <div className='space-y-4 p-6'>
+        <div className='space-y-4 p-3 sm:p-6'>
           <Skeleton className='h-10 w-full max-w-md' />
           <Skeleton className='h-64 w-full' />
         </div>
@@ -131,7 +133,7 @@ export function ChatWidgetSettings({ channelId }: ChatWidgetSettingsProps) {
           { title: 'Channels', href: '/app/settings/channels' },
           { title: 'Chat Widget' },
         ]}>
-        <div className='p-6'>
+        <div className='p-3 sm:p-6'>
           <Alert variant='destructive'>
             <AlertCircle className='h-4 w-4' />
             <AlertTitle>Error</AlertTitle>
@@ -174,37 +176,51 @@ export function ChatWidgetSettings({ channelId }: ChatWidgetSettingsProps) {
         { title: widgetName },
       ]}
       button={
-        <Button variant='outline' size='sm' onClick={openPreview}>
+        // Popup launcher — desktop only. On smaller screens the in-page
+        // preview sheet is triggered next to the tab dropdown / floating.
+        <Button variant='outline' size='sm' onClick={openPreview} className='hidden lg:inline-flex'>
           <ExternalLink />
           Open preview
         </Button>
+      }
+      subHeader={
+        <div className='flex items-center gap-2'>
+          <div className='min-w-0 flex-1'>
+            <ResponsiveTabs
+              value={activeSection}
+              onValueChange={setActiveSection}
+              size='sm'
+              items={SETTINGS_SECTIONS.map((section) => ({
+                value: section.id,
+                label: section.label,
+                icon: section.icon,
+              }))}
+            />
+          </div>
+          {/* Beside the dropdown on mobile; tablet uses the floating trigger below. */}
+          <MobilePreviewTrigger
+            onOpen={() => setPreviewOpen(true)}
+            className='shrink-0 md:hidden'
+          />
+        </div>
       }>
       <ConfirmDialog />
-      <div className='sticky top-[68px] z-20 border-b border-border bg-background/90 p-3 backdrop-blur-sm'>
-        <RadioTab
-          value={activeSection}
-          onValueChange={setActiveSection}
-          size='sm'
-          radioGroupClassName='grid w-full grid-cols-6'
-          className='border border-primary-200 flex w-full'>
-          {SETTINGS_SECTIONS.map((section) => {
-            const Icon = section.icon
-            return (
-              <RadioTabItem key={section.id} value={section.id} size='sm'>
-                <Icon />
-                {section.label}
-              </RadioTabItem>
-            )
-          })}
-        </RadioTab>
-      </div>
       <div className='grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
         <div className='min-w-0'>{renderActiveSection()}</div>
         <div className='hidden border-l lg:block'>
           <PreviewPane channelId={channelId} intent={activeSection} />
         </div>
       </div>
-      <MobilePreviewLauncher channelId={channelId} intent={activeSection} />
+      {/* Tablet (md–lg): tab strip is shown instead of the dropdown, so float the trigger. */}
+      <MobilePreviewTrigger
+        onOpen={() => setPreviewOpen(true)}
+        className='fixed bottom-4 right-4 z-50 hidden shadow-lg md:flex lg:hidden'
+      />
+      <MobilePreviewSheet
+        channelId={channelId}
+        open={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+      />
     </SettingsPage>
   )
 }

--- a/apps/web/src/components/chat-widget/ui/settings/preview-pane.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/preview-pane.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/chat-widget/ui/settings/preview-pane.tsx
 'use client'
 import { Button } from '@auxx/ui/components/button'
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@auxx/ui/components/sheet'
 import { cn } from '@auxx/ui/lib/utils'
 import { Moon, Smartphone, Sun, SunMoon } from 'lucide-react'
 import { useState } from 'react'
@@ -77,44 +78,62 @@ function ThemeToggle({
 }
 
 /**
- * Floating button + sheet for the mobile/tablet breakpoint where the
- * persistent preview pane is hidden. Renders the same iframe at full width
- * inside a slide-up sheet.
+ * Compact trigger that opens the mobile preview sheet. Pair it with
+ * {@link MobilePreviewSheet} and a shared open-state in the parent. The
+ * `className` controls which breakpoint it shows at (e.g. next to the mobile
+ * tab dropdown vs. floating on tablet).
  */
-export function MobilePreviewLauncher({ channelId }: { channelId: string; intent: PreviewIntent }) {
-  const [open, setOpen] = useState(false)
-  const src = `/preview/widget/${channelId}/embed?theme=system`
+export function MobilePreviewTrigger({
+  onOpen,
+  className,
+}: {
+  onOpen: () => void
+  className?: string
+}) {
+  return (
+    <Button type='button' variant='outline' size='sm' onClick={onOpen} className={className}>
+      <Smartphone className='size-3.5' />
+      Preview
+    </Button>
+  )
+}
+
+/**
+ * Full-screen slide-up sheet showing the widget preview at the mobile/tablet
+ * breakpoint where the persistent {@link PreviewPane} is hidden. Controlled —
+ * the parent owns the open state so multiple triggers can share one sheet.
+ *
+ * Uses the Radix-backed {@link Sheet}, which portals to `document.body`. That
+ * matters here: an ancestor `transform` (framer-motion in the page shell) plus
+ * the settings card's `overflow-hidden` would otherwise re-root and clip a
+ * plain `position: fixed` overlay to the settings window instead of the screen.
+ */
+export function MobilePreviewSheet({
+  channelId,
+  open,
+  onClose,
+}: {
+  channelId: string
+  open: boolean
+  onClose: () => void
+}) {
+  // `rounded=0` — full-screen sheet wants the widget edge-to-edge, not the
+  // rounded phone shell the desktop pane uses.
+  const src = `/preview/widget/${channelId}/embed?theme=system&rounded=0`
 
   return (
-    <>
-      <Button
-        type='button'
-        variant='outline'
-        size='sm'
-        onClick={() => setOpen(true)}
-        className='fixed bottom-4 right-4 z-50 shadow-lg lg:hidden'>
-        <Smartphone className='size-3.5' />
-        Preview
-      </Button>
-      {open ? (
-        <div
-          role='dialog'
-          aria-modal='true'
-          className='fixed inset-0 z-50 flex flex-col bg-background/95 backdrop-blur-sm lg:hidden'>
-          <div className='flex items-center justify-between border-b px-4 py-3'>
-            <div className='text-sm font-semibold'>Preview</div>
-            <Button type='button' variant='ghost' size='sm' onClick={() => setOpen(false)}>
-              Close
-            </Button>
-          </div>
-          <iframe
-            title='Chat widget preview'
-            src={src}
-            className='flex-1 w-full'
-            style={{ border: 'none', background: 'transparent' }}
-          />
-        </div>
-      ) : null}
-    </>
+    <Sheet open={open} onOpenChange={(next) => !next && onClose()}>
+      <SheetContent side='bottom' className='flex h-[100dvh] flex-col gap-0 p-0 lg:hidden'>
+        <SheetHeader className='flex-none border-b px-4 py-3 text-left'>
+          <SheetTitle className='text-sm font-semibold'>Preview</SheetTitle>
+        </SheetHeader>
+        <iframe
+          title='Chat widget preview'
+          src={src}
+          className='w-full flex-1'
+          style={{ border: 'none', background: 'transparent' }}
+        />
+      </SheetContent>
+    </Sheet>
   )
 }

--- a/apps/web/src/components/chat-widget/ui/settings/sections/ai-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/ai-section.tsx
@@ -14,7 +14,7 @@ import {
 } from '@auxx/ui/components/form'
 import { toastError } from '@auxx/ui/components/toast'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-import { BookOpen, Bot, Home, Sparkles } from 'lucide-react'
+import { BookOpen, Bot, Sparkles } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -113,7 +113,7 @@ export function AiSection({ widget, channelId }: AiSectionProps) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
-        <div className='p-6'>
+        <div className='p-3 sm:p-6'>
           <SettingsSection
             icon={Bot}
             title='Agent'
@@ -140,7 +140,7 @@ export function AiSection({ widget, channelId }: AiSectionProps) {
           </SettingsSection>
         </div>
 
-        <div className='border-t p-6 space-y-4'>
+        <div className='border-t p-3 sm:p-6 space-y-4'>
           <SettingsSection
             icon={BookOpen}
             title='Knowledge base'
@@ -161,6 +161,7 @@ export function AiSection({ widget, channelId }: AiSectionProps) {
                       validationError={fieldState.error?.message}>
                       <MultiRelationInput
                         entityDefinitionId='kb'
+                        triggerProps={{ className: 'w-full ps-0 pe-1' }}
                         value={recordId ? [recordId] : []}
                         multi={false}
                         placeholder='Link a knowledge base…'

--- a/apps/web/src/components/chat-widget/ui/settings/sections/appearance-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/appearance-section.tsx
@@ -130,7 +130,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
-        <div className='p-6 space-y-8'>
+        <div className='p-3 sm:p-6 space-y-8'>
           <div>
             <SettingsSection
               className='mb-6'

--- a/apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
@@ -91,13 +91,13 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
-        <div className='p-6 space-y-8'>
+        <div className='p-3 sm:p-6 space-y-8'>
           <SettingsSection
             icon={SlidersHorizontal}
             title='Engagement'
             description='How and when the widget engages visitors.'>
             <VarEditorField
-              orientation='responsive'
+              orientation='horizontal'
               className='p-0 **:data-[slot=field-row-label]:w-auto! @sm:**:data-[slot=field-row-label]:w-auto! **:data-[slot=field-row-content]:flex **:data-[slot=field-row-content]:justify-end **:data-[slot=field-row-content]:pe-3'>
               <FormField
                 control={form.control}

--- a/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
@@ -126,7 +126,7 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
-        <div className='p-6'>
+        <div className='p-3 sm:p-6'>
           <SettingsSection
             className='space-y-6'
             icon={Settings}
@@ -268,7 +268,7 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
           </SettingsSection>
         </div>
 
-        <div className='border-t p-6'>
+        <div className='border-t p-3 sm:p-6'>
           <SettingsSection icon={Users} title='Audience' description='Who is this widget for?'>
             <FormField
               control={form.control}
@@ -328,7 +328,7 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
           </SettingsSection>
         </div>
 
-        <div className='flex flex-wrap items-center justify-between gap-3 border-t p-6'>
+        <div className='flex flex-wrap items-center justify-between gap-3 border-t p-3 sm:p-6'>
           <div className='space-y-1'>
             <div className='flex items-center gap-2 text-base font-semibold tracking-tight text-destructive'>
               <Trash2 className='size-4' /> Danger zone

--- a/apps/web/src/components/chat-widget/ui/settings/sections/identity-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/identity-section.tsx
@@ -133,7 +133,7 @@ export function IdentitySection({ widget, channelId }: IdentitySectionProps) {
   return (
     <>
       <ConfirmDialog />
-      <div className='p-6 space-y-8'>
+      <div className='p-3 sm:p-6 space-y-8'>
         <SettingsSection
           icon={ShieldCheck}
           title='Identity verification'

--- a/apps/web/src/components/chat-widget/ui/settings/sections/setup-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/setup-section.tsx
@@ -77,7 +77,7 @@ export function SetupSection({ widget, channelId }: SetupSectionProps) {
           : snippets.angular
 
   return (
-    <div className='p-6 space-y-8'>
+    <div className='p-3 sm:p-6 space-y-8'>
       <SettingsSection
         icon={Code}
         title='Install'

--- a/apps/web/src/components/global/settings-page.tsx
+++ b/apps/web/src/components/global/settings-page.tsx
@@ -29,6 +29,12 @@ type Props = {
   description?: React.ReactNode
   breadcrumbs?: IBradcrumbItem[]
   button?: React.ReactNode
+  /**
+   * Optional row rendered inside the sticky header, below the title (e.g. a
+   * tab strip). Keeping it in the same sticky block avoids a second sticky bar
+   * with a hardcoded top offset that can overlap the header on tall layouts.
+   */
+  subHeader?: React.ReactNode
   backLink?: string
 }
 
@@ -39,6 +45,7 @@ export default function SettingsPage({
   description,
   breadcrumbs,
   button,
+  subHeader,
   backLink,
 }: Props) {
   breadcrumbs = breadcrumbs || []
@@ -127,6 +134,7 @@ export default function SettingsPage({
           </div>
           {button && <div className='sm:ml-auto shrink-0'>{button}</div>}
         </div>
+        {subHeader && <div className='border-t bg-background/60 px-3 py-2.5'>{subHeader}</div>}
         <Separator className='bg-background' />
         <Separator />
         {/* Shadow that appears on scroll with edge flare */}

--- a/packages/ui/src/components/responsive-tabs.tsx
+++ b/packages/ui/src/components/responsive-tabs.tsx
@@ -1,0 +1,136 @@
+// packages/ui/src/components/responsive-tabs.tsx
+/**
+ * ResponsiveTabs
+ *
+ * A radio-tab strip that collapses to a dropdown on small screens. Takes an
+ * `items` array (rather than children) so the same data can drive both the
+ * desktop {@link RadioTab} and the mobile {@link Select}. The switch is purely
+ * CSS-breakpoint based (`md`) to avoid hydration flicker from JS media queries.
+ *
+ * Use this for dense tab strips (5+ items). For 2-3 item strips, plain
+ * `RadioTab` is fine on mobile — reach for this only when the row overflows.
+ *
+ * @example
+ * ```tsx
+ * <ResponsiveTabs
+ *   value={section}
+ *   onValueChange={setSection}
+ *   items={[
+ *     { value: 'general', label: 'General', icon: Settings },
+ *     { value: 'ai', label: 'AI', icon: Bot },
+ *   ]}
+ * />
+ * ```
+ */
+'use client'
+
+import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+import { cn } from '@auxx/ui/lib/utils'
+import type * as React from 'react'
+
+export interface ResponsiveTabItem {
+  /** Stable identifier and the value reported via `onValueChange`. */
+  value: string
+  /** Visible label, shown in both the desktop tab and the mobile dropdown. */
+  label: string
+  /** Optional leading icon (e.g. a lucide icon component). */
+  icon?: React.ComponentType<{ className?: string }>
+  /** Disable selection of this item. */
+  disabled?: boolean
+  /** Optional tooltip for the desktop tab. */
+  tooltip?: string
+}
+
+export interface ResponsiveTabsProps {
+  /** Currently selected item value. */
+  value: string
+  /** Called with the new value when the selection changes. */
+  onValueChange: (value: string) => void
+  /** The tabs to render. */
+  items: ResponsiveTabItem[]
+  /** Size of the desktop tab strip and mobile trigger. */
+  size?: 'default' | 'sm'
+  /** Custom className for the desktop RadioTab container. */
+  className?: string
+  /** Custom className for the desktop RadioGroup. */
+  radioGroupClassName?: string
+  /** Custom className for the mobile Select trigger. */
+  triggerClassName?: string
+}
+
+/**
+ * Renders a radio-tab strip on `md+` screens and a select dropdown below it.
+ */
+function ResponsiveTabs({
+  value,
+  onValueChange,
+  items,
+  size = 'default',
+  className,
+  radioGroupClassName,
+  triggerClassName,
+}: ResponsiveTabsProps) {
+  return (
+    <>
+      {/* Mobile: dropdown. The icon lives inside each SelectItem so Radix
+          mirrors it (alongside the label) into the closed trigger. */}
+      <div className='md:hidden'>
+        <Select value={value} onValueChange={onValueChange}>
+          <SelectTrigger
+            size={size === 'sm' ? 'sm' : 'default'}
+            variant='outline'
+            className={cn('w-full', triggerClassName)}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {items.map((item) => {
+              const Icon = item.icon
+              return (
+                <SelectItem key={item.value} value={item.value} disabled={item.disabled}>
+                  <span className='flex items-center gap-2'>
+                    {Icon && <Icon className='size-4 shrink-0 text-muted-foreground' />}
+                    {item.label}
+                  </span>
+                </SelectItem>
+              )
+            })}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Desktop: tab strip */}
+      <div className='hidden md:block'>
+        <RadioTab
+          value={value}
+          onValueChange={onValueChange}
+          size={size}
+          radioGroupClassName={cn('w-full', radioGroupClassName)}
+          className={cn('flex w-full border border-primary-200', className)}>
+          {items.map((item) => {
+            const Icon = item.icon
+            return (
+              <RadioTabItem
+                key={item.value}
+                value={item.value}
+                size={size}
+                disabled={item.disabled}
+                tooltip={item.tooltip}>
+                {Icon && <Icon />}
+                {item.label}
+              </RadioTabItem>
+            )
+          })}
+        </RadioTab>
+      </div>
+    </>
+  )
+}
+
+export { ResponsiveTabs }


### PR DESCRIPTION
## Summary

Makes the chat-widget settings page work well on mobile. The 6-item tab strip overflowed on small screens, the sticky header overlapped the tabs, and the in-page preview overlay was clipped to the settings card instead of going full-screen.

## Changes

**`@auxx/ui` — new `ResponsiveTabs`**
- Renders the `RadioTab` strip on `md+` and collapses to a `Select` dropdown below it.
- CSS-breakpoint switch (no `useIsMobile` JS query) → no hydration flicker.
- Opt-in via an `items` array; the selected item's icon mirrors into the closed `Select` trigger. Existing 2–3 item `RadioTab`s are untouched.

**`SettingsPage` — `subHeader` slot**
- Optional row rendered *inside* the existing sticky header. Lets the tab strip live in the same sticky block instead of a second sticky bar with a hardcoded `top-[68px]` offset that overlapped the header on tall (mobile) layouts. Backward-compatible (optional prop).

**Chat-widget settings**
- Tabs moved into `subHeader`.
- Desktop "Open preview" popup button is now `lg`-only.
- Mobile/tablet get an in-page preview: an inline trigger next to the dropdown (mobile) + a floating trigger (tablet), sharing one controlled sheet via lifted state.

**Mobile preview overlay**
- Now uses the Radix `Sheet` (`side='bottom'`, `h-[100dvh]`), which **portals to `body`** — fixing the overlay being clipped to the settings card by an ancestor `transform` (framer-motion shell) + the card's `overflow-hidden`. Also gains focus-trap, ESC-to-close, scroll-lock, and animation for free.
- The embed iframe takes `rounded=0` so the widget renders edge-to-edge in the full-screen sheet (the desktop side-pane keeps its rounded phone shell).

**Section bodies**
- Responsive padding (`p-6` → `p-3 sm:p-6`) and minor mobile layout tweaks.

## Test plan
- [ ] Mobile (`< md`): tabs are a dropdown with icon; inline Preview button beside it opens a full-screen sheet; widget is edge-to-edge.
- [ ] Tablet (`md–lg`): tab strip + floating Preview button → same sheet.
- [ ] Desktop (`lg+`): tab strip + header "Open preview" popup + side preview pane unchanged.
- [ ] Sticky header no longer overlaps/hides anything on scroll.