### PR TITLE
feat(web): out-of-tab new-message indicator + notification sounds

### DIFF
--- a/apps/web/src/app/unread-icon/route.tsx
+++ b/apps/web/src/app/unread-icon/route.tsx
@@ -1,0 +1,64 @@
+// apps/web/src/app/unread-icon/route.tsx
+import { ImageResponse } from 'next/og'
+
+export const contentType = 'image/png'
+
+/**
+ * Unread variant of the favicon (`icon.tsx`) — the same logo mark with a
+ * contrasting alert dot in the top-right corner. NOT a Next metadata route, so
+ * it is never auto-linked into the document; the new-message indicator swaps the
+ * `<link rel="icon">` to `/unread-icon` client-side when there are unseen
+ * incoming messages, then removes it (restoring the base `/icon`) on clear.
+ */
+export function GET() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}>
+      <svg width='32' height='32' viewBox='0 0 68 68' xmlns='http://www.w3.org/2000/svg'>
+        <circle fill='#69b3fe' cx='34' cy='33.5' r='34'></circle>
+        <g>
+          <path
+            fill='#fff'
+            d='M7.74,39.14c-.69,0-1.39-.24-1.95-.72-1.37-1.17-1.29-3.34-.02-4.62L31.78,7.59c1.19-1.2,3.13-1.2,4.32,0l26.06,26.25c1.05,1.05,1.31,2.73.47,3.96-1.11,1.61-3.31,1.75-4.62.44l-24.04-24.22s-.04-.02-.06,0l-24.04,24.22c-.59.59-1.36.89-2.13.89Z'></path>
+          <rect
+            fill='#fff'
+            x='18.88'
+            y='31.89'
+            width='13.68'
+            height='13.79'
+            rx='2.46'
+            ry='2.46'></rect>
+          <rect
+            fill='#fff'
+            x='33.93'
+            y='31.89'
+            width='13.68'
+            height='13.79'
+            rx='2.39'
+            ry='2.39'></rect>
+          <rect
+            fill='#fff'
+            x='33.93'
+            y='47.06'
+            width='13.68'
+            height='13.79'
+            rx='2.5'
+            ry='2.5'></rect>
+        </g>
+        {/* Alert dot — white ring for contrast against the blue mark, red core. */}
+        <circle fill='#fff' cx='53' cy='15' r='15'></circle>
+        <circle fill='#ef4444' cx='53' cy='15' r='11'></circle>
+      </svg>
+    </div>,
+    {
+      width: 32,
+      height: 32,
+    }
+  )
+}

--- a/apps/web/src/components/global/auxx-app-providers.tsx
+++ b/apps/web/src/components/global/auxx-app-providers.tsx
@@ -5,6 +5,7 @@ import { TooltipProvider } from '@auxx/ui/components/tooltip'
 import type { ReactNode } from 'react'
 import { FavoritesProvider } from '~/components/favorites/providers/favorites-provider'
 import { FilesystemProvider } from '~/components/files/provider/filesystem-provider'
+import { useNewMessageIndicator } from '~/components/global/new-message-indicator/use-new-message-indicator'
 import { useNotificationSubscription } from '~/components/global/notifications/notification-center'
 import { ResourceProvider } from '~/components/resources'
 import { useResourceSync } from '~/components/resources/hooks/use-resource-sync'
@@ -36,6 +37,9 @@ export function AuxxAppProviders({ children }: AuxxAppProvidersProps) {
   usePresenceHeartbeat()
   useResourceSync()
   useMailSync()
+  // Out-of-tab new-message indicator: favicon dot + tab-title prefix, driven by
+  // the same inbound `message:created` arrival as the in-app toast cue.
+  useNewMessageIndicator()
   // Live notification-bell updates: subscribes to the user's private channel
   // so the dropdown list + unread badge refresh the instant a notification
   // lands, instead of only on popover-open / window-focus refetch.

--- a/apps/web/src/components/global/new-message-indicator/store.ts
+++ b/apps/web/src/components/global/new-message-indicator/store.ts
@@ -1,0 +1,28 @@
+// apps/web/src/components/global/new-message-indicator/store.ts
+import { create } from 'zustand'
+
+/**
+ * Single source of truth for the out-of-tab new-message indicator (favicon dot
+ * + tab-title prefix). Shared with the in-app toast cue
+ * (`use-message-arrival-cue`) so the two surfaces never contradict each other:
+ * the same arrival that fires a toast flips `hasUnseen`, and opening a thread /
+ * refocusing on mail clears both.
+ *
+ * Binary only — no count. Session-state today; becomes server-backed once the
+ * sibling plan wires live `mail-counts-store` deltas.
+ */
+interface NewMessageIndicatorState {
+  hasUnseen: boolean
+  markUnseen: () => void
+  clearUnseen: () => void
+}
+
+export const useNewMessageIndicatorStore = create<NewMessageIndicatorState>((set) => ({
+  hasUnseen: false,
+  markUnseen: () => set((s) => (s.hasUnseen ? s : { hasUnseen: true })),
+  clearUnseen: () => set((s) => (s.hasUnseen ? { hasUnseen: false } : s)),
+}))
+
+/** Imperative accessors for non-React callers (e.g. the arrival-cue callback). */
+export const markUnseenMessages = () => useNewMessageIndicatorStore.getState().markUnseen()
+export const clearUnseenMessages = () => useNewMessageIndicatorStore.getState().clearUnseen()

--- a/apps/web/src/components/global/new-message-indicator/use-new-message-indicator.ts
+++ b/apps/web/src/components/global/new-message-indicator/use-new-message-indicator.ts
@@ -1,0 +1,89 @@
+// apps/web/src/components/global/new-message-indicator/use-new-message-indicator.ts
+'use client'
+
+import { useEffect } from 'react'
+import { useActiveThreadId } from '~/components/threads/store/thread-selection-store'
+import { clearUnseenMessages, useNewMessageIndicatorStore } from './store'
+
+/** Title prefix shown while there are unseen messages (binary, no count). */
+const TITLE_PREFIX = '• '
+/** Id of the client-injected favicon link pointing at the unread variant. */
+const FAVICON_LINK_ID = 'auxx-unread-favicon'
+
+/**
+ * Out-of-tab new-message indicator controller. Mount once in the authed shell.
+ *
+ * Reads the shared `hasUnseen` flag (set by the arrival cue on inbound
+ * `message:created`) and drives two browser-only surfaces in lockstep:
+ *
+ * - **Favicon** — appends a `<link rel="icon" href="/unread-icon">` (last icon
+ *   link wins) while unseen; removes it on clear, restoring the base `/icon`.
+ * - **Tab title** — prefixes `document.title` with `• `. A `MutationObserver` on
+ *   `<head>` re-asserts the prefix whenever Next re-applies the route title on
+ *   navigation (the `%s | Auxx.ai` template would otherwise strip it).
+ *
+ * Clears when the user opens any thread (= reading their mail) or refocuses the
+ * tab while on a mail route. Tying clear to a read action — not bare focus —
+ * matches the persistent-unread UX of Gmail/Slack.
+ */
+export function useNewMessageIndicator(): void {
+  const hasUnseen = useNewMessageIndicatorStore((s) => s.hasUnseen)
+  const activeThreadId = useActiveThreadId()
+
+  // Clear on thread open — opening any thread means "I'm reading my mail now".
+  useEffect(() => {
+    if (activeThreadId) clearUnseenMessages()
+  }, [activeThreadId])
+
+  // Clear on tab refocus while on a mail route.
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const onVisibility = () => {
+      if (!document.hidden && window.location.pathname.startsWith('/app/mail')) {
+        clearUnseenMessages()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => document.removeEventListener('visibilitychange', onVisibility)
+  }, [])
+
+  // Favicon swap.
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const existing = document.getElementById(FAVICON_LINK_ID)
+    if (hasUnseen) {
+      if (!existing) {
+        const link = document.createElement('link')
+        link.id = FAVICON_LINK_ID
+        link.rel = 'icon'
+        link.type = 'image/png'
+        link.href = '/unread-icon'
+        document.head.appendChild(link)
+      }
+    } else {
+      existing?.remove()
+    }
+  }, [hasUnseen])
+
+  // Tab-title prefix. Re-asserted via a head observer so Next's per-route title
+  // writes (the `%s | Auxx.ai` template) can't strip the prefix on navigation.
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+
+    const apply = () => {
+      const stripped = document.title.startsWith(TITLE_PREFIX)
+        ? document.title.slice(TITLE_PREFIX.length)
+        : document.title
+      const next = hasUnseen ? TITLE_PREFIX + stripped : stripped
+      // Guard against the observer re-triggering on our own write.
+      if (document.title !== next) document.title = next
+    }
+
+    apply()
+    if (!hasUnseen) return
+
+    const observer = new MutationObserver(apply)
+    observer.observe(document.head, { childList: true, subtree: true, characterData: true })
+    return () => observer.disconnect()
+  }, [hasUnseen])
+}

--- a/apps/web/src/components/global/notifications/notification-center.tsx
+++ b/apps/web/src/components/global/notifications/notification-center.tsx
@@ -28,6 +28,8 @@ import { useEffect, useRef, useState } from 'react'
 import { HumanConfirmationDialog } from '~/components/workflow/dialogs/human-confirmation-dialog'
 import { useIsMobile } from '~/hooks/use-mobile'
 import { useUser } from '~/hooks/use-user'
+import { NEW_NOTIFICATION_SOUND, playNotificationSound } from '~/lib/play-notification-sound'
+import { useDehydratedSettings } from '~/providers/dehydrated-state-provider'
 import { useRealtimeRoom } from '~/realtime/hooks'
 import { api } from '~/trpc/react'
 
@@ -452,6 +454,11 @@ export const NotificationCenter = () => {
 export function useNotificationSubscription(userId: string) {
   const utils = api.useUtils()
   const { organizationId } = useUser()
+  // Bell sound preference (default on), mirrored into a ref so the realtime
+  // event closure reads the latest value without rebinding the channel.
+  const settings = useDehydratedSettings()
+  const bellSoundRef = useRef(true)
+  bellSoundRef.current = settings['notification.sound.bell'] !== false
   // Rides the shared realtime adapter (one multiplexed socket) instead of
   // opening its own Pusher connection.
   useRealtimeRoom(userId ? rooms.user(userId) : null, {
@@ -467,6 +474,8 @@ export function useNotificationSubscription(userId: string) {
             utils.notification.getUnreadCount.setData(undefined, (prev) => ({
               count: (prev?.count ?? 0) + 1,
             }))
+            // Chime in step with the badge tick, gated on the preference.
+            if (bellSoundRef.current) playNotificationSound(NEW_NOTIFICATION_SOUND)
           }
           // The dropdown list spans all orgs and only fetches while open, so
           // invalidate is a no-op when closed and refetches fresh (with the

--- a/apps/web/src/components/threads/realtime/use-message-arrival-cue.tsx
+++ b/apps/web/src/components/threads/realtime/use-message-arrival-cue.tsx
@@ -7,6 +7,9 @@ import { toastMessage } from '@auxx/ui/components/toast'
 import { MailPlus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef } from 'react'
+import { markUnseenMessages } from '~/components/global/new-message-indicator/store'
+import { NEW_MESSAGE_SOUND, playNotificationSound } from '~/lib/play-notification-sound'
+import { useDehydratedSettings } from '~/providers/dehydrated-state-provider'
 import { getMessageStoreState } from '../store/message-store'
 import { getParticipantStoreState } from '../store/participant-store'
 import { getThreadSelectionState } from '../store/thread-selection-store'
@@ -44,6 +47,12 @@ function resolveSender(messageId: string): string | null {
 export function useMessageArrivalCue() {
   const router = useRouter()
 
+  // Sound preference (default on). Read from dehydrated state and mirrored into
+  // a ref so the non-React flush callback sees the latest value.
+  const settings = useDehydratedSettings()
+  const soundEnabledRef = useRef(true)
+  soundEnabledRef.current = settings['notification.sound.newMessage'] !== false
+
   // threadId -> latest messageId, drained on flush.
   const pendingRef = useRef(new Map<string, string>())
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -60,6 +69,9 @@ export function useMessageArrivalCue() {
     const entries = Array.from(pendingRef.current.entries())
     pendingRef.current.clear()
     if (entries.length === 0) return
+
+    // One chime per cue (after coalescing), gated on the user preference.
+    if (soundEnabledRef.current) playNotificationSound(NEW_MESSAGE_SOUND)
 
     if (entries.length === 1) {
       const [threadId, messageId] = entries[0]
@@ -88,6 +100,10 @@ export function useMessageArrivalCue() {
       if (!msg || !msg.isInbound) return
       // Don't cue the thread the user is already reading.
       if (getThreadSelectionState().activeThreadId === threadId) return
+
+      // Flip the out-of-tab indicator (favicon dot + title prefix) immediately —
+      // it doesn't wait for the toast's coalescing window.
+      markUnseenMessages()
 
       // Warm the sender so its name is resolvable by flush time.
       const fromId = groupParticipantsByRole(msg.participants).from

--- a/apps/web/src/lib/play-notification-sound.ts
+++ b/apps/web/src/lib/play-notification-sound.ts
@@ -1,0 +1,28 @@
+// apps/web/src/lib/play-notification-sound.ts
+
+/** Public paths for the bundled notification sounds (served from `public/`). */
+export const NEW_MESSAGE_SOUND = '/sounds/new-message.mp3'
+export const NEW_NOTIFICATION_SOUND = '/sounds/new-notification.mp3'
+
+/** One reused `HTMLAudioElement` per source so rapid plays don't spawn nodes. */
+const cache = new Map<string, HTMLAudioElement>()
+
+/**
+ * Play a short notification sound. The audio element is created lazily
+ * (client-only) and reused. Autoplay rejections — when the tab hasn't had a
+ * user gesture yet — are swallowed so callers never need to handle them.
+ */
+export function playNotificationSound(src: string, volume = 1): void {
+  try {
+    let el = cache.get(src)
+    if (!el) {
+      el = new Audio(src)
+      el.volume = volume
+      cache.set(src, el)
+    }
+    el.currentTime = 0
+    void el.play().catch(() => {})
+  } catch {
+    /* ignore — audio unsupported or blocked */
+  }
+}


### PR DESCRIPTION
## Summary

Adds two related out-of-focus cues for inbound mail, both driven off the existing realtime `message:created` arrival:

- **New-message indicator** — favicon dot + tab-title prefix (`• `) while there are unseen incoming messages. Backed by a shared `hasUnseen` zustand store so it never contradicts the in-app toast cue. Clears when the user opens any thread (= reading their mail) or refocuses the tab on a mail route, matching Gmail/Slack persistent-unread UX.
- **Notification sounds** — short chimes for new messages and bell notifications, each gated on its own user sound preference (default on).

## Changes

- `app/unread-icon/route.tsx` — `ImageResponse` favicon variant: base logo mark + red alert dot. Not a metadata route; swapped in client-side via `<link rel="icon">`.
- `components/global/new-message-indicator/` — `store.ts` (shared `hasUnseen` flag + imperative accessors) and `use-new-message-indicator.ts` (favicon swap + title-prefix controller with a `<head>` MutationObserver so Next's per-route title writes can't strip the prefix).
- `lib/play-notification-sound.ts` — lazy, cached `HTMLAudioElement` per source; swallows autoplay rejections.
- Wired `useNewMessageIndicator()` into `auxx-app-providers`; `use-message-arrival-cue` flips `hasUnseen` + plays the new-message chime; `notification-center` plays the bell chime on unread tick.

## Notes

- Indicator is binary (no count); session-state today, becomes server-backed once live mail-count deltas land.
- Sound assets already tracked under `public/sounds/`.