### PR TITLE
feat(chat): surface + audience prompt profile for live chat agent

### DIFF
--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -695,6 +695,10 @@ async function runInProcessPath(params: {
     defaultProvider,
     maxIterations: 30,
     agentConfig,
+    // In-app Kopilot/builder renders to the rich in-app surface for a workspace
+    // member (incl. DM triggers — a member is still the reader/author).
+    surface: 'builder',
+    audience: 'member',
     triggerContext,
   })
 

--- a/packages/lib/src/agents/__tests__/filter-catalog-to-agent-toolsets.test.ts
+++ b/packages/lib/src/agents/__tests__/filter-catalog-to-agent-toolsets.test.ts
@@ -49,6 +49,7 @@ const runtimeTools: AgentToolDefinition[] = UNIVERSE.flatMap(({ slug, tools }) =
 function agentConfig(selections: AgentToolsetSelection[]): ResolvedAgentConfig {
   return {
     agentId: 'agent_1',
+    kind: 'chat',
     name: 'Test Agent',
     userId: 'user_1',
     prompt: {},

--- a/packages/lib/src/agents/__tests__/filter-tools.test.ts
+++ b/packages/lib/src/agents/__tests__/filter-tools.test.ts
@@ -17,6 +17,7 @@ function tool(name: string, slug?: string): AgentToolDefinition {
 
 const masterEmpty: ResolvedAgentConfig = {
   agentId: null,
+  kind: 'internal',
   name: 'Kopilot',
   userId: null,
   prompt: null,
@@ -32,6 +33,7 @@ function agent(
 ): ResolvedAgentConfig {
   return {
     agentId: 'agent_1',
+    kind: 'chat',
     name: 'Test Agent',
     userId: 'user_1',
     prompt: {},

--- a/packages/lib/src/agents/resolve-agent-config.ts
+++ b/packages/lib/src/agents/resolve-agent-config.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/agents/resolve-agent-config.ts
 
-import type { Database } from '@auxx/database'
+import type { AgentKind, Database } from '@auxx/database'
 import { database as defaultDb, schema } from '@auxx/database'
 import { and, eq } from 'drizzle-orm'
 import { loadMasterKopilotSettings } from '../ai/kopilot/load-master-settings'
@@ -17,6 +17,13 @@ import { getOrgToolsetCatalog, type ToolsetCatalogEntry } from './toolset-catalo
 export interface ResolvedAgentConfig {
   /** null = master Kopilot session. */
   agentId: string | null
+  /**
+   * Invocation-surface discriminator from the Agent row (`internal | chat`) —
+   * what the agent *is* and where it binds. Master Kopilot is `'internal'`.
+   * NOT the per-run prompt `audience` (a chat-kind agent serves a customer, but
+   * audience is computed at the entry point, never read off `kind`).
+   */
+  kind: AgentKind
   /** Master = 'Kopilot'. */
   name: string
   /** Backing User row id. null for master. */
@@ -80,6 +87,7 @@ export async function resolveAgentConfig(
     const toolsets = buildMasterToolsets(master.toolsets, master.appAccounts, catalog)
     return {
       agentId: null,
+      kind: 'internal',
       name: 'Kopilot',
       userId: null,
       prompt: null,
@@ -143,6 +151,7 @@ export async function resolveAgentConfig(
 
   return {
     agentId: agent.id,
+    kind: agent.kind,
     // Setup-mode drafts may have a null name; the engine just needs *something*
     // for log lines and turn breadcrumbs. The UI's placeholder string is the
     // honest fallback.

--- a/packages/lib/src/ai/agent-framework/effective-runtime.ts
+++ b/packages/lib/src/ai/agent-framework/effective-runtime.ts
@@ -13,6 +13,7 @@ import {
   computeEffectiveBindings,
   projectBindingSchemas,
 } from '../../agents/bindings'
+import type { AgentSurface } from '../../agents/client'
 import { PROCEDURE_CONTROL_TOOLS } from '../../agents/procedures'
 import {
   type CapabilityRegistry,
@@ -59,6 +60,18 @@ export interface BuildEffectiveAgentRuntimeArgs {
   page?: string
   /** Present iff kicked off by an AgentTrigger — renders the autonomous-run prompt section. */
   triggerContext?: TriggerContext
+  /**
+   * Rendering medium → prompt formatting. When unset, derived: `builder` domain
+   * → `'builder'`; a `customer_message` trigger on the `chat` channel → `'chat'`;
+   * otherwise → `'email'`. The Simulation sets it from the eval channel so
+   * sim↔prod formatting matches (a chat eval renders the chat plain-text rule).
+   */
+  surface?: AgentSurface
+  /**
+   * Who reads the output → prompt semantics. When unset, derived: a
+   * `customer_message` trigger → `'customer'`; otherwise → `'member'`.
+   */
+  audience?: 'member' | 'customer'
   /**
    * Which agent behavior view to run (build-plan §4.2). `'active'` (default) is
    * the published version production runs; `'draft'` resolves the live Agent row
@@ -227,6 +240,23 @@ export async function buildEffectiveAgentRuntime(
   // binding clamp below and snapshot digests are unaffected. No-op in production.
   const tools = args.wrapTools ? args.wrapTools(projected) : projected
 
+  // Surface/audience: explicit override wins; otherwise derive from the run's
+  // domain + trigger envelope. A `customer_message` trigger is the customer
+  // envelope (live-chat eval or a customer email); its `payload.channel`
+  // distinguishes the plain-text chat surface from the email surface, so a chat
+  // eval renders the same formatting rule production chat does.
+  const isCustomerTrigger = args.triggerContext?.kind === 'customer_message'
+  const triggerChannel = (args.triggerContext?.payload as { channel?: unknown } | undefined)
+    ?.channel
+  const audience = args.audience ?? (isCustomerTrigger ? 'customer' : 'member')
+  const surface: AgentSurface =
+    args.surface ??
+    (domain === 'builder'
+      ? 'builder'
+      : isCustomerTrigger && triggerChannel === 'chat'
+        ? 'chat'
+        : 'email')
+
   const domainConfig = createKopilotDomainConfig({
     capabilityRegistry: registry,
     page: resolvedPage,
@@ -234,6 +264,8 @@ export async function buildEffectiveAgentRuntime(
     defaultModel: defaults.model,
     defaultProvider: defaults.provider,
     agentConfig,
+    surface,
+    audience,
     triggerContext: args.triggerContext,
     // Long-running plans (≥30 steps × ~1–2 LLM rounds each) need headroom past
     // the framework's small-loop default.

--- a/packages/lib/src/ai/kopilot/agents/agent.ts
+++ b/packages/lib/src/ai/kopilot/agents/agent.ts
@@ -3,6 +3,7 @@
 import { createScopedLogger } from '@auxx/logger'
 import { toActorId } from '@auxx/types/actor'
 import { getOrgToolCatalog, getOrgToolsetCatalog, type ResolvedAgentConfig } from '../../../agents'
+import type { AgentSurface } from '../../../agents/client'
 import { PROCEDURE_STEP_KEY } from '../../../agents/procedures/persist'
 import { getCachedIntegrationCatalog } from '../../../cache/integration-catalog'
 import { getCachedMembersByUserIds, getCachedResources } from '../../../cache/org-cache-helpers'
@@ -17,7 +18,7 @@ import type { Message, ToolCall } from '../../clients/base/types'
 import { transformAssistantContentForLLM } from '../blocks/transform-for-llm'
 import { buildKopilotPromptSerialized } from '../prompts/build-kopilot-prompt'
 import { buildInstructionReferenceResolver } from '../prompts/resolve-instruction-references'
-import type { ProcedureStepInput } from '../prompts/sections/types'
+import type { Audience, ProcedureStepInput } from '../prompts/sections/types'
 import type { CurrentUserInfo } from '../prompts/shared-types'
 import type { TriggerContext } from '../prompts/trigger-context'
 import type { KopilotDomainState } from '../types'
@@ -44,6 +45,10 @@ export interface CreateKopilotAgentOptions {
    * agent renders its persona from `prompt` / `name` / `description`.
    */
   agentConfig?: ResolvedAgentConfig
+  /** Rendering medium → formatting. Defaults to `'builder'`. See `buildKopilotPrompt`. */
+  surface?: AgentSurface
+  /** Who reads this turn → semantics. Defaults to `'member'`. See `buildKopilotPrompt`. */
+  audience?: Audience
   /**
    * Present iff this run was kicked off by an AgentTrigger. Threads the
    * autonomous-run prompt section through `buildKopilotPrompt`. Chat runs
@@ -68,6 +73,8 @@ export function createKopilotAgent(
     maxIterations = 15,
     toolsetPromptAdditions = '',
     agentConfig,
+    surface,
+    audience,
     triggerContext,
   } = options
 
@@ -123,6 +130,8 @@ export function createKopilotAgent(
         integrations,
         toolsetPromptAdditions,
         agentConfig,
+        surface,
+        audience,
         triggerContext,
         instructionsReferences,
         procedureStep,

--- a/packages/lib/src/ai/kopilot/domain-config.ts
+++ b/packages/lib/src/ai/kopilot/domain-config.ts
@@ -2,6 +2,7 @@
 
 import { createScopedLogger } from '@auxx/logger'
 import type { ResolvedAgentConfig } from '../../agents'
+import type { AgentSurface } from '../../agents/client'
 import { PROCEDURE_SLICE_KEY } from '../../agents/procedures/persist'
 import { CONTEXT_SLICE_KEY, readContextSlice } from '../agent-framework/context'
 import type {
@@ -52,6 +53,17 @@ export interface KopilotDomainConfigOptions {
    */
   agentConfig?: ResolvedAgentConfig
   /**
+   * The rendering medium this turn outputs to → drives prompt formatting
+   * (chat = plain text, builder = `auxx:*` rich blocks). Defaults to
+   * `'builder'`. Chat leaves `triggerContext` undefined but sets `surface: 'chat'`.
+   */
+  surface?: AgentSurface
+  /**
+   * Who reads this turn's output → drives prompt semantics (customer-facing
+   * opacity vs member debugging). Defaults to `'member'`.
+   */
+  audience?: 'member' | 'customer'
+  /**
    * Present iff this run was kicked off by an AgentTrigger. Threaded into
    * `createKopilotAgent` so the autonomous-run section renders in the system
    * prompt. Chat runs leave this undefined.
@@ -78,6 +90,8 @@ export function createKopilotDomainConfig(
     defaultProvider = 'openai',
     maxIterations = 30,
     agentConfig,
+    surface,
+    audience,
     triggerContext,
   } = options
 
@@ -120,6 +134,8 @@ export function createKopilotDomainConfig(
     maxIterations,
     toolsetPromptAdditions,
     agentConfig,
+    surface,
+    audience,
     triggerContext,
   })
 

--- a/packages/lib/src/ai/kopilot/prompts/build-kopilot-prompt.ts
+++ b/packages/lib/src/ai/kopilot/prompts/build-kopilot-prompt.ts
@@ -2,6 +2,7 @@
 
 import { createScopedLogger } from '@auxx/logger'
 import type { ResolvedAgentConfig } from '../../../agents'
+import type { AgentSurface } from '../../../agents/client'
 import type { IntegrationCatalogEntry } from '../../../cache/integration-catalog'
 import type { AgentToolDefinition } from '../../agent-framework/types'
 import type { KopilotDomainState } from '../types'
@@ -13,7 +14,7 @@ import {
   serializePromptBlocks,
   summarizePromptBlocks,
 } from './sections/render'
-import type { ProcedureStepInput, PromptCtx, RunMode } from './sections/types'
+import type { Audience, ProcedureStepInput, PromptCtx, RunMode } from './sections/types'
 
 export type { PromptBlock } from './sections/render'
 export { CACHE_BREAK_SENTINEL, stripCacheBreakSentinels } from './sections/render'
@@ -31,6 +32,17 @@ export interface BuildKopilotPromptArgs {
   toolsetPromptAdditions: string
   /** Master sentinel or undefined → master persona; agent → agent persona. */
   agentConfig?: ResolvedAgentConfig
+  /**
+   * The rendering medium this turn outputs to → drives formatting. Defaults to
+   * `'builder'` (the in-app renderer) so existing callers are unchanged.
+   */
+  surface?: AgentSurface
+  /**
+   * Who reads this turn's output → drives semantics. Defaults to `'member'`,
+   * except a `customer_message` trigger implies `'customer'` (so the eval
+   * envelope and any caller that only sets `triggerContext` stays correct).
+   */
+  audience?: Audience
   /** Present iff this run was fired by an AgentTrigger. */
   triggerContext?: TriggerContext
   /**
@@ -106,6 +118,14 @@ function buildPromptCtx(args: BuildKopilotPromptArgs): PromptCtx {
   const isDmTrigger = args.triggerContext?.kind === 'dm'
   const runMode: RunMode = args.triggerContext && !isDmTrigger ? 'autonomous' : 'interactive'
 
+  // Surface defaults to the in-app builder renderer (today's behavior when
+  // unset). Audience defaults to `member`, except a `customer_message` trigger
+  // implies `customer` — so callers that only set `triggerContext` (the eval
+  // envelope) keep the customer-facing prose without a second flag.
+  const surface: AgentSurface = args.surface ?? 'builder'
+  const audience: Audience =
+    args.audience ?? (args.triggerContext?.kind === 'customer_message' ? 'customer' : 'member')
+
   // Any triggerContext (autonomous or DM) is always backed by a user-authored
   // agent; the master Kopilot never runs on a trigger. Fail fast if they ever
   // contradict.
@@ -115,6 +135,8 @@ function buildPromptCtx(args: BuildKopilotPromptArgs): PromptCtx {
 
   return {
     runMode,
+    surface,
+    audience,
     tools: args.tools,
     toolNames: new Set(args.tools.map((t) => t.name)),
     currentUser: args.currentUser,

--- a/packages/lib/src/ai/kopilot/prompts/core-runtime-prompt.ts
+++ b/packages/lib/src/ai/kopilot/prompts/core-runtime-prompt.ts
@@ -1,11 +1,12 @@
 // packages/lib/src/ai/kopilot/prompts/core-runtime-prompt.ts
 
+import type { AgentSurface } from '../../../agents/client'
 import type { IntegrationCatalogEntry } from '../../../cache/integration-catalog'
 import type { AgentToolDefinition } from '../../agent-framework/types'
 import type { KopilotDomainState } from '../types'
 import { CORE_SECTIONS } from './sections/registry'
 import { renderSections } from './sections/render'
-import type { PromptCtx, RunMode } from './sections/types'
+import type { Audience, PromptCtx, RunMode } from './sections/types'
 import type { CurrentUserInfo, EntityCatalogEntry } from './shared-types'
 
 export type { RunMode } from './sections/types'
@@ -26,9 +27,15 @@ export function buildCoreRuntimePrompt(args: {
   integrations: IntegrationCatalogEntry[]
   toolsetPromptAdditions: string
   runMode: RunMode
+  /** Rendering medium → formatting. Defaults to the in-app `'builder'` surface. */
+  surface?: AgentSurface
+  /** Who reads the output → semantics. Defaults to `'member'`. */
+  audience?: Audience
 }): string {
   const ctx: PromptCtx = {
     runMode: args.runMode,
+    surface: args.surface ?? 'builder',
+    audience: args.audience ?? 'member',
     tools: args.tools,
     toolNames: new Set(args.tools.map((t) => t.name)),
     currentUser: args.currentUser,

--- a/packages/lib/src/ai/kopilot/prompts/sections/__test-helpers.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/__test-helpers.ts
@@ -9,6 +9,9 @@ import type { PromptCtx, RunMode } from './types'
 export function makeCtx(overrides: Partial<PromptCtx> & { runMode: RunMode }): PromptCtx {
   return {
     runMode: overrides.runMode,
+    // Defaults reproduce the in-app member path; tests override as needed.
+    surface: overrides.surface ?? 'builder',
+    audience: overrides.audience ?? 'member',
     tools: overrides.tools ?? [],
     toolNames: overrides.toolNames ?? new Set((overrides.tools ?? []).map((t) => t.name)),
     currentUser: overrides.currentUser ?? null,

--- a/packages/lib/src/ai/kopilot/prompts/sections/__tests__/chat-formatting.test.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/__tests__/chat-formatting.test.ts
@@ -1,0 +1,51 @@
+// packages/lib/src/ai/kopilot/prompts/sections/__tests__/chat-formatting.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { makeCtx } from '../__test-helpers'
+import { chatFormatting } from '../chat-formatting'
+import { SYSTEM_PROMPT_SECTIONS } from '../registry'
+import { renderSections } from '../render'
+
+describe('chatFormatting', () => {
+  it('declares the plain-text rule on the chat surface', () => {
+    const out = chatFormatting.render(makeCtx({ runMode: 'interactive', surface: 'chat' }))
+    expect(out).toContain('plain text')
+    expect(out).toContain('does not render markdown')
+  })
+
+  it('is gated to the chat surface only', () => {
+    expect(chatFormatting.surfaces?.has('chat')).toBe(true)
+    expect(chatFormatting.surfaces?.has('builder')).toBe(false)
+    expect(chatFormatting.surfaces?.has('email')).toBe(false)
+  })
+})
+
+// Production live chat (`build-chat-engine-config.ts`) and the chat-channel eval
+// (`buildEffectiveAgentRuntime` deriving from a `customer_message`/`chat`
+// trigger) both resolve to surface `chat` + audience `customer` +
+// runMode `interactive`. Assert that profile renders the plain-text rule and
+// drops every in-app formatting section, so what evals grade is what chat runs.
+describe('chat customer profile (prod ↔ sim parity)', () => {
+  const prompt = renderSections(
+    SYSTEM_PROMPT_SECTIONS,
+    makeCtx({ runMode: 'interactive', surface: 'chat', audience: 'customer' })
+  )
+
+  it('includes the chat plain-text formatting rule', () => {
+    expect(prompt).toContain('Respond in plain text')
+  })
+
+  it('drops the builder-only rich-block catalog', () => {
+    expect(prompt).not.toContain('## Rich Blocks')
+    expect(prompt).not.toContain('auxx:entity-list')
+  })
+
+  it('drops the builder-only caller preamble link syntax', () => {
+    expect(prompt).not.toContain('auxx://actor/')
+  })
+
+  it('uses customer-facing instructions with tool-failure opacity', () => {
+    expect(prompt).toContain('reply to the customer')
+    expect(prompt).toContain('do not tell the customer a tool/integration failed')
+  })
+})

--- a/packages/lib/src/ai/kopilot/prompts/sections/__tests__/instructions.test.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/__tests__/instructions.test.ts
@@ -17,16 +17,17 @@ describe('instructions', () => {
     expect(out).toContain('Do not emit fenced code blocks')
   })
 
-  it('customer-conversation instructions reply to the customer, not an audit trail', () => {
-    const out = instructions.render(
-      makeCtx({
-        runMode: 'autonomous',
-        triggerContext: { kind: 'customer_message', instructions: null, payload: {} },
-      })
-    )
+  it('customer audience replies to the customer, not an audit trail', () => {
+    const out = instructions.render(makeCtx({ runMode: 'autonomous', audience: 'customer' }))
     expect(out).toContain('## Instructions')
     expect(out).toContain('reply to the customer')
     expect(out).not.toContain('audit trail')
     expect(out).not.toContain('by id')
+  })
+
+  it('customer audience forbids naming a failed tool/integration or error code', () => {
+    const out = instructions.render(makeCtx({ runMode: 'interactive', audience: 'customer' }))
+    expect(out).toContain('do not tell the customer a tool/integration failed')
+    expect(out).toContain('quote an error code')
   })
 })

--- a/packages/lib/src/ai/kopilot/prompts/sections/__tests__/job-statement.test.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/__tests__/job-statement.test.ts
@@ -15,15 +15,18 @@ describe('jobStatement', () => {
     expect(out).toContain('audit trail')
   })
 
-  it('customer-conversation job is a customer reply, not an audit trail', () => {
-    const out = jobStatement.render(
-      makeCtx({
-        runMode: 'autonomous',
-        triggerContext: { kind: 'customer_message', instructions: null, payload: {} },
-      })
-    )
+  it('customer audience is a customer reply, not an audit trail (autonomous email)', () => {
+    const out = jobStatement.render(makeCtx({ runMode: 'autonomous', audience: 'customer' }))
     expect(out).toContain('customer')
     expect(out).not.toContain('audit trail')
     expect(out).not.toContain('by id')
+  })
+
+  it('customer audience on the interactive chat surface is also a customer reply', () => {
+    const out = jobStatement.render(
+      makeCtx({ runMode: 'interactive', surface: 'chat', audience: 'customer' })
+    )
+    expect(out).toContain('customer')
+    expect(out).not.toContain('rich UI blocks')
   })
 })

--- a/packages/lib/src/ai/kopilot/prompts/sections/block-catalog.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/block-catalog.ts
@@ -1,6 +1,9 @@
 // packages/lib/src/ai/kopilot/prompts/sections/block-catalog.ts
 
+import type { AgentSurface } from '../../../../agents/client'
 import { INTERACTIVE_ONLY, type PromptSection } from './types'
+
+const BUILDER_SURFACE: ReadonlySet<AgentSurface> = new Set(['builder'])
 
 /**
  * Rich-block catalog section. Schemas sourced from a specific tool
@@ -8,10 +11,16 @@ import { INTERACTIVE_ONLY, type PromptSection } from './types'
  * `search_docs`/`search_knowledge`) are dropped when those tools aren't
  * resolved for this turn — otherwise the model is invited to emit blocks
  * it can't populate.
+ *
+ * `auxx:*` fences and `auxx://` links only render in the in-app builder
+ * renderer, so this is gated to the `builder` surface — it never reaches a
+ * chat (plain-text) or email turn, where it would contradict the medium's
+ * formatting rule.
  */
 export const blockCatalog: PromptSection = {
   id: 'block-catalog',
   modes: INTERACTIVE_ONLY,
+  surfaces: BUILDER_SURFACE,
   stability: 'static',
   render: (ctx) => {
     const has = (name: string) => ctx.toolNames.has(name)

--- a/packages/lib/src/ai/kopilot/prompts/sections/caller-preamble.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/caller-preamble.ts
@@ -1,10 +1,18 @@
 // packages/lib/src/ai/kopilot/prompts/sections/caller-preamble.ts
 
+import type { AgentSurface } from '../../../../agents/client'
 import { INTERACTIVE_ONLY, type PromptSection } from './types'
 
+const BUILDER_SURFACE: ReadonlySet<AgentSurface> = new Set(['builder'])
+
+// The caller preamble mentions the workspace member as
+// `[name](auxx://actor/<id>)` — in-app link syntax for a member-driven turn.
+// Gated to the `builder` surface so it never reaches a chat/email turn (where
+// the link syntax would render literally and there's no "caller" to mention).
 export const callerPreamble: PromptSection = {
   id: 'caller-preamble',
   modes: INTERACTIVE_ONLY,
+  surfaces: BUILDER_SURFACE,
   stability: 'turn',
   render: (ctx) => {
     const user = ctx.currentUser

--- a/packages/lib/src/ai/kopilot/prompts/sections/chat-formatting.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/chat-formatting.ts
@@ -1,0 +1,29 @@
+// packages/lib/src/ai/kopilot/prompts/sections/chat-formatting.ts
+
+import type { AgentSurface } from '../../../../agents/client'
+import { ALL_MODES, type PromptSection } from './types'
+
+const CHAT_SURFACE: ReadonlySet<AgentSurface> = new Set(['chat'])
+
+/**
+ * Plain-text formatting rule for the live chat widget. The widget renders its
+ * messages as plain text (`whitespace-pre-wrap`, no markdown parser), so any
+ * markdown, `auxx:*` fences, or `auxx://`/`[[…]]` link syntax shows literally to
+ * the customer. Gated on the `chat` surface only — email/builder keep their own
+ * formatting. This is a property of the medium, not the audience: it loads even
+ * for a member-facing chat surface, and never for an email customer.
+ */
+export const chatFormatting: PromptSection = {
+  id: 'chat-formatting',
+  modes: ALL_MODES,
+  surfaces: CHAT_SURFACE,
+  stability: 'static',
+  render: () =>
+    `## Formatting
+
+**Respond in plain text.** The chat widget shows your message verbatim — it does not render markdown or rich blocks, so any formatting shows up literally to the person reading it. Therefore:
+
+- No markdown: no \`**bold**\`, \`_italic_\`, \`#\` headings, or \`-\`/\`*\` bullet lists.
+- No fenced or \`auxx:*\` code blocks, and no \`auxx://\` or \`[[…]]\` link syntax.
+- Separate ideas with line breaks. Write any short list inline as "1." "2." "3." in running text, not as bulleted lines.`,
+}

--- a/packages/lib/src/ai/kopilot/prompts/sections/instructions.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/instructions.ts
@@ -10,13 +10,15 @@ const AUTONOMOUS_INSTRUCTIONS = `1. **Use tools, not prose, to act.** Text alone
 2. End with a 1–3 sentence summary, referencing affected records/threads/tasks by id. Do not emit fenced code blocks — no surface renders them.
 3. If blocked, stop and state why in the summary. Do not paste a would-be message body — the summary is an audit trail.`
 
-// Customer-conversation runs are `autonomous`, but the final prose is the reply
-// the customer reads — not an audit trail. Keep the autonomous mechanics (tools
-// act, no fenced blocks) while dropping the "summary / name records by id"
-// framing that leaks internal ids into customer replies. See job-statement.ts.
+// The final prose is the reply the customer reads — not an audit trail. Drop the
+// "summary / name records by id" framing that leaks internal ids, and add
+// tool-failure opacity: a member debugging wants the integration name + error
+// code, a customer must never see them. Keyed on `audience` so it covers both
+// the interactive live chat turn and the autonomous customer-email turn.
 const CUSTOMER_INSTRUCTIONS = `1. **Use tools, not prose, to act.** Text alone does not run actions or fetch data.
 2. End the turn with a short, plain-language reply to the customer — no internal ids, tool names, or fenced blocks. No tool calls in the final reply — that ends the turn.
-3. If blocked, tell the customer what you need or hand off — don't reassure or claim work a tool call didn't do.`
+3. If blocked, tell the customer what you genuinely need from them, or hand off to a human framed naturally ("Let me get a teammate to help with that"). Never reassure or claim work a tool call didn't do.
+4. **If a tool errors, is unavailable, or returns nothing, do not tell the customer a tool/integration failed, name the system, or quote an error code or status.** Ask for what you need to proceed, or hand off — without exposing why.`
 
 export const instructions: PromptSection = {
   id: 'instructions',
@@ -24,11 +26,11 @@ export const instructions: PromptSection = {
   stability: 'static',
   render: (ctx) => {
     const body =
-      ctx.runMode !== 'autonomous'
-        ? INTERACTIVE_INSTRUCTIONS
-        : ctx.triggerContext?.kind === 'customer_message'
-          ? CUSTOMER_INSTRUCTIONS
-          : AUTONOMOUS_INSTRUCTIONS
+      ctx.audience === 'customer'
+        ? CUSTOMER_INSTRUCTIONS
+        : ctx.runMode === 'autonomous'
+          ? AUTONOMOUS_INSTRUCTIONS
+          : INTERACTIVE_INSTRUCTIONS
     return `## Instructions
 
 ${body}`

--- a/packages/lib/src/ai/kopilot/prompts/sections/job-statement.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/job-statement.ts
@@ -8,12 +8,12 @@ const INTERACTIVE_TEXT =
 const AUTONOMOUS_TEXT =
   'Your job is to follow the trigger instructions by calling tools and, when the work is done, ending the turn with a short prose summary that names the affected records/threads/tasks by id. The summary is your audit trail — no human reads it as a chat reply. End the turn by simply not calling any more tools.'
 
-// Customer-conversation runs are `autonomous` (trigger-fired) but the end-of-turn
-// prose IS the customer-facing reply — not an internal audit trail. The generic
-// AUTONOMOUS_TEXT ("name records by id… no human reads it as a chat reply")
-// contradicts the `customer_message` run-mode banner and makes the model append
-// audit-style notes (internal ids, third-person recaps) to what the customer
-// reads. Mirror the banner's kind-aware split here.
+// A customer-facing turn's end-of-turn prose IS the reply the customer reads —
+// not an internal audit trail. The generic AUTONOMOUS_TEXT ("name records by
+// id… no human reads it as a chat reply") and the INTERACTIVE_TEXT ("embed
+// `auxx:*` rich UI blocks") both leak into what the customer sees. Keyed on
+// `audience` (not `runMode`/trigger kind) so it covers BOTH the interactive live
+// chat turn and the autonomous customer-email turn with one branch.
 const CUSTOMER_TEXT =
   'Your job is to help the customer by calling tools and, when the work is done, replying with a short, plain-language message that goes straight to them. Do not expose internal ids, tool names, or workspace link syntax. End the turn by simply not calling any more tools.'
 
@@ -22,7 +22,7 @@ export const jobStatement: PromptSection = {
   modes: ALL_MODES,
   stability: 'static',
   render: (ctx) => {
-    if (ctx.runMode !== 'autonomous') return INTERACTIVE_TEXT
-    return ctx.triggerContext?.kind === 'customer_message' ? CUSTOMER_TEXT : AUTONOMOUS_TEXT
+    if (ctx.audience === 'customer') return CUSTOMER_TEXT
+    return ctx.runMode === 'autonomous' ? AUTONOMOUS_TEXT : INTERACTIVE_TEXT
   },
 }

--- a/packages/lib/src/ai/kopilot/prompts/sections/registry.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/registry.ts
@@ -6,6 +6,7 @@ import { agentProcedureStep } from './agent-procedure-step'
 import { approval } from './approval'
 import { blockCatalog } from './block-catalog'
 import { callerPreamble } from './caller-preamble'
+import { chatFormatting } from './chat-formatting'
 import { contextSection } from './context'
 import { entityCatalog } from './entity-catalog'
 import { houseRules } from './house-rules'
@@ -45,7 +46,8 @@ export const SYSTEM_PROMPT_SECTIONS: readonly PromptSection[] = [
   jobStatement,
   instructions,
   membersVsContacts,
-  blockCatalog,
+  blockCatalog, // builder surface only
+  chatFormatting, // chat surface only — plain-text rule
   approval,
   runModeBanner,
   houseRules, // last in tier 1 — strongest recency vs persona

--- a/packages/lib/src/ai/kopilot/prompts/sections/render.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/render.ts
@@ -14,14 +14,27 @@ export interface PromptBlock {
 }
 
 /**
- * Filter `sections` by ctx.runMode, render each, drop empty results,
- * join with `\n\n`. In dev builds, asserts the whitespace contract on
+ * A section renders this turn iff its mode, surface, and audience gates all
+ * pass. `surfaces`/`audiences` are optional — `undefined` matches every value
+ * (so existing sections that declare neither are untouched). Factored out so
+ * `renderSections` and `renderSectionsToBlocks` can never drift on the gate.
+ */
+export function sectionApplies(section: PromptSection, ctx: PromptCtx): boolean {
+  if (!section.modes.has(ctx.runMode)) return false
+  if (section.surfaces && !section.surfaces.has(ctx.surface)) return false
+  if (section.audiences && !section.audiences.has(ctx.audience)) return false
+  return true
+}
+
+/**
+ * Filter `sections` by ctx.runMode/surface/audience, render each, drop empty
+ * results, join with `\n\n`. In dev builds, asserts the whitespace contract on
  * each section's output: no leading or trailing whitespace.
  */
 export function renderSections(sections: readonly PromptSection[], ctx: PromptCtx): string {
   const parts: string[] = []
   for (const section of sections) {
-    if (!section.modes.has(ctx.runMode)) continue
+    if (!sectionApplies(section, ctx)) continue
     const out = section.render(ctx)
     if (!out) continue
     if (process.env.NODE_ENV !== 'production' && out !== out.trim()) {
@@ -51,7 +64,7 @@ export function renderSectionsToBlocks(
   // Group section outputs by stability tier, preserving registry order.
   const groups: { stability: Stability; parts: string[] }[] = []
   for (const section of sections) {
-    if (!section.modes.has(ctx.runMode)) continue
+    if (!sectionApplies(section, ctx)) continue
     const out = section.render(ctx)
     if (!out) continue
     if (process.env.NODE_ENV !== 'production' && out !== out.trim()) {

--- a/packages/lib/src/ai/kopilot/prompts/sections/types.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/types.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/ai/kopilot/prompts/sections/types.ts
 
 import type { ResolvedAgentConfig } from '../../../../agents'
+import type { AgentSurface } from '../../../../agents/client'
 import type { IntegrationCatalogEntry } from '../../../../cache/integration-catalog'
 import type { AgentToolDefinition } from '../../../agent-framework/types'
 import type { KopilotDomainState } from '../../types'
@@ -12,6 +13,23 @@ export type RunMode = 'interactive' | 'autonomous'
 export const ALL_MODES: ReadonlySet<RunMode> = new Set(['interactive', 'autonomous'])
 export const INTERACTIVE_ONLY: ReadonlySet<RunMode> = new Set(['interactive'])
 export const AUTONOMOUS_ONLY: ReadonlySet<RunMode> = new Set(['autonomous'])
+
+/**
+ * Who reads this turn's output. Orthogonal to {@link RunMode} (human-in-loop vs
+ * not) and to {@link AgentSurface} (the rendering medium):
+ *
+ * - `member`   — a workspace member (in-app Kopilot, background-trigger audit
+ *   trail). Real ids / tool names / error codes are surfaced — they're debugging.
+ * - `customer` — an external person on the other end of a conversation (live
+ *   chat, customer email). Drives plain-language semantics: no internal ids,
+ *   tool names, link syntax, and tool-failure opacity (never name the failing
+ *   integration or quote an error code; ask or hand off).
+ *
+ * Computed per-run at the entry point — NOT a stored column and NOT
+ * `agent.kind === 'chat'` (they coincide today but diverge the moment an
+ * `internal`/`email` agent serves a customer).
+ */
+export type Audience = 'member' | 'customer'
 
 /**
  * Stability tier — drives cache-tier grouping in Phase E.
@@ -61,6 +79,10 @@ export interface ProcedureStepInput {
  */
 export interface PromptCtx {
   readonly runMode: RunMode
+  /** The rendering medium this turn outputs to → drives formatting. */
+  readonly surface: AgentSurface
+  /** Who reads this turn's output → drives semantics (see {@link Audience}). */
+  readonly audience: Audience
   readonly tools: readonly AgentToolDefinition[]
   readonly toolNames: ReadonlySet<string>
   readonly currentUser: CurrentUserInfo | null
@@ -83,6 +105,14 @@ export interface PromptSection {
   readonly id: string
   /** Modes this section may render in. Empty ≡ never (useful for staging). */
   readonly modes: ReadonlySet<RunMode>
+  /**
+   * Surfaces this section may render on. `undefined` ⇒ all surfaces
+   * (back-compat default). Mirrors `modes` — the renderer skips a section
+   * whose set doesn't include `ctx.surface`.
+   */
+  readonly surfaces?: ReadonlySet<AgentSurface>
+  /** Audiences this section may render for. `undefined` ⇒ all audiences. */
+  readonly audiences?: ReadonlySet<Audience>
   /** Cache stability tier — see `Stability`. */
   readonly stability: Stability
   /**

--- a/packages/lib/src/chat/agent/build-chat-engine-config.ts
+++ b/packages/lib/src/chat/agent/build-chat-engine-config.ts
@@ -164,8 +164,14 @@ export async function buildChatEngineConfig(
     defaultModel: model,
     defaultProvider: provider,
     agentConfig,
-    // No `triggerContext` — chat is not an AgentTrigger run; the autonomous-run
-    // prompt section stays off (escalation guidance lives in the persona).
+    // A chat turn renders to the plain-text widget (surface) for an external
+    // visitor (audience). These drive the prompt's formatting + opacity rules;
+    // chat ALWAYS serves a customer, so we never consult `agent.kind` here.
+    surface: 'chat',
+    audience: 'customer',
+    // No `triggerContext` — chat is not an AgentTrigger run; it stays
+    // `runMode: 'interactive'` (the visitor is in the loop). The surface/audience
+    // gates do the customer-facing work the trigger envelope used to.
   })
 
   const callModel = createCallModel({

--- a/packages/lib/src/evals/simulation/customer-envelope.ts
+++ b/packages/lib/src/evals/simulation/customer-envelope.ts
@@ -2,10 +2,12 @@
 //
 // The synthetic trigger context that gives a Simulation run the production
 // customer-conversation envelope. Threading it through the shared runtime
-// builder flips `runMode` to `autonomous` (no caller preamble, no internal
-// block catalog) and renders the `customer_message` trigger block + run-mode
-// banner — the same prompt shape a real inbound customer message produces.
-// See plans/evals/sim-fidelity-and-agent-quality-plan.md §1.1.
+// builder renders the `customer_message` trigger block + run-mode banner, and
+// `buildEffectiveAgentRuntime` derives `audience: 'customer'` from the kind plus
+// `surface` from `payload.channel` (`chat` → plain-text chat surface, else
+// `email`) — so the eval's formatting + opacity rules match what production
+// chat/email actually run. See plans/evals/sim-fidelity-and-agent-quality-plan.md
+// §1.1 and plans/chat/v10/chat-agent-system-prompt.md.
 
 import type { TriggerContext } from '../../ai/kopilot/prompts/trigger-context'
 


### PR DESCRIPTION
## Problem

Live chat AI replies were assembled under the **in-app builder** prompt profile (chat passes no `triggerContext`, so it ran `interactive` = the builder profile). Two concrete leaks resulted:

- Customers saw **literal markdown / `auxx:*` fences / `auxx://` link syntax** — the widget renders plain text (`whitespace-pre-wrap`, no markdown parser), so `**bold**`, fences, and `[text](auxx://…)` all showed verbatim.
- A tool failure leaked **member-only internals** to the customer: *"the Shopify integration doesn't have permission … (INSUFFICIENT_PERMISSIONS)"* — integration name + error code.

Root cause is the wrong **prompt profile**, not a missing instruction.

## Approach

Thread two orthogonal per-run signals into the prompt builder and let sections branch on them:

- **`surface`** (`internal | chat | email | builder`) → **formatting**. New plain-text `chat-formatting` section gated to `chat`; `block-catalog` + `caller-preamble` gated to `builder` so `auxx:*`/`auxx://` syntax is never emitted on a chat/email turn (nothing to contradict).
- **`audience`** (`member | customer`) → **semantics**. `job-statement` / `instructions` now branch on `audience` (not the `customer_message` trigger kind), covering interactive chat and autonomous customer-email with one branch. Customer instructions add **tool-failure opacity** — never name a failed integration or quote an error code; ask or hand off.

Gating reuses the existing declarative section pattern: optional `surfaces?` / `audiences?` sets on `PromptSection`, factored into one `sectionApplies()` shared by both render loops (`undefined` ⇒ matches all → back-compat).

### Entry points

| Entry point | sets |
| --- | --- |
| Visitor chat (`build-chat-engine-config.ts`) | `surface: 'chat'`, `audience: 'customer'` |
| In-app Kopilot (`api/kopilot/stream/route.ts`) | `surface: 'builder'`, `audience: 'member'` |
| Trigger / eval runtime (`effective-runtime.ts`) | derives `audience` from trigger kind, `surface` from channel — prod↔sim parity |

Defaults are `surface: 'builder'`, `audience: 'member'` (a `customer_message` trigger implies `customer`), so existing in-app and trigger output is byte-identical.

Also adds `kind` to `ResolvedAgentConfig` and a prod↔sim parity test.

## Realtime impact

**None.** This PR is server-side prompt assembly only. None of the changed files reference `realtime`/`pusher`; the separate pusher→realtime-client migration in `packages/chat` + `packages/lib/src/realtime` is deliberately **excluded** from this branch. Realtime delivery is format-agnostic (it ships whatever text the agent produced), so the plain-text change only improves what the widget renders.

## Testing

- New `chat-formatting.test.ts` incl. a chat customer-profile parity test (plain-text rule present; rich-block catalog + caller preamble dropped; customer instructions + opacity present).
- Updated `job-statement` / `instructions` section tests to drive on `audience`.
- Affected suites pass: prompts (89/91 — the 2 failures pre-exist on `main`, unrelated), evals + chat + domain-config (147).

Implements `plans/chat/v10/chat-agent-system-prompt.md`.