### PR TITLE
fix(contacts): render contact displayName in drawer header + batch NAME field writes

### DIFF
--- a/apps/web/src/components/contacts/drawer/contact-drawer.tsx
+++ b/apps/web/src/components/contacts/drawer/contact-drawer.tsx
@@ -5,7 +5,6 @@
 import { Button } from '@auxx/ui/components/button'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import { getFullName } from '@auxx/utils/contact'
 import { formatDistanceToNow } from 'date-fns'
 import { Expand, Mail, MessagesSquare, Trash, User } from 'lucide-react'
 import { useRouter } from 'next/navigation'
@@ -87,7 +86,7 @@ export function ContactDrawer({
           id: contact.id,
           identifier: primaryEmail,
           identifierType: 'EMAIL',
-          name: getFullName(contact) || undefined,
+          name: contact.displayName || undefined,
         },
       ],
     }
@@ -105,7 +104,7 @@ export function ContactDrawer({
 
   if (!open || !contactId) return null
 
-  const contactLabel = contact ? getFullName(contact) : undefined
+  const contactLabel = contact?.displayName
 
   return (
     <>
@@ -185,7 +184,7 @@ export function ContactDrawer({
             </div>
             <div className='flex flex-col align-start w-full'>
               <div className='text-lg font-medium text-neutral-900 dark:text-neutral-400 truncate'>
-                {contact ? getFullName(contact) : <Skeleton className='h-6 w-80 mb-1' />}
+                {contact ? contact.displayName : <Skeleton className='h-6 w-80 mb-1' />}
               </div>
               <div className='text-xs text-neutral-500 truncate'>
                 {contact ? createdAtText : <Skeleton className='h-4 w-40' />}

--- a/apps/web/src/components/fields/property-provider.tsx
+++ b/apps/web/src/components/fields/property-provider.tsx
@@ -226,6 +226,7 @@ export function PropertyProvider({
   const {
     saveFieldValue: storeSave,
     saveFieldValueAsync: storeSaveAsync,
+    saveMultipleAsync: storeSaveMultiple,
     isPending: isSaving,
   } = useSaveFieldValue({
     getFieldMetadata,
@@ -282,9 +283,25 @@ export function PropertyProvider({
         setIsDirty(false)
         setServerValue(newValue)
 
-        // Fire mutations to both source fields (computed system auto-updates NAME value)
-        storeSave(recordId, firstNameFieldId, nameValue.firstName ?? '', FieldTypeEnum.TEXT)
-        storeSave(recordId, lastNameFieldId, nameValue.lastName ?? '', FieldTypeEnum.TEXT)
+        // Write BOTH source fields in a single batch mutation. Two separate
+        // single-field writes race on the server-side displayName recompute:
+        // each NAME source write recomputes the composed displayName by reading
+        // its sibling from the DB, so concurrent first/last writes can read a
+        // stale sibling and persist an outdated displayName. Batching writes
+        // them sequentially in one request, so the final recompute always sees
+        // the freshly-written sibling. The computed NAME value updates itself.
+        void storeSaveMultiple(recordId, [
+          {
+            fieldId: firstNameFieldId,
+            value: nameValue.firstName ?? '',
+            fieldType: FieldTypeEnum.TEXT,
+          },
+          {
+            fieldId: lastNameFieldId,
+            value: nameValue.lastName ?? '',
+            fieldType: FieldTypeEnum.TEXT,
+          },
+        ])
         return
       }
 
@@ -297,7 +314,7 @@ export function PropertyProvider({
       // Store handles the optimistic update, so also update local serverValue
       setServerValue(newValue)
     },
-    [recordId, serverValue, storeSave, field.id, field.fieldType, field.options]
+    [recordId, serverValue, storeSave, storeSaveMultiple, field.id, field.fieldType, field.options]
   )
 
   /**


### PR DESCRIPTION
## Problem

The contact drawer header rendered `Contact #<id>` instead of the contact's name — even after a refresh, and even though the EntityFields panel showed the correct name.

## Root cause

`contact-drawer.tsx` built the header name with `getFullName(contact)`, but `contact` comes from `useRecord`, which returns a **`RecordPickerItem`** — it only carries `displayName` / `secondaryInfo` / `avatarUrl`, **not** `firstName` / `lastName` / `email` / `phone`.

`getFullName` (`@auxx/utils/contact`) expects a `ContactName` shape. Given a `RecordPickerItem`, all its name fields are `undefined`, so it fell straight through to its last branch:

```ts
if (id) return `Contact #${id}`
```

So the header showed `Contact #<id>` for **any** contact through this drawer, ignoring the denormalized `displayName` that the field-value write path already computes.

## Fix

- **`contact-drawer.tsx`** — render `contact.displayName` (the canonical, server-computed value) for the header, kopilot label, and compose recipient name. Drop the now-unused `getFullName` import.
- **`property-provider.tsx`** — NAME field edits previously fired two separate single-field `fieldValue.set` calls (first_name + last_name). Each recomputes the composed `displayName` server-side by reading its sibling from the DB, so two concurrent writes could read a stale sibling and persist an outdated `displayName`. Now both source fields are written in one batch mutation (`saveMultipleAsync`), so they run sequentially in one request and the final recompute always sees the freshly-written sibling.

## Notes

- The backend displayName recompute itself was verified correct via live repro — these are the client-render bug and a write-path race, not a recompute logic bug.
- Known minor follow-up (not in this PR): the editing tab is excluded from the `record:updated` realtime echo, so without a refetch the header can briefly show the *previous* name after an edit (no longer `Contact #id`). An optimistic `record-store` displayName update would close that gap.

## Test plan

- [ ] Open a contact drawer → header shows the contact's name, not `Contact #<id>`.
- [ ] Edit a contact's name via the Details panel → DB `EntityInstance.displayName` recomputes correctly; header shows the new name after refresh.
