### PR TITLE
refactor(mail): extract shared composer shell

### DIFF
--- a/apps/web/src/components/mail/chat-composer/index.tsx
+++ b/apps/web/src/components/mail/chat-composer/index.tsx
@@ -1,56 +1,27 @@
 // apps/web/src/components/mail/chat-composer/index.tsx
 'use client'
 
-import { Badge } from '@auxx/ui/components/badge'
 import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
-import { Upload } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useDropzone } from 'react-dropzone'
 import { EditorToolbar } from '~/components/editor/editor-button'
 import { EditorProvider, useEditorContext } from '~/components/editor/editor-context'
-import { useFileSelect } from '~/components/file-select/hooks/use-file-select'
-import { api } from '~/trpc/react'
-import {
-  AI_OPERATION,
-  type AIOperation,
-  COMPOSE_ENTITY_TYPE,
-  OUTPUT_FORMAT,
-} from '~/types/ai-tools'
 import { ChatPanelHeader } from '../chat-panel/header'
 import {
-  EditorActiveStateProvider,
-  useEditorActiveStateContext,
-} from '../email-editor/editor-active-state-context'
-import { useAIToolsState } from '../email-editor/hooks'
-import { LazyTiptapEditor } from '../email-editor/lazy-tiptap-editor'
-import { MessageFile } from '../email-editor/message-file'
-import type { FileAttachment } from '../email-editor/types'
+  AttachmentStrip,
+  ComposerBody,
+  INTERACTIVE_ELEMENT_SELECTORS,
+  isContentEmpty,
+  useComposerAITools,
+  useComposerAttachments,
+} from '../composer-shared'
+import { EditorActiveStateProvider } from '../email-editor/editor-active-state-context'
 import type { ChatComposerProps } from './types'
 import { useChatSend } from './use-chat-send'
 
-const INTERACTIVE_ELEMENT_SELECTORS = `
-  button, a, input, select, textarea,
-  [role="button"], [role="option"], [role="combobox"], [role="menuitem"], [role="tab"],
-  .ProseMirror, [data-radix-popper-content-wrapper], [data-radix-select-trigger],
-  .tippy-box, .editor-toolbar-wrapper
-`.trim()
-
-const isContentEmpty = (editor: any): boolean => {
-  if (!editor) return true
-  const plainText = editor.getText()?.trim() ?? ''
-  if (plainText === '') {
-    const html = editor.getHTML()
-    const strippedHtml = html.replace(/<([a-z][a-z0-9]*)\s+[^>]*>/gi, '<$1>').replace(/\s+/g, '')
-    return /^(<p>(<br>)*<\/p>)+$/.test(strippedHtml)
-  }
-  return false
-}
-
 function ChatComposerInner({
   thread,
-  onClose,
   onSendSuccess,
   isDialogMode = false,
   onPopOut,
@@ -61,29 +32,10 @@ function ChatComposerInner({
 }: ChatComposerProps) {
   const popoverZIndex = isDialogMode ? 'z-[200]' : undefined
   const { editor } = useEditorContext()
-  const activeState = useEditorActiveStateContext()
 
   const [content, setContent] = useState('')
-  const [attachments, setAttachments] = useState<FileAttachment[]>([])
 
-  const tempEntityId = useMemo(
-    () => `temp-message-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-    []
-  )
-  const fileSelect = useFileSelect({
-    entityType: 'MESSAGE',
-    entityId: tempEntityId,
-    allowMultiple: true,
-    maxFiles: 10,
-    maxFileSize: 25 * 1024 * 1024,
-    autoStart: true,
-  })
-
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    onDrop: (acceptedFiles) => fileSelect.addFiles(acceptedFiles),
-    noClick: true,
-    noKeyboard: true,
-  })
+  const { fileSelect, allAttachments, removeAttachment, dropzone } = useComposerAttachments()
 
   const integrationId = thread.integrationId ?? ''
   const { send, isSending } = useChatSend({
@@ -92,7 +44,6 @@ function ChatComposerInner({
     onSendSuccess: () => {
       editor?.commands.clearContent(true)
       setContent('')
-      setAttachments([])
       onSendSuccess()
     },
   })
@@ -112,22 +63,8 @@ function ChatComposerInner({
     wasSendingRef.current = isSending
   }, [isSending, editor])
 
-  const allAttachments = useMemo(() => {
-    const filesFromSelect: FileAttachment[] = fileSelect.selectedItems
-      .filter((item) => item.source === 'filesystem' || item.serverFileId)
-      .map((item) => ({
-        id: item.source === 'filesystem' ? item.id : item.serverFileId!,
-        name: item.name,
-        size: Number(item.size ?? 0),
-        mimeType: item.mimeType || 'application/octet-stream',
-        type: 'file' as const,
-      }))
-    const existingIds = new Set(attachments.map((a) => a.id))
-    return [...attachments, ...filesFromSelect.filter((f) => !existingIds.has(f.id))]
-  }, [attachments, fileSelect.selectedItems])
-
-  const removeAttachment = useCallback((id: string) => {
-    setAttachments((prev) => prev.filter((a) => a.id !== id))
+  const handleContentChange = useCallback((next: string) => {
+    setContent((prev) => (prev === next ? prev : next))
   }, [])
 
   const handleSendClick = useCallback(() => {
@@ -159,83 +96,17 @@ function ChatComposerInner({
     [handleSendClick]
   )
 
-  const handleContentChange = useCallback((next: string) => {
-    setContent((prev) => (prev === next ? prev : next))
-  }, [])
-
-  // AI tools
-  const {
-    state: aiToolsState,
-    pushToHistory,
-    setProcessing,
-    setCurrentOperation,
-    setError,
-    clearError,
-  } = useAIToolsState(editor)
-  const aiStartTimeRef = useRef<number>(0)
-
-  const processAI = api.aiFeature.compose.useMutation({
-    onSuccess: (response) => {
-      if (!editor) return
-      const html =
-        response.format === OUTPUT_FORMAT.EDITOR
-          ? null
-          : response.format === OUTPUT_FORMAT.HTML
-            ? response.content
-            : `<p>${response.content}</p>`
-      if (response.format === OUTPUT_FORMAT.EDITOR) {
-        editor.commands.setContent(JSON.parse(response.content))
-      } else if (html !== null) {
-        editor.commands.setContent(html)
-      }
-      const next = editor.getHTML()
-      handleContentChange(next)
-      pushToHistory(next, aiToolsState.currentOperation)
-      setProcessing(false)
-      setCurrentOperation(null)
-      clearError()
-    },
-    onError: (error) => {
-      toastError({ title: 'AI operation failed', description: error.message })
-      setError(error.message)
-      setProcessing(false)
-      setCurrentOperation(null)
-    },
+  const { state: aiToolsState, handleAIOperation } = useComposerAITools({
+    editor,
+    entityId: thread.id,
+    applyContent: (next) =>
+      editor?.commands.setContent(
+        next as Parameters<NonNullable<typeof editor>['commands']['setContent']>[0]
+      ),
+    onContentChanged: handleContentChange,
   })
 
-  const handleAIOperation = useCallback(
-    async (operation: AIOperation, options?: { tone?: string; language?: string }) => {
-      if (!editor || aiToolsState.isProcessing) return
-      const currentContent = editor.getHTML()
-      if (operation !== AI_OPERATION.COMPOSE && !currentContent.replace(/<[^>]*>/g, '').trim()) {
-        toastError({ title: 'No content', description: 'Add content before using AI tools.' })
-        return
-      }
-      pushToHistory(currentContent, `before-${operation}`)
-      setProcessing(true)
-      setCurrentOperation(operation)
-      aiStartTimeRef.current = Date.now()
-      await processAI.mutateAsync({
-        operation,
-        messageHtml: currentContent,
-        entityType: COMPOSE_ENTITY_TYPE.THREAD,
-        entityId: thread.id,
-        senderId: 'current-user',
-        output: OUTPUT_FORMAT.HTML,
-        ...options,
-      })
-    },
-    [
-      editor,
-      aiToolsState.isProcessing,
-      thread.id,
-      processAI,
-      setProcessing,
-      setCurrentOperation,
-      pushToHistory,
-    ]
-  )
-
+  // biome-ignore lint/correctness/useExhaustiveDependencies: content triggers recalculation when editor content changes
   const hasContent = useMemo(() => {
     if (!editor) return false
     return !isContentEmpty(editor)
@@ -269,98 +140,28 @@ function ChatComposerInner({
         />
       )}
 
-      {/* Body */}
-      <div
-        {...getRootProps()}
-        className={cn(
-          'relative flex flex-col border border-transparent ring-2 ring-transparent bg-white dark:bg-background',
-          hideHeader ? 'rounded-[20px] shadow-lg m-1 mt-0' : 'rounded-[12px] m-1 mt-0',
-          'focus-within:ring-blue-500 focus-within:hover:bg-white focus-within:hover:border-transparent dark:hover:bg-background',
-          activeState.isActive && 'ring-blue-500 hover:bg-white hover:border-transparent',
-          isDragActive && 'border-transparent bg-white hover:bg-white hover:border-transparent'
-        )}
-        onClick={handleWrapperClick}
+      <ComposerBody
+        content={content}
+        onContentChange={handleContentChange}
+        placeholder='Type your reply...'
+        editable={!aiToolsState.isProcessing && !isSending}
+        popoverClassName={popoverZIndex}
+        contentClassName='sm:min-h-[60px] py-2 text-sm'
+        editorMinHeightClassName='min-h-[60px]'
+        onWrapperClick={handleWrapperClick}
         onKeyDown={handleKeyDown}
-        onFocus={(e) => {
-          if (!e.currentTarget.contains(e.relatedTarget)) {
-            activeState.setHasFocus(true)
-          }
-        }}
-        onBlur={(e) => {
-          if (!e.currentTarget.contains(e.relatedTarget)) {
-            setTimeout(() => activeState.setHasFocus(false), 0)
-          }
-        }}>
-        <input {...getInputProps()} />
-
-        {isDragActive && (
-          <div
-            className={cn(
-              'absolute inset-[-1px] z-50 flex items-center justify-center bg-blue-500/10 border-1 border-dashed border-info',
-              hideHeader ? 'rounded-[20px]' : 'rounded-[12px]'
-            )}>
-            <div className='text-center'>
-              <Upload className='mx-auto size-8 text-blue-500' />
-              <Badge variant='blue' className='cursor-default'>
-                Drop here
-              </Badge>
-            </div>
-          </div>
-        )}
-
-        <div className='flex flex-col flex-1 min-h-[60px]'>
-          <LazyTiptapEditor
-            content={content}
-            onChange={handleContentChange}
-            placeholder='Type your reply...'
-            editable={!aiToolsState.isProcessing && !isSending}
-            popoverClassName={popoverZIndex}
-            contentClassName='sm:min-h-[60px] py-2 text-sm'
+        dropzone={dropzone}
+        rounded={hideHeader ? 'lg' : 'sm'}
+        frameClassName={hideHeader ? 'shadow-lg' : undefined}
+        belowEditor={
+          <AttachmentStrip
+            attachments={[]}
+            selectedItems={fileSelect.selectedItems}
+            onRemoveAttachment={removeAttachment}
+            onRemoveUpload={fileSelect.removeItem}
           />
-
-          {(attachments.length > 0 || fileSelect.selectedItems.length > 0) && (
-            <div className='mx-4 mb-3 mt-2'>
-              <div className='text-xs text-muted-foreground mb-2'>
-                Attachments ({attachments.length + fileSelect.selectedItems.length})
-              </div>
-              <div className='flex flex-wrap gap-2'>
-                {attachments.map((attachment) => (
-                  <MessageFile
-                    key={attachment.id}
-                    file={{
-                      id: attachment.id,
-                      name: attachment.name,
-                      mimeType: attachment.mimeType,
-                      size: BigInt(attachment.size || 0),
-                      source: 'existing' as const,
-                    }}
-                    showRemoveButton={true}
-                    onRemove={() => removeAttachment(attachment.id)}
-                    className='group'
-                  />
-                ))}
-                {fileSelect.selectedItems.map((file) => (
-                  <MessageFile
-                    key={file.id}
-                    file={{
-                      id: file.id,
-                      name: file.name,
-                      mimeType: file.mimeType ?? undefined,
-                      size: file.size ?? undefined,
-                      source: 'upload' as const,
-                    }}
-                    showRemoveButton={true}
-                    onRemove={() => fileSelect.removeItem(file.id)}
-                    className='group'
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* Toolbar — AI Tools + Attachments + Send */}
-        <div className='editor-toolbar-wrapper relative px-2 py-1'>
+        }
+        toolbar={
           <div className='flex items-center gap-1 shrink-0 no-scrollbar md:gap-2'>
             <EditorToolbar
               editor={editor}
@@ -380,8 +181,8 @@ function ChatComposerInner({
               }}
             />
           </div>
-        </div>
-      </div>
+        }
+      />
     </div>
   )
 }

--- a/apps/web/src/components/mail/composer-shared/attachment-strip.tsx
+++ b/apps/web/src/components/mail/composer-shared/attachment-strip.tsx
@@ -1,0 +1,70 @@
+// apps/web/src/components/mail/composer-shared/attachment-strip.tsx
+'use client'
+
+import type { useFileSelect } from '~/components/file-select/hooks/use-file-select'
+import { MessageFile } from '../email-editor/message-file'
+import type { FileAttachment } from '../email-editor/types'
+
+interface AttachmentStripProps {
+  /** Persisted attachments (e.g. from a restored draft). */
+  attachments: FileAttachment[]
+  /** In-progress / completed uploads from the file-select hook. */
+  selectedItems: ReturnType<typeof useFileSelect>['selectedItems']
+  onRemoveAttachment: (id: string) => void
+  onRemoveUpload: (id: string) => void
+}
+
+/**
+ * The "Attachments (N)" block shared by the email and chat composers — renders
+ * persisted attachments plus in-progress uploads. Renders nothing when empty.
+ */
+export function AttachmentStrip({
+  attachments,
+  selectedItems,
+  onRemoveAttachment,
+  onRemoveUpload,
+}: AttachmentStripProps) {
+  if (attachments.length === 0 && selectedItems.length === 0) return null
+
+  return (
+    <div className='mx-4 mb-3 mt-2'>
+      <div className='text-xs text-muted-foreground mb-2'>
+        Attachments ({attachments.length + selectedItems.length})
+      </div>
+      <div className='flex flex-wrap gap-2'>
+        {/* Persisted attachments */}
+        {attachments.map((attachment) => (
+          <MessageFile
+            key={attachment.id}
+            file={{
+              id: attachment.id,
+              name: attachment.name,
+              mimeType: attachment.mimeType,
+              size: BigInt(attachment.size || 0),
+              source: 'existing' as const,
+            }}
+            showRemoveButton={true}
+            onRemove={() => onRemoveAttachment(attachment.id)}
+            className='group'
+          />
+        ))}
+        {/* In-progress uploads */}
+        {selectedItems.map((file) => (
+          <MessageFile
+            key={file.id}
+            file={{
+              id: file.id,
+              name: file.name,
+              mimeType: file.mimeType ?? undefined,
+              size: file.size ?? undefined,
+              source: 'upload' as const,
+            }}
+            showRemoveButton={true}
+            onRemove={() => onRemoveUpload(file.id)}
+            className='group'
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/mail/composer-shared/composer-body.tsx
+++ b/apps/web/src/components/mail/composer-shared/composer-body.tsx
@@ -1,0 +1,134 @@
+// apps/web/src/components/mail/composer-shared/composer-body.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { cn } from '@auxx/ui/lib/utils'
+import { Upload } from 'lucide-react'
+import type React from 'react'
+import type { useDropzone } from 'react-dropzone'
+import { useEditorActiveStateContext } from '../email-editor/editor-active-state-context'
+import { LazyTiptapEditor } from '../email-editor/lazy-tiptap-editor'
+
+interface ComposerBodyProps {
+  // editor wiring
+  content: string
+  onContentChange: (html: string) => void
+  placeholder?: string
+  editable: boolean
+  popoverClassName?: string
+  contentClassName?: string
+  /** Min-height for the editor region. Email 'min-h-[150px]', chat 'min-h-[60px]'. */
+  editorMinHeightClassName?: string
+
+  // interaction
+  onWrapperClick: React.MouseEventHandler<HTMLDivElement>
+  onKeyDown: React.KeyboardEventHandler<HTMLDivElement>
+
+  // dropzone (from useComposerAttachments)
+  dropzone: Pick<ReturnType<typeof useDropzone>, 'getRootProps' | 'getInputProps' | 'isDragActive'>
+
+  // framing
+  /** Corner radius: 'sm' → rounded-[12px] (default), 'lg' → rounded-[20px] (chat hideHeader). */
+  rounded?: 'sm' | 'lg'
+  /** Extra classes for the frame wrapper (e.g. chat hideHeader adds shadow-lg). */
+  frameClassName?: string
+  /** Fully-wired toolbar content rendered inside `.editor-toolbar-wrapper`. */
+  toolbar: React.ReactNode
+  /** Email: From/To/Cc/Bcc/Subject — rendered inside the frame, above the editor. */
+  headerFields?: React.ReactNode
+  /**
+   * Content rendered below the editor and inside the editor flex region —
+   * email: signature, attachments, quick actions, prev-message; chat: attachments.
+   */
+  belowEditor?: React.ReactNode
+}
+
+/**
+ * The presentational composer frame shared by the email reply editor and the
+ * chat composer: the dropzone wrapper, drag overlay, active-state focus/blur
+ * wiring, the Tiptap editor, and the toolbar row. Domain chrome (recipients,
+ * signature, attachments, quick actions, send wiring) is injected via slots.
+ */
+export function ComposerBody({
+  content,
+  onContentChange,
+  placeholder,
+  editable,
+  popoverClassName,
+  contentClassName,
+  editorMinHeightClassName = 'min-h-[150px]',
+  onWrapperClick,
+  onKeyDown,
+  dropzone,
+  rounded = 'sm',
+  frameClassName,
+  toolbar,
+  headerFields,
+  belowEditor,
+}: ComposerBodyProps) {
+  const activeState = useEditorActiveStateContext()
+  const roundedClass = rounded === 'lg' ? 'rounded-[20px]' : 'rounded-[12px]'
+
+  return (
+    <div
+      {...dropzone.getRootProps()}
+      className={cn(
+        'relative flex flex-col m-1 mt-0 border border-transparent ring-2 ring-transparent bg-white dark:bg-background',
+        roundedClass,
+        'focus-within:ring-blue-500 focus-within:hover:bg-white focus-within:hover:border-transparent dark:hover:bg-background',
+        activeState.isActive && 'ring-blue-500 hover:bg-white hover:border-transparent',
+        dropzone.isDragActive &&
+          'border-transparent bg-white hover:bg-white hover:border-transparent',
+        frameClassName
+      )}
+      onClick={onWrapperClick}
+      onKeyDown={onKeyDown}
+      onFocus={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget)) {
+          activeState.setHasFocus(true)
+        }
+      }}
+      onBlur={(e) => {
+        // Small delay to allow popovers/selects to register as open before blur.
+        if (!e.currentTarget.contains(e.relatedTarget)) {
+          setTimeout(() => activeState.setHasFocus(false), 0)
+        }
+      }}>
+      <input {...dropzone.getInputProps()} />
+
+      {/* Drag overlay */}
+      {dropzone.isDragActive && (
+        <div
+          className={cn(
+            'absolute inset-[-1px] z-50 flex items-center justify-center bg-blue-500/10 border-1 border-dashed border-info',
+            roundedClass
+          )}>
+          <div className='text-center'>
+            <Upload className='mx-auto size-8 text-blue-500' />
+            <Badge variant='blue' className='cursor-default'>
+              Drop here
+            </Badge>
+          </div>
+        </div>
+      )}
+
+      {headerFields}
+
+      {/* Editor Section */}
+      <div className={cn('flex flex-col flex-1', editorMinHeightClassName)}>
+        <LazyTiptapEditor
+          content={content}
+          onChange={onContentChange}
+          placeholder={placeholder}
+          editable={editable}
+          popoverClassName={popoverClassName}
+          contentClassName={contentClassName}
+        />
+        {belowEditor}
+      </div>
+
+      {/* Toolbar row */}
+      <div className='editor-toolbar-wrapper relative px-2 py-1'>{toolbar}</div>
+    </div>
+  )
+}

--- a/apps/web/src/components/mail/composer-shared/content-empty.ts
+++ b/apps/web/src/components/mail/composer-shared/content-empty.ts
@@ -1,0 +1,32 @@
+// apps/web/src/components/mail/composer-shared/content-empty.ts
+'use client'
+
+import type { Editor } from '@tiptap/react'
+
+/**
+ * Selectors for elements that should not steal focus into the editor when the
+ * composer body wrapper is clicked. Superset of the email + chat selectors —
+ * the extra `[data-recipient-row]` / `.signature-picker-popover` entries are
+ * inert in surfaces that don't render those (e.g. chat), so sharing is safe.
+ */
+export const INTERACTIVE_ELEMENT_SELECTORS = `
+  button, a, input, select, textarea,
+  [role="button"], [role="option"], [role="combobox"], [role="menuitem"], [role="tab"],
+  [data-recipient-row],
+  .ProseMirror, [data-radix-popper-content-wrapper], [data-radix-select-trigger],
+  .tippy-box, .editor-toolbar-wrapper, .signature-picker-popover
+`.trim()
+
+/**
+ * Check if editor content is effectively empty (no text, only empty paragraphs).
+ */
+export function isContentEmpty(editor: Editor | null): boolean {
+  if (!editor) return true
+  const plainText = editor.getText()?.trim() ?? ''
+  if (plainText === '') {
+    const html = editor.getHTML()
+    const strippedHtml = html.replace(/<([a-z][a-z0-9]*)\s+[^>]*>/gi, '<$1>').replace(/\s+/g, '')
+    return /^(<p>(<br>)*<\/p>)+$/.test(strippedHtml)
+  }
+  return false
+}

--- a/apps/web/src/components/mail/composer-shared/index.ts
+++ b/apps/web/src/components/mail/composer-shared/index.ts
@@ -1,0 +1,7 @@
+// apps/web/src/components/mail/composer-shared/index.ts
+
+export { AttachmentStrip } from './attachment-strip'
+export { ComposerBody } from './composer-body'
+export { INTERACTIVE_ELEMENT_SELECTORS, isContentEmpty } from './content-empty'
+export { useComposerAITools } from './use-composer-ai-tools'
+export { useComposerAttachments } from './use-composer-attachments'

--- a/apps/web/src/components/mail/composer-shared/use-composer-ai-tools.ts
+++ b/apps/web/src/components/mail/composer-shared/use-composer-ai-tools.ts
@@ -1,0 +1,133 @@
+// apps/web/src/components/mail/composer-shared/use-composer-ai-tools.ts
+'use client'
+
+import { toastError } from '@auxx/ui/components/toast'
+import type { Editor } from '@tiptap/react'
+import { useCallback, useRef } from 'react'
+import { api } from '~/trpc/react'
+import {
+  AI_OPERATION,
+  type AIOperation,
+  COMPOSE_ENTITY_TYPE,
+  OUTPUT_FORMAT,
+  type OutputFormat,
+} from '~/types/ai-tools'
+import { useAIToolsState } from '../email-editor/hooks'
+
+interface UseComposerAIToolsOptions {
+  editor: Editor | null
+  /** Entity id for the compose request (thread id, or '' when unknown). */
+  entityId: string
+  /**
+   * How applied AI output is written back. Email passes the contentApplier-
+   * backed setter; chat passes `editor.commands.setContent` directly. `content`
+   * is a Tiptap JSON object for EDITOR output, otherwise an HTML string.
+   */
+  applyContent: (content: string | object, format: OutputFormat) => void
+  /** Sync React content state after an AI write (editor.getHTML()). */
+  onContentChanged: (html: string) => void
+  /** Optional analytics hooks — email wires posthog; chat omits. */
+  analytics?: {
+    onComposeStarted?: () => void
+    onComposeCompleted?: (durationMs?: number) => void
+    onComposeFailed?: (error: string) => void
+    onToolUsed?: (op: string, tone?: string, language?: string) => void
+  }
+}
+
+/**
+ * Shared AI-tools wiring: the undo/redo history state, the compose mutation,
+ * and the `handleAIOperation` entrypoint. Consumer-specific side effects
+ * (analytics, how content is applied) are injected via options.
+ */
+export function useComposerAITools({
+  editor,
+  entityId,
+  applyContent,
+  onContentChanged,
+  analytics,
+}: UseComposerAIToolsOptions) {
+  const aiTools = useAIToolsState(editor)
+  const { state, pushToHistory, setProcessing, setCurrentOperation, setError, clearError } = aiTools
+  const aiStartTimeRef = useRef<number>(0)
+
+  const processAI = api.aiFeature.compose.useMutation({
+    onSuccess: (response) => {
+      if (!editor) return
+      // Apply new content based on format. EDITOR returns Tiptap JSON; HTML is
+      // applied as-is; plain text is wrapped in a paragraph.
+      if (response.format === OUTPUT_FORMAT.EDITOR) {
+        applyContent(JSON.parse(response.content), response.format)
+      } else if (response.format === OUTPUT_FORMAT.HTML) {
+        applyContent(response.content, response.format)
+      } else {
+        applyContent(`<p>${response.content}</p>`, response.format)
+      }
+      // Sync React state — setContent doesn't emit onUpdate by default.
+      const next = editor.getHTML()
+      onContentChanged(next)
+      pushToHistory(next, state.currentOperation)
+      setProcessing(false)
+      setCurrentOperation(null)
+      clearError()
+      analytics?.onComposeCompleted?.(
+        aiStartTimeRef.current ? Date.now() - aiStartTimeRef.current : undefined
+      )
+    },
+    onError: (error) => {
+      toastError({ title: 'AI operation failed', description: error.message })
+      setError(error.message)
+      setProcessing(false)
+      setCurrentOperation(null)
+      analytics?.onComposeFailed?.(error.message)
+    },
+  })
+
+  const handleAIOperation = useCallback(
+    async (operation: AIOperation, options?: { tone?: string; language?: string }) => {
+      if (!editor || state.isProcessing) return
+      const currentContent = editor.getHTML()
+      // Don't process if content is empty (except for compose).
+      if (operation !== AI_OPERATION.COMPOSE && !currentContent.replace(/<[^>]*>/g, '').trim()) {
+        toastError({
+          title: 'No content',
+          description: 'Please add some content before using AI tools',
+        })
+        return
+      }
+
+      if (operation === AI_OPERATION.COMPOSE) {
+        analytics?.onComposeStarted?.()
+      } else {
+        analytics?.onToolUsed?.(operation.toLowerCase(), options?.tone, options?.language)
+      }
+
+      // Save current state to history so the operation can be undone.
+      pushToHistory(currentContent, `before-${operation}`)
+      setProcessing(true)
+      setCurrentOperation(operation)
+      aiStartTimeRef.current = Date.now()
+      await processAI.mutateAsync({
+        operation,
+        messageHtml: currentContent,
+        entityType: COMPOSE_ENTITY_TYPE.THREAD,
+        entityId,
+        senderId: 'current-user', // filled by backend
+        output: OUTPUT_FORMAT.HTML,
+        ...options,
+      })
+    },
+    [
+      editor,
+      state.isProcessing,
+      entityId,
+      processAI,
+      setProcessing,
+      setCurrentOperation,
+      pushToHistory,
+      analytics,
+    ]
+  )
+
+  return { ...aiTools, handleAIOperation }
+}

--- a/apps/web/src/components/mail/composer-shared/use-composer-attachments.ts
+++ b/apps/web/src/components/mail/composer-shared/use-composer-attachments.ts
@@ -1,0 +1,103 @@
+// apps/web/src/components/mail/composer-shared/use-composer-attachments.ts
+'use client'
+
+import type { Dispatch, SetStateAction } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useDropzone } from 'react-dropzone'
+import { useFileSelect } from '~/components/file-select/hooks/use-file-select'
+import type { FileAttachment } from '../email-editor/types'
+
+interface UseComposerAttachmentsOptions {
+  /** Seed persisted attachments (email draft restore). Chat passes nothing. */
+  initialAttachments?: FileAttachment[]
+  /**
+   * Pin the file-select entity id (email reuses the draft id). When omitted a
+   * temp id is generated. The id is captured once at hook creation and stays
+   * static — files uploaded before a draft exists associate via the temp id.
+   */
+  entityId?: string
+  /**
+   * Fired whenever attachments change or an upload completes / is removed —
+   * email uses it to mark the draft dirty. Chat omits it (no-op).
+   */
+  onDirty?: () => void
+}
+
+interface UseComposerAttachmentsReturn {
+  attachments: FileAttachment[]
+  setAttachments: Dispatch<SetStateAction<FileAttachment[]>>
+  fileSelect: ReturnType<typeof useFileSelect>
+  /** Persisted attachments merged with ready files from fileSelect (deduped). */
+  allAttachments: FileAttachment[]
+  removeAttachment: (id: string) => void
+  dropzone: Pick<ReturnType<typeof useDropzone>, 'getRootProps' | 'getInputProps' | 'isDragActive'>
+}
+
+/**
+ * Shared attachment wiring for the composer surfaces: persisted-attachment
+ * state, the file-select upload hook, the dropzone, the merge of persisted +
+ * in-progress files, and the remove handler.
+ */
+export function useComposerAttachments(
+  options: UseComposerAttachmentsOptions = {}
+): UseComposerAttachmentsReturn {
+  const { initialAttachments, entityId, onDirty } = options
+
+  const [attachments, setAttachments] = useState<FileAttachment[]>(() => initialAttachments ?? [])
+
+  // Entity id is captured once and stays static for the life of the hook.
+  const [resolvedEntityId] = useState(
+    () => entityId ?? `temp-message-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+  )
+
+  const fileSelect = useFileSelect({
+    entityType: 'MESSAGE',
+    entityId: resolvedEntityId,
+    allowMultiple: true,
+    maxFiles: 10,
+    maxFileSize: 25 * 1024 * 1024, // 25MB
+    autoStart: true,
+    onChange: onDirty,
+    onUploadComplete: onDirty,
+  })
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop: (acceptedFiles) => fileSelect.addFiles(acceptedFiles),
+    noClick: true, // editor handles clicks
+    noKeyboard: true,
+  })
+
+  // Combine persisted attachments + files from select that are ready to save:
+  // existing filesystem files (id is the server file id) and completed uploads
+  // (use serverFileId). Dedupe against persisted ids.
+  const allAttachments = useMemo(() => {
+    const filesFromSelect: FileAttachment[] = fileSelect.selectedItems
+      .filter((item) => item.source === 'filesystem' || item.serverFileId)
+      .map((item) => ({
+        id: item.source === 'filesystem' ? item.id : item.serverFileId!,
+        name: item.name,
+        size: Number(item.size ?? 0),
+        mimeType: item.mimeType || 'application/octet-stream',
+        type: 'file' as const,
+      }))
+    const existingIds = new Set(attachments.map((a) => a.id))
+    return [...attachments, ...filesFromSelect.filter((f) => !existingIds.has(f.id))]
+  }, [attachments, fileSelect.selectedItems])
+
+  const removeAttachment = useCallback(
+    (id: string) => {
+      setAttachments((prev) => prev.filter((a) => a.id !== id))
+      onDirty?.()
+    },
+    [onDirty]
+  )
+
+  return {
+    attachments,
+    setAttachments,
+    fileSelect,
+    allAttachments,
+    removeAttachment,
+    dropzone: { getRootProps, getInputProps, isDragActive },
+  }
+}

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -8,27 +8,15 @@ import { Button } from '@auxx/ui/components/button'
 import { Separator } from '@auxx/ui/components/separator'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
-import {
-  ArrowDownLeft,
-  ArrowUpRight,
-  Loader2,
-  Mail,
-  Minus,
-  Plus,
-  Trash2,
-  Upload,
-  X,
-} from 'lucide-react'
+import { ArrowDownLeft, ArrowUpRight, Loader2, Mail, Minus, Plus, Trash2, X } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
-import { useDropzone } from 'react-dropzone'
 import { useChannel } from '~/components/channels/hooks/use-channels'
 import { useDefaultChannelId } from '~/components/channels/hooks/use-default-channel'
 import { EditorToolbar } from '~/components/editor/editor-button'
 import { EditorProvider, useEditorContext } from '~/components/editor/editor-context'
 import { type ContentApplier, makeContentApplier } from '~/components/editor/inline-picker'
-import { useFileSelect } from '~/components/file-select/hooks/use-file-select'
 import { useCountUpdates } from '~/components/mail/hooks'
 import { useComposeStore } from '~/components/mail/store/compose-store'
 import { ChannelPicker } from '~/components/pickers/channel-picker'
@@ -45,26 +33,24 @@ import { useDebouncedCallback } from '~/hooks/use-debounced-value'
 // Local imports
 import { api } from '~/trpc/react'
 import {
-  AI_OPERATION,
-  type AIOperation,
-  COMPOSE_ENTITY_TYPE,
-  OUTPUT_FORMAT,
-} from '~/types/ai-tools'
+  AttachmentStrip,
+  ComposerBody,
+  INTERACTIVE_ELEMENT_SELECTORS,
+  isContentEmpty,
+  useComposerAITools,
+  useComposerAttachments,
+} from '../composer-shared'
 import { AIStatus } from './ai-status'
 import { deriveInitialState, type InitState } from './derive-initial'
 import {
   EditorActiveStateProvider,
   useEditorActiveStateContext,
 } from './editor-active-state-context'
-import { useAIToolsState, useDraftMutations } from './hooks'
-// Editor Imports
-import { LazyTiptapEditor } from './lazy-tiptap-editor'
-import { MessageFile } from './message-file'
+import { useDraftMutations } from './hooks'
 import PrevMessage from './prev-message'
 import { AddActionButton, QuickActionPanel } from './quick-action-panel'
 import { type RecipientField, RecipientInput, type RecipientInputHandle } from './recipient-input'
 import type {
-  FileAttachment,
   ParticipantInputData,
   RecipientState,
   Recipients,
@@ -72,26 +58,6 @@ import type {
 } from './types'
 import { useDraftAutosave } from './use-draft-autosave'
 
-const INTERACTIVE_ELEMENT_SELECTORS = `
-  button, a, input, select, textarea,
-  [role="button"], [role="option"], [role="combobox"], [role="menuitem"], [role="tab"],
-  [data-recipient-row],
-  .ProseMirror, [data-radix-popper-content-wrapper], [data-radix-select-trigger],
-  .tippy-box, .editor-toolbar-wrapper, .signature-picker-popover
-`.trim()
-/**
- * Check if editor content is effectively empty
- */
-const isContentEmpty = (editor: any): boolean => {
-  if (!editor) return true
-  const plainText = editor.getText()?.trim() ?? ''
-  if (plainText === '') {
-    const html = editor.getHTML()
-    const strippedHtml = html.replace(/<([a-z][a-z0-9]*)\s+[^>]*>/gi, '<$1>').replace(/\s+/g, '')
-    return /^(<p>(<br>)*<\/p>)+$/.test(strippedHtml)
-  }
-  return false
-}
 /**
  * Convert recipients array to mutation payload format
  */
@@ -214,10 +180,18 @@ function ReplyComposeEditorComponent({
   const [isDraftSaved, setIsDraftSaved] = useState(!!initialDraft)
   const [showNoToWarning, setShowNoToWarning] = useState(false)
 
-  // Attachments state - persisted attachments from draft
-  const [attachments, setAttachments] = useState<FileAttachment[]>(
-    () => initialDraft?.attachments ?? []
-  )
+  // Mark the draft dirty so autosave picks up changes.
+  const markDraftDirty = useCallback(() => setIsDraftSaved(false), [])
+
+  // Attachments + file uploads + dropzone + persisted/in-progress merge.
+  // Entity id is pinned to the draft id (or a static temp id) so files uploaded
+  // before the draft exists associate correctly.
+  const { attachments, setAttachments, fileSelect, allAttachments, removeAttachment, dropzone } =
+    useComposerAttachments({
+      initialAttachments: initialDraft?.attachments ?? [],
+      entityId: state.draftId ?? undefined,
+      onDirty: markDraftDirty,
+    })
 
   // Quick actions state - persisted in draft content
   const [quickActions, setQuickActions] = useState<DraftActionPayload[]>(
@@ -272,28 +246,6 @@ function ReplyComposeEditorComponent({
     }
   }, [initialDraft?.actions, quickActions.length])
 
-  // Generate temp ID for file uploads before draft exists
-  const tempEntityId = useMemo(
-    () => state.draftId || `temp-message-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-    [state.draftId]
-  )
-  // File selection hook - used ONLY for new uploads
-  const fileSelect = useFileSelect({
-    entityType: 'MESSAGE',
-    entityId: tempEntityId,
-    allowMultiple: true,
-    maxFiles: 10,
-    maxFileSize: 25 * 1024 * 1024, // 25MB
-    autoStart: true,
-    onChange: () => {
-      setIsDraftSaved(false)
-    },
-    onUploadComplete: () => {
-      // Mark draft as unsaved so autosave picks up the completed uploads
-      setIsDraftSaved(false)
-    },
-  })
-
   // Handle preset attachments on initial mount (when no draft exists)
   // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount
   useEffect(() => {
@@ -301,23 +253,6 @@ function ReplyComposeEditorComponent({
       setAttachments(presetValues.attachments)
     }
   }, []) // Only run on mount
-
-  // Remove attachment handler
-  const removeAttachment = useCallback((id: string) => {
-    setAttachments((prev) => prev.filter((a) => a.id !== id))
-    setIsDraftSaved(false)
-  }, [])
-  // Dropzone configuration
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    onDrop: (acceptedFiles) => {
-      fileSelect.addFiles(acceptedFiles)
-    },
-    noClick: true, // Don't trigger on click (editor handles clicks)
-    noKeyboard: true,
-  })
-  // Handle draft ID update after save
-  // Note: Entity ID is set during initial hook creation and remains static
-  // Files uploaded before draft creation will be associated via tempEntityId
 
   // Track when user requested discard to handle late autosave completions
   const discardAfterSave = useRef(false)
@@ -497,28 +432,9 @@ function ReplyComposeEditorComponent({
     300,
     { leading: true, trailing: false } // fire immediately; ignore rapid subsequent clicks
   )
-  // Prepare payload for autosave - combines persisted attachments + files from fileSelect
+  // Prepare payload for autosave — attachments come from the shared hook's
+  // persisted + ready-upload merge.
   const draftPayload = useMemo(() => {
-    // Get files from fileSelect that are ready to save:
-    // 1. Existing filesystem files (source === 'filesystem') - id is already the server file ID
-    // 2. Completed uploads (serverFileId exists) - use serverFileId
-    const filesFromSelect: FileAttachment[] = fileSelect.selectedItems
-      .filter((item) => item.source === 'filesystem' || item.serverFileId)
-      .map((item) => ({
-        id: item.source === 'filesystem' ? item.id : item.serverFileId!,
-        name: item.name,
-        size: Number(item.size ?? 0),
-        mimeType: item.mimeType || 'application/octet-stream',
-        type: 'file' as const,
-      }))
-
-    // Combine persisted attachments + files from select (avoiding duplicates)
-    const existingIds = new Set(attachments.map((a) => a.id))
-    const allAttachments = [
-      ...attachments,
-      ...filesFromSelect.filter((f) => !existingIds.has(f.id)),
-    ]
-
     return {
       threadId: state.threadId,
       integrationId: state.integrationId,
@@ -534,7 +450,7 @@ function ReplyComposeEditorComponent({
       actions: quickActions.length > 0 ? quickActions : undefined,
       draftId: state.draftId,
     }
-  }, [state, content, recipients, attachments, fileSelect.selectedItems, quickActions])
+  }, [state, content, recipients, allAttachments, quickActions])
   const draftAutosave = useDraftAutosave({
     enabled: !isSending && !!state.integrationId,
     payload: draftPayload,
@@ -666,66 +582,32 @@ function ReplyComposeEditorComponent({
     if (!thread) return false
     return thread.messageCount > 0
   }, [thread])
-  // AI Tools State Management
+  // AI Tools — shared state + compose wiring, with email's posthog analytics
+  // and the contentApplier-backed write-back (so duplicate writes no-op).
+  const aiTicketId = thread?.id || state.threadId || undefined
   const {
     state: aiToolsState,
-    pushToHistory,
     undo,
     redo,
     canUndo,
     canRedo,
-    setProcessing,
-    setCurrentOperation,
-    setError,
-    clearError,
-  } = useAIToolsState(editor)
-
-  // Track AI operation timing
-  const aiStartTimeRef = useRef<number>(0)
-
-  // Process AI operation mutation
-  const processAI = api.aiFeature.compose.useMutation({
-    onSuccess: (response) => {
-      if (!editor) return
-      // Apply new content based on format — routed through the applier so a
-      // duplicate write (same HTML as the user already has) no-ops.
-      if (response.format === OUTPUT_FORMAT.EDITOR) {
-        const tiptapContent = JSON.parse(response.content)
-        contentApplier.apply(tiptapContent)
-      } else if (response.format === OUTPUT_FORMAT.HTML) {
-        contentApplier.apply(response.content)
-      } else {
-        // Plain text - wrap in paragraph
-        contentApplier.apply(`<p>${response.content}</p>`)
-      }
-      // Sync React content state — setContent doesn't emit onUpdate by default
-      handleContentChange(editor.getHTML())
-      // Push the new state to history after applying it
-      pushToHistory(editor.getHTML(), aiToolsState.currentOperation)
-      setProcessing(false)
-      setCurrentOperation(null)
-      clearError()
-
-      // Track AI compose completion
-      posthog?.capture('ai_compose_completed', {
-        ticket_id: thread?.id || state.threadId || undefined,
-        duration_ms: aiStartTimeRef.current ? Date.now() - aiStartTimeRef.current : undefined,
-      })
-    },
-    onError: (error) => {
-      toastError({
-        title: 'AI operation failed',
-        description: error.message,
-      })
-      setError(error.message)
-      setProcessing(false)
-      setCurrentOperation(null)
-
-      // Track AI compose failure
-      posthog?.capture('ai_compose_failed', {
-        ticket_id: thread?.id || state.threadId || undefined,
-        error: error.message,
-      })
+    handleAIOperation,
+  } = useComposerAITools({
+    editor,
+    entityId: thread?.id || state.threadId || '',
+    applyContent: (content) => contentApplier.apply(content),
+    onContentChanged: handleContentChange,
+    analytics: {
+      onComposeStarted: () => posthog?.capture('ai_compose_started', { ticket_id: aiTicketId }),
+      onComposeCompleted: (durationMs) =>
+        posthog?.capture('ai_compose_completed', {
+          ticket_id: aiTicketId,
+          duration_ms: durationMs,
+        }),
+      onComposeFailed: (error) =>
+        posthog?.capture('ai_compose_failed', { ticket_id: aiTicketId, error }),
+      onToolUsed: (operation, tone, language) =>
+        posthog?.capture('ai_tool_used', { operation, tone, language }),
     },
   })
 
@@ -734,67 +616,6 @@ function ReplyComposeEditorComponent({
     undo()
     posthog?.capture('ai_change_undone')
   }, [undo, posthog])
-
-  // Handle AI operation
-  const handleAIOperation = useCallback(
-    async (
-      operation: AIOperation,
-      options?: {
-        tone?: string
-        language?: string
-      }
-    ) => {
-      if (!editor || aiToolsState.isProcessing) return
-      const currentContent = editor.getHTML()
-      // Don't process if content is empty (except for compose)
-      if (operation !== AI_OPERATION.COMPOSE && !currentContent.replace(/<[^>]*>/g, '').trim()) {
-        toastError({
-          title: 'No content',
-          description: 'Please add some content before using AI tools',
-        })
-        return
-      }
-
-      // Track AI events
-      const ticketId = thread?.id || state.threadId || undefined
-      if (operation === AI_OPERATION.COMPOSE) {
-        posthog?.capture('ai_compose_started', { ticket_id: ticketId })
-      } else {
-        posthog?.capture('ai_tool_used', {
-          operation: operation.toLowerCase(),
-          tone: options?.tone,
-          language: options?.language,
-        })
-      }
-
-      // Save current state to history before AI operation
-      // This ensures we can undo back to the state before the operation
-      pushToHistory(currentContent, `before-${operation}`)
-      setProcessing(true)
-      setCurrentOperation(operation)
-      aiStartTimeRef.current = Date.now()
-      await processAI.mutateAsync({
-        operation,
-        messageHtml: currentContent,
-        entityType: COMPOSE_ENTITY_TYPE.THREAD,
-        entityId: thread?.id || state.threadId || '',
-        senderId: 'current-user', // Will be filled by backend
-        output: OUTPUT_FORMAT.HTML,
-        ...options,
-      })
-    },
-    [
-      editor,
-      aiToolsState.isProcessing,
-      thread?.id,
-      state.threadId,
-      processAI,
-      setProcessing,
-      setCurrentOperation,
-      pushToHistory,
-      posthog,
-    ]
-  )
   const handleSendClick = useCallback(async () => {
     if (isSending || !editor?.isEditable) return
     // 0. Commit any pending recipient input before validation
@@ -1176,358 +997,286 @@ function ReplyComposeEditorComponent({
           </div>
         </div>
 
-        {/* Main Editor Body with Dropzone */}
-        <div
-          {...getRootProps()}
-          className={cn(
-            'relative flex flex-col rounded-[12px] m-1 mt-0 border border-transparent  ring-2 ring-transparent bg-white dark:bg-background',
-            'focus-within:ring-blue-500 focus-within:hover:bg-white focus-within:hover:border-transparent dark:hover:bg-background',
-            // 'hover:border-gray-400 dark:hover:border-black/20 hover:bg-gray-50 dark:hover:bg-background',
-            activeState.isActive && 'ring-blue-500 hover:bg-white hover:border-transparent',
-            isDragActive && 'border-transparent bg-white hover:bg-white hover:border-transparent '
-          )}
-          onClick={handleWrapperClick}
+        <ComposerBody
+          content={content}
+          onContentChange={handleContentChange}
+          placeholder='Type / to insert a snippet.'
+          editable={!aiToolsState.isProcessing}
+          popoverClassName={popoverZIndex}
+          onWrapperClick={handleWrapperClick}
           onKeyDown={handleKeyDown}
-          onFocus={(e) => {
-            // Check if focus is within editor content areas
-            if (!e.currentTarget.contains(e.relatedTarget)) {
-              activeState.setHasFocus(true)
-            }
-          }}
-          onBlur={(e) => {
-            // Only blur if focus moves outside editor AND no UI elements are open
-            if (!e.currentTarget.contains(e.relatedTarget)) {
-              // Small delay to allow popovers/selects to register as open
-              setTimeout(() => {
-                activeState.setHasFocus(false)
-              }, 0)
-            }
-          }}>
-          <input {...getInputProps()} />
-
-          {/* Drag overlay */}
-          {isDragActive && (
-            <div className='absolute inset-[-1px] z-50 flex items-center justify-center rounded-[12px] bg-blue-500/10 border-1 border-dashed border-info'>
-              <div className='text-center'>
-                <Upload className='mx-auto size-8 text-blue-500' />
-                <Badge variant='blue' className='cursor-default'>
-                  Drop here
-                </Badge>
-              </div>
-            </div>
-          )}
-          {/* Header Fields */}
-          <div className='flex flex-col border-b border-border'>
-            {/* From Field */}
-            <div className='flex items-center gap-2 px-4 py-2'>
-              <span className='w-10 shrink-0 text-sm text-muted-foreground'>From:</span>
-              <div className='flex-1'>
-                <ChannelPicker
-                  value={state.integrationId}
-                  onChange={handleIntegrationChange}
-                  disabled={isSending}
-                  className={popoverZIndex}
-                />
-              </div>
-            </div>
-            <Separator className='mx-4 w-auto' />
-
-            {/* To Field & Toggles */}
-            {showRecipientField && (
+          dropzone={dropzone}
+          headerFields={
+            <div className='flex flex-col border-b border-border'>
+              {/* From Field */}
               <div className='flex items-center gap-2 px-4 py-2'>
-                <span className='w-10 shrink-0 text-sm text-muted-foreground'>To:</span>
-                <RecipientInput
-                  ref={toInputRef}
-                  field='TO'
-                  recipients={recipients.TO}
-                  onAdd={(r) => upsertRecipient('TO', r)}
-                  onRemove={(id) => removeRecipient('TO', id)}
-                  onMoveTo={(id, target) => handleMoveTo('TO', id, target)}
-                  onContactSelect={(c) => handleContactSelect('TO', c)}
-                  placeholder='Add recipients...'
-                  disabled={isSending}
-                  popoverClassName={popoverZIndex}
-                />
-                <div className='ml-auto flex shrink-0 items-center gap-1'>
-                  {showSubjectField && !showSubject && (
-                    <Button
-                      variant='ghost'
-                      size='sm'
-                      className='h-6 px-1 text-xs text-info'
-                      onClick={() => setShowSubject(true)}
-                      disabled={isSending}>
-                      Subject
-                    </Button>
-                  )}
-                  {showCcBccToggle && !showCc && (
-                    <Button
-                      variant='ghost'
-                      size='sm'
-                      className='h-6 px-1 text-xs text-info'
-                      onClick={() => setShowCc(true)}
-                      disabled={isSending}>
-                      Cc
-                    </Button>
-                  )}
-                  {showCcBccToggle && !showBcc && (
-                    <Button
-                      variant='ghost'
-                      size='sm'
-                      className='h-6 px-1 text-xs text-info'
-                      onClick={() => setShowBcc(true)}
-                      disabled={isSending}>
-                      Bcc
-                    </Button>
-                  )}
+                <span className='w-10 shrink-0 text-sm text-muted-foreground'>From:</span>
+                <div className='flex-1'>
+                  <ChannelPicker
+                    value={state.integrationId}
+                    onChange={handleIntegrationChange}
+                    disabled={isSending}
+                    className={popoverZIndex}
+                  />
                 </div>
               </div>
-            )}
+              <Separator className='mx-4 w-auto' />
 
-            {/* Cc Field */}
-            {showCcBccToggle && showCc && (
-              <>
-                <Separator className='mx-4 w-auto' />
+              {/* To Field & Toggles */}
+              {showRecipientField && (
                 <div className='flex items-center gap-2 px-4 py-2'>
-                  <span className='w-10 shrink-0 text-sm text-muted-foreground'>Cc:</span>
+                  <span className='w-10 shrink-0 text-sm text-muted-foreground'>To:</span>
                   <RecipientInput
-                    ref={ccInputRef}
-                    field='CC'
-                    recipients={recipients.CC}
-                    onAdd={(r) => upsertRecipient('CC', r)}
-                    onRemove={(id) => removeRecipient('CC', id)}
-                    onMoveTo={(id, target) => handleMoveTo('CC', id, target)}
-                    onContactSelect={(c) => handleContactSelect('CC', c)}
-                    placeholder='Add Cc recipients...'
+                    ref={toInputRef}
+                    field='TO'
+                    recipients={recipients.TO}
+                    onAdd={(r) => upsertRecipient('TO', r)}
+                    onRemove={(id) => removeRecipient('TO', id)}
+                    onMoveTo={(id, target) => handleMoveTo('TO', id, target)}
+                    onContactSelect={(c) => handleContactSelect('TO', c)}
+                    placeholder='Add recipients...'
                     disabled={isSending}
                     popoverClassName={popoverZIndex}
                   />
-                  <Button
-                    variant='ghost'
-                    size='sm'
-                    className='ml-auto h-6 px-1 text-xs text-muted-foreground'
-                    onClick={() => {
-                      setShowCc(false)
-                      setRecipients((prev) => ({ ...prev, CC: [] }))
-                    }}
-                    disabled={isSending}>
-                    Remove
-                  </Button>
+                  <div className='ml-auto flex shrink-0 items-center gap-1'>
+                    {showSubjectField && !showSubject && (
+                      <Button
+                        variant='ghost'
+                        size='sm'
+                        className='h-6 px-1 text-xs text-info'
+                        onClick={() => setShowSubject(true)}
+                        disabled={isSending}>
+                        Subject
+                      </Button>
+                    )}
+                    {showCcBccToggle && !showCc && (
+                      <Button
+                        variant='ghost'
+                        size='sm'
+                        className='h-6 px-1 text-xs text-info'
+                        onClick={() => setShowCc(true)}
+                        disabled={isSending}>
+                        Cc
+                      </Button>
+                    )}
+                    {showCcBccToggle && !showBcc && (
+                      <Button
+                        variant='ghost'
+                        size='sm'
+                        className='h-6 px-1 text-xs text-info'
+                        onClick={() => setShowBcc(true)}
+                        disabled={isSending}>
+                        Bcc
+                      </Button>
+                    )}
+                  </div>
                 </div>
-              </>
-            )}
+              )}
 
-            {/* Bcc Field */}
-            {showCcBccToggle && showBcc && (
-              <>
-                <Separator className='mx-4 w-auto' />
-                <div className='flex items-center gap-2 px-4 py-2'>
-                  <span className='w-10 shrink-0 text-sm text-muted-foreground'>Bcc:</span>
-                  <RecipientInput
-                    ref={bccInputRef}
-                    field='BCC'
-                    recipients={recipients.BCC}
-                    onAdd={(r) => upsertRecipient('BCC', r)}
-                    onRemove={(id) => removeRecipient('BCC', id)}
-                    onMoveTo={(id, target) => handleMoveTo('BCC', id, target)}
-                    onContactSelect={(c) => handleContactSelect('BCC', c)}
-                    placeholder='Add Bcc recipients...'
-                    disabled={isSending}
-                    popoverClassName={popoverZIndex}
-                  />
-                  <Button
-                    variant='ghost'
-                    size='sm'
-                    className='ml-auto h-6 px-1 text-xs text-muted-foreground'
-                    onClick={() => {
-                      setShowBcc(false)
-                      setRecipients((prev) => ({ ...prev, BCC: [] }))
-                    }}
-                    disabled={isSending}>
-                    Remove
-                  </Button>
-                </div>
-              </>
-            )}
-
-            {/* Subject Field */}
-            {showSubjectField && showSubject && (
-              <>
-                <Separator className='mx-4 w-auto' />
-                <div className='flex items-center gap-2 px-4 py-2'>
-                  <span className='shrink-0 text-sm text-muted-foreground'>Subject:</span>
-                  <input
-                    type='text'
-                    className='w-full flex-1 bg-transparent text-sm outline-hidden placeholder:text-muted-foreground/60'
-                    value={state.subject}
-                    onChange={(e) => handleSubjectChange(e.target.value)}
-                    placeholder='Enter subject'
-                    disabled={isSending}
-                  />
-                  <Button
-                    variant='ghost'
-                    size='sm'
-                    className='ml-auto h-6 px-1 text-xs text-muted-foreground'
-                    onClick={() => setShowSubject(false)}
-                    disabled={isSending}>
-                    Remove
-                  </Button>
-                </div>
-              </>
-            )}
-          </div>
-
-          {/* Editor Section */}
-          <div className='flex flex-col flex-1 min-h-[150px]'>
-            <LazyTiptapEditor
-              content={content}
-              onChange={handleContentChange}
-              placeholder='Type / to insert a snippet.'
-              editable={!aiToolsState.isProcessing}
-              popoverClassName={popoverZIndex}
-            />
-            <SignatureEditor
-              integrationId={state.integrationId}
-              selectedSignatureId={state.signatureId}
-              onSignatureChange={handleSignatureChange}
-              disabled={isSending}
-              className={popoverZIndex}
-            />
-
-            {/* File Attachments Display - Persisted + In-Progress Uploads */}
-            {(attachments.length > 0 || fileSelect.selectedItems.length > 0) && (
-              <div className='mx-4 mb-3 mt-2'>
-                <div className='text-xs text-muted-foreground mb-2'>
-                  Attachments ({attachments.length + fileSelect.selectedItems.length})
-                </div>
-                <div className='flex flex-wrap gap-2'>
-                  {/* Persisted attachments */}
-                  {attachments.map((attachment) => (
-                    <MessageFile
-                      key={attachment.id}
-                      file={{
-                        id: attachment.id,
-                        name: attachment.name,
-                        mimeType: attachment.mimeType,
-                        size: BigInt(attachment.size || 0),
-                        source: 'existing' as const,
-                      }}
-                      showRemoveButton={true}
-                      onRemove={() => removeAttachment(attachment.id)}
-                      className='group'
+              {/* Cc Field */}
+              {showCcBccToggle && showCc && (
+                <>
+                  <Separator className='mx-4 w-auto' />
+                  <div className='flex items-center gap-2 px-4 py-2'>
+                    <span className='w-10 shrink-0 text-sm text-muted-foreground'>Cc:</span>
+                    <RecipientInput
+                      ref={ccInputRef}
+                      field='CC'
+                      recipients={recipients.CC}
+                      onAdd={(r) => upsertRecipient('CC', r)}
+                      onRemove={(id) => removeRecipient('CC', id)}
+                      onMoveTo={(id, target) => handleMoveTo('CC', id, target)}
+                      onContactSelect={(c) => handleContactSelect('CC', c)}
+                      placeholder='Add Cc recipients...'
+                      disabled={isSending}
+                      popoverClassName={popoverZIndex}
                     />
-                  ))}
-                  {/* In-progress uploads */}
-                  {fileSelect.selectedItems.map((file) => (
-                    <MessageFile
-                      key={file.id}
-                      file={{
-                        id: file.id,
-                        name: file.name,
-                        mimeType: file.mimeType ?? undefined,
-                        size: file.size ?? undefined,
-                        source: 'upload' as const,
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='ml-auto h-6 px-1 text-xs text-muted-foreground'
+                      onClick={() => {
+                        setShowCc(false)
+                        setRecipients((prev) => ({ ...prev, CC: [] }))
                       }}
-                      showRemoveButton={true}
-                      onRemove={() => fileSelect.removeItem(file.id)}
-                      className='group'
+                      disabled={isSending}>
+                      Remove
+                    </Button>
+                  </div>
+                </>
+              )}
+
+              {/* Bcc Field */}
+              {showCcBccToggle && showBcc && (
+                <>
+                  <Separator className='mx-4 w-auto' />
+                  <div className='flex items-center gap-2 px-4 py-2'>
+                    <span className='w-10 shrink-0 text-sm text-muted-foreground'>Bcc:</span>
+                    <RecipientInput
+                      ref={bccInputRef}
+                      field='BCC'
+                      recipients={recipients.BCC}
+                      onAdd={(r) => upsertRecipient('BCC', r)}
+                      onRemove={(id) => removeRecipient('BCC', id)}
+                      onMoveTo={(id, target) => handleMoveTo('BCC', id, target)}
+                      onContactSelect={(c) => handleContactSelect('BCC', c)}
+                      placeholder='Add Bcc recipients...'
+                      disabled={isSending}
+                      popoverClassName={popoverZIndex}
                     />
-                  ))}
-                </div>
-              </div>
-            )}
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='ml-auto h-6 px-1 text-xs text-muted-foreground'
+                      onClick={() => {
+                        setShowBcc(false)
+                        setRecipients((prev) => ({ ...prev, BCC: [] }))
+                      }}
+                      disabled={isSending}>
+                      Remove
+                    </Button>
+                  </div>
+                </>
+              )}
 
-            {/* Quick Actions Panel */}
-            <QuickActionPanel
-              actions={quickActions}
-              onAdd={(action) => setQuickActions((prev) => [...prev, action])}
-              onRemove={(actionId) =>
-                setQuickActions((prev) => prev.filter((a) => a.actionId !== actionId))
-              }
-              onUpdate={(actionId, inputs) =>
-                setQuickActions((prev) =>
-                  prev.map((a) => (a.actionId === actionId ? { ...a, inputs } : a))
-                )
-              }
-              threadId={thread?.id || state.threadId || undefined}
-              disabled={isSending}
-              popoverClassName={popoverZIndex}
-              onPopoverOpenChange={(open) =>
-                open
-                  ? activeState.trackPopoverOpen('quick-action')
-                  : activeState.trackPopoverClose('quick-action')
-              }
-            />
-
-            {/* Add Action Button (always visible when not sending) */}
-            {!isSending && (
-              <div className='px-2'>
-                <AddActionButton
-                  threadId={thread?.id || state.threadId || undefined}
-                  currentActions={quickActions}
-                  onAdd={(action) => setQuickActions((prev) => [...prev, action])}
-                  onRemove={(actionId) =>
-                    setQuickActions((prev) => prev.filter((a) => a.actionId !== actionId))
-                  }
-                  disabled={isSending}
-                  popoverClassName={popoverZIndex}
-                  onOpenChange={(open) =>
-                    open
-                      ? activeState.trackPopoverOpen('add-action')
-                      : activeState.trackPopoverClose('add-action')
-                  }
-                />
-              </div>
-            )}
-
-            {showQuotedReply && state.includePrev && messageForPrevComponent && (
-              <PrevMessage
-                message={messageForPrevComponent}
-                onRemove={() => setState((prev) => ({ ...prev, includePrev: false }))}
-              />
-            )}
-            {showQuotedReply && !state.includePrev && messageForPrevComponent && (
-              <div className='px-2'>
-                <Button
-                  variant='ghost'
-                  size='xs'
-                  onClick={() => setState((prev) => ({ ...prev, includePrev: true }))}
-                  title='Add previous message'
-                  className='text-muted-foreground/50'
-                  disabled={isSending}>
-                  <Plus />
-                  Add previous message
-                </Button>
-              </div>
-            )}
-          </div>
-
-          {/* Toolbar with integrated AI Tools */}
-          <div className='editor-toolbar-wrapper relative px-2 py-1 '>
-            {showRecipientField && showNoToWarning && (
-              <Badge variant='red' size='sm' className='absolute right-3 bottom-full z-10'>
-                Add a To recipient to send
-              </Badge>
-            )}
-            <div className='flex items-center gap-1 shrink-0 no-scrollbar md:gap-2'>
-              <EditorToolbar
-                editor={editor}
-                onSend={handleSendClick}
-                onSchedule={handleScheduleClick}
-                isSending={isSending}
-                disabled={isSending || !editor?.isEditable || aiToolsState.isProcessing}
-                fileSelect={fileSelect}
-                popoverClassName={popoverZIndex}
-                aiToolsProps={{
-                  threadId: thread?.id || state.threadId || undefined,
-                  hasContent,
-                  hasPreviousMessages,
-                  state: aiToolsState,
-                  onOperation: handleAIOperation,
-                }}
-              />
+              {/* Subject Field */}
+              {showSubjectField && showSubject && (
+                <>
+                  <Separator className='mx-4 w-auto' />
+                  <div className='flex items-center gap-2 px-4 py-2'>
+                    <span className='shrink-0 text-sm text-muted-foreground'>Subject:</span>
+                    <input
+                      type='text'
+                      className='w-full flex-1 bg-transparent text-sm outline-hidden placeholder:text-muted-foreground/60'
+                      value={state.subject}
+                      onChange={(e) => handleSubjectChange(e.target.value)}
+                      placeholder='Enter subject'
+                      disabled={isSending}
+                    />
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='ml-auto h-6 px-1 text-xs text-muted-foreground'
+                      onClick={() => setShowSubject(false)}
+                      disabled={isSending}>
+                      Remove
+                    </Button>
+                  </div>
+                </>
+              )}
             </div>
-          </div>
-        </div>
+          }
+          belowEditor={
+            <>
+              <SignatureEditor
+                integrationId={state.integrationId}
+                selectedSignatureId={state.signatureId}
+                onSignatureChange={handleSignatureChange}
+                disabled={isSending}
+                className={popoverZIndex}
+              />
+
+              {/* File Attachments Display - Persisted + In-Progress Uploads */}
+              <AttachmentStrip
+                attachments={attachments}
+                selectedItems={fileSelect.selectedItems}
+                onRemoveAttachment={removeAttachment}
+                onRemoveUpload={fileSelect.removeItem}
+              />
+
+              {/* Quick Actions Panel */}
+              <QuickActionPanel
+                actions={quickActions}
+                onAdd={(action) => setQuickActions((prev) => [...prev, action])}
+                onRemove={(actionId) =>
+                  setQuickActions((prev) => prev.filter((a) => a.actionId !== actionId))
+                }
+                onUpdate={(actionId, inputs) =>
+                  setQuickActions((prev) =>
+                    prev.map((a) => (a.actionId === actionId ? { ...a, inputs } : a))
+                  )
+                }
+                threadId={thread?.id || state.threadId || undefined}
+                disabled={isSending}
+                popoverClassName={popoverZIndex}
+                onPopoverOpenChange={(open) =>
+                  open
+                    ? activeState.trackPopoverOpen('quick-action')
+                    : activeState.trackPopoverClose('quick-action')
+                }
+              />
+
+              {/* Add Action Button (always visible when not sending) */}
+              {!isSending && (
+                <div className='px-2'>
+                  <AddActionButton
+                    threadId={thread?.id || state.threadId || undefined}
+                    currentActions={quickActions}
+                    onAdd={(action) => setQuickActions((prev) => [...prev, action])}
+                    onRemove={(actionId) =>
+                      setQuickActions((prev) => prev.filter((a) => a.actionId !== actionId))
+                    }
+                    disabled={isSending}
+                    popoverClassName={popoverZIndex}
+                    onOpenChange={(open) =>
+                      open
+                        ? activeState.trackPopoverOpen('add-action')
+                        : activeState.trackPopoverClose('add-action')
+                    }
+                  />
+                </div>
+              )}
+
+              {showQuotedReply && state.includePrev && messageForPrevComponent && (
+                <PrevMessage
+                  message={messageForPrevComponent}
+                  onRemove={() => setState((prev) => ({ ...prev, includePrev: false }))}
+                />
+              )}
+              {showQuotedReply && !state.includePrev && messageForPrevComponent && (
+                <div className='px-2'>
+                  <Button
+                    variant='ghost'
+                    size='xs'
+                    onClick={() => setState((prev) => ({ ...prev, includePrev: true }))}
+                    title='Add previous message'
+                    className='text-muted-foreground/50'
+                    disabled={isSending}>
+                    <Plus />
+                    Add previous message
+                  </Button>
+                </div>
+              )}
+            </>
+          }
+          toolbar={
+            <>
+              {showRecipientField && showNoToWarning && (
+                <Badge variant='red' size='sm' className='absolute right-3 bottom-full z-10'>
+                  Add a To recipient to send
+                </Badge>
+              )}
+              <div className='flex items-center gap-1 shrink-0 no-scrollbar md:gap-2'>
+                <EditorToolbar
+                  editor={editor}
+                  onSend={handleSendClick}
+                  onSchedule={handleScheduleClick}
+                  isSending={isSending}
+                  disabled={isSending || !editor?.isEditable || aiToolsState.isProcessing}
+                  fileSelect={fileSelect}
+                  popoverClassName={popoverZIndex}
+                  aiToolsProps={{
+                    threadId: thread?.id || state.threadId || undefined,
+                    hasContent,
+                    hasPreviousMessages,
+                    state: aiToolsState,
+                    onOperation: handleAIOperation,
+                  }}
+                />
+              </div>
+            </>
+          }
+        />
       </div>
     </>
   )


### PR DESCRIPTION
Implements `plans/tiptap/mail-composer-shell-unification.md` (PR 1 of the sequence — standalone, no dependency on the slash/JSON work).

## What

Extracts the duplicated composer shell shared by the email reply editor (`ReplyComposeEditorComponent`) and the chat composer (`ChatComposerInner`) into one presentational `ComposerBody` plus a small set of shared hooks, under a neutral `apps/web/src/components/mail/composer-shared/` so both consumers import as peers (chat previously reached *into* `email-editor/`).

### New `composer-shared/`
- **`content-empty.ts`** — `isContentEmpty(editor: Editor | null)` (typed, dropped the `any`) + the **superset** `INTERACTIVE_ELEMENT_SELECTORS` (email's, incl. `[data-recipient-row]` + `.signature-picker-popover`). Removes the drift that was the canary in the plan.
- **`attachment-strip.tsx`** — the "Attachments (N)" block (persisted + in-progress uploads).
- **`use-composer-attachments.ts`** — attachments state, `useFileSelect`, dropzone, the `allAttachments` merge, `removeAttachment`. `entityId` is captured once (static), `onDirty` wires draft-dirty for email.
- **`use-composer-ai-tools.ts`** — `useAIToolsState` + compose mutation + `handleAIOperation`; consumer side-effects (analytics, `applyContent`) injected via options.
- **`composer-body.tsx`** — dropzone frame, drag overlay, focus/blur active-state, `LazyTiptapEditor`, toolbar row; domain chrome injected via `headerFields` / `belowEditor` / `toolbar` slots.

### Consumers
- email keeps all draft / recipient / subject / schedule / quick-action / header-bar logic.
- chat keeps `useChatSend` + the focus-after-send falling-edge effect.
- chat `398 → 198` lines, email `1544 → 1292`.

## Deviation from the plan
`ComposerBody` does **not** expose a separate `attachmentStrip` slot — each consumer places `<AttachmentStrip/>` inside its `belowEditor` slot. This preserves the **exact** original email render order (signature → attachments → quick-actions → prev-message); a fixed slot would have forced attachments above the signature picker. Same component reuse, zero layout change.

## Scope
Pure refactor against the current HTML content contract. No schema / tRPC / package-export changes — all `apps/web` UI. Ready for the PR 2 JSON re-type (plan §10).

## Test plan (manual, per plan §9)
- [ ] Chat: type → ⌘+Enter sends; drag-drop a file; AI Compose; focus returns after send.
- [ ] Email: recipients/subject/signature render; autosave fires; attach marks draft dirty; AI undo/redo + AIStatus; schedule send.
- [ ] Drift: wrapper-click on a recipient chip (email) does not steal focus into the editor.