### PR TITLE
fix(realtime): recover chat messages missed during subscribe gaps; fix off-page toasts

### DIFF
--- a/apps/web/src/components/threads/realtime/use-mail-sync.ts
+++ b/apps/web/src/components/threads/realtime/use-mail-sync.ts
@@ -14,7 +14,8 @@ import type {
   ThreadDeletedEvent,
   ThreadUpdatedEvent,
 } from '@auxx/lib/realtime/client'
-import { useCallback, useMemo } from 'react'
+import { extractUniqueParticipantIds } from '@auxx/types'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { useInboxChannels, useOrgChannel } from '~/realtime/hooks'
@@ -23,6 +24,7 @@ import { useInboxes } from '../hooks'
 import { useMessageListStore } from '../store/message-list-store'
 import { useMessageStore } from '../store/message-store'
 import { useParticipantStore } from '../store/participant-store'
+import { getThreadSelectionState } from '../store/thread-selection-store'
 import { useThreadStore } from '../store/thread-store'
 import { useMessageArrivalCue } from './use-message-arrival-cue'
 
@@ -61,10 +63,12 @@ export function useMailSync() {
   const removeMessage = useMessageStore((s) => s.removeMessage)
 
   const appendMessage = useMessageListStore((s) => s.appendMessage)
+  const setMessageList = useMessageListStore((s) => s.setList)
   const removeFromMessageList = useMessageListStore((s) => s.removeMessage)
   const invalidateMessageList = useMessageListStore((s) => s.invalidate)
 
   const updateParticipant = useParticipantStore((s) => s.updateParticipant)
+  const requestParticipant = useParticipantStore((s) => s.requestParticipant)
 
   const utils = api.useUtils()
 
@@ -126,11 +130,22 @@ export function useMailSync() {
       // patch until the message data lands. Without this, the id sits in
       // `messageIds` with no entry in `messages` for ~50ms (batch window),
       // and `useMessages` filters it out — visible as a missing message.
+      // Also tear down if the fetch resolves to not-found, so the one-shot
+      // subscription doesn't leak.
       requestMessage(messageId)
       const unsub = useMessageStore.subscribe(
-        (s) => s.messages.has(messageId),
-        (hasNow) => {
-          if (!hasNow) return
+        (s) =>
+          s.messages.has(messageId)
+            ? 'found'
+            : s.notFoundIds.has(messageId)
+              ? 'notfound'
+              : 'pending',
+        (status) => {
+          if (status === 'pending') return
+          if (status === 'notfound') {
+            unsub()
+            return
+          }
           appendMessage(threadId, messageId)
           setThreadPatch(threadId, { latestMessageId: messageId })
           cueIncomingMessage(messageId, threadId)
@@ -280,6 +295,71 @@ export function useMailSync() {
     [realtimeMailEnabled, handleParticipantUpdated]
   )
 
-  useInboxChannels(realtimeMailEnabled ? slugs : [], { onEvent: onInboxEvent })
+  // Catch-up on (re)subscribe. Pusher does NOT replay events published while a
+  // channel was mid-subscribe — and inbox channels bind in two phases (the real
+  // inboxes only after the async `inboxes` query resolves), plus rebind on
+  // every reconnect. Messages sent in those windows never reach
+  // `handleMessageCreated` and only surface on a manual refresh. So when an
+  // inbox channel finishes subscribing, refetch the thread list and the
+  // currently-open thread's messages to recover anything missed.
+  const catchUpTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const runCatchUp = useCallback(() => {
+    utils.thread.listIds.invalidate()
+    const threadId = getThreadSelectionState().activeThreadId
+    if (!threadId) return
+    // Force-fresh fetch (the open thread's `listByThread` query is disabled once
+    // cached, so a normal invalidate wouldn't refetch). Reconcile additively —
+    // append only missing ids so the view doesn't flash.
+    utils.message.listByThread
+      .fetch({ threadId }, { staleTime: 0 })
+      .then((data) => {
+        if (!data?.messages) return
+        useMessageStore.getState().setMessages(data.messages)
+        // Seed the list when it isn't cached yet — our fetch is the freshest
+        // (forced `staleTime: 0`), so it beats `useMessages`' possibly-older
+        // initial fetch and includes any gap messages. `useMessages` only
+        // `setList`s when absent, so it won't clobber this. When the list is
+        // already cached, merge additively (append missing ids) to avoid a
+        // flash and preserve optimistic entries.
+        const existing = useMessageListStore.getState().lists.get(threadId)
+        if (existing) {
+          for (const m of data.messages) appendMessage(threadId, m.id)
+        } else {
+          setMessageList(threadId, {
+            messageIds: data.messages.map((m) => m.id),
+            total: data.total,
+            fetchedAt: Date.now(),
+          })
+        }
+        const ids = extractUniqueParticipantIds(data.messages.flatMap((m) => m.participants))
+        for (const id of ids) requestParticipant(id)
+      })
+      .catch(() => {
+        /* best-effort recovery; next subscribe/refresh retries */
+      })
+  }, [utils, appendMessage, setMessageList, requestParticipant])
+
+  // Coalesce the burst of per-inbox `onSubscribed` callbacks on load into one
+  // catch-up pass.
+  const handleInboxSubscribed = useCallback(() => {
+    if (catchUpTimerRef.current) return
+    catchUpTimerRef.current = setTimeout(() => {
+      catchUpTimerRef.current = null
+      runCatchUp()
+    }, 250)
+  }, [runCatchUp])
+
+  useEffect(
+    () => () => {
+      if (catchUpTimerRef.current) clearTimeout(catchUpTimerRef.current)
+    },
+    []
+  )
+
+  useInboxChannels(realtimeMailEnabled ? slugs : [], {
+    onEvent: onInboxEvent,
+    onSubscribed: handleInboxSubscribed,
+  })
   useOrgChannel({ onEvent: onOrgEvent })
 }

--- a/apps/web/src/components/threads/realtime/use-message-arrival-cue.tsx
+++ b/apps/web/src/components/threads/realtime/use-message-arrival-cue.tsx
@@ -98,8 +98,15 @@ export function useMessageArrivalCue() {
       const msg = getMessageStoreState().getMessage(messageId)
       // Incoming only — skip the user's own outbound sends.
       if (!msg || !msg.isInbound) return
-      // Don't cue the thread the user is already reading.
-      if (getThreadSelectionState().activeThreadId === threadId) return
+      // Don't cue the thread the user is actively reading — but only while the
+      // mail view is on screen. `activeThreadId` is global state that is NOT
+      // reset when you leave /app/mail (the mount effect in `mail-box` keeps it
+      // so the last thread can be restored on return), so without the route
+      // check a stale value silently suppresses toasts for the last-opened
+      // thread on every other page. Mirrors the out-of-tab indicator's gate.
+      const onMailRoute =
+        typeof window !== 'undefined' && window.location.pathname.startsWith('/app/mail')
+      if (onMailRoute && getThreadSelectionState().activeThreadId === threadId) return
 
       // Flip the out-of-tab indicator (favicon dot + title prefix) immediately —
       // it doesn't wait for the toast's coalescing window.

--- a/apps/web/src/realtime/hooks.ts
+++ b/apps/web/src/realtime/hooks.ts
@@ -27,6 +27,7 @@ export function useRealtimeRoom(
     if (!roomKey) return
     const sub = realtimeAdapter.subscribe(roomKey, {
       onEvent: (event, payload) => handlersRef.current.onEvent?.(event, payload),
+      onSubscribed: () => handlersRef.current.onSubscribed?.(),
     })
     return () => sub.unsubscribe()
   }, [roomKey])
@@ -148,6 +149,7 @@ export function useInboxChannels(
     const subs = list.map((slug) =>
       realtimeAdapter.subscribe(rooms.orgInbox(organizationId, slug), {
         onEvent: (event, payload) => handlersRef.current?.onEvent?.(event, payload),
+        onSubscribed: () => handlersRef.current?.onSubscribed?.(),
       })
     )
     return () => {

--- a/packages/lib/src/realtime/client/adapters/pusher.ts
+++ b/packages/lib/src/realtime/client/adapters/pusher.ts
@@ -176,6 +176,15 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
           if (event === 'pusher:subscription_succeeded' || event === 'pusher:subscription_error') {
             console.log('[realtime.sub]', roomKey, event)
           }
+          // Fan out subscribe-success to consumers so they can catch up on any
+          // events published during the subscribe/reconnect window. Fires again
+          // on every resubscribe (Pusher refires this on reconnect).
+          if (event === 'pusher:subscription_succeeded') {
+            const current = this.rooms.get(roomKey)
+            if (current) {
+              for (const h of current.handlers) h.onSubscribed?.()
+            }
+          }
           return
         }
         console.log('[realtime.sub]', roomKey, event, payload)
@@ -245,6 +254,17 @@ export class PusherRealtimeAdapter implements RealtimeAdapter {
     if (entry.refCount === 1) {
       this.refreshRoomsSnapshot()
       this.notifyRooms()
+    }
+
+    // Late-join replay: if the channel already completed its handshake before
+    // this handler attached, `pusher:subscription_succeeded` won't fire again
+    // for it — so replay `onSubscribed` once, async, to match the natural
+    // ordering of a fresh subscription.
+    if (!presence && (entry.channel as Pusher.Channel).subscribed) {
+      const h = handlers as SubscribeHandlers
+      queueMicrotask(() => {
+        if (this.rooms.get(roomKey)?.handlers.has(handlers)) h.onSubscribed?.()
+      })
     }
 
     // Late-join replay: if the channel is already past `subscription_succeeded`

--- a/packages/lib/src/realtime/client/types.ts
+++ b/packages/lib/src/realtime/client/types.ts
@@ -14,6 +14,13 @@ export interface PresenceMember {
 /** Event-only handlers (plain rooms). */
 export interface SubscribeHandlers {
   onEvent?(event: string, payload: unknown): void
+  /**
+   * Fired once the channel completes its `pusher:subscription_succeeded`
+   * handshake — and again on every resubscribe (e.g. after a reconnect). Use
+   * it to catch up on anything published while the channel was not yet bound:
+   * Pusher does not replay events sent during the subscribe/reconnect window.
+   */
+  onSubscribed?(): void
 }
 
 /** Presence-room handlers — extend plain handlers with member tracking. */


### PR DESCRIPTION
## What

Two admin-side realtime message-delivery bugs in the mail/chat inbox.

### 1. Off-page new-message toast was silently suppressed
The arrival cue suppresses the toast for the thread you're reading, keyed on a global `activeThreadId`. That id is set from `?tid=` on mail-box mount and is **never reset when you leave `/app/mail`** (deliberately, so the last thread restores on return). The result: after opening any thread and navigating away, new messages on *that* thread produced no toast anywhere in the app — while other threads toasted. That's the "sometimes a toast, sometimes nothing."

**Fix:** the suppression now only applies while `location.pathname` starts with `/app/mail`, mirroring the out-of-tab indicator's existing gate.

### 2. Messages sent during a subscribe/reconnect window never showed up
Pusher does not replay events published while a channel is mid-subscribe. The inbox channels bind in **two phases** (the real inboxes only after the async `inboxes` query resolves), and rebind on every reconnect. Messages that land in those windows never reach `handleMessageCreated` and only surface on a manual refresh — the "messages don't show up in `thread-messages.tsx`" report.

**Fix:** added `SubscribeHandlers.onSubscribed`, fired by the adapter on `pusher:subscription_succeeded` (and again on every resubscribe, with late-join replay for handlers attaching to an already-subscribed channel). `useMailSync` uses it to **catch up**: invalidate the thread list and force-fresh (`staleTime: 0`) refetch the open thread's messages, reconciled additively (seed the list if absent so it beats `useMessages`' older fetch; merge if present — no flash). Also tears down the deferred one-shot message subscription on a not-found fetch so it doesn't leak.

## Files
- `packages/lib/src/realtime/client/types.ts` — `SubscribeHandlers.onSubscribed`
- `packages/lib/src/realtime/client/adapters/pusher.ts` — fan out `subscription_succeeded` + late-join replay
- `apps/web/src/realtime/hooks.ts` — thread `onSubscribed` through room/inbox hooks
- `apps/web/src/components/threads/realtime/use-mail-sync.ts` — catch-up on (re)subscribe + not-found teardown
- `apps/web/src/components/threads/realtime/use-message-arrival-cue.tsx` — route-gate the toast suppression

## Testing
Verified end-to-end with a live widget + admin inbox (Chrome DevTools):
- **Off-page toast:** message on the last-opened thread fired the toast from `/app/settings`; on `/app/mail` viewing that thread it stayed silent (suppression still correct).
- **Catch-up (deterministic):** took the admin tab Offline, sent a chat message (confirmed missed — not rendered, no realtime events), restored the network → on reconnect the catch-up fired and the message appeared in the pane **with no `message:created` delivery** (Pusher never replayed it; recovered purely by the refetch).

> Note: `@auxx/lib` realtime client resolves `import` → `dist`, so a `pnpm --filter @auxx/lib build` is needed for the web dev server to pick up the adapter/type changes.