### PR TITLE
feat(chat): lock composer on closed threads + visitor-channel event fan-out

### DIFF
--- a/apps/api/src/routes/chat/initialize.ts
+++ b/apps/api/src/routes/chat/initialize.ts
@@ -234,6 +234,10 @@ initializeRoute.post('/', async (c) => {
         threadId: thread.id,
         visitorId: chat.sessionId,
         isNewSession: isNew,
+        // A chat thread accepts new visitor messages only while OPEN — the
+        // provider rejects inbound on any other status. Surface that so the
+        // widget can lock the composer instead of letting a send fail opaquely.
+        closed: thread.status !== 'OPEN',
         messages,
         nextCursor,
         threadEvents,

--- a/apps/api/src/routes/chat/threads.ts
+++ b/apps/api/src/routes/chat/threads.ts
@@ -223,7 +223,7 @@ threadsRoute.get('/:threadId/messages', async (c) => {
 
   try {
     const [thread] = await database
-      .select({ id: schema.Thread.id })
+      .select({ id: schema.Thread.id, status: schema.Thread.status })
       .from(schema.Thread)
       .where(
         and(
@@ -301,7 +301,10 @@ threadsRoute.get('/:threadId/messages', async (c) => {
         ? (recentRows[recentRows.length - 1]?.sentAt?.toISOString() ?? null)
         : null
 
-    return c.json({ success: true, data: { messages, threadEvents, nextCursor } })
+    return c.json({
+      success: true,
+      data: { messages, threadEvents, nextCursor, closed: thread.status !== 'OPEN' },
+    })
   } catch (error) {
     log.error('Failed to load chat history', {
       threadId,

--- a/apps/web/src/components/mail/chat-message-display.tsx
+++ b/apps/web/src/components/mail/chat-message-display.tsx
@@ -15,9 +15,9 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatDistanceToNow } from 'date-fns'
 import { Check, CheckCheck, CopyPlusIcon, EllipsisVertical, Mail, Trash } from 'lucide-react'
+import { useQueryState } from 'nuqs'
 import { useMessage, useMessageParticipants, useThreadReadStatus } from '~/components/threads/hooks'
 import type { AttachmentMeta, MessageMeta } from '~/components/threads/store'
-import { ContactHoverCard } from '../contacts/contact-hover-card'
 import { AttachmentDisplay } from '../files/utils/attachment-display'
 import { Tooltip } from '../global/tooltip'
 import type { EmailActions } from './email-actions'
@@ -66,6 +66,8 @@ const ChatMessageDisplay = ({
   const { message, isLoading } = useMessage({ messageId })
   const { markAsUnread } = useThreadReadStatus(message?.threadId ?? null)
   const { from: sender } = useMessageParticipants(message?.participants ?? [])
+  const [, setContactId] = useQueryState('contactId', { defaultValue: '' })
+  const [, setParticipantId] = useQueryState('participantId', { defaultValue: '' })
 
   if (isLoading) return <ChatMessageSkeleton />
   if (!message) return null
@@ -73,8 +75,21 @@ const ChatMessageDisplay = ({
   const isInbound = message.isInbound
   const senderName = sender?.displayName ?? 'Unknown'
   const senderInitials = sender?.initials ?? senderName.charAt(0).toUpperCase()
-  const contactId = sender?.entityInstanceId
   const content = message.textPlain ?? message.snippet ?? ''
+
+  // Open the sender in the shared mail drawer. A linked contact opens the
+  // richer contact drawer; an unlinked participant opens the participant
+  // drawer (which offers "Create Contact"). Mirrors ThreadParticipantButton.
+  const openSenderDrawer = () => {
+    if (!sender) return
+    if (sender.entityInstanceId) {
+      void setParticipantId('')
+      void setContactId(sender.entityInstanceId)
+    } else {
+      void setContactId('')
+      void setParticipantId(sender.id)
+    }
+  }
   const isSending = !!message.sendStatus && message.sendStatus !== 'SENT'
   const nonInlineAttachments = (message.attachments ?? []).filter((a) => !a.inline)
 
@@ -96,17 +111,21 @@ const ChatMessageDisplay = ({
     <div
       className={cn('group/message flex flex-col gap-1', isInbound ? 'items-start' : 'items-end')}>
       {showHeader && (
-        <div className='flex items-center gap-2 pl-1'>
-          <ContactHoverCard contactId={contactId ?? undefined}>
-            <Avatar className='size-4 rounded-full'>
-              <AvatarFallback className='bg-foreground/50 text-[8px] text-background hover:bg-foreground/70'>
-                {senderInitials}
-              </AvatarFallback>
-              <AvatarImage src={sender?.avatarUrl ?? undefined} />
-            </Avatar>
-          </ContactHoverCard>
-          <span className='text-xs font-medium text-foreground'>{senderName}</span>
-        </div>
+        <button
+          type='button'
+          onClick={openSenderDrawer}
+          disabled={!sender}
+          className='group/sender flex items-center gap-2 rounded pl-1 disabled:pointer-events-none'>
+          <Avatar className='size-4 rounded-full'>
+            <AvatarFallback className='bg-foreground/50 text-[8px] text-background group-hover/sender:bg-foreground/70'>
+              {senderInitials}
+            </AvatarFallback>
+            <AvatarImage src={sender?.avatarUrl ?? undefined} />
+          </Avatar>
+          <span className='text-xs font-medium text-foreground group-hover/sender:underline'>
+            {senderName}
+          </span>
+        </button>
       )}
       <div className='relative w-fit max-w-full'>
         <div

--- a/packages/chat/src/transport/chat-api.ts
+++ b/packages/chat/src/transport/chat-api.ts
@@ -35,6 +35,8 @@ export interface InitializeResponse {
   threadId: string
   visitorId: string
   isNewSession: boolean
+  /** True when the thread is no longer OPEN — the composer locks. */
+  closed: boolean
   messages: ChatMessage[]
   /** Cursor for fetching older messages via `getHistory`. Null = no more. */
   nextCursor: string | null
@@ -111,6 +113,7 @@ export function chatApi(channelId: string) {
         messages: ChatMessage[]
         threadEvents: ThreadEvent[]
         nextCursor: string | null
+        closed: boolean
       }>(channelId, `/api/chat/threads/${threadId}/messages`, {
         method: 'GET',
         query,

--- a/packages/chat/src/views/conversation/conversation-view.tsx
+++ b/packages/chat/src/views/conversation/conversation-view.tsx
@@ -15,6 +15,7 @@ import {
   THREAD_EVENT_TYPES,
   type ThreadEvent,
   type ThreadEventData,
+  type ThreadEventType,
 } from '~/transport/thread-events'
 import { Bubble, type MessageGroup } from './bubble'
 import { Composer, type ComposerSendArgs } from './composer/composer'
@@ -33,6 +34,7 @@ interface InitState {
   sessionId: string
   pusherChannel: string
   threadPusherChannel: string
+  visitorPusherChannel: string
 }
 
 export function ConversationView({ channelId, threadId, config }: ConversationViewProps) {
@@ -40,6 +42,9 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [threadEvents, setThreadEvents] = useState<ThreadEvent[]>([])
   const [init, setInit] = useState<InitState | null>(null)
+  // Composer lock: a chat thread only accepts new visitor messages while OPEN.
+  // Seeded from initialize/history and flipped live by archived/reopened events.
+  const [closed, setClosed] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [privacyDismissed, setPrivacyDismissed] = useState(() =>
     isPrivacyBannerDismissed(channelId)
@@ -72,6 +77,33 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
     []
   )
 
+  // Ingest a thread lifecycle event from either the per-thread room or the
+  // (redundant) per-visitor channel. Deduped by event id so double-delivery is
+  // harmless. `archived` / `reopened` also drive the composer lock so a chat
+  // that ends mid-session locks without a reload.
+  const ingestThreadEvent = useCallback(
+    (type: ThreadEventType, payload: { id?: string; createdAt?: string } & ThreadEventData) => {
+      if ((payload as { threadId?: string }).threadId !== threadId) return
+      if (type === 'thread:archived') setClosed(true)
+      else if (type === 'thread:reopened') setClosed(false)
+      setThreadEvents((prev) => {
+        const id =
+          payload.id ?? `${type}:${threadId}:${payload.createdAt ?? new Date().toISOString()}`
+        if (prev.some((e) => e.id === id)) return prev
+        return [
+          ...prev,
+          {
+            id,
+            type,
+            createdAt: payload.createdAt ?? new Date().toISOString(),
+            data: payload as ThreadEventData,
+          },
+        ]
+      })
+    },
+    [threadId]
+  )
+
   // Bootstrap: call initialize so we always have a sessionId + pusherChannel
   // matched to the visitor's current passport. The endpoint resumes when a
   // thread already exists, so this is cheap on re-open.
@@ -90,10 +122,12 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
           sessionId: data.sessionId,
           pusherChannel: data.pusherChannel,
           threadPusherChannel: data.threadPusherChannel,
+          visitorPusherChannel: data.visitorPusherChannel,
         })
         if (data.threadId === threadId) {
           setMessages(data.messages)
           setThreadEvents(data.threadEvents ?? [])
+          setClosed(data.closed)
         } else {
           // Defensive: the server now honors `resumeThreadId` so this branch
           // shouldn't fire in practice. If it does, surface the error loudly
@@ -105,6 +139,7 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
               if (cancelled) return
               setMessages(hist.messages)
               setThreadEvents(hist.threadEvents ?? [])
+              setClosed(hist.closed)
             })
             .catch((e) => {
               if (cancelled) return
@@ -186,55 +221,48 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
     }
   }, [init, threadId, config.realtime.key, config.realtime.cluster])
 
-  // Subscribe to the per-thread private channel for live lifecycle events
-  // (taken_over / returned_to_ai / archived / reopened / …). The server pushes
-  // these via the shared realtime helper; the widget binds the same set of
-  // type names directly as Pusher event keys.
+  // Subscribe to live lifecycle events (taken_over / returned_to_ai /
+  // archived / reopened / …) on BOTH the per-thread room AND the per-visitor
+  // channel. The server fans out to both; the per-thread room is the primary
+  // path while the per-visitor channel is a redundant one that survives a
+  // per-thread subscription hiccup and catches takeovers that fire before this
+  // view (re)subscribes. `ingestThreadEvent` dedupes the double-delivery by id.
   useEffect(() => {
     if (!init) return
-    const channelName = init.threadPusherChannel
-    const expected = `private-thread-${threadId}`
-    if (channelName !== expected) return
-    const conn = connectPrivatePusher({
-      key: config.realtime.key,
-      cluster: config.realtime.cluster,
-      channelName,
-      channelId,
+    const channels = [
+      init.threadPusherChannel === `private-thread-${threadId}` ? init.threadPusherChannel : null,
+      init.visitorPusherChannel,
+    ].filter((c): c is string => !!c)
+
+    const conns = channels.map((channelName) => {
+      const conn = connectPrivatePusher({
+        key: config.realtime.key,
+        cluster: config.realtime.cluster,
+        channelName,
+        channelId,
+      })
+      const handlers = THREAD_EVENT_TYPES.map((type) => {
+        const handler = (payload: { id?: string; createdAt?: string } & ThreadEventData) =>
+          ingestThreadEvent(type, payload)
+        conn.channel.bind(type, handler)
+        return { type, handler }
+      })
+      return { conn, handlers }
     })
-    const handlers = THREAD_EVENT_TYPES.map((type) => {
-      const handler = (payload: { id?: string; createdAt?: string } & ThreadEventData) => {
-        if ((payload as { threadId?: string }).threadId !== threadId) return
-        setThreadEvents((prev) => {
-          // Dedupe by id when the server provides one; fall back to
-          // (type, threadId, createdAt) for transient payloads.
-          const id =
-            payload.id ?? `${type}:${threadId}:${payload.createdAt ?? new Date().toISOString()}`
-          if (prev.some((e) => e.id === id)) return prev
-          return [
-            ...prev,
-            {
-              id,
-              type,
-              createdAt: payload.createdAt ?? new Date().toISOString(),
-              data: payload as ThreadEventData,
-            },
-          ]
-        })
-      }
-      conn.channel.bind(type, handler)
-      return { type, handler }
-    })
+
     return () => {
-      for (const { type, handler } of handlers) {
-        try {
-          conn.channel.unbind(type, handler)
-        } catch {
-          /* ignore */
+      for (const { conn, handlers } of conns) {
+        for (const { type, handler } of handlers) {
+          try {
+            conn.channel.unbind(type, handler)
+          } catch {
+            /* ignore */
+          }
         }
+        conn.disconnect()
       }
-      conn.disconnect()
     }
-  }, [init, threadId, channelId, config.realtime.key, config.realtime.cluster])
+  }, [init, threadId, channelId, config.realtime.key, config.realtime.cluster, ingestThreadEvent])
 
   // Mark read whenever the last message changes.
   useEffect(() => {
@@ -334,7 +362,9 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
        * for a muted notice. Suggested replies + privacy banner would have
        * nothing to act on so we drop them too. */}
       <div className='auxx-chat-composer-plinth'>
-        {config.isOffline ? (
+        {closed ? (
+          <ClosedNotice />
+        ) : config.isOffline ? (
           <OfflineNotice message={config.appearance.offlineMessage} />
         ) : (
           <>
@@ -362,6 +392,20 @@ export function ConversationView({ channelId, threadId, config }: ConversationVi
           Powered by Auxx
         </div>
       ) : null}
+    </div>
+  )
+}
+
+/**
+ * Replaces the composer once the thread is closed (archived). The provider
+ * rejects inbound messages on a non-OPEN thread, so locking the input here
+ * keeps the visitor from typing into a send that would fail. Flips back to a
+ * live composer if the thread is reopened (`thread:reopened`).
+ */
+function ClosedNotice() {
+  return (
+    <div className='mx-1 mb-1 rounded-md border border-[color:var(--auxx-chat-hairline)] bg-background/60 px-3 py-3 text-center text-xs text-muted-foreground'>
+      This conversation is closed. Start a new chat to keep talking with us.
     </div>
   )
 }

--- a/packages/chat/src/widget.tsx
+++ b/packages/chat/src/widget.tsx
@@ -573,6 +573,11 @@ function pickHeaderVariant(view: NavView, isAtRoot: boolean): FrameHeaderVariant
 }
 
 function headerTitle(view: NavView, frame: NavFrame | null, config: ChatConfig): string {
+  // The conversation header answers "who am I talking to?" — always the agent
+  // name, regardless of how the thread was opened (Home passed the thread
+  // subject like "Chat #2892", Messages passed the agent name). KB frames keep
+  // their own pushed label (article/section title).
+  if (frame?.view === 'thread') return config.agent?.name ?? 'Support'
   if (frame) return frame.label
   if (view === 'home') return config.appearance.title
   if (view === 'messages') return 'Messages'

--- a/packages/lib/src/ai/agent-framework/sessions/find-or-create-thread-session.ts
+++ b/packages/lib/src/ai/agent-framework/sessions/find-or-create-thread-session.ts
@@ -41,7 +41,7 @@ export interface FindOrCreateThreadSessionInput {
  * kopilot domain config, with `triggerContext.kind === 'chat'` as the
  * distinguisher and `agentTriggerId = null`.
  *
- * Per-thread serialization rides the `chat-turn:{threadId}` BullMQ jobId
+ * Per-thread serialization rides the `chat-turn-{threadId}` BullMQ jobId
  * (only one turn per thread runs at a time), so a find-then-create here can't
  * realistically race. The find is still scoped tightly enough that a
  * pathological double-run would at worst create a second session, never

--- a/packages/lib/src/chat/agent/enqueue-chat-turn.ts
+++ b/packages/lib/src/chat/agent/enqueue-chat-turn.ts
@@ -30,12 +30,15 @@ export const CHAT_TURN_JOB_NAME = 'processChatTurn'
 /**
  * Enqueue a visitor chat turn onto the dedicated `chat-agent` queue.
  *
- * **Per-thread serialization rides `jobId = chat-turn:{threadId}`** — while a
+ * **Per-thread serialization rides `jobId = chat-turn-{threadId}`** — while a
  * turn for a thread is waiting/active, BullMQ ignores a second add with the
  * same id, so at most one turn per thread runs at a time. A second visitor
  * message that lands mid-turn is therefore not a new job; the in-flight turn's
  * catchup-replay folds it in. `removeOnComplete: true` frees the id the moment
  * a turn finishes, so the next message enqueues normally.
+ *
+ * The id uses a `-` separator, not `:` — BullMQ rejects custom job ids
+ * containing a colon (`Custom Ids cannot contain :`).
  *
  * Retries are safe: `findOrCreateThreadSession` + catchup-replay make a re-run
  * resume cleanly, and the reply write is guarded against double-posting
@@ -44,7 +47,7 @@ export const CHAT_TURN_JOB_NAME = 'processChatTurn'
 export async function enqueueChatTurn(payload: ChatTurnJobPayload) {
   const queue = getQueue(Queues.chatAgentQueue)
   return queue.add(CHAT_TURN_JOB_NAME, payload, {
-    jobId: `chat-turn:${payload.threadId}`,
+    jobId: `chat-turn-${payload.threadId}`,
     attempts: 3,
     backoff: { type: 'exponential', delay: 1000 },
     removeOnComplete: true,

--- a/packages/lib/src/chat/agent/process-chat-turn.ts
+++ b/packages/lib/src/chat/agent/process-chat-turn.ts
@@ -25,6 +25,7 @@ import { buildChatEngineConfig } from './build-chat-engine-config'
 import { buildChatSubjectFromPassport } from './build-chat-subject'
 import type { ChatTurnJobPayload } from './enqueue-chat-turn'
 import { flipHandoffState } from './handoff'
+import { withChatRunLog } from './run-log'
 
 const logger = createScopedLogger('process-chat-turn')
 
@@ -32,8 +33,20 @@ const logger = createScopedLogger('process-chat-turn')
  * Worker handler for one visitor chat turn (plans/chat/v5 phase-3b §3). Mirrors
  * `processAgentMessage`, swapping in the per-thread chat session + a Pusher
  * reply sink. Runs on the dedicated `chat-agent` queue.
+ *
+ * Dev only: tees the turn's chat/agent logs to a per-thread file under
+ * `.logs/chat-sessions/`. Gated on `!== 'production'` so the worker dev script
+ * (which doesn't set NODE_ENV) still gets traces — same convention as
+ * `process-agent-job`.
  */
 export async function processChatTurn(ctx: JobContext<ChatTurnJobPayload>): Promise<void> {
+  if (process.env.NODE_ENV !== 'production') {
+    return withChatRunLog(ctx.data.threadId, () => processChatTurnInternal(ctx))
+  }
+  return processChatTurnInternal(ctx)
+}
+
+async function processChatTurnInternal(ctx: JobContext<ChatTurnJobPayload>): Promise<void> {
   const { data, signal } = ctx
   const {
     organizationId,

--- a/packages/lib/src/chat/agent/run-log.ts
+++ b/packages/lib/src/chat/agent/run-log.ts
@@ -1,0 +1,52 @@
+// packages/lib/src/chat/agent/run-log.ts
+
+import { type RunLogFilter, runLogPath, withRunLog } from '@auxx/logger/run-log'
+
+/**
+ * Scope prefixes considered relevant to a chat-conversation trace. We keep the
+ * chat orchestration scopes (`process-chat-turn`, `chat-`, `procedure-`) AND the
+ * agent-engine scopes (`agent-`, `kopilot-`) because a chat turn drives the real
+ * agent engine — the agent's turn-by-turn reasoning, tool calls, and procedure
+ * stepping are precisely what you want to inspect when debugging a live chat.
+ * Everything else (provider clients, registry plumbing, unrelated cross-cutting
+ * work) is dropped.
+ *
+ * Add a prefix here when introducing a new chat- or agent-domain module that
+ * should appear in chat traces.
+ */
+const CHAT_SCOPE_PREFIXES = ['process-chat-turn', 'chat-', 'procedure-', 'agent-', 'kopilot-']
+
+/**
+ * Levels excluded from the chat trace. Debug/trace are useful for targeted local
+ * debugging via console but produce too much noise in the per-turn file (full
+ * message dumps, internal state snapshots, etc.).
+ */
+const EXCLUDED_LEVELS = new Set(['debug', 'trace'])
+
+const chatRunLogFilter: RunLogFilter = ({ scope, level }) => {
+  if (EXCLUDED_LEVELS.has(level)) return false
+  return CHAT_SCOPE_PREFIXES.some((prefix) => scope.startsWith(prefix))
+}
+
+/**
+ * Tee chat-relevant logs from `fn`'s async context to a per-thread file.
+ * Dev only — callers should gate on NODE_ENV before invoking.
+ *
+ * The path, scope allowlist, and level threshold are all decided here so the
+ * logger package stays domain-blind. Mirrors `withAgentRunLog`, but keyed on the
+ * chat `Thread` (one file per turn) and bucketed under its own `chat-sessions`
+ * root so live chat traces don't intermix with builder/trigger agent sessions.
+ *
+ * File layout: `<root>/.logs/chat-sessions/<YYYY-MM-DD>/<HH-mm-ss-SSSZ>__<threadId>.log`.
+ * The root `.logs` is shared across apps (see `runLogPath`). Date-bucketed so a
+ * day's turns sort lexically; thread id stays in the filename for grep +
+ * multi-turn lookup. Colons replaced with hyphens so the names work on every
+ * filesystem.
+ */
+export function withChatRunLog<T>(threadId: string, fn: () => T): T {
+  const now = new Date()
+  const datePart = now.toISOString().slice(0, 10) // YYYY-MM-DD
+  const timePart = now.toISOString().slice(11, 23).replace(/[:.]/g, '-') // HH-mm-ss-SSS
+  const logFile = runLogPath('chat-sessions', datePart, `${timePart}Z__${threadId}.log`)
+  return withRunLog(threadId, logFile, fn, { filter: chatRunLogFilter })
+}

--- a/packages/lib/src/events/handlers/publish-thread-event-to-realtime.ts
+++ b/packages/lib/src/events/handlers/publish-thread-event-to-realtime.ts
@@ -3,6 +3,7 @@
 import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
+import { eq } from 'drizzle-orm'
 import { getRealtimeService, rooms } from '../../realtime'
 import type {
   AuxxEvent,
@@ -79,17 +80,59 @@ export const publishThreadEventToRealtime = async (job: Job<AuxxEvent>) => {
     })
   }
 
+  const payload = {
+    ...typed.data,
+    id: row?.id,
+    createdAt: row?.createdAt?.toISOString() ?? new Date().toISOString(),
+  }
+
+  // Per-thread room: the admin conversation panel and the widget's per-thread
+  // subscription both listen here. This is the primary delivery path.
   try {
-    await getRealtimeService().publish(rooms.chatThread(threadId), event.type, {
-      ...typed.data,
-      id: row?.id,
-      createdAt: row?.createdAt?.toISOString() ?? new Date().toISOString(),
-    })
+    await getRealtimeService().publish(rooms.chatThread(threadId), event.type, payload)
   } catch (error) {
     logger.error('Failed to publish thread event to realtime', {
       type: event.type,
       threadId,
       error: error instanceof Error ? error.message : String(error),
     })
+  }
+
+  // Redundant fan-out to the visitor's per-thread-agnostic channel. The widget
+  // only subscribes to the per-thread room while that conversation is open, so
+  // without this a takeover that happens while the visitor sits on Home (or
+  // whose per-thread subscription hiccuped) never surfaces live. The visitor
+  // channel is always connected for the widget session; the client dedupes
+  // against the per-thread delivery by event `id`. Chat threads only — email
+  // threads carry no `visitorParticipantId` and resolve to `null` here.
+  const visitorParticipantId = await resolveVisitorParticipantId(threadId)
+  if (visitorParticipantId) {
+    try {
+      await getRealtimeService().publish(rooms.visitor(visitorParticipantId), event.type, payload)
+    } catch (error) {
+      logger.error('Failed to publish thread event to visitor channel', {
+        type: event.type,
+        threadId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+}
+
+/**
+ * Resolve the chat visitor's Participant id from the thread's metadata, or
+ * `null` for non-chat threads (which have no visitor channel to fan out to).
+ */
+async function resolveVisitorParticipantId(threadId: string): Promise<string | null> {
+  try {
+    const [row] = await database
+      .select({ metadata: schema.Thread.metadata })
+      .from(schema.Thread)
+      .where(eq(schema.Thread.id, threadId))
+      .limit(1)
+    const metadata = row?.metadata as { visitorParticipantId?: string } | null | undefined
+    return metadata?.visitorParticipantId ?? null
+  } catch {
+    return null
   }
 }


### PR DESCRIPTION
## Summary
Chat widget reliability + UX pass for live conversation lifecycle.

- **Composer lock on closed threads** — a chat thread only accepts new visitor messages while `OPEN`. `initialize` and history now return a `closed` flag; the conversation view seeds from it and flips live on `thread:archived` / `thread:reopened`. When closed, the composer is replaced with a "conversation is closed" notice instead of letting a send fail opaquely.
- **Visitor-channel event fan-out** — `publishThreadEventToRealtime` now publishes lifecycle events to both the per-thread room (primary) and the visitor's per-thread-agnostic channel (redundant). The widget subscribes to both and dedupes by event `id`, so a takeover/archive that fires while the visitor is on Home — or whose per-thread subscription hiccuped — still surfaces live.
- **Clickable sender header** — chat message header opens the sender's contact drawer (linked) or participant drawer (unlinked, offers "Create Contact"), mirroring `ThreadParticipantButton`.
- **Header title fix** — conversation frame header always shows the agent name regardless of how the thread was opened.
- **BullMQ jobId fix** — `chat-turn:{threadId}` → `chat-turn-{threadId}`; BullMQ rejects custom job ids containing `:`.
- **Dev chat run logging** — per-thread turn traces under `.logs/chat-sessions/` (gated on non-production), mirroring `withAgentRunLog`.

## Test plan
- [ ] Open a widget chat, archive the thread from admin → composer locks live without reload
- [ ] Reopen the thread → composer returns
- [ ] Trigger a takeover while sitting on widget Home → event surfaces via visitor channel
- [ ] Verify no duplicate thread events when both channels deliver
- [ ] Click a chat sender name → correct drawer opens (contact vs participant)